### PR TITLE
search-plan: increase verbosity of output

### DIFF
--- a/dev/internal/cmd/search-plan/BUILD.bazel
+++ b/dev/internal/cmd/search-plan/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//internal/conf",
         "//internal/search",
         "//internal/search/client",
+        "//internal/search/job",
         "//internal/search/job/jobutil",
         "//internal/search/job/printer",
         "//lib/errors",

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/printer"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -66,7 +67,7 @@ func run(w io.Writer, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create planJob")
 	}
-	fmt.Fprintln(w, printer.SexpPretty(planJob))
+	fmt.Fprintln(w, printer.SexpVerbose(planJob, job.VerbosityMax, true))
 
 	return nil
 }


### PR DESCRIPTION
This is quite useful in this tool. Especially since it includes useful information like how selectors are applied.

Test Plan: go run . -dotcom -pattern_type literal 'type:file select:repo content:"hello\nworld"'
