### PR TITLE
Embeddings: use SIMD instructions for search on arm64

### DIFF
--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
         "dot.go",
         "dot_amd64.go",
         "dot_amd64.s",
-        "dot_noamd64.go",
+        "dot_arm64.go",
+        "dot_arm64.s",
+        "dot_portable.go",
         "index_name.go",
         "index_storage.go",
         "quantize.go",
@@ -33,6 +35,9 @@ go_library(
         "@org_golang_x_sync//errgroup",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
+            "@com_github_klauspost_cpuid_v2//:cpuid",
+        ],
+        "@io_bazel_rules_go//go/platform:arm64": [
             "@com_github_klauspost_cpuid_v2//:cpuid",
         ],
         "//conditions:default": [],

--- a/enterprise/internal/embeddings/dot_arm64.go
+++ b/enterprise/internal/embeddings/dot_arm64.go
@@ -26,7 +26,7 @@ func dotArch(a []int8, b []int8) int32 {
 		return 0
 	}
 
-	rem := la % 32
+	rem := la % 16
 	blockA := a[:la-rem]
 	blockB := b[:lb-rem]
 

--- a/enterprise/internal/embeddings/dot_arm64.go
+++ b/enterprise/internal/embeddings/dot_arm64.go
@@ -15,24 +15,21 @@ var (
 )
 
 func dotArch(a []int8, b []int8) int32 {
-	la := len(a)
-	lb := len(b)
-
-	if la != lb {
+	if len(a) != len(b) {
 		panic("mismatched lengths")
 	}
 
-	if la == 0 {
+	if len(a) == 0 {
 		return 0
 	}
 
-	rem := la % 16
-	blockA := a[:la-rem]
-	blockB := b[:lb-rem]
+	rem := len(a) % 16
+	blockA := a[:len(a)-rem]
+	blockB := b[:len(b)-rem]
 
 	sum := int32(dotSIMD(blockA, blockB))
 
-	for i := la - rem; i < la; i++ {
+	for i := len(a) - rem; i < len(a); i++ {
 		sum += int32(a[i]) * int32(b[i])
 	}
 

--- a/enterprise/internal/embeddings/dot_arm64.go
+++ b/enterprise/internal/embeddings/dot_arm64.go
@@ -1,0 +1,42 @@
+//go:build arm64
+
+package embeddings
+
+import (
+	"github.com/klauspost/cpuid/v2"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+var (
+	simdEnabled   = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
+	hasDotProduct = cpuid.CPU.Has(cpuid.ASIMDDP)
+	haveDotArch   = simdEnabled && hasDotProduct
+)
+
+func dotArch(a []int8, b []int8) int32 {
+	la := len(a)
+	lb := len(b)
+
+	if la != lb {
+		panic("mismatched lengths")
+	}
+
+	if la == 0 {
+		return 0
+	}
+
+	rem := la % 32
+	blockA := a[:la-rem]
+	blockB := b[:lb-rem]
+
+	sum := int32(dotSIMD(blockA, blockB))
+
+	for i := la - rem; i < la; i++ {
+		sum += int32(a[i]) * int32(b[i])
+	}
+
+	return sum
+}
+
+func dotSIMD(a, b []int8) int64

--- a/enterprise/internal/embeddings/dot_arm64.go
+++ b/enterprise/internal/embeddings/dot_arm64.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	simdEnabled   = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
-	hasDotProduct = cpuid.CPU.Has(cpuid.ASIMDDP)
+	hasDotProduct = cpuid.CPU.Supports(cpuid.ASIMD, cpuid.ASIMDDP)
 	haveDotArch   = simdEnabled && hasDotProduct
 )
 

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -1,0 +1,40 @@
+#include "textflag.h"
+
+#define BLOCKSIZE $16
+
+TEXT ·dotSIMD(SB), NOSPLIT, $0-56
+	// Offsets based on slice header offsets.
+	// To check, use `GOARCH=amd64 go vet`
+	MOVD a_base+0(FP), R4
+	MOVD b_base+24(FP), R5
+	MOVD a_len+8(FP), R6
+
+
+	// Zero V0, which will store 4 packed 32-bit sums
+	VEOR V0.B16, V0.B16, V0.B16
+
+blockloop:
+    CMP BLOCKSIZE, R6
+    BLT reduce
+
+    // TODO: consider loading 32 bytes at a time with
+    // VLD1.W 16(R4), [V1.B16, V2.B16]
+    VLD1 (R4), [V1.B16]
+    VLD1 (R5), [V2.B16]
+
+    // The following instruction is not supported
+    // by the go assembler, so use the binary format.
+    // VSDOT V1.B16, V2.B16, V0.S4
+    WORD $0x4E829420
+
+	ADD BLOCKSIZE, R4
+	ADD BLOCKSIZE, R5
+	SUB BLOCKSIZE, R6
+	JMP blockloop
+
+reduce:
+    VADDV V0.S4, V0
+    VMOV V0.S[0], R6
+    MOVD R6, ret+48(FP)
+	RET
+

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -8,7 +8,7 @@
 // must be a multiple of 16.
 TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 	// Offsets based on slice header offsets.
-	// To check, use `GOARCH=amd64 go vet`
+	// To check, use `GOARCH=arm64 go vet`
 	MOVD a_base+0(FP), R4
 	MOVD b_base+24(FP), R5
 	MOVD a_len+8(FP), R6

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -17,8 +17,6 @@ blockloop:
     CMP BLOCKSIZE, R6
     BLT reduce
 
-    // TODO: consider loading 32 bytes at a time with
-    // VLD1.W 16(R4), [V1.B16, V2.B16]
     VLD1 (R4), [V1.B16]
     VLD1 (R5), [V2.B16]
 

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -1,6 +1,5 @@
 #include "textflag.h"
 
-
 TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 	// Offsets based on slice header offsets.
 	// To check, use `GOARCH=amd64 go vet`
@@ -19,7 +18,7 @@ blockloop:
 	CMP R4, R6
 	BEQ reduce
 
-	// Load 16 bytes from each slice
+	// Load 16 bytes from each slice, post-incrementing the pointers
 	VLD1.P 16(R4), [V1.B16]
 	VLD1.P 16(R5), [V2.B16]
 

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -1,5 +1,11 @@
 #include "textflag.h"
 
+// dotSIMD uses NEON instructions and the SDOT instruction
+// (required after Armv8.4) to compute the dot product of
+// two int8 vectors.
+//
+// The vectors must be of the same length, and that length
+// must be a multiple of 16.
 TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 	// Offsets based on slice header offsets.
 	// To check, use `GOARCH=amd64 go vet`

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -1,6 +1,5 @@
 #include "textflag.h"
 
-#define BLOCKSIZE $16
 
 TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 	// Offsets based on slice header offsets.
@@ -9,30 +8,35 @@ TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 	MOVD b_base+24(FP), R5
 	MOVD a_len+8(FP), R6
 
+	ADD R4, R6, R6 // end pointer
 
 	// Zero V0, which will store 4 packed 32-bit sums
 	VEOR V0.B16, V0.B16, V0.B16
 
+#define BLOCKSIZE $16
+
 blockloop:
-    CMP BLOCKSIZE, R6
-    BLT reduce
+	CMP R4, R6
+	BEQ reduce
 
-    VLD1 (R4), [V1.B16]
-    VLD1 (R5), [V2.B16]
+	// Load 16 bytes from each slice
+	VLD1.P 16(R4), [V1.B16]
+	VLD1.P 16(R5), [V2.B16]
 
-    // The following instruction is not supported
-    // by the go assembler, so use the binary format.
+	// The following instruction is not supported by the go assembler, so use
+	// the binary format. It would be the equivalent of the following instruction:
+	//
     // VSDOT V1.B16, V2.B16, V0.S4
-    WORD $0x4E829420
+	//
+	// I generated the binary form of the instruction using this godbolt setup:
+	// https://godbolt.org/z/3jPohn4dn
+	WORD $0x4E829420
 
-	ADD BLOCKSIZE, R4
-	ADD BLOCKSIZE, R5
-	SUB BLOCKSIZE, R6
 	JMP blockloop
 
 reduce:
-    VADDV V0.S4, V0
-    VMOV V0.S[0], R6
-    MOVD R6, ret+48(FP)
+	VADDV V0.S4, V0
+	VMOV V0.S[0], R6
+	MOVD R6, ret+48(FP)
 	RET
 

--- a/enterprise/internal/embeddings/dot_portable.go
+++ b/enterprise/internal/embeddings/dot_portable.go
@@ -1,4 +1,4 @@
-//go:build !amd64
+//go:build !amd64 && !arm64
 
 package embeddings
 

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDot(t *testing.T) {
-	t.Run("previously failed", func(t *testing.T) {
+	t.Run("edge cases", func(t *testing.T) {
 		repeat := func(n int8, size int) []int8 {
 			res := make([]int8, size)
 			for i := 0; i < size; i++ {

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -20,14 +20,14 @@ func TestDot(t *testing.T) {
 			b    []int8
 			want int32
 		}{{
-			// 	a:    []int8{1},
-			// 	b:    []int8{1},
-			// 	want: 1,
-			// }, {
-			// 	a:    append(repeat(0, 16), 1),
-			// 	b:    append(repeat(0, 16), 2),
-			// 	want: 2,
-			// }, {
+			a:    []int8{1},
+			b:    []int8{1},
+			want: 1,
+		}, {
+			a:    append(repeat(0, 16), 1),
+			b:    append(repeat(0, 16), 2),
+			want: 2,
+		}, {
 			a:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			b:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
 			want: 102,

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -20,6 +20,7 @@ func TestDot(t *testing.T) {
 			b    []int8
 			want int32
 		}{
+			{[]int8{}, []int8{}, 0},
 			{[]int8{1}, []int8{1}, 1},
 			{append(repeat(0, 16), 1), append(repeat(0, 16), 2), 2},
 			{

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -20,14 +20,14 @@ func TestDot(t *testing.T) {
 			b    []int8
 			want int32
 		}{{
-			a:    []int8{1},
-			b:    []int8{1},
-			want: 1,
-		}, {
-			a:    append(repeat(0, 16), 1),
-			b:    append(repeat(0, 16), 2),
-			want: 2,
-		}, {
+			// 	a:    []int8{1},
+			// 	b:    []int8{1},
+			// 	want: 1,
+			// }, {
+			// 	a:    append(repeat(0, 16), 1),
+			// 	b:    append(repeat(0, 16), 2),
+			// 	want: 2,
+			// }, {
 			a:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			b:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
 			want: 102,

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -91,26 +91,3 @@ func TestDot(t *testing.T) {
 		}
 	})
 }
-
-func FuzzDot(f *testing.F) {
-	if !haveDotArch {
-		f.Skip("skipping test because arch-specific dot product is disabled")
-	}
-
-	f.Fuzz(func(t *testing.T, input1, input2 []byte) {
-		b1 := *(*[]int8)(unsafe.Pointer(&input1))
-		b2 := *(*[]int8)(unsafe.Pointer(&input2))
-
-		if len(b1) > len(b2) {
-			b1 = b1[:len(b2)]
-		} else {
-			b2 = b2[:len(b1)]
-		}
-
-		got := Dot(b1, b2)
-		want := dotPortable(b1, b2)
-		if want != got {
-			t.Fatalf("want: %d, got: %d", want, got)
-		}
-	})
-}

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -1,8 +1,6 @@
 package embeddings
 
 import (
-	"math/rand"
-	"strconv"
 	"testing"
 	"testing/quick"
 )
@@ -90,21 +88,4 @@ func TestDot(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-}
-
-func BenchmarkDot(b *testing.B) {
-	prng := rand.New(rand.NewSource(0))
-	const size = 1_000_000
-	for _, offset := range []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16} {
-		embeddings1 := getRandomEmbeddings(prng, size+offset)
-		embeddings1 = embeddings1[offset:]
-		embeddings2 := getRandomEmbeddings(prng, size+offset)
-		embeddings2 = embeddings2[offset:]
-		b.Run(strconv.Itoa(offset), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				_ = Dot(embeddings1, embeddings2)
-			}
-		})
-	}
-
 }

--- a/enterprise/internal/embeddings/dot_test.go
+++ b/enterprise/internal/embeddings/dot_test.go
@@ -1,9 +1,10 @@
 package embeddings
 
 import (
+	"math/rand"
+	"strconv"
 	"testing"
 	"testing/quick"
-	"unsafe"
 )
 
 func TestDot(t *testing.T) {
@@ -15,43 +16,42 @@ func TestDot(t *testing.T) {
 			}
 			return res
 		}
+
 		cases := []struct {
 			a    []int8
 			b    []int8
 			want int32
-		}{{
-			a:    []int8{1},
-			b:    []int8{1},
-			want: 1,
-		}, {
-			a:    append(repeat(0, 16), 1),
-			b:    append(repeat(0, 16), 2),
-			want: 2,
-		}, {
-			a:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
-			b:    []int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
-			want: 102,
-		}, {
-			a:    repeat(0, 16),
-			b:    repeat(0, 16),
-			want: 0,
-		}, {
-			a:    repeat(0, 16),
-			b:    repeat(1, 16),
-			want: 0,
-		}, {
-			a:    repeat(1, 16),
-			b:    repeat(1, 16),
-			want: 16,
-		}, {
-			a:    repeat(1, 16),
-			b:    repeat(2, 16),
-			want: 32,
-		}, {
-			a:    repeat(1, 17),
-			b:    repeat(1, 17),
-			want: 17,
-		}}
+		}{
+			{[]int8{1}, []int8{1}, 1},
+			{append(repeat(0, 16), 1), append(repeat(0, 16), 2), 2},
+			{
+				[]int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				[]int8{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+				102,
+			},
+			{repeat(0, 16), repeat(0, 16), 0},
+			{repeat(0, 16), repeat(1, 16), 0},
+			{repeat(1, 16), repeat(1, 16), 16},
+			{repeat(1, 16), repeat(2, 16), 32},
+			{repeat(1, 17), repeat(1, 17), 17},
+
+			// A couple of large ones to ensure no weird behavior at scale
+			{repeat(1, 1000000), repeat(1, 1000000), 1000000},
+			{repeat(1, 1000000), repeat(2, 1000000), 2000000},
+
+			// This will come very close to overflowing an int32.
+			// Make sure nothing crashes.
+			{repeat(127, 133000), repeat(127, 133000), 2145157000},
+
+			// This will overflow an int32 and return garbage.
+			// Just make sure nothing crashes.
+			{repeat(127, 134000), repeat(127, 134000), -2133681296},
+
+			// These will overflow if we don't multiply into larger ints
+			{repeat(127, 40), repeat(127, 40), 645160},
+			{repeat(-128, 40), repeat(-128, 40), 655360},
+			{repeat(-128, 40), repeat(127, 40), -650240},
+		}
 
 		for _, tc := range cases {
 			t.Run("dot", func(t *testing.T) {
@@ -90,4 +90,21 @@ func TestDot(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func BenchmarkDot(b *testing.B) {
+	prng := rand.New(rand.NewSource(0))
+	const size = 1_000_000
+	for _, offset := range []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16} {
+		embeddings1 := getRandomEmbeddings(prng, size+offset)
+		embeddings1 = embeddings1[offset:]
+		embeddings2 := getRandomEmbeddings(prng, size+offset)
+		embeddings2 = embeddings2[offset:]
+		b.Run(strconv.Itoa(offset), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Dot(embeddings1, embeddings2)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
This adds an SIMD version of embeddings search for the arm64 arch. It uses the builtin dot product vector instruction (SDOT), which works beautifully for our use case.

Not high priority since this would only actually be useful for searching embeddings in App and/or local dev, but I was playing around with ARM assembly this weekend and this was the motivating problem.

## Test plan

Added a bunch of tests comparing it to the naive version. Quicktests exercise many cases. Behind the same environment variable as SIMD instructions on amd64, so this is low risk. Benchmark below.

```
name                               old time/op              new time/op              delta
SimilaritySearch/numWorkers=1-10                433ms ± 1%                93ms ± 0%   -78.41%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=2-10                224ms ± 1%                47ms ± 0%   -78.80%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=4-10                115ms ± 0%                24ms ± 0%   -79.23%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=8-10               58.8ms ± 3%              13.0ms ± 1%   -77.81%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=16-10              66.2ms ± 2%              13.6ms ± 1%   -79.45%  (p=0.000 n=10+10)

name                               old embeddings/s         new embeddings/s         delta
SimilaritySearch/numWorkers=1-10                2.31M ± 1%              10.71M ± 0%  +363.19%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=2-10                4.47M ± 1%              21.11M ± 0%  +371.71%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=4-10                8.73M ± 0%              42.01M ± 0%  +381.47%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=8-10                17.0M ± 3%               76.6M ± 1%  +350.52%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=16-10               15.1M ± 2%               73.5M ± 1%  +386.52%  (p=0.000 n=10+10)

name                               old embeddings/s/worker  new embeddings/s/worker  delta
SimilaritySearch/numWorkers=1-10                2.31M ± 1%              10.71M ± 0%  +363.19%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=2-10                2.24M ± 1%              10.55M ± 0%  +371.71%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=4-10                2.18M ± 0%              10.50M ± 0%  +381.47%  (p=0.000 n=10+8)
SimilaritySearch/numWorkers=8-10                2.13M ± 3%               9.58M ± 1%  +350.52%  (p=0.000 n=10+9)
SimilaritySearch/numWorkers=16-10                944k ± 2%               4593k ± 1%  +386.52%  (p=0.000 n=10+10)
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
