### PR TITLE
Replace community page link with Discord server url

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -265,7 +265,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             items={[
                                 {
                                     content: 'Join our Discord',
-                                    path: 'https://about.sourcegraph.com/community',
+                                    path: 'https://discord.com/servers/sourcegraph-969688426372825169',
                                     target: '_blank',
                                 },
                                 {


### PR DESCRIPTION
When running the app locally the Feedback dropdown currently links to our [community page](https://about.sourcegraph.com/community), which doesn't make sense. It should link to our [Discord server page](https://discord.com/servers/sourcegraph-969688426372825169) so they have a better idea of what they are getting before they join.

<img width="807" alt="Image 2023-05-05 at 4 17 58 PM" src="https://user-images.githubusercontent.com/398230/236583704-e196a59b-c683-42ee-af3a-fae891181701.png">


## Test plan

* Test the link

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
