### PR TITLE
llm-proxy: close redis conn after healthcheck

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -132,6 +132,8 @@ func healthz(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "redis: failed to get conn")
 	}
+	defer rconn.Close()
+
 	data, err := rconn.Do("PING")
 	if err != nil {
 		return errors.Wrap(err, "redis: failed to ping")


### PR DESCRIPTION
## Test plan

n/a