### PR TITLE
Embeddings: replace closures with structs

### DIFF
--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "@com_github_weaviate_weaviate//entities/models",
         "@com_github_weaviate_weaviate_go_client_v4//weaviate",
         "@com_github_weaviate_weaviate_go_client_v4//weaviate/graphql",
+        "@org_golang_x_sync//singleflight",
     ],
 )
 

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -73,7 +73,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return gitserverClient.ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repoName, revision, fileName)
 	}
 
-	getRepoEmbeddingIndex, err := getCachedRepoEmbeddingIndex(
+	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		repoStore,
 		repoEmbeddingJobsStore,
 		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
@@ -100,7 +100,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	getContextDetectionEmbeddingIndex := getCachedContextDetectionEmbeddingIndex(uploadStore)
 
 	// Create HTTP server
-	handler := NewHandler(logger, readFile, getRepoEmbeddingIndex, getQueryEmbedding, weaviate, getContextDetectionEmbeddingIndex)
+	handler := NewHandler(logger, readFile, indexGetter.Get, getQueryEmbedding, weaviate, getContextDetectionEmbeddingIndex)
 	handler = handlePanic(logger, handler)
 	handler = featureflag.Middleware(db.FeatureFlags(), handler)
 	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -138,17 +138,18 @@ func getCachedRepoEmbeddingIndex(
 			repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
 
 			cacheEntry, ok := cache.Get(repoEmbeddingIndexName)
-			// Check if the index is in the cache.
-			if ok {
-				// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
-				if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
-					return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
-				}
-				// Otherwise, return the cached index.
-				return cacheEntry.index, nil
+			if !ok {
+				// We do not have the index in the cache. Download and cache it.
+				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
 			}
-			// We do not have the index in the cache. Download and cache it.
-			return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+
+			// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
+			if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
+				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+			}
+
+			// Otherwise, return the cached index.
+			return cacheEntry.index, nil
 		})
 	}, nil
 }

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -90,17 +90,6 @@ func (c *embeddingsIndexCache) onEvict(_ embeddings.RepoEmbeddingIndexName, valu
 	c.remainingSizeBytes += value.index.EstimateSize()
 }
 
