### PR TITLE
llm-proxy: implement initial rate-limiting and rate limit updates

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
@@ -8,5 +8,8 @@ go_library(
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor",
     visibility = ["//enterprise/cmd/llm-proxy:__subpackages__"],
-    deps = ["//enterprise/cmd/llm-proxy/internal/limiter"],
+    deps = [
+        "//enterprise/cmd/llm-proxy/internal/limiter",
+        "//lib/errors",
+    ],
 )

--- a/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
@@ -2,8 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "actor",
-    srcs = ["actor.go"],
+    srcs = [
+        "actor.go",
+        "source.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor",
     visibility = ["//enterprise/cmd/llm-proxy:__subpackages__"],
-    deps = ["//enterprise/cmd/llm-proxy/internal/dotcom"],
+    deps = ["//enterprise/cmd/llm-proxy/internal/limiter"],
 )

--- a/enterprise/cmd/llm-proxy/internal/actor/actor.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/actor.go
@@ -2,44 +2,42 @@ package actor
 
 import (
 	"context"
+	"errors"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/limiter"
 )
 
-type SubscriptionRateLimit struct {
+type RateLimit struct {
 	Limit    int
 	Interval time.Duration
 }
 
-type Subscription struct {
-	// ID is the subscription ID.
-	ID string `json:"id"`
-	// AccessEnabled is an evaluated field that summarizes whether or not LLM-proxy access
-	// is enabled, based on whether the subscription is archived, if access is enabled, and
-	// if any rate limits are set.
-	AccessEnabled bool `json:"accessEnabled"`
-	// RateLimit is the rate limit for LLM-proxy access.
-	RateLimit *SubscriptionRateLimit `json:"rateLimit"`
-}
-
-func NewSubscriptionFromDotCom(s dotcom.ProductSubscriptionState) *Subscription {
-	var rateLimit *SubscriptionRateLimit
-	if s.LlmProxyAccess.RateLimit != nil {
-		rateLimit = &SubscriptionRateLimit{
-			Limit:    s.LlmProxyAccess.RateLimit.Limit,
-			Interval: time.Duration(s.LlmProxyAccess.RateLimit.IntervalSeconds) * time.Second,
-		}
-	}
-	return &Subscription{
-		ID:            s.Id,
-		AccessEnabled: !s.IsArchived && rateLimit != nil && s.LlmProxyAccess.Enabled,
-		RateLimit:     rateLimit,
-	}
+func (r *RateLimit) IsValid() bool {
+	return r != nil && r.Interval > 0 && r.Limit > 0
 }
 
 type Actor struct {
-	Subscription *Subscription
+	// Key is the original key used to identify the actor.
+	//
+	// For example, for product subscriptions this is the license-based access token.
+	Key string `json:"key"`
+	// ID is the identifier for this actor's rate-limiting pool.
+	//
+	// For example, for product subscriptions this is the subscription ID.
+	ID string `json:"id"`
+	// AccessEnabled is an evaluated field that summarizes whether or not LLM-proxy access
+	// is enabled.
+	//
+	// For example, for product subscriptions it is based on whether the subscription is
+	// archived, if access is enabled, and if any rate limits are set.
+	AccessEnabled bool `json:"accessEnabled"`
+	// RateLimit is the rate limit for LLM-proxy access for this actor.
+	RateLimit RateLimit `json:"rateLimit"`
+	// LastUpdated indicates when this actor's state was last updated.
+	LastUpdated *time.Time `json:"lastUpdated"`
+	// Source is a reference to the source of this actor's state.
+	Source Source `json:"-"`
 }
 
 type contextKey int
@@ -56,7 +54,47 @@ func FromContext(ctx context.Context) *Actor {
 	return a
 }
 
+// Update updates the given actor's state using the actor's originating source.
+// The source may define additional conditions for updates, such that an update
+// does not necessarily occur on every call.
+//
+// If the actor has no source, this is a no-op.
+func (a *Actor) Update(ctx context.Context) {
+	if a.Source != nil {
+		a.Source.Update(ctx, a)
+	}
+}
+
 // WithActor returns a new context with the given Actor instance.
 func WithActor(ctx context.Context, a *Actor) context.Context {
 	return context.WithValue(ctx, actorKey, a)
+}
+
+func (a *Actor) Limiter(redis limiter.RedisStore) limiter.Limiter {
+	if a == nil {
+		return &limiter.StaticLimiter{}
+	}
+	return updateOnFailureLimiter{Redis: redis, Actor: a}
+}
+
+type updateOnFailureLimiter struct {
+	Redis limiter.RedisStore
+	*Actor
+}
+
+func (u updateOnFailureLimiter) TryAcquire(ctx context.Context) error {
+	err := (limiter.StaticLimiter{
+		Identifier: u.ID,
+		Redis:      u.Redis,
+		Limit:      u.RateLimit.Limit,
+		Interval:   u.RateLimit.Interval,
+		// Only update rate limit TTL if the actor has been updated recently.
+		UpdateRateLimitTTL: u.LastUpdated != nil && time.Since(*u.LastUpdated) < 5*time.Minute,
+	}).TryAcquire(ctx)
+
+	if errors.Is(err, limiter.NoAccessError{}) || errors.Is(err, limiter.RateLimitExceededError{}) {
+		u.Actor.Update(ctx)
+	}
+
+	return err
 }

--- a/enterprise/cmd/llm-proxy/internal/actor/actor.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/actor.go
@@ -2,10 +2,10 @@ package actor
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/limiter"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type RateLimit struct {

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "productsubscription",
+    srcs = ["productsubscription.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor/productsubscription",
+    visibility = ["//enterprise/cmd/llm-proxy:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/llm-proxy/internal/actor",
+        "//enterprise/cmd/llm-proxy/internal/dotcom",
+        "//lib/errors",
+        "@com_github_gregjones_httpcache//:httpcache",
+        "@com_github_khan_genqlient//graphql",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -1,0 +1,116 @@
+package productsubscription
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/gregjones/httpcache"
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	minUpdateInterval = 10 * time.Minute
+
+	defaultUpdateInterval       = 24 * time.Hour
+	defaultUpdateIntervalJitter = 15 * time.Minute
+)
+
+type Source struct {
+	log    log.Logger
+	cache  httpcache.Cache // TODO: add something to regularly clean up the cache
+	dotcom graphql.Client
+	// random source used to add jitter to repo update intervals.
+	randGenerator interface {
+		Int63n(n int64) int64
+	}
+}
+
+func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client) *Source {
+	return &Source{
+		log:    logger.Scoped("productsubscriptions", "product subscription actor source"),
+		cache:  cache,
+		dotcom: dotComClient,
+	}
+}
+
+func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
+	data, hit := s.cache.Get(token)
+	if !hit {
+		return s.fetchAndCache(ctx, token)
+	}
+
+	var act *actor.Actor
+	if err := json.Unmarshal(data, &act); err != nil {
+		s.log.Error("failed to unmarshal subscription", log.Error(err))
+		return s.fetchAndCache(ctx, token)
+	}
+
+	// Try to avoid lots of actors updating all at once
+	delta := defaultUpdateIntervalJitter.Nanoseconds()
+	if time.Since(*act.LastUpdated) > defaultUpdateInterval+time.Duration(s.randGenerator.Int63n(2*delta)-delta) {
+		return s.fetchAndCache(ctx, token)
+	}
+
+	return act, nil
+}
+
+func (s *Source) Update(ctx context.Context, actor *actor.Actor) {
+	if time.Since(*actor.LastUpdated) < minUpdateInterval {
+		// Last update was too recent - do it later.
+		return
+	}
+
+	if _, err := s.fetchAndCache(ctx, actor.Key); err != nil {
+		s.log.Info("failed to update actor", log.Error(err))
+	}
+}
+
+func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor, error) {
+	var act *actor.Actor
+	resp, checkErr := dotcom.CheckAccessToken(ctx, s.dotcom, token)
+	if checkErr != nil {
+		// Generate a stateless actor so that we aren't constantly hitting the dotcom API
+		act = NewActor(s, token, dotcom.ProductSubscriptionState{})
+	} else {
+		act = NewActor(s, token, resp.Dotcom.ProductSubscriptionByAccessToken.ProductSubscriptionState)
+	}
+
+	if data, err := json.Marshal(act); err != nil {
+		s.log.Error("failed to marshal actor",
+			log.Error(err))
+	} else {
+		s.cache.Set(token, data)
+	}
+
+	if checkErr != nil {
+		return nil, errors.Wrap(checkErr, "failed to validate access token")
+	}
+	return act, nil
+}
+
+// NewActor creates an actor from Sourcegraph.com product subscription state.
+func NewActor(source *Source, token string, s dotcom.ProductSubscriptionState) *actor.Actor {
+	var rateLimit actor.RateLimit
+	if s.LlmProxyAccess.RateLimit != nil {
+		rateLimit = actor.RateLimit{
+			Limit:    s.LlmProxyAccess.RateLimit.Limit,
+			Interval: time.Duration(s.LlmProxyAccess.RateLimit.IntervalSeconds) * time.Second,
+		}
+	}
+
+	now := time.Now()
+	return &actor.Actor{
+		Key:           token,
+		ID:            s.Id,
+		AccessEnabled: !s.IsArchived && s.LlmProxyAccess.Enabled && rateLimit.IsValid(),
+		RateLimit:     rateLimit,
+		LastUpdated:   &now,
+		Source:        source,
+	}
+}

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -17,18 +17,13 @@ import (
 var (
 	minUpdateInterval = 10 * time.Minute
 
-	defaultUpdateInterval       = 24 * time.Hour
-	defaultUpdateIntervalJitter = 15 * time.Minute
+	defaultUpdateInterval = 24 * time.Hour
 )
 
 type Source struct {
 	log    log.Logger
 	cache  httpcache.Cache // TODO: add something to regularly clean up the cache
 	dotcom graphql.Client
-	// random source used to add jitter to repo update intervals.
-	randGenerator interface {
-		Int63n(n int64) int64
-	}
 }
 
 func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client) *Source {
@@ -51,9 +46,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 		return s.fetchAndCache(ctx, token)
 	}
 
