### PR TITLE
codeintel: address out-of-range bugs in snapshot UI

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -294,7 +294,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
                 initialSelection: position.line !== undefined ? position : null,
                 navigateToLineOnAnyClick: navigateToLineOnAnyClick ?? false,
             }),
-            scipSnapshot(blobInfo.snapshotData),
+            scipSnapshot(blobInfo.content, blobInfo.snapshotData),
             codeFoldingExtension(),
             isCodyEnabled()
                 ? codyWidgetExtension(

--- a/client/web/src/repo/blob/codemirror/scip-snapshot.ts
+++ b/client/web/src/repo/blob/codemirror/scip-snapshot.ts
@@ -14,7 +14,7 @@ class SCIPSnapshotDecorations extends WidgetType {
     }
 }
 
-export const scipSnapshot = (data?: { offset: number; data: string }[] | null): Extension =>
+export const scipSnapshot = (blob: string, data?: { offset: number; data: string }[] | null): Extension =>
     data
         ? [
               EditorView.decorations.of(
@@ -23,7 +23,14 @@ export const scipSnapshot = (data?: { offset: number; data: string }[] | null): 
                           Decoration.widget({
                               widget: new SCIPSnapshotDecorations(line.data),
                               block: true,
-                          }).range(line.offset, line.offset)
+                          }).range(
+                              // If the offset is beyond the document, we have to bring it back one
+                              // so codemirror will render them. This only looks correct when there
+                              // are no lines after it, which is the case for the final line, otherwise
+                              // offsetting by -1 gives weird extra newlines
+                              line.offset - (line.offset > blob.length ? 1 : 0),
+                              line.offset - (line.offset > blob.length ? 1 : 0)
+                          )
                       )
                   )
               ),

--- a/enterprise/internal/codeintel/codenav/BUILD.bazel
+++ b/enterprise/internal/codeintel/codenav/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "service_implementations_test.go",
         "service_ranges_test.go",
         "service_references_test.go",
+        "service_snapshot_test.go",
         "service_stencil_test.go",
         "service_test.go",
     ],

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -1405,6 +1405,9 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 		return nil, err
 	}
 
+	// client-side normalizes the file to LF, so normalize CRLF files to that so the offsets are correct
+	file = bytes.ReplaceAll(file, []byte("\r\n"), []byte("\n"))
+
 	repo, err := s.repoStore.Get(ctx, api.RepoID(dump.RepositoryID))
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/codeintel/codenav/service_snapshot_test.go
+++ b/enterprise/internal/codeintel/codenav/service_snapshot_test.go
@@ -1,0 +1,60 @@
+package codenav
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/scip/bindings/go/scip"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+const sampleFile1 = `package food
+
+type banana struct{}`
+
+func TestSnapshotForDocument(t *testing.T) {
+	// Set up mocks
+	mockRepoStore := defaultMockRepoStore()
+	mockLsifStore := NewMockLsifStore()
+	mockUploadSvc := NewMockUploadService()
+	mockGitserverClient := gitserver.NewMockClient()
+
+	// Init service
+	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
+
+	mockUploadSvc.GetDumpsByIDsFunc.SetDefaultReturn([]shared.Dump{{}}, nil)
+	mockRepoStore.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
+	mockGitserverClient.ReadFileFunc.SetDefaultReturn([]byte(sampleFile1), nil)
+	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{
+		RelativePath: "burger.go",
+		Occurrences: []*scip.Occurrence{{
+			Range:       []int32{2, 4, 9},
+			Symbol:      "scip-go gomod github.com/sourcegraph/banter v4.2.0 github.com/sourcegraph/banter/food/banana#",
+			SymbolRoles: int32(scip.SymbolRole_Definition),
+		}},
+		Symbols: []*scip.SymbolInformation{{
+			Symbol: "scip-go gomod github.com/sourcegraph/banter v4.2.0 github.com/sourcegraph/banter/food/banana#",
+			Relationships: []*scip.Relationship{{
+				Symbol:           "scip-go gomod github.com/golang/go go1.18 fmt/Banterer#",
+				IsImplementation: true,
+			}},
+		}},
+	}, nil)
+
+	data, err := svc.SnapshotForDocument(context.Background(), 0, "deadbeef", "burger.go", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(data) != 1 {
+		t.Fatal("no snapshot data returned")
+	}
+
+	if data[0].DocumentOffset != 35 {
+		t.Fatalf("unexpected document offset (want=%d,got=%d)", 35, data[0].DocumentOffset)
+	}
+}

--- a/enterprise/internal/codeintel/codenav/utils.go
+++ b/enterprise/internal/codeintel/codenav/utils.go
@@ -137,11 +137,15 @@ type linemap struct {
 }
 
 func newLinemap(source string) linemap {
+	// first line starts at offset 0
 	l := linemap{positions: []int{0}}
 	for i, char := range source {
 		if char == '\n' {
-			l.positions = append(l.positions, i+1)
+			l.positions = append(l.positions, i)
 		}
 	}
+	// as we want the offset of the line _following_ a symbol's line,
+	// we need to add one extra here for when symbols exist on the final line
+	l.positions = append(l.positions, l.positions[len(l.positions)-1]+1)
 	return l
 }

--- a/enterprise/internal/codeintel/codenav/utils.go
+++ b/enterprise/internal/codeintel/codenav/utils.go
@@ -141,11 +141,13 @@ func newLinemap(source string) linemap {
 	l := linemap{positions: []int{0}}
 	for i, char := range source {
 		if char == '\n' {
-			l.positions = append(l.positions, i)
+			l.positions = append(l.positions, i+1)
 		}
 	}
 	// as we want the offset of the line _following_ a symbol's line,
 	// we need to add one extra here for when symbols exist on the final line
-	l.positions = append(l.positions, l.positions[len(l.positions)-1]+1)
+	lastNewline := l.positions[len(l.positions)-1]
+	lenToEnd := len(source[lastNewline:])
+	l.positions = append(l.positions, lastNewline+lenToEnd+1)
 	return l
 }


### PR DESCRIPTION
Cases where theres an occurrence on the very last line (with no newline after it) would cause a panic. Fixes this :+1: 

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/9e0183fd-ab72-439e-9be1-699de2a79b0f)

## Test plan

Added unit test and tested in local environment as above ^