-type embeddingSingleflight struct {
-	sf singleflight.Group
-}
-
-func (e *embeddingSingleflight) Do(repoName api.RepoName, f func() (*embeddings.RepoEmbeddingIndex, error)) (*embeddings.RepoEmbeddingIndex, error) {
-	res, err, _ := e.sf.Do(string(repoName), func() (interface{}, error) {
-		return f()
-	})
-	return res.(*embeddings.RepoEmbeddingIndex), err
-}
-
 func NewCachedEmbeddingIndexGetter(
 	repoStore database.RepoStore,
 	repoEmbeddingJobStore repo.RepoEmbeddingJobsStore,

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -101,55 +101,73 @@ func (e *embeddingSingleflight) Do(repoName api.RepoName, f func() (*embeddings.
 	return res.(*embeddings.RepoEmbeddingIndex), err
 }
 
-func getCachedRepoEmbeddingIndex(
+func NewCachedEmbeddingIndexGetter(
 	repoStore database.RepoStore,
-	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
+	repoEmbeddingJobStore repo.RepoEmbeddingJobsStore,
 	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn,
 	cacheSizeBytes int64,
-) (getRepoEmbeddingIndexFn, error) {
+) (*CachedEmbeddingIndexGetter, error) {
 	cache, err := newEmbeddingsIndexCache(cacheSizeBytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating repo embedding index cache")
+		return nil, err
 	}
-
-	getAndCacheIndex := func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
-		embeddingIndex, err := downloadRepoEmbeddingIndex(ctx, repoEmbeddingIndexName)
-		if err != nil {
-			return nil, errors.Wrap(err, "downloading repo embedding index")
-		}
-		cache.Add(repoEmbeddingIndexName, repoEmbeddingIndexCacheEntry{index: embeddingIndex, finishedAt: *finishedAt})
-		return embeddingIndex, nil
-	}
-
-	var sf embeddingSingleflight
-
-	return func(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		return sf.Do(repoName, func() (*embeddings.RepoEmbeddingIndex, error) {
-			repo, err := repoStore.GetByName(ctx, repoName)
-			if err != nil {
-				return nil, err
-			}
-
-			lastFinishedRepoEmbeddingJob, err := repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repo.ID)
-			if err != nil {
-				return nil, err
-			}
-
-			repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
-
-			cacheEntry, ok := cache.Get(repoEmbeddingIndexName)
-			if !ok {
-				// We do not have the index in the cache. Download and cache it.
-				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
-			}
-
-			// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
-			if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
-				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
-			}
-
-			// Otherwise, return the cached index.
-			return cacheEntry.index, nil
-		})
+	return &CachedEmbeddingIndexGetter{
+		repoStore:                  repoStore,
+		repoEmbeddingJobsStore:     repoEmbeddingJobStore,
+		downloadRepoEmbeddingIndex: downloadRepoEmbeddingIndex,
+		cache:                      cache,
 	}, nil
+}
+
+type CachedEmbeddingIndexGetter struct {
+	repoStore                  database.RepoStore
+	repoEmbeddingJobsStore     repo.RepoEmbeddingJobsStore
+	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn
+
+	cache *embeddingsIndexCache
+	sf    singleflight.Group
+}
+
+func (c *CachedEmbeddingIndexGetter) Get(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	// Run the fetch request through a singleflight to keep from fetching the
+	// same index multiple times concurrently
+	v, err, _ := c.sf.Do(string(repoName), func() (interface{}, error) {
+		return c.get(ctx, repoName)
+	})
+	return v.(*embeddings.RepoEmbeddingIndex), err
+}
+
+func (c *CachedEmbeddingIndexGetter) get(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	repo, err := c.repoStore.GetByName(ctx, repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	lastFinishedRepoEmbeddingJob, err := c.repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repo.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
+
+	cacheEntry, ok := c.cache.Get(repoEmbeddingIndexName)
+	if !ok {
+		// We do not have the index in the cache. Download and cache it.
+		return c.getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+	} else if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
+		// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
+		return c.getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+	}
+
+	// Otherwise, return the cached index.
+	return cacheEntry.index, nil
+}
+
+func (c *CachedEmbeddingIndexGetter) getAndCacheIndex(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
+	embeddingIndex, err := c.downloadRepoEmbeddingIndex(ctx, repoEmbeddingIndexName)
+	if err != nil {
+		return nil, errors.Wrap(err, "downloading repo embedding index")
+	}
+	c.cache.Add(repoEmbeddingIndexName, repoEmbeddingIndexCacheEntry{index: embeddingIndex, finishedAt: *finishedAt})
+	return embeddingIndex, nil
 }

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -20,36 +21,6 @@ type downloadRepoEmbeddingIndexFn func(ctx context.Context, repoEmbeddingIndexNa
 type repoEmbeddingIndexCacheEntry struct {
 	index      *embeddings.RepoEmbeddingIndex
 	finishedAt time.Time
-}
-
-// repoMutexMap tracks a mutex for each repository, creating one if it does not yet exist for a given repository ID.
-// This allows concurrent access to the cache for different repositories, while serializing access for a given repository.
-type repoMutexMap struct {
-	init        sync.Once
-	mu          sync.RWMutex
-	repoMutexes map[api.RepoID]*sync.Mutex
-}
-
-func (m *repoMutexMap) GetLock(repoID api.RepoID) *sync.Mutex {
-	m.init.Do(func() { m.repoMutexes = make(map[api.RepoID]*sync.Mutex) })
-
-	m.mu.RLock()
-	lock, ok := m.repoMutexes[repoID]
-	m.mu.RUnlock()
-
-	if ok {
-		return lock
-	}
-
-	m.mu.Lock()
-	lock, ok = m.repoMutexes[repoID]
-	if !ok {
-		lock = &sync.Mutex{}
-		m.repoMutexes[repoID] = lock
-	}
-	m.mu.Unlock()
-
-	return lock
 }
 
 // embeddingsIndexCache is a thin wrapper around an LRU cache that is
@@ -119,6 +90,17 @@ func (c *embeddingsIndexCache) onEvict(_ embeddings.RepoEmbeddingIndexName, valu
 	c.remainingSizeBytes += value.index.EstimateSize()
 }
 
+type embeddingSingleflight struct {
+	sf singleflight.Group
+}
+
+func (e *embeddingSingleflight) Do(repoName api.RepoName, f func() (*embeddings.RepoEmbeddingIndex, error)) (*embeddings.RepoEmbeddingIndex, error) {
+	res, err, _ := e.sf.Do(string(repoName), func() (interface{}, error) {
+		return f()
+	})
+	return res.(*embeddings.RepoEmbeddingIndex), err
+}
+
 func getCachedRepoEmbeddingIndex(
 	repoStore database.RepoStore,
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
@@ -130,8 +112,6 @@ func getCachedRepoEmbeddingIndex(
 		return nil, errors.Wrap(err, "creating repo embedding index cache")
 	}
 
-	repoMutexMap := &repoMutexMap{}
-
 	getAndCacheIndex := func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
 		embeddingIndex, err := downloadRepoEmbeddingIndex(ctx, repoEmbeddingIndexName)
 		if err != nil {
@@ -141,37 +121,34 @@ func getCachedRepoEmbeddingIndex(
 		return embeddingIndex, nil
 	}
 
+	var sf embeddingSingleflight
+
 	return func(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		repo, err := repoStore.GetByName(ctx, repoName)
-		if err != nil {
-			return nil, err
-		}
-
-		// Acquire a mutex for the given repository to serialize access.
-		// This avoids multiple routines concurrently downloading the same embedding index
-		// when the cache is empty, which can lead to an out-of-memory error.
-		lock := repoMutexMap.GetLock(repo.ID)
-		lock.Lock()
-		defer lock.Unlock()
-
-		lastFinishedRepoEmbeddingJob, err := repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repo.ID)
-		if err != nil {
-			return nil, err
-		}
-
-		repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
-
-		cacheEntry, ok := cache.Get(repoEmbeddingIndexName)
-		// Check if the index is in the cache.
-		if ok {
-			// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
-			if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
-				return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+		return sf.Do(repoName, func() (*embeddings.RepoEmbeddingIndex, error) {
+			repo, err := repoStore.GetByName(ctx, repoName)
+			if err != nil {
+				return nil, err
 			}
-			// Otherwise, return the cached index.
-			return cacheEntry.index, nil
-		}
-		// We do not have the index in the cache. Download and cache it.
-		return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+
+			lastFinishedRepoEmbeddingJob, err := repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repo.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
+
+			cacheEntry, ok := cache.Get(repoEmbeddingIndexName)
+			// Check if the index is in the cache.
+			if ok {
+				// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
+				if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
+					return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+				}
+				// Otherwise, return the cached index.
+				return cacheEntry.index, nil
+			}
+			// We do not have the index in the cache. Download and cache it.
+			return getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+		})
 	}, nil
 }


### PR DESCRIPTION
Things were getting pretty complex with the number of closures we were passing around, and it's somewhat difficult to figure out what all the dependencies between things are. 

This replaces the `getCachedRepoEmbeddingIndex` function, which returns a function that closes over local variables, with a struct that explicitly lists its dependencies. 

As part of this, I replaced the hand-rolled `repoMutexMap` with the `x/sync/singleflight` package, which is purpose built to solve that problem.

Stacked on #51384 

## Test plan

Existing tests pass. The singleflight behavior is exercised by the concurrent fetch test. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
