### PR TITLE
Make dompurify markdown config more restrictive

### DIFF
--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -87,7 +87,8 @@ export const renderMarkdown = (
           }
         : {
               USE_PROFILES: { html: true },
-              FORBID_ATTR: ['rel', 'style'],
+              FORBID_TAGS: ['style', 'form'],
+              FORBID_ATTR: ['rel', 'style', 'method', 'action'],
           }
 
     return DOMPurify.sanitize(rendered, dompurifyConfig).trim()

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -87,7 +87,7 @@ export const renderMarkdown = (
           }
         : {
               USE_PROFILES: { html: true },
-              FORBID_TAGS: ['style', 'form'],
+              FORBID_TAGS: ['style', 'form', 'input', 'button'],
               FORBID_ATTR: ['rel', 'style', 'method', 'action'],
           }
 


### PR DESCRIPTION
Resolves https://sourcegraph.slack.com/archives/C1JH2BEHZ/p1683057397336689; see DOMPurify's [tags.js](https://sourcegraph.com/github.com/cure53/DOMPurify/-/blob/src/tags.js?L3:15-3:19) and [attrs.js](https://sourcegraph.com/github.com/cure53/DOMPurify/-/blob/src/attrs.js?L3:15-3:19) for default allowed tags with the `html` profile.

Looking at references of this code, this shouldn't break anything as it only affects markdown previews, alerts, and Cody (unless a team is intentionally using inline style tags/forms for some reason, but that does seem unlikely).

## Test plan

Tested locally, problem resolved.
