### PR TITLE
feat: allow disabling of user centric or repo centric permission sync

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2489,9 +2489,9 @@ type SiteConfiguration struct {
 	// PermissionsSyncJobsHistorySize description: The number of last repo/user permission jobs to keep for history.
 	PermissionsSyncJobsHistorySize *int `json:"permissions.syncJobsHistorySize,omitempty"`
 	// PermissionsSyncOldestRepos description: Number of repo permissions to schedule for syncing in single scheduler iteration.
-	PermissionsSyncOldestRepos int `json:"permissions.syncOldestRepos,omitempty"`
+	PermissionsSyncOldestRepos *int `json:"permissions.syncOldestRepos,omitempty"`
 	// PermissionsSyncOldestUsers description: Number of user permissions to schedule for syncing in single scheduler iteration.
-	PermissionsSyncOldestUsers int `json:"permissions.syncOldestUsers,omitempty"`
+	PermissionsSyncOldestUsers *int `json:"permissions.syncOldestUsers,omitempty"`
 	// PermissionsSyncReposBackoffSeconds description: Don't sync a repo's permissions if it has synced within the last n seconds.
 	PermissionsSyncReposBackoffSeconds int `json:"permissions.syncReposBackoffSeconds,omitempty"`
 	// PermissionsSyncScheduleInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1022,12 +1022,18 @@
     "permissions.syncOldestUsers": {
       "description": "Number of user permissions to schedule for syncing in single scheduler iteration.",
       "type": "integer",
-      "default": 10
+      "default": 10,
+      "!go": {
+        "pointer": true
+      }
     },
     "permissions.syncOldestRepos": {
       "description": "Number of repo permissions to schedule for syncing in single scheduler iteration.",
       "type": "integer",
-      "default": 10
+      "default": 10,
+      "!go": {
+        "pointer": true
+      }
     },
     "permissions.syncUsersBackoffSeconds": {
       "description": "Don't sync a user's permissions if they have synced within the last n seconds.",


### PR DESCRIPTION
This is beneficial in cases where one or the other is clearly much faster. It is also beneficial in cases when we have a clash between user centric and repo centric permission sync.

## Test plan

It's basically just a site config schema change. Tested locally + unit tests.
