### PR TITLE
Cody: Add suffix to prompt knowledge base and better cut-off for multiline suggestions

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 ### Changed
 
 - Replace `Cody: Set Access Token` command with `Cody: Sign in`
+- Various improvements to the experimental completions feature
 
 ## [0.0.9]
 

--- a/client/cody/src/completions/docprovider.ts
+++ b/client/cody/src/completions/docprovider.ts
@@ -60,10 +60,7 @@ export class CompletionsDocumentProvider implements vscode.TextDocumentContentPr
             .map(({ completions, lang, meta }) =>
                 completions
                     .map(({ prompt, content, stopReason: finishReason }, index) => {
-                        let completionText = `\`\`\`${lang}\n$${content}\n\`\`\``
-                        if (this.isDebug() && meta) {
-                            completionText = '===== PROMPT:\n' + prompt + '\n===== Result:\n' + content + '\n'
-                        }
+                        let completionText = `\`\`\`${lang}\n${content}\n\`\`\``
                         const headerComponents = [`${index + 1} / ${completions.length}`]
                         if (finishReason) {
                             headerComponents.push(`finish_reason:${finishReason}`)

--- a/client/cody/src/completions/docprovider.ts
+++ b/client/cody/src/completions/docprovider.ts
@@ -53,10 +53,10 @@ export class CompletionsDocumentProvider implements vscode.TextDocumentContentPr
         }
 
         return completionGroups
-            .map(({ completions, lang, meta }) =>
+            .map(({ completions, lang }) =>
                 completions
-                    .map(({ prompt, content, stopReason: finishReason }, index) => {
-                        let completionText = `\`\`\`${lang}\n${content}\n\`\`\``
+                    .map(({ content, stopReason: finishReason }, index) => {
+                        const completionText = `\`\`\`${lang}\n${content}\n\`\`\``
                         const headerComponents = [`${index + 1} / ${completions.length}`]
                         if (finishReason) {
                             headerComponents.push(`finish_reason:${finishReason}`)

--- a/client/cody/src/completions/docprovider.ts
+++ b/client/cody/src/completions/docprovider.ts
@@ -21,10 +21,6 @@ export interface CompletionGroup {
 export class CompletionsDocumentProvider implements vscode.TextDocumentContentProvider {
     private completionsByUri: { [uri: string]: CompletionGroup[] } = {}
 
-    private isDebug(): boolean {
-        return vscode.workspace.getConfiguration().get<boolean>('cody.debug') === true
-    }
-
     private fireDocumentChanged(uri: vscode.Uri): void {
         this.onDidChangeEmitter.fire(uri)
     }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -91,7 +91,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        const { prefix, prevLine: precedingLine } = docContext
+        const { prefix, suffix, prevLine: precedingLine } = docContext
 
         const cachedCompletions = inlineCompletionsCache.get(prefix)
         if (cachedCompletions) {
@@ -106,6 +106,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             this.responseTokens,
             [],
             prefix,
+            suffix,
             '\n'
         )
         const emptyPromptLength = completionNoSnippets.emptyPromptLength()
@@ -133,6 +134,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     this.responseTokens,
                     similarCode,
                     prefix,
+                    suffix,
                     '',
                     2 // tries
                 )
@@ -150,6 +152,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     this.responseTokens,
                     similarCode,
                     prefix,
+                    suffix,
                     '',
                     2 // tries
                 ),
@@ -161,6 +164,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     this.responseTokens,
                     similarCode,
                     prefix,
+                    suffix,
                     '\n', // force a new line in the case we are at end of line
                     1 // tries
                 )
@@ -221,7 +225,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             console.error('not showing completions, no currently open doc')
             return
         }
-        const { prefix } = docContext
+        const { prefix, suffix } = docContext
 
         const remainingChars = this.tokToChar(this.promptTokens)
 
@@ -231,6 +235,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             this.responseTokens,
             [],
             prefix,
+            suffix,
             ''
         )
         const emptyPromptLength = completionNoSnippets.emptyPromptLength()
@@ -252,6 +257,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             this.responseTokens,
             similarCode,
             prefix,
+            suffix,
             ''
         )
 

--- a/client/cody/src/completions/provider.test.ts
+++ b/client/cody/src/completions/provider.test.ts
@@ -1,0 +1,36 @@
+import { sliceUntilFirstNLinesOfSuffixMatch } from './provider'
+
+describe('sliceUntilFirstNLinesOfSuffixMatch', () => {
+    it('returns the right text', () => {
+        const suggestion = `foo\nbar\nbaz\nline-1\nline-2\noh no\nline-1\nline-2\nline-3`
+        const suffix = `line-1\nline-2\nline-3\nline-4\nline-5`
+
+        expect(sliceUntilFirstNLinesOfSuffixMatch(suggestion, suffix, 3)).toMatchInlineSnapshot(`
+            "foo
+            bar
+            baz
+            line-1
+            line-2
+            oh no"
+        `)
+    })
+
+    it('works with the example suggested by Cody', () => {
+        const suggestion = 'foo\nbar\nbaz\nqux\nquux'
+        const suffix = 'baz\nqux\nquux'
+
+        expect(sliceUntilFirstNLinesOfSuffixMatch(suggestion, suffix, 3)).toMatchInlineSnapshot(`
+            "foo
+            bar"
+        `)
+    })
+
+    it('works with a real-world suggestion', () => {
+        const suggestion =
+            ' \n]; \n\nexport default function LogKit() {\n\n  const data = useLoaderData(); \n\n  return (\n    <div className="h-screen w-full flex bg-zinc-900 [color-scheme:dark] text-white">\n      <div className="w-[500px] bg-zinc-900 border-r border-zinc-800 p-4"></div>\n      <div className="flex-1"> \n        <div className="w-full border-b border-zinc-800 h-12 flex items-center p-4"> \n          <h2 className="font-semibold text-lg">Event Log</h2> \n        </div> \n        <div> \n          <table className="w-full font-mono text-xs"> \n            <thead>\n              <tr> \n                <th>Event</th> \n                <th>Payload</th> \n                <th>Timestamp</th> \n              </tr>'
+        const suffix =
+            '\n];\n\nexport async function action({ request, context }: ActionArgs) {\n  const payload: any = await request.json();\n\n  data.push({ ...payload, timestamp: Date.now() });\n\n  return null;\n}\n\nexport async function loader() {\n  return json(data);\n}\n\nexport default function LogKit() {\n  const data = useLoaderData();\n\n  return (\n    <div className="h-screen w-full flex bg-zinc-900 [color-scheme:dark] text-white">\n      <div className="w-[500px] bg-zinc-900 border-r border-zinc-800 p-4"></div>\n      <div className="flex-1">\n        <div className="w-full border-b border-zinc-800 h-12 flex items-center p-4">\n          <h2 className="font-semibold text-lg">Event Log</h2>\n        </div>\n        <div>\n          <table className="w-full font-mono text-xs">'
+
+        expect(sliceUntilFirstNLinesOfSuffixMatch(suggestion, suffix, 5)).toMatchInlineSnapshot()
+    })
+})

--- a/client/cody/src/completions/provider.test.ts
+++ b/client/cody/src/completions/provider.test.ts
@@ -2,8 +2,8 @@ import { sliceUntilFirstNLinesOfSuffixMatch } from './provider'
 
 describe('sliceUntilFirstNLinesOfSuffixMatch', () => {
     it('returns the right text', () => {
-        const suggestion = `foo\nbar\nbaz\nline-1\nline-2\noh no\nline-1\nline-2\nline-3`
-        const suffix = `line-1\nline-2\nline-3\nline-4\nline-5`
+        const suggestion = 'foo\nbar\nbaz\nline-1\nline-2\noh no\nline-1\nline-2\nline-3'
+        const suffix = 'line-1\nline-2\nline-3\nline-4\nline-5'
 
         expect(sliceUntilFirstNLinesOfSuffixMatch(suggestion, suffix, 3)).toMatchInlineSnapshot(`
             "foo

--- a/client/cody/src/completions/provider.test.ts
+++ b/client/cody/src/completions/provider.test.ts
@@ -24,13 +24,4 @@ describe('sliceUntilFirstNLinesOfSuffixMatch', () => {
             bar"
         `)
     })
-
-    it('works with a real-world suggestion', () => {
-        const suggestion =
-            ' \n]; \n\nexport default function LogKit() {\n\n  const data = useLoaderData(); \n\n  return (\n    <div className="h-screen w-full flex bg-zinc-900 [color-scheme:dark] text-white">\n      <div className="w-[500px] bg-zinc-900 border-r border-zinc-800 p-4"></div>\n      <div className="flex-1"> \n        <div className="w-full border-b border-zinc-800 h-12 flex items-center p-4"> \n          <h2 className="font-semibold text-lg">Event Log</h2> \n        </div> \n        <div> \n          <table className="w-full font-mono text-xs"> \n            <thead>\n              <tr> \n                <th>Event</th> \n                <th>Payload</th> \n                <th>Timestamp</th> \n              </tr>'
-        const suffix =
-            '\n];\n\nexport async function action({ request, context }: ActionArgs) {\n  const payload: any = await request.json();\n\n  data.push({ ...payload, timestamp: Date.now() });\n\n  return null;\n}\n\nexport async function loader() {\n  return json(data);\n}\n\nexport default function LogKit() {\n  const data = useLoaderData();\n\n  return (\n    <div className="h-screen w-full flex bg-zinc-900 [color-scheme:dark] text-white">\n      <div className="w-[500px] bg-zinc-900 border-r border-zinc-800 p-4"></div>\n      <div className="flex-1">\n        <div className="w-full border-b border-zinc-800 h-12 flex items-center p-4">\n          <h2 className="font-semibold text-lg">Event Log</h2>\n        </div>\n        <div>\n          <table className="w-full font-mono text-xs">'
-
-        expect(sliceUntilFirstNLinesOfSuffixMatch(suggestion, suffix, 5)).toMatchInlineSnapshot()
-    })
 })


### PR DESCRIPTION
Closes #51345

Some more Cody completions tweaks:

1. We now include the suffix (the part of the prompt after the cursor) into the knowledge base for more context. To avoid Cody repeating the suffix without generting content, we cut away the first 5 lines of the suffix though. This yielded better results in my limites testing. 
  
  If we didn't do that, Cody would just repeat the suffix in roughly two out of three suggestions:
   <img width="1609" alt="Screenshot 2023-05-03 at 15 25 05" src="https://user-images.githubusercontent.com/458591/235961816-223a7053-f666-471a-8ec9-2d1f4f898ddc.png">
2. Better cut-off for multiline suggestions: We now compare the suffix with the completion until we find 5 matching lines in the suffix. This way, we can cut away content that is already in the suffix pretty effectively, leading to smaller suggestion windows. E.g.:
<img width="1663" alt="Screenshot 2023-05-03 at 17 22 49" src="https://user-images.githubusercontent.com/458591/235962380-f301f8b1-a2af-45e6-9eee-c66aeb9770af.png"> (Note: for this prompt I removed the highlighted part first. All three suggestions are very relevant already!)
3. Removed the debug mode specialcasing for the multiline suggestions window. It was tripping me off and I think if we do broader dogfooding it might confuse others as well.

## Test plan

See screenshot above. Lots of back and forth 😬 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
