### PR TITLE
output: change grey colour to darker

### DIFF
--- a/lib/output/style.go
+++ b/lib/output/style.go
@@ -63,7 +63,7 @@ var (
 	StyleLinesAdded   = Fg256Color(2)
 
 	// Colors
-	StyleGrey   = Fg256Color(7)
+	StyleGrey   = Fg256Color(8)
 	StyleYellow = Fg256Color(220)
 	StyleOrange = Fg256Color(202)
 )


### PR DESCRIPTION
Existing grey was brighter than my default text color, see "Translating container/service name ..." below

After:
![image](https://user-images.githubusercontent.com/18282288/236263027-8843efea-4ba1-411b-90f9-cbd574408c5e.png)

Before:
![image](https://user-images.githubusercontent.com/18282288/236263098-3a3e52c7-ced0-4aa8-ad35-7c7eb7292270.png)



## Test plan

It compiles :+1: 
