### PR TITLE
Add Cody across docsite

### DIFF
--- a/doc/cody/explanations/enabling_cody.md
+++ b/doc/cody/explanations/enabling_cody.md
@@ -4,11 +4,12 @@ Cody uses Sourcegraph to fetch relevant context to generate answers and code. Th
 
 ## Initial setup
 
-1. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
-2. Open Cody in your editor and sign in. 
-3. Set the Sourcegraph URL to be `https://sourcegraph.com`
+1. [Create a Sourcegraph.com account](https://sourcegraph.com/sign-up)
+2. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
+3. Open the Cody extension in your editor and sign in with your Sourcegraph.com credentials
+4. When prompted by the extesnion, set the Sourcegraph URL to `https://sourcegraph.com`
 
-You're now ready to use Cody!
+You're now ready to use Cody in VS Code!
 
 ## Configure code graph context for code-aware answers
 

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -1,0 +1,5 @@
+# Explanations
+
+- [Enabling Cody for Sourcegraph Enterprise](enabling_cody_enterprise.md)
+- [Enabling Cody for Sourcegraph Enterprise](enabling_cody.md)
+- [Configuring code graph context](code_graph_context.md)

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -2,4 +2,5 @@
 
 - [Enabling Cody for Sourcegraph Enterprise](enabling_cody_enterprise.md)
 - [Enabling Cody for Sourcegraph Enterprise](enabling_cody.md)
+- [Installing the Cody VS Code extension](installing_vs_code.md)
 - [Configuring code graph context](code_graph_context.md)

--- a/doc/cody/explanations/installing_vs_code.md
+++ b/doc/cody/explanations/installing_vs_code.md
@@ -1,0 +1,58 @@
+# Installing Cody in VS Code
+
+## Introduction
+
+In this guide, you will:
+
+- Install the VS Code extension
+- Connect the extension to your Sourcegraph Enterprise instance or Sourcegraph.com account
+
+## Requirements
+
+- A Sourcegraph instance with Cody enabled on it OR a Sourcegraph.com account.
+
+If you haven't yet done this, see Step 1 on the following pages:
+
+- [Enabling Cody for Sourcegraph Enterprise](enabling_cody_enterprise.md)
+- [Enabling Cody for Sourcegraph.com](enabling_cody.md)
+
+## Install the VS Code extension
+
+You can install Cody in VS Code in 2 ways:
+
+- Click the Extensions icon on the VS Code activity bar
+- Search for "Sourcegraph Cody"
+- Install the extension directly to VS Code
+
+Or:
+
+- [Download and install the extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
+
+## Connect the extension to Sourcegraph
+
+Next, you'll open the VS Code extension and configure it to connect to a Sourcegraph instance (either an enterprise instance or Sourcegraph.com).
+
+**For Sourcegraph Enterprise users:**
+
+Log in to your Sourcegraph instance and go to `settings` / `access token` (`https://<your-instance>.sourcegraph.com/users/<your-instance>/settings/tokens`). From here, generate a new access token.
+
+Then, you will paste your access token and instance address in to the Cody extension.
+
+**For Sourcegraph.com users:**
+
+Click `Continue with Sourcegraph.com` in the Cody extension. From there, you'll be taken to Sourcegraph.com, which will authenticate your extension.
+
+## (Optional) Enable code graph context for context-aware answers
+
+You can optional configure code graph content, which gives Cody the ability to provide context-aware answers. For example, Cody can write example API calls if has context of a codebase's API schema.
+
+- [Configure code graph context for Sourcegraph.com](enabling_cody#configure-code-graph-context-for-code-aware-answers)
+- [Configure code graph context for Sourcegraph Enterprise](enabling_cody_enterprise#enabling-codebase-aware-answers)
+
+## Get started with Cody
+
+You're now ready to use Cody! See our recommendations for getting started with using Cody.
+
+## Congratulations!
+
+**You're now up-and-running with your very own AI code asisstant!** 🎉

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -1,6 +1,6 @@
 # <picture title="Cody"><img class="theme-dark-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
 
-<span class="badge badge-experimental">Experimental</span>
+<span class="badge badge-beta">Beta</span>
 
 Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
 

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -8,13 +8,13 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 
 ## Get Cody
 
-- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://sourcegraph.typeform.com/to/pIXTgwrd) to use Cody on your existing Sourcegraph instance.
-- **Everyone:** Cody for open source code is now available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
+- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody) to use Cody on your existing Sourcegraph instance.
+- **Everyone:** Cody for open source code is available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
 
-Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in Sourcegraph itself.
+Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in the Sourcegraph web interface.
 
 <div class="cta-group">
-<a class="btn btn-primary" href="quickstart">★ VS Code extension quickstart</a>
+<a class="btn btn-primary" href="quickstart">★ Cody quickstart</a>
 <a class="btn" href="explanations/use_cases">Cody use cases</a>
 <a class="btn" href="faq">FAQ</a>
 <a class="btn" href="https://discord.com/servers/sourcegraph-969688426372825169">Join our Discord</a>
@@ -75,4 +75,5 @@ See [Cody troubleshooting guide](troubleshooting.md).
 
 - [Enabling Cody for Sourcegraph Enterprise customers](explanations/enabling_cody_enterprise.md)
 - [Enabling Cody for open source Sourcegraph.com users](explanations/enabling_cody.md)
+- [Installing the Cody VS Code extension](explanations/installing_vs_code.md)
 - [Configuring code graph context](explanations/code_graph_context.md)

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -11,6 +11,13 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 - **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody) to use Cody on your existing Sourcegraph instance.
 - **Everyone:** Cody for open source code is available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
 
+There are currently two ways to experience Cody:
+
+- In Sourcegraph itself
+- In your editor
+  - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
+  - Jetbrains extension (coming soon)
+
 Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in the Sourcegraph web interface.
 
 <div class="cta-group">

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -8,7 +8,7 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 
 ## Get Cody
 
-- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody) to use Cody on your existing Sourcegraph instance.
+- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody#cody-for-work) to use Cody on your existing Sourcegraph instance.
 - **Everyone:** Cody for open source code is available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
 
 There are currently two ways to experience Cody:

--- a/doc/cody/quickstart.md
+++ b/doc/cody/quickstart.md
@@ -1,70 +1,27 @@
 # Quickstart for Cody in VS Code
 
-Get started with the Cody VS Code extension and start using Cody recipes in under 10 minutes.
+This guide provides recommendations for first things to try once you have Cody up and running. 
 
-If you haven't yet enabled Cody for your Sourcegraph instance, go here first:
+If you haven't yet enabled Cody for your Sourcegraph instance or installed the VS Code extension, go here first:
 
 - [Enabling Cody for Sourcegraph Enterprise customers](explanations/enabling_cody_enterprise.md)
 - [Enabling Cody for Sourcegraph.com users](explanations/enabling_cody.md)
+- [Installing Cody for VS Code](explanations/installing_vs_code.md)
 
 ## Introduction
 
-In this guide, you will:
+Once you have access to Cody, we recommend:
 
-- Install the VS Code extension
-- Connect the extension to your Sourcegraph Enterprise instance or Sourcegraph.com account
-- Generate a unit test for your code
-- Have Cody summarize recent changes to your code
+- Trying the `Generate a unit test` recipe
+- Trying the `Summarize recent code changes` recipe
+- Asking Cody to pull information from documentation
+- Asking Cody to write context-aware code
 
-## Requirements
-
-- A Sourcegraph instance with Cody enabled on it OR a Sourcegraph.com account with Cody enabled on it.
-
-If you haven't yet done this, see Step 1 on the following pages:
-
-- [Enabling Cody for Sourcegraph Enterprise](explanations/enabling_cody_enterprise.md)
-- [Enabling Cody for Sourcegraph.com](explanations/enabling_cody.md)
-
-## Install the VS Code extension
-
-The first thing you need to do is install the VS Code extension. You can do this in 2 ways:
-
-- Click the Extensions icon on the VS Code activity bar
-- Search for "Sourcegraph Cody"
-- Install the extension directly to VS Code
-
-Or:
-
-- [Download and install the extension from the VS Code marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
-
-## Generate an access token from your Sourcegraph instance
-
-Next, you must generate an access token so that Cody can talk to your Sourcegraph instance. You'll add this to your extension in the next step.
-
-**For Sourcegraph Enterprise users:**
-
-Log in to your Sourcegraph instance and go to `settings` / `access token` (`https://<your-instance>.sourcegraph.com/users/<your-instance>/settings/tokens`). From here, generate a new access token.
-
-**For Sourcegraph.com users:**
-
-Log in to Sourcegraph.com and go to the [Access tokens page](https://sourcegraph.com/user/settings/tokens). Generate a new access token.
-
-## Configure your extension settings
-
-When you first install the Cody extension, you will see this screen:
-
-  <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
-
-In the `Access Token` field, paste in your access token from the previous step.
-
-In the `Sourcegraph Instance` field, paste in the URL of your Sourcegraph instance.
-
-- For Sourcegraph Enterprise, this is your own instance's URL.
-- For Sourcegraph.com, this is `https://sourcegraph.com`
-
-## Generate a unit test
+## Getting started with the Cody extension and recipes
 
 The Cody icon should now appear in the activity bar in VS Code. Clicking the icon will open the Cody side panel. The `Chat` tab can be used to ask Cody questions and paste in snippets of code, and the `Recipes` tab can be used to run premade functions over whatever code you currently have highlighted.
+
+## Generate a unit test
 
 As one recipe example, let's generate a unit test:
 
@@ -85,6 +42,26 @@ Imagine you've stepped away from a project for the last week. Let's see what's c
 3. A dropdown will appear. Click `Last week`
 4. Cody will provide a summary of changes to your codebase that occurred in that time period
 
+## Ask Cody to pull reference documentation
+
+Cody can also directly reference documentation. If Cody has context of a codebase, and docs are committed within that codebase, Cody can search through the text of docs to understand documentation and quickly pull out information so that you don't have to search for it yourself.
+
+In the `Chat` tab of the VS Code extension, you can ask Cody examples like:
+
+- "What happens when Service X runs out of memory?"
+- "Where can I find a list of all experimental features and their feature flags?"
+- "How is the changelog generated?"
+
+## Ask Cody to write context-aware code
+
+One of Cody's strengths is writing code, especially boilerplate code or simple code that requires general awareness of the broader codebase.
+
+One great example of this is writing an API call. Once Cody has context of a codebase, including existing API schemas within that codebase, you can ask Cody to write code for API calls.
+
+For example, ask Cody:
+
+- "Write an API call to retrieve user permissions data"
+
 ## Try other recipes and Cody chat
 
 Cody can do many other things, including:
@@ -94,9 +71,3 @@ Cody can do many other things, including:
 3. Translate code to different languages
 4. Answer general questions about your code
 5. Suggest bugfixes and changes to code snippets
-
-To see this in action, try asking Codying a question in the chat sidebar such as "Are there any bugs in this code snippet?"
-
-## Congratulations!
-
-**You're now up-and-running with your very own AI code asisstant!** 🎉

--- a/doc/getting-started/index.md
+++ b/doc/getting-started/index.md
@@ -39,6 +39,7 @@ Sourcegraph's main features are:
 - [Code navigation](#code-navigation): jump-to-definition, find references, and other smart, IDE-like code browsing features on any branch, commit, or PR/code review
 - [Code search](#code-search): fast, up-to-date, and scalable, with regexp support on any branch or commit without an indexing delay (and diff search)
 - [Notebooks](#notebooks): pair code and markdown to create powerful live and persistent documentation
+- [Cody](#cody): read and write code with the help of a context-aware AI code assistant
 - [Code Insights](#code-insights): reveal high-level information about your codebase at its current state and over time, to track migrations, version usage, vulnerability remediation, ownership, and anything else you can search in Sourcegraph
 - [Batch Changes](#batch-changes): make large-scale code changes across many repositories and code hosts
 - [Integrations](#integrations) with code hosts, code review tools, editors, web browsers, etc.
@@ -105,6 +106,14 @@ Sourcegraph gives you code navigation in:
 ![GitHub file integration](https://storage.googleapis.com/sourcegraph-assets/code-graph/docs/github-file.png)
 
 Read the [code navigation documentation](../code_navigation/index.md) to learn more and to set it up.
+
+---
+
+## Cody
+
+Cody is an AI code assistant that uses Sourcegraph code search, the code graph, and LLMs to provide context-aware answers about your codebase. Cody can explain code, refactor code, and write code, all within the context of your existing codebase.
+
+[Learn more about about Cody](../cody/index.md).
 
 ---
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -5,10 +5,12 @@ Sourcegraph makes it easy to read, write, and fix code—even in big, complex co
 - **Code search:** Search all of your repositories across all branches and all code hosts.
 - **Code intelligence:** Navigate code, find references, see code owners, trace history, and more.
 - **Fix and refactor:** Roll out large-scale changes to many repositories at once and track big migrations.
+- **AI code assistant:** Use Cody to read, write, and understand code faster.
 
 ## Usage
 
 - [**Download Sourcegraph**](https://about.sourcegraph.com/app) for macOS and Linux
+- [**Get Cody**](cody/index.md), the AI coding assistant
 - [Use Sourcegraph on the cloud or self-hosted](admin/deploy/index.md)
 - [Sourcegraph.com public code search](https://sourcegraph.com/search)
 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -72,7 +72,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Contributing](dev/contributing.md)
 - [Dotcom](dotcom/index.md)
 - [Cody (beta)](cody/index.md)
-  - Quickstart
+  - [Quickstart](cody/quickstart.md)
   - [Explanations](cody/explanations/index.md)
   - [FAQ](cody/faq.md)
 - [App (experimental)](app/index.md)

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -71,9 +71,11 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Background information](dev/background-information/index.md)
   - [Contributing](dev/contributing.md)
 - [Dotcom](dotcom/index.md)
-- [App (experimental)](app/index.md)
-- [Cody (experimental)](cody/index.md)
+- [Cody (beta)](cody/index.md)
+  - Quickstart
+  - [Explanations](cody/explanations/index.md)
   - [FAQ](cody/faq.md)
+- [App (experimental)](app/index.md)
 - [Own (experimental)](own/index.md)
 - <br/>
 - [★ Search query syntax](code_search/reference/queries.md)

--- a/doc/tutorials/index.md
+++ b/doc/tutorials/index.md
@@ -74,3 +74,4 @@
 | Topic | Content Type | Description |
 | -------- | -------- | -------- |
 | [Sourcegraph Tour](../getting-started/tour.md) | How-to-Guide | A tour of a sample Sourcegraph use cases, including using Sourcegraph for code reviews, debugging, and understanding how a function works. |
+| [Cody Use Cases](../cody/explanations/use_cases.md) | How-to-Guide | A tour of Cody and where the AI code assistant fits into everyday workflows. |


### PR DESCRIPTION
Adding Cody across the docsite to improve visibility + frictionless onboarding.

## Test plan

Docs only. Preview.