### PR TITLE
Embeddings: allow max embedding counts to be configurable

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -62,10 +62,12 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	excludedGlobPatterns = append(excludedGlobPatterns, embed.CompileGlobPatterns(config.ExcludedFilePathPatterns)...)
 
 	opts := embed.EmbedRepoOpts{
-		RepoName:        repo.Name,
-		Revision:        record.Revision,
-		ExcludePatterns: excludedGlobPatterns,
-		SplitOptions:    splitOptions,
+		RepoName:          repo.Name,
+		Revision:          record.Revision,
+		ExcludePatterns:   excludedGlobPatterns,
+		SplitOptions:      splitOptions,
+		MaxCodeEmbeddings: embed.MAX_CODE_EMBEDDING_VECTORS,
+		MaxTextEmbeddings: embed.MAX_TEXT_EMBEDDING_VECTORS,
 	}
 
 	repoEmbeddingIndex, stats, err := embed.EmbedRepo(

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -61,15 +61,19 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	excludedGlobPatterns := embed.GetDefaultExcludedFilePathPatterns()
 	excludedGlobPatterns = append(excludedGlobPatterns, embed.CompileGlobPatterns(config.ExcludedFilePathPatterns)...)
 
+	opts := embed.EmbedRepoOpts{
+		RepoName:        repo.Name,
+		Revision:        record.Revision,
+		ExcludePatterns: excludedGlobPatterns,
+		SplitOptions:    splitOptions,
+	}
+
 	repoEmbeddingIndex, stats, err := embed.EmbedRepo(
 		ctx,
-		repo.Name,
-		record.Revision,
-		excludedGlobPatterns,
 		embeddingsClient,
-		splitOptions,
 		fetcher,
 		getDocumentRanks,
+		opts,
 	)
 	if err != nil {
 		return err

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -14,8 +14,6 @@ import (
 )
 
 const GET_EMBEDDINGS_MAX_RETRIES = 5
-const MAX_CODE_EMBEDDING_VECTORS = 3_072_000
-const MAX_TEXT_EMBEDDING_VECTORS = 512_000
 
 const EMBEDDING_BATCHES = 5
 const EMBEDDING_BATCH_SIZE = 512
@@ -55,12 +53,12 @@ func EmbedRepo(
 		return nil, nil, err
 	}
 
-	codeIndex, codeIndexStats, err := embedFiles(ctx, codeFileNames, client, opts.ExcludePatterns, opts.SplitOptions, readLister, MAX_CODE_EMBEDDING_VECTORS, ranks)
+	codeIndex, codeIndexStats, err := embedFiles(ctx, codeFileNames, client, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxCodeEmbeddings, ranks)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	textIndex, textIndexStats, err := embedFiles(ctx, textFileNames, client, opts.ExcludePatterns, opts.SplitOptions, readLister, MAX_TEXT_EMBEDDING_VECTORS, ranks)
+	textIndex, textIndexStats, err := embedFiles(ctx, textFileNames, client, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxTextEmbeddings, ranks)
 	if err != nil {
 		return nil, nil, err
 

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -84,10 +84,12 @@ func EmbedRepo(
 }
 
 type EmbedRepoOpts struct {
-	RepoName        api.RepoName
-	Revision        api.CommitID
-	ExcludePatterns []*paths.GlobPattern
-	SplitOptions    split.SplitOptions
+	RepoName          api.RepoName
+	Revision          api.CommitID
+	ExcludePatterns   []*paths.GlobPattern
+	SplitOptions      split.SplitOptions
+	MaxCodeEmbeddings int
+	MaxTextEmbeddings int
 }
 
 // embedFiles embeds file contents from the given file names. Since embedding models can only handle a certain amount of text (tokens) we cannot embed

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -162,7 +162,7 @@ func embedFiles(
 	)
 	for _, file := range files {
 		// This is a fail-safe measure to prevent producing an extremely large index for large repositories.
-		if len(index.RowMetadata) >= maxEmbeddingVectors {
+		if statsEmbeddedChunkCount >= maxEmbeddingVectors {
 			statsSkipped.Add(SkipReasonMaxEmbeddings, int(file.Size))
 			continue
 		}

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -102,10 +102,12 @@ func TestEmbedRepo(t *testing.T) {
 	excludedGlobPatterns := GetDefaultExcludedFilePathPatterns()
 
 	opts := EmbedRepoOpts{
-		RepoName:        repoName,
-		Revision:        revision,
-		ExcludePatterns: excludedGlobPatterns,
-		SplitOptions:    splitOptions,
+		RepoName:          repoName,
+		Revision:          revision,
+		ExcludePatterns:   excludedGlobPatterns,
+		SplitOptions:      splitOptions,
+		MaxCodeEmbeddings: 100000,
+		MaxTextEmbeddings: 100000,
 	}
 
 	t.Run("no files", func(t *testing.T) {

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -236,6 +236,21 @@ func TestEmbedRepo(t *testing.T) {
 		stats.TextIndexStats.Duration = 0
 		require.Equal(t, expectedStats, stats)
 	})
+
+	t.Run("embeddings limited", func(t *testing.T) {
+		optsCopy := opts
+		optsCopy.MaxCodeEmbeddings = 3
+		optsCopy.MaxTextEmbeddings = 1
+
+		rl := newReadLister("a.go", "b.md", "c.java", "autogen.py", "empty.rb", "lines_too_long.c", "binary.bin")
+		index, _, err := EmbedRepo(ctx, client, rl, getDocumentRanks, optsCopy)
+		require.NoError(t, err)
+
+		// a.md has 2 chunks, c.java has 3 chunks
+		require.Len(t, index.CodeIndex.Embeddings, index.CodeIndex.ColumnDimension*5)
+		// b.md has 2 chunks
+		require.Len(t, index.TextIndex.Embeddings, index.CodeIndex.ColumnDimension*2)
+	})
 }
 
 func NewMockEmbeddingsClient() EmbeddingsClient {

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -101,8 +101,15 @@ func TestEmbedRepo(t *testing.T) {
 
 	excludedGlobPatterns := GetDefaultExcludedFilePathPatterns()
 
+	opts := EmbedRepoOpts{
+		RepoName:        repoName,
+		Revision:        revision,
+		ExcludePatterns: excludedGlobPatterns,
+		SplitOptions:    splitOptions,
+	}
+
 	t.Run("no files", func(t *testing.T) {
-		index, stats, err := EmbedRepo(ctx, repoName, revision, excludedGlobPatterns, client, splitOptions, newReadLister(), getDocumentRanks)
+		index, stats, err := EmbedRepo(ctx, client, newReadLister(), getDocumentRanks, opts)
 		require.NoError(t, err)
 		require.Len(t, index.CodeIndex.Embeddings, 0)
 		require.Len(t, index.TextIndex.Embeddings, 0)
@@ -126,7 +133,7 @@ func TestEmbedRepo(t *testing.T) {
 	})
 
 	t.Run("code files only", func(t *testing.T) {
-		index, stats, err := EmbedRepo(ctx, repoName, revision, excludedGlobPatterns, client, splitOptions, newReadLister("a.go"), getDocumentRanks)
+		index, stats, err := EmbedRepo(ctx, client, newReadLister("a.go"), getDocumentRanks, opts)
 		require.NoError(t, err)
 		require.Len(t, index.TextIndex.Embeddings, 0)
 		require.Len(t, index.CodeIndex.Embeddings, 6)
@@ -155,7 +162,7 @@ func TestEmbedRepo(t *testing.T) {
 	})
 
 	t.Run("text files only", func(t *testing.T) {
-		index, stats, err := EmbedRepo(ctx, repoName, revision, excludedGlobPatterns, client, splitOptions, newReadLister("b.md"), getDocumentRanks)
+		index, stats, err := EmbedRepo(ctx, client, newReadLister("b.md"), getDocumentRanks, opts)
 		require.NoError(t, err)
 		require.Len(t, index.CodeIndex.Embeddings, 0)
 		require.Len(t, index.TextIndex.Embeddings, 6)
@@ -185,7 +192,7 @@ func TestEmbedRepo(t *testing.T) {
 
 	t.Run("mixed code and text files", func(t *testing.T) {
 		rl := newReadLister("a.go", "b.md", "c.java", "autogen.py", "empty.rb", "lines_too_long.c", "binary.bin")
-		index, stats, err := EmbedRepo(ctx, repoName, revision, excludedGlobPatterns, client, splitOptions, rl, getDocumentRanks)
+		index, stats, err := EmbedRepo(ctx, client, rl, getDocumentRanks, opts)
 		require.NoError(t, err)
 		require.Len(t, index.CodeIndex.Embeddings, 15)
 		require.Len(t, index.CodeIndex.RowMetadata, 5)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -608,6 +608,10 @@ type Embeddings struct {
 	Enabled bool `json:"enabled"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
+	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
+	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`
+	// MaxTextEmbeddingsPerRepo description: The maximum number of embeddings for text files to generate per repo
+	MaxTextEmbeddingsPerRepo int `json:"maxTextEmbeddingsPerRepo,omitempty"`
 	// Model description: The model used for embedding.
 	Model string `json:"model"`
 	// Url description: The url to the external embedding API service.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2057,6 +2057,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "maxCodeEmbeddingsPerRepo": {
+          "description": "The maximum number of embeddings for code files to generate per repo",
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxTextEmbeddingsPerRepo": {
+          "description": "The maximum number of embeddings for text files to generate per repo",
+          "type": "integer",
+          "minimum": 0
         }
       }
     },


### PR DESCRIPTION
This adds the `maxCodeEmbeddingsPerRepo` and `maxTextEmbeddingsPerRepo` config options to our embeddings config. This will allow us to adjust the max to support larger monorepos without pushing a new patch release.

## Test plan

Added a test, manually tested that the stats we spit out reflect what I'd expect.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
