### PR TITLE
embeddings: metric for search throughput

### DIFF
--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -151,6 +151,9 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, SearchOptions{})
 			}
+			m := float64(numRows) * float64(b.N) / b.Elapsed().Seconds()
+			b.ReportMetric(m, "embeddings/s")
+			b.ReportMetric(m/float64(numWorkers), "embeddings/s/worker")
 		})
 	}
 }

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -148,10 +149,11 @@ func BenchmarkSimilaritySearch(b *testing.B) {
 
 	for _, numWorkers := range []int{1, 2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("numWorkers=%d", numWorkers), func(b *testing.B) {
+			start := time.Now()
 			for n := 0; n < b.N; n++ {
 				_ = index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers}, SearchOptions{})
 			}
-			m := float64(numRows) * float64(b.N) / b.Elapsed().Seconds()
+			m := float64(numRows) * float64(b.N) / time.Since(start).Seconds()
 			b.ReportMetric(m, "embeddings/s")
 			b.ReportMetric(m/float64(numWorkers), "embeddings/s/worker")
 		})


### PR DESCRIPTION
I was playing around with the benchmark and was interested in the throughput of the implementations. This is the numbers we seem to be quoting in text which I assume previously we calculated manually.

Test Plan: go test -bench Search -run '^$'