### PR TITLE
Completions: ignore ping events from Anthropic

### DIFF
--- a/enterprise/internal/completions/streaming/anthropic/decoder_test.go
+++ b/enterprise/internal/completions/streaming/anthropic/decoder_test.go
@@ -41,4 +41,10 @@ func TestDecoder(t *testing.T) {
 		_, err := decodeAll("datas:b\r\n\r\n")
 		require.Contains(t, err.Error(), "malformed data, expected data")
 	})
+
+	t.Run("InterleavedPing", func(t *testing.T) {
+		events, err := decodeAll("data:a\r\n\r\nevent: ping\r\ndata: 2023-04-28 21:18:31.866238\r\n\r\ndata:b\r\n\r\ndata: [DONE]\r\n\r\n")
+		require.NoError(t, err)
+		require.Equal(t, events, []event{{data: "a"}, {data: "b"}, {data: "[DONE]"}})
+	})
 }


### PR DESCRIPTION
In the completions stream, we occasionally get a ping event that breaks our assumptions about what is contained in the stream. We can safely ignore these events.

Thread [here](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1682711611736249)

## Test plan

Added a test for the ping event I captured.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
