### PR TITLE
App: Update CodyEnabled logic to support usage in App

### DIFF
--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//internal/actor",
         "//internal/conf",
+        "//internal/conf/deploy",
         "//internal/featureflag",
     ],
 )
@@ -19,6 +20,7 @@ go_test(
     deps = [
         "//internal/actor",
         "//internal/conf",
+        "//internal/conf/deploy",
         "//internal/featureflag",
         "//schema",
     ],

--- a/internal/cody/feature_flag.go
+++ b/internal/cody/feature_flag.go
@@ -19,7 +19,7 @@ func IsCodyEnabled(ctx context.Context) bool {
 	}
 
 	if deploy.IsApp() {
-		return isCodyEnabledInApp(ctx)
+		return isCodyEnabledInApp()
 	}
 
 	return isCodyEnabled(ctx)
@@ -53,7 +53,7 @@ func isCodyEnabled(ctx context.Context) bool {
 // If Completions are configured and enabled, cody is enabled.
 // If the App user's dotcom auth token is present, cody is enabled.
 // In all other cases Cody is disabled.
-func isCodyEnabledInApp(ctx context.Context) bool {
+func isCodyEnabledInApp() bool {
 	completionsConfig := conf.Get().Completions
 	appConfig := conf.Get().App
 	if completionsConfig != nil && completionsConfig.Enabled {

--- a/internal/cody/feature_flag.go
+++ b/internal/cody/feature_flag.go
@@ -5,21 +5,34 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
 // IsCodyEnabled determines if cody is enabled for the actor in the given context.
 // If it is an unauthenticated request, cody is disabled.
-// If Completions aren't configured, cody is disabled.
-// If Completions are not enabled, cody is disabled
-// If CodyRestrictUsersFeatureFlag is set, the cody-experimental featureflag
-// will determine access.
-// Otherwise, all authenticated users are granted access.
+// If authenticated it checks if cody is enabled for the deployment type
 func IsCodyEnabled(ctx context.Context) bool {
 	a := actor.FromContext(ctx)
 	if !a.IsAuthenticated() {
 		return false
 	}
+
+	if deploy.IsApp() {
+		return isCodyEnabledInApp(ctx)
+	}
+
+	return isCodyEnabled(ctx)
+}
+
+// isCodyEnabled determines if cody is enabled for the actor in the given context
+// for all deployment types except "app".
+// If Completions aren't configured, cody is disabled.
+// If Completions are not enabled, cody is disabled
+// If CodyRestrictUsersFeatureFlag is set, the cody-experimental featureflag
+// will determine access.
+// Otherwise, all authenticated users are granted access.
+func isCodyEnabled(ctx context.Context) bool {
 	completionsConfig := conf.Get().Completions
 	if completionsConfig == nil {
 		return false
@@ -34,4 +47,22 @@ func IsCodyEnabled(ctx context.Context) bool {
 		return featureflag.FromContext(ctx).GetBoolOr("cody-experimental", false)
 	}
 	return true
+}
+
+// isCodyEnabledInApp determines if cody is enabled within Sourcegraph App.
+// If Completions are configured and enabled, cody is enabled.
+// If the App user's dotcom auth token is present, cody is enabled.
+// In all other cases Cody is disabled.
+func isCodyEnabledInApp(ctx context.Context) bool {
+	completionsConfig := conf.Get().Completions
+	appConfig := conf.Get().App
+	if completionsConfig != nil && completionsConfig.Enabled {
+		return true
+	}
+
+	if appConfig != nil && len(appConfig.DotcomAuthToken) > 0 {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
When running Sourcegraph App the logic to determine if Cody is enabled differs,  because Cody can be enabled either by configuring the completion settings or by connecting App to the users sourcegraph.com account. 

## Test plan
Unit tests pass 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
