### PR TITLE
app: reduce Go binary size by 20M

### DIFF
--- a/enterprise/cmd/sourcegraph/BUILD.bazel
+++ b/enterprise/cmd/sourcegraph/BUILD.bazel
@@ -33,17 +33,20 @@ go_library(
 go_binary(
     name = "sourcegraph",
     embed = [":sourcegraph_lib"],
-    # x_defs = {
-    #     "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
-    # },
-    visibility = ["//visibility:public"],
+    # -trimpath removes useless information like e.g. /Users/stephen/stephen@sourcegraph.com/
+    # prefixes from import paths in stack traces
+    gc_goopts = ["-trimpath"],
 
     # The options below reduce the final binary size considerably.
     #
     # -s strips debug symbols (not needed for stack traces)
     # -w strips the DWARF debug symbol table (not needed for stack traces)
-    gc_linkopts = ["-s", "-w"],
-    # -trimpath removes useless information like e.g. /Users/stephen/stephen@sourcegraph.com/
-    # prefixes from import paths in stack traces
-    gc_goopts = ["-trimpath"],
+    gc_linkopts = [
+        "-s",
+        "-w",
+    ],
+    # x_defs = {
+    #     "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
+    # },
+    visibility = ["//visibility:public"],
 )

--- a/enterprise/cmd/sourcegraph/BUILD.bazel
+++ b/enterprise/cmd/sourcegraph/BUILD.bazel
@@ -37,4 +37,13 @@ go_binary(
     #     "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
     # },
     visibility = ["//visibility:public"],
+
+    # The options below reduce the final binary size considerably.
+    #
+    # -s strips debug symbols (not needed for stack traces)
+    # -w strips the DWARF debug symbol table (not needed for stack traces)
+    gc_linkopts = ["-s", "-w"],
+    # -trimpath removes useless information like e.g. /Users/stephen/stephen@sourcegraph.com/
+    # prefixes from import paths in stack traces
+    gc_goopts = ["-trimpath"],
 )


### PR DESCRIPTION
This is a quick change to reduce the Go binary size by 20M, while losing little to nothing.

```
268M	../.bin/sourcegraph-backend-aarch64-apple-darwin
297M	../.bin/sourcegraph-backend-aarch64-apple-darwin-BEFORE
```

## Test plan

Produced a build and confirmed it runs as expected:

```
./enterprise/dev/app/build-release.sh
```
