### PR TITLE
remove tests and linter from backend integration branch

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -350,5 +350,3 @@ Base pipeline (more steps might be included based on branch changes):
 - Build server
 - Backend integration tests (gRPC)
 - Backend integration tests
-- **Linters and static analysis**: Run sg lint
-- **Go checks**: Test (all), Test (all (gRPC)), Test (enterprise/internal/insights), Test (enterprise/internal/insights (gRPC)), Test (internal/repos), Test (internal/repos (gRPC)), Test (enterprise/internal/batches), Test (enterprise/internal/batches (gRPC)), Test (cmd/frontend), Test (cmd/frontend (gRPC)), Test (enterprise/cmd/frontend/internal/batches/resolvers), Test (enterprise/cmd/frontend/internal/batches/resolvers (gRPC)), Test (dev/sg), Test (dev/sg (gRPC)), Test (internal/database), Test (enterprise/internal/database), Build


### PR DESCRIPTION
No longer used on the backend integration branch because of bazel 

## Test plan

Pass CI