### PR TITLE
app: fix asset resolution for builds outside of bazel

### DIFF
--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-sync */
 import fs from 'fs'
 import path from 'path'
+
 import { getEnvironmentBoolean } from './utils/environment-config'
 
 // TODO(bazel): drop when non-bazel removed.
@@ -22,13 +23,10 @@ export function resolveWithSymlink(...args: string[]): string {
 
 export function resolveAssetsPath(root: string): string {
     if (IS_BAZEL && process.env.WEB_BUNDLE_PATH) {
-        return resolveWithSymlink(
-            root,
-            process.env.WEB_BUNDLE_PATH
-        )
+        return resolveWithSymlink(root, process.env.WEB_BUNDLE_PATH)
     }
 
-    if (process.env.NODE_ENV && process.env.NODE_ENV == "development") {
+    if (process.env.NODE_ENV && process.env.NODE_ENV == 'development') {
         return resolveWithSymlink(root, 'ui/assets')
     }
 
@@ -36,13 +34,9 @@ export function resolveAssetsPath(root: string): string {
     // and be done with it. With Bazel, we have different loaders on the backend where the assets gets embedded. So
     // what we do here is "simulate" what happens in bazel, by putting the assets in the correct relative directory
     // so that when the backend is compiled the assets gets embedded properly
-    let isEnterprise: boolean = getEnvironmentBoolean("ENTERPRISE");
-    let relativeAssetPath: string = isEnterprise ? "enterprise" : "oss"
-    const path: string = resolveWithSymlink(
-        root,
-        'ui/assets',
-        relativeAssetPath
-    )
+    let isEnterprise: boolean = getEnvironmentBoolean('ENTERPRISE')
+    let relativeAssetPath: string = isEnterprise ? 'enterprise' : 'oss'
+    const path: string = resolveWithSymlink(root, 'ui/assets', relativeAssetPath)
 
     return path
 }

--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -20,12 +20,27 @@ export function resolveWithSymlink(...args: string[]): string {
     }
 }
 
-function resolveAssetsPath(ROOT_PATH: string): string {
+export function resolveAssetsPath(root: string): string {
+    if (IS_BAZEL && process.env.WEB_BUNDLE_PATH) {
+        return resolveWithSymlink(
+            root,
+            process.env.WEB_BUNDLE_PATH
+        )
+    }
+
+    if (process.env.NODE_ENV && process.env.NODE_ENV == "development") {
+        return resolveWithSymlink(root, 'ui/assets')
+    }
+
+    // With Bazel we changed how assets gets bundled. Previsouly, we would just put the assets at /ui/assets/.assets
+    // and be done with it. With Bazel, we have different loaders on the backend where the assets gets embedded. So
+    // what we do here is "simulate" what happens in bazel, by putting the assets in the correct relative directory
+    // so that when the backend is compiled the assets gets embedded properly
     let isEnterprise: boolean = getEnvironmentBoolean("ENTERPRISE");
     let relativeAssetPath: string = isEnterprise ? "enterprise" : "oss"
     const path: string = resolveWithSymlink(
-        ROOT_PATH,
-        IS_BAZEL && process.env.WEB_BUNDLE_PATH ? process.env.WEB_BUNDLE_PATH : 'ui/assets',
+        root,
+        'ui/assets',
         relativeAssetPath
     )
 

--- a/client/build-config/src/paths.ts
+++ b/client/build-config/src/paths.ts
@@ -26,7 +26,7 @@ export function resolveAssetsPath(root: string): string {
         return resolveWithSymlink(root, process.env.WEB_BUNDLE_PATH)
     }
 
-    if (process.env.NODE_ENV && process.env.NODE_ENV == 'development') {
+    if (process.env.NODE_ENV && process.env.NODE_ENV === 'development') {
         return resolveWithSymlink(root, 'ui/assets')
     }
 
@@ -34,8 +34,8 @@ export function resolveAssetsPath(root: string): string {
     // and be done with it. With Bazel, we have different loaders on the backend where the assets gets embedded. So
     // what we do here is "simulate" what happens in bazel, by putting the assets in the correct relative directory
     // so that when the backend is compiled the assets gets embedded properly
-    let isEnterprise: boolean = getEnvironmentBoolean('ENTERPRISE')
-    let relativeAssetPath: string = isEnterprise ? 'enterprise' : 'oss'
+    const isEnterprise: boolean = getEnvironmentBoolean('ENTERPRISE')
+    const relativeAssetPath: string = isEnterprise ? 'enterprise' : 'oss'
     const path: string = resolveWithSymlink(root, 'ui/assets', relativeAssetPath)
 
     return path

--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -1,6 +1,16 @@
 const path = require('path')
 
-const STATIC_ASSETS_PATH = process.env.WEB_BUNDLE_PATH || path.join(__dirname, '../../ui/assets')
+function relativeAssets(base) {
+  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV == "development") {
+    return path.join(base, '../../ui/assets')
+  }
+  if (process.env.ENTERPRISE !== undefined && process.env.ENTERPRISE == "1") {
+    return path.join(base, '../../ui/assets/enterprise')
+  }
+  return path.join(base, '../../ui/assets/oss')
+}
+
+const STATIC_ASSETS_PATH = process.env.WEB_BUNDLE_PATH || relativeAssets(__dirname)
 
 const config = {
   files: [

--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -1,10 +1,10 @@
 const path = require('path')
 
 function relativeAssets(base) {
-  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV == "development") {
+  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV == 'development') {
     return path.join(base, '../../ui/assets')
   }
-  if (process.env.ENTERPRISE !== undefined && process.env.ENTERPRISE == "1") {
+  if (process.env.ENTERPRISE !== undefined && process.env.ENTERPRISE == '1') {
     return path.join(base, '../../ui/assets/enterprise')
   }
   return path.join(base, '../../ui/assets/oss')

--- a/client/web/bundlesize.config.js
+++ b/client/web/bundlesize.config.js
@@ -1,10 +1,10 @@
 const path = require('path')
 
 function relativeAssets(base) {
-  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV == 'development') {
+  if (process.env.NODE_ENV !== undefined && process.env.NODE_ENV === 'development') {
     return path.join(base, '../../ui/assets')
   }
-  if (process.env.ENTERPRISE !== undefined && process.env.ENTERPRISE == '1') {
+  if (process.env.ENTERPRISE !== undefined && process.env.ENTERPRISE === '1') {
     return path.join(base, '../../ui/assets/enterprise')
   }
   return path.join(base, '../../ui/assets/oss')

--- a/client/web/scripts/report-bundle-diff.ts
+++ b/client/web/scripts/report-bundle-diff.ts
@@ -25,6 +25,33 @@ const STATOSCOPE_BIN = path.join(ROOT_PATH, 'node_modules/@statoscope/cli/bin/cl
 const MERGE_BASE = exec('git merge-base HEAD origin/main').toString().trim()
 let COMPARE_REV = ''
 
+async function findFile(root: string, filename: string): Promise<string> {
+    // file can be in one of 3 base paths
+    const parts: string[] = ["oss", "enterprise", ""]
+    const files = await Promise.all(parts.flatMap(async (p: string) => {
+        const filePath = path.join(root, p, filename)
+        try {
+            await fs.access(filePath)
+            return filePath
+        } catch (e) { }
+        return ""
+    }))
+
+    const foundFile = files.reduce((acc: string, p: string): string => {
+        if (p) {
+            return p
+        }
+        return acc
+    })
+
+    if (!foundFile) {
+        throw new Error(`"${filename} not found under root ${root}`)
+    }
+
+    return foundFile
+
+}
+
 /**
  * We may not have a stats.json file for the merge base commit as these are only
  * created for commits that touch frontend files. Instead, we scan for 20 commits
@@ -65,13 +92,11 @@ async function prepareStats(): Promise<{ commitFile: string; compareFile: string
         exec(`tar -xf ${tarPath} --strip-components=2 -C ${STATIC_ASSETS_PATH}`)
         exec(`ls -la ${STATIC_ASSETS_PATH}`)
 
-        const commitFile = path.join(STATIC_ASSETS_PATH, `stats-${BUILDKITE_COMMIT}.json`)
-        const compareFile = path.join(STATIC_ASSETS_PATH, `stats-${COMPARE_REV}.json`)
-        console.log({ commitFile, compareFile })
 
         try {
-            await fs.access(commitFile)
-            await fs.access(compareFile)
+            const commitFile = await findFile(STATIC_ASSETS_PATH, `stats-${BUILDKITE_COMMIT}.json`)
+            const compareFile = await findFile(STATIC_ASSETS_PATH, `stats-${COMPARE_REV}.json`)
+            console.log({ commitFile, compareFile })
 
             const compareReportPath = path.join(STATIC_ASSETS_PATH, 'compare-report.html')
 

--- a/client/web/scripts/report-bundle-diff.ts
+++ b/client/web/scripts/report-bundle-diff.ts
@@ -34,8 +34,9 @@ async function findFile(root: string, filename: string): Promise<string> {
             try {
                 await fs.access(filePath)
                 return filePath
-            } catch (e) {}
-            return ''
+            } catch {
+                return ''
+            }
         })
     )
 

--- a/client/web/scripts/report-bundle-diff.ts
+++ b/client/web/scripts/report-bundle-diff.ts
@@ -27,21 +27,23 @@ let COMPARE_REV = ''
 
 async function findFile(root: string, filename: string): Promise<string> {
     // file can be in one of 3 base paths
-    const parts: string[] = ["oss", "enterprise", ""]
-    const files = await Promise.all(parts.flatMap(async (p: string) => {
-        const filePath = path.join(root, p, filename)
-        try {
-            await fs.access(filePath)
-            return filePath
-        } catch (e) { }
-        return ""
-    }))
+    const parts: string[] = ['oss', 'enterprise', '']
+    const files = await Promise.all(
+        parts.flatMap(async (dir: string) => {
+            const filePath = path.join(root, dir, filename)
+            try {
+                await fs.access(filePath)
+                return filePath
+            } catch (e) {}
+            return ''
+        })
+    )
 
-    const foundFile = files.reduce((acc: string, p: string): string => {
-        if (p) {
-            return p
+    const foundFile = files.reduce((accumulator: string, possibleFile: string): string => {
+        if (possibleFile) {
+            return possibleFile
         }
-        return acc
+        return accumulator
     })
 
     if (!foundFile) {
@@ -49,7 +51,6 @@ async function findFile(root: string, filename: string): Promise<string> {
     }
 
     return foundFile
-
 }
 
 /**
@@ -91,7 +92,6 @@ async function prepareStats(): Promise<{ commitFile: string; compareFile: string
     if (tarPath) {
         exec(`tar -xf ${tarPath} --strip-components=2 -C ${STATIC_ASSETS_PATH}`)
         exec(`ls -la ${STATIC_ASSETS_PATH}`)
-
 
         try {
             const commitFile = await findFile(STATIC_ASSETS_PATH, `stats-${BUILDKITE_COMMIT}.json`)


### PR DESCRIPTION
We recently changed how assets are resolved in the backend. If the backend is built with Bazel it just works, as well as when you run in Dev mode.

But if the backend is built the normal go way, the assets are not where the backend expects it to be. This fixes the frontend code to resolve the assets directory depending on the environment
## Test plan
Check assets gets rendered with the following commands
* `sg start`
* `bazel build //enterprise/cmd/sourcegraph:sourcegraph`
* `./enterprise/dev/app/build-release.sh`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
