### PR TITLE
adds `extensionDetails` to `public_argument` on JetBrains Logger

### DIFF
--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -44,15 +44,22 @@ function logEvent(eventVariable: Event): void {
 
 let eventId = 1
 
+const EXTENSION_DETAILS = { ide: 'JetBrains', ideExtensionType: 'Sourcegraph' }
 // Event Logger for the JetBrains Extension
 export class EventLogger implements TelemetryService {
     private readonly anonymousUserId: string
     private listeners: Set<(eventName: string) => void> = new Set()
+    // this is redudant with the extensionDetails object, but we need to keep it for backwards compatibility
     private readonly editorInfo: { editor: string; version: string }
+    private extensionDetails: { ide: string; ideExtensionType: string; ideExtensionVersion: string }
 
     constructor(anonymousUserId: string, editorInfo: { editor: string; version: string }) {
         this.anonymousUserId = anonymousUserId
         this.editorInfo = editorInfo
+        this.extensionDetails = {
+            ...EXTENSION_DETAILS,
+            ideExtensionVersion: editorInfo.version,
+        }
     }
 
     /**
@@ -88,8 +95,8 @@ export class EventLogger implements TelemetryService {
     ): void {
         this.tracker(
             eventName,
-            { ...eventProperties, ...this.editorInfo },
-            { ...publicArgument, ...this.editorInfo },
+            { ...eventProperties, ...this.editorInfo, ...this.extensionDetails },
+            { ...publicArgument, ...this.editorInfo, ...this.extensionDetails },
             uri
         )
     }

--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -51,14 +51,13 @@ export class EventLogger implements TelemetryService {
     private listeners: Set<(eventName: string) => void> = new Set()
     // this is redudant with the extensionDetails object, but we need to keep it for backwards compatibility
     private readonly editorInfo: { editor: string; version: string }
-    private extensionDetails: { ide: string; ideExtensionType: string; ideExtensionVersion: string }
+    private extensionDetails: { ide: string; ideExtensionType: string }
 
     constructor(anonymousUserId: string, editorInfo: { editor: string; version: string }) {
         this.anonymousUserId = anonymousUserId
         this.editorInfo = editorInfo
         this.extensionDetails = {
             ...EXTENSION_DETAILS,
-            ideExtensionVersion: editorInfo.version,
         }
     }
 


### PR DESCRIPTION
adds `extensionDetails` as an arg to public_arguments and `event_properties`. Mimics the changes made here on Cody EventLogger:
- https://github.com/sourcegraph/sourcegraph/pull/50671#event-9029992611
## Test plan
TBD