### PR TITLE
Add instructions for building p4-fusion manually

### DIFF
--- a/doc/dev/background-information/build_p4_fusion.md
+++ b/doc/dev/background-information/build_p4_fusion.md
@@ -80,9 +80,9 @@ You will need `cmake` to build `p4-fusion`. The compiler it uses
 - `openssl@3.0.8`
 
 - the P4 API for your OS + platform:
-  - [macOS ARM 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.macosx12arm64/p4api-openssl3.tgz)
-  - [macOS Intel 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl3.tgz)
-  - [Linux Intel 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz)
+  - [macOS ARM 64-bit](https://filehost.perforce.com/perforce/r22.2/bin.macosx12arm64/p4api-openssl3.tgz)
+  - [macOS Intel 64-bit](https://filehost.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl3.tgz)
+  - [Linux Intel 64-bit](https://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz)
   - If you need a different one, browse the parent directory of one of the above to see if it's available.
 
 ###### Source code
@@ -165,7 +165,7 @@ cd p4-fusion
   tar xzf v1.12.tar.gz
 }
 cd p4-fusion-1.12
-curl -sSLO http://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz
+curl -sSLO https://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz
 tar xzf p4api-glibc2.3-openssl3.tgz
 rm -rf vendor/helix-core-api/linux
 mkdir -p vendor/helix-core-api/linux

--- a/doc/dev/background-information/build_p4_fusion.md
+++ b/doc/dev/background-information/build_p4_fusion.md
@@ -93,7 +93,7 @@ You will need `cmake` to build `p4-fusion`. The compiler it uses
 
 1. Set the `OPENSSL_ROOT_DIR` environment variable to point to the OpenSSL install location - the directory that contains OpenSSL's `bin`, `include`, and `lib` directories.
 
-Note that we're building with dynamic linking, so the OpenSSL libraries need to sstay there for `p4-fusion` to be able to run.
+Note that we're building with dynamic linking, so the OpenSSL libraries need to stay there for `p4-fusion` to be able to run.
 You might be able to fiddle with that using `LD_LIBRARY_PATH`, but it's safest to leave them there.
 
 1. Unpack the P4 API archives into the `p4-fusion` source directory tree, into the `vendor/helix-core-api/{OS}` directory, where `{OS}` is either `mac` or `linux`, depending on your OS. You'll need the `include` and `lib` dirs from the P4 API archive.

--- a/doc/dev/background-information/build_p4_fusion.md
+++ b/doc/dev/background-information/build_p4_fusion.md
@@ -4,7 +4,9 @@ In order to import Perforce depots into Sourcegraph we first convert them into g
 
 > A fast Perforce depot to Git repository converter using the Helix Core C/C++ API as an attempt to mitigate the performance bottlenecks in git-p4.py.
 
-[Building](https://github.com/salesforce/p4-fusion#build) p4-fusion can be a little tricky as it depends on some older libraries and also doesn't build on M1 Apple laptops. To get around this we use [nix](https://nixos.org).
+# Nix
+
+[Building](https://github.com/salesforce/p4-fusion#build) p4-fusion can be a little tricky as it depends on some older libraries. To get around this we use [nix](https://nixos.org).
 
 ## How to build
 
@@ -62,4 +64,115 @@ do
   nix --extra-experimental-features nix-command hash to-sri "${hash_type}:${hash_value}"
   echo
 done
+```
+
+# Manual
+
+Although building p4-fusion manually can take some effort, it is possible on macOS (may require 13+) and Linux. Windows has not been researched.
+
+## Build tools
+
+In addition to the compiler, which can be installed with the `build-essential` package on Debian 
+You will need `cmake` to build `p4-fusion`. The compiler it uses 
+
+## Dependencies
+
+- `openssl@3.0.8`
+
+- the P4 API for your OS + platform:
+  - [macOS ARM 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.macosx12arm64/p4api-openssl3.tgz)
+  - [macOS Intel 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl3.tgz)
+  - [Linux Intel 64-bit](http://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz)
+  - If you need a different one, browse the parent directory of one of the above to see if it's available.
+
+###### Source code
+
+`git clone` the [p4-fusion repository](https://github/salesforce/p4-fusion) or download a zip archive of the source. Or do the same on your chosen fork/branch.
+
+###### Setup
+
+1. Set the `OPENSSL_ROOT_DIR` environment variable to point to the OpenSSL install location - the directory that contains OpenSSL's `bin`, `include`, and `lib` directories.
+
+Note that we're building with dynamic linking, so the OpenSSL libraries need to sstay there for `p4-fusion` to be able to run.
+You might be able to fiddle with that using `LD_LIBRARY_PATH`, but it's safest to leave them there.
+
+1. Unpack the P4 API archives into the `p4-fusion` source directory tree, into the `vendor/helix-core-api/{OS}` directory, where `{OS}` is either `mac` or `linux`, depending on your OS. You'll need the `include` and `lib` dirs from the P4 API archive.
+
+###### Build
+
+Now that everything is in place, from within the `p4-fusion` source directory, run the following:
+
+```bash
+./generate_cache.sh Debug
+./build.sh
+```
+
+###### Use
+
+If it all worked out as planned, the executable will be in `build/p4-fusion/p4-fusion`. Use it there, or copy it to somewhere in your `PATH`.
+
+###### Examples
+
+Here's a sample shell script for macOS that follows all of the steps outlined above to build a Debug binary of the `p4-fusion` `1.12` release using OpenSSL 3.0.8 and the `22.2` P4 API.
+
+```bash
+brew install cmake openssl@3.0
+export OPENSSL_ROOT_DIR=$(brew --prefix openssl@3.0)
+mkdir p4-fusion 2>/dev/null
+cd p4-fusion
+[ -s "v1.12.tar.gz" ] || {
+  curl -sSLO https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.12.tar.gz
+  tar xzf v1.12.tar.gz
+}
+cd p4-fusion-1.12
+[ -f "p4api-openssl3.tgz" ] || {
+  arch=x86_64
+  [[ "$(arch)" = "arm64" ]] && arch=arm64
+  curl -sSLO https://cdist2.perforce.com/perforce/r22.2/bin.macosx12${arch}/p4api-openssl3.tgz
+  tar xzf p4api-openssl3.tgz
+}
+rm -rf vendor/helix-core-api/mac
+mkdir -p vendor/helix-core-api/mac
+mv -f p4api-2022.2.2407422/include p4api-2022.2.2407422/lib vendor/helix-core-api/mac
+rm -rf p4api-2022.2.2407422
+./generate_cache.sh Debug
+./build.sh
+ls -l "${PWD}/build/p4-fusion/p4-fusion"
+```
+
+
+Here's a sample shell script for Debian with OpenSSL 3.0.8.
+Debian 11 installs with OpenSSL 1.1, so make OpenSSL 3.0.8 from source (which takes awhile).
+Note that P4 API has only Intel/AMD for Linux, not ARM.
+
+```
+sudo apt-get update
+apt install build-essential checkinstall zlib1g-dev curl cmake
+
+mkdir openssl
+cd openssl
+curl -sSLO https://www.openssl.org/source/openssl-3.0.8.tar.gz
+tar xzf openssl-3.0.8.tar.gz
+cd openssl-3.0.8
+sudo ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+sudo make && sudo make test && sudo make install
+cd ../../
+export OPENSSL_ROOT_DIR=/usr/local/ssl
+mkdir p4-fusion
+cd p4-fusion
+[ -s "v1.12.tar.gz" ] || {
+  wget https://github.com/salesforce/p4-fusion/archive/refs/tags/v1.12.tar.gz
+  tar xzf v1.12.tar.gz
+}
+cd p4-fusion-1.12
+curl -sSLO http://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz
+tar xzf p4api-glibc2.3-openssl3.tgz
+rm -rf vendor/helix-core-api/linux
+mkdir -p vendor/helix-core-api/linux
+mv -f p4api-2022.2.2407422/include p4api-2022.2.2407422/lib vendor/helix-core-api/linux
+rm -rf p4api-2022.2.2407422
+ln -s /usr/local/ssl/lib64 /usr/local/ssl/lib
+./generate_cache.sh Debug
+./build.sh
+ls -l "${PWD}/build/p4-fusion/p4-fusion"
 ```

--- a/doc/dev/background-information/build_p4_fusion.md
+++ b/doc/dev/background-information/build_p4_fusion.md
@@ -85,20 +85,20 @@ You will need `cmake` to build `p4-fusion`. The compiler it uses
   - [Linux Intel 64-bit](https://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz)
   - If you need a different one, browse the parent directory of one of the above to see if it's available.
 
-###### Source code
+## Source code
 
 `git clone` the [p4-fusion repository](https://github/salesforce/p4-fusion) or download a zip archive of the source. Or do the same on your chosen fork/branch.
 
-###### Setup
+## Setup
 
 1. Set the `OPENSSL_ROOT_DIR` environment variable to point to the OpenSSL install location - the directory that contains OpenSSL's `bin`, `include`, and `lib` directories.
 
-Note that we're building with dynamic linking, so the OpenSSL libraries need to stay there for `p4-fusion` to be able to run.
+    Note that we're building with dynamic linking, so the OpenSSL libraries need to stay there for `p4-fusion` to be able to run.
 You might be able to fiddle with that using `LD_LIBRARY_PATH`, but it's safest to leave them there.
 
-1. Unpack the P4 API archives into the `p4-fusion` source directory tree, into the `vendor/helix-core-api/{OS}` directory, where `{OS}` is either `mac` or `linux`, depending on your OS. You'll need the `include` and `lib` dirs from the P4 API archive.
+2. Unpack the P4 API archives into the `p4-fusion` source directory tree, into the `vendor/helix-core-api/{OS}` directory, where `{OS}` is either `mac` or `linux`, depending on your OS. You'll need the `include` and `lib` dirs from the P4 API archive.
 
-###### Build
+## Build
 
 Now that everything is in place, from within the `p4-fusion` source directory, run the following:
 
@@ -107,11 +107,13 @@ Now that everything is in place, from within the `p4-fusion` source directory, r
 ./build.sh
 ```
 
-###### Use
+## Use
 
-If it all worked out as planned, the executable will be in `build/p4-fusion/p4-fusion`. Use it there, or copy it to somewhere in your `PATH`.
+If it all worked out as planned, the executable will be `${PWD}/build/p4-fusion/p4-fusion`. Use it there, or copy it to somewhere in your `PATH`.
 
-###### Examples
+## Examples
+
+### macOS
 
 Here's a sample shell script for macOS that follows all of the steps outlined above to build a Debug binary of the `p4-fusion` `1.12` release using OpenSSL 3.0.8 and the `22.2` P4 API.
 
@@ -140,6 +142,7 @@ rm -rf p4api-2022.2.2407422
 ls -l "${PWD}/build/p4-fusion/p4-fusion"
 ```
 
+### Linux
 
 Here's a sample shell script for Debian with OpenSSL 3.0.8.
 Debian 11 installs with OpenSSL 1.1, so make OpenSSL 3.0.8 from source (which takes awhile).


### PR DESCRIPTION
Add to the Nix instructions so that manual builds of `p4-fusion` are documented



## Test plan

Docs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
