### PR TITLE
Embeddings: simplify embeddings search index

### DIFF
--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -46,14 +46,8 @@ func searchRepoEmbeddingIndex(
 		UseDocumentRanks: params.UseDocumentRanks,
 	}
 
-	var codeResults, textResults []embeddings.EmbeddingSearchResult
-	if params.CodeResultsCount > 0 && len(embeddingIndex.CodeIndex.Embeddings) > 0 {
-		codeResults = searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.CodeIndex, readFile, embeddedQuery, params.CodeResultsCount, opts)
-	}
-
-	if params.TextResultsCount > 0 && len(embeddingIndex.TextIndex.Embeddings) > 0 {
-		textResults = searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.TextIndex, readFile, embeddedQuery, params.TextResultsCount, opts)
-	}
+	codeResults := searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.CodeIndex, readFile, embeddedQuery, params.CodeResultsCount, opts)
+	textResults := searchEmbeddingIndex(ctx, logger, embeddingIndex.RepoName, embeddingIndex.Revision, &embeddingIndex.TextIndex, readFile, embeddedQuery, params.TextResultsCount, opts)
 
 	return &embeddings.EmbeddingSearchResults{CodeResults: codeResults, TextResults: textResults}, nil
 }

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -84,7 +84,7 @@ type WorkerOptions struct {
 // SimilaritySearch finds the `nResults` most similar rows to a query vector. It uses the cosine similarity metric.
 // IMPORTANT: The vectors in the embedding index have to be normalized for similarity search to work correctly.
 func (index *EmbeddingIndex) SimilaritySearch(query []int8, numResults int, workerOptions WorkerOptions, opts SearchOptions) []EmbeddingSearchResult {
-	if numResults == 0 {
+	if numResults == 0 || len(index.Embeddings) == 0 {
 		return []EmbeddingSearchResult{}
 	}
 


### PR DESCRIPTION
This is just a small simplification to searchRepoEmbeddingIndex. We do not need to check ahead of time whether there are any embeddings or whether the limit is zero. We already check in index.SimilaritySearch for numResults == 0, and to make it more obvious that this does not change any behavior, I moved the check for zero embeddings to the same place.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/51386

## Test plan

Just a small semantics-preserving refactor.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
