### PR TITLE
Disable injectHTML by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - SCIM user provisioning support for Deactivate/Reactivation of users. [#50533](https://github.com/sourcegraph/sourcegraph/pull/50533)
 - Login form can now be configured with ordering and limit of auth providers. [See docs](https://docs.sourcegraph.com/admin/auth/login_form). [#50586](https://github.com/sourcegraph/sourcegraph/pull/50586), [50284](https://github.com/sourcegraph/sourcegraph/pull/50284) and [#50705](https://github.com/sourcegraph/sourcegraph/pull/50705)
 - When creating a new batch change, spaces are automatically replaced with dashes in the name field. [#50825](https://github.com/sourcegraph/sourcegraph/pull/50825) and [51071](https://github.com/sourcegraph/sourcegraph/pull/51071)
+- Support for custom HTML injection behind an environment variable (`ENABLE_INJECT_HTML`). This allows users to enable or disable HTML customization as needed, which is now disabled by default. [#51400](https://github.com/sourcegraph/sourcegraph/pull/51400)
 
 ### Changed
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -48,7 +48,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
-var enableHtmlInject = env.Get("ENABLE_INJECT_HTML", "false", "Enable HTML customization")
+var enableHTMLInject = env.Get("ENABLE_INJECT_HTML", "false", "Enable HTML customization")
 
 type InjectedHTML struct {
 	HeadTop    template.HTML
@@ -185,7 +185,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 		WebpackDevServer: webpackDevServer,
 	}
 
-	if enableHtmlInject != "true" {
+	if enableHTMLInject != "true" {
 		common.Injected = InjectedHTML{}
 	}
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -48,6 +48,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
+var enableHtmlInject = env.Get("ENABLE_INJECT_HTML", "false", "Enable HTML customization")
+
 type InjectedHTML struct {
 	HeadTop    template.HTML
 	HeadBottom template.HTML
@@ -181,6 +183,10 @@ func newCommon(w http.ResponseWriter, r *http.Request, db database.DB, title str
 		},
 
 		WebpackDevServer: webpackDevServer,
+	}
+
+	if enableHtmlInject != "true" {
+		common.Injected = InjectedHTML{}
 	}
 
 	if _, ok := mux.Vars(r)["Repo"]; ok {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2423,13 +2423,13 @@ type SiteConfiguration struct {
 	GitRecorder *GitRecorder `json:"gitRecorder,omitempty"`
 	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
 	GitUpdateInterval []*UpdateIntervalRule `json:"gitUpdateInterval,omitempty"`
-	// HtmlBodyBottom description: HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts
+	// HtmlBodyBottom description: HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
 	HtmlBodyBottom string `json:"htmlBodyBottom,omitempty"`
-	// HtmlBodyTop description: HTML to inject at the top of the `<body>` element on each page, for analytics scripts
+	// HtmlBodyTop description: HTML to inject at the top of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
 	HtmlBodyTop string `json:"htmlBodyTop,omitempty"`
-	// HtmlHeadBottom description: HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts
+	// HtmlHeadBottom description: HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
 	HtmlHeadBottom string `json:"htmlHeadBottom,omitempty"`
-	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts
+	// HtmlHeadTop description: HTML to inject at the top of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.
 	HtmlHeadTop string `json:"htmlHeadTop,omitempty"`
 	// InsightsAggregationsBufferSize description: The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend
 	InsightsAggregationsBufferSize int `json:"insights.aggregations.bufferSize,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1576,22 +1576,22 @@
       "default": 5
     },
     "htmlHeadTop": {
-      "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
+      "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
       "type": "string",
       "group": "Misc."
     },
     "htmlHeadBottom": {
-      "description": "HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts",
+      "description": "HTML to inject at the bottom of the `<head>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
       "type": "string",
       "group": "Misc."
     },
     "htmlBodyTop": {
-      "description": "HTML to inject at the top of the `<body>` element on each page, for analytics scripts",
+      "description": "HTML to inject at the top of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
       "type": "string",
       "group": "Misc."
     },
     "htmlBodyBottom": {
-      "description": "HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts",
+      "description": "HTML to inject at the bottom of the `<body>` element on each page, for analytics scripts. Requires env var ENABLE_INJECT_HTML=true.",
       "type": "string",
       "group": "Misc."
     },


### PR DESCRIPTION
This change will, by default, disable the HTML injection feature in site-admin. Customers who want to customize their instance can add the environment variable to add scripts or other HTML content. This will make customers (the majority) who don't want this customization feature protected against potential XSS attack.

## Test plan
Tested the changes on my local instance.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
