### PR TITLE
migrate gitserver archive to use gRPC when enabled

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"context"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -105,7 +103,7 @@ func (gs *GRPCServer) Search(req *proto.SearchRequest, ss proto.GitserverService
 	})
 }
 
-func (gs *GRPCServer) Archive(ctx context.Context, req *proto.ArchiveRequest, ss proto.GitserverService_ArchiveServer) error {
+func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverService_ArchiveServer) error {
 	//TODO(mucles): re-enable access logging (see server.go handleArchive)
 	// Log which which actor is accessing the repo.
 	// accesslog.Record(ctx, req.Repo,

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -146,7 +146,7 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 	execStatus, err := gs.Server.exec(ss.Context(), gs.Server.Logger, execReq, "unknown-grpc-client", w)
 	if err != nil {
 		if v := (&NotFoundError{}); errors.As(err, &v) {
-			s, err := status.New(codes.NotFound, "repo not found").WithDetails(&proto.NotFoundPayload{
+			s, err := status.New(codes.NotFound, "not found").WithDetails(&proto.NotFoundPayload{
 				Repo:            req.GetRepo(),
 				CloneInProgress: v.Payload.CloneInProgress,
 				CloneProgress:   v.Payload.CloneProgress,

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -82,16 +82,16 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 	// 	log.Strings("path", req.Pathspecs),
 	// )
 
-	if err := checkSpecArgSafety(req.Treeish); err != nil {
+	if err := checkSpecArgSafety(req.GetTreeish()); err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	if req.Repo == "" || req.Format == "" {
+	if req.GetRepo() == "" || req.GetFormat() == "" {
 		return status.Error(codes.InvalidArgument, "empty repo or format")
 	}
 
 	execReq := &protocol.ExecRequest{
-		Repo: api.RepoName(req.Repo),
+		Repo: api.RepoName(req.GetRepo()),
 		Args: []string{
 			"archive",
 			"--worktree-attributes",
@@ -103,8 +103,8 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 		execReq.Args = append(execReq.Args, "-0")
 	}
 
-	execReq.Args = append(execReq.Args, req.Treeish, "--")
-	execReq.Args = append(execReq.Args, req.Pathspecs...)
+	execReq.Args = append(execReq.Args, req.GetTreeish(), "--")
+	execReq.Args = append(execReq.Args, req.GetPathspecs()...)
 
 	w := streamio.NewWriter(func(p []byte) error {
 		return ss.Send(&proto.ArchiveResponse{

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -129,7 +129,7 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 		},
 	}
 
-	if req.Format == string(gitserver.ArchiveFormatZip) {
+	if req.GetFormat() == string(gitserver.ArchiveFormatZip) {
 		execReq.Args = append(execReq.Args, "-0")
 	}
 

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -114,7 +114,6 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 
 	// TODO(mucles): set user agent from all grpc clients
 	return gs.doExec(ss.Context(), gs.Server.Logger, execReq, "unknown-grpc-client", w)
-
 }
 
 // doExec executes the given git command and streams the output to the given writer.

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -116,7 +116,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 
 func TestHead(t *testing.T) {
 	inttests.InitGitserver()
-	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil)
 
 	t.Run("with sub-repo permissions", func(t *testing.T) {
 		gitCommands := []string{

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -67,7 +67,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, defaultGRPCSource).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -116,7 +116,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 
 func TestHead(t *testing.T) {
 	inttests.InitGitserver()
-	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses)
 
 	t.Run("with sub-repo permissions", func(t *testing.T) {
 		gitCommands := []string{

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -67,7 +67,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, defaultGRPCSource).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -67,7 +67,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}

--- a/enterprise/internal/gitserver/integration_tests/commits_test.go
+++ b/enterprise/internal/gitserver/integration_tests/commits_test.go
@@ -66,8 +66,9 @@ func TestGetCommits(t *testing.T) {
 			nil,
 			nil,
 		}
+		source := gitserver.NewTestClientSource(inttests.GitserverAddresses)
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, source).GetCommits(ctx, getTestSubRepoPermsChecker("file1", "file3"), repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -116,7 +117,8 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 
 func TestHead(t *testing.T) {
 	inttests.InitGitserver()
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses)
+	source := gitserver.NewTestClientSource(inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 
 	t.Run("with sub-repo permissions", func(t *testing.T) {
 		gitCommands := []string{

--- a/enterprise/internal/gitserver/integration_tests/tree_test.go
+++ b/enterprise/internal/gitserver/integration_tests/tree_test.go
@@ -57,7 +57,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 		t.Fatalf("unexpected error creating sub-repo perms client: %s", err)
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil)
 	files, err := client.ReadDir(ctx, checker, repo, commitID, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/enterprise/internal/gitserver/integration_tests/tree_test.go
+++ b/enterprise/internal/gitserver/integration_tests/tree_test.go
@@ -57,7 +57,7 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 		t.Fatalf("unexpected error creating sub-repo perms client: %s", err)
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, inttests.GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses)
 	files, err := client.ReadDir(ctx, checker, repo, commitID, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/enterprise/internal/gitserver/integration_tests/tree_test.go
+++ b/enterprise/internal/gitserver/integration_tests/tree_test.go
@@ -57,7 +57,8 @@ func TestReadDir_SubRepoFiltering(t *testing.T) {
 		t.Fatalf("unexpected error creating sub-repo perms client: %s", err)
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, inttests.GitserverAddresses)
+	source := gitserver.NewTestClientSource(inttests.GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 	files, err := client.ReadDir(ctx, checker, repo, commitID, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -39,19 +41,70 @@ func NewGitserverAddressesFromConf(cfg *conf.Unified) GitserverAddresses {
 	return addrs
 }
 
-func newTestGitserverConns(addrs []string) *GitserverConns {
+type TestClientSourceOptions struct {
+	// ClientFunc is the function that is used to return a gRPC client
+	// given the provided connection.
+	ClientFunc func(conn *grpc.ClientConn) proto.GitserverServiceClient
+}
+
+func NewTestClientSource(addrs []string, options ...func(o *TestClientSourceOptions)) ClientSource {
+	opts := TestClientSourceOptions{
+		ClientFunc: func(conn *grpc.ClientConn) proto.GitserverServiceClient {
+			return proto.NewGitserverServiceClient(conn)
+		},
+	}
+
+	for _, o := range options {
+		o(&opts)
+	}
+
 	conns := make(map[string]connAndErr)
 	for _, addr := range addrs {
 		conn, err := defaults.Dial(addr)
 		conns[addr] = connAndErr{conn: conn, err: err}
 	}
-	return &GitserverConns{
-		GitserverAddresses: GitserverAddresses{
-			Addresses: addrs,
+
+	source := testGitserverConns{
+		conns: &GitserverConns{
+			GitserverAddresses: GitserverAddresses{
+				Addresses: addrs,
+			},
+			grpcConns: conns,
 		},
-		grpcConns: conns,
+
+		clientFunc: opts.ClientFunc,
 	}
+
+	return &source
 }
+
+type testGitserverConns struct {
+	conns *GitserverConns
+
+	clientFunc func(conn *grpc.ClientConn) proto.GitserverServiceClient
+}
+
+// AddrForRepo implements ClientSource
+func (c *testGitserverConns) AddrForRepo(userAgent string, repo api.RepoName) string {
+	return c.conns.AddrForRepo(userAgent, repo)
+}
+
+// Addresses implements ClientSource
+func (c *testGitserverConns) Addresses() []string {
+	return c.conns.Addresses
+}
+
+// ClientForRepo implements ClientSource
+func (c *testGitserverConns) ClientForRepo(userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error) {
+	conn, err := c.conns.ConnForRepo(userAgent, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.clientFunc(conn), nil
+}
+
+var _ ClientSource = &testGitserverConns{}
 
 type GitserverAddresses struct {
 	// The current list of gitserver addresses
@@ -108,6 +161,22 @@ type connAndErr struct {
 type atomicGitServerConns struct {
 	conns     atomic.Pointer[GitserverConns]
 	watchOnce sync.Once
+}
+
+func (a *atomicGitServerConns) AddrForRepo(userAgent string, repo api.RepoName) string {
+	return a.get().AddrForRepo(userAgent, repo)
+}
+
+func (a *atomicGitServerConns) ClientForRepo(userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error) {
+	conn, err := a.get().ConnForRepo(userAgent, repo)
+	if err != nil {
+		return nil, err
+	}
+	return proto.NewGitserverServiceClient(conn), nil
+}
+
+func (a *atomicGitServerConns) Addresses() []string {
+	return a.get().Addresses
 }
 
 func (a *atomicGitServerConns) get() *GitserverConns {
@@ -168,3 +237,5 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 		}
 	}
 }
+
+var _ ClientSource = &atomicGitServerConns{}

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -84,17 +84,17 @@ type testGitserverConns struct {
 	clientFunc func(conn *grpc.ClientConn) proto.GitserverServiceClient
 }
 
-// AddrForRepo implements ClientSource
+// AddrForRepo returns the gitserver address to use for the given repo name.
 func (c *testGitserverConns) AddrForRepo(userAgent string, repo api.RepoName) string {
 	return c.conns.AddrForRepo(userAgent, repo)
 }
 
-// Addresses implements ClientSource
+// Addresses returns the current list of gitserver addresses.
 func (c *testGitserverConns) Addresses() []string {
 	return c.conns.Addresses
 }
 
-// ClientForRepo implements ClientSource
+// ClientForRepo returns a client or host for the given repo name.
 func (c *testGitserverConns) ClientForRepo(userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error) {
 	conn, err := c.conns.ConnForRepo(userAgent, repo)
 	if err != nil {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -82,17 +82,17 @@ func NewClient() Client {
 		// frontend internal API)
 		userAgent:  filepath.Base(os.Args[0]),
 		operations: getOperations(),
-		grpcClient: getGRPCClient,
+		grpcClient: DefaultGRPCSource,
 	}
 }
 
-func defaultGRPCClientSource(cc grpc.ClientConnInterface) proto.GitserverServiceClient {
+func DefaultGRPCSource(cc grpc.ClientConnInterface) proto.GitserverServiceClient {
 	return proto.NewGitserverServiceClient(cc)
 }
 
 // NewTestClient returns a test client that will use the given hard coded list of
 // addresses instead of reading them from config.
-func NewTestClient(cli httpcli.Doer, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient,  addrs []string) Client {
+func NewTestClient(cli httpcli.Doer, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient, addrs []string) Client {
 	logger := sglog.Scoped("NewTestClient", "Test New client")
 	return &clientImplementor{
 		logger:      logger,
@@ -200,7 +200,7 @@ type clientImplementor struct {
 	// operations are used for internal observability
 	operations *operations
 
-	// grpcClient is a function that returns a gRPC client to use for the given connection 
+	// grpcClient is a function that returns a gRPC client to use for the given connection
 	grpcClient func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -92,7 +92,7 @@ func defaultGRPCClientSource(cc grpc.ClientConnInterface) proto.GitserverService
 
 // NewTestClient returns a test client that will use the given hard coded list of
 // addresses instead of reading them from config.
-func NewTestClient(cli httpcli.Doer, addrs []string, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient) Client {
+func NewTestClient(cli httpcli.Doer, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient,  addrs []string) Client {
 	logger := sglog.Scoped("NewTestClient", "Test New client")
 	return &clientImplementor{
 		logger:      logger,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -80,9 +80,9 @@ func NewClient() Client {
 		// Use the binary name for userAgent. This should effectively identify
 		// which service is making the request (excluding requests proxied via the
 		// frontend internal API)
-		userAgent:  filepath.Base(os.Args[0]),
-		operations: getOperations(),
-		grpcClient: DefaultGRPCSource,
+		userAgent:        filepath.Base(os.Args[0]),
+		operations:       getOperations(),
+		gRPCClientSource: DefaultGRPCSource,
 	}
 }
 
@@ -102,9 +102,9 @@ func NewTestClient(cli httpcli.Doer, grpcClientFunc func(cc grpc.ClientConnInter
 		// Use the binary name for userAgent. This should effectively identify
 		// which service is making the request (excluding requests proxied via the
 		// frontend internal API)
-		userAgent:  filepath.Base(os.Args[0]),
-		operations: newOperations(observation.ContextWithLogger(logger, &observation.TestContext)),
-		grpcClient: grpcClientFunc,
+		userAgent:        filepath.Base(os.Args[0]),
+		operations:       newOperations(observation.ContextWithLogger(logger, &observation.TestContext)),
+		gRPCClientSource: grpcClientFunc,
 	}
 }
 
@@ -201,7 +201,7 @@ type clientImplementor struct {
 	operations *operations
 
 	// grpcClient is a function that returns a gRPC client to use for the given connection
-	grpcClient func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
+	gRPCClientSource func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
 }
 
 type RawBatchLogResult struct {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -70,6 +70,8 @@ func ResetClientMocks() {
 
 var _ Client = &clientImplementor{}
 
+type gRPCClientSource func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
+
 // NewClient returns a new gitserver.Client.
 func NewClient() Client {
 	return &clientImplementor{
@@ -92,7 +94,7 @@ func DefaultGRPCSource(cc grpc.ClientConnInterface) proto.GitserverServiceClient
 
 // NewTestClient returns a test client that will use the given hard coded list of
 // addresses instead of reading them from config.
-func NewTestClient(cli httpcli.Doer, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient, addrs []string) Client {
+func NewTestClient(cli httpcli.Doer, grpcClientFunc gRPCClientSource, addrs []string) Client {
 	logger := sglog.Scoped("NewTestClient", "Test New client")
 	return &clientImplementor{
 		logger:      logger,
@@ -201,7 +203,7 @@ type clientImplementor struct {
 	operations *operations
 
 	// grpcClient is a function that returns a gRPC client to use for the given connection
-	gRPCClientSource func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
+	gRPCClientSource gRPCClientSource
 }
 
 type RawBatchLogResult struct {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -200,7 +200,7 @@ type clientImplementor struct {
 	// operations are used for internal observability
 	operations *operations
 
-	// grpcClient is a function that returns the current grpc client
+	// grpcClient is a function that returns a gRPC client to use for the given connection 
 	grpcClient func(cc grpc.ClientConnInterface) proto.GitserverServiceClient
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -86,7 +86,7 @@ func NewClient() Client {
 	}
 }
 
-func getGRPCClient(cc grpc.ClientConnInterface) proto.GitserverServiceClient {
+func defaultGRPCClientSource(cc grpc.ClientConnInterface) proto.GitserverServiceClient {
 	return proto.NewGitserverServiceClient(cc)
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -656,6 +656,10 @@ func (r *readCloseWrapper) Close() error {
 // convertGRPCErrorToGitDomainError translates a GRPC error to a gitdomain error.
 // If the error is not a GRPC error, it is returned as-is.
 func convertGRPCErrorToGitDomainError(err error) error {
+	if status.Code(err) == codes.Canceled {
+		return context.Canceled
+	}
+
 	st, ok := status.FromError(err)
 	if !ok {
 		return err

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -455,6 +455,35 @@ type ArchiveOptions struct {
 	Pathspecs []gitdomain.Pathspec // if nonempty, only include these pathspecs.
 }
 
+func (o *ArchiveOptions) FromProto(x *proto.ArchiveRequest) {
+	protoPathSpecs := x.GetPathspecs()
+	pathSpecs := make([]gitdomain.Pathspec, 0, len(protoPathSpecs))
+
+	for _, path := range protoPathSpecs {
+		pathSpecs = append(pathSpecs, gitdomain.Pathspec(path))
+	}
+
+	*o = ArchiveOptions{
+		Treeish:   x.GetTreeish(),
+		Format:    ArchiveFormat(x.GetFormat()),
+		Pathspecs: pathSpecs,
+	}
+}
+
+func (o *ArchiveOptions) ToProto() *proto.ArchiveRequest {
+	protoPathSpecs := make([]string, 0, len(o.Pathspecs))
+
+	for _, path := range o.Pathspecs {
+		protoPathSpecs = append(protoPathSpecs, string(path))
+	}
+
+	return &proto.ArchiveRequest{
+		Treeish:   o.Treeish,
+		Format:    string(o.Format),
+		Pathspecs: protoPathSpecs,
+	}
+}
+
 type BatchLogOptions protocol.BatchLogRequest
 
 func (opts BatchLogOptions) LogFields() []log.Field {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -471,7 +471,7 @@ func (o *ArchiveOptions) FromProto(x *proto.ArchiveRequest) {
 	}
 }
 
-func (o *ArchiveOptions) ToProto() *proto.ArchiveRequest {
+func (o *ArchiveOptions) ToProto(repo string) *proto.ArchiveRequest {
 	protoPathSpecs := make([]string, 0, len(o.Pathspecs))
 
 	for _, path := range o.Pathspecs {
@@ -479,6 +479,7 @@ func (o *ArchiveOptions) ToProto() *proto.ArchiveRequest {
 	}
 
 	return &proto.ArchiveRequest{
+		Repo:      repo,
 		Treeish:   o.Treeish,
 		Format:    string(o.Format),
 		Pathspecs: protoPathSpecs,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -478,7 +478,7 @@ func (a *archiveReader) Read(p []byte) (int, error) {
 	n, err := a.base.Read(p)
 	if err != nil {
 		// handle the special case where git archive failed because of an invalid spec
-		if strings.Contains(err.Error(), "Not a valid object") {
+		if strings.Contains(err.Error(), "not a valid object") {
 			return 0, &gitdomain.RevisionNotFoundError{Repo: a.repo, Spec: a.spec}
 		}
 	}
@@ -670,6 +670,11 @@ func (c *CommandStatusError) Error() string {
 		return fmt.Sprintf("non-zero exit status: %d (stderr: %q)", c.StatusCode, stderr)
 	}
 	return stderr
+}
+
+func (c *CommandStatusError) isRevisionNotFound() bool {
+	loweredErr := strings.ToLower(c.Stderr)
+	return strings.Contains(loweredErr, "not a valid object")
 }
 
 func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, err error) {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -154,9 +154,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 			}
 
 			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: test.revision, Format: gitserver.ArchiveFormatZip})
-			if err != nil {
-				t.Fatal(err.Error())
-			}
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}
@@ -170,6 +167,14 @@ func TestClient_ArchiveReader(t *testing.T) {
 				}
 			})
 			data, err := io.ReadAll(rc)
+			if err != nil {
+				if name == "revision-not-found-http" {
+					assert.Contains(t, fmt.Sprint(err), "not a valid object")
+					return
+				} else {
+					t.Fatal(err)
+				}
+			}
 			zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 			if err != nil {
 				t.Fatal(err)
@@ -242,39 +247,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 			}
 		}
 	})
-
 }
-
-// func TestArchiveReader_Read(t *testing.T) {
-// 	repo := "test/repo"
-// 	spec := "invalid_spec"
-// 	// base := &mockReadCloser{
-// 	// 	readErr: errors.New("Not a valid object"),
-// 	// }
-// 	reader := &gitserver.archiveReader{
-// 		base: &gitserver.cmdReader{
-// 			rc:      nil,
-// 			trailer: nil,
-// 		},
-// 		repo: repo,
-// 		spec: spec,
-// 	}
-
-// 	_, err := reader.Read([]byte{})
-// 	if err == nil {
-// 		t.Errorf("Expected error, got nil")
-// 	}
-// 	if !errors.Is(err, &gitdomain.RevisionNotFoundError{}) {
-// 		t.Errorf("Expected RevisionNotFoundError, got %v", err)
-// 	}
-// 	notFoundErr := err.(*gitdomain.RevisionNotFoundError)
-// 	if notFoundErr.Repo != repo {
-// 		t.Errorf("Expected repo %s, got %s", repo, notFoundErr.Repo)
-// 	}
-// 	if notFoundErr.Spec != spec {
-// 		t.Errorf("Expected spec %s, got %s", spec, notFoundErr.Spec)
-// 	}
-// }
 
 func createRepoWithDotGitDir(t *testing.T, root string) string {
 	t.Helper()

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -67,8 +67,8 @@ func TestClient_Remove(t *testing.T) {
 				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
 			}
 		}),
+		gitserver.DefaultGRPCSource,
 		addrs,
-		nil,
 	)
 
 	err := cli.Remove(context.Background(), repo)
@@ -146,7 +146,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		return spyGitserverService
 	}
 
-	cli := gitserver.NewTestClient(&http.Client{}, addrs, spy)
+	cli := gitserver.NewTestClient(&http.Client{}, spy, addrs)
 
 	runArchiveReaderTestfunc := func(t *testing.T, ctx context.Context, cli gitserver.Client, tests map[api.RepoName]test) {
 
@@ -384,7 +384,7 @@ func TestClient_P4Exec(t *testing.T) {
 
 			u, _ := url.Parse(testServer.URL)
 			addrs := []string{u.Host}
-			cli := gitserver.NewTestClient(&http.Client{}, addrs, nil)
+			cli := gitserver.NewTestClient(&http.Client{}, gitserver.DefaultGRPCSource, addrs)
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -466,7 +466,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs, nil)
+	cli := gitserver.NewTestClient(&http.Client{}, gitserver.DefaultGRPCSource, addrs)
 
 	ctx := context.Background()
 	for _, test := range tests {
@@ -509,8 +509,8 @@ func TestClient_BatchLog(t *testing.T) {
 			body := io.NopCloser(strings.NewReader(strings.TrimSpace(string(encoded))))
 			return &http.Response{StatusCode: 200, Body: body}, nil
 		}),
+		gitserver.DefaultGRPCSource,
 		addrs,
-		nil,
 	)
 
 	opts := gitserver.BatchLogOptions{
@@ -629,8 +629,8 @@ func TestClient_ReposStats(t *testing.T) {
 				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
 			}
 		}),
+		gitserver.DefaultGRPCSource,
 		addrs,
-		nil,
 	)
 
 	gotStatsMap, err := cli.ReposStats(context.Background())

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -91,23 +91,23 @@ func TestClient_ArchiveReader(t *testing.T) {
 	}
 
 	tests := map[api.RepoName]test{
-		// "simple": {
-		// 	remote: createSimpleGitRepo(t, root),
-		// 	want: map[string]string{
-		// 		"dir1/":      "",
-		// 		"dir1/file1": "infile1",
-		// 		"file 2":     "infile2",
-		// 	},
-		// },
-		// "repo-with-dotgit-dir": {
-		// 	remote: createRepoWithDotGitDir(t, root),
-		// 	want: map[string]string{
-		// 		"file1":            "hello\n",
-		// 		".git/mydir/file2": "milton\n",
-		// 		".git/mydir/":      "",
-		// 		".git/":            "",
-		// 	},
-		// },
+		"simple": {
+			remote: createSimpleGitRepo(t, root),
+			want: map[string]string{
+				"dir1/":      "",
+				"dir1/file1": "infile1",
+				"file 2":     "infile2",
+			},
+		},
+		"repo-with-dotgit-dir": {
+			remote: createRepoWithDotGitDir(t, root),
+			want: map[string]string{
+				"file1":            "hello\n",
+				".git/mydir/file2": "milton\n",
+				".git/mydir/":      "",
+				".git/":            "",
+			},
+		},
 		"not-found": {
 			err: errors.New("repository does not exist: not-found"),
 		},
@@ -155,7 +155,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 	// 	return reader, err
 	// }
 
-	runArchiveReaderTestfunc := func(t *testing.T, ctx context.Context, cli gitserver.Client, test map[api.RepoName]test) {
+	runArchiveReaderTestfunc := func(t *testing.T, ctx context.Context, cli gitserver.Client, tests map[api.RepoName]test) {
 
 		for name, test := range tests {
 			t.Run(string(name), func(t *testing.T) {
@@ -225,22 +225,20 @@ func TestClient_ArchiveReader(t *testing.T) {
 	// 		return gitserver.NewTestClient(&http.Client{}, addrs)
 	// 	}
 	// }
+	//
 
-	t.Setenv("SG_FEATURE_FLAG_GRPC", "true")
-	runArchiveReaderTestfunc(t, ctx, cli, tests)
+	t.Run("grpc", func(t *testing.T) {
+		foo := "whatever"
+		fmt.Println(foo)
 
-	// t.Run("grpc", func(t *testing.T) {
-	// 	foo := "whatever"
-	// 	fmt.Println(foo)
+		t.Setenv("SG_FEATURE_FLAG_GRPC", "true")
+		runArchiveReaderTestfunc(t, ctx, cli, tests)
+	})
 
-	// 	t.Setenv("SG_FEATURE_FLAG_GRPC", "true")
-	// 	runArchiveReaderTestfunc(t, ctx, cli, tests)
-	// })
-
-	// t.Run("http", func(t *testing.T) {
-	// 	t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
-	// 	runArchiveReaderTestfunc(t, ctx, cli, tests)
-	// })
+	t.Run("http", func(t *testing.T) {
+		t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
+		runArchiveReaderTestfunc(t, ctx, cli, tests)
+	})
 
 }
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -87,6 +87,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 	type test struct {
 		remote string
+		branch string
 		want   map[string]string
 		err    error
 	}
@@ -94,6 +95,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 	tests := map[api.RepoName]test{
 		"simple": {
 			remote: createSimpleGitRepo(t, root),
+			branch: "HEAD",
 			want: map[string]string{
 				"dir1/":      "",
 				"dir1/file1": "infile1",
@@ -102,6 +104,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		},
 		"repo-with-dotgit-dir": {
 			remote: createRepoWithDotGitDir(t, root),
+			branch: "HEAD",
 			want: map[string]string{
 				"file1":            "hello\n",
 				".git/mydir/file2": "milton\n",
@@ -110,7 +113,12 @@ func TestClient_ArchiveReader(t *testing.T) {
 			},
 		},
 		"not-found": {
-			err: errors.New("repository does not exist: not-found"),
+			branch: "HEAD",
+			err:    errors.New("repository does not exist: not-found"),
+		},
+		"revision-not-found": {
+			branch: "nonexistent-revision",
+			err:    errors.New("repository does not exist: revision-not-found"),
 		},
 	}
 
@@ -151,7 +159,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 				}
 			}
 
-			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: gitserver.ArchiveFormatZip})
+			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: test.branch, Format: gitserver.ArchiveFormatZip})
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -216,10 +216,10 @@ func TestClient_ArchiveReader(t *testing.T) {
 		runArchiveReaderTestfunc(t, ctx, cli, tests)
 	})
 
-	// t.Run("http", func(t *testing.T) {
-	// 	t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
-	// 	runArchiveReaderTestfunc(t, ctx, cli, tests)
-	// })
+	t.Run("http", func(t *testing.T) {
+		t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
+		runArchiveReaderTestfunc(t, ctx, cli, tests)
+	})
 
 }
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -68,6 +68,7 @@ func TestClient_Remove(t *testing.T) {
 			}
 		}),
 		addrs,
+		nil,
 	)
 
 	err := cli.Remove(context.Background(), repo)
@@ -140,20 +141,13 @@ func TestClient_ArchiveReader(t *testing.T) {
 	addrs := []string{u.Host}
 	t.Log("gitserver addrs:", addrs)
 	ctx := context.Background()
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	var spyGitserverService *spyGitserverServiceClient
+	spy := func(conns grpc.ClientConnInterface) proto.GitserverServiceClient {
+		spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
+		return spyGitserverService
+	}
 
-	// gitserver.ClientMocks.Archive = func(ctx context.Context, repo api.RepoName, opt gitserver.ArchiveOptions) (reader io.ReadCloser, err error) {
-	// 	if internalgrpc.IsGRPCEnabled(ctx) {
-	// 		// GRPC
-
-	// 	} else {
-	// 		// HTTP
-
-	// 	stringReader := strings.NewReader(resp)
-	// 	reader = io.NopCloser(stringReader)
-
-	// 	return reader, err
-	// }
+	cli := gitserver.NewTestClient(&http.Client{}, addrs, spy)
 
 	runArchiveReaderTestfunc := func(t *testing.T, ctx context.Context, cli gitserver.Client, tests map[api.RepoName]test) {
 
@@ -164,7 +158,11 @@ func TestClient_ArchiveReader(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
+
 				rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: "HEAD", Format: gitserver.ArchiveFormatZip})
+				if !spyGitserverService.archiveCalled {
+					t.Error("archiveReader should have been called")
+				}
 				if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 					t.Errorf("archive: have err %v, want %v", have, want)
 				}
@@ -209,23 +207,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 		}
 
 	}
-	// := gitserver.NewTestClient(....)
-	// client := func(ctx context.Context, addrs []string) gitserver.Client {
-	// 	if internalgrpc.IsGRPCEnabled(ctx) {
-	// 		// GRPC
-	// 		return &clientImplementor{
-	// 			logger:      logger,
-	// 			conns:       func() *GitserverConns { return newTestGitserverConns(addrs) },
-	// 			HTTPLimiter: limiter.New(500),
-	// 			userAgent:   filepath.Base(os.Args[0]),
-	// 			operations:  newOperations(observation.ContextWithLogger(logger, &observation.TestContext)),
-	// 		}
-	// 	} else {
-	// 		// HTTP
-	// 		return gitserver.NewTestClient(&http.Client{}, addrs)
-	// 	}
-	// }
-	//
 
 	t.Run("grpc", func(t *testing.T) {
 		foo := "whatever"
@@ -235,10 +216,10 @@ func TestClient_ArchiveReader(t *testing.T) {
 		runArchiveReaderTestfunc(t, ctx, cli, tests)
 	})
 
-	t.Run("http", func(t *testing.T) {
-		t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
-		runArchiveReaderTestfunc(t, ctx, cli, tests)
-	})
+	// t.Run("http", func(t *testing.T) {
+	// 	t.Setenv("SG_FEATURE_FLAG_GRPC", "false")
+	// 	runArchiveReaderTestfunc(t, ctx, cli, tests)
+	// })
 
 }
 
@@ -404,7 +385,7 @@ func TestClient_P4Exec(t *testing.T) {
 
 			u, _ := url.Parse(testServer.URL)
 			addrs := []string{u.Host}
-			cli := gitserver.NewTestClient(&http.Client{}, addrs)
+			cli := gitserver.NewTestClient(&http.Client{}, addrs, nil)
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -486,7 +467,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, addrs)
+	cli := gitserver.NewTestClient(&http.Client{}, addrs, nil)
 
 	ctx := context.Background()
 	for _, test := range tests {
@@ -530,6 +511,7 @@ func TestClient_BatchLog(t *testing.T) {
 			return &http.Response{StatusCode: 200, Body: body}, nil
 		}),
 		addrs,
+		nil,
 	)
 
 	opts := gitserver.BatchLogOptions{
@@ -649,6 +631,7 @@ func TestClient_ReposStats(t *testing.T) {
 			}
 		}),
 		addrs,
+		nil,
 	)
 
 	gotStatsMap, err := cli.ReposStats(context.Background())

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -86,16 +86,16 @@ func TestClient_ArchiveReader(t *testing.T) {
 	root := gitserver.CreateRepoDir(t)
 
 	type test struct {
-		remote string
-		branch string
-		want   map[string]string
-		err    error
+		remote   string
+		revision string
+		want     map[string]string
+		err      error
 	}
 
 	tests := map[api.RepoName]test{
 		"simple": {
-			remote: createSimpleGitRepo(t, root),
-			branch: "HEAD",
+			remote:   createSimpleGitRepo(t, root),
+			revision: "HEAD",
 			want: map[string]string{
 				"dir1/":      "",
 				"dir1/file1": "infile1",
@@ -103,8 +103,8 @@ func TestClient_ArchiveReader(t *testing.T) {
 			},
 		},
 		"repo-with-dotgit-dir": {
-			remote: createRepoWithDotGitDir(t, root),
-			branch: "HEAD",
+			remote:   createRepoWithDotGitDir(t, root),
+			revision: "HEAD",
 			want: map[string]string{
 				"file1":            "hello\n",
 				".git/mydir/file2": "milton\n",
@@ -113,12 +113,13 @@ func TestClient_ArchiveReader(t *testing.T) {
 			},
 		},
 		"not-found": {
-			branch: "HEAD",
-			err:    errors.New("repository does not exist: not-found"),
+			revision: "HEAD",
+			err:      errors.New("repository does not exist: not-found"),
 		},
-		"revision-not-found": {
-			branch: "nonexistent-revision",
-			err:    errors.New("repository does not exist: revision-not-found"),
+		"repo-with-dotgit-dir-1": {
+			remote:   createRepoWithDotGitDir(t, root),
+			revision: "nonexistent-revision",
+			err:      errors.New("exit status 128 (stderr: \"fatal: not a valid object name: nonexistent-revision\n\")"),
 		},
 	}
 
@@ -157,7 +158,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 				}
 			}
 
-			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: test.branch, Format: gitserver.ArchiveFormatZip})
+			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: test.revision, Format: gitserver.ArchiveFormatZip})
 			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -139,7 +139,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	t.Log("gitserver addrs:", addrs)
 	ctx := context.Background()
 	var spyGitserverService *spyGitserverServiceClient
 	spy := func(conns grpc.ClientConnInterface) proto.GitserverServiceClient {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -149,8 +149,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 	addrs := []string{u.Host}
 	ctx := context.Background()
 
-	var spyGitserverService *spyGitserverServiceClient
-
 	runArchiveReaderTestfunc := func(t *testing.T, ctx context.Context, cli gitserver.Client, name api.RepoName, test test) {
 		t.Run(string(name), func(t *testing.T) {
 			if test.remote != "" {
@@ -206,6 +204,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 	t.Run("grpc", func(t *testing.T) {
 		t.Setenv("SG_FEATURE_FLAG_GRPC", "true")
 		for name, test := range tests {
+			var spyGitserverService *spyGitserverServiceClient
 			spy := func(conns grpc.ClientConnInterface) proto.GitserverServiceClient {
 				spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
 				return spyGitserverService

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -113,7 +113,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		remote      string
 		revision    string
 		want        map[string]string
-		err         error
+		clientErr   error
 		readerError error
 		skipReader  bool
 	}
@@ -148,7 +148,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 			name: "not-found",
 
 			revision:   "HEAD",
-			err:        errors.New("repository does not exist: not-found"),
+			clientErr:  errors.New("repository does not exist: not-found"),
 			skipReader: false,
 		},
 		{
@@ -156,7 +156,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 			remote:      createRepoWithDotGitDir(t, root),
 			revision:    "revision-not-found",
-			err:         nil,
+			clientErr:   nil,
 			readerError: &gitdomain.RevisionNotFoundError{Repo: "revision-not-found", Spec: "revision-not-found"},
 			skipReader:  true,
 		},
@@ -200,7 +200,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 			}
 
 			rc, err := cli.ArchiveReader(ctx, nil, name, gitserver.ArchiveOptions{Treeish: test.revision, Format: gitserver.ArchiveFormatZip})
-			if have, want := fmt.Sprint(err), fmt.Sprint(test.err); have != want {
+			if have, want := fmt.Sprint(err), fmt.Sprint(test.clientErr); have != want {
 				t.Errorf("archive: have err %v, want %v", have, want)
 			}
 			if rc == nil {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -72,6 +72,7 @@ func TestClient_Remove(t *testing.T) {
 	addrs := []string{"172.16.8.1:8080", "172.16.8.2:8080"}
 
 	expected := "http://172.16.8.1:8080"
+	source := gitserver.NewTestClientSource(addrs)
 
 	cli := gitserver.NewTestClient(
 		httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
@@ -88,8 +89,8 @@ func TestClient_Remove(t *testing.T) {
 				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
 			}
 		}),
-		gitserver.DefaultGRPCSource,
-		addrs,
+
+		source,
 	)
 
 	err := cli.Remove(context.Background(), repo)
@@ -161,7 +162,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		},
 	}
 
-	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(addr []string) gitserver.Client, name api.RepoName, test test) {
+	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(t *testing.T, addrs []string) gitserver.Client, name api.RepoName, test test) {
 		t.Run(string(name), func(t *testing.T) {
 			// Setup: Prepare the test Gitserver server + register the gRPC server
 			s := &server.Server{
@@ -189,7 +190,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 			u, _ := url.Parse(srv.URL)
 
 			addrs := []string{u.Host}
-			cli := mkClient(addrs)
+			cli := mkClient(t, addrs)
 			ctx := context.Background()
 
 			if test.remote != "" {
@@ -256,20 +257,25 @@ func TestClient_ArchiveReader(t *testing.T) {
 		for _, test := range tests {
 			repoName := api.RepoName(test.name)
 
-			var spyGitserverService *spyGitserverServiceClient
-			spy := func(conns grpc.ClientConnInterface) proto.GitserverServiceClient {
-				spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
-				return spyGitserverService
-			}
-			GRPCSource := gitserver.GRPCClientImplementor{
-				Source: spy,
-			}
-			mkClient := func(addrs []string) gitserver.Client {
-				return gitserver.NewTestClient(&http.Client{}, GRPCSource, addrs)
+			spy := &spyGitserverServiceClient{}
+
+			mkClient := func(t *testing.T, addrs []string) gitserver.Client {
+
+				t.Helper()
+
+				source := gitserver.NewTestClientSource(addrs, func(o *gitserver.TestClientSourceOptions) {
+					o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+						spy.base = proto.NewGitserverServiceClient(cc)
+
+						return spy
+					}
+				})
+
+				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
 			runArchiveReaderTestfunc(t, mkClient, repoName, test)
-			if !spyGitserverService.archiveCalled {
+			if !spy.archiveCalled {
 				t.Error("archiveReader: GitserverServiceClient should have been called")
 			}
 
@@ -282,17 +288,20 @@ func TestClient_ArchiveReader(t *testing.T) {
 			repoName := api.RepoName(test.name)
 
 			var spyGitserverService *spyGitserverServiceClient
-			spy := func(conns grpc.ClientConnInterface) proto.GitserverServiceClient {
-				spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
-				return spyGitserverService
-			}
-			GRPCSource := gitserver.GRPCClientImplementor{
-				Source: spy,
-			}
+			mkClient := func(t *testing.T, addrs []string) gitserver.Client {
+				t.Helper()
 
-			fmt.Printf("GRPCSource: %+v\n", GRPCSource)
-			mkClient := func(addrs []string) gitserver.Client {
-				return gitserver.NewTestClient(&http.Client{}, GRPCSource, addrs)
+				spy := &spyGitserverServiceClient{}
+
+				source := gitserver.NewTestClientSource(addrs, func(o *gitserver.TestClientSourceOptions) {
+					o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+						spy.base = proto.NewGitserverServiceClient(cc)
+
+						return spy
+					}
+				})
+
+				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
 			runArchiveReaderTestfunc(t, mkClient, repoName, test)
@@ -465,7 +474,9 @@ func TestClient_P4Exec(t *testing.T) {
 
 			u, _ := url.Parse(testServer.URL)
 			addrs := []string{u.Host}
-			cli := gitserver.NewTestClient(&http.Client{}, gitserver.DefaultGRPCSource, addrs)
+			source := gitserver.NewTestClientSource(addrs)
+
+			cli := gitserver.NewTestClient(&http.Client{}, source)
 
 			rc, _, err := cli.P4Exec(ctx, test.host, test.user, test.password, test.args...)
 			if diff := cmp.Diff(test.wantErr, fmt.Sprintf("%v", err)); diff != "" {
@@ -547,7 +558,9 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 	u, _ := url.Parse(srv.URL)
 	addrs := []string{u.Host}
-	cli := gitserver.NewTestClient(&http.Client{}, gitserver.DefaultGRPCSource, addrs)
+	source := gitserver.NewTestClientSource(addrs)
+
+	cli := gitserver.NewTestClient(&http.Client{}, source)
 
 	ctx := context.Background()
 	for _, test := range tests {
@@ -569,6 +582,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 
 func TestClient_BatchLog(t *testing.T) {
 	addrs := []string{"172.16.8.1:8080", "172.16.8.2:8080", "172.16.8.3:8080"}
+	source := gitserver.NewTestClientSource(addrs)
 
 	cli := gitserver.NewTestClient(
 		httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
@@ -590,8 +604,7 @@ func TestClient_BatchLog(t *testing.T) {
 			body := io.NopCloser(strings.NewReader(strings.TrimSpace(string(encoded))))
 			return &http.Response{StatusCode: 200, Body: body}, nil
 		}),
-		gitserver.DefaultGRPCSource,
-		addrs,
+		source,
 	)
 
 	opts := gitserver.BatchLogOptions{
@@ -696,6 +709,7 @@ func TestClient_ReposStats(t *testing.T) {
 		GitDirBytes: 1337,
 	}
 
+	source := gitserver.NewTestClientSource(addrs)
 	cli := gitserver.NewTestClient(
 		httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
 			switch r.URL.String() {
@@ -710,8 +724,7 @@ func TestClient_ReposStats(t *testing.T) {
 				return nil, errors.Newf("unexpected URL: %q", r.URL.String())
 			}
 		}),
-		gitserver.DefaultGRPCSource,
-		addrs,
+		source,
 	)
 
 	gotStatsMap, err := cli.ReposStats(context.Background())

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -53,7 +53,7 @@ func TestProtoRoundTrip(t *testing.T) {
 	f := func(original gitserver.ArchiveOptions) bool {
 
 		var converted gitserver.ArchiveOptions
-		converted.FromProto(original.ToProto())
+		converted.FromProto(original.ToProto("test"))
 
 		if diff = cmp.Diff(original, converted); diff != "" {
 			return false

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -150,7 +150,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 	runArchiveReaderTestfunc := func(t *testing.T, clientFunc func(addr []string) gitserver.Client, name api.RepoName, test test) {
 		t.Run(string(name), func(t *testing.T) {
-
+// Setup: Prepare the test Gitserver server + register the gRPC server
 			s := &server.Server{
 				Logger:   logtest.Scoped(t),
 				ReposDir: filepath.Join(root, "repos"),

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -261,9 +261,11 @@ func TestClient_ArchiveReader(t *testing.T) {
 				spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
 				return spyGitserverService
 			}
-
+			GRPCSource := gitserver.GRPCClientImplementor{
+				Source: spy,
+			}
 			mkClient := func(addrs []string) gitserver.Client {
-				return gitserver.NewTestClient(&http.Client{}, spy, addrs)
+				return gitserver.NewTestClient(&http.Client{}, GRPCSource, addrs)
 			}
 
 			runArchiveReaderTestfunc(t, mkClient, repoName, test)
@@ -284,9 +286,13 @@ func TestClient_ArchiveReader(t *testing.T) {
 				spyGitserverService = &spyGitserverServiceClient{base: proto.NewGitserverServiceClient(conns)}
 				return spyGitserverService
 			}
+			GRPCSource := gitserver.GRPCClientImplementor{
+				Source: spy,
+			}
 
+			fmt.Printf("GRPCSource: %+v\n", GRPCSource)
 			mkClient := func(addrs []string) gitserver.Client {
-				return gitserver.NewTestClient(&http.Client{}, spy, addrs)
+				return gitserver.NewTestClient(&http.Client{}, GRPCSource, addrs)
 			}
 
 			runArchiveReaderTestfunc(t, mkClient, repoName, test)

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2419,10 +2419,6 @@ func (c *clientImplementor) ArchiveReader(
 			Treeish: options.Treeish,
 			Format:  string(options.Format),
 			Pathspecs: func() []string {
-				if options.Pathspecs == nil {
-					return nil
-				}
-
 				pathspec := make([]string, len(options.Pathspecs))
 
 				for i, path := range options.Pathspecs {

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2447,6 +2447,9 @@ func (c *clientImplementor) ArchiveReader(
 			return nil
 		}
 
+		// This Reads the first message to check for errors before contining reading the rest of the stream.
+		// if the first message is an error, the stream is closed and the error is returned.
+		// This is necessary because the first message may contain an error (e.g repo not found error), but the stream may not be closed so the error is not returned.
 		firstMessage, err := stream.Recv()
 		if err != nil {
 			cancel()

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2413,11 +2413,7 @@ func (c *clientImplementor) ArchiveReader(
 			return nil, err
 		}
 
-		// type clientForConn: (conn) -> gitserverserviceclient (interface)
-		//
-		// "normal usecase": we add actual proto.NewGitserverServiceClient to use with the connection
-		// "test usecase": we provide a mock client to use with the connection
-		client := proto.NewGitserverServiceClient(conn)
+		client := c.grpcClient(conn)
 
 		req := &proto.ArchiveRequest{
 			Repo:    string(repo),

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2413,7 +2413,7 @@ func (c *clientImplementor) ArchiveReader(
 			return nil, err
 		}
 
-		client := c.grpcClient(conn)
+		client := c.gRPCClientSource(conn)
 
 		req := &proto.ArchiveRequest{
 			Repo:    string(repo),

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2457,7 +2457,7 @@ func (c *clientImplementor) ArchiveReader(
 			err := convertGRPCErrorToGitDomainError(firstError)
 
 			var cse *CommandStatusError
-			if !errors.As(err, &cse) || !cse.isRevisionNotFound() {
+			if !errors.As(err, &cse) || !isRevisionNotFound(cse.Stderr) {
 				cancel()
 				return nil, handleStreamErr(err)
 			}

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2410,7 +2410,7 @@ func (c *clientImplementor) ArchiveReader(
 			return nil, err
 		}
 
-		client, err := c.grpc.ClientForRepo(c.userAgent, repo)
+		client, err := c.clientSource.ClientForRepo(c.userAgent, repo)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2405,11 +2405,6 @@ func (c *clientImplementor) ArchiveReader(
 	}
 
 	if internalgrpc.IsGRPCEnabled(ctx) {
-		//conn, err := c.ConnForRepo(repo)
-		if err != nil {
-			return nil, err
-		}
-
 		client, err := c.clientSource.ClientForRepo(c.userAgent, repo)
 		if err != nil {
 			return nil, err

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -37,7 +37,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/streamio"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -2415,19 +2414,8 @@ func (c *clientImplementor) ArchiveReader(
 
 		client := c.gRPCClientSource(conn)
 
-		req := &proto.ArchiveRequest{
-			Repo:    string(repo),
-			Treeish: options.Treeish,
-			Format:  string(options.Format),
-			Pathspecs: func() []string {
-				pathspec := make([]string, len(options.Pathspecs))
-
-				for i, path := range options.Pathspecs {
-					pathspec[i] = string(path)
-				}
-				return pathspec
-			}(),
-		}
+		req := options.ToProto()
+		req.Repo = string(repo) // HACK: ArchiveOptions doesn't have a repository here, so we have to add it ourselves.
 
 		ctx, cancel := context.WithCancel(ctx)
 

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2414,8 +2414,7 @@ func (c *clientImplementor) ArchiveReader(
 
 		client := c.gRPCClientSource(conn)
 
-		req := options.ToProto()
-		req.Repo = string(repo) // HACK: ArchiveOptions doesn't have a repository here, so we have to add it ourselves.
+		req := options.ToProto(string(repo)) // HACK: ArchiveOptions doesn't have a repository here, so we have to add it ourselves.
 
 		ctx, cancel := context.WithCancel(ctx)
 

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2405,12 +2405,15 @@ func (c *clientImplementor) ArchiveReader(
 	}
 
 	if internalgrpc.IsGRPCEnabled(ctx) {
-		conn, err := c.ConnForRepo(repo)
+		//conn, err := c.ConnForRepo(repo)
 		if err != nil {
 			return nil, err
 		}
 
-		client := c.gRPCClientSource(conn)
+		client, err := c.grpc.ClientForRepo(c.userAgent, repo)
+		if err != nil {
+			return nil, err
+		}
 
 		req := options.ToProto(string(repo)) // HACK: ArchiveOptions doesn't have a repository here, so we have to add it ourselves.
 

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	godiff "github.com/sourcegraph/go-diff/diff"
-
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 
 	"github.com/google/go-cmp/cmp"

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	godiff "github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 
 	"github.com/google/go-cmp/cmp"

--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -14,10 +14,10 @@ import (
 	"syscall"
 
 	"github.com/sourcegraph/log"
-	"google.golang.org/grpc"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -175,7 +175,7 @@ type RemoteGitCommand struct {
 type execer interface {
 	httpPost(ctx context.Context, repo api.RepoName, op string, payload any) (resp *http.Response, err error)
 	AddrForRepo(repo api.RepoName) string
-	ConnForRepo(repo api.RepoName) (*grpc.ClientConn, error)
+	ClientForRepo(repo api.RepoName) (proto.GitserverServiceClient, error)
 }
 
 // DividedOutput runs the command and returns its standard output and standard error.

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestClient_AddrMatchesTarget(t *testing.T) {
-	client := NewTestClient(nil, []string{"localhost:1234", "localhost:4321"}, nil).(*clientImplementor)
+	client := NewTestClient(nil, nil, []string{"localhost:1234", "localhost:4321"}).(*clientImplementor)
 
 	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
 		addr := client.AddrForRepo(repo)

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -7,18 +7,19 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 func TestClient_AddrMatchesTarget(t *testing.T) {
-	client := NewTestClient(nil, []string{"localhost:1234", "localhost:4321"}).(*clientImplementor)
+	client := NewTestClient(nil, []string{"localhost:1234", "localhost:4321"}, nil).(*clientImplementor)
 
 	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
 		addr := client.AddrForRepo(repo)

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
@@ -18,20 +17,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func TestClient_AddrMatchesTarget(t *testing.T) {
-	client := NewTestClient(nil, nil, []string{"localhost:1234", "localhost:4321"}).(*clientImplementor)
+// func TestClient_AddrMatchesTarget(t *testing.T) {
+// 	client := NewTestClient(nil, nil, []string{"localhost:1234", "localhost:4321"}).(*clientImplementor)
 
-	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
-		addr := client.AddrForRepo(repo)
-		conn, err := client.ConnForRepo(repo)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if addr != conn.Target() {
-			t.Fatalf("expected addr (%q) to equal target (%q)", addr, conn.Target())
-		}
-	}
-}
+// 	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
+// 		addr := client.AddrForRepo(repo)
+// 		conn, err := client.ConnForRepo(repo)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if addr != conn.Target() {
+// 			t.Fatalf("expected addr (%q) to equal target (%q)", addr, conn.Target())
+// 		}
+// 	}
+// }
 
 // mockGitserver implements both a gRPC server and an HTTP server that just tracks
 // whether or not it was called.

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
@@ -17,20 +18,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// func TestClient_AddrMatchesTarget(t *testing.T) {
-// 	client := NewTestClient(nil, nil, []string{"localhost:1234", "localhost:4321"}).(*clientImplementor)
+func TestClientSource_AddrMatchesTarget(t *testing.T) {
+	source := NewTestClientSource([]string{"localhost:1234", "localhost:4321"})
+	testGitserverConns := source.(*testGitserverConns)
+	conns := GitserverConns(*testGitserverConns.conns)
 
-// 	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
-// 		addr := client.AddrForRepo(repo)
-// 		conn, err := client.ConnForRepo(repo)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if addr != conn.Target() {
-// 			t.Fatalf("expected addr (%q) to equal target (%q)", addr, conn.Target())
-// 		}
-// 	}
-// }
+	for _, repo := range []api.RepoName{"a", "b", "c", "d"} {
+		addr := source.AddrForRepo("test", repo)
+		conn, err := conns.ConnForRepo("test", repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if addr != conn.Target() {
+			t.Fatalf("expected addr (%q) to equal target (%q)", addr, conn.Target())
+		}
+	}
+}
 
 // mockGitserver implements both a gRPC server and an HTTP server that just tracks
 // whether or not it was called.

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -78,7 +78,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil).GetCommits(ctx, nil, repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -109,7 +109,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 }
 
 func TestHead(t *testing.T) {
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
 	t.Run("basic", func(t *testing.T) {
 		gitCommands := []string{
 			"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -78,7 +78,7 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil).GetCommits(ctx, nil, repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -109,7 +109,7 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 }
 
 func TestHead(t *testing.T) {
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
 	t.Run("basic", func(t *testing.T) {
 		gitCommands := []string{
 			"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/gitserver/integration_tests/commits_test.go
+++ b/internal/gitserver/integration_tests/commits_test.go
@@ -78,7 +78,8 @@ func TestGetCommits(t *testing.T) {
 			nil,
 		}
 
-		commits, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses).GetCommits(ctx, nil, repoCommits, true)
+		source := gitserver.NewTestClientSource(GitserverAddresses)
+		commits, err := gitserver.NewTestClient(http.DefaultClient, source).GetCommits(ctx, nil, repoCommits, true)
 		if err != nil {
 			t.Fatalf("unexpected error calling getCommits: %s", err)
 		}
@@ -109,7 +110,8 @@ func mustParseDate(s string, t *testing.T) *time.Time {
 }
 
 func TestHead(t *testing.T) {
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
+	source := gitserver.NewTestClientSource(GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 	t.Run("basic", func(t *testing.T) {
 		gitCommands := []string{
 			"GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=2006-01-02T15:04:05Z git commit --allow-empty -m foo --author='a <a@a.com>' --date 2006-01-02T15:04:05Z",

--- a/internal/gitserver/integration_tests/object_test.go
+++ b/internal/gitserver/integration_tests/object_test.go
@@ -34,7 +34,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil).GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gitserver/integration_tests/object_test.go
+++ b/internal/gitserver/integration_tests/object_test.go
@@ -34,7 +34,7 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
+			obj, err := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gitserver/integration_tests/object_test.go
+++ b/internal/gitserver/integration_tests/object_test.go
@@ -34,7 +34,8 @@ func TestGetObject(t *testing.T) {
 
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
-			obj, err := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses).GetObject(context.Background(), test.repo, test.objectName)
+			source := gitserver.NewTestClientSource(GitserverAddresses)
+			obj, err := gitserver.NewTestClient(http.DefaultClient, source).GetObject(context.Background(), test.repo, test.objectName)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -83,7 +83,7 @@ func InitGitserver() {
 	}()
 
 	serverAddress := l.Addr().String()
-	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, []string{serverAddress}, nil)
+	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, gitserver.DefaultGRPCSource, []string{serverAddress})
 	GitserverAddresses = []string{serverAddress}
 }
 

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -83,7 +83,7 @@ func InitGitserver() {
 	}()
 
 	serverAddress := l.Addr().String()
-	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, []string{serverAddress})
+	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, []string{serverAddress}, nil)
 	GitserverAddresses = []string{serverAddress}
 }
 

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -83,7 +83,8 @@ func InitGitserver() {
 	}()
 
 	serverAddress := l.Addr().String()
-	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, gitserver.DefaultGRPCSource, []string{serverAddress})
+	source := gitserver.NewTestClientSource([]string{serverAddress})
+	testGitserverClient = gitserver.NewTestClient(httpcli.InternalDoer, source)
 	GitserverAddresses = []string{serverAddress}
 }
 

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -55,7 +55,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
 	for label, test := range tests {
 		// notafile should not exist.
 		if _, err := client.Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
@@ -81,7 +81,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		if got, want := "ab771ba54f5571c99ffdae54f44acc7993d9f115", dir1Info.Sys().(gitdomain.ObjectInfo).OID().String(); got != want {
 			t.Errorf("%s: got dir1 OID %q, want %q", label, got, want)
 		}
-		client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
+		client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
 
 		// dir1 should contain one entry: file1.
 		dir1Entries, err := client.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
@@ -247,7 +247,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {
@@ -307,7 +307,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -55,7 +55,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
 	for label, test := range tests {
 		// notafile should not exist.
 		if _, err := client.Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
@@ -81,7 +81,7 @@ func TestRepository_FileSystem(t *testing.T) {
 		if got, want := "ab771ba54f5571c99ffdae54f44acc7993d9f115", dir1Info.Sys().(gitdomain.ObjectInfo).OID().String(); got != want {
 			t.Errorf("%s: got dir1 OID %q, want %q", label, got, want)
 		}
-		client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
+		client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
 
 		// dir1 should contain one entry: file1.
 		dir1Entries, err := client.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
@@ -247,7 +247,7 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {
@@ -307,7 +307,7 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 		},
 	}
 
-	client := gitserver.NewTestClient(http.DefaultClient, GitserverAddresses, nil)
+	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {

--- a/internal/gitserver/integration_tests/tree_test.go
+++ b/internal/gitserver/integration_tests/tree_test.go
@@ -54,8 +54,8 @@ func TestRepository_FileSystem(t *testing.T) {
 			third:  "ba3c51080ed4a5b870952ecd7f0e15f255b24cca",
 		},
 	}
-
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
+	source := gitserver.NewTestClientSource(GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 	for label, test := range tests {
 		// notafile should not exist.
 		if _, err := client.Stat(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "notafile"); !os.IsNotExist(err) {
@@ -81,7 +81,8 @@ func TestRepository_FileSystem(t *testing.T) {
 		if got, want := "ab771ba54f5571c99ffdae54f44acc7993d9f115", dir1Info.Sys().(gitdomain.ObjectInfo).OID().String(); got != want {
 			t.Errorf("%s: got dir1 OID %q, want %q", label, got, want)
 		}
-		client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
+		source := gitserver.NewTestClientSource(GitserverAddresses)
+		client := gitserver.NewTestClient(http.DefaultClient, source)
 
 		// dir1 should contain one entry: file1.
 		dir1Entries, err := client.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, test.repo, test.first, "dir1", false)
@@ -246,8 +247,8 @@ func TestRepository_FileSystem_quoteChars(t *testing.T) {
 			repo: MakeGitRepository(t, append([]string{"git config core.quotepath off"}, gitCommands...)...),
 		},
 	}
-
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
+	source := gitserver.NewTestClientSource(GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {
@@ -306,8 +307,8 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 			repo: MakeGitRepository(t, gitCommands...),
 		},
 	}
-
-	client := gitserver.NewTestClient(http.DefaultClient, gitserver.DefaultGRPCSource, GitserverAddresses)
+	source := gitserver.NewTestClientSource(GitserverAddresses)
+	client := gitserver.NewTestClient(http.DefaultClient, source)
 	for label, test := range tests {
 		commitID, err := client.ResolveRevision(ctx, test.repo, "master", gitserver.ResolveRevisionOptions{})
 		if err != nil {

--- a/internal/gitserver/v1/gitserver.pb.go
+++ b/internal/gitserver/v1/gitserver.pb.go
@@ -1348,14 +1348,18 @@ func (x *CommitMatch) GetModifiedFiles() []string {
 	return nil
 }
 
+// ArchiveOptions contains options for the Archive func.
 type ArchiveRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Repo      string   `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
-	Treeish   string   `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
-	Format    string   `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
+	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
+	// the tree or commit to produce an archive for
+	Treeish string `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
+	// format of the resulting archive (usually "tar" or "zip")
+	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
+	// if nonempty, only include these pathspecs.
 	Pathspecs []string `protobuf:"bytes,4,rep,name=pathspecs,proto3" json:"pathspecs,omitempty"`
 }
 

--- a/internal/gitserver/v1/gitserver.pb.go
+++ b/internal/gitserver/v1/gitserver.pb.go
@@ -1348,6 +1348,124 @@ func (x *CommitMatch) GetModifiedFiles() []string {
 	return nil
 }
 
+type ArchiveRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Repo      string   `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
+	Treeish   string   `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
+	Format    string   `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
+	Pathspecs []string `protobuf:"bytes,4,rep,name=pathspecs,proto3" json:"pathspecs,omitempty"`
+}
+
+func (x *ArchiveRequest) Reset() {
+	*x = ArchiveRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitserver_proto_msgTypes[18]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ArchiveRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArchiveRequest) ProtoMessage() {}
+
+func (x *ArchiveRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitserver_proto_msgTypes[18]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArchiveRequest.ProtoReflect.Descriptor instead.
+func (*ArchiveRequest) Descriptor() ([]byte, []int) {
+	return file_gitserver_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ArchiveRequest) GetRepo() string {
+	if x != nil {
+		return x.Repo
+	}
+	return ""
+}
+
+func (x *ArchiveRequest) GetTreeish() string {
+	if x != nil {
+		return x.Treeish
+	}
+	return ""
+}
+
+func (x *ArchiveRequest) GetFormat() string {
+	if x != nil {
+		return x.Format
+	}
+	return ""
+}
+
+func (x *ArchiveRequest) GetPathspecs() []string {
+	if x != nil {
+		return x.Pathspecs
+	}
+	return nil
+}
+
+type ArchiveResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Data []byte `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+}
+
+func (x *ArchiveResponse) Reset() {
+	*x = ArchiveResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitserver_proto_msgTypes[19]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ArchiveResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ArchiveResponse) ProtoMessage() {}
+
+func (x *ArchiveResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitserver_proto_msgTypes[19]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ArchiveResponse.ProtoReflect.Descriptor instead.
+func (*ArchiveResponse) Descriptor() ([]byte, []int) {
+	return file_gitserver_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ArchiveResponse) GetData() []byte {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
 type CommitMatch_Signature struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1361,7 +1479,7 @@ type CommitMatch_Signature struct {
 func (x *CommitMatch_Signature) Reset() {
 	*x = CommitMatch_Signature{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitserver_proto_msgTypes[18]
+		mi := &file_gitserver_proto_msgTypes[20]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1374,7 +1492,7 @@ func (x *CommitMatch_Signature) String() string {
 func (*CommitMatch_Signature) ProtoMessage() {}
 
 func (x *CommitMatch_Signature) ProtoReflect() protoreflect.Message {
-	mi := &file_gitserver_proto_msgTypes[18]
+	mi := &file_gitserver_proto_msgTypes[20]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1423,7 +1541,7 @@ type CommitMatch_MatchedString struct {
 func (x *CommitMatch_MatchedString) Reset() {
 	*x = CommitMatch_MatchedString{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitserver_proto_msgTypes[19]
+		mi := &file_gitserver_proto_msgTypes[21]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1436,7 +1554,7 @@ func (x *CommitMatch_MatchedString) String() string {
 func (*CommitMatch_MatchedString) ProtoMessage() {}
 
 func (x *CommitMatch_MatchedString) ProtoReflect() protoreflect.Message {
-	mi := &file_gitserver_proto_msgTypes[19]
+	mi := &file_gitserver_proto_msgTypes[21]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1479,7 +1597,7 @@ type CommitMatch_Range struct {
 func (x *CommitMatch_Range) Reset() {
 	*x = CommitMatch_Range{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitserver_proto_msgTypes[20]
+		mi := &file_gitserver_proto_msgTypes[22]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1492,7 +1610,7 @@ func (x *CommitMatch_Range) String() string {
 func (*CommitMatch_Range) ProtoMessage() {}
 
 func (x *CommitMatch_Range) ProtoReflect() protoreflect.Message {
-	mi := &file_gitserver_proto_msgTypes[20]
+	mi := &file_gitserver_proto_msgTypes[22]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1535,7 +1653,7 @@ type CommitMatch_Location struct {
 func (x *CommitMatch_Location) Reset() {
 	*x = CommitMatch_Location{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitserver_proto_msgTypes[21]
+		mi := &file_gitserver_proto_msgTypes[23]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1548,7 +1666,7 @@ func (x *CommitMatch_Location) String() string {
 func (*CommitMatch_Location) ProtoMessage() {}
 
 func (x *CommitMatch_Location) ProtoReflect() protoreflect.Message {
-	mi := &file_gitserver_proto_msgTypes[21]
+	mi := &file_gitserver_proto_msgTypes[23]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,28 +1899,43 @@ var file_gitserver_proto_rawDesc = []byte{
 	0x28, 0x0d, 0x52, 0x06, 0x6f, 0x66, 0x66, 0x73, 0x65, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x6c, 0x69,
 	0x6e, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x04, 0x6c, 0x69, 0x6e, 0x65, 0x12, 0x16,
 	0x0a, 0x06, 0x63, 0x6f, 0x6c, 0x75, 0x6d, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x06,
-	0x63, 0x6f, 0x6c, 0x75, 0x6d, 0x6e, 0x2a, 0x71, 0x0a, 0x0c, 0x4f, 0x70, 0x65, 0x72, 0x61, 0x74,
-	0x6f, 0x72, 0x4b, 0x69, 0x6e, 0x64, 0x12, 0x1d, 0x0a, 0x19, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54,
-	0x4f, 0x52, 0x5f, 0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46,
-	0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f,
-	0x52, 0x5f, 0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x41, 0x4e, 0x44, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10,
-	0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f, 0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x4f, 0x52,
-	0x10, 0x02, 0x12, 0x15, 0x0a, 0x11, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f, 0x4b,
-	0x49, 0x4e, 0x44, 0x5f, 0x4e, 0x4f, 0x54, 0x10, 0x03, 0x32, 0x9e, 0x01, 0x0a, 0x10, 0x47, 0x69,
-	0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x41,
-	0x0a, 0x04, 0x45, 0x78, 0x65, 0x63, 0x12, 0x19, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76,
-	0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x45, 0x78, 0x65, 0x63, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
-	0x74, 0x1a, 0x1a, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31,
-	0x2e, 0x45, 0x78, 0x65, 0x63, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30,
-	0x01, 0x12, 0x47, 0x0a, 0x06, 0x53, 0x65, 0x61, 0x72, 0x63, 0x68, 0x12, 0x1b, 0x2e, 0x67, 0x69,
-	0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x61, 0x72, 0x63,
-	0x68, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1c, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65,
+	0x63, 0x6f, 0x6c, 0x75, 0x6d, 0x6e, 0x22, 0x74, 0x0a, 0x0e, 0x41, 0x72, 0x63, 0x68, 0x69, 0x76,
+	0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x12, 0x0a, 0x04, 0x72, 0x65, 0x70, 0x6f,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x72, 0x65, 0x70, 0x6f, 0x12, 0x18, 0x0a, 0x07,
+	0x74, 0x72, 0x65, 0x65, 0x69, 0x73, 0x68, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x74,
+	0x72, 0x65, 0x65, 0x69, 0x73, 0x68, 0x12, 0x16, 0x0a, 0x06, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x66, 0x6f, 0x72, 0x6d, 0x61, 0x74, 0x12, 0x1c,
+	0x0a, 0x09, 0x70, 0x61, 0x74, 0x68, 0x73, 0x70, 0x65, 0x63, 0x73, 0x18, 0x04, 0x20, 0x03, 0x28,
+	0x09, 0x52, 0x09, 0x70, 0x61, 0x74, 0x68, 0x73, 0x70, 0x65, 0x63, 0x73, 0x22, 0x25, 0x0a, 0x0f,
+	0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
+	0x12, 0x0a, 0x04, 0x64, 0x61, 0x74, 0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x04, 0x64,
+	0x61, 0x74, 0x61, 0x2a, 0x71, 0x0a, 0x0c, 0x4f, 0x70, 0x65, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x4b,
+	0x69, 0x6e, 0x64, 0x12, 0x1d, 0x0a, 0x19, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f,
+	0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x55, 0x4e, 0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44,
+	0x10, 0x00, 0x12, 0x15, 0x0a, 0x11, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f, 0x4b,
+	0x49, 0x4e, 0x44, 0x5f, 0x41, 0x4e, 0x44, 0x10, 0x01, 0x12, 0x14, 0x0a, 0x10, 0x4f, 0x50, 0x45,
+	0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f, 0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x4f, 0x52, 0x10, 0x02, 0x12,
+	0x15, 0x0a, 0x11, 0x4f, 0x50, 0x45, 0x52, 0x41, 0x54, 0x4f, 0x52, 0x5f, 0x4b, 0x49, 0x4e, 0x44,
+	0x5f, 0x4e, 0x4f, 0x54, 0x10, 0x03, 0x32, 0xea, 0x01, 0x0a, 0x10, 0x47, 0x69, 0x74, 0x73, 0x65,
+	0x72, 0x76, 0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x41, 0x0a, 0x04, 0x45,
+	0x78, 0x65, 0x63, 0x12, 0x19, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e,
+	0x76, 0x31, 0x2e, 0x45, 0x78, 0x65, 0x63, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1a,
+	0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x45, 0x78,
+	0x65, 0x63, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x12, 0x47,
+	0x0a, 0x06, 0x53, 0x65, 0x61, 0x72, 0x63, 0x68, 0x12, 0x1b, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65,
 	0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x61, 0x72, 0x63, 0x68, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x42, 0x3a, 0x5a, 0x38, 0x67, 0x69,
-	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x67,
-	0x72, 0x61, 0x70, 0x68, 0x2f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70, 0x68,
-	0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72,
-	0x76, 0x65, 0x72, 0x2f, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1c, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65,
+	0x72, 0x2e, 0x76, 0x31, 0x2e, 0x53, 0x65, 0x61, 0x72, 0x63, 0x68, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x22, 0x00, 0x30, 0x01, 0x12, 0x4a, 0x0a, 0x07, 0x41, 0x72, 0x63, 0x68, 0x69,
+	0x76, 0x65, 0x12, 0x1c, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76,
+	0x31, 0x2e, 0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x1a, 0x1d, 0x2e, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e,
+	0x41, 0x72, 0x63, 0x68, 0x69, 0x76, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x00, 0x30, 0x01, 0x42, 0x3a, 0x5a, 0x38, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
+	0x6d, 0x2f, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70, 0x68, 0x2f, 0x73, 0x6f,
+	0x75, 0x72, 0x63, 0x65, 0x67, 0x72, 0x61, 0x70, 0x68, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e,
+	0x61, 0x6c, 0x2f, 0x67, 0x69, 0x74, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2f, 0x76, 0x31, 0x62,
+	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1818,7 +1951,7 @@ func file_gitserver_proto_rawDescGZIP() []byte {
 }
 
 var file_gitserver_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_gitserver_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_gitserver_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_gitserver_proto_goTypes = []interface{}{
 	(OperatorKind)(0),                 // 0: gitserver.v1.OperatorKind
 	(*ExecRequest)(nil),               // 1: gitserver.v1.ExecRequest
@@ -1839,17 +1972,19 @@ var file_gitserver_proto_goTypes = []interface{}{
 	(*QueryNode)(nil),                 // 16: gitserver.v1.QueryNode
 	(*SearchResponse)(nil),            // 17: gitserver.v1.SearchResponse
 	(*CommitMatch)(nil),               // 18: gitserver.v1.CommitMatch
-	(*CommitMatch_Signature)(nil),     // 19: gitserver.v1.CommitMatch.Signature
-	(*CommitMatch_MatchedString)(nil), // 20: gitserver.v1.CommitMatch.MatchedString
-	(*CommitMatch_Range)(nil),         // 21: gitserver.v1.CommitMatch.Range
-	(*CommitMatch_Location)(nil),      // 22: gitserver.v1.CommitMatch.Location
-	(*timestamppb.Timestamp)(nil),     // 23: google.protobuf.Timestamp
+	(*ArchiveRequest)(nil),            // 19: gitserver.v1.ArchiveRequest
+	(*ArchiveResponse)(nil),           // 20: gitserver.v1.ArchiveResponse
+	(*CommitMatch_Signature)(nil),     // 21: gitserver.v1.CommitMatch.Signature
+	(*CommitMatch_MatchedString)(nil), // 22: gitserver.v1.CommitMatch.MatchedString
+	(*CommitMatch_Range)(nil),         // 23: gitserver.v1.CommitMatch.Range
+	(*CommitMatch_Location)(nil),      // 24: gitserver.v1.CommitMatch.Location
+	(*timestamppb.Timestamp)(nil),     // 25: google.protobuf.Timestamp
 }
 var file_gitserver_proto_depIdxs = []int32{
 	6,  // 0: gitserver.v1.SearchRequest.revisions:type_name -> gitserver.v1.RevisionSpecifier
 	16, // 1: gitserver.v1.SearchRequest.query:type_name -> gitserver.v1.QueryNode
-	23, // 2: gitserver.v1.CommitBeforeNode.timestamp:type_name -> google.protobuf.Timestamp
-	23, // 3: gitserver.v1.CommitAfterNode.timestamp:type_name -> google.protobuf.Timestamp
+	25, // 2: gitserver.v1.CommitBeforeNode.timestamp:type_name -> google.protobuf.Timestamp
+	25, // 3: gitserver.v1.CommitAfterNode.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 4: gitserver.v1.OperatorNode.kind:type_name -> gitserver.v1.OperatorKind
 	16, // 5: gitserver.v1.OperatorNode.operands:type_name -> gitserver.v1.QueryNode
 	7,  // 6: gitserver.v1.QueryNode.author_matches:type_name -> gitserver.v1.AuthorMatchesNode
@@ -1862,20 +1997,22 @@ var file_gitserver_proto_depIdxs = []int32{
 	14, // 13: gitserver.v1.QueryNode.boolean:type_name -> gitserver.v1.BooleanNode
 	15, // 14: gitserver.v1.QueryNode.operator:type_name -> gitserver.v1.OperatorNode
 	18, // 15: gitserver.v1.SearchResponse.match:type_name -> gitserver.v1.CommitMatch
-	19, // 16: gitserver.v1.CommitMatch.author:type_name -> gitserver.v1.CommitMatch.Signature
-	19, // 17: gitserver.v1.CommitMatch.committer:type_name -> gitserver.v1.CommitMatch.Signature
-	20, // 18: gitserver.v1.CommitMatch.message:type_name -> gitserver.v1.CommitMatch.MatchedString
-	20, // 19: gitserver.v1.CommitMatch.diff:type_name -> gitserver.v1.CommitMatch.MatchedString
-	23, // 20: gitserver.v1.CommitMatch.Signature.date:type_name -> google.protobuf.Timestamp
-	21, // 21: gitserver.v1.CommitMatch.MatchedString.ranges:type_name -> gitserver.v1.CommitMatch.Range
-	22, // 22: gitserver.v1.CommitMatch.Range.start:type_name -> gitserver.v1.CommitMatch.Location
-	22, // 23: gitserver.v1.CommitMatch.Range.end:type_name -> gitserver.v1.CommitMatch.Location
+	21, // 16: gitserver.v1.CommitMatch.author:type_name -> gitserver.v1.CommitMatch.Signature
+	21, // 17: gitserver.v1.CommitMatch.committer:type_name -> gitserver.v1.CommitMatch.Signature
+	22, // 18: gitserver.v1.CommitMatch.message:type_name -> gitserver.v1.CommitMatch.MatchedString
+	22, // 19: gitserver.v1.CommitMatch.diff:type_name -> gitserver.v1.CommitMatch.MatchedString
+	25, // 20: gitserver.v1.CommitMatch.Signature.date:type_name -> google.protobuf.Timestamp
+	23, // 21: gitserver.v1.CommitMatch.MatchedString.ranges:type_name -> gitserver.v1.CommitMatch.Range
+	24, // 22: gitserver.v1.CommitMatch.Range.start:type_name -> gitserver.v1.CommitMatch.Location
+	24, // 23: gitserver.v1.CommitMatch.Range.end:type_name -> gitserver.v1.CommitMatch.Location
 	1,  // 24: gitserver.v1.GitserverService.Exec:input_type -> gitserver.v1.ExecRequest
 	5,  // 25: gitserver.v1.GitserverService.Search:input_type -> gitserver.v1.SearchRequest
-	2,  // 26: gitserver.v1.GitserverService.Exec:output_type -> gitserver.v1.ExecResponse
-	17, // 27: gitserver.v1.GitserverService.Search:output_type -> gitserver.v1.SearchResponse
-	26, // [26:28] is the sub-list for method output_type
-	24, // [24:26] is the sub-list for method input_type
+	19, // 26: gitserver.v1.GitserverService.Archive:input_type -> gitserver.v1.ArchiveRequest
+	2,  // 27: gitserver.v1.GitserverService.Exec:output_type -> gitserver.v1.ExecResponse
+	17, // 28: gitserver.v1.GitserverService.Search:output_type -> gitserver.v1.SearchResponse
+	20, // 29: gitserver.v1.GitserverService.Archive:output_type -> gitserver.v1.ArchiveResponse
+	27, // [27:30] is the sub-list for method output_type
+	24, // [24:27] is the sub-list for method input_type
 	24, // [24:24] is the sub-list for extension type_name
 	24, // [24:24] is the sub-list for extension extendee
 	0,  // [0:24] is the sub-list for field type_name
@@ -2104,7 +2241,7 @@ func file_gitserver_proto_init() {
 			}
 		}
 		file_gitserver_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CommitMatch_Signature); i {
+			switch v := v.(*ArchiveRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2116,7 +2253,7 @@ func file_gitserver_proto_init() {
 			}
 		}
 		file_gitserver_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CommitMatch_MatchedString); i {
+			switch v := v.(*ArchiveResponse); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2128,7 +2265,7 @@ func file_gitserver_proto_init() {
 			}
 		}
 		file_gitserver_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*CommitMatch_Range); i {
+			switch v := v.(*CommitMatch_Signature); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -2140,6 +2277,30 @@ func file_gitserver_proto_init() {
 			}
 		}
 		file_gitserver_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CommitMatch_MatchedString); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitserver_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CommitMatch_Range); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitserver_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CommitMatch_Location); i {
 			case 0:
 				return &v.state
@@ -2173,7 +2334,7 @@ func file_gitserver_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_gitserver_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/gitserver/v1/gitserver.pb.go
+++ b/internal/gitserver/v1/gitserver.pb.go
@@ -1348,18 +1348,19 @@ func (x *CommitMatch) GetModifiedFiles() []string {
 	return nil
 }
 
-// ArchiveOptions contains options for the Archive func.
+// ArchiveRquest is the options for the Archive func.
 type ArchiveRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// repo is the name of the repo to be archived
 	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
-	// the tree or commit to produce an archive for
+	// treeish is the tree or commit to produce an archive for
 	Treeish string `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
-	// format of the resulting archive (usually "tar" or "zip")
+	// format is the format of the resulting archive (usually "tar" or "zip")
 	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
-	// if nonempty, only include these pathspecs.
+	// pathspecs is the list of pathspecs to include in the archive. If empty,
 	Pathspecs []string `protobuf:"bytes,4,rep,name=pathspecs,proto3" json:"pathspecs,omitempty"`
 }
 

--- a/internal/gitserver/v1/gitserver.pb.go
+++ b/internal/gitserver/v1/gitserver.pb.go
@@ -1348,7 +1348,7 @@ func (x *CommitMatch) GetModifiedFiles() []string {
 	return nil
 }
 
-// ArchiveRquest is the options for the Archive func.
+// ArchiveRequest is set of parameters for the Archive RPC.
 type ArchiveRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1360,7 +1360,7 @@ type ArchiveRequest struct {
 	Treeish string `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
 	// format is the format of the resulting archive (usually "tar" or "zip")
 	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
-	// pathspecs is the list of pathspecs to include in the archive. If empty,
+	// pathspecs is the list of pathspecs to include in the archive. If empty, all pathspecs are included.
 	Pathspecs []string `protobuf:"bytes,4,rep,name=pathspecs,proto3" json:"pathspecs,omitempty"`
 }
 
@@ -1424,6 +1424,7 @@ func (x *ArchiveRequest) GetPathspecs() []string {
 	return nil
 }
 
+// ArchiveResponse is the response from the Archive RPC that returns a chunk of the archive.
 type ArchiveResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -195,12 +195,12 @@ message CommitMatch {
 }
 
 message ArchiveRequest {
-    string repo = 1;
-    string treeish = 2;
-    string format = 3;
-    repeated string pathspecs = 4;
+  string repo = 1;
+  string treeish = 2;
+  string format = 3;
+  repeated string pathspecs = 4;
 }
 
 message ArchiveResponse {
-    bytes data = 1;
+  bytes data = 1;
 }

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -194,10 +194,14 @@ message CommitMatch {
   repeated string modified_files = 9;
 }
 
+// ArchiveOptions contains options for the Archive func.
 message ArchiveRequest {
   string repo = 1;
+  // the tree or commit to produce an archive for
   string treeish = 2;
+  // format of the resulting archive (usually "tar" or "zip")
   string format = 3;
+  // if nonempty, only include these pathspecs.
   repeated string pathspecs = 4;
 }
 

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -9,6 +9,7 @@ option go_package = "github.com/sourcegraph/sourcegraph/internal/gitserver/v1";
 service GitserverService {
   rpc Exec(ExecRequest) returns (stream ExecResponse) {}
   rpc Search(SearchRequest) returns (stream SearchResponse) {}
+  rpc Archive(ArchiveRequest) returns (stream ArchiveResponse) {}
 }
 
 message ExecRequest {
@@ -191,4 +192,15 @@ message CommitMatch {
   // to its first parent. May be unset if `include_modified_files` is not
   // specified in the request.
   repeated string modified_files = 9;
+}
+
+message ArchiveRequest {
+    string repo = 1;
+    string treeish = 2;
+    string format = 3;
+    repeated string pathspecs = 4;
+}
+
+message ArchiveResponse {
+    bytes data = 1;
 }

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -194,14 +194,15 @@ message CommitMatch {
   repeated string modified_files = 9;
 }
 
-// ArchiveOptions contains options for the Archive func.
+// ArchiveRquest is the options for the Archive func.
 message ArchiveRequest {
+  // repo is the name of the repo to be archived
   string repo = 1;
-  // the tree or commit to produce an archive for
+  // treeish is the tree or commit to produce an archive for
   string treeish = 2;
-  // format of the resulting archive (usually "tar" or "zip")
+  // format is the format of the resulting archive (usually "tar" or "zip")
   string format = 3;
-  // if nonempty, only include these pathspecs.
+  // pathspecs is the list of pathspecs to include in the archive. If empty,
   repeated string pathspecs = 4;
 }
 

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -194,7 +194,7 @@ message CommitMatch {
   repeated string modified_files = 9;
 }
 
-// ArchiveRquest is the options for the Archive func.
+// ArchiveRequest is set of parameters for the Archive RPC.
 message ArchiveRequest {
   // repo is the name of the repo to be archived
   string repo = 1;

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -202,10 +202,11 @@ message ArchiveRequest {
   string treeish = 2;
   // format is the format of the resulting archive (usually "tar" or "zip")
   string format = 3;
-  // pathspecs is the list of pathspecs to include in the archive. If empty,
+  // pathspecs is the list of pathspecs to include in the archive. If empty, all pathspecs are included.
   repeated string pathspecs = 4;
 }
 
+// ArchiveResponse is the response from the Archive RPC that returns a chunk of the archive.
 message ArchiveResponse {
   bytes data = 1;
 }

--- a/internal/gitserver/v1/gitserver_grpc.pb.go
+++ b/internal/gitserver/v1/gitserver_grpc.pb.go
@@ -19,8 +19,9 @@ import (
 const _ = grpc.SupportPackageIsVersion7
 
 const (
-	GitserverService_Exec_FullMethodName   = "/gitserver.v1.GitserverService/Exec"
-	GitserverService_Search_FullMethodName = "/gitserver.v1.GitserverService/Search"
+	GitserverService_Exec_FullMethodName    = "/gitserver.v1.GitserverService/Exec"
+	GitserverService_Search_FullMethodName  = "/gitserver.v1.GitserverService/Search"
+	GitserverService_Archive_FullMethodName = "/gitserver.v1.GitserverService/Archive"
 )
 
 // GitserverServiceClient is the client API for GitserverService service.
@@ -29,6 +30,7 @@ const (
 type GitserverServiceClient interface {
 	Exec(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (GitserverService_ExecClient, error)
 	Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (GitserverService_SearchClient, error)
+	Archive(ctx context.Context, in *ArchiveRequest, opts ...grpc.CallOption) (GitserverService_ArchiveClient, error)
 }
 
 type gitserverServiceClient struct {
@@ -103,12 +105,45 @@ func (x *gitserverServiceSearchClient) Recv() (*SearchResponse, error) {
 	return m, nil
 }
 
+func (c *gitserverServiceClient) Archive(ctx context.Context, in *ArchiveRequest, opts ...grpc.CallOption) (GitserverService_ArchiveClient, error) {
+	stream, err := c.cc.NewStream(ctx, &GitserverService_ServiceDesc.Streams[2], GitserverService_Archive_FullMethodName, opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &gitserverServiceArchiveClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type GitserverService_ArchiveClient interface {
+	Recv() (*ArchiveResponse, error)
+	grpc.ClientStream
+}
+
+type gitserverServiceArchiveClient struct {
+	grpc.ClientStream
+}
+
+func (x *gitserverServiceArchiveClient) Recv() (*ArchiveResponse, error) {
+	m := new(ArchiveResponse)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // GitserverServiceServer is the server API for GitserverService service.
 // All implementations must embed UnimplementedGitserverServiceServer
 // for forward compatibility
 type GitserverServiceServer interface {
 	Exec(*ExecRequest, GitserverService_ExecServer) error
 	Search(*SearchRequest, GitserverService_SearchServer) error
+	Archive(*ArchiveRequest, GitserverService_ArchiveServer) error
 	mustEmbedUnimplementedGitserverServiceServer()
 }
 
@@ -121,6 +156,9 @@ func (UnimplementedGitserverServiceServer) Exec(*ExecRequest, GitserverService_E
 }
 func (UnimplementedGitserverServiceServer) Search(*SearchRequest, GitserverService_SearchServer) error {
 	return status.Errorf(codes.Unimplemented, "method Search not implemented")
+}
+func (UnimplementedGitserverServiceServer) Archive(*ArchiveRequest, GitserverService_ArchiveServer) error {
+	return status.Errorf(codes.Unimplemented, "method Archive not implemented")
 }
 func (UnimplementedGitserverServiceServer) mustEmbedUnimplementedGitserverServiceServer() {}
 
@@ -177,6 +215,27 @@ func (x *gitserverServiceSearchServer) Send(m *SearchResponse) error {
 	return x.ServerStream.SendMsg(m)
 }
 
+func _GitserverService_Archive_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(ArchiveRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(GitserverServiceServer).Archive(m, &gitserverServiceArchiveServer{stream})
+}
+
+type GitserverService_ArchiveServer interface {
+	Send(*ArchiveResponse) error
+	grpc.ServerStream
+}
+
+type gitserverServiceArchiveServer struct {
+	grpc.ServerStream
+}
+
+func (x *gitserverServiceArchiveServer) Send(m *ArchiveResponse) error {
+	return x.ServerStream.SendMsg(m)
+}
+
 // GitserverService_ServiceDesc is the grpc.ServiceDesc for GitserverService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -193,6 +252,11 @@ var GitserverService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Search",
 			Handler:       _GitserverService_Search_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "Archive",
+			Handler:       _GitserverService_Archive_Handler,
 			ServerStreams: true,
 		},
 	},


### PR DESCRIPTION
This PR migrates the ArchiveReader in gitserver to use gRPC instead of HTTP when it is enabled. This change is part of an effort to consolidate all internal communication in Sourcegraph to use gRPC.

**Changes**

- [x]  Define Archive method in the GitserverService gRPC service in internal/gitserver/v1/gitserver.proto
- [x]  Generate Go code for the gRPC service using sg generate in internal/gitserver/v1/
- [x]  Implement ArchiveReader server in internal/gitserver/commands.go
- [x]  Implement ArchiveReader the use of a spy to test whether or not the grpc archive client was being called or not changes can be see in internal/gitserver/client.go and internal/gitserver/client_test.go
- [x]  Since function signature was update for from `func NewTestClient(cli httpcli.Doer, addrs []string) Client` --> `func NewTestClient(cli httpcli.Doer, addrs []string, grpcClientFunc func(cc grpc.ClientConnInterface) proto.GitserverServiceClient) Client` all instances of the use NewTestClient were also update in other test files such as (enterprise/internal/gitserver/integration_tests/commits_test.go,enterprise/internal/gitserver/integration_tests/tree_test.go, etc)

## Test plan
unit test 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