-	// Try to avoid lots of actors updating all at once
-	delta := defaultUpdateIntervalJitter.Nanoseconds()
-	if time.Since(*act.LastUpdated) > defaultUpdateInterval+time.Duration(s.randGenerator.Int63n(2*delta)-delta) {
+	if time.Since(*act.LastUpdated) > defaultUpdateInterval {
 		return s.fetchAndCache(ctx, token)
 	}
 

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -46,7 +46,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 		return s.fetchAndCache(ctx, token)
 	}
 
-	if time.Since(*act.LastUpdated) > defaultUpdateInterval {
+	if act.LastUpdated != nil && time.Since(*act.LastUpdated) > defaultUpdateInterval {
 		return s.fetchAndCache(ctx, token)
 	}
 

--- a/enterprise/cmd/llm-proxy/internal/actor/source.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/source.go
@@ -1,0 +1,11 @@
+package actor
+
+import "context"
+
+// Source is the interface for actor sources.
+type Source interface {
+	// Get retrieves an actor by an implementation-specific key.
+	Get(ctx context.Context, key string) (*Actor, error)
+	// Update updates the given actor's state.
+	Update(ctx context.Context, actor *Actor)
+}

--- a/enterprise/cmd/llm-proxy/internal/dotcom/operations.go
+++ b/enterprise/cmd/llm-proxy/internal/dotcom/operations.go
@@ -206,7 +206,7 @@ type __CheckAccessTokenInput struct {
 // GetToken returns __CheckAccessTokenInput.Token, and is useful for accessing the field via an interface.
 func (v *__CheckAccessTokenInput) GetToken() string { return v.Token }
 
-// CheckAccessToken returns traints of the product subscription associated with
+// CheckAccessToken returns traits of the product subscription associated with
 // the given access token.
 func CheckAccessToken(
 	ctx context.Context,

--- a/enterprise/cmd/llm-proxy/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/llm-proxy/internal/dotcom/operations.graphql
@@ -11,7 +11,7 @@ fragment ProductSubscriptionState on ProductSubscription {
     }
 }
 
-# CheckAccessToken returns traints of the product subscription associated with
+# CheckAccessToken returns traits of the product subscription associated with
 # the given access token.
 query CheckAccessToken($token: String!) {
     dotcom {

--- a/enterprise/cmd/llm-proxy/internal/limiter/error.go
+++ b/enterprise/cmd/llm-proxy/internal/limiter/error.go
@@ -2,6 +2,8 @@ package limiter
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -16,8 +18,23 @@ func (e RateLimitExceededError) Error() string {
 		e.Used, e.Limit, e.RetryAfter.Truncate(time.Second))
 }
 
+func (e RateLimitExceededError) WriteResponse(w http.ResponseWriter) {
+	// Rate limit exceeded, write well known headers and return correct status code.
+	w.Header().Set("x-ratelimit-limit", strconv.Itoa(e.Limit))
+	w.Header().Set("x-ratelimit-remaining", strconv.Itoa(max(e.Limit-e.Used, 0)))
+	w.Header().Set("retry-after", e.RetryAfter.Format(time.RFC3339))
+	http.Error(w, e.Error(), http.StatusTooManyRequests)
+}
+
 type NoAccessError struct{}
 
 func (e NoAccessError) Error() string {
 	return "completions access has not been granted"
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/enterprise/cmd/llm-proxy/shared/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/shared/BUILD.bazel
@@ -12,7 +12,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//enterprise/cmd/llm-proxy/internal/actor",
+        "//enterprise/cmd/llm-proxy/internal/actor/productsubscription",
         "//enterprise/cmd/llm-proxy/internal/dotcom",
+        "//enterprise/cmd/llm-proxy/internal/limiter",
         "//internal/debugserver",
         "//internal/env",
         "//internal/goroutine",
@@ -31,7 +33,6 @@ go_library(
         "@com_github_khan_genqlient//graphql",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_contrib_detectors_gcp//:gcp",
-        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:otelhttp",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//semconv/v1.7.0:v1_7_0",
         "@io_opentelemetry_go_otel_sdk//resource",

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -12,10 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gregjones/httpcache"
 	"github.com/sourcegraph/log"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor"
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
@@ -26,6 +23,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor/productsubscription"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/limiter"
 )
 
 func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFunc, config *Config) error {
@@ -37,8 +39,8 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	}
 	defer shutdownTracing()
 
-	handler := newHandler(obctx.Logger, config)
-	handler = otelhttp.NewHandler(handler, "llm-proxy")
+	handler := newServiceHandler(obctx.Logger, config)
+	handler = instrumentation.HTTPMiddleware("llm-proxy", handler)
 	handler = authenticate(
 		obctx.Logger,
 		rcache.New("llm-proxy-tokens"),
@@ -48,7 +50,6 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			AllowAnonymous: config.AllowAnonymous,
 		},
 	)
-	handler = instrumentation.HTTPMiddleware("", handler)
 
 	server := httpserver.NewFromAddr(config.Address, &http.Server{
 		ReadTimeout:  75 * time.Second,
@@ -75,7 +76,7 @@ func responseJSONError(logger log.Logger, w http.ResponseWriter, code int, err e
 	}
 }
 
-func newHandler(logger log.Logger, config *Config) http.Handler {
+func newServiceHandler(logger log.Logger, config *Config) http.Handler {
 	r := mux.NewRouter()
 
 	// For cluster liveness and readiness probes
@@ -137,28 +138,8 @@ type authenticateOptions struct {
 }
 
 func authenticate(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client, next http.Handler, opts authenticateOptions) http.Handler {
-	getSubscriptionFromCache := func(token string) (_ *actor.Subscription, hit bool) {
-		data, hit := cache.Get(token)
-		if !hit {
-			return nil, false
-		}
+	productSubscriptions := productsubscription.NewSource(logger, cache, dotComClient)
 
-		var subscription actor.Subscription
-		if err := json.Unmarshal(data, &subscription); err != nil {
-			logger.Error("failed to unmarshal subscription", log.Error(err))
-			return nil, false
-		}
-		return &subscription, true
-	}
-	saveSubscriptionToCache := func(token string, subscription *actor.Subscription) {
-		data, err := json.Marshal(subscription)
-		if err != nil {
-			logger.Error("failed to marshal subscription", log.Error(err))
-			return
-		}
-
-		cache.Set(token, data)
-	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
 		if token == "" {
@@ -175,27 +156,39 @@ func authenticate(logger log.Logger, cache httpcache.Cache, dotComClient graphql
 			return
 		}
 
-		subscription, hit := getSubscriptionFromCache(token)
-		if !hit {
-			resp, err := dotcom.CheckAccessToken(r.Context(), dotComClient, token)
-			if err != nil {
-				responseJSONError(logger, w, http.StatusUnauthorized,
-					errors.Errorf("failed to check access token: %s", err),
-				)
-				return
-			}
-
-			subscription = actor.NewSubscriptionFromDotCom(resp.Dotcom.ProductSubscriptionByAccessToken.ProductSubscriptionState)
-			saveSubscriptionToCache(token, subscription)
+		act, err := productSubscriptions.Get(r.Context(), token)
+		if err != nil {
+			responseJSONError(logger, w, http.StatusUnauthorized, err)
+			return
 		}
 
-		if !subscription.AccessEnabled {
+		if !act.AccessEnabled {
 			responseJSONError(logger, w, http.StatusBadRequest,
 				errors.New("license archived or LLM proxy access not enabled"))
 			return
 		}
 
-		r = r.WithContext(actor.WithActor(r.Context(), &actor.Actor{Subscription: subscription}))
+		r = r.WithContext(actor.WithActor(r.Context(), act))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func rateLimit(logger log.Logger, cache limiter.RedisStore, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		l := actor.FromContext(r.Context()).Limiter(cache)
+
+		err := l.TryAcquire(r.Context())
+
+		var rateLimitExceeded limiter.RateLimitExceededError
+		if err != nil {
+			if errors.As(err, &rateLimitExceeded) {
+				rateLimitExceeded.WriteResponse(w)
+				return
+			}
+
+			responseJSONError(logger, w, http.StatusInternalServerError, err)
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -163,7 +163,7 @@ func authenticate(logger log.Logger, cache httpcache.Cache, dotComClient graphql
 		}
 
 		if !act.AccessEnabled {
-			responseJSONError(logger, w, http.StatusBadRequest,
+			responseJSONError(logger, w, http.StatusForbidden,
 				errors.New("license archived or LLM proxy access not enabled"))
 			return
 		}

--- a/enterprise/cmd/llm-proxy/shared/main_test.go
+++ b/enterprise/cmd/llm-proxy/shared/main_test.go
@@ -55,7 +55,7 @@ func TestAuthenticate(t *testing.T) {
 			return nil
 		})
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.NotNil(t, actor.FromContext(r.Context()).Subscription)
+			require.NotNil(t, actor.FromContext(r.Context()))
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -75,7 +75,7 @@ func TestAuthenticate(t *testing.T) {
 		)
 		client := NewMockClient()
 		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.NotNil(t, actor.FromContext(r.Context()).Subscription)
+			require.NotNil(t, actor.FromContext(r.Context()))
 			w.WriteHeader(http.StatusOK)
 		})
 

--- a/enterprise/cmd/llm-proxy/shared/main_test.go
+++ b/enterprise/cmd/llm-proxy/shared/main_test.go
@@ -46,8 +46,11 @@ func TestAuthenticate(t *testing.T) {
 						Uuid:       "6452a8fc-e650-45a7-a0a2-357f776b3b46",
 						IsArchived: false,
 						LlmProxyAccess: dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccess{
-							Enabled:   true,
-							RateLimit: &dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccessRateLimitLLMProxyRateLimit{},
+							Enabled: true,
+							RateLimit: &dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccessRateLimitLLMProxyRateLimit{
+								Limit:           10,
+								IntervalSeconds: 10,
+							},
 						},
 					},
 				},
@@ -99,6 +102,6 @@ func TestAuthenticate(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
 		r.Header.Set("Authorization", "Bearer abc123")
 		authenticate(logger, cache, client, next, authenticateOptions{AllowAnonymous: false}).ServeHTTP(w, r)
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, http.StatusForbidden, w.Code)
 	})
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1426,6 +1426,7 @@ commandsets:
       - llm-proxy
     env:
       LLM_PROXY_ANTHROPIC_ACCESS_TOKEN: foobar
+      LLM_PROXY_DOTCOM_ACCESS_TOKEN: foobar
 
 tests:
   # These can be run with `sg test [name]`


### PR DESCRIPTION
Initial direction:

- Product subscriptions get updated opportunistically in hot-path of request if:
  - the record is old
  - a request hits a rate limit, and the record hasn't been updated recently
- Actors are the entity for rate-limiting, retrieved from actor.Source implementations that could later be another source or simply a static IP-based limiter

This aligns with [this model](https://stately.ai/registry/editor/f0eed212-1730-4052-abd7-b36689e0f50f?machineId=8cbb3591-a750-486d-a97e-cef2dc2b90e7&mode=Simulate) BUT I think we have consensus that a dumber full-sync model is probably easier to reason with, so will be implementing that soon(tm).

## Test plan

Manual testing only because we are likely replacing this system soon, not a critical dependency yet

```
you exceeded the rate limit for completions. Current usage: 50 out of 50 requests. Retry after 2023-05-06 17:04:12 +0000 UTC
```