### PR TITLE
release: add missing "v" for build script

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -726,7 +726,7 @@ cc @${release.captainGitHubUsername}
                                 ? `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version.version}"' enterprise/dev/ci/internal/ci/*.go`
                                 : 'echo "Skipping minimumUpgradeableVersion bump on patch release"',
                             updateUpgradeGuides(release.previous.version, release.version.version),
-                            `comby -in-place 'git_versions=(:[1])' 'git_versions=(:[1] ${release.version.version})' cmd/migrator/build.sh`,
+                            `comby -in-place 'git_versions=(:[1])' 'git_versions=(:[1] v${release.version.version})' cmd/migrator/build.sh`,
                         ],
                         ...prBodyAndDraftState(
                             ((): string[] => {


### PR DESCRIPTION
Followup of https://github.com/sourcegraph/sourcegraph/pull/51446

## Test plan

A dumb try of the following command worked:

```
$ comby -in-place 'git_versions=(:[1])' 'git_versions=(:[1] v5.0.4)' cmd/migrator/build.sh
$ git diff cmd/migrator/build.sh
```

```diff
diff --git a/cmd/migrator/build.sh b/cmd/migrator/build.sh
index 2d66a94b05..57720eb92b 100755
--- a/cmd/migrator/build.sh
+++ b/cmd/migrator/build.sh
@@ -68,7 +68,7 @@ git_versions=(
   v4.3.0 v4.3.1
   v4.4.0 v4.4.1 v4.4.2
   v4.5.0 v4.5.1
-  v5.0.0 v5.0.1 v5.0.2 v5.0.3)
+  v5.0.0 v5.0.1 v5.0.2 v5.0.3 v5.0.4)

 for version in "${git_versions[@]}"; do
   echo "Persisting schemas for ${version} from Git..."
```
