### PR TITLE
bazel: build cody-web typescript files with Bazel

### DIFF
--- a/client/cody-web/BUILD.bazel
+++ b/client/cody-web/BUILD.bazel
@@ -1,0 +1,43 @@
+load("//dev:defs.bzl", "ts_project")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+# gazelle:js_ignore_imports **/*.css
+
+npm_link_all_packages(name = "node_modules")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//:tsconfig",
+        "//client/cody-shared:tsconfig",
+        "//client/common:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "cody-web",
+    srcs = [
+        "src/App.tsx",
+        "src/Chat.tsx",
+        "src/globals.d.ts",
+        "src/index.tsx",
+        "src/settings/Settings.tsx",
+        "src/settings/useConfig.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        ":node_modules/@sourcegraph/cody-shared",
+        ":node_modules/@sourcegraph/cody-ui",
+        ":node_modules/@sourcegraph/common",
+        ":node_modules/@sourcegraph/wildcard",
+        "//:node_modules/@types/lodash",
+        "//:node_modules/@types/react",
+        "//:node_modules/@types/react-dom",
+        "//:node_modules/lodash",
+        "//:node_modules/react",
+        "//:node_modules/react-dom",
+    ],
+)

--- a/client/cody-web/BUILD.bazel
+++ b/client/cody-web/BUILD.bazel
@@ -13,7 +13,9 @@ ts_config(
     deps = [
         "//:tsconfig",
         "//client/cody-shared:tsconfig",
+        "//client/cody-ui:tsconfig",
         "//client/common:tsconfig",
+        "//client/wildcard:tsconfig",
     ],
 )
 


### PR DESCRIPTION
## Context

Build `client/cody-web` Typescript files with Bazel.

## Test plan

CI
