### PR TITLE
feat: fetch github app data on github app page

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -81,7 +81,7 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                 </div>
                 <div className="flex-grow-1">
                     <div>
-                        <Icon as={IconComponent} aria-label="Code host logo" className="mr-2" />
+                        <Icon as={IconComponent} aria-label="Code host logo" className="code-host-logo mr-2" />
                         <strong>
                             <Link to={`/site-admin/external-services/${node.id}`}>{node.displayName}</Link>{' '}
                             <small className="text-muted">

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -175,7 +175,7 @@ export const EXTERNAL_SERVICE_SYNC_JOBS = gql`
     }
 `
 
-const LIST_EXTERNAL_SERVICE_FRAGMENT = gql`
+export const LIST_EXTERNAL_SERVICE_FRAGMENT = gql`
     ${EXTERNAL_SERVICE_SYNC_JOB_CONNECTION_FIELDS_FRAGMENT}
     fragment ListExternalServiceFields on ExternalService {
         id

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -1,13 +1,35 @@
-import { FC, useEffect } from 'react'
+import { FC, useEffect, useMemo } from 'react'
 
-import { mdiCog, mdiChevronLeft } from '@mdi/js'
+import { mdiCog, mdiChevronLeft, mdiGithub, mdiRefresh, mdiPlus } from '@mdi/js'
+import classNames from 'classnames'
 import { useParams } from 'react-router-dom'
 
+import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import { useQuery } from '@sourcegraph/http-client'
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, ErrorAlert, PageHeader, ButtonLink, Icon } from '@sourcegraph/wildcard'
+import {
+    Container,
+    ErrorAlert,
+    PageHeader,
+    ButtonLink,
+    Icon,
+    LoadingSpinner,
+    Button,
+    H2,
+    Card,
+    Link,
+} from '@sourcegraph/wildcard'
 
-import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
+import { GitHubAppByIDResult, GitHubAppByIDVariables } from '../../graphql-operations'
+import { ExternalServiceNode } from '../externalServices/ExternalServiceNode'
+import { ConnectionList, SummaryContainer, ConnectionSummary, ShowMoreButton } from '../FilteredConnection/ui'
+import { hasNextPage } from '../FilteredConnection/utils'
 import { PageTitle } from '../PageTitle'
