### PR TITLE
codeintel: Improve `io.ReadAll` by supplying size hint

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -276,7 +276,12 @@ func (h *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 			return errors.Wrap(err, "store.CommitDate")
 		}
 
-		correlatedSCIPData, err := correlateSCIP(ctx, r, upload.Root, getChildren)
+		rSize := int64(0)
+		if upload.UncompressedSize != nil {
+			rSize = *upload.UncompressedSize
+		}
+
+		correlatedSCIPData, err := correlateSCIP(ctx, r, rSize, upload.Root, getChildren)
 		if err != nil {
 			return errors.Wrap(err, "conversion.Correlate")
 		}

--- a/enterprise/internal/codeintel/uploads/internal/background/processor/scip_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/scip_test.go
@@ -27,7 +27,7 @@ func TestCorrelateSCIP(t *testing.T) {
 	}
 
 	// Correlate and consume channels from returned object
-	correlatedSCIPData, err := correlateSCIP(ctx, r, "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
+	correlatedSCIPData, err := correlateSCIP(ctx, r, 0, "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		return scipDirectoryChildren, nil
 	})
 	if err != nil {

--- a/enterprise/internal/codeintel/uploads/internal/background/processor/scip_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/scip_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"compress/gzip"
 	"context"
+	"io"
 	"os"
 	"sort"
 	"testing"
@@ -17,17 +18,27 @@ import (
 func TestCorrelateSCIP(t *testing.T) {
 	ctx := context.Background()
 
-	gzipped, err := os.Open("./testdata/index1.scip.gz")
-	if err != nil {
-		t.Fatalf("unexpected error reading test file: %s", err)
-	}
-	r, err := gzip.NewReader(gzipped)
-	if err != nil {
-		t.Fatalf("unexpected error unzipping test file: %s", err)
+	testReader := func() io.Reader {
+		gzipped, err := os.Open("./testdata/index1.scip.gz")
+		if err != nil {
+			t.Fatalf("unexpected error reading test file: %s", err)
+		}
+		r, err := gzip.NewReader(gzipped)
+		if err != nil {
+			t.Fatalf("unexpected error unzipping test file: %s", err)
+		}
+
+		return r
 	}
 
+	content, err := io.ReadAll(testReader())
+	if err != nil {
+		t.Fatalf("unexpected error reading test reader: %s", err)
+	}
+	n := int64(len(content))
+
 	// Correlate and consume channels from returned object
-	correlatedSCIPData, err := correlateSCIP(ctx, r, 0, "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
+	correlatedSCIPData, err := correlateSCIP(ctx, testReader(), n, "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		return scipDirectoryChildren, nil
 	})
 	if err != nil {


### PR DESCRIPTION
Not an optimal solution, but I'd like to see if this reduces the heap profile when uploading an index for chromium/chromium. I think we'll have new bottlenecks in the proto Unmarshal, but I'd like to smash this red herring so I can focus on the real meat.

## Test plan

Tested the codeintel-qa pipeline locally.