### PR TITLE
codeintel: Add envvar to disable upload janitor tasks

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/background/BUILD.bazel
@@ -20,5 +20,6 @@ go_library(
         "//internal/uploadstore",
         "//internal/workerutil/dbworker",
         "//internal/workerutil/dbworker/store",
+        "@com_github_sourcegraph_log//:log",
     ],
 )


### PR DESCRIPTION
This PR gives us knobs to turn for an active customer issue.

## Test plan

Tested locally to ensure jobs would be disabled via comma-separated list.