### PR TITLE
drift: Do not compare table or column comments

### DIFF
--- a/internal/database/migration/schemas/BUILD.bazel
+++ b/internal/database/migration/schemas/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "schemas",
@@ -20,4 +20,10 @@ go_library(
         "//lib/errors",
         "//migrations",
     ],
+)
+
+go_test(
+    name = "schemas_test",
+    srcs = ["description_test.go"],
+    embed = [":schemas"],
 )

--- a/internal/database/migration/schemas/description.go
+++ b/internal/database/migration/schemas/description.go
@@ -115,10 +115,11 @@ func (d TriggerDescription) GetName() string    { return d.Name }
 func (d ViewDescription) GetName() string       { return d.Name }
 
 type Normalizer[T any] interface{ Normalize() T }
+type PreComparisonNormalizer[T any] interface{ PreComparisonNormalize() T }
 
 var whitespacePattern = lazyregexp.New(`\s+`)
 
-func (d FunctionDescription) Normalize() FunctionDescription {
+func (d FunctionDescription) PreComparisonNormalize() FunctionDescription {
 	d.Definition = strings.TrimSpace(whitespacePattern.ReplaceAllString(d.Definition, " "))
 	return d
 }
@@ -136,6 +137,14 @@ func (d ColumnDescription) Normalize() ColumnDescription {
 func Normalize[T any](v T) T {
 	if normalizer, ok := any(v).(Normalizer[T]); ok {
 		return normalizer.Normalize()
+	}
+
+	return v
+}
+
+func PreComparisonNormalize[T any](v T) T {
+	if normalizer, ok := any(v).(PreComparisonNormalizer[T]); ok {
+		return normalizer.PreComparisonNormalize()
 	}
 
 	return v

--- a/internal/database/migration/schemas/description.go
+++ b/internal/database/migration/schemas/description.go
@@ -117,13 +117,10 @@ func (d ViewDescription) GetName() string       { return d.Name }
 type Normalizer[T any] interface{ Normalize() T }
 type PreComparisonNormalizer[T any] interface{ PreComparisonNormalize() T }
 
-var whitespacePattern = lazyregexp.New(`\s+`)
-
 func (d FunctionDescription) PreComparisonNormalize() FunctionDescription {
-	d.Definition = strings.TrimSpace(whitespacePattern.ReplaceAllString(d.Definition, " "))
+	d.Definition = normalizeFunction(d.Definition)
 	return d
 }
-
 func (d TableDescription) Normalize() TableDescription {
 	d.Comment = ""
 	return d
@@ -148,4 +145,15 @@ func PreComparisonNormalize[T any](v T) T {
 	}
 
 	return v
+}
+
+var whitespacePattern = lazyregexp.New(`\s+`)
+
+func normalizeFunction(definition string) string {
+	lines := strings.Split(definition, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Split(line, "--")[0]
+	}
+
+	return strings.TrimSpace(whitespacePattern.ReplaceAllString(strings.Join(lines, "\n"), " "))
 }

--- a/internal/database/migration/schemas/description_test.go
+++ b/internal/database/migration/schemas/description_test.go
@@ -1,0 +1,75 @@
+package schemas
+
+import "testing"
+
+func TestNormalizeFunction(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		lhs  string
+		rhs  string
+	}{
+		{
+			name: "equivalent",
+			lhs: `
+				CREATE OR REPLACE FUNCTION public.lsif_data_docs_search_private_delete() RETURNS trigger LANGUAGE plpgsql AS $function$
+				BEGIN
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+				END $function$;
+			`,
+			rhs: `
+				CREATE OR REPLACE FUNCTION public.lsif_data_docs_search_private_delete() RETURNS trigger LANGUAGE plpgsql AS $function$
+				BEGIN
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+				END $function$;
+			`,
+		},
+		{
+			name: "different spacing",
+			lhs: `
+				CREATE OR REPLACE FUNCTION
+				public.lsif_data_docs_search_private_delete()
+				RETURNS trigger
+				LANGUAGE plpgsql
+				AS $function$
+				BEGIN
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+				END $function$;
+			`,
+			rhs: `
+				CREATE OR REPLACE FUNCTION public.lsif_data_docs_search_private_delete() RETURNS trigger LANGUAGE plpgsql AS $function$
+				BEGIN
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+				END $function$;
+			`,
+		},
+		{
+			name: "comments differ",
+			lhs: `
+				CREATE OR REPLACE FUNCTION public.lsif_data_docs_search_private_delete() RETURNS trigger LANGUAGE plpgsql AS $function$
+				BEGIN
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+					-- should not matter that this is here!
+				END $function$;
+			`,
+			rhs: `
+				CREATE OR REPLACE FUNCTION public.lsif_data_docs_search_private_delete() RETURNS trigger LANGUAGE plpgsql AS $function$
+				BEGIN
+					-- Decrement tally counting tables.
+					UPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);
+					RETURN NULL;
+				END $function$;
+			`,
+		},
+	} {
+		if normalizeFunction(testCase.lhs) != normalizeFunction(testCase.rhs) {
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Errorf("unexpected comparison. %q != %q", testCase.lhs, testCase.rhs)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Fixes #51173. We made two changes:

1. Removed the explicitly table + column checks (which are no-ops after the next change), and
2. Set the comment fields *permanently* to an empty string instead of just for the `cmp.Diff` check.

## Test plan

Tested locally. Could use some additional testing to confirm the exact scenario @DaedalusG described in the linked issue is now resolved.