### PR TITLE
Aggregate ownership signals GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -435,3 +435,7 @@ func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
 	repoUrl.Path += "@" + string(r.oid)
 	return &repoUrl
 }
+
+func (r *GitCommitResolver) Ownership(ctx context.Context, args ListOwnershipArgs) (OwnershipConnectionResolver, error) {
+	return EnterpriseResolvers.ownResolver.GitCommitOwnership(ctx, r, args)
+}

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -18,6 +18,7 @@ type ListOwnershipArgs struct {
 
 type OwnResolver interface {
 	GitBlobOwnership(ctx context.Context, blob *GitTreeEntryResolver, args ListOwnershipArgs) (OwnershipConnectionResolver, error)
+	GitCommitOwnership(ctx context.Context, commit *GitCommitResolver, args ListOwnershipArgs) (OwnershipConnectionResolver, error)
 
 	PersonOwnerField(person *PersonResolver) string
 	UserOwnerField(user *UserResolver) string

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -41,6 +41,22 @@ extend type GitBlob implements Ownable {
     ): OwnershipConnection!
 }
 
+extend type GitCommit {
+    """
+    Owners of the repository at this commit.
+    """
+    ownership(
+        """
+        Returns the first n ownership records from the list.
+        """
+        first: Int
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): OwnershipConnection!
+}
+
 """
 A list of ownership entries.
 """

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -122,6 +122,35 @@ func (r *ownResolver) GitBlobOwnership(
 	return r.ownershipConnection(args, ownerships)
 }
 
+// repoRootPath is the path that designates all the aggregate signals
+// for a repository.
+const repoRootPath = ""
+
+// GitCommitOwnership retrieves ownership signals (not CODEOWNERS data)
+// aggregated for the whole repository.
+//
+// It's a commit ownership rather than repo ownership because
+// from the resolution point of view repo needs to be versioned
+// at a certain commit to compute signals. At this point, however
+// signals are not versioned yet, so every commit gets the same data.
+func (r *ownResolver) GitCommitOwnership(
+	ctx context.Context,
+	commit *graphqlbackend.GitCommitResolver,
+	args graphqlbackend.ListOwnershipArgs,
+) (graphqlbackend.OwnershipConnectionResolver, error) {
+	if err := areOwnEndpointsAvailable(ctx); err != nil {
+		return nil, err
+	}
+
+	// Retrieve recent contributors signals.
+	ownerships, err := computeRecentContributorSignals(ctx, r.db, repoRootPath, commit.Repository().IDInt32())
+	if err != nil {
+		return nil, err
+	}
+
+	return r.ownershipConnection(args, ownerships)
+}
+
 func (r *ownResolver) PersonOwnerField(_ *graphqlbackend.PersonResolver) string {
 	return "owner"
 }

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -643,7 +643,7 @@ func TestOwnership_WithSignals(t *testing.T) {
 										}
 										reasons {
 											...CodeownersFileEntryFields
-											... on RecentContributorOwnershipSignal {
+											...on RecentContributorOwnershipSignal {
 											  title
 											  description
 											}
@@ -700,6 +700,92 @@ func TestOwnership_WithSignals(t *testing.T) {
 			"repo":        string(relay.MarshalID("Repository", repoID)),
 			"revision":    "revision",
 			"currentPath": "foo/bar.js",
+		},
+	})
+}
+
+func TestCommitOwnershipSignals(t *testing.T) {
+	logger := logtest.Scoped(t)
+	fakeDB := fakedb.New()
+	db := database.NewMockDB()
+
+	recentContribStore := database.NewMockRecentContributionSignalStore()
+	recentContribStore.FindRecentAuthorsFunc.SetDefaultReturn([]database.RecentContributorSummary{{
+		AuthorName:        "santa claus",
+		AuthorEmail:       "santa@northpole.com",
+		ContributionCount: 5,
+	}}, nil)
+	db.RecentContributionSignalsFunc.SetDefaultReturn(recentContribStore)
+
+	fakeDB.Wire(db)
+	repoID := api.RepoID(1)
+
+	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
+	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
+	repos := database.NewMockRepoStore()
+	db.ReposFunc.SetDefaultReturn(repos)
+	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
+	backend.Mocks.Repos.ResolveRev = func(_ context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
+		return "deadbeef", nil
+	}
+	git := fakeGitserver{}
+	own := fakeOwnService{}
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Schema:  schema,
+		Context: ctx,
+		Query: `
+			query FetchOwnership($repo: ID!) {
+				node(id: $repo) {
+					... on Repository {
+						commit(rev: "revision") {
+							ownership {
+								nodes {
+									owner {
+										...on Person {
+											displayName
+											email
+										}
+									}
+									reasons {
+										...on RecentContributorOwnershipSignal {
+											title
+											description
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}`,
+		ExpectedResult: `{
+			"node": {
+				"commit": {
+					"ownership": {
+						"nodes": [
+							{
+								"owner": {
+									"displayName": "santa claus",
+									"email": "santa@northpole.com"
+								},
+								"reasons": [
+									{
+										"title": "recent contributor",
+										"description": "Owner is associated because they are have contributed to this file in the last 90 days."
+									}
+								]
+							}
+						]
+					}
+				}
+			}
+		}`,
+		Variables: map[string]any{
+			"repo": string(relay.MarshalID("Repository", repoID)),
 		},
 	})
 }


### PR DESCRIPTION
Part of #50800

GraphQL API for repo-ownership (via the commit node for versioning).

## Test plan

Extend graphQL unit test with relevant cases.
