### PR TITLE
nix: start redis on localhost

### DIFF
--- a/dev/nix/start-redis.sh
+++ b/dev/nix/start-redis.sh
@@ -16,6 +16,9 @@ dir $data
 logfile $data/redis.log
 loglevel warning
 
+# listen on localhost to avoid firewall popups
+bind 127.0.0.1 ::1
+
 # run in background
 daemonize yes
 


### PR DESCRIPTION
This is to avoid the macos firewall popups. Also its just better to use localhost for local dev.

Test Plan: Killed the running server then ensured the started server was listening on localhost

``` shellsession
$ lsof -a -i TCP -c redis-server
COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
redis-ser 11553 keegan    6u  IPv4 0xa2de8513454245fd      0t0  TCP *:6379 (LISTEN)
redis-ser 11553 keegan    7u  IPv6 0xa2de8509ac45ddf5      0t0  TCP *:6379 (LISTEN)
$ pkill redis-server
$ ./dev/nix/start-redis.sh
Starting redis...
$ lsof -a -i TCP -c redis-server
COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
redis-ser 13301 keegan    6u  IPv4 0xa2de8513453ec5fd      0t0  TCP localhost:6379 (LISTEN)
redis-ser 13301 keegan    7u  IPv6 0xa2de8509ac45bdf5      0t0  TCP localhost:6379 (LISTEN)
```
