### PR TITLE
Include prop to disable structural search button

### DIFF
--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -115,6 +115,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                         settingsCascade={props.settingsCascade}
                         navbarSearchQuery={queryState.query}
                         submitSearch={submitSearchOnChange}
+                        structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                     />
                 </LazyExperimentalSearchInput>
             </Form>

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -152,6 +152,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                 navbarSearchQuery={queryState.query}
                 showCopyQueryButton={false}
                 showSmartSearchButton={false}
+                structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
             />
         </LazyExperimentalSearchInput>
     ) : (


### PR DESCRIPTION
The `structuralSearchDisabled` prop was missing in two places to exclude the toggle when structural search is disabled.  

## Test plan
### **Enabled structural search**

**Home**
<img width="242" alt="image" src="https://user-images.githubusercontent.com/6098507/236580320-06391c4a-c518-4a90-bd71-6079eb76b9a5.png">

**Navbar**
<img width="362" alt="image" src="https://user-images.githubusercontent.com/6098507/236580441-18b99744-f642-4632-9926-fc8911d5cd40.png">



### Disabled structural search
**Home**
<img width="192" alt="image" src="https://user-images.githubusercontent.com/6098507/236580119-f751a5fe-1e5c-4d0d-b1ba-5a5ef226d901.png">
**Navbar**
<img width="329" alt="image" src="https://user-images.githubusercontent.com/6098507/236580482-70815be0-fc42-4591-a2be-2a49001739b4.png">




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


