### PR TITLE
license-check: update pnpm

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         id: pnpm-install
         with:
-          version: 7.28.0
+          version: 8.1.0
           run_install: false
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
License check was still using the old pnpm and it is not forwards compatible
## Test plan
This PR
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
