### PR TITLE
Cody: Add support for more git clone urls and remove reload on codebase update

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -6,11 +6,15 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Added
 
+- Updating `cody.codebase` does not require reloading VS Code
+
 ### Fixed
 
 - Fixes an issue where code blocks were unexpectedly escaped [pull/51247](https://github.com/sourcegraph/sourcegraph/pull/51247)
 
 ### Changed
+
+- Replace `Cody: Set Access Token` command with `Cody: Sign in`
 
 ## [0.0.9]
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -99,84 +99,69 @@
       },
       {
         "command": "cody.recipe.explain-code",
-        "title": "Ask Cody: Explain Code in Detail",
-        "when": "cody.activated"
+        "title": "Ask Cody: Explain Code in Detail"
       },
       {
         "command": "cody.recipe.explain-code-high-level",
-        "title": "Ask Cody: Explain Code at a High Level",
-        "when": "cody.activated"
+        "title": "Ask Cody: Explain Code at a High Level"
       },
       {
         "command": "cody.recipe.generate-unit-test",
-        "title": "Ask Cody: Generate Unit Test",
-        "when": "cody.activated"
+        "title": "Ask Cody: Generate Unit Test"
       },
       {
         "command": "cody.recipe.generate-docstring",
-        "title": "Ask Cody: Generate Docstring",
-        "when": "cody.activated"
+        "title": "Ask Cody: Generate Docstring"
       },
       {
         "command": "cody.recipe.translate-to-language",
-        "title": "Ask Cody: Translate to Language",
-        "when": "cody.activated"
+        "title": "Ask Cody: Translate to Language"
       },
       {
         "command": "cody.recipe.git-history",
-        "title": "Ask Cody: Summarize Recent Code Changes",
-        "when": "cody.activated"
+        "title": "Ask Cody: Summarize Recent Code Changes"
       },
       {
         "command": "cody.recipe.improve-variable-names",
-        "title": "Ask Cody: Improve Variable Names",
-        "when": "cody.activated"
+        "title": "Ask Cody: Improve Variable Names"
       },
       {
         "command": "cody.recipe.fixup",
-        "title": "Cody: Fixup",
-        "when": "cody.activated"
+        "title": "Cody: Fixup"
       },
       {
         "command": "cody.set-access-token",
-        "title": "Cody: Set Access Token",
-        "when": "!cody.activated"
+        "title": "Cody: Set Access Token"
       },
       {
         "command": "cody.delete-access-token",
-        "title": "Cody: Delete Access Token",
-        "when": "cody.activated"
+        "title": "Cody: Sign out"
       },
       {
         "command": "cody.experimental.suggest",
-        "title": "Cody: View Suggestions",
-        "when": "cody.activated"
+        "title": "Cody: View Suggestions"
       },
       {
         "command": "cody.settings",
         "title": "Cody: Settings",
         "group": "Cody",
-        "icon": "$(gear)",
-        "when": "cody.activated"
+        "icon": "$(gear)"
       },
       {
         "command": "cody.focus",
-        "title": "Cody: Sign In to Use Cody",
-        "when": "!cody.activated"
+        "title": "Cody: Sign In"
       },
       {
         "command": "cody.interactive.clear",
         "title": "Cody: Clear & Restart Chat Session",
         "group": "Cody",
-        "icon": "$(clear-all)",
-        "when": "cody.activated"
+        "icon": "$(clear-all)"
       },
       {
         "command": "cody.history",
         "title": "Cody: Chat History",
         "group": "Cody",
-        "icon": "$(history)",
-        "when": "cody.activated"
+        "icon": "$(history)"
       }
     ],
     "keybindings": [
@@ -227,6 +212,15 @@
         {
           "command": "cody.recipe.fixup",
           "when": "cody.activated"
+        },
+        {
+          "command": "cody.set-access-token",
+          "when": "false"
+        },
+        {
+          "command": "cody.focus",
+          "title": "Cody: Sign In",
+          "when": "!cody.activated"
         }
       ],
       "editor/context": [

--- a/client/cody/src/chat/ChatViewProvider.test.ts
+++ b/client/cody/src/chat/ChatViewProvider.test.ts
@@ -19,6 +19,18 @@ describe('convertGitCloneURLToCodebaseName', () => {
         )
     })
 
