### PR TITLE
nix: set custom PATH for bazel actions

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -12,6 +12,7 @@ if [ -f /etc/NIXOS ]; then
   cat <<EOF > .bazelrc-nix
 build --host_platform=@rules_nixpkgs_core//platforms:host
 build --extra_toolchains=@nixpkgs_nodejs_toolchain//:nodejs_nix,@nixpkgs_rust_toolchain//:rust_nix
+build --action_env=PATH=$BAZEL_ACTION_PATH
 EOF
 fi
 

--- a/shell.nix
+++ b/shell.nix
@@ -32,7 +32,7 @@ let
     exec ${pkgs.bazelisk}/bin/bazelisk "$@"
   '' else ''
     if [ "$1" == "configure" ]; then
-      exec ${pkgs.bazelisk}/bin/bazelisk "$@"
+      exec env --unset=USE_BAZEL_VERSION ${pkgs.bazelisk}/bin/bazelisk "$@"
     fi
     exec ${bazel-static}/bin/bazel "$@"
   '');
@@ -150,6 +150,11 @@ pkgs.mkShell {
 
   # Tell rules_rust to use our custom cargo-bazel.
   CARGO_BAZEL_GENERATOR_URL = "file://${cargo-bazel}/bin/cargo-bazel";
+
+  # Some of the bazel actions require some tools assumed to be in the PATH defined by the "strict action env" that we enable
+  # through --incompatible_strict_action_env. We can poke a custom PATH through with --action_env=PATH=$BAZEL_ACTION_PATH.
+  # See https://sourcegraph.com/github.com/bazelbuild/bazel@6.1.2/-/blob/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java?L532-547
+  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bash stdenv.cc coreutils unzip zip curl ];
 
   # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
   # so we tell it to h*ck off here.


### PR DESCRIPTION
We're now looking up some less-than-hermetically provided tools in files such as https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/dev/buildCodeIntelExtensions.js?L15 that are invoked as part of the bazel build. These must be in the "strict" path defined [in this function](https://sourcegraph.com/github.com/bazelbuild/bazel@6.1.2/-/blob/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java?L532-547), HOWEVER as these dont exist on nixos, they're overridden by nix already to contain the paths of [the following tools](https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix?L83-124). This is missing some such as curl that we need, so we can pass in a custom PATH instead as in this PR

## Test plan

N/A, nix stuff
