### PR TITLE
Use second rate limit bucket for code completions

### DIFF
--- a/client/web/src/user/settings/quota/backend.ts
+++ b/client/web/src/user/settings/quota/backend.ts
@@ -4,11 +4,13 @@ export const USER_REQUEST_QUOTAS = gql`
     query UserRequestQuotas($userID: ID!) {
         site {
             perUserCompletionsQuota
+            perUserCodeCompletionsQuota
         }
         node(id: $userID) {
             __typename
             ... on User {
                 completionsQuotaOverride
+                codeCompletionsQuotaOverride
             }
         }
     }
@@ -19,6 +21,15 @@ export const SET_USER_COMPLETIONS_QUOTA = gql`
         setUserCompletionsQuota(user: $userID, quota: $quota) {
             id
             completionsQuotaOverride
+        }
+    }
+`
+
+export const SET_USER_CODE_COMPLETIONS_QUOTA = gql`
+    mutation SetUserCodeCompletionsQuota($userID: ID!, $quota: Int) {
+        setUserCodeCompletionsQuota(user: $userID, quota: $quota) {
+            id
+            codeCompletionsQuotaOverride
         }
     }
 `


### PR DESCRIPTION
Based on #51514

This only exists to make @eseliger happy

(Pointed to #51514 so the diff is readable, GitHub stacked diffs when 😢 )

## Test plan

https://user-images.githubusercontent.com/458591/236499559-336d2808-769c-4f39-a04d-f537ae28c13c.mov



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
