### PR TITLE
Cody web: Fix context label

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -1,5 +1,5 @@
 import { CodebaseContext } from '../codebase-context'
-import { ConfigurationUseContext, ConfigurationWithAccessToken } from '../configuration'
+import { ConfigurationWithAccessToken } from '../configuration'
 import { Editor } from '../editor'
 import { PrefilledOptions, withPreselectedOptions } from '../editor/withPreselectedOptions'
 import { SourcegraphEmbeddingsSearchClient } from '../embeddings/client'

--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -1,5 +1,5 @@
 import { CodebaseContext } from '../codebase-context'
-import { ConfigurationWithAccessToken } from '../configuration'
+import { ConfigurationUseContext, ConfigurationWithAccessToken } from '../configuration'
 import { Editor } from '../editor'
 import { PrefilledOptions, withPreselectedOptions } from '../editor/withPreselectedOptions'
 import { SourcegraphEmbeddingsSearchClient } from '../embeddings/client'
@@ -39,6 +39,7 @@ export interface Client {
         }
     ) => Promise<void>
     reset: () => void
+    codebaseContext: CodebaseContext
 }
 
 export async function createClient({
@@ -152,5 +153,6 @@ export async function createClient({
             transcript.reset()
             sendTranscript()
         },
+        codebaseContext,
     }
 }

--- a/client/web/src/stores/codyChat.ts
+++ b/client/web/src/stores/codyChat.ts
@@ -225,14 +225,14 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
     }
 
     const getChatContext = (): ChatContextStatus => {
-        const { config, editor } = get()
+        const { config, editor, client } = get()
 
         return {
             codebase: config?.codebase,
             filePath: editor?.getActiveTextEditorSelectionOrEntireFile()?.fileName,
             supportsKeyword: false,
             mode: config?.useContext,
-            connection: true,
+            connection: client?.codebaseContext.checkEmbeddingsConnection(),
         }
     }
 


### PR DESCRIPTION
I didn't notice this flaw in logic before but the branching of which context is used is actually done in `CodebaseContext` which was never exposed from the web client. This should wire things up like they are wired up in VS Code.

Let's quickly fix this 😅 

## Test plan

<img width="267" alt="Screenshot 2023-04-28 at 01 09 58" src="https://user-images.githubusercontent.com/458591/235009815-a4292f1a-b420-41ef-98f6-a30e1559ed94.png">
<img width="201" alt="Screenshot 2023-04-28 at 01 07 40" src="https://user-images.githubusercontent.com/458591/235009821-eff68003-4dd1-42f6-b057-1fc7575b8e05.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
