### PR TITLE
sg: include test and misc images in `ops update-images` selection

### DIFF
--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -288,7 +288,7 @@ func getUpdatedSourcegraphImage(originalImage string, creds credentials.Credenti
 	imageName := str[len(str)-1]
 
 	var found bool
-	for _, ourImages := range images.DeploySourcegraphDockerImages {
+	for _, ourImages := range images.SourcegraphDockerImages {
 		if strings.HasPrefix(imageName, ourImages) {
 			found = true
 			break


### PR DESCRIPTION
Currently `update-images` only selects the base images, but should also update tags for the miscellaneous images.

## Test plan
Tested locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
