### PR TITLE
batches: upade doc string for OrgsAllMembersBatchChangesAdmin

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2026,7 +2026,7 @@ type Settings struct {
 	Notices []*Notice `json:"notices,omitempty"`
 	// OpenInEditor description: Group of settings related to opening files in an editor.
 	OpenInEditor *SettingsOpenInEditor `json:"openInEditor,omitempty"`
-	// OrgsAllMembersBatchChangesAdmin description: Enables/Disables org-level admin access for Batch Changes to all members of an org
+	// OrgsAllMembersBatchChangesAdmin description: If enabled, all members of the org will be treated as admins (e.g. can edit, apply, delete) for all batch changes created in that org.
 	OrgsAllMembersBatchChangesAdmin *bool `json:"orgs.allMembersBatchChangesAdmin,omitempty"`
 	// PerforceCodeHostToSwarmMap description: Key-value pairs of code host URLs to Swarm URLs. Keys should have no prefix and should not end with a slash, like "perforce.company.com:1666". Values should look like "https://swarm.company.com/", with a slash at the end.
 	PerforceCodeHostToSwarmMap map[string]string `json:"perforce.codeHostToSwarmMap,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -510,7 +510,7 @@
       "default": {}
     },
     "orgs.allMembersBatchChangesAdmin": {
-      "description": "Enables/Disables org-level admin access for Batch Changes to all members of an org",
+      "description": "If enabled, all members of the org will be treated as admins (e.g. can edit, apply, delete) for all batch changes created in that org.",
       "type": "boolean",
       "default": false,
       "!go": {


### PR DESCRIPTION
Before merging #50604 I accepted a couple of suggestions from @courier-new, but while rebasing I force-pushed changes that didn't include the suggestions.
They were pretty great updates to the doc string for the `OrgsAllMembersBatchChangesAdmin` settings so I just had to bring them back.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Doc string update.