### PR TITLE
(feat) add repo match search results aggregation by repo metadata

### DIFF
--- a/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
@@ -126,6 +126,23 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     </Button>
                 </Tooltip>
             </div>
+            <div
+                onMouseEnter={() => handleModeEnter(SearchAggregationMode.REPO_METADATA)}
+                onMouseLeave={handleMouseLeave}
+            >
+                <Tooltip content={availabilityGroups[SearchAggregationMode.REPO_METADATA]?.reasonUnavailable}>
+                    <Button
+                        variant="secondary"
+                        size={size}
+                        outline={mode !== SearchAggregationMode.REPO_METADATA}
+                        disabled={!isModeAvailable(SearchAggregationMode.REPO_METADATA)}
+                        data-testid="repoMetadata-aggregation-mode"
+                        onClick={() => onModeChange(SearchAggregationMode.REPO_METADATA)}
+                    >
+                        Repo metadata
+                    </Button>
+                </Tooltip>
+            </div>
         </div>
     )
 }

--- a/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
@@ -6,6 +6,7 @@ import { useDebouncedCallback } from 'use-debounce'
 import { SearchAggregationMode } from '@sourcegraph/shared/src/graphql-operations'
 import { Button, Tooltip } from '@sourcegraph/wildcard'
 
+import { useFeatureFlag } from '../../../../../../featureFlags/useFeatureFlag'
 import { SearchAggregationModeAvailability } from '../../../../../../graphql-operations'
 
 import styles from './AggregationModeControls.module.scss'
@@ -23,6 +24,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
     const { mode, loading, availability = [], size, className, onModeChange, onModeHover, ...attributes } = props
 
     const debouncedOnModeHover = useDebouncedCallback(onModeHover, 1000)
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability
@@ -126,23 +128,25 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
                     </Button>
                 </Tooltip>
             </div>
-            <div
-                onMouseEnter={() => handleModeEnter(SearchAggregationMode.REPO_METADATA)}
-                onMouseLeave={handleMouseLeave}
-            >
-                <Tooltip content={availabilityGroups[SearchAggregationMode.REPO_METADATA]?.reasonUnavailable}>
-                    <Button
-                        variant="secondary"
-                        size={size}
-                        outline={mode !== SearchAggregationMode.REPO_METADATA}
-                        disabled={!isModeAvailable(SearchAggregationMode.REPO_METADATA)}
-                        data-testid="repoMetadata-aggregation-mode"
-                        onClick={() => onModeChange(SearchAggregationMode.REPO_METADATA)}
-                    >
-                        Repo metadata
-                    </Button>
-                </Tooltip>
-            </div>
+            {enableRepositoryMetadata && (
+                <div
+                    onMouseEnter={() => handleModeEnter(SearchAggregationMode.REPO_METADATA)}
+                    onMouseLeave={handleMouseLeave}
+                >
+                    <Tooltip content={availabilityGroups[SearchAggregationMode.REPO_METADATA]?.reasonUnavailable}>
+                        <Button
+                            variant="secondary"
+                            size={size}
+                            outline={mode !== SearchAggregationMode.REPO_METADATA}
+                            disabled={!isModeAvailable(SearchAggregationMode.REPO_METADATA)}
+                            data-testid="repoMetadata-aggregation-mode"
+                            onClick={() => onModeChange(SearchAggregationMode.REPO_METADATA)}
+                        >
+                            Repo metadata
+                        </Button>
+                    </Tooltip>
+                </div>
+            )}
         </div>
     )
 }

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -64,7 +64,7 @@ function useSyncedWithURLState<State, SerializedState>(
     return [queryParameter, setNextState]
 }
 
