### PR TITLE
bzl: add missing img folder to ent assets

### DIFF
--- a/ui/assets/enterprise/BUILD.bazel
+++ b/ui/assets/enterprise/BUILD.bazel
@@ -23,5 +23,6 @@ copy_to_directory(
     out = "dist",
     replace_prefixes = {
         "client/web/bundle-enterprise": "",
+        "ui/assets/img": "img",
     },
 )


### PR DESCRIPTION
Problem was the enterprise assets rules didn't rename properly the img folder.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
$ bazel build //ui/assets/enterprise:copy_bundle
# bla blah 
$ ls bazel-bin/ui/assets/enterprise/dist/img 
# stuff is there, all good 
```

