### PR TITLE
Add Markprompt icon next to search

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -248,7 +248,7 @@ body > #sidebar #search-form {
     margin-bottom: 0;
     position: relative;
     display: flex;
-    padding: calc(0.5*var(--spacing)) calc(1*var(--spacing));
+    flex-direction: row;
 }
 body > #sidebar #search-form #search {
     color: var(--text-color);
@@ -268,8 +268,8 @@ body > #sidebar #search-form .search-icon {
     color: var(--link-color);
     display: inline-block;
     position: absolute;
-    left: 26px;
-    top: 18px;
+    left: 10px;
+    top: 10px;
 }
 /* Nav */
 body > #sidebar nav.links {
@@ -1189,3 +1189,22 @@ markprompt-content.dark {
 
     --caret-color: var(--link-color);
   }
+
+.markprompt-search-container {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    padding: calc(0.5*var(--spacing)) calc(1*var(--spacing));
+}
+
+#markprompt-button {
+    background-color: transparent;
+    border: 0px;
+    color: var(--link-color);
+    cursor:pointer;
+}
+
+#markprompt-button:hover {
+    color: var(--link-hover-color);
+}

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -101,24 +101,17 @@
                         <img src="{{asset "logo-theme-light.svg"}}" class="theme-light" alt="Sourcegraph docs"/>
                         <img src="{{asset "logo-theme-dark.svg"}}" class="theme-dark" alt="Sourcegraph docs"/>
                     </a></h1>
-                    <div
-                        id="markprompt-button"
-                        style="padding: calc(0.5*var(--spacing)) calc(1*var(--spacing)); display: none">
-                        <button style="color: var(--text-color); border: solid 1px var(--input-border-color); border-radius: 4px; background-color: var(--body-bg); width: 100%; justify-self: center; font-size: 1.0rem; cursor:pointer;" onclick="showMarkprompt()">
-                            <div style="margin-bottom: 0; position: relative; display: flex; gap:0.5rem; padding: calc(0.5*var(--spacing)) 4px; width: 100%;">
-                                <svg class="search-icon" style="color: var(--link-color);" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>
-                                <span style="flex-grow: 1; text-align: left; color: var(--link-color); font-size:16px; font-family: var(--base-font-family);">
-                                    Ask docs...
-                                </span>
-                            </div>
+                    <div class="markprompt-search-container">
+                        <form id="search-form" method="get" action="/search">
+                            <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>
+                            <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="" spellcheck="false" aria-label="Query" />
+                            <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
+                            <button id="search-button" type="submit" aria-label="Search" class="sr-only">Search</button>
+                        </form>
+                        <button id="markprompt-button" aria-label="Open prompt" onclick="showMarkprompt()">
+                            <svg id="markprompt-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-square"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
                         </button>
                     </div>
-                    <form id="search-form" method="get" action="/search">
-                        <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>
-					    <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="" spellcheck="false" aria-label="Query" />
-                        <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
-					    <button id="search-button" type="submit" aria-label="Search" class="sr-only">Search</button>
-				    </form>
                 </header>
                 <nav id="sections" class="links sidebar">
                     <div class="nav-section tree">
@@ -167,19 +160,12 @@
                 <div id="markprompt-dialog" class="markprompt-dialog" onclick="onDialogClick(event)">
                     <markprompt-content
                         model="gpt-4"
-                        projectKey="sk_test_5FCapaMpGj2ghoQmFWzl7K1kdE2RJgbc"
+                        projectKey="D5is0GTlhrzxIR5a9BkalgbdPhv8RWs8"
                         placeholder="Ask docs..."
                     />
                 </div>
             </div>
             <script>
-                const markprompt = localStorage.getItem('markprompt') !== null
-                const markpromptButton = document.getElementById("markprompt-button");
-                const searchForm = document.getElementById("search-form");
-
-                markpromptButton.style.display = markprompt ? 'block' : 'none';
-                searchForm.style.display = markprompt ? 'none' : 'block';
-
                 const component = document.getElementsByTagName('markprompt-content')[0];
 
                 component.getRefFromId = (id) => {


### PR DESCRIPTION
This PR removes the feature flag, and puts the Markprompt icon next to the search bar, so that both can be used while we work through incorporating the instant search results straight into the Markprompt interface.

## Test plan
Manual

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
