### PR TITLE
App: disable structural by default in app

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -90,6 +90,9 @@ var App = conftypes.RawUnified{
 	"codeIntelAutoIndexing.enabled": true,
 	"codeIntelAutoIndexing.allowGlobalPolicies": true,
 	"executors.frontendURL": "http://host.docker.internal:3080",
+	"experimentalFeatures": {		
+		"structuralSearch": "disabled"
+	},
 }`,
 }
 


### PR DESCRIPTION
Since Comby is currently not embedded in app this is disable structural search by default. Once https://github.com/sourcegraph/sourcegraph/pull/51538 is merged the structural toggle will not appear in the search bar when it is disabled.
## Test plan
Default config change only
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
