### PR TITLE
nix: only set USE_BAZEL_VERSION on linux

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -153,5 +153,6 @@ pkgs.mkShell {
   # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
   # so we tell it to h*ck off here.
   # https://sourcegraph.com/github.com/bazelbuild/bazel@1a4da7f331c753c92e2c91efcad434dc29d10d43/-/blob/scripts/packages/bazel.sh?L23-28
-  USE_BAZEL_VERSION = pkgs.bazel_6.version;
+  USE_BAZEL_VERSION =
+    if pkgs.hostPlatform.isMacOS then "" else pkgs.bazel_6.version;
 }


### PR DESCRIPTION
Setting it broke bazel on darwin for me.

Test Plan: ran "bazel test //cmd/frontend/internal/search:search_test"