### PR TITLE
bazel: run gazelle and add keeps for backwards compat

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -1518,12 +1518,14 @@ def go_dependencies():
         version = "v0.4.13",
     )
     go_repository(
+        # This is no longer used but we keep it for backwards compatability
+        # tests while on 5.0.x.
         name = "com_github_crewjam_saml_samlidp",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/crewjam/saml/samlidp",
         sum = "h1:13Ix7LoUJ0Yu5F+s6Aw8Afc8x+n98RSJNGHpxEbcYus=",
         version = "v0.0.0-20221211125903-d951aa2d145a",
-    )
+    )  # keep
     go_repository(
         name = "com_github_cyphar_filepath_securejoin",
         build_file_proto_mode = "disable_global",
@@ -4332,8 +4334,8 @@ def go_dependencies():
         name = "com_github_klauspost_cpuid_v2",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/klauspost/cpuid/v2",
-        sum = "h1:t0wUqjowdm8ezddV5k0tLWVklVuvLJpoHeb4WBdydm0=",
-        version = "v2.1.1",
+        sum = "h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=",
+        version = "v2.2.4",
     )
 
     go_repository(


### PR DESCRIPTION
This is just running "bazel run :gazelle-update-repos". I added a keep
for the dependencies it removed since according to JH we still need them
around for backwards compatability tests.

Test Plan: bazel test //enterprise/cmd/frontend/internal/auth/saml/...