### PR TITLE
Cody completions: Add metrics for completion events

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 ### Added
 
 - Adds usage metrics to the experimental completions feature [pull/51350](https://github.com/sourcegraph/sourcegraph/pull/51350)
-
 - Updating `cody.codebase` does not require reloading VS Code
 
 ### Fixed

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Added
 
+- Adds usage metrics to the experimental completions feature [pull/51350](https://github.com/sourcegraph/sourcegraph/pull/51350)
+
 ### Fixed
 
 - Fixes an issue where code blocks were unexpectedly escaped [pull/51247](https://github.com/sourcegraph/sourcegraph/pull/51247)

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -11,7 +11,7 @@ import { History } from './history'
 import { CompletionProvider, EndOfLineCompletionProvider, MultilineCompletionProvider } from './provider'
 
 const LOG_INLINE = { type: 'inline' }
-const LOG_MULTILINE = { type: 'inline' }
+const LOG_MULTILINE = { type: 'multiline' }
 
 function lastNLines(text: string, n: number): string {
     const lines = text.split('\n')

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -2,11 +2,16 @@ import * as vscode from 'vscode'
 
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
+import { logEvent } from '../event-logger'
+
 import { CompletionsCache } from './cache'
 import { getContext } from './context'
 import { CompletionsDocumentProvider } from './docprovider'
 import { History } from './history'
 import { CompletionProvider, EndOfLineCompletionProvider, MultilineCompletionProvider } from './provider'
+
+const LOG_INLINE = { type: 'inline' }
+const LOG_MULTILINE = { type: 'inline' }
 
 function lastNLines(text: string, n: number): string {
     const lines = text.split('\n')
@@ -90,7 +95,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         const cachedCompletions = inlineCompletionsCache.get(prefix)
         if (cachedCompletions) {
-            return cachedCompletions.map(r => new vscode.InlineCompletionItem(r.content))
+            return cachedCompletions.map(toInlineCompletionItem)
         }
 
         const remainingChars = this.tokToChar(this.promptTokens)
@@ -174,11 +179,15 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
+        logEvent('CodyVSCodeExtension:completion:started', LOG_INLINE, LOG_INLINE)
+
         const results = (await Promise.all(completers.map(c => c.generateCompletions(abortController.signal)))).flat()
 
         inlineCompletionsCache.add(results)
 
-        return results.map(r => new vscode.InlineCompletionItem(r.content))
+        logEvent('CodyVSCodeExtension:completion:suggested', LOG_INLINE, LOG_INLINE)
+
+        return results.map(toInlineCompletionItem)
     }
 
     public async fetchAndShowCompletions(): Promise<void> {
@@ -247,12 +256,14 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         )
 
         try {
+            logEvent('CodyVSCodeExtension:completion:started', LOG_MULTILINE, LOG_MULTILINE)
             const completions = await completer.generateCompletions(abortController.signal, 3)
             this.documentProvider.addCompletions(completionsUri, ext, completions, {
                 suffix: '',
                 elapsedMillis: 0,
                 llmOptions: null,
             })
+            logEvent('CodyVSCodeExtension:completion:suggested', LOG_MULTILINE, LOG_MULTILINE)
         } catch (error) {
             if (error.message === 'aborted') {
                 return
@@ -347,4 +358,11 @@ export interface Completion {
     prompt: string
     content: string
     stopReason?: string
+}
+
+function toInlineCompletionItem(completion: Completion): vscode.InlineCompletionItem {
+    return new vscode.InlineCompletionItem(completion.content, undefined, {
+        title: 'Completion accepted',
+        command: 'cody.completions.inline.accepted',
+    })
 }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -205,6 +205,12 @@ const register = async (
             vscode.commands.registerCommand('cody.experimental.suggest', async () => {
                 await completionsProvider.fetchAndShowCompletions()
             }),
+            vscode.commands.registerCommand('cody.completions.inline.accepted', (...args) => {
+                const params = {
+                    type: 'inline',
+                }
+                logEvent('CodyVSCodeExtension:completion:accepted', params, params)
+            }),
             vscode.languages.registerInlineCompletionItemProvider({ scheme: 'file' }, completionsProvider)
         )
     }


### PR DESCRIPTION
Closes #51347 

This adds metrics for inline and multiline suggestions so we can know how often we trigger requests, how often they are presented to our users, and what the acceptance rate is (note: acceptance rate doesn't work for multiline suggestions yet as we only allow copy-pasting for this and don't have a distinct UI action for accepting)

## New events added:

- `CodyVSCodeExtension:completion:started` (`type: 'inline' | 'multiline'`)
  - Measure when we start a request to the backend for new suggestions (and in turn hit the LLM APIs). I wanted to add this so we can calculate how often these are aborted.
- `CodyVSCodeExtension:completion:suggested` (`type: 'inline' | 'multiline'`)
  - Measures when we receive a result from the backend and are displaying those to the user (Note: VS Code does not always present inline suggestions to the user, even if this event fires. We'll have to investigate why that's the case and make sure we don't start a completion unless they will be shown).
- `CodyVSCodeExtension:completion:accepted` (`type: 'inline'`)
  - Measures how often completions are inserted. 

## Open question: Logging completion on/off (cc @malomarrec)

It's not clear yet how we can measure total number of people that have suggestions enabled (changing the setting for this is not a discrete event since it can happen outside of our control). We could include the state of the feature flag in other Cody related pings but I really think given the occurence of inline completions, these will swiftly become the most-frequently-used Cody feature (when enabled). This leads me to believe that we should calculate DAUs based on the presence of an inline suggestion event.

## Test plan

- Add a console.log to the logging code so we can visualize logged events in the console
- https://user-images.githubusercontent.com/458591/235658549-779b1b4f-0603-49fe-9b47-3ca94a7393ab.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
