### PR TITLE
[github app] Add resolver to get GitHubApp by ID

### DIFF
--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -12,8 +12,11 @@ import (
 // enterprise/cmd/frontend/internal/auth/githubappauth/
 
 type GitHubAppsResolver interface {
+	NodeResolvers() map[string]NodeByIDFunc
+
 	// Queries
 	GitHubApps(ctx context.Context) (GitHubAppConnectionResolver, error)
+	GitHubApp(ctx context.Context, args *GitHubAppArgs) (GitHubAppResolver, error)
 
 	// Mutations
 	DeleteGitHubApp(ctx context.Context, args *DeleteGitHubAppArgs) (*EmptyResponse, error)
@@ -43,4 +46,8 @@ type GitHubAppsArgs struct {
 	graphqlutil.ConnectionArgs
 	After     *string
 	Namespace *graphql.ID
+}
+
+type GitHubAppArgs struct {
+	ID graphql.ID
 }

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -11,6 +11,10 @@ extend type Query {
     All configured GitHub Apps.
     """
     gitHubApps: GitHubAppConnection!
+    """
+    Looks up a GitHub App by its ID.
+    """
+    gitHubApp(id: ID!): GitHubApp
 }
 
 """

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -491,6 +491,9 @@ func NewSchema(
 		EnterpriseResolvers.gitHubAppsResolver = gitHubApps
 		resolver.GitHubAppsResolver = gitHubApps
 		schemas = append(schemas, gitHubAppsSchema)
+		for kind, res := range gitHubApps.NodeResolvers() {
+			resolver.nodeByIDFns[kind] = res
+		}
 	}
 
 	if license := optional.LicenseResolver; license != nil {

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -88,21 +88,7 @@ func (r *resolver) GitHubApps(ctx context.Context) (graphqlbackend.GitHubAppConn
 
 func (r *resolver) GitHubApp(ctx context.Context, args *graphqlbackend.GitHubAppArgs) (graphqlbackend.GitHubAppResolver, error) {
 	// 🚨 SECURITY: Check whether user is site-admin
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-		return nil, err
-	}
-
-	id, err := UnmarshalGitHubAppID(args.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	app, err := r.db.GitHubApps().GetByID(ctx, int(id))
-	if err != nil {
-		return nil, err
-	}
-
-	return &gitHubAppResolver{app: app}, nil
+	return r.GitHubAppByID(ctx, args.ID)
 }
 
 func (r *resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -86,6 +86,52 @@ func (r *resolver) GitHubApps(ctx context.Context) (graphqlbackend.GitHubAppConn
 	return gitHubAppConnection, nil
 }
 
+func (r *resolver) GitHubApp(ctx context.Context, args *graphqlbackend.GitHubAppArgs) (graphqlbackend.GitHubAppResolver, error) {
+	// 🚨 SECURITY: Check whether user is site-admin
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	id, err := UnmarshalGitHubAppID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	app, err := r.db.GitHubApps().GetByID(ctx, int(id))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gitHubAppResolver{app: app}, nil
+}
+
+func (r *resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
+	return map[string]graphqlbackend.NodeByIDFunc{
+		gitHubAppIDKind: func(ctx context.Context, id graphql.ID) (graphqlbackend.Node, error) {
+			return r.GitHubAppByID(ctx, id)
+		},
+	}
+}
+
+func (r *resolver) GitHubAppByID(ctx context.Context, id graphql.ID) (*gitHubAppResolver, error) {
+	// 🚨 SECURITY: Check whether user is site-admin
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+	gitHubAppID, err := UnmarshalGitHubAppID(id)
+	if err != nil {
+		return nil, err
+	}
+	app, err := r.db.GitHubApps().GetByID(ctx, int(gitHubAppID))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gitHubAppResolver{
+		app: app,
+	}, nil
+}
+
 // NewGitHubAppResolver creates a new GitHubAppResolver from a GitHubApp.
 func NewGitHubAppResolver(app *types.GitHubApp) *gitHubAppResolver {
 	return &gitHubAppResolver{app: app}

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
@@ -191,10 +191,8 @@ func TestResolver_GitHubApp(t *testing.T) {
 	})
 
 	gitHubAppsStore := store.NewStrictMockGitHubAppsStore()
-	gitHubAppsStore.ListFunc.SetDefaultReturn([]*ghtypes.GitHubApp{
-		{
-			ID: 1,
-		},
+	gitHubAppsStore.GetByIDFunc.SetDefaultReturn(&ghtypes.GitHubApp{
+		ID: 1,
 	}, nil)
 
 	db := edb.NewStrictMockEnterpriseDB()
@@ -212,31 +210,29 @@ func TestResolver_GitHubApp(t *testing.T) {
 		Schema:  schema,
 		Context: adminCtx,
 		Query: fmt.Sprintf(`
-			query GitHubApp() {
-				gitHubApp(id: "%s" {
+			query {
+				gitHubApp(id: "%s") {
 					id
 				}
 			}`, graphqlID),
 		ExpectedResult: fmt.Sprintf(`{
-			"gitHubApps": {
-				"nodes": [
-					{"id":"%s"}
-				]
+			"gitHubApp": {
+				"id": "%s"
 			}
 		}`, graphqlID),
 	}, {
 		Schema:  schema,
 		Context: userCtx,
 		Query: fmt.Sprintf(`
-			query GitHubApp() {
-				gitHubApp(id: "%s" {
+			query {
+				gitHubApp(id: "%s") {
 					id
 				}
 			}`, graphqlID),
-		ExpectedResult: `null`,
+		ExpectedResult: `{"gitHubApp": null}`,
 		ExpectedErrors: []*gqlerrors.QueryError{{
 			Message: "must be site admin",
-			Path:    []any{string("gitHubApps")},
+			Path:    []any{string("gitHubApp")},
 		}},
 	}})
 }

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
@@ -124,12 +124,6 @@ func TestResolver_GitHubApps(t *testing.T) {
 			ID: 1,
 		},
 	}, nil)
-	gitHubAppsStore.DeleteFunc.SetDefaultHook(func(ctx context.Context, app int) error {
-		if app != id {
-			return errors.New(fmt.Sprintf("app with id %d does not exist", id))
-		}
-		return nil
-	})
 
 	db := edb.NewStrictMockEnterpriseDB()
 
@@ -171,6 +165,74 @@ func TestResolver_GitHubApps(t *testing.T) {
 					}
 				}
 			}`,
+		ExpectedResult: `null`,
+		ExpectedErrors: []*gqlerrors.QueryError{{
+			Message: "must be site admin",
+			Path:    []any{string("gitHubApps")},
+		}},
+	}})
+}
+
+func TestResolver_GitHubApp(t *testing.T) {
+	logger := logtest.Scoped(t)
+	id := 1
+	graphqlID := MarshalGitHubAppID(int64(id))
+
+	userStore := database.NewMockUserStore()
+	userStore.GetByCurrentAuthUserFunc.SetDefaultHook(func(ctx context.Context) (*types.User, error) {
+		a := actor.FromContext(ctx)
+		if a.UID == 1 {
+			return &types.User{ID: 1, SiteAdmin: true}, nil
+		}
+		if a.UID == 2 {
+			return &types.User{ID: 2, SiteAdmin: false}, nil
+		}
+		return nil, errors.New("not found")
+	})
+
+	gitHubAppsStore := store.NewStrictMockGitHubAppsStore()
+	gitHubAppsStore.ListFunc.SetDefaultReturn([]*ghtypes.GitHubApp{
+		{
+			ID: 1,
+		},
+	}, nil)
+
+	db := edb.NewStrictMockEnterpriseDB()
+
+	db.GitHubAppsFunc.SetDefaultReturn(gitHubAppsStore)
+	db.UsersFunc.SetDefaultReturn(userStore)
+
+	adminCtx := userCtx(1)
+	userCtx := userCtx(2)
+
+	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(), nil, graphqlbackend.OptionalResolver{GitHubAppsResolver: NewResolver(logger, db)})
+	require.NoError(t, err)
+
+	graphqlbackend.RunTests(t, []*graphqlbackend.Test{{
+		Schema:  schema,
+		Context: adminCtx,
+		Query: fmt.Sprintf(`
+			query GitHubApp() {
+				gitHubApp(id: "%s" {
+					id
+				}
+			}`, graphqlID),
+		ExpectedResult: fmt.Sprintf(`{
+			"gitHubApps": {
+				"nodes": [
+					{"id":"%s"}
+				]
+			}
+		}`, graphqlID),
+	}, {
+		Schema:  schema,
+		Context: userCtx,
+		Query: fmt.Sprintf(`
+			query GitHubApp() {
+				gitHubApp(id: "%s" {
+					id
+				}
+			}`, graphqlID),
 		ExpectedResult: `null`,
 		ExpectedErrors: []*gqlerrors.QueryError{{
 			Message: "must be site admin",


### PR DESCRIPTION
Adds a resolver to fetch a single GitHub App by ID.

## Test plan

Unit tests and I verified that it works myself

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
