### PR TITLE
Executors: Add `securityContext.fsGroup` to k8s jobs

### DIFF
--- a/enterprise/cmd/batcheshelper/Dockerfile
+++ b/enterprise/cmd/batcheshelper/Dockerfile
@@ -20,4 +20,5 @@ RUN apk add --no-cache \
     # Don't use alpine/edge, the git release on this segfaults
     'git>=2.38.0' --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
 
+USER sourcegraph
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_client_go//kubernetes",
+        "@io_k8s_utils//pointer",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -207,8 +208,12 @@ func NewKubernetesJob(name string, image string, spec Spec, path string, options
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeName:      options.NodeName,
-					NodeSelector:  options.NodeSelector,
+					NodeName:     options.NodeName,
+					NodeSelector: options.NodeSelector,
+					SecurityContext: &corev1.PodSecurityContext{
+						// This corresponds to the GID of the "sourcegraph" user that is used to run the Docker image
+						FSGroup: pointer.Int64(1000),
+					},
 					Affinity:      affinity,
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -127,7 +127,6 @@ func transformRecord(ctx context.Context, db database.DB, index uploadsshared.In
 				"-upload-route", uploadRoute,
 				"-file", outfile,
 				"-associated-index-id", strconv.Itoa(index.ID),
-				"-trace=3",
 			),
 		},
 		Dir: index.Root,

--- a/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queues/codeintel/transform.go
@@ -127,6 +127,7 @@ func transformRecord(ctx context.Context, db database.DB, index uploadsshared.In
 				"-upload-route", uploadRoute,
 				"-file", outfile,
 				"-associated-index-id", strconv.Itoa(index.ID),
+				"-trace=3",
 			),
 		},
 		Dir: index.Root,


### PR DESCRIPTION
In order for a job step to perform operations that modify the file system, they need to set the `fsGroup` property to the GID of the user (which is `1000` for the user `sourcegraph`).

It also sets the same user in the `batcheshelper` image, otherwise this setting doesn't do much.

## Test plan
- Tested in the context of https://github.com/sourcegraph/sourcegraph/issues/50824
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
