### PR TITLE
bazel: disable `build-ts` and build `client/cody` with Bazel

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -46,4 +46,3 @@ cmd/sitemap
 # temporary ignores
 
 internal/cmd/progress-bot
-client/cody

--- a/client/app-shell/BUILD.bazel
+++ b/client/app-shell/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//dev:defs.bzl", "ts_project")
+
+npm_link_all_packages(name = "node_modules")
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//:tsconfig",
+        "//client/build-config:tsconfig",
+        "//client/common:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "app-shell",
+    srcs = ["src/app-shell.tsx"],
+    tsconfig = ":tsconfig",
+    deps = ["//:node_modules/@tauri-apps/api"],
+)

--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//dev:defs.bzl", "jest_test", "npm_package", "ts_project")
+load("//dev:defs.bzl", "npm_package", "ts_project")
 
 npm_link_all_packages(name = "node_modules")
 

--- a/client/cody-ui/BUILD.bazel
+++ b/client/cody-ui/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("//dev:defs.bzl", "jest_test", "npm_package", "ts_project")
+load("//dev:defs.bzl", "npm_package", "ts_project")
 
 # gazelle:js_ignore_imports **/*.css
 

--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -1,0 +1,106 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//dev:defs.bzl", "ts_project")
+
+npm_link_all_packages(name = "node_modules")
+
+# gazelle:js_resolve vscode //:node_modules/@vscode
+# gazelle:js_files src/**/*.{ts,tsx}
+# gazelle:js_files webviews/**/*.{ts,tsx}
+# gazelle:js_ignore_imports **/*.css
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//:tsconfig",
+        "//client/cody-shared:tsconfig",
+        "//client/cody-ui:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "cody",
+    srcs = [
+        "package.json",
+        "src/chat/ChatViewProvider.ts",
+        "src/chat/protocol.ts",
+        "src/command/LocalStorageProvider.ts",
+        "src/completions/cache.ts",
+        "src/completions/context.ts",
+        "src/completions/docprovider.ts",
+        "src/completions/history.ts",
+        "src/completions/index.ts",
+        "src/completions/prompts.ts",
+        "src/completions/provider.ts",
+        "src/configuration.ts",
+        "src/editor/vscode-editor.ts",
+        "src/event-logger.ts",
+        "src/extension.ts",
+        "src/extension-api.ts",
+        "src/external-services.ts",
+        "src/keyword-context/local-keyword-context-fetcher.ts",
+        "src/main.ts",
+        "src/rg.ts",
+        "src/secret-storage.ts",
+        "src/test-support.ts",
+        "src/wink-nlp-utils.d.ts",
+        "webviews/App.story.tsx",
+        "webviews/App.tsx",
+        "webviews/Chat.tsx",
+        "webviews/Debug.tsx",
+        "webviews/FileLink.tsx",
+        "webviews/Header.tsx",
+        "webviews/LoadingPage.tsx",
+        "webviews/Login.story.tsx",
+        "webviews/Login.tsx",
+        "webviews/NavBar.tsx",
+        "webviews/Recipes.tsx",
+        "webviews/Settings.tsx",
+        "webviews/UserHistory.tsx",
+        "webviews/globals.d.ts",
+        "webviews/index.tsx",
+        "webviews/storybook/VSCodeStoryDecorator.tsx",
+        "webviews/utils/VSCodeApi.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        ":node_modules/@anthropic-ai/sdk",
+        ":node_modules/@sourcegraph/cody-shared",
+        ":node_modules/@sourcegraph/cody-ui",
+        ":node_modules/lru-cache",
+        ":node_modules/wink-nlp-utils",
+        "//:node_modules/@storybook/react",  #keep
+        "//:node_modules/@types/classnames",
+        "//:node_modules/@types/jest",  #keep
+        "//:node_modules/@types/lru-cache",
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/react",
+        "//:node_modules/@types/react-dom",
+        "//:node_modules/@types/stream-json",
+        "//:node_modules/@types/vscode",  #keep
+        "//:node_modules/@vscode",
+        "//:node_modules/@vscode/webview-ui-toolkit",
+        "//:node_modules/classnames",
+        "//:node_modules/react",
+        "//:node_modules/react-dom",
+        "//:node_modules/stream-json",
+        "//:node_modules/util",
+    ],
+)
+
+ts_project(
+    name = "cody_tests",
+    testonly = True,
+    srcs = [
+        "src/chat/ChatViewProvider.test.ts",
+        "src/completions/context.test.ts",
+        "src/configuration.test.ts",
+        "src/keyword-context/local-keyword-context-fetcher.test.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        ":cody",
+    ],
+)

