### PR TITLE
Remove Cody CTA from home page and closes #51319

### DIFF
--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -104,24 +104,6 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                                 </Text>
                             </div>
                         )}
-                        {window.context?.codyEnabled && (
-                            <div className="d-flex justify-content-center mt-4">
-                                <Text className="text-muted">
-                                    <Badge variant="merged">Experimental</Badge>{' '}
-                                    <Link
-                                        to="/search/cody"
-                                        onClick={() =>
-                                            telemetryService.log('ClickedOnTryCodySearchCTA', {
-                                                location: 'SearchPage',
-                                            })
-                                        }
-                                    >
-                                        Ask Cody to construct a query from natural language <CodyIcon />{' '}
-                                        <Icon svgPath={mdiArrowRight} aria-hidden={true} />
-                                    </Link>
-                                </Text>
-                            </div>
-                        )}
                     </>
                 )}
             </div>


### PR DESCRIPTION
Remove the experimental "Ask Cody to construct a query from natural language" prompt on the .com homepage.
Related to:
- #51319

<img width="1113" alt="Screenshot 2023-05-01 at 6 17 16 PM" src="https://user-images.githubusercontent.com/64257673/235532976-831a5818-640a-402b-8c33-995c882b5c64.png">

## Test plan
- Check that the CTA is not visible on the home page.