### PR TITLE
Cody completions: Don't bubble errors

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -37,6 +37,11 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                     res.on('end', () => {
                         req.destroy()
                         try {
+                            // When rate-limiting occurs, the response is an error message
+                            if (res.statusCode === 429) {
+                                reject(new Error(buffer))
+                            }
+
                             const resp = JSON.parse(buffer) as CodeCompletionResponse
                             if (typeof resp.completion !== 'string' || typeof resp.stopReason !== 'string') {
                                 reject(new Error(`response does not satisfy CodeCompletionResponse: ${buffer}`))

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -53,11 +53,12 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         try {
             return await this.provideInlineCompletionItemsInner(document, position, context, token)
         } catch (error) {
+            console.error(error)
+
             if (error.message === 'aborted') {
                 return []
             }
 
-            await this.webviewErrorMessager(`ProvideInlineCompletionItems - ${error}`)
             return []
         }
     }


### PR DESCRIPTION
This PR does two thinks (albeit it would not need one of them to be fair):

- Don't bubble errors on inline completions to the user. Completions trigger very very often which means that any error that happens will likely repeat a looooot of times. We had this with rate limiting and with file not found errors and I think it's better for the user to fail silently, especially in this stage. This also mimics GitHub copilot that doesn't say a word when it e.g. can't connect to the backend properly.
- Properly unwrap rate limiting errors: Since we don't use the errors this is not 100% necessary however we know that the response won't parse to JSON so it still makes sense to handle this case properly. We might also revisit the first point and then we'll at least have better looking error message.

## Test plan

Tried it locally, no more errors. Bliss.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
