### PR TITLE
codeintel: Differentiate expiration of (directly) unreferenced and (indirectly) unreferenced expired uploads

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/store/expiration.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/expiration.go
@@ -312,7 +312,7 @@ func (s *store) SoftDeleteExpiredUploadsViaTraversal(ctx context.Context, traver
 
 	var a, b int
 	err = s.withTransaction(ctx, func(tx *store) error {
-		unset, _ := tx.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "soft-deleting expired uploads")
+		unset, _ := tx.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "soft-deleting expired uploads (via graph traversal)")
 		defer unset(ctx)
 		scannedCount, repositories, err := scanCountsWithTotalCount(tx.db.Query(ctx, sqlf.Sprintf(
 			softDeleteExpiredUploadsViaTraversalQuery,


### PR DESCRIPTION
Ensure audit log messages are unique per deletion reason.

## Test plan

N/A