### PR TITLE
Cody completions: Fix prompt size calculation for inline suggestions

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Changed
 
+- Various improvements to the experimental completions feature
+
 ## [0.0.10]
 
 ### Added

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -100,7 +100,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
 
         const remainingChars = this.tokToChar(this.promptTokens)
 
-        const completionNoSnippets = new MultilineCompletionProvider(
+        const completionNoSnippets = new EndOfLineCompletionProvider(
             this.completionsClient,
             remainingChars,
             this.responseTokens,


### PR DESCRIPTION
I noticed an error in the inline completion code. We create an "empty" completion (so one with no third-party code snippets) to measure the minimum size of the prompt. However, beacuse of a copy-paste error we were using the wrong prompt for the size (so we were creating the text prompt for a multiline completion and used this for inline prompts. Whoops.

I didn't notice any errors with this which might mean that multiline prompts >= inline prompts but better fix it 😬 

## Test plan

Inline completions still work

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
