### PR TITLE
nix: override USE_BAZEL_VERSION to silence version mismatches

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -149,4 +149,9 @@ pkgs.mkShell {
 
   # Tell rules_rust to use our custom cargo-bazel.
   CARGO_BAZEL_GENERATOR_URL = "file://${cargo-bazel}/bin/cargo-bazel";
+
+  # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
+  # so we tell it to h*ck off here.
+  # https://sourcegraph.com/github.com/bazelbuild/bazel@1a4da7f331c753c92e2c91efcad434dc29d10d43/-/blob/scripts/packages/bazel.sh?L23-28
+  USE_BAZEL_VERSION = pkgs.bazel_6.version;
 }


### PR DESCRIPTION
Bazel complains when theres even a patch mismatch (unstable is on 6.1.2, .bazelversion says 6.1.1). Might mask issues e.g. if unstable moves to 7.0.0 before we move there, but we'll likely see that fail audibly then

## Test plan

N/A, nix stuff
