### PR TITLE
Embeddings: fix frame size

### DIFF
--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-TEXT ·avx2Dot(SB), NOSPLIT, $0-54
+TEXT ·avx2Dot(SB), NOSPLIT, $0-56
 	MOVQ a_base+0(FP), AX
 	MOVQ b_base+24(FP), BX
 	MOVQ a_len+8(FP), DX


### PR DESCRIPTION
I miscalculated the frame size here, and I thought `go vet` runs in CI, but apparently it does not.

The frame size should be 24 bytes for the first slice argument, 24 bytes for the second slice argument, and 8 bytes for the return int64 for a total of 56 bytes.

## Test plan

Ran `GOARCH=amd64 go vet` on the package and it no longer spits out a warning.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
