### PR TITLE
cody: more efficient file path validator

### DIFF
--- a/client/cody-shared/src/hallucinations-detector/index.test.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import { highlightTokens } from '.'
+import { findFilePaths, highlightTokens } from '.'
 
 const markdownText = `# Title
 
@@ -32,7 +32,41 @@ const validFilePaths = new Set(['file/path.js'])
 
 describe('Hallucinations detector', () => {
     it('highlights hallucinated file paths', async () => {
-        const { text } = await highlightTokens(markdownText, filePath => Promise.resolve(validFilePaths.has(filePath)))
+        const { text } = await highlightTokens(markdownText, filePaths => {
+            const filePathExists: { [filePath: string]: boolean } = {}
+            for (const filePath of filePaths) {
+                filePathExists[filePath] = validFilePaths.has(filePath)
+            }
+            return Promise.resolve(filePathExists)
+        })
         assert.deepStrictEqual(text, expectedHighlightedTokensText)
+    })
+
+    it('findFilePaths', () => {
+        const cases: {
+            input: string
+            output: { pathMatch: string; fullMatch: string }[]
+        }[] = [
+            {
+                input: 'foo/bar/baz',
+                output: [{ fullMatch: 'foo/bar/baz', pathMatch: 'foo/bar/baz' }],
+            },
+            {
+                input: 'use of this/that in a sentence',
+                output: [],
+            },
+            {
+                input: '`this/that`',
+                output: [{ fullMatch: '`this/that`', pathMatch: 'this/that' }],
+            },
+            {
+                input: 'pattern/foo/bar/*.ts',
+                output: [],
+            },
+        ]
+        for (const { input, output } of cases) {
+            const actualOutput = findFilePaths(input)
+            assert.deepStrictEqual(actualOutput, output)
+        }
     })
 })

--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -15,10 +15,10 @@ interface HighlightTokensResult {
 
 export async function highlightTokens(
     text: string,
-    fileExists: (filePath: string) => Promise<boolean>
+    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean }>
 ): Promise<HighlightTokensResult> {
     const markdownLines = parseMarkdown(text)
-    const tokens = await detectTokens(markdownLines, fileExists)
+    const tokens = await detectTokens(markdownLines, filesExist)
     const highlightedText = markdownLines
         .map(({ line, isCodeBlock }) => (isCodeBlock ? line : highlightLine(line, tokens)))
         .join('\n')
@@ -27,17 +27,36 @@ export async function highlightTokens(
 
 async function detectTokens(
     lines: MarkdownLine[],
-    fileExists: (filePath: string) => Promise<boolean>
+    filesExist: (filePaths: string[]) => Promise<{ [filePath: string]: boolean }>
 ): Promise<HighlightedToken[]> {
-    const tokens: HighlightedToken[] = []
+    // mapping from file path to full match
+    const filePathToFullMatch: { [filePath: string]: Set<string> } = {}
     for (const { line, isCodeBlock } of lines) {
         if (isCodeBlock) {
             continue
         }
-        const lineTokens = await detectFilePaths(line, fileExists)
-        tokens.push(...lineTokens)
+        for (const { fullMatch, pathMatch } of findFilePaths(line)) {
+            if (!filePathToFullMatch[pathMatch]) {
+                filePathToFullMatch[pathMatch] = new Set<string>()
+            }
+            filePathToFullMatch[pathMatch].add(fullMatch)
+        }
     }
-    return deduplicateTokens(tokens)
+
+    const filePathsExist = await filesExist([...Object.keys(filePathToFullMatch)])
+    const tokens: HighlightedToken[] = []
+    for (const [filePath, fullMatches] of Object.entries(filePathToFullMatch)) {
+        const exists = filePathsExist[filePath]
+        for (const fullMatch of fullMatches) {
+            tokens.push({
+                type: 'file',
+                outerValue: fullMatch,
+                innerValue: filePath,
+                isHallucinated: !exists,
+            })
+        }
+    }
+    return tokens
 }
 
 function highlightLine(line: string, tokens: HighlightedToken[]): string {
@@ -53,33 +72,19 @@ function getHighlightedTokenHTML(token: HighlightedToken): string {
     return ` <span class="token-${token.type} token-${isHallucinatedClassName}">${token.outerValue.trim()}</span> `
 }
 
-function deduplicateTokens(tokens: HighlightedToken[]): HighlightedToken[] {
-    const deduplicatedTokens: HighlightedToken[] = []
-    const values = new Set<string>()
-    for (const token of tokens) {
-        if (!values.has(token.outerValue)) {
-            deduplicatedTokens.push(token)
-            values.add(token.outerValue)
+export function findFilePaths(line: string): { fullMatch: string; pathMatch: string }[] {
+    const matches: { fullMatch: string; pathMatch: string }[] = []
+    for (const m of line.matchAll(filePathRegexp)) {
+        const fullMatch = m[0]
+        const pathMatch = m[1]
+        if (isFilePathLike(fullMatch, pathMatch)) {
+            matches.push({ fullMatch, pathMatch })
         }
     }
-    return deduplicatedTokens
+    return matches
 }
 
-function detectFilePaths(
-    line: string,
-    fileExists: (filePath: string) => Promise<boolean>
-): Promise<HighlightedToken[]> {
-    const filePaths = Array.from(line.matchAll(filePathRegexp))
-        .map(match => ({ fullMatch: match[0], pathMatch: match[1] }))
-        .filter(match => isFilePathLike(match.fullMatch, match.pathMatch))
-        .map(async (match): Promise<HighlightedToken> => {
-            const exists = await fileExists(match.pathMatch)
-            return { type: 'file', outerValue: match.fullMatch, innerValue: match.pathMatch, isHallucinated: !exists }
-        })
-    return Promise.all(filePaths)
-}
-
-const filePathCharacters = '[\\w\\/\\._-]'
+const filePathCharacters = '[\\*\\w\\/\\._-]'
 
 const filePathRegexpParts = [
     // File path can start with a `, ", ', or a whitespace
