### PR TITLE
migrations: change `-db` flag to be alias for `-schema` & allow container name as values

### DIFF
--- a/dev/sg/sg_migration.go
+++ b/dev/sg/sg_migration.go
@@ -32,10 +32,15 @@ import (
 var (
 	migrateTargetDatabase     string
 	migrateTargetDatabaseFlag = &cli.StringFlag{
-		Name:        "db",
-		Usage:       "The target database `schema` to modify",
+		Name:        "schema",
+		Usage:       "The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Value:       db.DefaultDatabase.Name,
 		Destination: &migrateTargetDatabase,
+		Aliases:     []string{"db"},
+		Action: func(ctx *cli.Context, val string) error {
+			migrateTargetDatabase = cliutil.TranslateSchemaNames(val, std.Out.Output)
+			return nil
+		},
 	}
 
 	squashInContainer     bool

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -654,8 +654,8 @@ Arguments: `<name>`
 
 Flags:
 
-* `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
 
 ### sg migration revert
 
@@ -689,12 +689,12 @@ $ sg migration up [-db=<schema>]
 
 Flags:
 
-* `--db="<value>"`: The target `schema(s)` to modify. Comma-separated values are accepted. Supply "all" to migrate all schemas. (default: "all")
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--ignore-single-dirty-log`: Ignore a single previously failed attempt if it will be immediately retried by this operation.
 * `--ignore-single-pending-log`: Ignore a single pending migration attempt if it will be immediately retried by this operation.
 * `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--privileged-hash="<value>"`: Running --noop-privileged without this flag will print instructions and supply a value for use in a second invocation. Multiple privileged hash flags (for distinct schemas) may be supplied. Future (distinct) up operations will require a unique hash.
+* `--schema, --db="<value>"`: The target `schema(s)` to modify. Comma-separated values are accepted. Possible values are 'frontend', 'codeintel', 'codeinsights' and 'all'. (default: "all")
 * `--skip-oobmigration-validation`: Do not attempt to validate the progress of out-of-band migrations.
 * `--skip-upgrade-validation`: Do not attempt to compare the previous instance version with the target instance version for upgrade compatibility. Please refer to https://docs.sourcegraph.com/admin/updates#update-policy for our instance upgrade compatibility policy.
 * `--unprivileged-only`: Refuse to apply privileged migrations.
@@ -715,12 +715,12 @@ $ sg migration upto -db=<schema> -target=<target>,<target>,...
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--ignore-single-dirty-log`: Ignore a single previously failed attempt if it will be immediately retried by this operation.
 * `--ignore-single-pending-log`: Ignore a single pending migration attempt if it will be immediately retried by this operation.
 * `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--privileged-hash="<value>"`: Running --noop-privileged without this flag will print instructions and supply a value for use in a second invocation. Future (distinct) upto operations will require a unique hash.
+* `--schema, --db="<value>"`: The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 * `--target="<value>"`: The `migration` to apply. Comma-separated values are accepted.
 * `--unprivileged-only`: Refuse to apply privileged migrations.
 
@@ -740,8 +740,8 @@ $ sg migration undo -db=<schema>
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--schema, --db="<value>"`: The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 
 ### sg migration downto
 
@@ -759,12 +759,12 @@ $ sg migration downto -db=<schema> -target=<target>,<target>,...
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--ignore-single-dirty-log`: Ignore a single previously failed attempt if it will be immediately retried by this operation.
 * `--ignore-single-pending-log`: Ignore a single pending migration attempt if it will be immediately retried by this operation.
 * `--noop-privileged`: Skip application of privileged migrations, but record that they have been applied. This assumes the user has already applied the required privileged migrations with elevated permissions.
 * `--privileged-hash="<value>"`: Running --noop-privileged without this flag will print instructions and supply a value for use in a second invocation. Future (distinct) downto operations will require a unique hash.
+* `--schema, --db="<value>"`: The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 * `--target="<value>"`: The migration to apply. Comma-separated values are accepted.
 * `--unprivileged-only`: Refuse to apply privileged migrations.
 
@@ -781,8 +781,8 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target `schema(s)` to validate. Comma-separated values are accepted. Supply "all" to validate all schemas. (default: "all")
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--schema, --db="<value>"`: The target `schema(s)` to validate. Comma-separated values are accepted. Possible values are 'frontend', 'codeintel', 'codeinsights' and 'all'. (default: "all")
 * `--skip-out-of-band-migrations`: Do not attempt to validate out-of-band migration status.
 
 ### sg migration describe
@@ -798,12 +798,12 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to describe.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--force`: Force write the file if it already exists.
 * `--format="<value>"`: The target output format.
 * `--no-color`: If writing to stdout, disable output colorization.
 * `--out="<value>"`: The file to write to. If not supplied, stdout is used.
+* `--schema, --db="<value>"`: The target `schema` to describe. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 
 ### sg migration drift
 
@@ -840,8 +840,8 @@ $ sg migration add-log -db=<schema> -version=<version> [-up=true|false]
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to modify.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--schema, --db="<value>"`: The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 * `--up`: The migration direction.
 * `--version="<value>"`: The migration `version` to log. (default: 0)
 
@@ -875,10 +875,10 @@ Arguments: `<current-release>`
 
 Flags:
 
-* `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
 * `--in-timescaledb-container`: Launch TimescaleDB in a Docker container for squashing; do not use the host
+* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 
@@ -895,10 +895,10 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
 * `--in-timescaledb-container`: Launch TimescaleDB in a Docker container for squashing; do not use the host
+* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 * `-f="<value>"`: The output filepath
@@ -916,8 +916,8 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
 * `-f="<value>"`: The output filepath
 
 ### sg migration rewrite
@@ -933,9 +933,9 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target database `schema` to modify (default: frontend)
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--rev="<value>"`: The target revision
+* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
 
 ## sg insights
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -818,9 +818,9 @@ Available schemas:
 
 Flags:
 
-* `--db="<value>"`: The target `schema` to compare.
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--file="<value>"`: The target schema description file.
+* `--schema, --db="<value>"`: The target `schema` to compare. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 * `--skip-version-check`: Skip validation of the instance's current version.
 * `--version="<value>"`: The target schema version. Must be resolvable as a git revlike on the Sourcegraph repository.
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -655,7 +655,7 @@ Arguments: `<name>`
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
-* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--schema, --db="<value>"`: The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights' (default: frontend)
 
 ### sg migration revert
 
@@ -878,7 +878,7 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
 * `--in-timescaledb-container`: Launch TimescaleDB in a Docker container for squashing; do not use the host
-* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--schema, --db="<value>"`: The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights' (default: frontend)
 * `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 
@@ -898,7 +898,7 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--in-container`: Launch Postgres in a Docker container for squashing; do not use the host
 * `--in-timescaledb-container`: Launch TimescaleDB in a Docker container for squashing; do not use the host
-* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--schema, --db="<value>"`: The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights' (default: frontend)
 * `--skip-data`: Skip writing data rows into the squashed migration
 * `--skip-teardown`: Skip tearing down the database created to run all registered migrations
 * `-f="<value>"`: The output filepath
@@ -917,7 +917,7 @@ Available schemas:
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
-* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--schema, --db="<value>"`: The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights' (default: frontend)
 * `-f="<value>"`: The output filepath
 
 ### sg migration rewrite
@@ -935,7 +935,7 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--rev="<value>"`: The target revision
-* `--schema, --db="<value>"`: The target database `schema` to modify (default: frontend)
+* `--schema, --db="<value>"`: The target database `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights' (default: frontend)
 
 ## sg insights
 

--- a/internal/database/migration/cliutil/addlog.go
+++ b/internal/database/migration/cliutil/addlog.go
@@ -14,9 +14,10 @@ import (
 
 func AddLog(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to modify.",
+		Name:     "schema",
+		Usage:    "The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 	versionFlag := &cli.IntFlag{
 		Name:     "version",
@@ -31,7 +32,7 @@ func AddLog(commandName string, factory RunnerFactory, outFactory OutputFactory)
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
 		var (
-			schemaName  = schemaNameFlag.Get(cmd)
+			schemaName  = TranslateSchemaNames(schemaNameFlag.Get(cmd), out)
 			versionFlag = versionFlag.Get(cmd)
 			upFlag      = upFlag.Get(cmd)
 			logger      = log.Scoped("up", "migration up command")

--- a/internal/database/migration/cliutil/describe.go
+++ b/internal/database/migration/cliutil/describe.go
@@ -12,9 +12,10 @@ import (
 
 func Describe(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to describe.",
+		Name:     "schema",
+		Usage:    "The target `schema` to describe. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 	formatFlag := &cli.StringFlag{
 		Name:     "format",
@@ -49,7 +50,7 @@ func Describe(commandName string, factory RunnerFactory, outFactory OutputFactor
 			return flagHelp(out, "unrecognized format %q (must be json or psql)", formatFlag.Get(cmd))
 		}
 
-		schemaName := schemaNameFlag.Get(cmd)
+		schemaName := TranslateSchemaNames(schemaNameFlag.Get(cmd), out)
 		store, err := setupStore(ctx, factory, schemaName)
 		if err != nil {
 			return err

--- a/internal/database/migration/cliutil/downto.go
+++ b/internal/database/migration/cliutil/downto.go
@@ -12,9 +12,10 @@ import (
 
 func DownTo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to modify.",
+		Name:     "schema",
+		Usage:    "The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 	targetFlag := &cli.StringSliceFlag{
 		Name:     "target",
@@ -56,7 +57,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory OutputFactory,
 		return runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName:     schemaNameFlag.Get(cmd),
+					SchemaName:     TranslateSchemaNames(schemaNameFlag.Get(cmd), out),
 					Type:           runner.MigrationOperationTypeTargetedDown,
 					TargetVersions: versions,
 				},
@@ -77,7 +78,7 @@ func DownTo(commandName string, factory RunnerFactory, outFactory OutputFactory,
 			return flagHelp(out, "supply a target via -target")
 		}
 
-		r, err := setupRunner(factory, schemaNameFlag.Get(cmd))
+		r, err := setupRunner(factory, TranslateSchemaNames(schemaNameFlag.Get(cmd), out))
 		if err != nil {
 			return err
 		}

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -16,9 +16,10 @@ import (
 
 func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, expectedSchemaFactories ...ExpectedSchemaFactory) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to compare.",
+		Name:     "schema",
+		Usage:    "The target `schema` to compare. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 	versionFlag := &cli.StringFlag{
 		Name:     "version",

--- a/internal/database/migration/cliutil/undo.go
+++ b/internal/database/migration/cliutil/undo.go
@@ -12,16 +12,17 @@ import (
 
 func Undo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to modify.",
+		Name:     "schema",
+		Usage:    "The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 
-	makeOptions := func(cmd *cli.Context) runner.Options {
+	makeOptions := func(cmd *cli.Context, out *output.Output) runner.Options {
 		return runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName: schemaNameFlag.Get(cmd),
+					SchemaName: TranslateSchemaNames(schemaNameFlag.Get(cmd), out),
 					Type:       runner.MigrationOperationTypeRevert,
 				},
 			},
@@ -31,12 +32,12 @@ func Undo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		r, err := setupRunner(factory, schemaNameFlag.Get(cmd))
+		r, err := setupRunner(factory, TranslateSchemaNames(schemaNameFlag.Get(cmd), out))
 		if err != nil {
 			return err
 		}
 
-		return r.Run(ctx, makeOptions(cmd))
+		return r.Run(ctx, makeOptions(cmd, out))
 	})
 
 	return &cli.Command{

--- a/internal/database/migration/cliutil/up.go
+++ b/internal/database/migration/cliutil/up.go
@@ -15,9 +15,10 @@ import (
 
 func Up(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNamesFlag := &cli.StringSliceFlag{
-		Name:  "db",
-		Usage: "The target `schema(s)` to modify. Comma-separated values are accepted. Supply \"all\" to migrate all schemas.",
-		Value: cli.NewStringSlice("all"),
+		Name:    "schema",
+		Usage:   "The target `schema(s)` to modify. Comma-separated values are accepted. Possible values are 'frontend', 'codeintel', 'codeinsights' and 'all'.",
+		Value:   cli.NewStringSlice("all"),
+		Aliases: []string{"db"},
 	}
 	unprivilegedOnlyFlag := &cli.BoolFlag{
 		Name:  "unprivileged-only",
@@ -89,7 +90,7 @@ func Up(commandName string, factory RunnerFactory, outFactory OutputFactory, dev
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		schemaNames := sanitizeSchemaNames(schemaNamesFlag.Get(cmd))
+		schemaNames := sanitizeSchemaNames(schemaNamesFlag.Get(cmd), out)
 		if len(schemaNames) == 0 {
 			return flagHelp(out, "supply a schema via -db")
 		}

--- a/internal/database/migration/cliutil/upto.go
+++ b/internal/database/migration/cliutil/upto.go
@@ -12,9 +12,10 @@ import (
 
 func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool) *cli.Command {
 	schemaNameFlag := &cli.StringFlag{
-		Name:     "db",
-		Usage:    "The target `schema` to modify.",
+		Name:     "schema",
+		Usage:    "The target `schema` to modify. Possible values are 'frontend', 'codeintel' and 'codeinsights'",
 		Required: true,
+		Aliases:  []string{"db"},
 	}
 	targetFlag := &cli.StringSliceFlag{
 		Name:     "target",
@@ -56,7 +57,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 		return runner.Options{
 			Operations: []runner.MigrationOperation{
 				{
-					SchemaName:     schemaNameFlag.Get(cmd),
+					SchemaName:     TranslateSchemaNames(schemaNameFlag.Get(cmd), out),
 					Type:           runner.MigrationOperationTypeTargetedUp,
 					TargetVersions: versions,
 				},
@@ -77,7 +78,7 @@ func UpTo(commandName string, factory RunnerFactory, outFactory OutputFactory, d
 			return flagHelp(out, "supply a target via -target")
 		}
 
-		r, err := setupRunner(factory, schemaNameFlag.Get(cmd))
+		r, err := setupRunner(factory, TranslateSchemaNames(schemaNameFlag.Get(cmd), out))
 		if err != nil {
 			return err
 		}

--- a/internal/database/migration/cliutil/validate.go
+++ b/internal/database/migration/cliutil/validate.go
@@ -11,9 +11,10 @@ import (
 
 func Validate(commandName string, factory RunnerFactory, outFactory OutputFactory) *cli.Command {
 	schemaNamesFlag := &cli.StringSliceFlag{
-		Name:  "db",
-		Usage: "The target `schema(s)` to validate. Comma-separated values are accepted. Supply \"all\" to validate all schemas.",
-		Value: cli.NewStringSlice("all"),
+		Name:    "schema",
+		Usage:   "The target `schema(s)` to validate. Comma-separated values are accepted. Possible values are 'frontend', 'codeintel', 'codeinsights' and 'all'.",
+		Value:   cli.NewStringSlice("all"),
+		Aliases: []string{"db"},
 	}
 	skipOutOfBandMigrationsFlag := &cli.BoolFlag{
 		Name:  "skip-out-of-band-migrations",
@@ -22,7 +23,7 @@ func Validate(commandName string, factory RunnerFactory, outFactory OutputFactor
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		schemaNames := sanitizeSchemaNames(schemaNamesFlag.Get(cmd))
+		schemaNames := sanitizeSchemaNames(schemaNamesFlag.Get(cmd), out)
 		if len(schemaNames) == 0 {
 			return flagHelp(out, "supply a schema via -db")
 		}


### PR DESCRIPTION
Changes the drift command's `-db` flag to be `-schema` (but allowing `-db` as an alias).
Also translates values such as `pgsql`, which coincide with the container/service names, to their schema names. 

## Test plan

Tested the flags, aliases and value aliases, all working as intended
