### PR TITLE
[Backport 5.0] Embeddings: add SIMD search capability

### DIFF
--- a/enterprise/cmd/embeddings/shared/context_detection.go
+++ b/enterprise/cmd/embeddings/shared/context_detection.go
@@ -76,8 +76,8 @@ func isQuerySimilarToNoContextMessages(
 		return false, errors.Wrap(err, "getting query embedding")
 	}
 
-	messagesWithContextSimilarity := embeddings.CosineSimilarityFloat32(contextDetectionEmbeddingIndex.MessagesWithAdditionalContextMeanEmbedding, queryEmbedding)
-	messagesWithoutContextSimilarity := embeddings.CosineSimilarityFloat32(contextDetectionEmbeddingIndex.MessagesWithoutAdditionalContextMeanEmbedding, queryEmbedding)
+	messagesWithContextSimilarity := embeddings.DotFloat32(contextDetectionEmbeddingIndex.MessagesWithAdditionalContextMeanEmbedding, queryEmbedding)
+	messagesWithoutContextSimilarity := embeddings.DotFloat32(contextDetectionEmbeddingIndex.MessagesWithoutAdditionalContextMeanEmbedding, queryEmbedding)
 
 	// We have to be really sure that the query is similar to no context messages, so we include the `MIN_NO_CONTEXT_SIMILARITY_DIFF` threshold.
 	isSimilarToNoContextMessages := (messagesWithoutContextSimilarity - messagesWithContextSimilarity) >= MIN_NO_CONTEXT_SIMILARITY_DIFF

