### PR TITLE
[POC] internal/database: Add table repo_life_cycle and record events

### DIFF
--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -7948,6 +7948,9 @@ type MockEnterpriseDB struct {
 	// RepoKVPsFunc is an instance of a mock function object controlling the
 	// behavior of the method RepoKVPs.
 	RepoKVPsFunc *EnterpriseDBRepoKVPsFunc
+	// RepoLifeCycleStoreFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoLifeCycleStore.
+	RepoLifeCycleStoreFunc *EnterpriseDBRepoLifeCycleStoreFunc
 	// RepoStatisticsFunc is an instance of a mock function object
 	// controlling the behavior of the method RepoStatistics.
 	RepoStatisticsFunc *EnterpriseDBRepoStatisticsFunc
@@ -8191,6 +8194,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		RepoKVPsFunc: &EnterpriseDBRepoKVPsFunc{
 			defaultHook: func() (r0 database.RepoKVPStore) {
+				return
+			},
+		},
+		RepoLifeCycleStoreFunc: &EnterpriseDBRepoLifeCycleStoreFunc{
+			defaultHook: func() (r0 database.RepoLifeCycleStore) {
 				return
 			},
 		},
@@ -8481,6 +8489,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.RepoKVPs")
 			},
 		},
+		RepoLifeCycleStoreFunc: &EnterpriseDBRepoLifeCycleStoreFunc{
+			defaultHook: func() database.RepoLifeCycleStore {
+				panic("unexpected invocation of MockEnterpriseDB.RepoLifeCycleStore")
+			},
+		},
 		RepoStatisticsFunc: &EnterpriseDBRepoStatisticsFunc{
 			defaultHook: func() database.RepoStatisticsStore {
 				panic("unexpected invocation of MockEnterpriseDB.RepoStatistics")
@@ -8696,6 +8709,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		RepoKVPsFunc: &EnterpriseDBRepoKVPsFunc{
 			defaultHook: i.RepoKVPs,
+		},
+		RepoLifeCycleStoreFunc: &EnterpriseDBRepoLifeCycleStoreFunc{
+			defaultHook: i.RepoLifeCycleStore,
 		},
 		RepoStatisticsFunc: &EnterpriseDBRepoStatisticsFunc{
 			defaultHook: i.RepoStatistics,
@@ -12412,6 +12428,107 @@ func (c EnterpriseDBRepoKVPsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBRepoKVPsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBRepoLifeCycleStoreFunc describes the behavior when the
+// RepoLifeCycleStore method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBRepoLifeCycleStoreFunc struct {
+	defaultHook func() database.RepoLifeCycleStore
+	hooks       []func() database.RepoLifeCycleStore
+	history     []EnterpriseDBRepoLifeCycleStoreFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoLifeCycleStore delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) RepoLifeCycleStore() database.RepoLifeCycleStore {
+	r0 := m.RepoLifeCycleStoreFunc.nextHook()()
+	m.RepoLifeCycleStoreFunc.appendCall(EnterpriseDBRepoLifeCycleStoreFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RepoLifeCycleStore
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) SetDefaultHook(hook func() database.RepoLifeCycleStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoLifeCycleStore method of the parent MockEnterpriseDB instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) PushHook(hook func() database.RepoLifeCycleStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) SetDefaultReturn(r0 database.RepoLifeCycleStore) {
+	f.SetDefaultHook(func() database.RepoLifeCycleStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) PushReturn(r0 database.RepoLifeCycleStore) {
+	f.PushHook(func() database.RepoLifeCycleStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) nextHook() func() database.RepoLifeCycleStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) appendCall(r0 EnterpriseDBRepoLifeCycleStoreFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBRepoLifeCycleStoreFuncCall
+// objects describing the invocations of this function.
+func (f *EnterpriseDBRepoLifeCycleStoreFunc) History() []EnterpriseDBRepoLifeCycleStoreFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBRepoLifeCycleStoreFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBRepoLifeCycleStoreFuncCall is an object that describes an
+// invocation of method RepoLifeCycleStore on an instance of
+// MockEnterpriseDB.
+type EnterpriseDBRepoLifeCycleStoreFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.RepoLifeCycleStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBRepoLifeCycleStoreFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBRepoLifeCycleStoreFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -46,6 +46,7 @@ type DB interface {
 	Phabricator() PhabricatorStore
 	RedisKeyValue() RedisKeyValueStore
 	Repos() RepoStore
+	RepoLifeCycleStore() RepoLifeCycleStore
 	RepoKVPs() RepoKVPStore
 	RolePermissions() RolePermissionStore
 	Roles() RoleStore
@@ -222,6 +223,10 @@ func (d *db) RedisKeyValue() RedisKeyValueStore {
 
 func (d *db) Repos() RepoStore {
 	return ReposWith(d.logger, d.Store)
+}
+
+func (d *db) RepoLifeCycleStore() RepoLifeCycleStore {
+	return RepoLifeCycleWith(d.logger, d.Store)
 }
 
 func (d *db) RepoKVPs() RepoKVPStore {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -4979,6 +4979,9 @@ type MockDB struct {
 	// RepoKVPsFunc is an instance of a mock function object controlling the
 	// behavior of the method RepoKVPs.
 	RepoKVPsFunc *DBRepoKVPsFunc
+	// RepoLifeCycleStoreFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoLifeCycleStore.
+	RepoLifeCycleStoreFunc *DBRepoLifeCycleStoreFunc
 	// RepoStatisticsFunc is an instance of a mock function object
 	// controlling the behavior of the method RepoStatistics.
 	RepoStatisticsFunc *DBRepoStatisticsFunc
@@ -5199,6 +5202,11 @@ func NewMockDB() *MockDB {
 		},
 		RepoKVPsFunc: &DBRepoKVPsFunc{
 			defaultHook: func() (r0 RepoKVPStore) {
+				return
+			},
+		},
+		RepoLifeCycleStoreFunc: &DBRepoLifeCycleStoreFunc{
+			defaultHook: func() (r0 RepoLifeCycleStore) {
 				return
 			},
 		},
@@ -5464,6 +5472,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.RepoKVPs")
 			},
 		},
+		RepoLifeCycleStoreFunc: &DBRepoLifeCycleStoreFunc{
+			defaultHook: func() RepoLifeCycleStore {
+				panic("unexpected invocation of MockDB.RepoLifeCycleStore")
+			},
+		},
 		RepoStatisticsFunc: &DBRepoStatisticsFunc{
 			defaultHook: func() RepoStatisticsStore {
 				panic("unexpected invocation of MockDB.RepoStatistics")
@@ -5661,6 +5674,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		RepoKVPsFunc: &DBRepoKVPsFunc{
 			defaultHook: i.RepoKVPs,
+		},
+		RepoLifeCycleStoreFunc: &DBRepoLifeCycleStoreFunc{
+			defaultHook: i.RepoLifeCycleStore,
 		},
 		RepoStatisticsFunc: &DBRepoStatisticsFunc{
 			defaultHook: i.RepoStatistics,
@@ -8939,6 +8955,105 @@ func (c DBRepoKVPsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBRepoKVPsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBRepoLifeCycleStoreFunc describes the behavior when the
+// RepoLifeCycleStore method of the parent MockDB instance is invoked.
+type DBRepoLifeCycleStoreFunc struct {
+	defaultHook func() RepoLifeCycleStore
+	hooks       []func() RepoLifeCycleStore
+	history     []DBRepoLifeCycleStoreFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoLifeCycleStore delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) RepoLifeCycleStore() RepoLifeCycleStore {
+	r0 := m.RepoLifeCycleStoreFunc.nextHook()()
+	m.RepoLifeCycleStoreFunc.appendCall(DBRepoLifeCycleStoreFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RepoLifeCycleStore
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBRepoLifeCycleStoreFunc) SetDefaultHook(hook func() RepoLifeCycleStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoLifeCycleStore method of the parent MockDB instance invokes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBRepoLifeCycleStoreFunc) PushHook(hook func() RepoLifeCycleStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBRepoLifeCycleStoreFunc) SetDefaultReturn(r0 RepoLifeCycleStore) {
+	f.SetDefaultHook(func() RepoLifeCycleStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBRepoLifeCycleStoreFunc) PushReturn(r0 RepoLifeCycleStore) {
+	f.PushHook(func() RepoLifeCycleStore {
+		return r0
+	})
+}
+
+func (f *DBRepoLifeCycleStoreFunc) nextHook() func() RepoLifeCycleStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBRepoLifeCycleStoreFunc) appendCall(r0 DBRepoLifeCycleStoreFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBRepoLifeCycleStoreFuncCall objects
+// describing the invocations of this function.
+func (f *DBRepoLifeCycleStoreFunc) History() []DBRepoLifeCycleStoreFuncCall {
+	f.mutex.Lock()
+	history := make([]DBRepoLifeCycleStoreFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBRepoLifeCycleStoreFuncCall is an object that describes an invocation of
+// method RepoLifeCycleStore on an instance of MockDB.
+type DBRepoLifeCycleStoreFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 RepoLifeCycleStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBRepoLifeCycleStoreFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBRepoLifeCycleStoreFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/repo_life_cycle.go
+++ b/internal/database/repo_life_cycle.go
@@ -1,0 +1,117 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type RepoLifeCycleEvent string
+
+const (
+	RepoLifeCycleEventAddedFromCodeHostSync RepoLifeCycleEvent = "added from code host sync"
+	RepoLifeCycleEventCloneStarted          RepoLifeCycleEvent = "clone started"
+	RepoLifeCycleEventCloneCompleted        RepoLifeCycleEvent = "clone completed"
+	RepoLifeCycleEventMetadataUpdated       RepoLifeCycleEvent = "metadata updated"
+
+	RepoLifeCycleEventUpdateStarted RepoLifeCycleEvent = "update started"
+
+	RepoLifeCycleEventDeletedFromCodeHostSync RepoLifeCycleEvent = "deleted from code host sync"
+	RepoLifeCycleEventPurgedFromDisk          RepoLifeCycleEvent = "purged from disk"
+	RepoLifeCycleEventPurgedDiskPressure      RepoLifeCycleEvent = "purged due to disk pressure"
+	RepoLifeCycleEventGcStarted               RepoLifeCycleEvent = "git gc started"
+	RepoLifeCycleEventForegroundSyncStarted   RepoLifeCycleEvent = "foregound sync started"
+	RepoLifeCycleEventBackgroundSyncStarted   RepoLifeCycleEvent = "background sync started"
+)
+
+type RepoLifeCycleStore interface {
+	Transact(context.Context) (RepoLifeCycleStore, error)
+	With(basestore.ShareableStore) RepoLifeCycleStore
+
+	Upsert(ctx context.Context, repoID api.RepoID, event RepoLifeCycleEvent) error
+	Get(ctx context.Context, repoID int) (*RepoLifeCycle, error)
+}
+
+type repoLifeCycleStore struct {
+	*basestore.Store
+	logger log.Logger
+}
+
+var _ RepoLifeCycleStore = (*repoLifeCycleStore)(nil)
+
+// RepoLifeCycleWith instantiates and returns a new RepoLifeCycleStore using the other store handle.
+func RepoLifeCycleWith(logger log.Logger, other basestore.ShareableStore) RepoLifeCycleStore {
+	return &repoLifeCycleStore{
+		logger: logger,
+		Store:  basestore.NewWithHandle(other.Handle()),
+	}
+}
+
+// Wraps the basestore.With method to return the correct type.
+func (s *repoLifeCycleStore) With(other basestore.ShareableStore) RepoLifeCycleStore {
+	return &repoLifeCycleStore{Store: s.Store.With(other) /*, ... */}
+}
+
+// Wraps the basestore.Transact method to return the correct type.
+func (s *repoLifeCycleStore) Transact(ctx context.Context) (RepoLifeCycleStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &repoLifeCycleStore{Store: txBase /*, ... */}, nil
+}
+
+var upsertRepoLifeCycleFmtStr = `
+INSERT INTO repos_life_cycle (repo_id, logs)
+VALUES (%d, %s)
+ON CONFLICT (repo_id) DO UPDATE 
+SET logs = repos_life_cycle.logs || %s`
+
+func (s *repoLifeCycleStore) Upsert(ctx context.Context, repoID api.RepoID, event RepoLifeCycleEvent) error {
+	log, err := json.Marshal([]repoLifeCycleLogItem{{
+		Event:     event,
+		Timestamp: time.Now(),
+	}})
+	if err != nil {
+		return errors.Wrapf(err, "reposLifeCycleStore: failed to generate repoLifeCycleLogItem for event %q", event)
+	}
+
+	q := sqlf.Sprintf(upsertRepoLifeCycleFmtStr, repoID, string(log), string(log))
+	return errors.Wrap(s.Exec(ctx, q), "reposLifeCycleStore: failed to upsert")
+}
+
+var getRepoLifeCycleFmtStr = "SELECT repo_id, logs FROM repos_life_cycle WHERE repo_id = %d"
+
+func (s *repoLifeCycleStore) Get(ctx context.Context, repoID int) (*RepoLifeCycle, error) {
+	row := s.QueryRow(ctx, sqlf.Sprintf(getRepoLifeCycleFmtStr, repoID))
+	item, err := scanRepoLifeCycleRow(row)
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return item, err
+}
+
+type repoLifeCycleLogItem struct {
+	Event     RepoLifeCycleEvent `json:"event"`
+	Timestamp time.Time          `json:"timestamp"`
+}
+
+type RepoLifeCycle struct {
+	repoID int32
+	log    string
+}
+
+var scanRepoLifeCycleRow = func(scanner dbutil.Scanner) (*RepoLifeCycle, error) {
+	var s RepoLifeCycle
+	err := scanner.Scan(&s.repoID, &s.log)
+	return &s, err
+}

--- a/internal/database/repo_life_cycle_test.go
+++ b/internal/database/repo_life_cycle_test.go
@@ -1,0 +1,34 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoLifeCycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := actor.WithInternalActor(context.Background())
+
+	store := db.RepoLifeCycleStore()
+	require.NoError(t, store.Upsert(ctx, 1, RepoLifeCycleEventAddedFromCodeHostSync))
+
+	require.NoError(t, store.Upsert(ctx, 1, RepoLifeCycleEventCloneCompleted))
+
+	item, err := store.Get(ctx, 1)
+	require.NoError(t, err)
+
+	fmt.Printf("%#v", *item)
+
+}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -21408,6 +21408,52 @@
       "Triggers": []
     },
     {
+      "Name": "repo_life_cycle",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "logs",
+          "Index": 2,
+          "TypeName": "jsonb",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "repo_id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "repo_life_cycle_repo_id_unique",
+          "IsPrimaryKey": false,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX repo_life_cycle_repo_id_unique ON repo_life_cycle USING btree (repo_id)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        }
+      ],
+      "Constraints": null,
+      "Triggers": []
+    },
+    {
       "Name": "repo_paths",
       "Comment": "",
       "Columns": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3218,6 +3218,17 @@ Foreign-key constraints:
 
 ```
 
+# Table "public.repo_life_cycle"
+```
+ Column  |  Type   | Collation | Nullable | Default 
+---------+---------+-----------+----------+---------
+ repo_id | integer |           | not null | 
+ logs    | jsonb   |           | not null | 
+Indexes:
+    "repo_life_cycle_repo_id_unique" UNIQUE, btree (repo_id)
+
+```
+
 # Table "public.repo_paths"
 ```
     Column     |  Type   | Collation | Nullable |                Default                 

--- a/internal/repos/mocks_temp.go
+++ b/internal/repos/mocks_temp.go
@@ -54,6 +54,9 @@ type MockStore struct {
 	// ListSyncJobsFunc is an instance of a mock function object controlling
 	// the behavior of the method ListSyncJobs.
 	ListSyncJobsFunc *StoreListSyncJobsFunc
+	// RepoLifeCycleStoreFunc is an instance of a mock function object
+	// controlling the behavior of the method RepoLifeCycleStore.
+	RepoLifeCycleStoreFunc *StoreRepoLifeCycleStoreFunc
 	// RepoStoreFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoStore.
 	RepoStoreFunc *StoreRepoStoreFunc
@@ -129,6 +132,11 @@ func NewMockStore() *MockStore {
 		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
 			defaultHook: func(context.Context) (r0 []SyncJob, r1 error) {
+				return
+			},
+		},
+		RepoLifeCycleStoreFunc: &StoreRepoLifeCycleStoreFunc{
+			defaultHook: func() (r0 database.RepoLifeCycleStore) {
 				return
 			},
 		},
@@ -224,6 +232,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ListSyncJobs")
 			},
 		},
+		RepoLifeCycleStoreFunc: &StoreRepoLifeCycleStoreFunc{
+			defaultHook: func() database.RepoLifeCycleStore {
+				panic("unexpected invocation of MockStore.RepoLifeCycleStore")
+			},
+		},
 		RepoStoreFunc: &StoreRepoStoreFunc{
 			defaultHook: func() database.RepoStore {
 				panic("unexpected invocation of MockStore.RepoStore")
@@ -295,6 +308,9 @@ func NewMockStoreFrom(i Store) *MockStore {
 		},
 		ListSyncJobsFunc: &StoreListSyncJobsFunc{
 			defaultHook: i.ListSyncJobs,
+		},
+		RepoLifeCycleStoreFunc: &StoreRepoLifeCycleStoreFunc{
+			defaultHook: i.RepoLifeCycleStore,
 		},
 		RepoStoreFunc: &StoreRepoStoreFunc{
 			defaultHook: i.RepoStore,
@@ -1364,6 +1380,105 @@ func (c StoreListSyncJobsFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreListSyncJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreRepoLifeCycleStoreFunc describes the behavior when the
+// RepoLifeCycleStore method of the parent MockStore instance is invoked.
+type StoreRepoLifeCycleStoreFunc struct {
+	defaultHook func() database.RepoLifeCycleStore
+	hooks       []func() database.RepoLifeCycleStore
+	history     []StoreRepoLifeCycleStoreFuncCall
+	mutex       sync.Mutex
+}
+
+// RepoLifeCycleStore delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) RepoLifeCycleStore() database.RepoLifeCycleStore {
+	r0 := m.RepoLifeCycleStoreFunc.nextHook()()
+	m.RepoLifeCycleStoreFunc.appendCall(StoreRepoLifeCycleStoreFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RepoLifeCycleStore
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StoreRepoLifeCycleStoreFunc) SetDefaultHook(hook func() database.RepoLifeCycleStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RepoLifeCycleStore method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StoreRepoLifeCycleStoreFunc) PushHook(hook func() database.RepoLifeCycleStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreRepoLifeCycleStoreFunc) SetDefaultReturn(r0 database.RepoLifeCycleStore) {
+	f.SetDefaultHook(func() database.RepoLifeCycleStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreRepoLifeCycleStoreFunc) PushReturn(r0 database.RepoLifeCycleStore) {
+	f.PushHook(func() database.RepoLifeCycleStore {
+		return r0
+	})
+}
+
+func (f *StoreRepoLifeCycleStoreFunc) nextHook() func() database.RepoLifeCycleStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreRepoLifeCycleStoreFunc) appendCall(r0 StoreRepoLifeCycleStoreFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreRepoLifeCycleStoreFuncCall objects
+// describing the invocations of this function.
+func (f *StoreRepoLifeCycleStoreFunc) History() []StoreRepoLifeCycleStoreFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreRepoLifeCycleStoreFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreRepoLifeCycleStoreFuncCall is an object that describes an invocation
+// of method RepoLifeCycleStore on an instance of MockStore.
+type StoreRepoLifeCycleStoreFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.RepoLifeCycleStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreRepoLifeCycleStoreFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreRepoLifeCycleStoreFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // StoreRepoStoreFunc describes the behavior when the RepoStore method of

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -212,6 +212,14 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 				defer cancel()
 				defer s.updateQueue.remove(repo, true)
 
+				event := database.RepoLifeCycleEventUpdateStarted
+				if err := s.db.RepoLifeCycleStore().Upsert(ctx, repo.ID, event); err != nil {
+					s.logger.Error(
+						"failed to record repo lifecycle event",
+						log.String("event", string(event)),
+						log.Error(err))
+				}
+
 				// This is a blocking call since the repo will be cloned synchronously by gitserver
 				// if it doesn't exist or update it if it does. The timeout of this request depends
 				// on the value of conf.GitLongCommandTimeout() or if the passed context has a set

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -26,6 +26,10 @@ import (
 type Store interface {
 	// RepoStore returns a database.RepoStore using the same database handle.
 	RepoStore() database.RepoStore
+
+	// RepoStoreLifeCycleStore returns a database.RepoStore using the same database handle.
+	RepoLifeCycleStore() database.RepoLifeCycleStore
+
 	// GitserverReposStore returns a database.GitserverReposStore using the same
 	// database handle.
 	GitserverReposStore() database.GitserverRepoStore
@@ -118,6 +122,10 @@ func NewStore(logger log.Logger, db database.DB) Store {
 
 func (s *store) RepoStore() database.RepoStore {
 	return database.ReposWith(s.Logger, s)
+}
+
+func (s *store) RepoLifeCycleStore() database.RepoLifeCycleStore {
+	return database.RepoLifeCycleWith(s.Logger, s)
 }
 
 func (s *store) GitserverReposStore() database.GitserverRepoStore {

--- a/migrations/frontend/1683142671_add_table_repo_life_cycle/down.sql
+++ b/migrations/frontend/1683142671_add_table_repo_life_cycle/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS repo_life_cycle_repo_id_unique;
+
+DROP TABLE IF EXISTS repo_life_cycle;

--- a/migrations/frontend/1683142671_add_table_repo_life_cycle/metadata.yaml
+++ b/migrations/frontend/1683142671_add_table_repo_life_cycle/metadata.yaml
@@ -1,0 +1,2 @@
+name: add table repo_life_cycle
+parents: [1681300431, 1682626931, 1682114198]

--- a/migrations/frontend/1683142671_add_table_repo_life_cycle/up.sql
+++ b/migrations/frontend/1683142671_add_table_repo_life_cycle/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS repo_life_cycle (
+    repo_id integer NOT NULL,
+    logs jsonb NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS repo_life_cycle_repo_id_unique ON repo_life_cycle USING btree (repo_id);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -3923,6 +3923,11 @@ CREATE TABLE repo_kvps (
     value text
 );
 
+CREATE TABLE repo_life_cycle (
+    repo_id integer NOT NULL,
+    logs jsonb NOT NULL
+);
+
 CREATE TABLE repo_paths (
     id integer NOT NULL,
     repo_id integer NOT NULL,
@@ -5630,6 +5635,8 @@ CREATE INDEX repo_fork ON repo USING btree (fork);
 CREATE INDEX repo_hashed_name_idx ON repo USING btree (sha256((lower((name)::text))::bytea)) WHERE (deleted_at IS NULL);
 
 CREATE INDEX repo_is_not_blocked_idx ON repo USING btree (((blocked IS NULL)));
+
+CREATE UNIQUE INDEX repo_life_cycle_repo_id_unique ON repo_life_cycle USING btree (repo_id);
 
 CREATE INDEX repo_metadata_gin_idx ON repo USING gin (metadata);
 


### PR DESCRIPTION
## What

A ledger like append only record of all update related activity happening on a repo stored in the DB.

## Why

Primary use case: Debugging frequent customer issues like, "repo not syncing", "repo constantly cloning"

#### Why is logging not good enough?

We have debug logs which helps but debug level is disabled by default in customer environments and is always enabled once the issue is already happening, not to mention searching through debug logs is painful at the moment (maybe that's the problem that needs to be solved instead? I dunno, I'm using this PR as a discussion kick starter).

Just being able to look at the series of events of a repo and the timestamp is going to be immensely helpful for debugging repo sync issues for CEs as well as Sourcegraph site admins and us when we're pulled into customer calls.

## Scope

Only a few events are being logged at the moment for the PoC. We need to audit and add the event logging wherever we do repo-syncing voodoo.

## Potential pitfalls

1. Open ended growing infinitely - We should consider truncating event logs at say 1000 items for each repo by default
2. High write volume to the DB (similar to performance issues seen recently)

## Must have

1. Use `experimentalFeatures` site config so that this can be turned on / off at will without 


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
