### PR TITLE
dev: improve description of embeddings-qa

### DIFF
--- a/dev/sg/sg_embeddings_qa.go
+++ b/dev/sg/sg_embeddings_qa.go
@@ -9,7 +9,7 @@ import (
 var contextCommand = &cli.Command{
 	Name:        "embeddings-qa",
 	Usage:       "Calculate recall for embeddings",
-	Description: "Requires a running embeddings service with embeddings of the Sourcegraph repository.",
+	Description: "Recall is the fraction of relevant documents that were successfully retrieved. Recall=1 if, for every query in the test data, all relevant documents were retrieved. The command requires a running embeddings service with embeddings of the Sourcegraph repository.",
 	Category:    CategoryDev,
 	Flags: []cli.Flag{
 		&cli.StringFlag{

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1110,7 +1110,7 @@ Flags:
 
 Calculate recall for embeddings.
 
-Requires a running embeddings service with embeddings of the Sourcegraph repository.
+Recall is the fraction of relevant documents that were successfully retrieved. Recall=1 if, for every query in the test data, all relevant documents were retrieved. The command requires a running embeddings service with embeddings of the Sourcegraph repository.
 
 
 Flags:


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/pull/51089#discussion_r1185016509

This adds a defintion of "recall" to the description of "sg embeddings-qa".

Test Plan:
- check output of `go run ./dev/sg/. embeddings-qa --help`
