### PR TITLE
Embeddings: add repo source to results

### DIFF
--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -74,6 +75,7 @@ func searchEmbeddingIndex(
 		repoName,
 		revision,
 		readFile,
+		opts.Debug,
 		results,
 	)
 }
@@ -87,29 +89,41 @@ func filterAndHydrateContent(
 	repoName api.RepoName,
 	revision api.CommitID,
 	readFile readFileFn,
-	unfiltered []embeddings.EmbeddingSearchResult,
+	debug bool,
+	unfiltered []embeddings.SimilaritySearchResult,
 ) []embeddings.EmbeddingSearchResult {
-	filtered := unfiltered[:0]
+	filtered := make([]embeddings.EmbeddingSearchResult, 0, len(unfiltered))
 
-	for idx, result := range unfiltered {
+	for _, result := range unfiltered {
 		fileContent, err := readFile(ctx, repoName, revision, result.FileName)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				logger.Error("error reading file", log.String("repoName", string(repoName)), log.String("revision", string(revision)), log.String("fileName", result.FileName), log.Error(err))
 			}
-			// scrub row just in case we leak it out
-			unfiltered[idx] = embeddings.EmbeddingSearchResult{}
 			continue
 		}
 		lines := strings.Split(string(fileContent), "\n")
 
 		// Sanity check: check that startLine and endLine are within 0 and len(lines).
-		result.StartLine = max(0, min(len(lines), result.StartLine))
-		result.EndLine = max(0, min(len(lines), result.EndLine))
+		startLine := max(0, min(len(lines), result.StartLine))
+		endLine := max(0, min(len(lines), result.EndLine))
 
-		result.Content = strings.Join(lines[result.StartLine:result.EndLine], "\n")
+		content := strings.Join(lines[result.StartLine:result.EndLine], "\n")
 
-		filtered = append(filtered, result)
+		var debugString string
+		if debug {
+			debugString = fmt.Sprintf("score:%d, similarity:%d, rank:%d", result.Score(), result.SimilarityScore, result.RankScore)
+		}
+
+		filtered = append(filtered, embeddings.EmbeddingSearchResult{
+			RepoEmbeddingRowMetadata: embeddings.RepoEmbeddingRowMetadata{
+				FileName:  result.FileName,
+				StartLine: startLine,
+				EndLine:   endLine,
+			},
+			Debug:   debugString,
+			Content: content,
+		})
 	}
 
 	return filtered

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -116,6 +116,8 @@ func filterAndHydrateContent(
 		}
 
 		filtered = append(filtered, embeddings.EmbeddingSearchResult{
+			RepoName: repoName,
+			Revision: revision,
 			RepoEmbeddingRowMetadata: embeddings.RepoEmbeddingRowMetadata{
 				FileName:  result.FileName,
 				StartLine: startLine,

--- a/enterprise/cmd/embeddings/shared/weaviate.go
+++ b/enterprise/cmd/embeddings/shared/weaviate.go
@@ -86,7 +86,7 @@ func (w *weaviateClient) Search(ctx context.Context, params embeddings.Embedding
 			return nil
 		}
 
-		srs := make([]embeddings.EmbeddingSearchResult, 0, len(code))
+		srs := make([]embeddings.SimilaritySearchResult, 0, len(code))
 		revision := ""
 		for _, c := range code {
 			cMap := c.(map[string]any)
@@ -100,7 +100,7 @@ func (w *weaviateClient) Search(ctx context.Context, params embeddings.Embedding
 				}
 			}
 
-			srs = append(srs, embeddings.EmbeddingSearchResult{
+			srs = append(srs, embeddings.SimilaritySearchResult{
 				RepoEmbeddingRowMetadata: embeddings.RepoEmbeddingRowMetadata{
 					FileName:  fileName,
 					StartLine: int(cMap["start_line"].(float64)),
@@ -115,7 +115,7 @@ func (w *weaviateClient) Search(ctx context.Context, params embeddings.Embedding
 			commit = api.CommitID("HEAD")
 		}
 
-		return filterAndHydrateContent(ctx, w.logger, params.RepoName, commit, w.readFile, srs)
+		return filterAndHydrateContent(ctx, w.logger, params.RepoName, commit, w.readFile, false, srs)
 	}
 
 	// We partition the indexes by type and repository. Each class in

--- a/enterprise/internal/embeddings/similarity_search_test.go
+++ b/enterprise/internal/embeddings/similarity_search_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -55,7 +56,7 @@ func TestSimilaritySearch(t *testing.T) {
 	}
 
 	for i := 0; i < numRows; i++ {
-		index.RowMetadata = append(index.RowMetadata, RepoEmbeddingRowMetadata{FileName: fmt.Sprintf("%d", i)})
+		index.RowMetadata = append(index.RowMetadata, RepoEmbeddingRowMetadata{FileName: strconv.Itoa(i)})
 	}
 
 	for _, numWorkers := range []int{0, 1, 2, 3, 5, 8, 9, 16, 20, 33} {
@@ -66,7 +67,7 @@ func TestSimilaritySearch(t *testing.T) {
 					results := index.SimilaritySearch(query, numResults, WorkerOptions{NumWorkers: numWorkers, MinRowsToSplit: 0}, SearchOptions{})
 					resultRowNums := make([]int, len(results))
 					for i, r := range results {
-						resultRowNums[i] = r.RowNum
+						resultRowNums[i], _ = strconv.Atoi(r.RepoEmbeddingRowMetadata.FileName)
 					}
 					expectedResults := ranks[q]
 					require.Equal(t, expectedResults[:min(numResults, len(expectedResults))], resultRowNums)

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -51,6 +51,8 @@ type EmbeddingSearchResults struct {
 }
 
 type EmbeddingSearchResult struct {
+	RepoName api.RepoName
+	Revision api.CommitID
 	RepoEmbeddingRowMetadata
 	Content string `json:"content"`
 	// Experimental: Clients should not rely on any particular format of debug

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -52,8 +52,6 @@ type EmbeddingSearchResults struct {
 
 type EmbeddingSearchResult struct {
 	RepoEmbeddingRowMetadata
-	// The row number in the index to correlate this result back with its source.
-	RowNum  int    `json:"rowNum"`
 	Content string `json:"content"`
 	// Experimental: Clients should not rely on any particular format of debug
 	Debug string `json:"debug,omitempty"`


### PR DESCRIPTION
To support searching multiple repos with embeddings, we need to add the source repo to the results. 

I want to avoid lazily hydrating repo name and revision like we do with the file content. I prefer structs to be fully constructed on creation. So to support this, I added a new intermediate `SimilaritySearchResult` type that only contains the information that is available at the time of doing the similarity search. We then convert it to the final search result type `EmbeddingsSearchResult` afterwards, which adds fields like `RepoName`, `Revision`, and `Content`.

## Test plan

Minimal change, existing tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
