### PR TITLE
ci: re-enable build-ts

### DIFF
--- a/client/cody-web/src/Chat.tsx
+++ b/client/cody-web/src/Chat.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import { noop } from 'lodash'
+
 import { Chat as ChatUI, ChatUISubmitButtonProps, ChatUITextAreaProps } from '@sourcegraph/cody-ui/src/Chat'
 import { FileLinkProps } from '@sourcegraph/cody-ui/src/chat/ContextFiles'
 import { CODY_TERMS_MARKDOWN } from '@sourcegraph/cody-ui/src/terms'
@@ -10,7 +12,11 @@ import styles from './Chat.module.css'
 export const Chat: React.FunctionComponent<
     Omit<
         React.ComponentPropsWithoutRef<typeof ChatUI>,
-        'textAreaComponent' | 'submitButtonComponent' | 'fileLinkComponent'
+        | 'textAreaComponent'
+        | 'submitButtonComponent'
+        | 'fileLinkComponent'
+        | 'messageBeingEdited'
+        | 'setMessageBeingEdited'
     >
 > = ({
     messageInProgress,
@@ -23,6 +29,8 @@ export const Chat: React.FunctionComponent<
     onSubmit,
 }) => (
     <ChatUI
+        messageBeingEdited={false}
+        setMessageBeingEdited={noop}
         messageInProgress={messageInProgress}
         transcript={transcript}
         contextStatus={contextStatus}

--- a/client/web/dev/esbuild/htmlIndexPlugin.ts
+++ b/client/web/dev/esbuild/htmlIndexPlugin.ts
@@ -12,7 +12,7 @@ import { WebpackManifest, HTML_INDEX_PATH } from '../utils'
 export const assetPathPrefix = '/'
 
 export const getManifest = (jsEntrypoint: string, cssEntrypoint?: string): WebpackManifest => ({
-    'shell.js': path.join(assetPathPrefix, jsEntrypoint ?? 'scripts/app.js'),
+    'app.js': path.join(assetPathPrefix, jsEntrypoint ?? 'scripts/app.js'),
     'app.css': path.join(assetPathPrefix, cssEntrypoint ?? 'scripts/app.css'),
     isModule: true,
 })
@@ -22,7 +22,7 @@ const writeHtmlIndex = async (manifest: WebpackManifest): Promise<void> => {
     const render = handlebars.compile(template)
     const content = render({
         cssBundle: manifest['app.css'],
-        jsBundle: manifest['shell.js'],
+        jsBundle: manifest['app.js'],
         isModule: manifest.isModule,
     })
     await fs.promises.writeFile(HTML_INDEX_PATH, content)
@@ -72,7 +72,7 @@ export const htmlIndexPlugin: esbuild.Plugin = {
                 }
             }
 
-            await writeHtmlIndex(getManifest(jsEntrypoint, cssEntrypoint))
+            await writeHtmlIndex(getManifest(jsEntrypoint ?? '', cssEntrypoint))
         })
     },
 }

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -53,6 +53,10 @@ const batchChangeDefaults: BatchChangeFields = {
         unpublished: 4,
         isCompleted: false,
         percentComplete: 30,
+        failed: 0,
+        retrying: 0,
+        scheduled: 0,
+        processing: 0,
     },
     createdAt: subDays(now, 5).toISOString(),
     creator: {

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -24,6 +24,7 @@ const repoDefaults: RepositoryFields = {
     name: 'github.com/sourcegraph/awesome',
     url: 'http://test.test/awesome',
     isFork: false,
+    metadata: [],
 }
 
 const queryRepoBatchChangeStats: typeof _queryRepoBatchChangeStats = () =>

--- a/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
@@ -47,6 +47,7 @@ const repo: RepositoryFields = {
         displayName: 'main',
         abbrevName: 'main',
     },
+    metadata: [],
 }
 
 const empyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCodeownersVariables> = {

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -937,7 +937,9 @@ Batch change: ${batchChangeURL}`,
                     )
                 } catch (error) {
                     console.error(error)
-                    console.error(`Failed to create tag ${tag} on ${repo}@${release.branch}`)
+                    console.error(
+                        `Failed to create tag ${repoConfig.tagPattern} on ${repoConfig.repo}@${release.branch}`
+                    )
                     failed = true
                 }
             }

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -23,13 +23,13 @@ The default run type.
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
   - **Linters and static analysis**: Run sg lint
-  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
-  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
@@ -179,7 +179,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg, Publish executor image, Publish executor binary, Publish docker registry mirror image
@@ -196,7 +196,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg
@@ -254,7 +254,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg, Publish executor image, Publish executor binary
@@ -276,7 +276,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -77,8 +77,8 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 				// addBrowserExtensionsUnitTests is now covered by Bazel
 				// addBrowserExtensionUnitTests, // ~4.5m
 				addJetBrainsUnitTests, // ~2.5m
-				// addTypescriptCheck is now covered by Bazel
-				// addTypescriptCheck,    // ~4m
+				// addTypescriptCheck is now covered by Bazel, but some Cody stuff not being is Bazel still requires it.
+				addTypescriptCheck,    // ~4m
 				addVsceTests,          // ~3.0m
 				addCodyExtensionTests, // ~2.5m
 			)


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/C01C3NCGD40/p1682683420737709, `cody-web` compilation errors slipped in, because we disabled the `build-ts` job with Bazel and cody web is not yet built with Bazel, so concretely, it wasn't tested in CI. 

We'll need to also fix those compilation errors in that PR. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI should now fail with compilation errors about cody-web. 
