### PR TITLE
Revert "cody: hide cody.experimental.suggest (#51444)"

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -321,6 +321,10 @@
           ],
           "default": "embeddings"
         },
+        "cody.experimental.suggestions": {
+          "type": "boolean",
+          "default": false
+        },
         "cody.experimental.chatPredictions": {
           "type": "boolean",
           "default": false


### PR DESCRIPTION
This reverts commit 123810bad5c9950f4f6361cf240e212f7e256130.

Now that we have a separate rate limit for dotcom, we can enable this option again.

## Test plan

CI needs to pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
