### PR TITLE
app docs: fix social image sizes on Safari

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -16,6 +16,10 @@
 .socials a:hover {
   filter: brightness(0.75);
 }
+.socials a img {
+  width: 100%;
+  height: 100%;
+}
 </style>
 
 # Sourcegraph App


### PR DESCRIPTION
The Twitter icon wasn't being properly sized because Safari doesn't support the `attr()` function.

![image](https://user-images.githubusercontent.com/206864/236882613-ad6da2e0-fec5-4602-b621-e52599ed33c1.png)


## Test plan

Verified images look fine on Safari now

![image](https://user-images.githubusercontent.com/206864/236882723-2ea14d78-e217-43e3-ac2d-08844e223989.png)

