### PR TITLE
Cody: Fix markdown parsing

### DIFF
--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -21,7 +21,6 @@ ts_project(
     name = "cody-shared_lib",
     srcs = [
         "src/chat/bot-response-multiplexer.ts",
-        "src/chat/markdown.test.ts",
         "src/chat/chat.ts",
         "src/chat/client.ts",
         "src/chat/context.ts",
@@ -104,6 +103,7 @@ ts_project(
     testonly = True,
     srcs = [
         "src/chat/bot-response-multiplexer.test.ts",
+        "src/chat/markdown.test.ts",
         "src/chat/transcript/transcript.test.ts",
         "src/hallucinations-detector/index.test.ts",
         "src/sourcegraph-api/utils.test.ts",

--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -21,6 +21,7 @@ ts_project(
     name = "cody-shared_lib",
     srcs = [
         "src/chat/bot-response-multiplexer.ts",
+        "src/chat/markdown.test.ts",
         "src/chat/chat.ts",
         "src/chat/client.ts",
         "src/chat/context.ts",

--- a/client/cody-shared/src/chat/markdown.test.ts
+++ b/client/cody-shared/src/chat/markdown.test.ts
@@ -1,0 +1,192 @@
+import { parseMarkdown } from './markdown'
+
+describe('parseMarkdown', () => {
+    it('parses paragraphs', () => {
+        const markdown = 'Paragraph 1\n\nParagraph 2'
+        const result = parseMarkdown(markdown)
+        expect(result).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "isCodeBlock": false,
+                "line": "Paragraph 1",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "Paragraph 2",
+              },
+            ]
+        `)
+    })
+
+    it('parses code blocks', () => {
+        const markdown = '```js\ncode block\n```'
+        const result = parseMarkdown(markdown)
+        expect(result).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`js",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "code block",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`",
+              },
+            ]
+        `)
+    })
+
+    it('parses code blocks with languages', () => {
+        const markdown = '```python\ncode block\n```'
+        const result = parseMarkdown(markdown)
+        expect(result).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`python",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "code block",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`",
+              },
+            ]
+        `)
+    })
+
+    it('parses a mix of elements', () => {
+        const markdown = `
+Paragraph
+
+\`\`\`js
+code block
+\`\`\`
+
+# Header
+
+Paragraph
+    `
+        const result = parseMarkdown(markdown)
+        expect(result).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "Paragraph",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`js",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "code block",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "\`\`\`",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "# Header",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "Paragraph",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "    ",
+              },
+            ]
+        `)
+    })
+
+    it('parses tiled code blocks', () => {
+        const markdown = `
+      ~~~js
+      code block
+      ~~~
+
+      Paragraph
+
+      ~~~python
+      code block
+      ~~~
+      `
+        const result = parseMarkdown(markdown)
+        expect(result).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      ~~~js",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      code block",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      ~~~",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "      Paragraph",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      ~~~python",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      code block",
+              },
+              Object {
+                "isCodeBlock": true,
+                "line": "      ~~~",
+              },
+              Object {
+                "isCodeBlock": false,
+                "line": "      ",
+              },
+            ]
+        `)
+    })
+})

--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -48,8 +48,9 @@ export interface MarkdownLine {
 export function parseMarkdown(text: string): MarkdownLine[] {
     const markdownLines: MarkdownLine[] = []
     let isCodeBlock = false
+
     for (const line of text.split('\n')) {
-        if (line.trim().startsWith('```')) {
+        if (line.trim().startsWith('```') || line.trim().startsWith('~~~')) {
             markdownLines.push({ line, isCodeBlock: true })
             isCodeBlock = !isCodeBlock
         } else {

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- Fixes an issue where code blocks were unexpectedly escaped []()
+- Fixes an issue where code blocks were unexpectedly escaped [pull/51247](https://github.com/sourcegraph/sourcegraph/pull/51247)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
+- Fixes an issue where code blocks were unexpectedly escaped []()
+
 ### Changed
 
 ## [0.0.9]


### PR DESCRIPTION
TIL about tilde code blocks 😱 

https://www.markdownguide.org/extended-syntax/#fenced-code-blocks

~~~
Look ma, I’m code!
~~~

![image](https://user-images.githubusercontent.com/458591/235114193-404155f7-a9a4-450d-bafe-d03e74d7827d.png)

## Test plan

Added a unit test (examples courtesy of Cody)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
