### PR TITLE
own: refactor indexer initialization

### DIFF
--- a/enterprise/cmd/worker/internal/own/job.go
+++ b/enterprise/cmd/worker/internal/own/job.go
@@ -34,7 +34,6 @@ func (o *ownRepoIndexingQueue) Routines(startupCtx context.Context, observationC
 	var routines []goroutine.BackgroundRoutine
 	routines = append(routines, background.NewOwnBackgroundWorker(context.Background(), db, observationCtx)...)
 	routines = append(routines, background.GetOwnIndexSchedulerRoutines(db, observationCtx)...)
-	routines = append(routines, background.NewOwnRecentViewsIndexer(db, observationCtx))
 
 	return routines, nil
 }

--- a/enterprise/internal/own/background/background.go
+++ b/enterprise/internal/own/background/background.go
@@ -27,20 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type IndexJobType struct {
-	Name            string
-	Id              JobTypeID
-	IndexInterval   time.Duration
-	RefreshInterval time.Duration
-}
-
-var IndexJobTypes = []IndexJobType{{
-	Name:            "recent-contributors",
-	Id:              RecentContributors,
-	IndexInterval:   time.Hour * 24,
-	RefreshInterval: time.Minute * 5,
-}}
-
 type JobTypeID int
 
 const (

--- a/enterprise/internal/own/background/recent_views.go
+++ b/enterprise/internal/own/background/recent_views.go
@@ -2,16 +2,12 @@ package background
 
 import (
 	"context"
-	"database/sql"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/metrics"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -21,29 +17,7 @@ var (
 		Namespace: "src",
 		Name:      "own_recent_views_events_processed_total",
 	})
-	indexInterval     = time.Minute * 5
-	mockIndexInterval time.Duration
 )
-
-func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Context) goroutine.BackgroundRoutine {
-	redMetrics := metrics.NewREDMetrics(
-		observationCtx.Registerer,
-		"own_background_recent_views_indexer",
-		metrics.WithLabels("op"),
-		metrics.WithCountHelp("Total number of method invocations."),
-	)
-	operation := observationCtx.Operation(observation.Op{
-		Name:              "own.background.index.recent-views",
-		MetricLabelValues: []string{"recent-views"},
-		Metrics:           redMetrics,
-	})
-	handler := newRecentViewsIndexer(db, operation.Logger)
-	interval := indexInterval
-	if mockIndexInterval != 0 {
-		interval = mockIndexInterval
-	}
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", interval, handler, operation)
-}
 
 type recentViewsIndexer struct {
 	db     database.DB
@@ -55,24 +29,6 @@ func newRecentViewsIndexer(db database.DB, logger log.Logger) *recentViewsIndexe
 }
 
 func (r *recentViewsIndexer) Handle(ctx context.Context) error {
-	logJobDisabled := func() {
-		r.logger.Info("skipping own background job, job disabled", log.String("job-name", "recent-views"))
-	}
-	flag, err := r.db.FeatureFlags().GetFeatureFlag(ctx, "own-background-index-repo-recent-views")
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			logJobDisabled()
-			return nil
-		} else {
-			return errors.Wrap(err, "database.FeatureFlagsWith")
-		}
-	}
-	res, ok := flag.EvaluateGlobal()
-	if !ok || !res {
-		logJobDisabled()
-		return nil
-	}
-
 	// The job is enabled, here we go. First we need to get the ID of last processed event.
 	bookmark, err := r.db.EventLogsScrapeState().GetBookmark(ctx, int(RecentViews))
 	if err != nil {

--- a/enterprise/internal/own/background/recent_views.go
+++ b/enterprise/internal/own/background/recent_views.go
@@ -21,8 +21,6 @@ var (
 		Namespace: "src",
 		Name:      "own_recent_views_events_processed_total",
 	})
-	indexInterval     = time.Minute * 5
-	mockIndexInterval time.Duration
 )
 
 func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Context) goroutine.BackgroundRoutine {
@@ -38,11 +36,7 @@ func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Contex
 		Metrics:           redMetrics,
 	})
 	handler := newRecentViewsIndexer(db, operation.Logger)
-	interval := indexInterval
-	if mockIndexInterval != 0 {
-		interval = mockIndexInterval
-	}
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", interval, handler, operation)
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", time.Minute*5, handler, operation)
 }
 
 type recentViewsIndexer struct {

--- a/enterprise/internal/own/background/recent_views.go
+++ b/enterprise/internal/own/background/recent_views.go
@@ -21,6 +21,8 @@ var (
 		Namespace: "src",
 		Name:      "own_recent_views_events_processed_total",
 	})
+	indexInterval     = time.Minute * 5
+	mockIndexInterval time.Duration
 )
 
 func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Context) goroutine.BackgroundRoutine {
@@ -36,7 +38,11 @@ func NewOwnRecentViewsIndexer(db database.DB, observationCtx *observation.Contex
 		Metrics:           redMetrics,
 	})
 	handler := newRecentViewsIndexer(db, operation.Logger)
