### PR TITLE
Add CTA for sales on rate limit errors.

### DIFF
--- a/enterprise/internal/completions/streaming/limiter.go
+++ b/enterprise/internal/completions/streaming/limiter.go
@@ -25,7 +25,7 @@ type RateLimitExceededError struct {
 }
 
 func (e RateLimitExceededError) Error() string {
-	return fmt.Sprintf("you exceeded the rate limit for completions, only %d requests are allowed per day at the moment to ensure the service stays functional. Current usage: %d. Retry after %s", e.Limit, e.Used, e.RetryAfter.Truncate(time.Second))
+	return fmt.Sprintf("you exceeded the rate limit for completions, only %d requests are allowed per day at the moment to ensure the service stays functional. Current usage: %d. Retry after %s. \n\n Interested in using Cody with higher rates and priority support? Cody now comes with Sourcegraph Enterprise, <a href='https://about.sourcegraph.com/contact/request-info'>contact our sales team</a> to discuss customized plans for your business. ", e.Limit, e.Used, e.RetryAfter.Truncate(time.Second))
 }
 
 func NewRateLimiter(db database.DB, rstore redispool.KeyValue) RateLimiter {


### PR DESCRIPTION

## Test plan

Manually test the response to ensure:
* the link to sales properly sends the user to the about site in the same browser window
* the text displays in two paragraphs