### PR TITLE
[github app] Allow GitHub App installation connections to be validated

### DIFF
--- a/enterprise/internal/database/external_services_test.go
+++ b/enterprise/internal/database/external_services_test.go
@@ -670,7 +670,7 @@ func TestValidateExternalServiceConfig(t *testing.T) {
 			config: `{}`,
 			assert: includes(
 				"url is required",
-				"token must be set",
+				"either token or GitHub App Details must be set",
 				"at least one of repositoryQuery, repos or orgs must be set",
 			),
 		},

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -445,8 +445,8 @@ func validateGitHubConnection(githubValidators []func(*types.GitHubConnection) e
 		)
 	}
 
-	if c.Token == "" {
-		err = errors.Append(err, errors.New("token must be set"))
+	if c.Token == "" && c.GitHubAppDetails == nil {
+		err = errors.Append(err, errors.New("either token or GitHub App Details must be set"))
 	}
 	if c.Repos == nil && c.RepositoryQuery == nil && c.Orgs == nil {
 		err = errors.Append(err, errors.New("at least one of repositoryQuery, repos or orgs must be set"))

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -148,7 +148,7 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			name:    "2 errors",
 			kind:    extsvc.KindGitHub,
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": ""}`,
-			wantErr: "2 errors occurred:\n\t* token: String length must be greater than or equal to 1\n\t* token must be set",
+			wantErr: "2 errors occurred:\n\t* token: String length must be greater than or equal to 1\n\t* either token or GitHub App Details must be set",
 		},
 		{
 			name:   "no conflicting rate limit",

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -220,7 +220,7 @@ type githubResult struct {
 
 func (s *GitHubSource) ValidateAuthenticator(ctx context.Context) error {
 	var err error
-	_, err = s.v3Client.GetAuthenticatedUser(ctx)
+	_, err = s.v3Client.GetAuthenticatedOAuthScopes(ctx)
 	return err
 }
 


### PR DESCRIPTION
Simply changes the "ValidateAuthenticator" api endpoint to one that a GitHub App authenticator can use as well.

## Test plan

Existing tests should still pass. Also verified locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
