### PR TITLE
App: Sync the site config to file

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -299,7 +299,7 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 var siteConfigAllowEdits, _ = strconv.ParseBool(env.Get("SITE_CONFIG_ALLOW_EDITS", "false", "When SITE_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
 
 func canUpdateSiteConfiguration() bool {
-	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
+	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits || deploy.IsApp()
 }
 
 // IsCodeInsightsEnabled tells if code insights are enabled or not.

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -218,13 +218,13 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 
 	siteConfigEscapeHatchPath = os.ExpandEnv(siteConfigEscapeHatchPath)
 	if deploy.IsApp() {
-        // App always store the site config on disk, and this is achieved through
-        // making the "escape hatch file" point to our desired location on disk.
-        // The concept of an escape hatch file is not something App users care
-        // about (it only makes sense in Docker/Kubernetes, e.g. to edit the config
-        // file if the sourcegraph-frontend container is crashing) - App runs
-        // natively and this mechanism is just a convenient way for us to keep
-        // the file on disk as our source of truth.
+		// App always store the site config on disk, and this is achieved through
+		// making the "escape hatch file" point to our desired location on disk.
+		// The concept of an escape hatch file is not something App users care
+		// about (it only makes sense in Docker/Kubernetes, e.g. to edit the config
+		// file if the sourcegraph-frontend container is crashing) - App runs
+		// natively and this mechanism is just a convenient way for us to keep
+		// the file on disk as our source of truth.
 		siteConfigEscapeHatchPath = os.Getenv("SITE_CONFIG_FILE")
 	}
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -218,6 +218,13 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 
 	siteConfigEscapeHatchPath = os.ExpandEnv(siteConfigEscapeHatchPath)
 	if deploy.IsApp() {
+        // App always store the site config on disk, and this is achieved through
+        // making the "escape hatch file" point to our desired location on disk.
+        // The concept of an escape hatch file is not something App users care
+        // about (it only makes sense in Docker/Kubernetes, e.g. to edit the config
+        // file if the sourcegraph-frontend container is crashing) - App runs
+        // natively and this mechanism is just a convenient way for us to keep
+        // the file on disk as our source of truth.
 		siteConfigEscapeHatchPath = os.Getenv("SITE_CONFIG_FILE")
 	}
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -217,6 +217,9 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 	}
 
 	siteConfigEscapeHatchPath = os.ExpandEnv(siteConfigEscapeHatchPath)
+	if deploy.IsApp() {
+		siteConfigEscapeHatchPath = os.Getenv("SITE_CONFIG_FILE")
+	}
 
 	var (
 		ctx                                        = context.Background()
@@ -294,6 +297,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 					time.Sleep(1 * time.Second)
 					continue
 				}
+				lastKnownDBContents = newDBConfig.Site
 				lastKnownFileContents = newDBConfig.Site
 				lastKnownConfigID = newDBConfig.ID
 			}

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -108,16 +108,12 @@ func Init(logger log.Logger) {
 
 	siteConfigPath := filepath.Join(configDir, "site-config.json")
 	setDefaultEnv(logger, "SITE_CONFIG_FILE", siteConfigPath)
-	setDefaultEnv(logger, "SITE_CONFIG_ALLOW_EDITS", "true")
 	writeFileIfNotExists(siteConfigPath, []byte(confdefaults.App.Site))
 
 	globalSettingsPath := filepath.Join(configDir, "global-settings.json")
 	setDefaultEnv(logger, "GLOBAL_SETTINGS_FILE", globalSettingsPath)
 	setDefaultEnv(logger, "GLOBAL_SETTINGS_ALLOW_EDITS", "true")
 	writeFileIfNotExists(globalSettingsPath, []byte("{}\n"))
-
-	// Escape hatch isn't needed in local dev since the site config can always just be a file on disk.
-	setDefaultEnv(logger, "NO_SITE_CONFIG_ESCAPE_HATCH", "1")
 
 	// We disable the use of executors passwords, because executors only listen on `localhost` this
 	// is safe to do.


### PR DESCRIPTION
This use SITE_CONFIG_FILE in combination with the site config escape hatch to have two-way sync between the site config file and the database.

Normally the site config escape hatch changes are wiped on restart. By using the same path for the escape hatch file as for the initial site config file, the changes are persisted now.

Only applies to App.

## Test plan

- build and run App
- make a change to config
- verify that it's reflected in the site config file
- make a change to the site config file
- verify that it's reflected in the App site config.