### PR TITLE
App: Enable connect to dotcom and use scheme url to return to app

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -21,7 +21,6 @@ export type FeatureFlagName =
     | 'search-ownership'
     | 'search-ranking'
     | 'blob-page-switch-areas-shortcuts'
-    | 'app-connect-dotcom'
     | 'sentinel'
     | 'clone-progress-logging'
     | 'sourcegraph-operator-site-admin-hide-maintenance'

--- a/client/web/src/nav/AppUserConnectDotComAccount.tsx
+++ b/client/web/src/nav/AppUserConnectDotComAccount.tsx
@@ -33,6 +33,7 @@ export const AppUserConnectDotComAccount: React.FC = () => {
         <MenuLink
             as={Link}
             to={`https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=APP&destination=${destination}`}
+            target="_blank"
         >
             Connect to Sourcegraph.com
         </MenuLink>

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -68,7 +68,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
     const { themeSetting, setThemeSetting } = useTheme()
     const keyboardShortcutSwitchTheme = useKeyboardShortcut('switchTheme')
     const [enableTeams] = useFeatureFlag('search-ownership')
-    const [enableAppConnectDotCom] = useFeatureFlag('app-connect-dotcom')
 
     const supportsSystemTheme = useMemo(
         () => Boolean(window.matchMedia?.('not all and (prefers-color-scheme), (prefers-color-scheme)').matches),
@@ -156,7 +155,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     Repositories
                                 </MenuLink>
                             )}
-                            {isSourcegraphApp && enableAppConnectDotCom && <AppUserConnectDotComAccount />}
+                            {isSourcegraphApp && <AppUserConnectDotComAccount />}
                             {enableTeams && !isSourcegraphDotCom && (
                                 <MenuLink as={Link} to="/teams">
                                     Teams

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -71,7 +71,7 @@ const REQUESTERS: Record<string, TokenRequester> = {
     },
     APP: {
         name: 'Sourcegraph App',
-        redirectURL: 'http://localhost:3080/app/auth/callback?code=$TOKEN',
+        redirectURL: 'sourcegraph://app/auth/callback?code=$TOKEN',
         description: 'Authenticate Sourcegraph App',
         successMessage: 'Click on the link bellow to continue in Sourcegraph App',
         infoMessage: 'You will be redirected to Sourcegraph App',


### PR DESCRIPTION
Enable connecting App to a Dotcom account.

- Enables the "Connect to Sourcegraph.com" menu link and removes the feature flag that gated it
- Make the redirect go to `sourcegraph://` to return to the app

Depends on:
-  #51270 

## Test plan

- Launch app and use "Connect to Sourcegraph.com"