### PR TITLE
own: recent view signal indexing background job.

### DIFF
--- a/enterprise/cmd/worker/internal/own/job.go
+++ b/enterprise/cmd/worker/internal/own/job.go
@@ -34,6 +34,7 @@ func (o *ownRepoIndexingQueue) Routines(startupCtx context.Context, observationC
 	var routines []goroutine.BackgroundRoutine
 	routines = append(routines, background.NewOwnBackgroundWorker(context.Background(), db, observationCtx)...)
 	routines = append(routines, background.GetOwnIndexSchedulerRoutines(db, observationCtx)...)
+	routines = append(routines, background.NewOwnRecentViewsIndexer(db, observationCtx))
 
 	return routines, nil
 }

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -176,6 +176,10 @@ func TestHandlerLoadsEvents(t *testing.T) {
 					123,
 					125,
 				},
+				PublicArgument: json.RawMessage{
+					123,
+					125,
+				},
 				Source:           "test",
 				Version:          "0.0.0+dev",
 				EvaluatedFlagSet: featureflag.EvaluatedFlagSet{"testflag": true},
@@ -187,6 +191,10 @@ func TestHandlerLoadsEvents(t *testing.T) {
 				Name:   "event2",
 				UserID: 2,
 				Argument: json.RawMessage{
+					123,
+					125,
+				},
+				PublicArgument: json.RawMessage{
 					123,
 					125,
 				},
@@ -218,6 +226,10 @@ func TestHandlerLoadsEvents(t *testing.T) {
 			Name:   "event1",
 			UserID: 1,
 			Argument: json.RawMessage{
+				123,
+				125,
+			},
+			PublicArgument: json.RawMessage{
 				123,
 				125,
 			},
@@ -285,6 +297,10 @@ func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 					123,
 					125,
 				},
+				PublicArgument: json.RawMessage{
+					123,
+					125,
+				},
 				Source:   "test",
 				Version:  "0.0.0+dev",
 				DeviceID: valast.Addr("device").(*string),
@@ -305,6 +321,10 @@ func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 				Name:   "event2",
 				UserID: 2,
 				Argument: json.RawMessage{
+					123,
+					125,
+				},
+				PublicArgument: json.RawMessage{
 					123,
 					125,
 				},
@@ -398,6 +418,10 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 						123,
 						125,
 					},
+					PublicArgument: json.RawMessage{
+						123,
+						125,
+					},
 					Source:   "test",
 					Version:  "0.0.0+dev",
 					DeviceID: valast.Addr("device").(*string),
@@ -408,6 +432,10 @@ func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 					Name:   "allowed",
 					UserID: 3,
 					Argument: json.RawMessage{
+						123,
+						125,
+					},
+					PublicArgument: json.RawMessage{
 						123,
 						125,
 					},

--- a/enterprise/internal/database/mocks_temp.go
+++ b/enterprise/internal/database/mocks_temp.go
@@ -7863,6 +7863,9 @@ type MockEnterpriseDB struct {
 	// EventLogsFunc is an instance of a mock function object controlling
 	// the behavior of the method EventLogs.
 	EventLogsFunc *EnterpriseDBEventLogsFunc
+	// EventLogsScrapeStateFunc is an instance of a mock function object
+	// controlling the behavior of the method EventLogsScrapeState.
+	EventLogsScrapeStateFunc *EnterpriseDBEventLogsScrapeStateFunc
 	// ExecContextFunc is an instance of a mock function object controlling
 	// the behavior of the method ExecContext.
 	ExecContextFunc *EnterpriseDBExecContextFunc
@@ -7942,6 +7945,9 @@ type MockEnterpriseDB struct {
 	// object controlling the behavior of the method
 	// RecentContributionSignals.
 	RecentContributionSignalsFunc *EnterpriseDBRecentContributionSignalsFunc
+	// RecentViewSignalFunc is an instance of a mock function object
+	// controlling the behavior of the method RecentViewSignal.
+	RecentViewSignalFunc *EnterpriseDBRecentViewSignalFunc
 	// RedisKeyValueFunc is an instance of a mock function object
 	// controlling the behavior of the method RedisKeyValue.
 	RedisKeyValueFunc *EnterpriseDBRedisKeyValueFunc
@@ -8051,6 +8057,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		EventLogsFunc: &EnterpriseDBEventLogsFunc{
 			defaultHook: func() (r0 database.EventLogStore) {
+				return
+			},
+		},
+		EventLogsScrapeStateFunc: &EnterpriseDBEventLogsScrapeStateFunc{
+			defaultHook: func() (r0 database.EventLogsScrapeStateStore) {
 				return
 			},
 		},
@@ -8181,6 +8192,11 @@ func NewMockEnterpriseDB() *MockEnterpriseDB {
 		},
 		RecentContributionSignalsFunc: &EnterpriseDBRecentContributionSignalsFunc{
 			defaultHook: func() (r0 database.RecentContributionSignalStore) {
+				return
+			},
+		},
+		RecentViewSignalFunc: &EnterpriseDBRecentViewSignalFunc{
+			defaultHook: func() (r0 database.RecentViewSignalStore) {
 				return
 			},
 		},
@@ -8341,6 +8357,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 				panic("unexpected invocation of MockEnterpriseDB.EventLogs")
 			},
 		},
