### PR TITLE
llmproxy: Mirror status code and headers

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -91,7 +91,6 @@ func newHandler(logger log.Logger, config *Config) http.Handler {
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("healthz: ok"))
-		return
 	})
 	r.HandleFunc("/-/__version", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -123,6 +122,9 @@ func newHandler(logger log.Logger, config *Config) http.Handler {
 				return
 			}
 			defer func() { _ = resp.Body.Close() }()
+
+			w.WriteHeader(resp.StatusCode)
+			_ = resp.Header.Write(w)
 
 			_, _ = io.Copy(w, resp.Body)
 		}),


### PR DESCRIPTION
I think this is needed, but didn't fully validate yet.
Not sure if we want to mirror _all_ headers but for now this should be okay and we can restrict it more if needed.

## Test plan

Will test if errors propagate correctly.