### PR TITLE
bazel: add new info to docs

### DIFF
--- a/doc/dev/background-information/bazel_web.md
+++ b/doc/dev/background-information/bazel_web.md
@@ -76,11 +76,13 @@ load("@npm//:rawr/package_json.bzl", my_alias = "bin")
 
 With the above statement `rules_js` generated the following targets for `rawr`:
 
-* `rawr` for use with `bazel build`
-* `rawr_binary` for use with `bazel run`
-* `rawr_test` for use with `bazel test`
+* `rawr` for use with `bazel build` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) + [js_run_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary) interanlly)
+* `rawr_binary` for use with `bazel run` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) interanlly)
+* `rawr_test` for use with `bazel test` ([js_test](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary#js_test) interanlly)
 
-Cool? I mean we technically have rawr now available but HTF do we use this? To create a build target using rawr we can now do:
+See the generated macro implementation [here](https://sourcegraph.com/github.com/aspect-build/rules_js@f60bbf809ec013df3979659b4dfa84bc248da3fa/-/blob/npm/private/npm_import.bzl?L281-331) for more details.
+
+Cool? I mean we technically have `rawr` now available but HTF do we use this? To create a build target using `rawr` we can now do:
 
 ```
 my_alias.rawr (

--- a/doc/dev/background-information/bazel_web.md
+++ b/doc/dev/background-information/bazel_web.md
@@ -76,9 +76,9 @@ load("@npm//:rawr/package_json.bzl", my_alias = "bin")
 
 With the above statement `rules_js` generated the following targets for `rawr`:
 
-* `rawr` for use with `bazel build` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) + [js_run_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary) interanlly)
-* `rawr_binary` for use with `bazel run` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) interanlly)
-* `rawr_test` for use with `bazel test` ([js_test](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary#js_test) interanlly)
+* `rawr` for use with `bazel build` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) + [js_run_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary) internally)
+* `rawr_binary` for use with `bazel run` ([js_binary](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary) internally)
+* `rawr_test` for use with `bazel test` ([js_test](https://docs.aspect.build/rules/aspect_rules_js/docs/js_binary#js_test) internally)
 
 See the generated macro implementation [here](https://sourcegraph.com/github.com/aspect-build/rules_js@f60bbf809ec013df3979659b4dfa84bc248da3fa/-/blob/npm/private/npm_import.bzl?L281-331) for more details.
 


### PR DESCRIPTION
## Context

Adding info that I recently discovered debugging `rules_js` locally to our Bazel documentation.

## Test plan

N/a
