### PR TITLE
gitserver: quote commit message in `createCommitFromPatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix.
+- The commit message defined in a batch spec will now be quoted when git is invoked, i.e. `git commit -m "commit message"`, to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash. This may mean that previous escaping strategies will behave differently.
 
 ### Fixed
 

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -217,7 +217,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		committerEmail = authorEmail
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "commit", "-m", `"`+message+`"`)
+	cmd = exec.CommandContext(ctx, "git", "commit", "-m", fmt.Sprintf("%q", message))
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), []string{
 		tmpGitPathEnv,

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -217,7 +217,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		committerEmail = authorEmail
 	}
 
-	cmd = exec.CommandContext(ctx, "git", "commit", "-m", message)
+	cmd = exec.CommandContext(ctx, "git", "commit", "-m", `"`+message+`"`)
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), []string{
 		tmpGitPathEnv,


### PR DESCRIPTION
A customer ran into a difficult-to-debug edge case because their batch spec commit message began with a dash. Since the message was passed "bare" to `git commit -m`, it was misinterpreted by the shell as passing misformatted args, and running the command didn't produce any useful output to provide in the error logs.

It could be argued that it's safer to quote the message. I don't fully understand the environment in which these commands are executed, but some considerations I had about this change included:
- Question: Does having quotes/not having quotes change how users can use other special characters in commit messages, like `!` or `$`?
	- Answer: No, commit messages with ! and $ were properly interpreted and appeared in the final commit message string, with or without the quotes.
- Question: Does having quotes mean users would now need to escape quotes `"` in their commit messages?
    - Answer: No, we seem to do that already and quotation marks properly appeared in the final commit message string.
- Question: Does having quotes mean users can no longer do shell expansions in commit messages, like `git commit -m This is $(uname -s)`?
    - Answer: Yes, but they also couldn't do this to begin with: we don't appear to evaluate these today. 

Cody didn't have any other concerns about the change when asked, so that's an additional vote of confidence. 😉

## Test plan

- Create a new batch change, modify the commit message in the batch spec to start with a dash, for example:
```yaml
message: |
      - Do some work
      - And something else
```

- Execute the spec
- Designate a changeset to be published from the preview
- Apply the spec

**Before**
- Observe the failure/retry loop with UI error message about blank head SHA

**After**
- Observe the changeset publishes successfully with the correct commit message



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
