### PR TITLE
nix: set formatter & use nil instead of rnix-lsp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
         }
       );
 
+      formatter = genAttrs defaultSystems (system: nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
+
       # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
       overlays.ctags = (import ./dev/nix/ctags.nix { inherit nixpkgs utils; inherit (nixpkgs) lib; }).overlay;
 

--- a/shell.nix
+++ b/shell.nix
@@ -77,7 +77,8 @@ pkgs.mkShell {
 
   # The packages in the `buildInputs` list will be added to the PATH in our shell
   nativeBuildInputs = with pkgs; [
-    rnix-lsp
+    # nix language server
+    nil
 
     # Our core DB.
     postgresql_13


### PR DESCRIPTION
Allows formatting everything with `nix fmt`

[nil](https://github.com/oxalica/nil) appears more maintained and higher quality than rnix-lsp

## Test plan

N/A, nix stuff