### PR TITLE
cody: hide cody.experimental.suggest

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -313,10 +313,6 @@
           ],
           "default": "embeddings"
         },
-        "cody.experimental.suggestions": {
-          "type": "boolean",
-          "default": false
-        },
         "cody.experimental.chatPredictions": {
           "type": "boolean",
           "default": false


### PR DESCRIPTION
Hides the `cody.experimental.suggest` settings while we figure out the rate limit story for suggestions.

## Test plan

Tested locally. Hiding experimental feature.