### PR TITLE
5.0: manually fix backend integration tests

### DIFF
--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -46,8 +46,8 @@ func TestSiteAdminEndpoints(t *testing.T) {
 				}
 				defer func() { _ = resp.Body.Close() }()
 
-				if resp.StatusCode != http.StatusUnauthorized {
-					t.Fatalf(`Want status code %d error but got %d`, http.StatusUnauthorized, resp.StatusCode)
+				if resp.StatusCode != http.StatusForbidden {
+					t.Fatalf(`Want status code %d error but got %d`, http.StatusForbidden, resp.StatusCode)
 				}
 			})
 		}


### PR DESCRIPTION
This is in a funny situation that a [backported commit](https://github.com/sourcegraph/sourcegraph/commit/bffe76953782fca6e4ddfdf48f2c201aae8b7e5e) got reverted in `main` but the re-attempt can't be merged in because [CI refuses to start backend integration test dry-run](https://sourcegraph.slack.com/archives/C07KZF47K/p1682952741367899). 😂 

So manually port the [fix](https://github.com/sourcegraph/sourcegraph/pull/51331/files#diff-8e131337736d5def881b5a3a6ffee82dca23198d1e573f2ddb9605fc3a67506c) here to unblock the release process.

## Test plan

CI
