### PR TITLE
admin: rename the "Code host" to "Code host connections"

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -1,12 +1,13 @@
 import { FC, useEffect, useCallback, useState } from 'react'
 
+import { FetchResult } from '@apollo/client'
 import { useNavigate } from 'react-router-dom'
 
 import { logger, renderMarkdown } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Container, H2, H3, H4, Markdown } from '@sourcegraph/wildcard'
 
-import { AddExternalServiceInput } from '../../graphql-operations'
+import { AddExternalServiceInput, AddExternalServiceResult } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 import { PageTitle } from '../PageTitle'
 
@@ -63,11 +64,11 @@ export const AddExternalServicePage: FC<Props> = ({
         useAddExternalService()
 
     const onSubmit = useCallback(
-        (event?: React.FormEvent<HTMLFormElement>): void => {
+        async (event?: React.FormEvent<HTMLFormElement>): Promise<FetchResult<AddExternalServiceResult>> => {
             if (event) {
                 event.preventDefault()
             }
-            addExternalService({
+            return addExternalService({
                 variables: {
                     input: { ...getExternalServiceInput() },
                 },
@@ -81,7 +82,7 @@ export const AddExternalServicePage: FC<Props> = ({
                 },
             })
         },
-        [addExternalService, telemetryService, getExternalServiceInput]
+        [addExternalService, telemetryService, getExternalServiceInput, client, navigate]
     )
     const createdExternalService = addExternalServiceResult?.addExternalService
 

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -1,17 +1,16 @@
 import { FC, useEffect, useCallback, useState } from 'react'
 
-import { useApolloClient } from '@apollo/client'
 import { useNavigate } from 'react-router-dom'
 
-import { asError, isErrorLike, logger, renderMarkdown } from '@sourcegraph/common'
+import { logger, renderMarkdown } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Alert, Container, ErrorMessage, H2, H3, H4, Markdown } from '@sourcegraph/wildcard'
+import { Alert, Container, H2, H3, H4, Markdown } from '@sourcegraph/wildcard'
 
-import { ExternalServiceFields, AddExternalServiceInput } from '../../graphql-operations'
+import { AddExternalServiceInput } from '../../graphql-operations'
 import { refreshSiteFlags } from '../../site/backend'
 import { PageTitle } from '../PageTitle'
 
-import { addExternalService, useAddExternalService } from './backend'
+import { useAddExternalService } from './backend'
 import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import { AddExternalServiceOptions } from './externalServices'
@@ -91,11 +90,6 @@ export const AddExternalServicePage: FC<Props> = ({
             <PageTitle title="Add code host connection" />
             <H2>Add code host connection</H2>
             <Container>
-                {error && (
-                    <Alert className="compact" variant="danger">
-                        <ErrorMessage error={error} />
-                    </Alert>
-                )}
                 {createdExternalService?.warning ? (
                     <div>
                         <div className="mb-3">
@@ -120,7 +114,7 @@ export const AddExternalServicePage: FC<Props> = ({
                         <div className="mb-4">{externalService.instructions}</div>
                         <ExternalServiceForm
                             telemetryService={telemetryService}
-                            error={isErrorLike(isCreating) ? isCreating : undefined}
+                            error={error}
                             input={getExternalServiceInput()}
                             editorActions={externalService.editorActions}
                             jsonSchema={externalService.jsonSchema}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -81,10 +81,10 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
 
     return (
         <>
-            <PageTitle title="Add repositories" />
-            <H2>Add repositories</H2>
+            <PageTitle title="Add code host connection" />
+            <H2>Add code host connection</H2>
             <Container>
-                <Text>Add repositories from one of these code hosts.</Text>
+                <Text>Add code host connection to one of the supported code hosts.</Text>
                 {hasDismissedPrivacyWarning && (
                     <Alert variant="info">
                         <Text>

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -158,7 +158,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                     variant="primary"
                 >
                     {loading && <LoadingSpinner />}
-                    {submitName ?? 'Add repositories'}
+                    {submitName ?? 'Add connection'}
                 </Button>
             )}
         </Form>

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -52,10 +52,10 @@ export const ExternalServicesPage: FC<Props> = ({
         <Navigate to="/site-admin/external-services/new" replace={true} />
     ) : (
         <div className="site-admin-external-services-page">
-            <PageTitle title="Manage code hosts" />
+            <PageTitle title="Code host connections" />
             <PageHeader
-                path={[{ text: 'Manage code hosts' }]}
-                description="Manage code host connections to sync repositories."
+                path={[{ text: 'Code host connections' }]}
+                description="Code host connections to sync repositories."
                 headingElement="h2"
                 actions={
                     <>
@@ -71,7 +71,7 @@ export const ExternalServicesPage: FC<Props> = ({
                             as={Link}
                             disabled={editingDisabled}
                         >
-                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add code host
+                            <Icon aria-hidden={true} svgPath={mdiPlus} /> Add connection
                         </ButtonLink>
                     </>
                 }
@@ -85,7 +85,7 @@ export const ExternalServicesPage: FC<Props> = ({
                 <ConnectionContainer>
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}
-                    <ConnectionList as="ul" className="list-group" aria-label="CodeHosts">
+                    <ConnectionList as="ul" className="list-group" aria-label="Code Host Connections">
                         {connection?.nodes?.map(node => (
                             <ExternalServiceNode key={node.id} node={node} editingDisabled={editingDisabled} />
                         ))}
@@ -97,8 +97,8 @@ export const ExternalServicesPage: FC<Props> = ({
                                 first={connection.totalCount ?? 0}
                                 centered={true}
                                 connection={connection}
-                                noun="code host"
-                                pluralNoun="code hosts"
+                                noun="code host connection"
+                                pluralNoun="code host connections"
                                 hasNextPage={hasNextPage}
                             />
                             {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`ExternalServiceForm create GitHub 1`] = `
       class="btn btnPrimary test-add-external-service-button"
       type="submit"
     >
-      Add repositories
+      Add connection
     </button>
   </form>
 </DocumentFragment>
@@ -90,7 +90,7 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
       class="btn btnPrimary test-add-external-service-button"
       type="submit"
     >
-      Add repositories
+      Add connection
     </button>
   </form>
 </DocumentFragment>
@@ -146,7 +146,7 @@ exports[`ExternalServiceForm edit GitHub, loading 1`] = `
         data-loading-spinner="true"
         role="img"
       />
-      Add repositories
+      Add connection
     </button>
   </form>
 </DocumentFragment>

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -1,10 +1,9 @@
-import { QueryTuple, MutationTuple, MutationHookOptions } from '@apollo/client'
+import { QueryTuple, MutationTuple } from '@apollo/client'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql, dataOrThrowErrors, useMutation, useLazyQuery } from '@sourcegraph/http-client'
-import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { requestGraphQL } from '../../backend/graphql'
 import {

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -1,4 +1,4 @@
-import { QueryTuple, MutationTuple } from '@apollo/client'
+import { QueryTuple, MutationTuple, MutationHookOptions } from '@apollo/client'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -48,34 +48,18 @@ export const externalServiceFragment = gql`
     }
 `
 
-export async function addExternalService(
-    variables: AddExternalServiceVariables,
-    eventLogger: TelemetryService
-): Promise<AddExternalServiceResult['addExternalService']> {
-    return requestGraphQL<AddExternalServiceResult, AddExternalServiceVariables>(
-        gql`
-            mutation AddExternalService($input: AddExternalServiceInput!) {
-                addExternalService(input: $input) {
-                    ...ExternalServiceFields
-                }
-            }
+export const ADD_EXTERNAL_SERVICE = gql`
+    mutation AddExternalService($input: AddExternalServiceInput!) {
+        addExternalService(input: $input) {
+            ...ExternalServiceFields
+        }
+    }
 
-            ${externalServiceFragment}
-        `,
-        variables
-    )
-        .pipe(
-            map(({ data, errors }) => {
-                if (!data?.addExternalService || (errors && errors.length > 0)) {
-                    eventLogger.log('AddExternalServiceFailed')
-                    throw createAggregateError(errors)
-                }
-                eventLogger.log('AddExternalServiceSucceeded')
-                return data.addExternalService
-            })
-        )
-        .toPromise()
-}
+    ${externalServiceFragment}
+`
+
+export const useAddExternalService = (): MutationTuple<AddExternalServiceResult, AddExternalServiceVariables> =>
+    useMutation<AddExternalServiceResult, AddExternalServiceVariables>(ADD_EXTERNAL_SERVICE)
 
 export const UPDATE_EXTERNAL_SERVICE = gql`
     mutation UpdateExternalService($input: UpdateExternalServiceInput!) {

--- a/client/web/src/site-admin/SiteAdminArea.module.scss
+++ b/client/web/src/site-admin/SiteAdminArea.module.scss
@@ -1,3 +1,3 @@
 .sidebar {
-    width: 11rem;
+    width: 12rem;
 }

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -87,7 +87,7 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
     },
     items: [
         {
-            label: 'Manage code hosts',
+            label: 'Code host connections',
             to: '/site-admin/external-services',
         },
         {


### PR DESCRIPTION
The current wording is quite confusing as to what is actually happening.

This is more in line with all the other wording in the application. It is also more in line with what people are actually configuring.

As a good side effect migrated a call using rxjs to `useMutation` instead.

## Screenshots

### Old behavior

<img width="1149" alt="Screenshot 2023-05-03 at 12 48 16" src="https://user-images.githubusercontent.com/9974711/235895919-e560e516-45ca-4a2c-8829-9160c4bb137e.png">
<img width="1165" alt="Screenshot 2023-05-03 at 12 48 23" src="https://user-images.githubusercontent.com/9974711/235895926-71ca67a1-5aaa-4ffe-b62b-2c40ad8d09fd.png">


### New behavior

<img width="1160" alt="Screenshot 2023-05-03 at 12 46 53" src="https://user-images.githubusercontent.com/9974711/235895725-ad161bf5-d900-447a-a917-3ee0bc30f9c4.png">
<img width="1149" alt="Screenshot 2023-05-03 at 12 47 03" src="https://user-images.githubusercontent.com/9974711/235895736-c07ee076-b4e3-433f-99a1-c8ff745d9131.png">

## Test plan

Just UI changes, tested locally that everything still works as it should.

