### PR TITLE
bazel+ci: upload logs of failing test/build targets as artefacts

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -31,3 +31,7 @@ build --test_env=PERCY_TOKEN
 
 # temp
 build --test_env=INCLUDE_ADMIN_ONBOARDING=false
+
+# Used by BEP and ci-agent
+# See https://github.com/bazelbuild/continuous-integration/releases/tag/agent-0.1.4
+build --build_event_json_file=bep.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .tmp/
 
 # Bazel
-bazel-*
+bazel-*   # bazel local folders
+bep.json  # bazel build events raw output (used for uploading logs, formatting errors, etc ...)
+/dev/backcompat/back_compat_migrations.patch  # Backward compatibility database tests patch, generated on the fly in CI for `bazel test @sourcegraph_back_compat//...` targets.
 
 # Vim
 *.swp
@@ -190,6 +192,3 @@ index.scip
 /tr
 /cache-*.tar
 
-# Backward compatibility database tests patch, generated on the fly in CI
-# for `bazel test @sourcegraph_back_compat//...` targets.
-/dev/backcompat/back_compat_migrations.patch

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -17,6 +17,7 @@ func testSG() *cli.App {
 
 func TestAppRun(t *testing.T) {
 	sg := testSG()
+	assert.Empty(t, "not empty")
 
 	// Capture output
 	var out, err bytes.Buffer

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -81,7 +81,7 @@ func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 }
 
 func bazelUploadFailedlogs() bk.StepOpt {
-	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 10 --mode buildkite &")
+	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 20 --mode buildkite &")
 }
 
 func bazelTest(targets ...string) func(*bk.Pipeline) {

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -81,17 +81,14 @@ func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 }
 
 func bazelUploadFailedlogs() bk.StepOpt {
-	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 20 --mode buildkite &")
+	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 5 --debug --mode buildkite &")
 }
 
 func bazelTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
-		// bazelUploadFailedlogs(),
-		bk.Cmd("wget https://github.com/bazelbuild/continuous-integration/releases/download/agent-0.1.4/bazelci-agent-0.1.4-x86_64-unknown-linux-musl -O bazelci-agent"),
-		bk.Cmd("chmod +x bazelci-agent"),
-		bk.Cmd("./bazelci-agent artifact upload --build_event_json_file bep.json --delay 10 --mode buildkite &"),
+		bazelUploadFailedlogs(),
 	}
 
 	// Test commands

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -81,7 +81,7 @@ func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 }
 
 func bazelUploadFailedlogs() bk.StepOpt {
-	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 5 --debug --mode buildkite &")
+	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 5 --debug --mode buildkite")
 }
 
 func bazelTest(targets ...string) func(*bk.Pipeline) {
@@ -97,7 +97,9 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 		cmd := bazelCmd(fmt.Sprintf("test %s", target))
 		bazelTestCmds = append(bazelTestCmds,
 			bazelAnnouncef("bazel test %s", target),
-			bk.Cmd(cmd))
+			bk.Cmd(cmd),
+			bazelUploadFailedlogs(),
+		)
 	}
 	cmds = append(cmds, bazelTestCmds...)
 

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -88,7 +88,10 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
-		bazelUploadFailedlogs(),
+		// bazelUploadFailedlogs(),
+		bk.Cmd("wget https://github.com/bazelbuild/continuous-integration/releases/download/agent-0.1.4/bazelci-agent-0.1.4-x86_64-unknown-linux-musl -O bazelci-agent"),
+		bk.Cmd("chmod +x bazelci-agent"),
+		bk.Cmd("./bazelci-agent artifact upload --build_event_json_file bep.json --delay 10 --mode buildkite &"),
 	}
 
 	// Test commands

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -88,7 +88,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
-		bazelUploadFailedlogs(),
+		// bazelUploadFailedlogs(),
 	}
 
 	// Test commands
@@ -98,6 +98,9 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 		bazelTestCmds = append(bazelTestCmds,
 			bazelAnnouncef("bazel test %s", target),
 			bk.Cmd(cmd),
+			bk.Cmd(`echo "--- debug"`),
+			bk.Cmd("ls -lah bep.json"),
+			bk.Cmd(`echo "--- end"`),
 			bazelUploadFailedlogs(),
 		)
 	}

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -80,10 +80,15 @@ func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 	return bk.Cmd(fmt.Sprintf(`echo "--- :bazel: %s"`, msg))
 }
 
+func bazelUploadFailedlogs() bk.StepOpt {
+	return bk.Cmd("bazelci-agent artifact upload --build_event_json_file bep.json --delay 10 --mode buildkite &")
+}
+
 func bazelTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
+		bazelUploadFailedlogs(),
 	}
 
 	// Test commands
@@ -118,6 +123,7 @@ func bazelBackCompatTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.DependsOn("bazel-configure"),
 		bk.Agent("queue", "bazel"),
+		bazelUploadFailedlogs(),
 
 		// Generate a patch that backports the migration from the new code into the old one.
 		bk.Cmd("git diff origin/ci/backcompat-v5.0.0..HEAD -- migrations/ > dev/backcompat/patches/back_compat_migrations.patch"),

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -12,13 +12,13 @@ func BazelOperations() *operations.Set {
 	ops := operations.NewNamedSet("Bazel")
 	ops.Append(bazelConfigure())
 	ops.Append(bazelTest("//...", "//client/web:test"))
-	ops.Append(bazelBackCompatTest(
-		"@sourcegraph_back_compat//cmd/...",
-		"@sourcegraph_back_compat//lib/...",
-		"@sourcegraph_back_compat//internal/...",
-		"@sourcegraph_back_compat//enterprise/cmd/...",
-		"@sourcegraph_back_compat//enterprise/internal/...",
-	))
+	// ops.Append(bazelBackCompatTest(
+	// 	"@sourcegraph_back_compat//cmd/...",
+	// 	"@sourcegraph_back_compat//lib/...",
+	// 	"@sourcegraph_back_compat//internal/...",
+	// 	"@sourcegraph_back_compat//enterprise/cmd/...",
+	// 	"@sourcegraph_back_compat//enterprise/internal/...",
+	// ))
 	return ops
 }
 
@@ -94,7 +94,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	// Test commands
 	bazelTestCmds := []bk.StepOpt{}
 	for _, target := range targets {
-		cmd := bazelCmd(fmt.Sprintf("test %s", target))
+		cmd := bazelCmd(fmt.Sprintf("test %s || true", target))
 		bazelTestCmds = append(bazelTestCmds,
 			bazelAnnouncef("bazel test %s", target),
 			bk.Cmd(cmd),


### PR DESCRIPTION
The standard output when something fails can sometimes be insufficient to understand what happened. This PR introduces the uses of https://github.com/bazelbuild/continuous-integration/releases/tag/agent-0.1.4 which I found in Bazel own CI setup, which is open-source and using Buildkite.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Pushed a build with an intentional failure, to ensure we get logs uploaded as an artefact 
- Green CI after removal of that commit. 