### PR TITLE
Update packge.json pnpm engine field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "engines": {
     "node": "^v16.18.1",
-    "pnpm": "^8.0.0"
+    "pnpm": "^8.1.0"
   },
   "scripts": {
     "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",


### PR DESCRIPTION
@valerybugakov I've noticed I missed this update in my recent PR to update it. 

Still I'm getting this locally when running things like `yarn run format`:

```
~/work/sourcegraph U jh/doc/update-pnpm $ yarn run format
yarn run v1.22.17
warning @: The engine "pnpm" appears to be invalid.
``` 

Do you know how to fix this? 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 
