### PR TITLE
llm-proxy: response error in JSON format

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,7 +23,7 @@ import (
 )
 
 func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFunc, config *Config) error {
-	handler := newHandler(config)
+	handler := newHandler(obctx.Logger, config)
 	handler = trace.HTTPMiddleware(obctx.Logger, handler, conf.DefaultClient())
 	handler = instrumentation.HTTPMiddleware("", handler)
 	handler = actor.HTTPMiddleware(obctx.Logger, handler)
@@ -42,7 +43,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	return nil
 }
 
-func newHandler(config *Config) http.Handler {
+func newHandler(logger log.Logger, config *Config) http.Handler {
 	r := mux.NewRouter()
 	s := r.PathPrefix("/v1").Subrouter()
 
@@ -51,7 +52,12 @@ func newHandler(config *Config) http.Handler {
 			r, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/complete", r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "failed to create request: %s"}`, err)))
+				err = json.NewEncoder(w).Encode(map[string]string{
+					"error": fmt.Sprintf("failed to create request: %s", err),
+				})
+				if err != nil {
+					logger.Error("failed to write response", log.Error(err))
+				}
 				return
 			}
 
@@ -66,7 +72,12 @@ func newHandler(config *Config) http.Handler {
 			resp, err := httpcli.ExternalDoer.Do(r)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "failed to make request to Anthropic: %s"}`, err)))
+				err = json.NewEncoder(w).Encode(map[string]string{
+					"error": fmt.Sprintf("failed to make request to Anthropic: %s", err),
+				})
+				if err != nil {
+					logger.Error("failed to write response", log.Error(err))
+				}
 				return
 			}
 			defer func() { _ = resp.Body.Close() }()

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -51,7 +51,7 @@ func newHandler(config *Config) http.Handler {
 			r, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/complete", r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("failed to create request: %s", err)))
+				_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "failed to create request: %s"}`, err)))
 				return
 			}
 
@@ -66,12 +66,12 @@ func newHandler(config *Config) http.Handler {
 			resp, err := httpcli.ExternalDoer.Do(r)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
-				w.Write([]byte(fmt.Sprintf("failed to make request to Anthropic: %s", err)))
+				_, _ = w.Write([]byte(fmt.Sprintf(`{"error": "failed to make request to Anthropic: %s"}`, err)))
 				return
 			}
 			defer func() { _ = resp.Body.Close() }()
 
-			io.Copy(w, resp.Body)
+			_, _ = io.Copy(w, resp.Body)
 		}),
 	).Methods(http.MethodPost)
 	return r


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/51226#discussion_r1182231135. The client asks for JSON response and we should respect that.

## Test plan

CI
