### PR TITLE
llmproxy: Implement client for anthropic-through-llmproxy

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -96,6 +96,7 @@ ts_project(
     srcs = [
         "src/chat/ChatViewProvider.test.ts",
         "src/completions/context.test.ts",
+        "src/completions/provider.test.ts",
         "src/configuration.test.ts",
         "src/keyword-context/local-keyword-context-fetcher.test.ts",
     ],

--- a/enterprise/internal/completions/streaming/BUILD.bazel
+++ b/enterprise/internal/completions/streaming/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//enterprise/internal/completions/streaming/anthropic",
         "//enterprise/internal/completions/streaming/dotcom",
+        "//enterprise/internal/completions/streaming/llmproxy",
         "//enterprise/internal/completions/streaming/openai",
         "//enterprise/internal/completions/types",
         "//internal/actor",

--- a/enterprise/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/internal/completions/streaming/anthropic/anthropic.go
@@ -160,8 +160,8 @@ func (a *anthropicClient) Stream(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return errors.Errorf("Anthropic API failed with: %s", string(respBody))
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return errors.Errorf("Anthropic API failed with status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	dec := NewDecoder(resp.Body)

--- a/enterprise/internal/completions/streaming/llmproxy/BUILD.bazel
+++ b/enterprise/internal/completions/streaming/llmproxy/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "llmproxy",
+    srcs = ["llmproxy.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/llmproxy",
+    visibility = ["//enterprise:__subpackages__"],
+    deps = [
+        "//enterprise/internal/completions/streaming/anthropic",
+        "//enterprise/internal/completions/types",
+        "//internal/httpcli",
+    ],
+)

--- a/enterprise/internal/completions/streaming/llmproxy/llmproxy.go
+++ b/enterprise/internal/completions/streaming/llmproxy/llmproxy.go
@@ -1,0 +1,61 @@
+package llmproxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/anthropic"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+)
+
+const ProviderName = "llmproxy"
+
+var llmProxyURL = mustParseURL("https://llm-proxy-ytplpvhyiq-uc.a.run.app/v1/completions/anthropic")
+
+type llmProxyAnthropicClient struct {
+	cli             httpcli.Doer
+	accessToken     string
+	model           string
+	anthropicClient types.CompletionsClient
+}
+
+func NewClient(cli httpcli.Doer, accessToken string, model string) types.CompletionsClient {
+	anthropicDoer := httpcli.DoerFunc(func(req *http.Request) (*http.Response, error) {
+		req.Host = llmProxyURL.Host
+		req.URL = llmProxyURL
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+		return cli.Do(req)
+	})
+	return &llmProxyAnthropicClient{
+		cli:             cli,
+		accessToken:     accessToken,
+		model:           model,
+		anthropicClient: anthropic.NewAnthropicClient(anthropicDoer, "", model),
+	}
+}
+
+func (a *llmProxyAnthropicClient) Complete(
+	ctx context.Context,
+	requestParams types.CodeCompletionRequestParameters,
+) (*types.CodeCompletionResponse, error) {
+	return a.anthropicClient.Complete(ctx, requestParams)
+}
+
+func (a *llmProxyAnthropicClient) Stream(
+	ctx context.Context,
+	requestParams types.ChatCompletionRequestParameters,
+	sendEvent types.SendCompletionEvent,
+) error {
+	return a.anthropicClient.Stream(ctx, requestParams, sendEvent)
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse URL %q: %s", s, err.Error()))
+	}
+	return u
+}

--- a/enterprise/internal/completions/streaming/stream.go
+++ b/enterprise/internal/completions/streaming/stream.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/anthropic"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/llmproxy"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming/openai"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/cody"
@@ -49,6 +50,8 @@ func GetCompletionClient(provider string, accessToken string, model string) (typ
 		return openai.NewOpenAIClient(httpcli.ExternalDoer, accessToken, model), nil
 	case dotcom.ProviderName:
 		return dotcom.NewClient(httpcli.ExternalDoer, accessToken, model), nil
+	case llmproxy.ProviderName:
+		return llmproxy.NewClient(httpcli.ExternalDoer, accessToken, model), nil
 	default:
 		return nil, errors.Newf("unknown completion stream provider: %s", provider)
 	}

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2100,7 +2100,7 @@
           "type": "string",
           "description": "The external completions provider.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai", "dotcom", "llmproxy"]
+          "enum": ["anthropic", "openai", "llmproxy"]
         },
         "perUserDailyLimit": {
           "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2100,7 +2100,7 @@
           "type": "string",
           "description": "The external completions provider.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai"]
+          "enum": ["anthropic", "openai", "dotcom", "llmproxy"]
         },
         "perUserDailyLimit": {
           "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",


### PR DESCRIPTION
This is a thin wrapper around LLM proxy that adds the sourcegraph authentication to it and rewrites the URL.

## Test plan

Verified that I get completions responses.