### PR TITLE
(draft) feat: add cody usage survey on new dotcom signup

### DIFF
--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -78,6 +78,7 @@ export interface TemporarySettingsSchema {
     'cody.blobPageCta.dismissed': boolean
     'cody.searchPageCta.dismissed': boolean
     'cody.chatPageCta.dismissed': boolean
+    'cody.survey.submitted': boolean
 }
 
 /**

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1045,6 +1045,7 @@ ts_project(
         "src/marketing/components/TweetFeedback.tsx",
         "src/marketing/page/SurveyForm.tsx",
         "src/marketing/page/SurveyPage.tsx",
+        "src/marketing/toast/CodySurveyToast.tsx",
         "src/marketing/toast/SurveySuccessToast.tsx",
         "src/marketing/toast/SurveyToastContent.tsx",
         "src/marketing/toast/SurveyToastTrigger.tsx",

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -23,7 +23,7 @@ import { useFeatureFlag } from './featureFlags/useFeatureFlag'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { useHandleSubmitFeedback } from './hooks'
 import { LegacyLayoutRouteContext } from './LegacyRouteContext'
-import { SurveyToast } from './marketing/toast'
+import { CodySurveyToast, SurveyToast } from './marketing/toast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
 import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
 import { parseSearchURLQuery } from './search'
@@ -190,6 +190,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
             {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && !disableFeedbackSurvey && (
                 <SurveyToast authenticatedUser={props.authenticatedUser} />
             )}
+            {props.isSourcegraphDotCom && props.authenticatedUser && <CodySurveyToast />}
             {!isSiteInit && !isSignInOrUp && (
                 <GlobalNavbar
                     {...props}

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -12,6 +12,7 @@ import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../graphql-operations'
 import { AuthProvider, SourcegraphContext } from '../jscontext'
+import { useCodySurveyToast } from '../marketing/toast/CodySurveyToast'
 import { USER_AREA_USER_PROFILE } from '../user/area/UserArea'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
@@ -58,6 +59,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     isSourcegraphDotCom,
 }) => {
     const location = useLocation()
+    const { setShouldShowCodySurvey } = useCodySurveyToast()
 
     const queryWithUseEmailToggled = new URLSearchParams(location.search)
     if (showEmailForm) {
@@ -78,7 +80,8 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     })
     const invitedByUser = data?.user
 
-    const logEvent = (type: AuthProvider['serviceType']): void => {
+    const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
+        setShouldShowCodySurvey(true)
         const eventType = type === 'builtin' ? 'form' : type
         telemetryService.log('SignupInitiated', { type: eventType }, { type: eventType })
     }
@@ -86,7 +89,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const signUpForm = (
         <SignUpForm
             onSignUp={args => {
-                logEvent('builtin')
+                logEventAndSetFlags('builtin')
                 return onSignUp(args)
             }}
             context={{
@@ -106,7 +109,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
                 context={context}
                 githubLabel="Continue with GitHub"
                 gitlabLabel="Continue with GitLab"
-                onClick={logEvent}
+                onClick={logEventAndSetFlags}
             />
 
             <div className="mb-4">

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -1,0 +1,103 @@
+import { useState, useCallback } from 'react'
+
+import { gql, useMutation } from '@sourcegraph/http-client'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { Checkbox, Form, H3, Modal, Text, useLocalStorage } from '@sourcegraph/wildcard'
+
+import { LoaderButton } from '../../components/LoaderButton'
+import { SubmitCodySurveyResult, SubmitCodySurveyVariables } from '../../graphql-operations'
+
+const SUBMIT_CODY_SURVEY = gql`
+    mutation SubmitCodySurvey($isForWork: Boolean!, $isForPersonal: Boolean!) {
+        submitCodySurvey(isForWork: $isForWork, isForPersonal: $isForPersonal) {
+            alwaysNil
+        }
+    }
+`
+
+const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void }> = ({ onSubmitEnd }) => {
+    const [isCodyForWork, setIsCodyForWork] = useState(false)
+    const [isCodyForPersonalStuff, setIsCodyForPersonalStuff] = useState(false)
+
+    const handleCodyForWorkChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
+        setIsCodyForWork(event.target.checked)
+    }, [])
+    const handleCodyForPersonalStuffChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
+        setIsCodyForPersonalStuff(event.target.checked)
+    }, [])
+
+    const [submitCodySurvey, { loading }] = useMutation<SubmitCodySurveyResult, SubmitCodySurveyVariables>(
+        SUBMIT_CODY_SURVEY,
+        {
+            variables: {
+                isForWork: isCodyForWork,
+                isForPersonal: isCodyForPersonalStuff,
+            },
+        }
+    )
+
+    const handleSubmit = useCallback(
+        (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault()
+            // eslint-disable-next-line no-console
+            submitCodySurvey().catch(console.error).finally(onSubmitEnd)
+        },
+        [onSubmitEnd, submitCodySurvey]
+    )
+
+    return (
+        <Modal position="center" aria-label="Welcome message">
+            <H3 className="mb-4">Just one more thing...</H3>
+            <Text className="mb-3">How will you be using Cody, our AI assistant?</Text>
+            <Form onSubmit={handleSubmit}>
+                <Checkbox
+                    id="cody-for-work"
+                    label="for work"
+                    wrapperClassName="mb-2"
+                    checked={isCodyForWork}
+                    disabled={loading}
+                    onChange={handleCodyForWorkChange}
+                />
+                <Checkbox
+                    id="cody-for-personal"
+                    label="for personal stuff"
+                    wrapperClassName="mb-2"
+                    checked={isCodyForPersonalStuff}
+                    disabled={loading}
+                    onChange={handleCodyForPersonalStuffChange}
+                />
+                <div className="d-flex justify-content-end">
+                    <LoaderButton variant="primary" type="submit" loading={loading} label="Get started" />
+                </div>
+            </Form>
+        </Modal>
+    )
+}
+
+export const useCodySurveyToast = (): {
+    show: boolean
+    dismiss: () => void
+    setShouldShowCodySurvey: (show: boolean) => void
+} => {
+    // we specifically use local storage as we want consistent value between when user is logged out and logged in / signed up
+    // eslint-disable-next-line no-restricted-syntax
+    const [shouldShowCodySurvey, setShouldShowCodySurvey] = useLocalStorage('cody.survey.show', false)
+    const [hasSubmitted, setHasSubmitted] = useTemporarySetting('cody.survey.submitted', false)
+    const dismiss = useCallback(() => setHasSubmitted(true), [setHasSubmitted])
+
+    return {
+        // we calculate "show" value based whether this a new signup and whether they already have submitted survey
+        show: !hasSubmitted && shouldShowCodySurvey,
+        dismiss,
+        setShouldShowCodySurvey,
+    }
+}
+
+export const CodySurveyToast: React.FC = () => {
+    const { show, dismiss } = useCodySurveyToast()
+    if (!show) {
+        return null
+    }
+
+    return <CodySurveyToastInner onSubmitEnd={dismiss} />
+}

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -47,7 +47,7 @@ const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void }> = ({ onSubmitE
 
     return (
         <Modal position="center" aria-label="Welcome message">
-            <H3 className="mb-4">Just one more thing...</H3>
+            <H3 className="mb-4">Quick question...</H3>
             <Text className="mb-3">How will you be using Cody, our AI assistant?</Text>
             <Form onSubmit={handleSubmit}>
                 <Checkbox

--- a/client/web/src/marketing/toast/index.ts
+++ b/client/web/src/marketing/toast/index.ts
@@ -1,1 +1,2 @@
 export { SurveyToastTrigger as SurveyToast } from './SurveyToastTrigger'
+export { CodySurveyToast } from './CodySurveyToast'

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -22,7 +22,7 @@ import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { GlobalAlerts } from '../../../global/GlobalAlerts'
 import { useHandleSubmitFeedback } from '../../../hooks'
 import { LegacyLayoutRouteContext } from '../../../LegacyRouteContext'
-import { SurveyToast } from '../../../marketing/toast'
+import { CodySurveyToast, SurveyToast } from '../../../marketing/toast'
 import { GlobalNavbar } from '../../../nav/GlobalNavbar'
 import { EnterprisePageRoutes, PageRoutes } from '../../../routes.constants'
 import { parseSearchURLQuery } from '../../../search'
@@ -197,6 +197,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
             {!isSiteInit && !isSignInOrUp && !props.isSourcegraphDotCom && !disableFeedbackSurvey && (
                 <SurveyToast authenticatedUser={props.authenticatedUser} />
             )}
+            {!isSiteInit && !props.isSourcegraphDotCom && <CodySurveyToast />}
             {!isSiteInit && !isSignInOrUp && (
                 <GlobalNavbar
                     {...props}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -892,12 +892,13 @@ type Mutation {
     use the default quota.
     """
     setUserCompletionsQuota(user: ID!, quota: Int): User!
-
     """
     Sets the code completions requests quota for the user per day. Quota: Null means
     use the default quota.
     """
     setUserCodeCompletionsQuota(user: ID!, quota: Int): User!
+
+    submitCodySurvey(isForWork: Boolean!, isForPersonal: Boolean!): EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -897,7 +897,9 @@ type Mutation {
     use the default quota.
     """
     setUserCodeCompletionsQuota(user: ID!, quota: Int): User!
-
+    """
+    Submits a post-signup user survey about intended Cody usage.
+    """
     submitCodySurvey(isForWork: Boolean!, isForPersonal: Boolean!): EmptyResponse!
 }
 

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -17,10 +18,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
@@ -276,4 +279,44 @@ func exportPrometheusSearchRanking(payload json.RawMessage) error {
 
 	searchRankingResultClicked.WithLabelValues(v.Type, resultsLength, ranked).Observe(v.Index)
 	return nil
+}
+
+type codySurveySubmissionForHubSpot struct {
+	Email         string `url:"email"`
+	IsForWork     bool   `url:"is_for_work"`
+	IsForPersonal bool   `url:"is_for_personal"`
+}
+
+func (r *schemaResolver) SubmitCodySurvey(ctx context.Context, args *struct {
+	IsForWork     bool
+	IsForPersonal bool
+}) (*EmptyResponse, error) {
+	if !envvar.SourcegraphDotComMode() {
+		return nil, errors.New("Cody survey is not supported outside sourcegraph.com")
+	}
+
+	// If user is authenticated, use their uid and overwrite the optional email field.
+	actor := actor.FromContext(ctx)
+	if !actor.IsAuthenticated() {
+		return nil, errors.New("user must be authenticated to submit a Cody survey")
+	}
+
+	email, _, err := r.db.UserEmails().GetPrimaryEmail(ctx, actor.UID)
+	if err != nil && !errcode.IsNotFound(err) {
+		return nil, err
+	}
+
+	// Submit form to HubSpot
+	if err := hubspotutil.Client().SubmitForm(hubspotutil.CodySurveyFormID, &codySurveySubmissionForHubSpot{
+		Email:         email,
+		IsForWork:     args.IsForWork,
+		IsForPersonal: args.IsForPersonal,
+	}); err != nil {
+		// Log an error, but don't return one if the only failure was in submitting survey results to HubSpot.
+		log15.Error("Unable to submit cody survey results to Sourcegraph remote", "error", err)
+		// fixme: remove this log line after we've confirmed that the survey is working
+		fmt.Printf("Unable to submit cody survey results to Sourcegraph remote: Email=%v, isForWork=%v, isForPersonal=%v\n", email, args.IsForWork, args.IsForPersonal)
+	}
+
+	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -283,8 +283,8 @@ func exportPrometheusSearchRanking(payload json.RawMessage) error {
 
 type codySurveySubmissionForHubSpot struct {
 	Email         string `url:"email"`
-	IsForWork     bool   `url:"is_for_work"`
-	IsForPersonal bool   `url:"is_for_personal"`
+	IsForWork     bool   `url:"using_cody_for_work"`
+	IsForPersonal bool   `url:"using_cody_for_personal"`
 }
 
 func (r *schemaResolver) SubmitCodySurvey(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -314,8 +313,6 @@ func (r *schemaResolver) SubmitCodySurvey(ctx context.Context, args *struct {
 	}); err != nil {
 		// Log an error, but don't return one if the only failure was in submitting survey results to HubSpot.
 		log15.Error("Unable to submit cody survey results to Sourcegraph remote", "error", err)
-		// fixme: remove this log line after we've confirmed that the survey is working
-		fmt.Printf("Unable to submit cody survey results to Sourcegraph remote: Email=%v, isForWork=%v, isForPersonal=%v\n", email, args.IsForWork, args.IsForPersonal)
 	}
 
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -23,6 +23,9 @@ var HubSpotAccessToken = env.Get("HUBSPOT_ACCESS_TOKEN", "", "HubSpot access tok
 // SurveyFormID is the ID for a satisfaction (NPS) survey.
 var SurveyFormID = "ee042306-491a-4b06-bd9c-1181774dfda0"
 
+// CodySurveyFormID is the ID for a Cody usage survey on dotcom users.
+var CodySurveyFormID = "todo: replace with a real ID"
+
 // HappinessFeedbackFormID is the ID for a Happiness survey.
 var HappinessFeedbackFormID = "417ec50b-39b4-41fa-a267-75da6f56a7cf"
 

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -24,7 +24,7 @@ var HubSpotAccessToken = env.Get("HUBSPOT_ACCESS_TOKEN", "", "HubSpot access tok
 var SurveyFormID = "ee042306-491a-4b06-bd9c-1181774dfda0"
 
 // CodySurveyFormID is the ID for a Cody usage survey on dotcom users.
-var CodySurveyFormID = "todo: replace with a real ID"
+var CodySurveyFormID = "fadc00c7-8cf4-48dd-8502-c386b0311f5d"
 
 // HappinessFeedbackFormID is the ID for a Happiness survey.
 var HappinessFeedbackFormID = "417ec50b-39b4-41fa-a267-75da6f56a7cf"


### PR DESCRIPTION
This PR adds Cody usage survey on the new dotcom signup.

**NOTE** that It will not show new survey for existing users

## Test plan
- `sg start dotcom`
- Go to https://sourcegraph.test:3443/signup page and signup with a new account
- Check that you see a new popup form
- Submit it, and make sure you don't see it again, even when re-signing in again

## Screenshot

https://user-images.githubusercontent.com/6717049/236505928-123a1601-c62e-430f-ad68-0a51e13973c0.mov


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