+
+import { GITHUB_APP_BY_ID_QUERY } from './backend'
+
+import styles from './GitHubAppCard.module.scss'
 
 interface Props extends TelemetryProps {
     externalServicesFromFile: boolean
@@ -25,22 +47,26 @@ export const GitHubAppPage: FC<Props> = ({
         telemetryService.logPageView('SiteAdminGitHubApp')
     }, [telemetryService])
 
+    const { data, loading, error } = useQuery<GitHubAppByIDResult, GitHubAppByIDVariables>(GITHUB_APP_BY_ID_QUERY, {
+        variables: { id: appID },
+    })
+
+    const app = useMemo(() => data?.gitHubApp, [data])
+
+    console.log('APP', app)
+
+    // TODO - make an actual GraphQL request to do it here...
+    const refreshFromGH = () => {}
+
     if (!appID) {
         return null
     }
-
-    const app: any = {
-        id: atob(appID).replace('GitHubApp:', ''),
-        name: appID,
-        createdAt: '2021-07-01T00:00:00Z',
-        updatedAt: '2023-04-04T12:35:21Z',
-    }
-    const error = null
 
     return (
         <div>
             {app ? <PageTitle title={`GitHub App - ${app.name}`} /> : <PageTitle title="GitHub App" />}
             {error && <ErrorAlert className="mb-3" error={error} />}
+            {loading && <LoadingSpinner />}
             {app && (
                 <Container className="mb-3">
                     <PageHeader
@@ -52,24 +78,95 @@ export const GitHubAppPage: FC<Props> = ({
                                 text: app.name,
                             },
                         ]}
-                        byline={
-                            <CreatedByAndUpdatedByInfoByline
-                                createdAt={app.createdAt}
-                                updatedAt={app.updatedAt}
-                                noAuthor={true}
-                            />
-                        }
                         className="mb-3"
                         headingElement="h2"
                         actions={
-                            <ButtonLink to="/site-admin/github-apps/" variant="secondary">
-                                <Icon aria-hidden={true} className="mr-1" svgPath={mdiChevronLeft} />
-                                Back
-                            </ButtonLink>
+                            <>
+                                <Button onClick={refreshFromGH} variant="info" className="ml-auto">
+                                    <Icon inline={true} svgPath={mdiRefresh} aria-hidden={true} /> Refresh from GitHub
+                                </Button>
+                                <ButtonLink to={app.appURL} variant="info" className="ml-2">
+                                    <Icon inline={true} svgPath={mdiGithub} aria-hidden={true} /> Edit
+                                </ButtonLink>
+                            </>
                         }
                     />
+                    <span className="d-flex align-items-center mt-2 mb-3">
+                        <img className={classNames(styles.logo, 'mr-4')} src={app.logo} />
+                        <div className="d-flex flex-column">
+                            <small className="text-muted">AppID: {app.appID}</small>
+                            <small className="text-muted">Slug: {app.slug}</small>
+                            <small className="text-muted">ClientID: {app.clientID}</small>
+                        </div>
+                        <span className="ml-auto">
+                            <span>
+                                Created <Timestamp date={app.createdAt} />
+                            </span>
+                            <span className="ml-3">
+                                Updated <Timestamp date={app.updatedAt} />
+                            </span>
+                        </span>
+                    </span>
                     <hr />
-                    ID: {app.id}
+
+                    <div className="mt-4">
+                        <H2>App installations</H2>
+                        <div className="list-group mb-3" aria-label="GitHub App Installations">
+                            {app.installations?.map(installation => (
+                                <Card
+                                    className={classNames(styles.listNode, 'd-flex flex-row align-items-center')}
+                                    key={installation.id}
+                                >
+                                    <span className="mr-3">
+                                        <Link to={installation.account.url} className="mr-3">
+                                            <UserAvatar size={32} user={installation.account} className="mr-2" />
+                                            {installation.account.login}
+                                        </Link>
+                                        <span>Type: {installation.account.type}</span>
+                                    </span>
+                                    <small className="text-muted mr-3">ID: {installation.id}</small>
+                                    <ButtonLink to={installation.url} variant="secondary" className="ml-auto" size="sm">
+                                        <Icon inline={true} svgPath={mdiGithub} aria-hidden={true} /> Edit
+                                    </ButtonLink>
+                                </Card>
+                            ))}
+                        </div>
+                        <ButtonLink
+                            to={
+                                app.appURL.endsWith('/')
+                                    ? app.appURL + 'installations/new'
+                                    : app.appURL + '/installations/new'
+                            }
+                            variant="success"
+                        >
+                            <Icon svgPath={mdiPlus} aria-hidden={true} /> Add installation
+                        </ButtonLink>
+                    </div>
+                    <hr className="mt-4" />
+                    <div className="mt-4">
+                        <H2>Code host connections</H2>
+                        <ConnectionList as="ul" className="list-group" aria-label="Code Host Connections">
+                            {app.externalServices?.nodes?.map(node => (
+                                <ExternalServiceNode key={node.id} node={node} editingDisabled={true} />
+                            ))}
+                        </ConnectionList>
+                        {app.externalServices && (
+                            <SummaryContainer className="mt-2" centered={true}>
+                                <ConnectionSummary
+                                    noSummaryIfAllNodesVisible={false}
+                                    first={app.externalServices.totalCount ?? 0}
+                                    centered={true}
+                                    connection={app.externalServices}
+                                    noun="code host connection"
+                                    pluralNoun="code host connections"
+                                    hasNextPage={false}
+                                />
+                            </SummaryContainer>
+                        )}
+                        <Button variant="success">
+                            <Icon svgPath={mdiPlus} aria-hidden={true} /> Add connection
+                        </Button>
+                    </div>
                 </Container>
             )}
         </div>

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -1,5 +1,9 @@
 import { gql } from '@sourcegraph/http-client'
 
+import { LIST_EXTERNAL_SERVICE_FRAGMENT } from '../externalServices/backend'
+
+console.log('fragment', LIST_EXTERNAL_SERVICE_FRAGMENT)
+
 export const GITHUB_APPS_QUERY = gql`
     query GitHubApps {
         gitHubApps {
@@ -13,6 +17,39 @@ export const GITHUB_APPS_QUERY = gql`
                 logo
                 createdAt
                 updatedAt
+            }
+        }
+    }
+`
+
+export const GITHUB_APP_BY_ID_QUERY = gql`
+    ${LIST_EXTERNAL_SERVICE_FRAGMENT}
+    query GitHubAppByID($id: ID!) {
+        gitHubApp(id: $id) {
+            id
+            appID
+            name
+            slug
+            appURL
+            clientID
+            logo
+            createdAt
+            updatedAt
+            installations {
+                id
+                url
+                account {
+                    login
+                    avatarURL
+                    url
+                    type
+                }
+            }
+            externalServices(first: 100) {
+                nodes {
+                    ...ListExternalServiceFields
+                }
+                totalCount
             }
         }
     }

