### PR TITLE
httpapi: Use repo.Name instead of URI for URL construction

### DIFF
--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -154,7 +154,7 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 				Filename:  h.Filename,
 				Commit: BlameHunkCommitResponse{
 					Parents: parents,
-					URL:     fmt.Sprintf("%s/-/commit/%s", repo.URI, h.CommitID),
+					URL:     fmt.Sprintf("%s/-/commit/%s", repo.Name, h.CommitID),
 				},
 				User: blameHunkUserResponse,
 			}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/customer/issues/2113.

For repos synced with `src server-git` the URI is set to `repos/<repo-name>` in the database. This leads to an incorrect URL in the git-blames when the feature flag `enable-streaming-git-blame` is enabled.

Instead we should use the `repo.Name` because:

1. For regular code hosts like GitHub.com, it is set to: `github.com/sourcegraph/sourcegraph`
2. For `src serve-git`, it is set to `sourcegraph` (provided that's the repo being served)

Using the `repo.Name` in the URL construction fixes the issue.

## Test plan

- Tested locally
- Added unit tests
- Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
