### PR TITLE
[Backport 5.0] zoekt: update to sourcegraph/zoekt@f818d968ddad0bb708b958cfb66ab08ee6ec4aa5

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5723,8 +5723,15 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:O834DoaXIyOiQ27/qrev1Pjd79njJru1Kqjwf59ahpg=",
-        version = "v0.0.0-20230308131753-939eb52f3486",
+        patch_args = ["-p1"],
+        patches = [
+            "//third_party/com_github_sourcegraph_zoekt:zoekt_archive_index.patch",
+            "//third_party/com_github_sourcegraph_zoekt:zoekt_git_index.patch",
+            "//third_party/com_github_sourcegraph_zoekt:zoekt_webserver.patch",
+            "//third_party/com_github_sourcegraph_zoekt:zoekt_indexserver.patch",
+        ],
+        sum = "h1:lCxBFbLdzt0m789CNyYWEqPURhta69aRA9ixPyWilvI=",
+        version = "v0.0.0-20230503105159-f818d968ddad",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -294,7 +294,7 @@ replace (
 )
 
 require (
-	github.com/sourcegraph/zoekt v0.0.0-20230328081101-02541e61dd57
+	github.com/sourcegraph/zoekt v0.0.0-20230503105159-f818d968ddad
 	github.com/stretchr/objx v0.5.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1553,8 +1553,8 @@ github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef h1:fWPxLkDObzzK
 github.com/sourcegraph/scip v0.2.4-0.20221213205653-aa0e511dcfef/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230328081101-02541e61dd57 h1:dZN5lUWLL4I3jkxQG9SAtF+Ufv92JnQhNiGoXJfRHjU=
-github.com/sourcegraph/zoekt v0.0.0-20230328081101-02541e61dd57/go.mod h1:G3dj/2qn2M/cjDexzuINNETdXFdqIJyAHd42UAGwuqc=
+github.com/sourcegraph/zoekt v0.0.0-20230503105159-f818d968ddad h1:lCxBFbLdzt0m789CNyYWEqPURhta69aRA9ixPyWilvI=
+github.com/sourcegraph/zoekt v0.0.0-20230503105159-f818d968ddad/go.mod h1:G3dj/2qn2M/cjDexzuINNETdXFdqIJyAHd42UAGwuqc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Updating zoekt for a CVE. See original PR https://github.com/sourcegraph/sourcegraph/pull/51406 and https://github.com/sourcegraph/zoekt/pull/580

Test Plan: In original PR