### PR TITLE
Cody completions: Don't send request when VS Code would not use the result

### DIFF
--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -123,6 +123,15 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         let waitMs: number
         const completers: CompletionProvider[] = []
+
+        // VS Code does not show completions if we are in the process of writing a word or if a
+        // selected completion info is present (so something is selected from the completions
+        // dropdown list based on the lang server) and the returned completion range does not
+        // contain the same selection.
+        if (/[A-Za-z]$/.test(precedingLine) || context.selectedCompletionInfo) {
+            return []
+        }
+
         if (precedingLine.trim() === '') {
             // Start of line: medium debounce
             waitMs = 500

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -128,7 +128,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         // selected completion info is present (so something is selected from the completions
         // dropdown list based on the lang server) and the returned completion range does not
         // contain the same selection.
-        if (/[A-Za-z]$/.test(precedingLine) || context.selectedCompletionInfo) {
+        if (context.selectedCompletionInfo || /[A-Za-z]$/.test(precedingLine)) {
             return []
         }
 


### PR DESCRIPTION
Closes #51401

I observed some scenarios where VS Code calls the inline completions API but disregards the suggestions we return. These are:

- When the `selectedCompletionInfo` is set ([see documentation](https://sourcegraph.com/github.com/microsoft/azuredatastudio/-/blob/src/vscode-dts/vscode.proposed.inlineCompletionsNew.d.ts?L63-66))
- When the user is in the middle of a word. In my experiments, this never showed the inline completions either. I’m not exactly sure how word is defined but I've decided to bail out from the completions for now if the character before the selection is alphabetical. 

## Test plan

- Added a console.log to the logger code to visualize when requests are made. Observe that they are not made in the scenarios above

https://user-images.githubusercontent.com/458591/235881428-63a1feab-ff2b-4705-9786-e25cb331a7d5.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