+		EventLogsScrapeStateFunc: &EnterpriseDBEventLogsScrapeStateFunc{
+			defaultHook: func() database.EventLogsScrapeStateStore {
+				panic("unexpected invocation of MockEnterpriseDB.EventLogsScrapeState")
+			},
+		},
 		ExecContextFunc: &EnterpriseDBExecContextFunc{
 			defaultHook: func(context.Context, string, ...interface{}) (sql.Result, error) {
 				panic("unexpected invocation of MockEnterpriseDB.ExecContext")
@@ -8469,6 +8490,11 @@ func NewStrictMockEnterpriseDB() *MockEnterpriseDB {
 		RecentContributionSignalsFunc: &EnterpriseDBRecentContributionSignalsFunc{
 			defaultHook: func() database.RecentContributionSignalStore {
 				panic("unexpected invocation of MockEnterpriseDB.RecentContributionSignals")
+			},
+		},
+		RecentViewSignalFunc: &EnterpriseDBRecentViewSignalFunc{
+			defaultHook: func() database.RecentViewSignalStore {
+				panic("unexpected invocation of MockEnterpriseDB.RecentViewSignal")
 			},
 		},
 		RedisKeyValueFunc: &EnterpriseDBRedisKeyValueFunc{
@@ -8613,6 +8639,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		EventLogsFunc: &EnterpriseDBEventLogsFunc{
 			defaultHook: i.EventLogs,
 		},
+		EventLogsScrapeStateFunc: &EnterpriseDBEventLogsScrapeStateFunc{
+			defaultHook: i.EventLogsScrapeState,
+		},
 		ExecContextFunc: &EnterpriseDBExecContextFunc{
 			defaultHook: i.ExecContext,
 		},
@@ -8690,6 +8719,9 @@ func NewMockEnterpriseDBFrom(i EnterpriseDB) *MockEnterpriseDB {
 		},
 		RecentContributionSignalsFunc: &EnterpriseDBRecentContributionSignalsFunc{
 			defaultHook: i.RecentContributionSignals,
+		},
+		RecentViewSignalFunc: &EnterpriseDBRecentViewSignalFunc{
+			defaultHook: i.RecentViewSignal,
 		},
 		RedisKeyValueFunc: &EnterpriseDBRedisKeyValueFunc{
 			defaultHook: i.RedisKeyValue,
@@ -9551,6 +9583,108 @@ func (c EnterpriseDBEventLogsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBEventLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBEventLogsScrapeStateFunc describes the behavior when the
+// EventLogsScrapeState method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBEventLogsScrapeStateFunc struct {
+	defaultHook func() database.EventLogsScrapeStateStore
+	hooks       []func() database.EventLogsScrapeStateStore
+	history     []EnterpriseDBEventLogsScrapeStateFuncCall
+	mutex       sync.Mutex
+}
+
+// EventLogsScrapeState delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) EventLogsScrapeState() database.EventLogsScrapeStateStore {
+	r0 := m.EventLogsScrapeStateFunc.nextHook()()
+	m.EventLogsScrapeStateFunc.appendCall(EnterpriseDBEventLogsScrapeStateFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the EventLogsScrapeState
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBEventLogsScrapeStateFunc) SetDefaultHook(hook func() database.EventLogsScrapeStateStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// EventLogsScrapeState method of the parent MockEnterpriseDB instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *EnterpriseDBEventLogsScrapeStateFunc) PushHook(hook func() database.EventLogsScrapeStateStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBEventLogsScrapeStateFunc) SetDefaultReturn(r0 database.EventLogsScrapeStateStore) {
+	f.SetDefaultHook(func() database.EventLogsScrapeStateStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBEventLogsScrapeStateFunc) PushReturn(r0 database.EventLogsScrapeStateStore) {
+	f.PushHook(func() database.EventLogsScrapeStateStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBEventLogsScrapeStateFunc) nextHook() func() database.EventLogsScrapeStateStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBEventLogsScrapeStateFunc) appendCall(r0 EnterpriseDBEventLogsScrapeStateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBEventLogsScrapeStateFuncCall
+// objects describing the invocations of this function.
+func (f *EnterpriseDBEventLogsScrapeStateFunc) History() []EnterpriseDBEventLogsScrapeStateFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBEventLogsScrapeStateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBEventLogsScrapeStateFuncCall is an object that describes an
+// invocation of method EventLogsScrapeState on an instance of
+// MockEnterpriseDB.
+type EnterpriseDBEventLogsScrapeStateFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.EventLogsScrapeStateStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBEventLogsScrapeStateFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBEventLogsScrapeStateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -12214,6 +12348,106 @@ func (c EnterpriseDBRecentContributionSignalsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c EnterpriseDBRecentContributionSignalsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// EnterpriseDBRecentViewSignalFunc describes the behavior when the
+// RecentViewSignal method of the parent MockEnterpriseDB instance is
+// invoked.
+type EnterpriseDBRecentViewSignalFunc struct {
+	defaultHook func() database.RecentViewSignalStore
+	hooks       []func() database.RecentViewSignalStore
+	history     []EnterpriseDBRecentViewSignalFuncCall
+	mutex       sync.Mutex
+}
+
+// RecentViewSignal delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockEnterpriseDB) RecentViewSignal() database.RecentViewSignalStore {
+	r0 := m.RecentViewSignalFunc.nextHook()()
+	m.RecentViewSignalFunc.appendCall(EnterpriseDBRecentViewSignalFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RecentViewSignal
+// method of the parent MockEnterpriseDB instance is invoked and the hook
+// queue is empty.
+func (f *EnterpriseDBRecentViewSignalFunc) SetDefaultHook(hook func() database.RecentViewSignalStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RecentViewSignal method of the parent MockEnterpriseDB instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *EnterpriseDBRecentViewSignalFunc) PushHook(hook func() database.RecentViewSignalStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *EnterpriseDBRecentViewSignalFunc) SetDefaultReturn(r0 database.RecentViewSignalStore) {
+	f.SetDefaultHook(func() database.RecentViewSignalStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *EnterpriseDBRecentViewSignalFunc) PushReturn(r0 database.RecentViewSignalStore) {
+	f.PushHook(func() database.RecentViewSignalStore {
+		return r0
+	})
+}
+
+func (f *EnterpriseDBRecentViewSignalFunc) nextHook() func() database.RecentViewSignalStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *EnterpriseDBRecentViewSignalFunc) appendCall(r0 EnterpriseDBRecentViewSignalFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of EnterpriseDBRecentViewSignalFuncCall
+// objects describing the invocations of this function.
+func (f *EnterpriseDBRecentViewSignalFunc) History() []EnterpriseDBRecentViewSignalFuncCall {
+	f.mutex.Lock()
+	history := make([]EnterpriseDBRecentViewSignalFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// EnterpriseDBRecentViewSignalFuncCall is an object that describes an
+// invocation of method RecentViewSignal on an instance of MockEnterpriseDB.
+type EnterpriseDBRecentViewSignalFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 database.RecentViewSignalStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c EnterpriseDBRecentViewSignalFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c EnterpriseDBRecentViewSignalFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/own/background/BUILD.bazel
+++ b/enterprise/internal/own/background/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "background.go",
         "recent_contributors.go",
+        "recent_views.go",
         "scheduler.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/own/background",

--- a/enterprise/internal/own/background/BUILD.bazel
+++ b/enterprise/internal/own/background/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     timeout = "moderate",
     srcs = [
         "recent_contributors_test.go",
+        "recent_views_test.go",
         "scheduler_test.go",
     ],
     embed = [":background"],

--- a/enterprise/internal/own/background/background.go
+++ b/enterprise/internal/own/background/background.go
@@ -46,6 +46,7 @@ type JobTypeID int
 const (
 	_ JobTypeID = iota
 	RecentContributors
+	RecentViews
 )
 
 func featureFlagName(jobType IndexJobType) string {

--- a/enterprise/internal/own/background/recent_contributors.go
+++ b/enterprise/internal/own/background/recent_contributors.go
@@ -71,9 +71,5 @@ func (r *recentContributorsIndexer) indexRepo(ctx context.Context, repoId api.Re
 	}
 	r.logger.Info("commits inserted", logger.Int("count", len(commitLog)), logger.Int("repo_id", int(repoId)))
 	commitCounter.Add(float64(len(commitLog)))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }

--- a/enterprise/internal/own/background/recent_views.go
+++ b/enterprise/internal/own/background/recent_views.go
@@ -1,0 +1,92 @@
+package background
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	viewBlobEventName      = "ViewBlob"
+	processedEventsCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "src",
+		Name:      "own_recent_views_events_processed_total",
+	})
+)
+
+func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Context) goroutine.BackgroundRoutine {
+	redMetrics := metrics.NewREDMetrics(
+		observationCtx.Registerer,
+		"own_background_recent_views_indexer",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+	operation := observationCtx.Operation(observation.Op{
+		Name:              "own.background.index.recent-views",
+		MetricLabelValues: []string{"recent-views"},
+		Metrics:           redMetrics,
+	})
+	handler := newRecentViewsIndexer(db, operation.Logger)
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", time.Minute*5, handler, operation)
+}
+
+type recentViewsIndexer struct {
+	db     database.DB
+	logger log.Logger
+}
+
+func newRecentViewsIndexer(db database.DB, logger log.Logger) *recentViewsIndexer {
+	return &recentViewsIndexer{db: db, logger: logger}
+}
+
+// TODO(sashaostrikov): write tests before merging this PR
+func (r *recentViewsIndexer) Handle(ctx context.Context) error {
+	logJobDisabled := func() {
+		r.logger.Info("skipping own background job, job disabled", log.String("job-name", "recent-views"))
+	}
+	flag, err := r.db.FeatureFlags().GetFeatureFlag(ctx, "own-background-index-repo-recent-views")
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			logJobDisabled()
+			return nil
+		} else {
+			return errors.Wrap(err, "database.FeatureFlagsWith")
+		}
+	}
+	res, ok := flag.EvaluateGlobal()
+	if !ok || !res {
+		logJobDisabled()
+		return nil
+	}
+
+	// The job is enabled, here we go. First we need to get the ID of last processed event.
+	bookmark, err := r.db.EventLogsScrapeState().GetBookmark(ctx, int(RecentViews))
+	if err != nil {
+		return errors.Wrap(err, "getting latest processed event ID")
+	}
+	events, err := r.db.EventLogs().ListAll(ctx, database.EventLogsListOptions{LimitOffset: &database.LimitOffset{Limit: 5000}, EventName: &viewBlobEventName, AfterID: bookmark})
+	if err != nil {
+		return errors.Wrap(err, "getting event logs")
+	}
+	numberOfEvents := len(events)
+	if numberOfEvents == 0 {
+		return nil
+	}
+	err = r.db.RecentViewSignal().BuildAggregateFromEvents(ctx, events)
+	if err != nil {
+		return errors.Wrap(err, "building aggregates from events")
+	}
+	newBookmark := int(events[numberOfEvents-1].ID)
+	r.logger.Info("events processed", log.Int("count", numberOfEvents))
+	processedEventsCounter.Add(float64(numberOfEvents))
+	return r.db.EventLogsScrapeState().UpdateBookmark(ctx, newBookmark, int(RecentViews))
+}

--- a/enterprise/internal/own/background/recent_views_test.go
+++ b/enterprise/internal/own/background/recent_views_test.go
@@ -1,0 +1,152 @@
+package background
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecentViewsIndexer(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	// Creating a user.
+	_, err := db.Users().Create(ctx, database.NewUser{Username: "user1"})
+	require.NoError(t, err)
+
+	// Creating a repo.
+	err = db.Repos().Create(ctx, &types.Repo{ID: 1, Name: "github.com/sourcegraph/sourcegraph"})
+	require.NoError(t, err)
+
+	// Enabling a feature flag.
+	_, err = db.FeatureFlags().CreateBool(ctx, "own-background-index-repo-recent-views", true)
+	require.NoError(t, err)
+
+	// Creating a worker.
+	observationCtx := &observation.TestContext
+	mockIndexInterval = time.Second * 3
+	cleanMock := func() { mockIndexInterval = 0 }
+	t.Cleanup(cleanMock)
+	worker := NewOwnRecentViewsIndexer(db, observationCtx)
+	go worker.Start()
+	t.Cleanup(worker.Stop)
+
+	// Adding events.
+	insertEvents(ctx, t, db)
+
+	// 30 seconds timeout in case of something being wrong, to terminate the test
+	// run.
+	timeout := time.After(30 * time.Second)
+	// First round is to wait for 2 summaries to be inserted to the database.
+	//
+	// Second round is to wait for the same summaries to be updated (their count
+	// should be incremented).
+	round := 1
+
+	assertSummaries := func() (needToWait bool) {
+		summaries, err := db.RecentViewSignal().List(ctx, database.ListRecentViewSignalOpts{})
+		require.NoError(t, err)
+		if round == 1 && len(summaries) == 2 {
+			// We don't need to check all summary fields because it is covered in
+			// `recent_view_signal_test.go`.
+			for _, summary := range summaries {
+				// Count of views is equal to round number.
+				assert.Equal(t, round, summary.ViewsCount)
+			}
+			// We are fine to add more events and go to next round.
+			insertEvents(ctx, t, db)
+			round++
+		} else if round == 2 {
+			// In round 2, we're waiting for the second iteration of worker which should
+			// increment the counts.
+			sum := 0
+			for _, summary := range summaries {
+				// Count of views is equal to round number.
+				sum += summary.ViewsCount
+			}
+			// If both counts have been incremented -- we go to next round, which leads to
+			// successful end of this test.
+			if sum == 4 {
+				round++
+				return false
+			}
+		}
+		return true
+	}
+loop:
+	for {
+		// We need to do assertions for rounds 1 and 2. Round 3 is success -- exit the
+		// loop.
+		switch round {
+		case 1, 2:
+			needToWait := assertSummaries()
+			if needToWait {
+				// Waiting for the summaries to be inserted.
+				time.Sleep(1 * time.Second)
+			}
+		default:
+			break loop
+		}
+
+		// Checking for timeout.
+		select {
+		case <-timeout:
+			t.Fatal("Event logs are not processing or processing takes too much time.")
+		default:
+			continue loop
+		}
+	}
+}
+
+func insertEvents(ctx context.Context, t *testing.T, db database.DB) {
+	t.Helper()
+	events := []*database.Event{
+		{
+			UserID: 1,
+			Name:   "SearchResultsQueried",
+			URL:    "http://sourcegraph.com",
+			Source: "test",
+		}, {
+			UserID: 1,
+			Name:   "codeintel",
+			URL:    "http://sourcegraph.com",
+			Source: "test",
+		},
+		{
+			UserID:         1,
+			Name:           "ViewBlob",
+			URL:            "http://sourcegraph.com",
+			Source:         "test",
+			PublicArgument: json.RawMessage(`{"filePath": "cmd/gitserver/server/patch.go", "repoName": "github.com/sourcegraph/sourcegraph"}`),
+		},
+		{
+			UserID: 1,
+			Name:   "SearchResultsQueried",
+			URL:    "http://sourcegraph.com",
+			Source: "test",
+		},
+		{
+			UserID:         1,
+			Name:           "ViewBlob",
+			URL:            "http://sourcegraph.com",
+			Source:         "test",
+			PublicArgument: json.RawMessage(`{"filePath": "cmd/gitserver/server/main.go", "repoName": "github.com/sourcegraph/sourcegraph"}`),
+		},
+	}
+
+	require.NoError(t, db.EventLogs().BulkInsert(ctx, events))
+}

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "encryption_tables.go",
         "encryption_utils.go",
         "event_logs.go",
+        "event_logs_scrape_state_own.go",
         "executor_secret_access_logs.go",
         "executor_secrets.go",
         "executors.go",

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,6 +66,8 @@ type DB interface {
 	ExecutorSecretAccessLogs() ExecutorSecretAccessLogStore
 	ZoektRepos() ZoektReposStore
 	Teams() TeamStore
+	EventLogsScrapeState() EventLogsScrapeStateStore
+	RecentViewSignal() RecentViewSignalStore
 
 	WithTransact(context.Context, func(tx DB) error) error
 }
@@ -302,4 +304,12 @@ func (d *db) ZoektRepos() ZoektReposStore {
 
 func (d *db) Teams() TeamStore {
 	return TeamsWith(d.Store)
+}
+
+func (d *db) EventLogsScrapeState() EventLogsScrapeStateStore {
+	return EventLogsScrapeStateStoreWith(d.Store)
+}
+
+func (d *db) RecentViewSignal() RecentViewSignalStore {
+	return RecentViewSignalStoreWith(d.Store, d.logger)
 }

--- a/internal/database/event_logs_scrape_state_own.go
+++ b/internal/database/event_logs_scrape_state_own.go
@@ -1,0 +1,48 @@
+package database
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+)
+
+type eventLogsScrapeStateStore struct {
+	*basestore.Store
+}
+
+// TODO(sashaostrikov): write tests before merging this PR
+func NewEventLogsScrapeStateStore(db DB) EventLogsScrapeStateStore {
+	return &eventLogsScrapeStateStore{Store: basestore.NewWithHandle(db.Handle())}
+}
+
+func EventLogsScrapeStateStoreWith(other basestore.ShareableStore) EventLogsScrapeStateStore {
+	return &eventLogsScrapeStateStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
+type EventLogsScrapeStateStore interface {
+	GetBookmark(ctx context.Context, jobType int) (int, error)
+	UpdateBookmark(ctx context.Context, val, jobType int) error
+}
+
+func (s *eventLogsScrapeStateStore) GetBookmark(ctx context.Context, jobType int) (int, error) {
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	val, found, err := basestore.ScanFirstInt(tx.Query(ctx, sqlf.Sprintf("SELECT bookmark_id FROM event_logs_scrape_state_own WHERE job_type = %d ORDER BY id LIMIT 1", jobType)))
+	if err != nil {
+		return 0, err
+	}
+	if !found {
+		// generate a row and return the value
+		return basestore.ScanInt(tx.QueryRow(ctx, sqlf.Sprintf("INSERT INTO event_logs_scrape_state_own (bookmark_id, job_type) SELECT MAX(id), %d FROM event_logs RETURNING bookmark_id", jobType)))
+	}
+	return val, err
+}
+
+func (s *eventLogsScrapeStateStore) UpdateBookmark(ctx context.Context, val, jobType int) error {
+	return s.Exec(ctx, sqlf.Sprintf("UPDATE event_logs_scrape_state_own SET bookmark_id = %d WHERE id = (SELECT id FROM event_logs_scrape_state_own WHERE job_type = %d ORDER BY id LIMIT 1)", val, jobType))
+}

--- a/internal/database/event_logs_scrape_state_own.go
+++ b/internal/database/event_logs_scrape_state_own.go
@@ -11,11 +11,6 @@ type eventLogsScrapeStateStore struct {
 	*basestore.Store
 }
 
-// TODO(sashaostrikov): write tests before merging this PR
-func NewEventLogsScrapeStateStore(db DB) EventLogsScrapeStateStore {
-	return &eventLogsScrapeStateStore{Store: basestore.NewWithHandle(db.Handle())}
-}
-
 func EventLogsScrapeStateStoreWith(other basestore.ShareableStore) EventLogsScrapeStateStore {
 	return &eventLogsScrapeStateStore{Store: basestore.NewWithHandle(other.Handle())}
 }

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -1512,6 +1512,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 				Source:          "test",
 				Timestamp:       timestamp,
 				Argument:        json.RawMessage(`{"key": "value1"}`),
+				PublicArgument:  json.RawMessage("{}"),
 				DeviceID:        ptr("device-id"),
 				InsertID:        ptr("insert-id"),
 			}, {
@@ -1522,6 +1523,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 				Source:          "test",
 				Timestamp:       timestamp,
 				Argument:        json.RawMessage(`{"key": "value2"}`),
+				PublicArgument:  json.RawMessage("{}"),
 				DeviceID:        ptr("device-id"),
 				InsertID:        ptr("insert-id"),
 			},
@@ -1544,6 +1546,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 			AnonymousUserID: events[1].AnonymousUserID,
 			Version:         version.Version(),
 			Argument:        events[1].Argument,
+			PublicArgument:  events[1].PublicArgument,
 			Source:          events[1].Source,
 			Timestamp:       timestamp,
 		}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -4900,6 +4900,9 @@ type MockDB struct {
 	// EventLogsFunc is an instance of a mock function object controlling
 	// the behavior of the method EventLogs.
 	EventLogsFunc *DBEventLogsFunc
+	// EventLogsScrapeStateFunc is an instance of a mock function object
+	// controlling the behavior of the method EventLogsScrapeState.
+	EventLogsScrapeStateFunc *DBEventLogsScrapeStateFunc
 	// ExecContextFunc is an instance of a mock function object controlling
 	// the behavior of the method ExecContext.
 	ExecContextFunc *DBExecContextFunc
@@ -4973,6 +4976,9 @@ type MockDB struct {
 	// object controlling the behavior of the method
 	// RecentContributionSignals.
 	RecentContributionSignalsFunc *DBRecentContributionSignalsFunc
+	// RecentViewSignalFunc is an instance of a mock function object
+	// controlling the behavior of the method RecentViewSignal.
+	RecentViewSignalFunc *DBRecentViewSignalFunc
 	// RedisKeyValueFunc is an instance of a mock function object
 	// controlling the behavior of the method RedisKeyValue.
 	RedisKeyValueFunc *DBRedisKeyValueFunc
@@ -5069,6 +5075,11 @@ func NewMockDB() *MockDB {
 		},
 		EventLogsFunc: &DBEventLogsFunc{
 			defaultHook: func() (r0 EventLogStore) {
+				return
+			},
+		},
+		EventLogsScrapeStateFunc: &DBEventLogsScrapeStateFunc{
+			defaultHook: func() (r0 EventLogsScrapeStateStore) {
 				return
 			},
 		},
@@ -5189,6 +5200,11 @@ func NewMockDB() *MockDB {
 		},
 		RecentContributionSignalsFunc: &DBRecentContributionSignalsFunc{
 			defaultHook: func() (r0 RecentContributionSignalStore) {
+				return
+			},
+		},
+		RecentViewSignalFunc: &DBRecentViewSignalFunc{
+			defaultHook: func() (r0 RecentViewSignalStore) {
 				return
 			},
 		},
@@ -5334,6 +5350,11 @@ func NewStrictMockDB() *MockDB {
 				panic("unexpected invocation of MockDB.EventLogs")
 			},
 		},
+		EventLogsScrapeStateFunc: &DBEventLogsScrapeStateFunc{
+			defaultHook: func() EventLogsScrapeStateStore {
+				panic("unexpected invocation of MockDB.EventLogsScrapeState")
+			},
+		},
 		ExecContextFunc: &DBExecContextFunc{
 			defaultHook: func(context.Context, string, ...interface{}) (sql.Result, error) {
 				panic("unexpected invocation of MockDB.ExecContext")
@@ -5452,6 +5473,11 @@ func NewStrictMockDB() *MockDB {
 		RecentContributionSignalsFunc: &DBRecentContributionSignalsFunc{
 			defaultHook: func() RecentContributionSignalStore {
 				panic("unexpected invocation of MockDB.RecentContributionSignals")
+			},
+		},
+		RecentViewSignalFunc: &DBRecentViewSignalFunc{
+			defaultHook: func() RecentViewSignalStore {
+				panic("unexpected invocation of MockDB.RecentViewSignal")
 			},
 		},
 		RedisKeyValueFunc: &DBRedisKeyValueFunc{
@@ -5584,6 +5610,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		EventLogsFunc: &DBEventLogsFunc{
 			defaultHook: i.EventLogs,
 		},
+		EventLogsScrapeStateFunc: &DBEventLogsScrapeStateFunc{
+			defaultHook: i.EventLogsScrapeState,
+		},
 		ExecContextFunc: &DBExecContextFunc{
 			defaultHook: i.ExecContext,
 		},
@@ -5655,6 +5684,9 @@ func NewMockDBFrom(i DB) *MockDB {
 		},
 		RecentContributionSignalsFunc: &DBRecentContributionSignalsFunc{
 			defaultHook: i.RecentContributionSignals,
+		},
+		RecentViewSignalFunc: &DBRecentViewSignalFunc{
+			defaultHook: i.RecentViewSignal,
 		},
 		RedisKeyValueFunc: &DBRedisKeyValueFunc{
 			defaultHook: i.RedisKeyValue,
@@ -6311,6 +6343,105 @@ func (c DBEventLogsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBEventLogsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBEventLogsScrapeStateFunc describes the behavior when the
+// EventLogsScrapeState method of the parent MockDB instance is invoked.
+type DBEventLogsScrapeStateFunc struct {
+	defaultHook func() EventLogsScrapeStateStore
+	hooks       []func() EventLogsScrapeStateStore
+	history     []DBEventLogsScrapeStateFuncCall
+	mutex       sync.Mutex
+}
+
+// EventLogsScrapeState delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) EventLogsScrapeState() EventLogsScrapeStateStore {
+	r0 := m.EventLogsScrapeStateFunc.nextHook()()
+	m.EventLogsScrapeStateFunc.appendCall(DBEventLogsScrapeStateFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the EventLogsScrapeState
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBEventLogsScrapeStateFunc) SetDefaultHook(hook func() EventLogsScrapeStateStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// EventLogsScrapeState method of the parent MockDB instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBEventLogsScrapeStateFunc) PushHook(hook func() EventLogsScrapeStateStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBEventLogsScrapeStateFunc) SetDefaultReturn(r0 EventLogsScrapeStateStore) {
+	f.SetDefaultHook(func() EventLogsScrapeStateStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBEventLogsScrapeStateFunc) PushReturn(r0 EventLogsScrapeStateStore) {
+	f.PushHook(func() EventLogsScrapeStateStore {
+		return r0
+	})
+}
+
+func (f *DBEventLogsScrapeStateFunc) nextHook() func() EventLogsScrapeStateStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBEventLogsScrapeStateFunc) appendCall(r0 DBEventLogsScrapeStateFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBEventLogsScrapeStateFuncCall objects
+// describing the invocations of this function.
+func (f *DBEventLogsScrapeStateFunc) History() []DBEventLogsScrapeStateFuncCall {
+	f.mutex.Lock()
+	history := make([]DBEventLogsScrapeStateFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBEventLogsScrapeStateFuncCall is an object that describes an invocation
+// of method EventLogsScrapeState on an instance of MockDB.
+type DBEventLogsScrapeStateFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 EventLogsScrapeStateStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBEventLogsScrapeStateFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBEventLogsScrapeStateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -8743,6 +8874,105 @@ func (c DBRecentContributionSignalsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBRecentContributionSignalsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// DBRecentViewSignalFunc describes the behavior when the RecentViewSignal
+// method of the parent MockDB instance is invoked.
+type DBRecentViewSignalFunc struct {
+	defaultHook func() RecentViewSignalStore
+	hooks       []func() RecentViewSignalStore
+	history     []DBRecentViewSignalFuncCall
+	mutex       sync.Mutex
+}
+
+// RecentViewSignal delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDB) RecentViewSignal() RecentViewSignalStore {
+	r0 := m.RecentViewSignalFunc.nextHook()()
+	m.RecentViewSignalFunc.appendCall(DBRecentViewSignalFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RecentViewSignal
+// method of the parent MockDB instance is invoked and the hook queue is
+// empty.
+func (f *DBRecentViewSignalFunc) SetDefaultHook(hook func() RecentViewSignalStore) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RecentViewSignal method of the parent MockDB instance invokes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBRecentViewSignalFunc) PushHook(hook func() RecentViewSignalStore) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *DBRecentViewSignalFunc) SetDefaultReturn(r0 RecentViewSignalStore) {
+	f.SetDefaultHook(func() RecentViewSignalStore {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *DBRecentViewSignalFunc) PushReturn(r0 RecentViewSignalStore) {
+	f.PushHook(func() RecentViewSignalStore {
+		return r0
+	})
+}
+
+func (f *DBRecentViewSignalFunc) nextHook() func() RecentViewSignalStore {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBRecentViewSignalFunc) appendCall(r0 DBRecentViewSignalFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBRecentViewSignalFuncCall objects
+// describing the invocations of this function.
+func (f *DBRecentViewSignalFunc) History() []DBRecentViewSignalFuncCall {
+	f.mutex.Lock()
+	history := make([]DBRecentViewSignalFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBRecentViewSignalFuncCall is an object that describes an invocation of
+// method RecentViewSignal on an instance of MockDB.
+type DBRecentViewSignalFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 RecentViewSignalStore
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBRecentViewSignalFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBRecentViewSignalFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/recent_view_signal.go
+++ b/internal/database/recent_view_signal.go
@@ -41,7 +41,8 @@ type RecentViewSummary struct {
 }
 
 func RecentViewSignalStoreWith(other basestore.ShareableStore, logger log.Logger) RecentViewSignalStore {
-	return &recentViewSignalStore{Store: basestore.NewWithHandle(other.Handle()), Logger: logger}
+	lgr := logger.Scoped("RecentViewSignalStore", "Store for a table containing a number of views of a single file by a given viewer")
+	return &recentViewSignalStore{Store: basestore.NewWithHandle(other.Handle()), Logger: lgr}
 }
 
 type recentViewSignalStore struct {
@@ -76,7 +77,7 @@ const insertRecentViewSignalFmtstr = `
 	INSERT INTO own_aggregate_recent_view(viewer_id, viewed_file_path_id, views_count)
 	VALUES(%s, %s, %s)
 	ON CONFLICT(viewer_id, viewed_file_path_id) DO UPDATE
-	SET views_count = EXCLUDED.views_count
+	SET views_count = EXCLUDED.views_count + own_aggregate_recent_view.views_count
 `
 
 func (s *recentViewSignalStore) Insert(ctx context.Context, userID int32, repoPathID, count int) error {
@@ -88,7 +89,7 @@ const bulkInsertRecentViewSignalsFmtstr = `
 	INSERT INTO own_aggregate_recent_view(viewer_id, viewed_file_path_id, views_count)
 	VALUES %s
 	ON CONFLICT(viewer_id, viewed_file_path_id) DO UPDATE
-	SET views_count = EXCLUDED.views_count
+	SET views_count = EXCLUDED.views_count + own_aggregate_recent_view.views_count
 `
 
 // InsertPaths inserts paths and view counts for a given `userID`. This function

--- a/internal/database/recent_view_signal.go
+++ b/internal/database/recent_view_signal.go
@@ -142,12 +142,6 @@ func (s *recentViewSignalStore) List(ctx context.Context, _ ListRecentViewSignal
 // events. One signal has a userID, repoPathID and a count. This data is derived
 // from the event, please refer to inline comments for more implementation
 // details.
-//
-// TODO(sashaostrikov): BuildAggregateFromEvents should be called from worker,
-// which queries events like so:
-//
-// db := NewDBWith(s.Logger, s)
-// events, err := db.EventLogs().ListEventsByName(ctx, viewBlobEventType, after, limit)
 func (s *recentViewSignalStore) BuildAggregateFromEvents(ctx context.Context, events []*Event) error {
 	// Map of repo name to repo ID and paths+repoPathIDs of files specified in
 	// "ViewBlob" events. Used to aggregate all the paths for a single repo to then

--- a/internal/database/recent_view_signal_test.go
+++ b/internal/database/recent_view_signal_test.go
@@ -192,7 +192,7 @@ func TestRecentViewSignalStore_Insert(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, summaries, 1)
 		assert.Equal(t, 2, summaries[0].FilePathID)
-		assert.Equal(t, 100, summaries[0].ViewsCount)
+		assert.Equal(t, 110, summaries[0].ViewsCount)
 		clearTable(ctx, db)
 	})
 }


### PR DESCRIPTION
### ~I will add tests before merging the PR, opening it earlier to get a review during EU night time.~
### Added a test in a second commit

Test plan:
Unit tests added.
Local run and checks that the job runs and adds signals to the DB.

Closes https://github.com/sourcegraph/sourcegraph/issues/51465