### PR TITLE
own: use internal actor for recent contributors indexing

### DIFF
--- a/enterprise/internal/own/background/BUILD.bazel
+++ b/enterprise/internal/own/background/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/shared/background",
+        "//internal/actor",
         "//internal/api",
         "//internal/conf",
         "//internal/database",
@@ -49,7 +50,11 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//cmd/frontend/globals",
+        "//enterprise/internal/database",
+        "//internal/actor",
         "//internal/api",
+        "//internal/authz",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbtest",


### PR DESCRIPTION
This fixes an issue where private repos (repos with permissions enabled) were skipped during indexing ownership recent contributors. The indexer needs access to see all repos and paths, which also implies we are going to have to filter these out at query time.

## Test plan

I tested this using explicit permissions API, and included an automated test for the same.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
