### PR TITLE
Cody completions: Ignore crashes when reading history files

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 ### Fixed
 
 - Error notification display pattern for rate limit [pull/51521](https://github.com/sourcegraph/sourcegraph/pull/51521)
+- Fixes issues with branch switching and file deletions when using the experimental completions feature [pull/51565](https://github.com/sourcegraph/sourcegraph/pull/51565)
 
 ### Changed
 

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -68,14 +68,21 @@ async function getFiles(currentEditor: vscode.TextEditor, history: History): Pro
     }
     const historyFiles = await Promise.all(
         history.lastN(10, curLang, [currentEditor.document.uri, ...files.map(f => f.uri)]).map(async item => {
-            const contents = (await vscode.workspace.openTextDocument(item.document.uri)).getText()
-            return {
-                uri: item.document.uri,
-                contents,
+            try {
+                const contents = (await vscode.workspace.openTextDocument(item.document.uri)).getText()
+                return [
+                    {
+                        uri: item.document.uri,
+                        contents,
+                    },
+                ]
+            } catch (error) {
+                console.error(error)
+                return []
             }
         })
     )
-    files.push(...historyFiles)
+    files.push(...historyFiles.flat())
     return files
 }
 


### PR DESCRIPTION
Fixes an issue where branch switching and file deletion would cause Cody to spew lots of erros.

Reported here: https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1683309073854139

## Test plan

<img width="2037" alt="Screenshot 2023-05-08 at 10 56 36" src="https://user-images.githubusercontent.com/458591/236782305-8557d51b-b83f-4e06-adae-2b45e3b7bf7f.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
