### PR TITLE
App: apply recommended tauri rust build config

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,13 @@ rust-version = "1.59"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+panic = "abort" # Strip expensive panic clean-up logic
+codegen-units = 1 # Compile crates one after another so the compiler can optimize better
+lto = true # Enables link to optimizations
+opt-level = "s" # Optimize for binary size
+strip = true # Remove debug symbols
+
 [build-dependencies]
 tauri-build = { version = "1.2.1", features = [] }
 


### PR DESCRIPTION
Added the [recommended settings](https://tauri.app/v1/guides/building/app-size#rust-build-time-optimizations) for building the entry point binary.

Size reduction 
```
6.9M May  3 16:27 Sourcegraph App

2.8M May  3 16:34 Sourcegraph App
 ```
## Test plan
Built release version and opened app ran as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
