### PR TITLE
Cody: fix error notification display pattern for rate limit

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- Display error messages from compeletion client in webview instead of system messages
+- Display error messages from compeletion client in webview instead of system messages [pull/51521](https://github.com/sourcegraph/sourcegraph/pull/51521)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
+- Display error messages from compeletion client in webview instead of system messages
+
 ### Changed
 
 ## [0.0.10]

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- Display error messages from compeletion client in webview instead of system messages [pull/51521](https://github.com/sourcegraph/sourcegraph/pull/51521)
+- Error notification display pattern for rate limit [pull/51521](https://github.com/sourcegraph/sourcegraph/pull/51521)
 
 ### Changed
 

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -596,7 +596,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      */
     public sendErrorToWebview(errorMsg: string): void {
         void this.webview?.postMessage({ type: 'errors', errors: errorMsg })
-        console.error(errorMsg)
     }
 
     /**

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -594,7 +594,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Display error message in webview view as banner in chat view
      * It does not display error message as assistant response
      */
-    private sendErrorToWebview(errorMsg: string): void {
+    public sendErrorToWebview(errorMsg: string): void {
         void this.webview?.postMessage({ type: 'errors', errors: errorMsg })
         console.error(errorMsg)
     }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -285,7 +285,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return
             }
 
-            this.webviewErrorMessager(`FetchAndShowCompletions - ${error}`)
+            await this.webviewErrorMessager(`FetchAndShowCompletions - ${error}`)
         }
     }
 }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -29,6 +29,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     private abortOpenMultilineCompletion: () => void = () => {}
 
     constructor(
+        private webviewErrorMessager: (error: string) => void,
         private completionsClient: SourcegraphNodeCompletionsClient,
         private documentProvider: CompletionsDocumentProvider,
         private history: History,
@@ -56,7 +57,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return []
             }
 
-            await vscode.window.showErrorMessage(`Error in provideInlineCompletionItems: ${error}`)
+            this.webviewErrorMessager(`Error in provideInlineCompletionItems: ${error}`)
             return []
         }
     }
@@ -284,7 +285,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return
             }
 
-            await vscode.window.showErrorMessage(`Error in fetchAndShowCompletions: ${error}`)
+            this.webviewErrorMessager(`Error in fetchAndShowCompletions: ${error}`)
         }
     }
 }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -57,7 +57,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return []
             }
 
-            this.webviewErrorMessager(`Error in provideInlineCompletionItems: ${error}`)
+            this.webviewErrorMessager(`ProvideInlineCompletionItems - ${error}`)
             return []
         }
     }
@@ -285,7 +285,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return
             }
 
-            this.webviewErrorMessager(`Error in fetchAndShowCompletions: ${error}`)
+            this.webviewErrorMessager(`FetchAndShowCompletions - ${error}`)
         }
     }
 }

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -29,7 +29,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
     private abortOpenMultilineCompletion: () => void = () => {}
 
     constructor(
-        private webviewErrorMessager: (error: string) => void,
+        private webviewErrorMessager: (error: string) => Promise<void>,
         private completionsClient: SourcegraphNodeCompletionsClient,
         private documentProvider: CompletionsDocumentProvider,
         private history: History,
@@ -57,7 +57,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                 return []
             }
 
-            this.webviewErrorMessager(`ProvideInlineCompletionItems - ${error}`)
+            await this.webviewErrorMessager(`ProvideInlineCompletionItems - ${error}`)
             return []
         }
     }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -103,7 +103,23 @@ const register = async (
         await chatProvider.executeRecipe(recipe, '')
     }
 
-    const webviewErrorMessager = (error: string): void => {
+    const webviewErrorMessager = async (error: string): Promise<void> => {
+        if (error.includes('rate limit')) {
+            const currentTime: number = Date.now()
+            const userPref = localStorage.get('rateLimitError')
+            // 21600000 is 6h in ms. ex 6 * 60 * 60 * 1000
+            if (!userPref || userPref !== 'never' || currentTime - 86400000 >= parseInt(userPref, 10)) {
+                const input = await vscode.window.showErrorMessage(error, 'Do not show again', 'Close')
+                switch (input) {
+                    case 'Do not show again':
+                        await localStorage.set('rateLimitError', 'never')
+                        break
+                    default:
+                        // Save current time as a reminder stamp in 6 hours
+                        await localStorage.set('rateLimitError', currentTime.toString())
+                }
+            }
+        }
         chatProvider.sendErrorToWebview(error)
     }
 

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -108,7 +108,7 @@ const register = async (
             const currentTime: number = Date.now()
             const userPref = localStorage.get('rateLimitError')
             // 21600000 is 6h in ms. ex 6 * 60 * 60 * 1000
-            if (!userPref || userPref !== 'never' || currentTime - 86400000 >= parseInt(userPref, 10)) {
+            if (!userPref || userPref !== 'never' || currentTime - 21600000 >= parseInt(userPref, 10)) {
                 const input = await vscode.window.showErrorMessage(error, 'Do not show again', 'Close')
                 switch (input) {
                     case 'Do not show again':

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -103,6 +103,10 @@ const register = async (
         await chatProvider.executeRecipe(recipe, '')
     }
 
+    const webviewErrorMessager = (error: string): void => {
+        chatProvider.sendErrorToWebview(error)
+    }
+
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
 
@@ -180,7 +184,12 @@ const register = async (
         disposables.push(vscode.workspace.registerTextDocumentContentProvider('cody', docprovider))
 
         const history = new History()
-        const completionsProvider = new CodyCompletionItemProvider(completionsClient, docprovider, history)
+        const completionsProvider = new CodyCompletionItemProvider(
+            webviewErrorMessager,
+            completionsClient,
+            docprovider,
+            history
+        )
         disposables.push(
             vscode.commands.registerCommand('cody.experimental.suggest', async () => {
                 await completionsProvider.fetchAndShowCompletions()

--- a/client/cody/webviews/App.css
+++ b/client/cody/webviews/App.css
@@ -28,12 +28,14 @@ button {
 .error {
     flex-direction: row;
     display: flex;
-    padding: 0.5rem 1rem;
+    padding: 1rem;
     color: var(--vscode-input-foreground);
     background-color: var(--vscode-inputValidation-errorBackground);
     align-items: center;
     min-height: 2rem;
     position: relative;
+    overflow: scroll;
+    align-items: baseline;
 }
 
 .close-btn {


### PR DESCRIPTION
RE https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1683290207798969?thread_ts=1683288519.959009&cid=C052G9Y5Y8H

Issue: 

- A user who has hit the daily limit was getting a persistent error message as a system message that they can only get rid of if Cody is disabled. 
- Send repeated notification is against [VS code guideline](https://code.visualstudio.com/api/ux-guidelines/notifications#notification-examples)

![issue](https://user-images.githubusercontent.com/68532117/236532147-bc0945be-7967-4ac5-a2bd-bcced95c5680.gif)

Proposed solution:

- This PR moves the error message to UI as a banner in chatview to address the pinpoint of getting a system popup repeatedly where the only solution is to disable Cody

- Issue: Users who are not on Chat view will not be notified that they have hit the quota when their sidebar is closed
- Solution: Display as error notification 4 time per day max (every 6 hours) and allow user to opt out from the notification

Edit: Updated for clarity.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

<img width="409" alt="image" src="https://user-images.githubusercontent.com/68532117/236495322-90553bfb-9c0c-410f-a743-aa623257f41e.png">

