### PR TITLE
bzl: use our buildkite aspect-cli plugin to annotate failures 

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -10,3 +10,6 @@ plugins:
   - name: buildkite
     version: v0.0.1
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
+    properties:
+    #   pretend: false
+      buildkite_agent_path: "/usr/local/bin/buildkite-agent"

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,8 +8,5 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: v0.0.4
+    version: v0.0.5
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
-    # properties:
-    #   # pretend: true
-    #   buildkite_agent_path: "/usr/local/bin/buildkite-agent"

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,8 +8,8 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: v0.0.1
+    version: v0.0.2
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
-      pretend: true
+      # pretend: true
       buildkite_agent_path: "/usr/local/bin/buildkite-agent"

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -11,5 +11,5 @@ plugins:
     version: v0.0.1
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
-    #   pretend: false
+      pretend: true
       buildkite_agent_path: "/usr/local/bin/buildkite-agent"

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,7 +8,7 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: v0.0.2
+    version: v0.0.3
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
       # pretend: true

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -7,3 +7,6 @@ plugins:
   - name: fix-visibility
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
+  - name: buildkite
+    version: v0.0.1
+    from: github.com/sourcegraph/aspect-cli-plugin-buildkite

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,8 +8,8 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: v0.0.3
+    version: v0.0.4
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
-    properties:
-      # pretend: true
-      buildkite_agent_path: "/usr/local/bin/buildkite-agent"
+    # properties:
+    #   # pretend: true
+    #   buildkite_agent_path: "/usr/local/bin/buildkite-agent"

--- a/dev/bkstats/main.go
+++ b/dev/bkstats/main.go
@@ -22,6 +22,7 @@ var shortDateFormat = "2006-01-02"
 var longDateFormat = "2006-01-02 15:04 (MST)"
 
 func init() {
+	wfpwfpw
 	flag.StringVar(&token, "buildkite.token", "", "mandatory buildkite token")
 	flag.StringVar(&date, "date", "", "date for builds")
 	flag.StringVar(&pipeline, "buildkite.pipeline", "sourcegraph", "name of the pipeline to inspect")

--- a/dev/buildchecker/branch.go
+++ b/dev/buildchecker/branch.go
@@ -25,6 +25,7 @@ type repoBranchLocker struct {
 }
 
 func NewBranchLocker(ghc *github.Client, owner, repo, branch string) BranchLocker {
+	fefefefefef
 	return &repoBranchLocker{
 		ghc:    ghc,
 		owner:  owner,

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -16,6 +16,8 @@ func testSG() *cli.App {
 }
 
 func TestAppRun(t *testing.T) {
+	t.Fail()
+	wfpwfp
 	sg := testSG()
 
 	// Capture output

--- a/dev/sg/main_test.go
+++ b/dev/sg/main_test.go
@@ -17,7 +17,6 @@ func testSG() *cli.App {
 
 func TestAppRun(t *testing.T) {
 	t.Fail()
-	wfpwfp
 	sg := testSG()
 
 	// Capture output


### PR DESCRIPTION
This introduces https://github.com/sourcegraph/aspect-cli-plugin-buildkite which only runs in Buildkite, and produces annotations when stuff is failing. It's a bit rough at the moment, but it does the job. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="1165" alt="CleanShot 2023-05-02 at 15 02 16@2x" src="https://user-images.githubusercontent.com/10151/235674059-d9a8b63c-a99d-4a4d-bc64-e1f793dc12b9.png">
