### PR TITLE
cody: make the Cody contributing doc link clearer

### DIFF
--- a/client/cody/README.md
+++ b/client/cody/README.md
@@ -71,4 +71,8 @@ We welcome PRs that contribute new, useful recipes.
 
 ## Development
 
-[Cody's code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/cody) is open source (Apache 2). See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## License
+
+[Cody's code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/client/cody) is open source (Apache 2).


### PR DESCRIPTION
At first glance I missed the CONTRIBUTING.md link in Cody readme, so this just makes it a little more prominent.

## Test plan

n/a