### PR TITLE
(feat) add repo metadata key filter query link

### DIFF
--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -2,18 +2,6 @@
     gap: 0.5rem;
 }
 
-.text {
-    color: var(--body-color);
-}
-
-.button,
-.text {
-    font-size: 0.75rem;
-}
-
-.container.small {
-    .button,
-    .text {
-        font-size: 0.625rem;
-    }
+.highlight {
+    color: var(--search-filter-keyword-color);
 }

--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -2,22 +2,18 @@
     gap: 0.5rem;
 }
 
-.meta {
+.text {
     color: var(--body-color);
 }
 
-.highlight {
-    color: var(--search-filter-keyword-color);
-}
-
-.delete-button,
-.meta {
+.button,
+.text {
     font-size: 0.75rem;
 }
 
 .container.small {
-    .delete-button,
-    .meta {
+    .button,
+    .text {
         font-size: 0.625rem;
     }
 }

--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -5,3 +5,9 @@
 .highlight {
     color: var(--search-filter-keyword-color);
 }
+
+.badge-button {
+    &:focus, &:hover {
+        background-color: var(--badge-dark);
+    }
+}

--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -7,7 +7,8 @@
 }
 
 .badge-button {
-    &:focus, &:hover {
+    &:focus,
+    &:hover {
         background-color: var(--badge-dark);
     }
 }

--- a/client/branded/src/search-ui/components/RepoMetadata.story.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.story.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 
-import { Card, Text } from '@sourcegraph/wildcard'
+import { Card, Grid, H2, H3 } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
 import { RepoMetadataItem, RepoMetadata } from './RepoMetadata'
@@ -32,22 +32,30 @@ export const RepoMetadataStory: Story = () => (
     <BrandedStory>
         {() => (
             <Card className="p-3">
-                <div className="d-flex align-items-center mb-3">
-                    <Text className="mb-0 mr-3 text-no-wrap">Default</Text>
+                <Grid columnCount={3}>
+                    <div />
+                    <H2 className="mb-0 mr-3 text-no-wrap">small=false (default)</H2>
+                    <H2 className="mb-0 mr-3 text-no-wrap">small=true</H2>
+
+                    <H3 className="mb-0 mr-3 text-no-wrap">Default</H3>
                     <RepoMetadata items={mockItems} />
-                </div>
-                <div className="d-flex align-items-center mb-3">
-                    <Text className="mb-0 mr-3 text-no-wrap">Deletable metadata</Text>
-                    <RepoMetadata items={mockItems} onDelete={key => alert(key)} />
-                </div>
-                <div className="d-flex align-items-center mb-3">
-                    <Text className="mb-0 mr-3 text-no-wrap">Small</Text>
                     <RepoMetadata items={mockItems} small={true} />
-                </div>
-                <div className="d-flex align-items-center">
-                    <Text className="mb-0 mr-3 text-no-wrap">Small & Deletable metadata</Text>
+                    <H3 className="mb-0 mr-3 text-no-wrap">Clickable</H3>
+                    <RepoMetadata
+                        items={mockItems}
+                        queryState={{ query: '' }}
+                        buildSearchURLQueryFromQueryState={() => ''}
+                    />
+                    <RepoMetadata
+                        items={mockItems}
+                        queryState={{ query: '' }}
+                        buildSearchURLQueryFromQueryState={() => ''}
+                        small={true}
+                    />
+                    <H3 className="mb-0 mr-3 text-no-wrap">Deletable</H3>
+                    <RepoMetadata items={mockItems} onDelete={key => alert(key)} />
                     <RepoMetadata items={mockItems} onDelete={key => alert(key)} small={true} />
-                </div>
+                </Grid>
             </Card>
         )}
     </BrandedStory>

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -16,6 +16,10 @@ export interface RepoMetadataItem {
     value?: string | null
 }
 
+const MetaContainer: React.FC<React.PropsWithChildren<{ to?: string }>> = ({ children, to }) => (
+    <Code className={styles.text}>{to ? <Link to={to}>{children}</Link> : children}</Code>
+)
+
 interface MetaProps {
     meta: RepoMetadataItem
     buildSearchURLQueryFromQueryState?: (queryParameters: BuildSearchQueryURLParameters) => string
@@ -28,27 +32,23 @@ const Meta: React.FC<MetaProps> = ({ meta: { key, value }, queryState, buildSear
             return undefined
         }
 
-        const query = appendFilter(queryState.query, 'repo', `has.key(${key})`)
+        const query = appendFilter(queryState.query, 'repo', value ? `has(${key}:${value})` : `has.key(${key})`)
 
         const searchParams = buildSearchURLQueryFromQueryState({ query })
         return `/search?${searchParams}`
-    }, [buildSearchURLQueryFromQueryState, key, queryState])
+    }, [buildSearchURLQueryFromQueryState, key, value, queryState])
 
     return (
-        <Code className={styles.meta}>
-            {filterLink ? (
-                <Link aria-label="Filter by repository metadata" className={styles.highlight} to={filterLink}>
-                    {key}
-                </Link>
-            ) : (
-                <span aria-label="Repository metadata key">{key}</span>
-            )}
+        <MetaContainer to={filterLink}>
+            <span aria-label="Repository metadata key">
+                {key}
+            </span>
             {value ? (
-                <span aria-label="Repository metadata value">:{value}</span>
+                <span aria-label="Repository metadata value" className={styles.text}>:{value}</span>
             ) : (
                 <VisuallyHidden>No metadata value</VisuallyHidden>
             )}
-        </Code>
+        </MetaContainer>
     )
 }
 
@@ -83,7 +83,7 @@ export const RepoMetadata: React.FC<RepoMetadataProps> = ({
                     {onDelete ? (
                         <Tooltip content="Delete metadata">
                             <Button
-                                className={styles.deleteButton}
+                                className={styles.button}
                                 variant="secondary"
                                 outline={true}
                                 size="sm"

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -5,7 +5,9 @@ import { VisuallyHidden } from '@reach/visually-hidden'
 import classNames from 'classnames'
 import { sortBy } from 'lodash'
 
-import { Badge, Button, Code, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { BuildSearchQueryURLParameters, QueryState } from '@sourcegraph/shared/src/search'
+import { appendFilter } from '@sourcegraph/shared/src/search/query/transformer'
+import { Badge, Button, Code, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './RepoMetadata.module.scss'
 
@@ -14,30 +16,57 @@ export interface RepoMetadataItem {
     value?: string | null
 }
 
-const Meta: React.FC<React.PropsWithChildren<{ meta: RepoMetadataItem; highlight?: boolean }>> = ({
-    meta: { key, value },
-    highlight = true,
-}) => (
-    <Code className={styles.meta}>
-        <span aria-label="Repository metadata key" className={classNames({ [styles.highlight]: highlight })}>
-            {key}
-        </span>
-        {value ? (
-            <span aria-label="Repository metadata value">:{value}</span>
-        ) : (
-            <VisuallyHidden>No metadata value</VisuallyHidden>
-        )}
-    </Code>
-)
+interface MetaProps {
+    meta: RepoMetadataItem
+    buildSearchURLQueryFromQueryState?: (queryParameters: BuildSearchQueryURLParameters) => string
+    queryState?: QueryState
+}
 
-interface RepoMetadataProps {
+const Meta: React.FC<MetaProps> = ({ meta: { key, value }, queryState, buildSearchURLQueryFromQueryState }) => {
+    const filterLink = useMemo(() => {
+        if (!queryState || !buildSearchURLQueryFromQueryState) {
+            return undefined
+        }
+
+        const query = appendFilter(queryState.query, 'repo', `has.key(${key})`)
+
+        const searchParams = buildSearchURLQueryFromQueryState({ query })
+        return `/search?${searchParams}`
+    }, [buildSearchURLQueryFromQueryState, key, queryState])
+
+    return (
+        <Code className={styles.meta}>
+            {filterLink ? (
+                <Link aria-label="Filter by repository metadata" className={styles.highlight} to={filterLink}>
+                    {key}
+                </Link>
+            ) : (
+                <span aria-label="Repository metadata key">{key}</span>
+            )}
+            {value ? (
+                <span aria-label="Repository metadata value">:{value}</span>
+            ) : (
+                <VisuallyHidden>No metadata value</VisuallyHidden>
+            )}
+        </Code>
+    )
+}
+
+interface RepoMetadataProps extends Pick<MetaProps, 'buildSearchURLQueryFromQueryState' | 'queryState'> {
     items: RepoMetadataItem[]
     className?: string
     onDelete?: (item: RepoMetadataItem) => void
     small?: boolean
 }
 
-export const RepoMetadata: React.FC<RepoMetadataProps> = ({ items, className, onDelete, small }) => {
+export const RepoMetadata: React.FC<RepoMetadataProps> = ({
+    items,
+    className,
+    onDelete,
+    small,
+    queryState,
+    buildSearchURLQueryFromQueryState,
+}) => {
     const sortedItems = useMemo(() => sortBy(items, ['key', 'value']), [items])
     if (sortedItems.length === 0) {
         return null
@@ -62,12 +91,16 @@ export const RepoMetadata: React.FC<RepoMetadataProps> = ({ items, className, on
                                 onClick={() => onDelete(item)}
                             >
                                 <Icon svgPath={mdiDelete} aria-hidden={true} className="mr-1" />
-                                <Meta meta={item} highlight={false} />
+                                <Meta meta={item} />
                             </Button>
                         </Tooltip>
                     ) : (
                         <Badge key={`${item.key}:${item.value}`} className="d-flex">
-                            <Meta meta={item} />
+                            <Meta
+                                meta={item}
+                                queryState={queryState}
+                                buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                            />
                         </Badge>
                     )}
                 </li>

--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -62,6 +62,7 @@ const Meta: React.FC<MetaProps> = ({ meta, queryState, buildSearchURLQueryFromQu
                     as={Button}
                     onClick={() => onDelete(meta)}
                     aria-label="Delete metadata"
+                    className={styles.badgeButton}
                 >
                     <Icon svgPath={mdiDelete} aria-hidden={true} className="mr-1" />
                     <MetaContent meta={meta} />

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { highlightNode } from '@sourcegraph/common'
 import { codeHostSubstrLength, displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import { QueryState } from '@sourcegraph/shared/src/search'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { Icon, Link } from '@sourcegraph/wildcard'
 
@@ -19,6 +20,8 @@ const REPO_DESCRIPTION_CHAR_LIMIT = 500
 export interface RepoSearchResultProps {
     result: RepositoryMatch
     onSelect: () => void
+    buildSearchURLQueryFromQueryState?: (queryParameters: BuildSearchQueryURLParameters) => string
+    queryState?: QueryState
     containerClassName?: string
     as?: React.ElementType
     index: number
@@ -32,6 +35,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     as,
     index,
     enableRepositoryMetadata,
+    buildSearchURLQueryFromQueryState,
+    queryState,
 }) => {
     const repoDescriptionElement = useRef<HTMLDivElement>(null)
     const repoNameElement = useRef<HTMLAnchorElement>(null)
@@ -92,13 +97,6 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                     <div className="d-flex align-items-center flex-row">
                         <div className={styles.matchType}>
                             <small>Repository match</small>
-                            {enableRepositoryMetadata && !!result.metadata && (
-                                <RepoMetadata
-                                    small={true}
-                                    className="justify-content-end mt-1"
-                                    items={Object.entries(result.metadata).map(([key, value]) => ({ key, value }))}
-                                />
-                            )}
                         </div>
                         {result.fork && (
                             <>
@@ -146,6 +144,15 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                             </>
                         )}
                     </div>
+                    {enableRepositoryMetadata && !!result.metadata && (
+                        <RepoMetadata
+                            small={true}
+                            className="mt-1"
+                            queryState={queryState}
+                            buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                            items={Object.entries(result.metadata).map(([key, value]) => ({ key, value }))}
+                        />
+                    )}
                     {result.description && (
                         <>
                             <div className={styles.dividerVertical} />

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { highlightNode } from '@sourcegraph/common'
 import { codeHostSubstrLength, displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import { QueryState } from '@sourcegraph/shared/src/search'
+import { BuildSearchQueryURLParameters, QueryState } from '@sourcegraph/shared/src/search'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { Icon, Link } from '@sourcegraph/wildcard'
 

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -214,6 +214,8 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 result={result}
                                 onSelect={() => logSearchResultClicked?.(index, 'repo')}
                                 containerClassName={resultClassName}
+                                buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                                queryState={queryState}
                                 enableRepositoryMetadata={enableRepositoryMetadata}
                                 as="li"
                             />
@@ -248,7 +250,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             )
         },
         [
-            enableRepositoryMetadata,
             prefetchFileEnabled,
             prefetchFile,
             location,
@@ -260,6 +261,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             resultClassName,
             platformContext,
             queryState,
+            enableRepositoryMetadata,
             buildSearchURLQueryFromQueryState,
             logSearchResultClicked,
         ]

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -248,6 +248,7 @@ const ExtraInfoSection: React.FC<{
                         <RepoMetadata
                             items={metadataItems}
                             queryState={queryState}
+                            queryBuildOptions={{ omitRepoFilter: true }}
                             buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
                         />
                     ) : (

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -44,6 +44,7 @@ import {
 } from '../../graphql-operations'
 import { PersonLink } from '../../person/PersonLink'
 import { quoteIfNeeded, searchQueryForRepoRevision } from '../../search'
+import { buildSearchURLQueryFromQueryState, useNavbarQueryState } from '../../stores'
 import { GitCommitNodeTableRow } from '../commits/GitCommitNodeTableRow'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 import { getRefType } from '../utils'
@@ -205,6 +206,7 @@ const ExtraInfoSection: React.FC<{
     const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
 
     const metadataItems = useMemo(() => repo.metadata.map(({ key, value }) => ({ key, value })) || [], [repo.metadata])
+    const queryState = useNavbarQueryState(state => state.queryState)
 
     return (
         <Card className={className}>
@@ -243,7 +245,11 @@ const ExtraInfoSection: React.FC<{
                         )}
                     </ExtraInfoSectionItemHeader>
                     {metadataItems.length ? (
-                        <RepoMetadata items={metadataItems} />
+                        <RepoMetadata
+                            items={metadataItems}
+                            queryState={queryState}
+                            buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                        />
                     ) : (
                         <Text className="text-muted">None</Text>
                     )}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

## Test plan
- `sg start`
- Enable the `repository-metadata` feature flag
- Search repos (`select:repo`) with metadata. If not, add some via repo root page UI

## Screenshot

https://user-images.githubusercontent.com/6717049/235146640-bfb69bfd-a2ce-4602-b30f-b9b9ee585d98.mov




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