--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -4,6 +4,10 @@ go_library(
     name = "embeddings",
     srcs = [
         "client.go",
+        "dot.go",
+        "dot_amd64.go",
+        "dot_amd64.s",
+        "dot_noamd64.go",
         "index_name.go",
         "index_storage.go",
         "quantize.go",
@@ -27,12 +31,18 @@ go_library(
         "@com_github_sourcegraph_conc//:conc",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_x_sync//errgroup",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:amd64": [
+            "@com_github_klauspost_cpuid_v2//:cpuid",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(
     name = "embeddings_test",
     srcs = [
+        "dot_test.go",
         "index_storage_test.go",
         "similarity_search_test.go",
     ],

--- a/enterprise/internal/embeddings/dot.go
+++ b/enterprise/internal/embeddings/dot.go
@@ -1,0 +1,60 @@
+package embeddings
+
+func Dot(a, b []int8) int32 {
+	if haveArchDot {
+		return archDot(a, b)
+	}
+	return dotPortable(a, b)
+}
+
+func dotPortable(a, b []int8) int32 {
+	similarity := int32(0)
+
+	count := len(a)
+	if count > len(b) {
+		// Do this ahead of time so the compiler doesn't need to bounds check
+		// every time we index into b.
+		panic("mismatched vector lengths")
+	}
+
+	i := 0
+	for ; i+3 < count; i += 4 {
+		m0 := int32(a[i]) * int32(b[i])
+		m1 := int32(a[i+1]) * int32(b[i+1])
+		m2 := int32(a[i+2]) * int32(b[i+2])
+		m3 := int32(a[i+3]) * int32(b[i+3])
+		similarity += (m0 + m1 + m2 + m3)
+	}
+
+	for ; i < count; i++ {
+		similarity += int32(a[i]) * int32(b[i])
+	}
+
+	return similarity
+}
+
+func DotFloat32(row []float32, query []float32) float32 {
+	similarity := float32(0)
+
+	count := len(row)
+	if count > len(query) {
+		// Do this ahead of time so the compiler doesn't need to bounds check
+		// every time we index into query.
+		panic("mismatched vector lengths")
+	}
+
+	i := 0
+	for ; i+3 < count; i += 4 {
+		m0 := row[i] * query[i]
+		m1 := row[i+1] * query[i+1]
+		m2 := row[i+2] * query[i+2]
+		m3 := row[i+3] * query[i+3]
+		similarity += (m0 + m1 + m2 + m3)
+	}
+
+	for ; i < count; i++ {
+		similarity += row[i] * query[i]
+	}
+
+	return similarity
+}

--- a/enterprise/internal/embeddings/dot_amd64.go
+++ b/enterprise/internal/embeddings/dot_amd64.go
@@ -1,0 +1,29 @@
+//go:build amd64
+
+package embeddings
+
+import (
+	"github.com/klauspost/cpuid/v2"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var (
+	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
+	hasAVX2     = cpuid.CPU.Has(cpuid.AVX2)
+	haveArchDot = simdEnabled && hasAVX2
+)
+
+func archDot(a []int8, b []int8) int32 {
+	if len(a) != len(b) {
+		panic("mismatched lengths")
+	}
+
+	if len(a) == 0 {
+		return 0
+	}
+
+	return int32(avx2Dot(a, b))
+}
+
+func avx2Dot(a, b []int8) int64

--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-TEXT ·avx2Dot(SB), NOSPLIT, $0-54
+TEXT ·avx2Dot(SB), NOSPLIT, $0-56
 	MOVQ a_base+0(FP), AX
 	MOVQ b_base+24(FP), BX
 	MOVQ a_len+8(FP), DX

--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -1,0 +1,70 @@
+#include "textflag.h"
+
+TEXT ·avx2Dot(SB), NOSPLIT, $0-54
+	MOVQ a_base+0(FP), AX
+	MOVQ b_base+24(FP), BX
+	MOVQ a_len+8(FP), DX
+
+	XORQ R8, R8 // return sum
+
+	// Zero Y0, which will store 8 packed 32-bit sums
+	VPXOR Y0, Y0, Y0
+
+// In blockloop, we calculate the dot product 16 at a time
+blockloop:
+	CMPQ DX, $16
+	JB reduce
+
+	// Sign-extend 16 bytes into 16 int16s
+	VPMOVSXBW (AX), Y1
+	VPMOVSXBW (BX), Y2
+
+	// Multiply words vertically to form doubleword intermediates,
+	// then add adjacent doublewords.
+	VPMADDWD Y1, Y2, Y1
+
+	// Add results to the running sum
+	VPADDD Y0, Y1, Y0
+
+	ADDQ $16, AX
+	ADDQ $16, BX
+	SUBQ $16, DX
+	JMP blockloop
+
+reduce:
+	// X0 is the low bits of Y0.
+	// Extract the high bits into X1, fold in half, add, repeat.
+	VEXTRACTI128 $1, Y0, X1
+	VPADDD X0, X1, X0
+
+	VPSRLDQ $8, X0, X1
+	VPADDD X0, X1, X0
+
+	VPSRLDQ $4, X0, X1
+	VPADDD X0, X1, X0
+
+	// Store the reduced sum
+	VMOVD X0, R8
+
+// In tailloop, we add to the dot product one at a time
+tailloop:
+	CMPQ DX, $0
+	JE end
+
+	// Load values from the input slices
+	MOVBQSX (AX), R9
+	MOVBQSX (BX), R10
+
+	// Multiply and accumulate
+	IMULQ R9, R10
+	ADDQ R10, R8
+
+	INCQ AX
+	INCQ BX
+	DECQ DX
+	JMP tailloop
+
+end:
+	MOVQ R8, ret+48(FP)
+	RET
+

--- a/enterprise/internal/embeddings/dot_noamd64.go
+++ b/enterprise/internal/embeddings/dot_noamd64.go
@@ -1,0 +1,9 @@
+//go:build !amd64
+
+package embeddings
+
+var haveArchDot = false
+
+func archDot(a, b []int8) int32 {
+	panic("unimplemented")
+}

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -1,0 +1,112 @@
+package embeddings
+
+import (
+	"testing"
+	"testing/quick"
+	"unsafe"
+)
+
+func TestDot(t *testing.T) {
+	t.Run("previously failed", func(t *testing.T) {
+		repeat := func(n int8, size int) []int8 {
+			res := make([]int8, size)
+			for i := 0; i < size; i++ {
+				res[i] = n
+			}
+			return res
+		}
+		cases := []struct {
+			a    []int8
+			b    []int8
+			want int32
+		}{{
+			a:    []int8{1},
+			b:    []int8{1},
+			want: 1,
+		}, {
+			a:    append(repeat(0, 16), 1),
+			b:    append(repeat(0, 16), 2),
+			want: 2,
+		}, {
+			a:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			b:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+			want: 102,
+		}, {
+			a:    repeat(0, 16),
+			b:    repeat(0, 16),
+			want: 0,
+		}, {
+			a:    repeat(0, 16),
+			b:    repeat(1, 16),
+			want: 0,
+		}, {
+			a:    repeat(1, 16),
+			b:    repeat(1, 16),
+			want: 16,
+		}, {
+			a:    repeat(1, 16),
+			b:    repeat(2, 16),
+			want: 32,
+		}, {
+			a:    repeat(1, 17),
+			b:    repeat(1, 17),
+			want: 17,
+		}}
+
+		for _, tc := range cases {
+			t.Run("dot", func(t *testing.T) {
+				got := Dot(tc.a, tc.b)
+				if tc.want != got {
+					t.Fatalf("want: %d, got: %d", tc.want, got)
+				}
+			})
+
+			t.Run("naive", func(t *testing.T) {
+				got := dotPortable(tc.a, tc.b)
+				if tc.want != got {
+					t.Fatalf("want: %d, got: %d", tc.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("quick", func(t *testing.T) {
+		err := quick.Check(func(a, b []int8) bool {
+			if len(a) > len(b) {
+				a = a[:len(b)]
+			} else {
+				b = b[:len(a)]
+			}
+
+			want := dotPortable(a, b)
+			got := Dot(a, b)
+
+			if want != got {
+				t.Fatalf("a: %#v\nb: %#v\ngot: %d\nwant: %d", a, b, got, want)
+			}
+			return want == got
+		}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func FuzzDot(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input1, input2 []byte) {
+		b1 := *(*[]int8)(unsafe.Pointer(&input1))
+		b2 := *(*[]int8)(unsafe.Pointer(&input2))
+
+		if len(b1) > len(b2) {
+			b1 = b1[:len(b2)]
+		} else {
+			b2 = b2[:len(b1)]
+		}
+
+		got := Dot(b1, b2)
+		want := dotPortable(b1, b2)
+		if want != got {
+			t.Fatalf("want: %d, got: %d", want, got)
+		}
+	})
+}

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -169,7 +169,7 @@ const (
 )
 
 func (index *EmbeddingIndex) score(query []int8, i int, opts SearchOptions) (score int32, debugInfo searchDebugInfo) {
-	similarityScore := scoreSimilarityWeight * CosineSimilarity(index.Row(i), query)
+	similarityScore := scoreSimilarityWeight * Dot(index.Row(i), query)
 
 	// handle missing ranks
 	rankScore := int32(0)
@@ -199,58 +199,6 @@ func (i *searchDebugInfo) String() string {
 		return ""
 	}
 	return fmt.Sprintf("score:%d, similarity:%d, rank:%d", i.similarity+i.rank, i.similarity, i.rank)
-}
-
-func CosineSimilarity(row []int8, query []int8) int32 {
-	similarity := int32(0)
-
-	count := len(row)
-	if count > len(query) {
-		// Do this ahead of time so the compiler doesn't need to bounds check
-		// every time we index into query.
-		panic("mismatched vector lengths")
-	}
-
-	i := 0
-	for ; i+3 < count; i += 4 {
-		m0 := int32(row[i]) * int32(query[i])
-		m1 := int32(row[i+1]) * int32(query[i+1])
-		m2 := int32(row[i+2]) * int32(query[i+2])
-		m3 := int32(row[i+3]) * int32(query[i+3])
-		similarity += (m0 + m1 + m2 + m3)
-	}
-
-	for ; i < count; i++ {
-		similarity += int32(row[i]) * int32(query[i])
-	}
-
-	return similarity
-}
-
-func CosineSimilarityFloat32(row []float32, query []float32) float32 {
-	similarity := float32(0)
-
-	count := len(row)
-	if count > len(query) {
-		// Do this ahead of time so the compiler doesn't need to bounds check
-		// every time we index into query.
-		panic("mismatched vector lengths")
-	}
-
-	i := 0
-	for ; i+3 < count; i += 4 {
-		m0 := row[i] * query[i]
-		m1 := row[i+1] * query[i+1]
-		m2 := row[i+2] * query[i+2]
-		m3 := row[i+3] * query[i+3]
-		similarity += (m0 + m1 + m2 + m3)
-	}
-
-	for ; i < count; i++ {
-		similarity += row[i] * query[i]
-	}
-
-	return similarity
 }
 
 func min(a, b int) int {

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"testing/quick"
 
 	"github.com/stretchr/testify/require"
 )
@@ -189,22 +188,4 @@ func simpleCosineSimilarity(a, b []int8) int32 {
 		similarity += int32(a[i]) * int32(b[i])
 	}
 	return similarity
-}
-
-func TestCosineSimilarity(t *testing.T) {
-	f := func(a, b []int8) bool {
-		if len(a) > len(b) {
-			a = a[:len(b)]
-		} else if len(a) < len(b) {
-			b = b[:len(a)]
-		}
-
-		want := simpleCosineSimilarity(a, b)
-		got := CosineSimilarity(a, b)
-		return want == got
-	}
-	err := quick.Check(f, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -260,6 +260,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/autogold/v2 v2.1.0
 	github.com/k3a/html2text v1.1.0
+	github.com/klauspost/cpuid/v2 v2.2.4
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13
 	github.com/pandatix/go-cvss v0.5.2
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06

--- a/go.sum
+++ b/go.sum
@@ -1130,6 +1130,8 @@ github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHU
 github.com/klauspost/compress v1.15.15 h1:EF27CXIuDsYJ6mmvtBRlEuB2UVOqHG1tAXgZ7yIO+lw=
 github.com/klauspost/compress v1.15.15/go.mod h1:ZcK2JAFqKOpnBlxcLsJzYfrS9X1akm9fHZNnD9+Vo/4=
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
+github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/kljensen/snowball v0.6.0 h1:6DZLCcZeL0cLfodx+Md4/OLC6b/bfurWUOUGs1ydfOU=
@@ -2074,6 +2076,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This implements a hand-written assembly version of the int8 dot product that takes advantage of AVX2 SIMD instructions. This speeds up our embeddings searches by roughly 10x on modern x86_64 machines.

(cherry picked from commit 17a8ec942c1eaca26ae62191460e7ff9bd6285aa)

## Test plan

In original PR

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