--- a/client/cody/integration-test/BUILD.bazel
+++ b/client/cody/integration-test/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+
+# load("@npm//:defs.bzl", "npm_link_all_packages")
+load("//dev:defs.bzl", "ts_project")
+
+# npm_link_all_packages(name = "node_modules")
+
+# gazelle:js_resolve vscode //:node_modules/@vscode
+# gazelle:js_files **/*.{ts,tsx}
+# gazelle:js_test_files **/*.{ts,tsx}
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    deps = [
+        "//client/cody:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "integration-test_tests",
+    testonly = True,
+    srcs = [
+        "api.test.ts",
+        "chat.test.ts",
+        "helpers.ts",
+        "index.ts",
+        "main.ts",
+        "mock-server.ts",
+        "recipes.test.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        "//:node_modules/@types/express",
+        "//:node_modules/@types/glob",
+        "//:node_modules/@types/mocha",
+        "//:node_modules/@types/node",
+        "//:node_modules/@vscode",
+        "//:node_modules/@vscode/test-electron",
+        "//:node_modules/express",
+        "//:node_modules/glob",
+        "//:node_modules/mocha",
+        "//client/cody",
+    ],
+)

--- a/client/cody/integration-test/tsconfig.json
+++ b/client/cody/integration-test/tsconfig.json
@@ -6,7 +6,7 @@
     "sourceRoot": ".",
     "outDir": "../out/integration-test",
     "types": ["mocha", "node"],
-    "jsx": "preserve",
+    "jsx": "react-jsx",
   },
   "references": [{ "path": "../" }],
   "include": ["*", "**/*", ".eslintrc.js"],

--- a/client/cody/scripts/BUILD.bazel
+++ b/client/cody/scripts/BUILD.bazel
@@ -25,6 +25,5 @@ ts_project(
         "//:node_modules/@types/semver",
         "//:node_modules/esbuild",
         "//:node_modules/semver",
-        "//client/cody",
     ],
 )

--- a/client/cody/scripts/BUILD.bazel
+++ b/client/cody/scripts/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
+load("//dev:defs.bzl", "ts_project")
+
+# gazelle:js_ignore_imports ../package.json
+# gazelle:js_files **/*.{ts,tsx}
+
+ts_config(
+    name = "tsconfig",
+    src = "tsconfig.json",
+    visibility = ["//client:__subpackages__"],
+    deps = [
+        "//client/cody:tsconfig",
+    ],
+)
+
+ts_project(
+    name = "scripts",
+    srcs = [
+        "bundle.ts",
+        "release.ts",
+    ],
+    tsconfig = ":tsconfig",
+    deps = [
+        "//:node_modules/@types/node",
+        "//:node_modules/@types/semver",
+        "//:node_modules/esbuild",
+        "//:node_modules/semver",
+        "//client/cody",
+    ],
+)

--- a/client/cody/scripts/release.ts
+++ b/client/cody/scripts/release.ts
@@ -3,6 +3,7 @@ import childProcess from 'child_process'
 
 import * as semver from 'semver'
 
+// eslint-disable-next-line  @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const { version } = require('../package.json')
 
 /**

--- a/client/cody/scripts/release.ts
+++ b/client/cody/scripts/release.ts
@@ -3,7 +3,7 @@ import childProcess from 'child_process'
 
 import * as semver from 'semver'
 
-import { version } from '../package.json'
+const { version } = require('../package.json')
 
 /**
  * This script is used by the CI to publish the extension to the VS Code Marketplace. It is

--- a/client/cody/scripts/tsconfig.json
+++ b/client/cody/scripts/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true,
-  },
   "include": [".*", "*"],
 }

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -23,13 +23,13 @@ The default run type.
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
   - **Linters and static analysis**: Run sg lint
-  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
   - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
-  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+  - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
@@ -179,7 +179,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg, Publish executor image, Publish executor binary, Publish docker registry mirror image
@@ -196,7 +196,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg
@@ -254,7 +254,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg, Publish executor image, Publish executor binary
@@ -276,7 +276,7 @@ Base pipeline (more steps might be included based on branch changes):
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
 - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Build TS, Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
 - **End-to-end tests**: Executors E2E, Sourcegraph E2E, Sourcegraph Upgrade
 - **Publish images**: symbols, server, executor, alpine-3.14, postgres-12-alpine, blobstore, cadvisor, codeinsights-db, codeintel-db, frontend, github-proxy, gitserver, grafana, indexed-searcher, migrator, node-exporter, opentelemetry-collector, postgres_exporter, precise-code-intel-worker, prometheus, prometheus-gcp, redis-cache, redis-store, redis_exporter, repo-updater, search-indexer, searcher, syntax-highlighter, worker, batcheshelper, blobstore2, bundled-executor, dind, embeddings, executor-kubernetes, executor-vm, jaeger-agent, jaeger-all-in-one, llm-proxy, sg

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -77,8 +77,7 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 				// addBrowserExtensionsUnitTests is now covered by Bazel
 				// addBrowserExtensionUnitTests, // ~4.5m
 				addJetBrainsUnitTests, // ~2.5m
-				// addTypescriptCheck is now covered by Bazel, but some Cody stuff not being is Bazel still requires it.
-				addTypescriptCheck,    // ~4m
+				// addTypescriptCheck is now covered by Bazel
 				addVsceTests,          // ~3.0m
 				addCodyExtensionTests, // ~2.5m
 			)


### PR DESCRIPTION
## Context

- Typescript in all client packages is now built with Bazel
- Disabled the `build-ts` job on CI

## Test plan

CI