--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -63,6 +63,7 @@ type GitHubAppInstallationAccount struct {
 	AccountName      string
 	AccountAvatarURL string
 	AccountURL       string
+	AccountType      string
 }
 
 func (ghai GitHubAppInstallationAccount) Login() string {
@@ -81,13 +82,22 @@ func (ghai GitHubAppInstallationAccount) URL() string {
 	return ghai.AccountURL
 }
 
+func (ghai GitHubAppInstallationAccount) Type() string {
+	return ghai.AccountType
+}
+
 type GitHubAppInstallation struct {
 	InstallID      int32
+	InstallURL     string
 	InstallAccount GitHubAppInstallationAccount
 }
 
 func (ghai GitHubAppInstallation) ID() int32 {
 	return ghai.InstallID
+}
+
+func (ghai GitHubAppInstallation) URL() string {
+	return ghai.InstallURL
 }
 
 func (ghai GitHubAppInstallation) Account() GitHubAppInstallationAccount {

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -101,6 +101,10 @@ type GitHubAccount {
     A link to the account on GitHub.
     """
     url: String!
+    """
+    The account type.
+    """
+    type: String!
 }
 
 """
@@ -111,6 +115,10 @@ type Installation {
     The installation ID of the App.
     """
     id: Int!
+    """
+    The installation URL.
+    """
+    url: String!
     """
     The account on which the App was installed
     """

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -236,11 +236,13 @@ func (r *gitHubAppResolver) Installations(ctx context.Context) (installations []
 
 	for _, install := range installs {
 		installations = append(installations, graphqlbackend.GitHubAppInstallation{
-			InstallID: int32(*install.ID),
+			InstallID:  int32(*install.ID),
+			InstallURL: install.GetHTMLURL(),
 			InstallAccount: graphqlbackend.GitHubAppInstallationAccount{
 				AccountLogin:     install.Account.GetLogin(),
 				AccountAvatarURL: install.Account.GetAvatarURL(),
-				AccountURL:       install.Account.GetURL(),
+				AccountURL:       install.Account.GetHTMLURL(),
+				AccountType:      install.Account.GetType(),
 			},
 		})
 	}


### PR DESCRIPTION
## Description

Adding a prototype for github app screen, which allows us to do various actions.

I'm saying a prototype because that's what it is. The code is intentionally left in this state, since I expect a lot of changes to happen to this screen next week. Important thing is that most of the functionality is there.

Last missing thing is tying it up with a new connection, but I decided to push it to a followup PR, since this one is already too big to my liking.

## Loom recording

https://www.loom.com/share/165e26cf46f34b00939af79253cf324b

## Screenshot
<img width="922" alt="Screenshot 2023-05-05 at 18 23 54" src="https://user-images.githubusercontent.com/9974711/236513921-14176811-034e-463d-9053-de19a7cc7c3e.png">


## Test plan

Tested locally. This change is adding to an unreleased feature, so should be quite safe to merge.