@@ -94,6 +99,10 @@ const filePathRegexp = new RegExp(filePathRegexpParts.join(''), 'g')
 
 function isFilePathLike(fullMatch: string, pathMatch: string): boolean {
     const parts = pathMatch.split(/[/\\]/)
+    if (pathMatch.includes('*')) {
+        // Probably a glob pattern
+        return false
+    }
 
     if (fullMatch.startsWith(' ') && parts.length <= 2) {
         // Probably a / used as an "or" in a sentence. For example, "This is a cool/awesome function."

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -242,7 +242,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 const lastInteraction = this.transcript.getLastInteraction()
                 if (lastInteraction) {
                     const { text, displayText } = lastInteraction.getAssistantMessage()
-                    const { text: highlightedDisplayText } = await highlightTokens(displayText || '', fileExists)
+                    const { text: highlightedDisplayText } = await highlightTokens(displayText || '', filesExist)
                     this.transcript.addAssistantResponse(text || '', highlightedDisplayText)
                 }
                 void this.onCompletionEnd()
@@ -674,32 +674,35 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     }
 }
 
-function trimPrefix(text: string, prefix: string): string {
-    if (text.startsWith(prefix)) {
-        return text.slice(prefix.length)
+function filePathContains(container: string, contained: string): boolean {
+    let trimmedContained = contained
+    if (trimmedContained.endsWith(path.sep)) {
+        trimmedContained = trimmedContained.slice(0, -path.sep.length)
     }
-    return text
+    if (trimmedContained.startsWith(path.sep)) {
+        trimmedContained = trimmedContained.slice(path.sep.length)
+    }
+    return (
+        container.includes(path.sep + trimmedContained + path.sep) || // mid-level directory
+        container.endsWith(path.sep + trimmedContained) // child
+    )
 }
 
-function trimSuffix(text: string, suffix: string): string {
-    if (text.endsWith(suffix)) {
-        return text.slice(0, -suffix.length)
-    }
-    return text
-}
-
-async function fileExists(filePath: string): Promise<boolean> {
-    const patterns = [filePath, '**/' + trimSuffix(trimPrefix(filePath, '/'), '/') + '/**']
-    if (!filePath.endsWith('/')) {
-        patterns.push('**/' + trimPrefix(filePath, '/') + '*')
-    }
-    for (const pattern of patterns) {
-        const files = await vscode.workspace.findFiles(pattern, null, 1)
-        if (files.length > 0) {
-            return true
+async function filesExist(filePaths: string[]): Promise<{ [filePath: string]: boolean }> {
+    const searchPath = `{${filePaths.join(',')}}`
+    const realFiles = await vscode.workspace.findFiles(searchPath, null, filePaths.length * 5)
+    const ret: { [filePath: string]: boolean } = {}
+    for (const filePath of filePaths) {
+        let pathExists = false
+        for (const realFile of realFiles) {
+            if (filePathContains(realFile.fsPath, filePath)) {
+                pathExists = true
+                break
+            }
         }
+        ret[filePath] = pathExists
     }
-    return false
+    return ret
 }
 
 // Converts a git clone URL to the codebase name that includes the slash-separated code host, owner, and repository name

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -256,9 +256,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 // TODO(dpc): The multiplexer can handle incremental text. Change chat to provide incremental text.
                 text = text.slice(textConsumed)
                 textConsumed += text.length
-                return this.multiplexer.publish(text)
+                void this.multiplexer.publish(text)
             },
-            onComplete: () => this.multiplexer.notifyTurnComplete(),
+            onComplete: () => {
+                void this.multiplexer.notifyTurnComplete()
+            },
             onError: (err, statusCode) => {
                 // Display error message as assistant response
                 this.transcript.addErrorAsAssistantResponse(
@@ -428,9 +430,11 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 // TODO(dpc): The multiplexer can handle incremental text. Change chat to provide incremental text.
                 text = text.slice(textConsumed)
                 textConsumed += text.length
-                return multiplexer.publish(text)
+                void multiplexer.publish(text)
             },
-            onComplete: () => multiplexer.notifyTurnComplete(),
+            onComplete: () => {
+                void multiplexer.notifyTurnComplete()
+            },
             onError: (error, statusCode) => {
                 console.error(error, statusCode)
             },


### PR DESCRIPTION
Problem: file path validation was taking a long time in large codebases ([user report](https://sourcegraph.slack.com/archives/C04NPH6SZMW/p1683216134155539)).

Diagnosis: the current implementation of file path validation roughly tracks this pseudocode:
```
for every line
  for every filepath-like item in the line
    search for that filepath via vscode.workspace.findFiles
```

This results in multiple whole-codebase filepath searches in serial.

Solution: update the implementation to gather all filepath-like things together, then issue one search for all of these.
```
gather all filepath-like items from every line
invoke vscode.workspace.findFiles with a search pattern that matches all such filepath candidates
```

10x performance improvement (40s -> 4s) on Sourcegraph's codebase:

<table>

<tr>
<td>Query</td><td>Before</td><td>After</td>
</tr>

<tr>
  <td>
  <img width="1092" alt="image" src="https://user-images.githubusercontent.com/1646931/236695706-7afa5411-92ce-4d11-8786-92aafdfc6f2e.png">
  </td>
  <td>
  <img width="228" alt="image" src="https://user-images.githubusercontent.com/1646931/236695945-160a4e61-7d62-4c8b-848c-ae8df4b3c56b.png">
  </td>
  <td>
  <img width="260" alt="image" src="https://user-images.githubusercontent.com/1646931/236695676-47511927-08ee-4435-94ea-5a6aee847b3a.png">
  </td>
</tr>

</table>

Also fixes a bug where `</span>` tags were being inserted into glob patterns that were incorrectly interpreted as file paths. Now, we ignore path-like strings with `*` (i.e., glob patterns):

<table>
  <tr><td>Before</td><td>After</td></tr>
  <tr>
  <td>
  <img width="905" alt="image" src="https://user-images.githubusercontent.com/1646931/236695994-60ec6ce0-2490-4736-8f6a-4948081963df.png">
  </td>
  <td>
  <img width="904" alt="image" src="https://user-images.githubusercontent.com/1646931/236696133-fbdc95ce-8153-438b-9866-2fae7ff13531.png">
  </td>
  </tr>
</table>

## Test plan

Cody beta. Tested locally.