-type SerializedAggregationMode = 'repo' | 'path' | 'author' | 'group' | ''
+type SerializedAggregationMode = 'repo' | 'path' | 'author' | 'group' | 'repo-metadata' | ''
 
 const aggregationModeSerializer = (mode: SearchAggregationMode | null): SerializedAggregationMode => {
     switch (mode) {
@@ -76,7 +76,8 @@ const aggregationModeSerializer = (mode: SearchAggregationMode | null): Serializ
             return 'author'
         case SearchAggregationMode.CAPTURE_GROUP:
             return 'group'
-
+        case SearchAggregationMode.REPO_METADATA:
+            return 'repo-metadata'
         default:
             return ''
     }
@@ -94,6 +95,8 @@ const aggregationModeDeserializer = (
             return SearchAggregationMode.AUTHOR
         case 'group':
             return SearchAggregationMode.CAPTURE_GROUP
+        case 'repo-metadata':
+            return SearchAggregationMode.REPO_METADATA
 
         default:
             return null

--- a/cmd/frontend/graphqlbackend/insights_aggregations.graphql
+++ b/cmd/frontend/graphqlbackend/insights_aggregations.graphql
@@ -13,6 +13,7 @@ enum SearchAggregationMode {
     PATH
     AUTHOR
     CAPTURE_GROUP
+    REPO_METADATA
 }
 
 """

--- a/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
@@ -233,7 +233,7 @@ func getDefaultAggregationMode(searchQuery, patternType string) types.SearchAggr
 		return types.PATH_AGGREGATION_MODE
 	}
 
-	repoMetadata,_, _ := canAggregateByRepoMetadata(searchQuery, patternType)
+	repoMetadata, _, _ := canAggregateByRepoMetadata(searchQuery, patternType)
 	if repoMetadata {
 		return types.REPO_METADATA_AGGREGATION_MODE
 	}

--- a/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
@@ -36,7 +36,7 @@ const (
 const invalidQueryMsg = "Grouping is disabled because the search query is not valid."
 const fileUnsupportedFieldValueFmt = `Grouping by file is not available for searches with "%s:%s".`
 const authNotCommitDiffMsg = "Grouping by author is only available for diff and commit searches."
-const repoMetadataNotRepoSelectMsg = "Grouping by repo metadata is only available for repository match searches."
+const repoMetadataNotRepoSelectMsg = "Grouping by repo metadata is only available for repository searches."
 const cgInvalidQueryMsg = "Grouping by capture group is only available for regexp searches that contain a capturing group."
 const cgMultipleQueryPatternMsg = "Grouping by capture group does not support search patterns with the following: and, or, negation."
 const cgUnsupportedSelectFmt = `Grouping by capture group is not available for searches with "%s:%s".`

--- a/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/aggregates_resolvers.go
@@ -233,11 +233,6 @@ func getDefaultAggregationMode(searchQuery, patternType string) types.SearchAggr
 		return types.PATH_AGGREGATION_MODE
 	}
 
-	repoMetadata, _, _ := canAggregateByRepoMetadata(searchQuery, patternType)
-	if repoMetadata {
-		return types.REPO_METADATA_AGGREGATION_MODE
-	}
-
 	return types.REPO_AGGREGATION_MODE
 }
 

--- a/enterprise/internal/insights/aggregation/BUILD.bazel
+++ b/enterprise/internal/insights/aggregation/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
     deps = [
         "//enterprise/internal/insights/query/querybuilder",
         "//enterprise/internal/insights/types",
+        "//internal/api",
+        "//internal/collections",
         "//internal/conf",
         "//internal/database",
         "//internal/search/query",
@@ -20,6 +22,7 @@ go_library(
         "//internal/search/streaming/api",
         "//internal/search/streaming/client",
         "//internal/trace",
+        "//internal/types",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",
     ],
@@ -36,6 +39,7 @@ go_test(
     deps = [
         "//enterprise/internal/insights/types",
         "//internal/api",
+        "//internal/database",
         "//internal/gitserver/gitdomain",
         "//internal/search/result",
         "//internal/search/streaming",

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/querybuilder"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -238,16 +239,12 @@ func (r *searchAggregationResults) ResultLimitHit(limit int) bool {
 }
 
 func repoIDs(results []result.Match) []api.RepoID {
-	ids := make(map[api.RepoID]struct{}, 5)
+	ids := collections.NewSet[api.RepoID]()
 	for _, r := range results {
-		ids[r.RepoName().ID] = struct{}{}
+		ids.Add(r.RepoName().ID)
 	}
 
-	res := make([]api.RepoID, 0, len(ids))
-	for id := range ids {
-		res = append(res, id)
-	}
-	return res
+	return ids.Values()
 }
 
 func (r *searchAggregationResults) Send(event streaming.SearchEvent) {

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -152,17 +152,17 @@ func matchContent(event result.Match) []string {
 }
 
 func countRepoMetadata(r result.Match, repo *sTypes.Repo) (map[MatchKey]int, error) {
-	metadata := map[string]*string{types.NO_REPO_METADATA_KEY: nil}
+	metadata := map[string]*string{types.NO_REPO_METADATA_TEXT: nil}
 	if repo != nil && repo.KeyValuePairs != nil {
 		metadata = repo.KeyValuePairs
 	}
 	matches := map[MatchKey]int{}
-	for key := range metadata {
+	for key, value := range metadata {
 		group := key
-		key := MatchKey{Repo: string(r.RepoName().Name), RepoID: int32(r.RepoName().ID), Group: group}
-		if len(key.Group) > 100 {
-			key.Group = key.Group[:100]
+		if value != nil && *value != "" {
+			group += ":" + *value
 		}
+		key := MatchKey{Repo: string(r.RepoName().Name), RepoID: int32(r.RepoName().ID), Group: group}
 		matches[key] = r.ResultCount()
 	}
 	return matches, nil
@@ -277,7 +277,7 @@ func (r *searchAggregationResults) Send(event streaming.SearchEvent) {
 			r.tabulator(nil, err)
 			return
 		default:
-			groups, err := r.countFunc(match, repos[match.RepoName().ID]) // pass metadata or entire repo here?
+			groups, err := r.countFunc(match, repos[match.RepoName().ID])
 			for groupKey, count := range groups {
 				// delegate error handling to the passed in tabulator
 				if err != nil {

--- a/enterprise/internal/insights/aggregation/aggregation.go
+++ b/enterprise/internal/insights/aggregation/aggregation.go
@@ -162,8 +162,8 @@ func countRepoMetadata(r result.Match, repo *sTypes.Repo) (map[MatchKey]int, err
 		if value != nil && *value != "" {
 			group += ":" + *value
 		}
-		key := MatchKey{Repo: string(r.RepoName().Name), RepoID: int32(r.RepoName().ID), Group: group}
-		matches[key] = r.ResultCount()
+		matchKey := MatchKey{Repo: string(r.RepoName().Name), RepoID: int32(r.RepoName().ID), Group: group}
+		matches[matchKey] = r.ResultCount()
 	}
 	return matches, nil
 }

--- a/enterprise/internal/insights/query/querybuilder/BUILD.bazel
+++ b/enterprise/internal/insights/query/querybuilder/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/compute",
+        "//enterprise/internal/insights/types",
         "//internal/search/client",
         "//internal/search/query",
         "//internal/search/repos",

--- a/enterprise/internal/insights/query/querybuilder/builder.go
+++ b/enterprise/internal/insights/query/querybuilder/builder.go
@@ -408,12 +408,12 @@ func AddRepoMetadataFilter(query BasicQuery, repoMeta string) (BasicQuery, error
 	mutatedQuery := searchquery.MapPlan(plan, func(basic searchquery.Basic) searchquery.Basic {
 		modified := make([]searchquery.Parameter, 0, len(basic.Parameters)+1)
 		modified = append(modified, basic.Parameters...)
-		fValue := fmt.Sprint("has.key(", repoMeta, ")")
+		fValue := fmt.Sprint("has.meta(", repoMeta, ")")
 		meta := strings.Split(repoMeta, ":")
 		if len(meta) == 2 {
 			key := meta[0]
 			value := meta[1]
-			fValue = fmt.Sprint("has(", key, ":", value, ")")
+			fValue = fmt.Sprint("has.meta(", key, ":", value, ")")
 		}
 		modified = append(modified, searchquery.Parameter{
 			Field:      searchquery.FieldRepo,

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -625,6 +625,38 @@ func Test_addFileFilter(t *testing.T) {
 	}
 }
 
+func Test_addRepoMetadataFilter(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		repoMetadata string
+		want         autogold.Value
+	}{
+		{
+			name:         "no repo meta value",
+			input:        "myquery",
+			repoMetadata: "open-source",
+			want:         autogold.Expect(BasicQuery("repo:has.key(open-source) myquery")),
+		},
+		{
+			name:         "with repo meta value",
+			input:        "myquery repo:supergreat",
+			repoMetadata: "team:backend",
+			want:         autogold.Expect(BasicQuery("repo:supergreat repo:has(team:backend) myquery")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := AddRepoMetadataFilter(BasicQuery(test.input), test.repoMetadata)
+			if err != nil {
+				test.want.Equal(t, err.Error())
+			} else {
+				test.want.Equal(t, got)
+			}
+		})
+	}
+}
+
 func TestRepositoryScopeQuery(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/enterprise/internal/insights/query/querybuilder/builder_test.go
+++ b/enterprise/internal/insights/query/querybuilder/builder_test.go
@@ -636,13 +636,13 @@ func Test_addRepoMetadataFilter(t *testing.T) {
 			name:         "no repo meta value",
 			input:        "myquery",
 			repoMetadata: "open-source",
-			want:         autogold.Expect(BasicQuery("repo:has.key(open-source) myquery")),
+			want:         autogold.Expect(BasicQuery("repo:has.meta(open-source) myquery")),
 		},
 		{
 			name:         "with repo meta value",
 			input:        "myquery repo:supergreat",
 			repoMetadata: "team:backend",
-			want:         autogold.Expect(BasicQuery("repo:supergreat repo:has(team:backend) myquery")),
+			want:         autogold.Expect(BasicQuery("repo:supergreat repo:has.meta(team:backend) myquery")),
 		},
 	}
 	for _, test := range tests {

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -213,9 +213,10 @@ const (
 	PATH_AGGREGATION_MODE          SearchAggregationMode = "PATH"
 	AUTHOR_AGGREGATION_MODE        SearchAggregationMode = "AUTHOR"
 	CAPTURE_GROUP_AGGREGATION_MODE SearchAggregationMode = "CAPTURE_GROUP"
+	REPO_METADATA_AGGREGATION_MODE SearchAggregationMode = "REPO_METADATA"
 )
 
-var SearchAggregationModes = []SearchAggregationMode{REPO_AGGREGATION_MODE, PATH_AGGREGATION_MODE, AUTHOR_AGGREGATION_MODE, CAPTURE_GROUP_AGGREGATION_MODE}
+var SearchAggregationModes = []SearchAggregationMode{REPO_AGGREGATION_MODE, PATH_AGGREGATION_MODE, AUTHOR_AGGREGATION_MODE, CAPTURE_GROUP_AGGREGATION_MODE, REPO_METADATA_AGGREGATION_MODE}
 
 type AggregationNotAvailableReasonType string
 
@@ -225,4 +226,8 @@ const (
 	TIMEOUT_EXTENSION_AVAILABLE        AggregationNotAvailableReasonType = "TIMEOUT_EXTENSION_AVAILABLE"
 	TIMEOUT_NO_EXTENSION_AVAILABLE     AggregationNotAvailableReasonType = "TIMEOUT_NO_EXTENSION_AVAILABLE"
 	ERROR_OCCURRED                     AggregationNotAvailableReasonType = "ERROR_OCCURRED"
+)
+
+const (
+	NO_REPO_METADATA_KEY = "No metadata"
 )

--- a/enterprise/internal/insights/types/types.go
+++ b/enterprise/internal/insights/types/types.go
@@ -229,5 +229,5 @@ const (
 )
 
 const (
-	NO_REPO_METADATA_KEY = "No metadata"
+	NO_REPO_METADATA_TEXT = "No metadata"
 )

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -17,6 +17,8 @@ type RepoMatch struct {
 
 	DescriptionMatches []Range
 	RepoNameMatches    []Range
+
+	Metadata map[string]*string
 }
 
 func (r RepoMatch) RepoName() types.MinimalRepo {

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -17,8 +17,6 @@ type RepoMatch struct {
 
 	DescriptionMatches []Range
 	RepoNameMatches    []Range
-
-	Metadata map[string]*string
 }
 
 func (r RepoMatch) RepoName() types.MinimalRepo {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

This PR introduces new aggregation mode over repository metadata. It works for `select:repo` and shows number of repositories for a given key-value pair metadata.

## Test plan
- `sg start`
- Set `repository-metadata` feature flag to `true`
- Use search with additional `select:repo` and check that aggregation panel had new "Repo metadata" option

## Screenshots

https://github.com/sourcegraph/sourcegraph/assets/6717049/8d3b4064-71a3-49aa-aaf0-9196e929fbe9



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
