### PR TITLE
drift: be more lenient in -version flag

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -822,7 +822,7 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--file="<value>"`: The target schema description file.
 * `--skip-version-check`: Skip validation of the instance's current version.
-* `--version="<value>"`: The target schema version. Must be resolvable as a git revlike on the Sourcegraph repository.
+* `--version="<value>"`: The target schema version. Can be a version (e.g. 5.0.2) or resolvable as a git revlike on the Sourcegraph repository (e.g. a branch, tag or commit hash).
 
 ### sg migration add-log
 

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -22,9 +22,8 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		Required: true,
 	}
 	versionFlag := &cli.StringFlag{
-		Name: "version",
-		Usage: "The target schema version. Must be resolvable as a git revlike  on the Sourcegraph repository." +
-			" Will be inferred from the instance if -skip-version-check is not also passed.",
+		Name:     "version",
+		Usage:    "The target schema version. Must be resolvable as a git revlike  on the Sourcegraph repository.",
 		Required: false,
 	}
 	fileFlag := &cli.StringFlag{
@@ -77,11 +76,9 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 			if version == "" {
 				version = inferred.GitTagWithPatch(patch)
 				out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "Checking drift against version %q", version))
-			} else {
-				if version != inferred.GitTagWithPatch(patch) {
-					err := fmt.Sprintf("version assertion failed: %q != %q", inferred, version)
-					return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
-				}
+			} else if version != inferred.GitTagWithPatch(patch) {
+				err := fmt.Sprintf("version assertion failed: %q != %q", inferred, version)
+				return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
 			}
 		} else if version == "" && file == "" {
 			return errors.New("-skip-version-check was supplied without -version or -file")

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -59,7 +59,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 
 		parsedVersion, patch, ok := oobmigration.NewVersionAndPatchFromString(version)
 		// if not parsable into a structured version, then it may be a revhash
-		if ok {
+		if ok && parsedVersion.GitTagWithPatch(patch) != version {
 			out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleGrey, "Parsed %q from version flag value %q", parsedVersion.GitTagWithPatch(patch), version))
 			version = parsedVersion.GitTagWithPatch(patch)
 		}

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -22,8 +22,9 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		Required: true,
 	}
 	versionFlag := &cli.StringFlag{
-		Name:     "version",
-		Usage:    "The target schema version. Must be resolvable as a git revlike  on the Sourcegraph repository.",
+		Name: "version",
+		Usage: "The target schema version. Can be a version (e.g. 5.0.2) or resolvable as a git revlike on the Sourcegraph repository " +
+			"(e.g. a branch, tag or commit hash).",
 		Required: false,
 	}
 	fileFlag := &cli.StringFlag{

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -60,7 +60,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		parsedVersion, patch, ok := oobmigration.NewVersionAndPatchFromString(version)
 		// if not parsable into a structured version, then it may be a revhash
 		if ok {
-			out.VerboseLine(output.Linef(output.EmojiLightbulb, output.StyleGrey, "Parsed %q from version flag value %q", parsedVersion.GitTagWithPatch(patch), version))
+			out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleGrey, "Parsed %q from version flag value %q", parsedVersion.GitTagWithPatch(patch), version))
 			version = parsedVersion.GitTagWithPatch(patch)
 		}
 

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -21,8 +22,9 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		Required: true,
 	}
 	versionFlag := &cli.StringFlag{
-		Name:     "version",
-		Usage:    "The target schema version. Must be resolvable as a git revlike on the Sourcegraph repository.",
+		Name: "version",
+		Usage: "The target schema version. Must be resolvable as a git revlike  on the Sourcegraph repository." +
+			" Will be inferred from the instance if -skip-version-check is not also passed.",
 		Required: false,
 	}
 	fileFlag := &cli.StringFlag{
@@ -55,33 +57,31 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 			return errors.New("the flags -version or -file are mutually exclusive")
 		}
 
-		// Note: Error is correctly checked here; we want to use the return value
-		// `patch` below but only if we can best-effort fetch it. We want to allow
-		// the user to skip erroring here if they are explicitly skipping this
-		// version check.
-		inferredVersion, ok, err := func() (string, bool, error) {
-			v, patch, ok, err := GetServiceVersion(ctx, r)
-			if err != nil || !ok {
-				return "", false, err
-			}
+		parsedVersion, patch, ok := oobmigration.NewVersionAndPatchFromString(version)
+		// if not parsable into a structured version, then it may be a revhash
+		if ok {
+			out.VerboseLine(output.Linef(output.EmojiLightbulb, output.StyleGrey, "Parsed %q from version flag value %q", parsedVersion.GitTagWithPatch(patch), version))
+			version = parsedVersion.GitTagWithPatch(patch)
+		}
 
-			return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, patch), true, nil
-		}()
 		if !skipVersionCheck {
+			inferred, patch, ok, err := GetServiceVersion(ctx, r)
 			if err != nil {
 				return err
 			}
 			if !ok {
-				err := errors.Newf("version assertion failed: unknown version != %q", version)
+				err := fmt.Sprintf("version assertion failed: unknown version != %q", version)
 				return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
 			}
 
 			if version == "" {
-				version = inferredVersion
+				version = inferred.GitTagWithPatch(patch)
 				out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "Checking drift against version %q", version))
-			} else if version != inferredVersion {
-				err := errors.Newf("version assertion failed: %q != %q", inferredVersion, version)
-				return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
+			} else {
+				if version != inferred.GitTagWithPatch(patch) {
+					err := fmt.Sprintf("version assertion failed: %q != %q", inferred, version)
+					return errors.Newf("%s. Re-invoke with --skip-version-check to ignore this check", err)
+				}
 			}
 		} else if version == "" && file == "" {
 			return errors.New("-skip-version-check was supplied without -version or -file")


### PR DESCRIPTION
Allows for values to the `-version` flag on the `drift` command to also include version specifiers similar to the `up/upgrade` commands, instead of a hard requirement on them being git resolvables (aka we use `v` prefixes in the git repo, so v5.0.2 had to be specified, but now the `v` can be excluded)

## Test plan

Tested by @DaedalusG on a call, see results below 