### PR TITLE
Fix build and update grpc/protobuf deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -85,6 +85,8 @@ gazelle(
 
 # Because the current implementation of rules_go uses the old protoc grpc compiler, we have to declare our own, and declare it manually in the build files.
 # See https://github.com/bazelbuild/rules_go/issues/3022
+
+# gazelle:go_grpc_compilers //:gen-go-grpc,@io_bazel_rules_go//proto:go_proto
 go_proto_compiler(
     name = "gen-go-grpc",
     plugin = "@org_golang_google_grpc_cmd_protoc_gen_go_grpc//:protoc-gen-go-grpc",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -202,6 +202,26 @@ go_repository(
     version = "v1.14.1",
 )
 
+# Overrides the default provided protobuf dep from rules_go by a more
+# recent one.
+go_repository(
+    name = "org_golang_google_protobuf",
+    build_file_proto_mode = "disable_global",
+    importpath = "google.golang.org/protobuf",
+    sum = "h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=",
+    version = "v1.29.1",
+)
+
+# Pin protoc-gen-go-grpc to 1.3.0
+# See also //:gen-go-grpc
+go_repository(
+    name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+    build_file_proto_mode = "disable_global",
+    importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+    sum = "h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=",
+    version = "v1.3.0",
+)
+
 # gazelle:repository_macro deps.bzl%go_dependencies
 go_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -210,7 +210,7 @@ go_repository(
     importpath = "google.golang.org/protobuf",
     sum = "h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=",
     version = "v1.29.1",
-)
+)  # keep
 
 # Pin protoc-gen-go-grpc to 1.3.0
 # See also //:gen-go-grpc
@@ -220,7 +220,7 @@ go_repository(
     importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
     sum = "h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=",
     version = "v1.3.0",
-)
+)  # keep
 
 # gazelle:repository_macro deps.bzl%go_dependencies
 go_dependencies()

--- a/cmd/gitserver/server/accesslog/BUILD.bazel
+++ b/cmd/gitserver/server/accesslog/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "accesslog",
     srcs = ["accesslog.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/gitserver/server/accesslog",
-    visibility = ["//cmd/gitserver/server:__subpackages__"],
+    visibility = ["//cmd/gitserver:__subpackages__"],
     deps = [
         "//internal/audit",
         "//internal/conf/conftypes",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5750,13 +5750,17 @@ def go_dependencies():
         sum = "h1:B4Y0XJQiPjpwYmkH55aratKX1VfR+JRqzmDKyZbC99o=",
         version = "v3.1.2",
     )
+
+    # Needed by back compat tests targeting 5.0.0
+    # Context+Owner: @jhchabran
     go_repository(
         name = "com_github_rafaeljusto_redigomock",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/rafaeljusto/redigomock",
         sum = "h1:d7uo5MVINMxnRr20MxbgDkmZ8QRfevjOVgEa4n0OZyY=",
         version = "v2.4.0+incompatible",
-    )
+    ) # keep
+
     go_repository(
         name = "com_github_rainycape_unidecode",
         build_file_proto_mode = "disable_global",
@@ -8891,27 +8895,11 @@ def go_dependencies():
         version = "v1.53.0",
     )
     go_repository(
-        name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
-        build_file_proto_mode = "disable_global",
-        importpath = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
-        sum = "h1:TLkBREm4nIsEcexnCjgQd5GQWaHcqMzwQV0TX9pq8S0=",
-        version = "v1.2.0",
-    )  # keep
-
-    go_repository(
         name = "org_golang_google_grpc_examples",
         build_file_proto_mode = "disable_global",
         importpath = "google.golang.org/grpc/examples",
         sum = "h1:qvsHH4rznMyt8C0umnWLr/oTJPjYrtZ2OMnPZaYLIK8=",
         version = "v0.0.0-20210424002626-9572fd6faeae",
-    )
-
-    go_repository(
-        name = "org_golang_google_protobuf",
-        build_file_proto_mode = "disable_global",
-        importpath = "google.golang.org/protobuf",
-        sum = "h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=",
-        version = "v1.28.1",
     )
 
     go_repository(

--- a/internal/gitserver/v1/BUILD.bazel
+++ b/internal/gitserver/v1/BUILD.bazel
@@ -14,7 +14,10 @@ proto_library(
 
 go_proto_library(
     name = "v1_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "//:gen-go-grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/gitserver/v1",
     proto = ":v1_proto",
     visibility = ["//visibility:private"],

--- a/internal/repoupdater/v1/BUILD.bazel
+++ b/internal/repoupdater/v1/BUILD.bazel
@@ -14,7 +14,10 @@ proto_library(
 
 go_proto_library(
     name = "v1_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "//:gen-go-grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/repoupdater/v1",
     proto = ":v1_proto",
     visibility = ["//visibility:private"],

--- a/internal/searcher/v1/BUILD.bazel
+++ b/internal/searcher/v1/BUILD.bazel
@@ -16,7 +16,10 @@ proto_library(
 
 go_proto_library(
     name = "v1_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "//:gen-go-grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/searcher/v1",
     proto = ":v1_proto",
     visibility = ["//visibility:private"],

--- a/internal/symbols/v1/BUILD.bazel
+++ b/internal/symbols/v1/BUILD.bazel
@@ -16,7 +16,10 @@ proto_library(
 
 go_proto_library(
     name = "v1_go_proto",
-    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
+    compilers = [
+        "//:gen-go-grpc",
+        "@io_bazel_rules_go//proto:go_proto",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/symbols/v1",
     proto = ":v1_proto",
     visibility = ["//visibility:private"],


### PR DESCRIPTION
@ggilmore this PR fixes the issues in your PR: 

1. Visibility was a trivial fix
2. Your PR bumped protoc-gen-grpc to 1.3.0 but no changes where made on the bazel side, so when built in CI it wasn't reflected. 
  - it's not a trivial fix, because this requires having a bit of context on how `rules_go` handles grpc, and its requires overriding to get the newest version. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

green ci 
