### PR TITLE
wildcard: Add missing description field to Select

### DIFF
--- a/client/wildcard/src/components/Form/Select/Select.story.tsx
+++ b/client/wildcard/src/components/Form/Select/Select.story.tsx
@@ -36,6 +36,7 @@ const BaseSelect = (props: { id: string } & Pick<SelectProps, 'isCustomStyle' | 
         <Select
             label="What is your favorite fruit?"
             message="I am a message"
+            description="I am a description"
             value={selected}
             onChange={handleChange}
             {...props}

--- a/client/wildcard/src/components/Form/Select/Select.tsx
+++ b/client/wildcard/src/components/Form/Select/Select.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import classNames from 'classnames'
 
+import { InputDescription } from '../Input'
 import { AccessibleFieldProps } from '../internal/AccessibleFieldType'
 import { FormFieldLabel } from '../internal/FormFieldLabel'
 import { FormFieldMessage } from '../internal/FormFieldMessage'
@@ -13,6 +14,8 @@ export const SELECT_SIZES = ['sm', 'lg'] as const
 
 export type SelectProps = AccessibleFieldProps<React.SelectHTMLAttributes<HTMLSelectElement>> &
     React.RefAttributes<HTMLSelectElement> & {
+        /** Description block shown above the input (but below the label) */
+        description?: ReactNode
         /**
          * Use the global `custom-select` class.
          */
@@ -68,6 +71,7 @@ export const Select: React.FunctionComponent<React.PropsWithChildren<SelectProps
         isCustomStyle,
         selectSize,
         labelVariant = 'inline',
+        description,
         ...props
     },
     reference
@@ -82,6 +86,7 @@ export const Select: React.FunctionComponent<React.PropsWithChildren<SelectProps
                     {props.label}
                 </FormFieldLabel>
             )}
+            {description && <InputDescription className="ml-0 mb-2 mt-n1">{description}</InputDescription>}
             {/* eslint-disable-next-line react/forbid-elements */}
             <select
                 ref={reference}


### PR DESCRIPTION
This is a low-effort fix to improve compatibility of Select and Input a bit further by implementing the missing description property on the Select as well.

## Test plan

CI and chromatic, also tried manually it looks alright.