### PR TITLE
[gitlab] Disable repo permissions syncing if auth type is oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Removed an incorrect beta label on the Search Context creation page [#51188](https://github.com/sourcegraph/sourcegraph/pull/51188)
 - Multi-version upgrades to version `5.0.2` in a fully airgapped environment will not work without the command `--skip-drift-check`. [#51164](https://github.com/sourcegraph/sourcegraph/pull/51164)
 - Could not set "permissions.syncOldestUsers" or "permissions.syncOldestRepos" to zero. [#51255](https://github.com/sourcegraph/sourcegraph/pull/51255)
+- GitLab code host connections will no longer use Personal Access Tokens to sync repository permissions when the authentication provider is set as "oauth". This prevents inconsistent user permissions from occuring. [#51452](https://github.com/sourcegraph/sourcegraph/pull/51452)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Removed an incorrect beta label on the Search Context creation page [#51188](https://github.com/sourcegraph/sourcegraph/pull/51188)
 - Multi-version upgrades to version `5.0.2` in a fully airgapped environment will not work without the command `--skip-drift-check`. [#51164](https://github.com/sourcegraph/sourcegraph/pull/51164)
 - Could not set "permissions.syncOldestUsers" or "permissions.syncOldestRepos" to zero. [#51255](https://github.com/sourcegraph/sourcegraph/pull/51255)
-- GitLab code host connections will no longer use Personal Access Tokens to sync repository permissions when the authentication provider is set as "oauth". This prevents inconsistent user permissions from occuring. [#51452](https://github.com/sourcegraph/sourcegraph/pull/51452)
+- GitLab code host connections will disable repo-centric repository permission syncs when the authentication provider is set as "oauth". This prevents repo-centric permission sync from getting incorrect data. [#51452](https://github.com/sourcegraph/sourcegraph/pull/51452)
 
 ### Removed
 

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -88,6 +88,9 @@ Then, [add or edit a GitLab connection](#repository-syncing) and include the `au
 }
 ```
 
+In this case, a user's OAuth token will be used to verify that user's access to repositories.
+[Repository-centric permissions syncing](../../permissions/syncing.md) will be disabled.
+
 ### Administrator (sudo-level) access token
 
 This method requires administrator access to GitLab so that Sourcegraph can access the [admin GitLab Users API endpoint](https://docs.gitlab.com/ee/api/users.html#for-admins). For each GitLab user, this endpoint provides the user ID that comes from the authentication provider, so Sourcegraph can associate a user in its system to a user in GitLab.

--- a/doc/admin/external_service/gitlab.md
+++ b/doc/admin/external_service/gitlab.md
@@ -88,7 +88,7 @@ Then, [add or edit a GitLab connection](#repository-syncing) and include the `au
 }
 ```
 
-In this case, a user's OAuth token will be used to verify that user's access to repositories.
+In this case, a user's OAuth token will be used to get a list of repositories that the user can access.
 [Repository-centric permissions syncing](../../permissions/syncing.md) will be disabled.
 
 ### Administrator (sudo-level) access token

--- a/enterprise/internal/authz/gitlab/BUILD.bazel
+++ b/enterprise/internal/authz/gitlab/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_inconshreveable_log15//:log15",
         "@com_github_sergi_go_diff//diffmatchpatch",
+        "@com_github_stretchr_testify//require",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -128,20 +128,5 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 //
 // API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
 func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
-	if repo == nil {
-		return nil, errors.New("no repository provided")
-	} else if !extsvc.IsHostOfRepo(p.codeHost, &repo.ExternalRepoSpec) {
-		return nil, errors.Errorf("not a code host of the repository: want %q but have %q",
-			repo.ServiceID, p.codeHost.ServiceID)
-	}
-
-	var client *gitlab.Client
-	switch p.tokenType {
-	case gitlab.TokenTypeOAuth:
-		client = p.clientProvider.GetOAuthClient(p.token)
-	default:
-		client = p.clientProvider.GetPATClient(p.token, "")
-	}
-
-	return listMembers(ctx, client, repo.ID)
+	return nil, authz.ErrUnimplemented{}
 }

--- a/enterprise/internal/authz/gitlab/oauth.go
+++ b/enterprise/internal/authz/gitlab/oauth.go
@@ -118,15 +118,9 @@ func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Acco
 	return listProjects(ctx, client)
 }
 
-// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
-// the given project on the code host. The user ID has the same value as it would
-// be used as extsvc.Account.AccountID. The returned list includes both direct access
-// and inherited from the group membership.
-//
-// This method may return partial but valid results in case of error, and it is up to
-// callers to decide whether to discard.
-//
-// API docs: https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project-including-inherited-members
+// FetchRepoPerms is not implemented for the OAuthProvider type.
+// When the authorization type is set to OAuth, we rely on user-based permissions syncs (FetchUserPerms)
+// to handle user permissions.
 func (p *OAuthProvider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, opts authz.FetchPermsOptions) ([]extsvc.AccountID, error) {
 	return nil, authz.ErrUnimplemented{}
 }

--- a/enterprise/internal/authz/gitlab/oauth_test.go
+++ b/enterprise/internal/authz/gitlab/oauth_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -141,44 +142,6 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 }
 
 func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
-	t.Run("nil repository", func(t *testing.T) {
-		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil)
-		_, err := p.FetchRepoPerms(context.Background(), nil, authz.FetchPermsOptions{})
-		want := "no repository provided"
-		got := fmt.Sprintf("%v", err)
-		if got != want {
-			t.Fatalf("err: want %q but got %q", want, got)
-		}
-	})
-
-	t.Run("not the code host of the repository", func(t *testing.T) {
-		p := newOAuthProvider(OAuthProviderOp{
-			BaseURL: mustURL(t, "https://gitlab.com"),
-		}, nil)
-		_, err := p.FetchRepoPerms(context.Background(),
-			&extsvc.Repository{
-				URI: "github.com/user/repo",
-				ExternalRepoSpec: api.ExternalRepoSpec{
-					ServiceType: extsvc.TypeGitHub,
-					ServiceID:   "https://github.com/",
-				},
-			},
-			authz.FetchPermsOptions{},
-		)
-		want := `not a code host of the repository: want "https://github.com/" but have "https://gitlab.com/"`
-		got := fmt.Sprintf("%v", err)
-		if got != want {
-			t.Fatalf("err: want %q but got %q", want, got)
-		}
-	})
-
-	// The OAuthProvider uses the gitlab.Client under the hood,
-	// which uses rcache, a caching layer that uses Redis.
-	// We need to clear the cache before we run the tests
-	rcache.SetupForTest(t)
-
 	t.Run("token type PAT", func(t *testing.T) {
 		p := newOAuthProvider(
 			OAuthProviderOp{
@@ -186,35 +149,10 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 				Token:     "admin_token",
 				TokenType: gitlab.TokenTypePAT,
 			},
-			&mockDoer{
-				do: func(r *http.Request) (*http.Response, error) {
-					want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
-					if r.URL.String() != want {
-						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
-					}
-
-					want = "admin_token"
-					got := r.Header.Get("Private-Token")
-					if got != want {
-						return nil, errors.Errorf("HTTP Private-Token: want %q but got %q", want, got)
-					}
-
-					body := `
-[
-	{"id": 1, "access_level": 10},
-	{"id": 2, "access_level": 20},
-	{"id": 3, "access_level": 30}
-]`
-					return &http.Response{
-						Status:     http.StatusText(http.StatusOK),
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
-					}, nil
-				},
-			},
+			nil,
 		)
 
-		accountIDs, err := p.FetchRepoPerms(context.Background(),
+		_, err := p.FetchRepoPerms(context.Background(),
 			&extsvc.Repository{
 				URI: "gitlab.com/user/repo",
 				ExternalRepoSpec: api.ExternalRepoSpec{
@@ -225,71 +163,6 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 			},
 			authz.FetchPermsOptions{},
 		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// 1 should not be included because of "access_level" < 20
-		expAccountIDs := []extsvc.AccountID{"2", "3"}
-		if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-			t.Fatal(diff)
-		}
-	})
-
-	t.Run("token type OAuth", func(t *testing.T) {
-		p := newOAuthProvider(
-			OAuthProviderOp{
-				BaseURL:   mustURL(t, "https://gitlab.com"),
-				Token:     "admin_token",
-				TokenType: gitlab.TokenTypeOAuth,
-			},
-			&mockDoer{
-				do: func(r *http.Request) (*http.Response, error) {
-					want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
-					if r.URL.String() != want {
-						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
-					}
-
-					want = "Bearer admin_token"
-					got := r.Header.Get("Authorization")
-					if got != want {
-						return nil, errors.Errorf("HTTP Private-Token: want %q but got %q", want, got)
-					}
-
-					body := `
-[
-	{"id": 1, "access_level": 10},
-	{"id": 2, "access_level": 20},
-	{"id": 3, "access_level": 30}
-]`
-					return &http.Response{
-						Status:     http.StatusText(http.StatusOK),
-						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
-					}, nil
-				},
-			},
-		)
-
-		accountIDs, err := p.FetchRepoPerms(context.Background(),
-			&extsvc.Repository{
-				URI: "gitlab.com/user/repo",
-				ExternalRepoSpec: api.ExternalRepoSpec{
-					ServiceType: "gitlab",
-					ServiceID:   "https://gitlab.com/",
-					ID:          "gitlab_project_id",
-				},
-			},
-			authz.FetchPermsOptions{},
-		)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// 1 should not be included because of "access_level" < 20
-		expAccountIDs := []extsvc.AccountID{"2", "3"}
-		if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-			t.Fatal(diff)
-		}
+		require.ErrorIs(t, err, &authz.ErrUnimplemented{})
 	})
 }

--- a/enterprise/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/internal/authz/gitlab/sudo_test.go
@@ -366,10 +366,10 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 	// We need to clear the cache before we run the tests
 	rcache.SetupForTest(t)
 
-	p := newOAuthProvider(
-		OAuthProviderOp{
+	p := newSudoProvider(
+		SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
-			Token:   "admin_token",
+			SudoToken: "admin_token",
 		},
 		&mockDoer{
 			do: func(r *http.Request) (*http.Response, error) {

--- a/enterprise/internal/authz/gitlab/sudo_test.go
+++ b/enterprise/internal/authz/gitlab/sudo_test.go
@@ -368,7 +368,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 
 	p := newSudoProvider(
 		SudoProviderOp{
-			BaseURL: mustURL(t, "https://gitlab.com"),
+			BaseURL:   mustURL(t, "https://gitlab.com"),
 			SudoToken: "admin_token",
 		},
 		&mockDoer{


### PR DESCRIPTION
Disables repo-based permissions syncing if the auth provider type for a GitLab code host connection is set as oauth. Repo-based permissions syncing has a lot of gotchas when it comes to token permissions, and they are _very_ hard to debug and fundamentally flawed.

## Test plan

Updated unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