-	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", time.Minute*5, handler, operation)
+	interval := indexInterval
+	if mockIndexInterval != 0 {
+		interval = mockIndexInterval
+	}
+	return goroutine.NewPeriodicGoroutineWithMetrics(context.Background(), "own.recent-views", "", interval, handler, operation)
 }
 
 type recentViewsIndexer struct {

--- a/enterprise/internal/own/background/recent_views_test.go
+++ b/enterprise/internal/own/background/recent_views_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,80 +34,42 @@ func TestRecentViewsIndexer(t *testing.T) {
 	_, err = db.FeatureFlags().CreateBool(ctx, "own-background-index-repo-recent-views", true)
 	require.NoError(t, err)
 
+	// Assertion function.
+	assertSummaries := func(summariesCount, expectedCount int) {
+		t.Helper()
+		summaries, err := db.RecentViewSignal().List(ctx, database.ListRecentViewSignalOpts{})
+		require.NoError(t, err)
+		assert.Len(t, summaries, summariesCount)
+		for _, summary := range summaries {
+			assert.Equal(t, expectedCount, summary.ViewsCount)
+		}
+	}
+
 	// Creating a worker.
-	observationCtx := &observation.TestContext
-	mockIndexInterval = time.Second * 3
-	cleanMock := func() { mockIndexInterval = 0 }
-	t.Cleanup(cleanMock)
-	worker := NewOwnRecentViewsIndexer(db, observationCtx)
-	go worker.Start()
-	t.Cleanup(worker.Stop)
+	indexer := newRecentViewsIndexer(db, logger)
+
+	// Dry run of handling: we should not have any summaries yet.
+	err = indexer.Handle(ctx)
+	require.NoError(t, err)
+	// Assertions are in the loop over listed summaries -- it won't error out when
+	// there are 0 summaries.
+	assertSummaries(0, -1)
 
 	// Adding events.
 	insertEvents(ctx, t, db)
 
-	// 30 seconds timeout in case of something being wrong, to terminate the test
-	// run.
-	timeout := time.After(30 * time.Second)
-	// First round is to wait for 2 summaries to be inserted to the database.
-	//
-	// Second round is to wait for the same summaries to be updated (their count
-	// should be incremented).
-	round := 1
+	// First round of handling: we should have all counts equal to 1.
+	err = indexer.Handle(ctx)
+	require.NoError(t, err)
+	assertSummaries(2, 1)
 
-	assertSummaries := func() (needToWait bool) {
-		summaries, err := db.RecentViewSignal().List(ctx, database.ListRecentViewSignalOpts{})
-		require.NoError(t, err)
-		if round == 1 && len(summaries) == 2 {
-			// We don't need to check all summary fields because it is covered in
-			// `recent_view_signal_test.go`.
-			for _, summary := range summaries {
-				// Count of views is equal to round number.
-				assert.Equal(t, round, summary.ViewsCount)
-			}
-			// We are fine to add more events and go to next round.
-			insertEvents(ctx, t, db)
-			round++
-		} else if round == 2 {
-			// In round 2, we're waiting for the second iteration of worker which should
-			// increment the counts.
-			sum := 0
-			for _, summary := range summaries {
-				// Count of views is equal to round number.
-				sum += summary.ViewsCount
-			}
-			// If both counts have been incremented -- we go to next round, which leads to
-			// successful end of this test.
-			if sum == 4 {
-				round++
-				return false
-			}
-		}
-		return true
-	}
-loop:
-	for {
-		// We need to do assertions for rounds 1 and 2. Round 3 is success -- exit the
-		// loop.
-		switch round {
-		case 1, 2:
-			needToWait := assertSummaries()
-			if needToWait {
-				// Waiting for the summaries to be inserted.
-				time.Sleep(1 * time.Second)
-			}
-		default:
-			break loop
-		}
+	// Now we can insert some more events.
+	insertEvents(ctx, t, db)
 
-		// Checking for timeout.
-		select {
-		case <-timeout:
-			t.Fatal("Event logs are not processing or processing takes too much time.")
-		default:
-			continue loop
-		}
-	}
+	// Second round of handling: we should have all counts equal to 2.
+	err = indexer.Handle(ctx)
+	require.NoError(t, err)
+	assertSummaries(2, 2)
 }
 
 func insertEvents(ctx context.Context, t *testing.T, db database.DB) {

--- a/enterprise/internal/own/background/scheduler_test.go
+++ b/enterprise/internal/own/background/scheduler_test.go
@@ -38,7 +38,7 @@ func TestOwnRepoIndexSchedulerJob_JobsAutoIndex(t *testing.T) {
 		require.Equal(t, expected, count)
 	}
 
-	for _, jobType := range IndexJobTypes {
+	for _, jobType := range QueuePerRepoIndexJobs {
 		t.Run(jobType.Name, func(t *testing.T) {
 			ctx := context.Background()
 


### PR DESCRIPTION
Refactoring the job initialization to reuse common boilerplate. @sashaostrikov This came out of the last PR discussion, PTAL!

## Test plan

Unit tests and started up to see indexers running successfully

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