+    test('converts Bitbucket HTTPS URL', () => {
+        expect(convertGitCloneURLToCodebaseName('https://username@bitbucket.org/sourcegraph/sourcegraph.git')).toEqual(
+            'bitbucket.org/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts Bitbucket SSH URL', () => {
+        expect(convertGitCloneURLToCodebaseName('git@bitbucket.sgdev.org:sourcegraph/sourcegraph.git')).toEqual(
+            'bitbucket.sgdev.org/sourcegraph/sourcegraph'
+        )
+    })
+
     test('converts GitLab SSH URL', () => {
         expect(convertGitCloneURLToCodebaseName('git@gitlab.com:sourcegraph/sourcegraph.git')).toEqual(
             'gitlab.com/sourcegraph/sourcegraph'
@@ -28,6 +40,24 @@ describe('convertGitCloneURLToCodebaseName', () => {
     test('converts GitLab HTTPS URL', () => {
         expect(convertGitCloneURLToCodebaseName('https://gitlab.com/sourcegraph/sourcegraph.git')).toEqual(
             'gitlab.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts GitHub SSH URL with Git', () => {
+        expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph.git')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts Eriks SSH Alias URL', () => {
+        expect(convertGitCloneURLToCodebaseName('github:sourcegraph/sourcegraph')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
+        )
+    })
+
+    test('converts HTTP URL', () => {
+        expect(convertGitCloneURLToCodebaseName('http://github.com/sourcegraph/sourcegraph')).toEqual(
+            'github.com/sourcegraph/sourcegraph'
         )
     })
 

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -677,7 +677,7 @@ async function fileExists(filePath: string): Promise<boolean> {
 
 // Converts a git clone URL to the codebase name that includes the slash-separated code host, owner, and repository name
 // This should captures:
-// - "github:sourcegraph/sourcegraph"
+// - "github:sourcegraph/sourcegraph" a common SSH host alias
 // - "https://github.com/sourcegraph/deploy-sourcegraph-k8s.git"
 // - "git@github.com:sourcegraph/sourcegraph.git"
 export function convertGitCloneURLToCodebaseName(cloneURL: string): string | null {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -23,7 +23,7 @@ import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { View } from '../../webviews/NavBar'
 import { LocalStorage } from '../command/LocalStorageProvider'
-import { updateConfiguration } from '../configuration'
+import { getFullConfig, updateConfiguration } from '../configuration'
 import { logEvent } from '../event-logger'
 import { LocalKeywordContextFetcher } from '../keyword-context/local-keyword-context-fetcher'
 import { CODY_ACCESS_TOKEN_SECRET, SecretStorage } from '../secret-storage'
@@ -97,6 +97,13 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(async () => {
                 await this.updateCodebaseContext()
+            }),
+            vscode.workspace.onDidChangeConfiguration(async () => {
+                this.config = await getFullConfig(this.secretStorage)
+                const newCodebaseContext = await getCodebaseContext(this.config, this.rgPath, this.editor)
+                if (newCodebaseContext) {
+                    this.codebaseContext = newCodebaseContext
+                }
             })
         )
     }
@@ -378,20 +385,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 return Promise.resolve()
             },
             onTurnComplete: () => {
-                console.log({ text })
-                console.log(text.split('\n'))
-                console.log(text.split('\n').slice(0, 3))
-                console.log(
-                    text
-                        .split('\n')
-                        .slice(3)
-                        .map(line => line.trim().replace(/^-/, '').trim())
-                )
                 const suggestions = text
                     .split('\n')
                     .slice(0, 3)
                     .map(line => line.trim().replace(/^-/, '').trim())
-                console.log({ suggestions })
                 this.sendSuggestions(suggestions)
                 return Promise.resolve()
             },
@@ -516,6 +513,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      */
     private publishConfig(): void {
         const send = async (): Promise<void> => {
+            // update codebase context on configuration change
+            void this.updateCodebaseContext()
             // check if new configuration change is valid or not
             // log user out if config is invalid
             const isAuthed = await isValidLogin({
@@ -677,42 +676,46 @@ async function fileExists(filePath: string): Promise<boolean> {
 }
 
 // Converts a git clone URL to the codebase name that includes the slash-separated code host, owner, and repository name
+// This should captures:
+// - "github:sourcegraph/sourcegraph"
+// - "https://github.com/sourcegraph/deploy-sourcegraph-k8s.git"
+// - "git@github.com:sourcegraph/sourcegraph.git"
 export function convertGitCloneURLToCodebaseName(cloneURL: string): string | null {
-    let parsed: URL | null = null
-    if (cloneURL.startsWith('git@')) {
-        // Handle Git SSH URL format
+    if (!cloneURL) {
+        console.error(`Unable to determine the git clone URL for this workspace.\ngit output: ${cloneURL}`)
+        return null
+    }
+    try {
+        const uri = new URL(cloneURL.replace('git@', ''))
+        // Handle common Git SSH URL format
         const match = cloneURL.match(/git@([^:]+):([\w-]+)\/([\w-]+)(\.git)?/)
-        if (match) {
+        if (cloneURL.startsWith('git@') && match) {
             const host = match[1]
             const owner = match[2]
             const repo = match[3]
             return `${host}/${owner}/${repo}`
         }
-    } else {
-        // Handle HTTP/HTTPS URL format
-        try {
-            parsed = new URL(cloneURL)
-        } catch {
-            return null
+        // Handle GitHub URLs
+        if (uri.protocol.startsWith('github') || uri.href.startsWith('github')) {
+            return `github.com/${uri.pathname.replace('.git', '')}`
         }
-    }
-
-    if (!parsed) {
+        // Handle GitLab URLs
+        if (uri.protocol.startsWith('gitlab') || uri.href.startsWith('gitlab')) {
+            return `gitlab.com/${uri.pathname.replace('.git', '')}`
+        }
+        // Handle HTTPS URLs
+        if (uri.protocol.startsWith('http') && uri.hostname && uri.pathname) {
+            return `${uri.hostname}${uri.pathname.replace('.git', '')}`
+        }
+        // Generic URL
+        if (uri.hostname && uri.pathname) {
+            return `${uri.hostname}${uri.pathname.replace('.git', '')}`
+        }
+        return null
+    } catch (error) {
+        console.error(`Cody could not extract repo name from clone URL ${cloneURL}:`, error)
         return null
     }
-
-    const host = parsed.host
-    const path = parsed.pathname
-
-    // Handle GitHub/GitLab URL format
-    if (host.includes('gitlab.com') || host.includes('github.com')) {
-        const [owner, repo] = path.slice(1).split('/')
-        return `${host}/${owner}/${repo}`.replace(/.git$/, '')
-    }
-
-    // Generic fallback - assume URL path contains owner/repo
-    const [owner, repo] = path.slice(1).split('/')
-    return `${host}/${owner}/${repo}`
 }
 
 async function getCodebaseContext(config: Config, rgPath: string, editor: Editor): Promise<CodebaseContext | null> {
@@ -721,26 +724,18 @@ async function getCodebaseContext(config: Config, rgPath: string, editor: Editor
     if (!workspaceRoot) {
         return null
     }
-
     const gitCommand = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: workspaceRoot })
     const gitOutput = gitCommand.stdout.toString().trim()
-    if (!gitOutput) {
-        void vscode.window.showErrorMessage(
-            `Unable to determine the git clone URL for this workspace.\ngit output: ${gitOutput}`
-        )
-        return null
-    }
-
-    // Get repository name from git clone URL
-    const codebase = convertGitCloneURLToCodebaseName(gitOutput)
+    // Get codebase from config or fallback to getting repository name from git clone URL
+    const codebase = config.codebase || convertGitCloneURLToCodebaseName(gitOutput)
     if (!codebase) {
-        void vscode.window.showErrorMessage(`could not extract repo name from clone URL ${gitOutput}`)
         return null
     }
+    // Check if repo is embedded in endpoint
     const repoId = await client.getRepoIdIfEmbeddingExists(codebase)
     if (isError(repoId)) {
-        const errorMessage = `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance.\n`
-        void vscode.window.showErrorMessage(errorMessage)
+        const infoMessage = `Cody could not find embeddings for '${codebase}' on your Sourcegraph instance.\n`
+        console.info(infoMessage)
         return null
     }
 

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -1,6 +1,12 @@
 import * as vscode from 'vscode'
 
-import type { ConfigurationUseContext, Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import type {
+    ConfigurationUseContext,
+    Configuration,
+    ConfigurationWithAccessToken,
+} from '@sourcegraph/cody-shared/src/configuration'
+
+import { SecretStorage, getAccessToken } from './secret-storage'
 
 /**
  * All configuration values, with some sanitization performed.
@@ -38,4 +44,9 @@ const codyConfiguration = vscode.workspace.getConfiguration('cody')
 // Update user configurations in VS Code for Cody
 export async function updateConfiguration(configKey: string, configValue: string): Promise<void> {
     await codyConfiguration.update(configKey, configValue, vscode.ConfigurationTarget.Global)
+}
+
+export const getFullConfig = async (secretStorage: SecretStorage): Promise<ConfigurationWithAccessToken> => {
+    const config = getConfiguration(vscode.workspace.getConfiguration())
+    return { ...config, accessToken: await getAccessToken(secretStorage) }
 }

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -1,5 +1,3 @@
-import { window } from 'vscode'
-
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
@@ -39,11 +37,10 @@ export async function configureExternalServices(
 
     const repoId = initialConfig.codebase ? await client.getRepoId(initialConfig.codebase) : null
     if (isError(repoId)) {
-        const errorMessage =
+        const infoMessage =
             `Cody could not find the '${initialConfig.codebase}' repository on your Sourcegraph instance.\n` +
             'Please check that the repository exists and is entered correctly in the cody.codebase setting.'
-        console.error(errorMessage)
-        void window.showErrorMessage(errorMessage)
+        console.info(infoMessage)
     }
     const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
 

--- a/client/cody/webviews/App.css
+++ b/client/cody/webviews/App.css
@@ -29,12 +29,9 @@ button {
 .error {
     flex-direction: row;
     display: flex;
-    margin: 0.5em;
-    padding: 1rem;
+    padding: 0.5rem 1rem;
     color: var(--vscode-input-foreground);
     background-color: var(--vscode-inputValidation-errorBackground);
-    border: 2px solid var(--vscode-inputValidation-errorBorder);
-    justify-content: space-between;
     align-items: center;
     min-height: 2rem;
     position: relative;


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/51271

1. Add support for more git clone urls, including @eseliger's alias for github clone URLs (which seems to be a common shorthand format for some codehost) 😄 

- see test results below.
- if codebase is set in config, it should always take precedence over inference.

2. remove reload requirement on cody.codebase update https://github.com/sourcegraph/sourcegraph/issues/51271

![reload](https://user-images.githubusercontent.com/68532117/235218855-fcffa49e-d912-42fe-abcf-81c5dea5481e.gif)

Other minor changes:
- Update error message style:
<img width="507" alt="Screenshot 2023-04-28 at 10 32 49 AM" src="https://user-images.githubusercontent.com/68532117/235218335-2b6646eb-54ce-40bd-9e11-1f76b5e843b6.png">
- Hide Set access token command , and add Sign in/Sign out to command palette 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

All tests have passed:
![image](https://user-images.githubusercontent.com/68532117/235219065-ec07d4dc-1c0f-4b67-86b9-cec9c3133270.png)
