### PR TITLE
Cody: add highlighted text from editor to prompt

### DIFF
--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -1,9 +1,12 @@
 import { CodebaseContext } from '../../codebase-context'
 import { ContextMessage, getContextMessageWithResponse } from '../../codebase-context/messages'
-import { Editor } from '../../editor'
+import { ActiveTextEditorSelection, Editor } from '../../editor'
 import { IntentDetector } from '../../intent-detector'
 import { MAX_CURRENT_FILE_TOKENS, MAX_HUMAN_INPUT_TOKENS } from '../../prompt/constants'
-import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
+import {
+    populateCurrentEditorContextTemplate,
+    populateCurrentEditorSelectedContextTemplate,
+} from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
@@ -13,20 +16,19 @@ export class ChatQuestion implements Recipe {
     public id = 'chat-question'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        // Add selected text to the end of prompt when available
-        const selection = context.editor.getActiveTextEditorSelection()
-        const selectedCode = selection
-            ? this.selectionPrompt
-                  .replace('{selectedText}', selection.selectedText)
-                  .replace('{fileName}', selection.fileName)
-            : ''
-        const truncatedText = truncateText(humanChatInput + selectedCode, MAX_HUMAN_INPUT_TOKENS)
+        const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
 
         return Promise.resolve(
             new Interaction(
                 { speaker: 'human', text: truncatedText, displayText: humanChatInput },
                 { speaker: 'assistant' },
-                this.getContextMessages(truncatedText, context.editor, context.intentDetector, context.codebaseContext)
+                this.getContextMessages(
+                    truncatedText,
+                    context.editor,
+                    context.intentDetector,
+                    context.codebaseContext,
+                    context.editor.getActiveTextEditorSelection() || null
+                )
             )
         )
     }
@@ -35,9 +37,15 @@ export class ChatQuestion implements Recipe {
         text: string,
         editor: Editor,
         intentDetector: IntentDetector,
-        codebaseContext: CodebaseContext
+        codebaseContext: CodebaseContext,
+        selection: ActiveTextEditorSelection | null
     ): Promise<ContextMessage[]> {
         const contextMessages: ContextMessage[] = []
+
+        // Add selected text as context when available
+        if (selection?.selectedText) {
+            contextMessages.push(...this.getEditorSelectionContext(selection))
+        }
 
         const isCodebaseContextRequired = await intentDetector.isCodebaseContextRequired(text)
         if (isCodebaseContextRequired) {
@@ -67,9 +75,11 @@ export class ChatQuestion implements Recipe {
         )
     }
 
-    private selectionPrompt = `\n\n
-    I am currently looking at this part of the code from {fileName}:
-    \`\`\`
-    {selectedText}
-    \`\`\``
+    private getEditorSelectionContext(selection: ActiveTextEditorSelection): ContextMessage[] {
+        const truncatedContent = truncateText(selection.selectedText, MAX_CURRENT_FILE_TOKENS)
+        return getContextMessageWithResponse(
+            populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName),
+            selection.fileName
+        )
+    }
 }

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -13,7 +13,14 @@ export class ChatQuestion implements Recipe {
     public id = 'chat-question'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)
+        // Add selected text to the end of prompt when available
+        const selection = context.editor.getActiveTextEditorSelection()
+        const selectedCode = selection
+            ? this.selectionPrompt
+                  .replace('{selectedText}', selection.selectedText)
+                  .replace('{fileName}', selection.fileName)
+            : ''
+        const truncatedText = truncateText(humanChatInput + selectedCode, MAX_HUMAN_INPUT_TOKENS)
 
         return Promise.resolve(
             new Interaction(
@@ -59,4 +66,10 @@ export class ChatQuestion implements Recipe {
             visibleContent.fileName
         )
     }
+
+    private selectionPrompt = `\n\n
+    I am currently looking at this part of the code from {fileName}:
+    \`\`\`
+    {selectedText}
+    \`\`\``
 }

--- a/client/cody-shared/src/prompt/templates.ts
+++ b/client/cody-shared/src/prompt/templates.ts
@@ -25,6 +25,15 @@ export function populateCurrentEditorContextTemplate(code: string, filePath: str
     return CURRENT_EDITOR_CODE_TEMPLATE.replace(/{filePath}/g, filePath) + context
 }
 
+const CURRENT_EDITOR_SELECTED_CODE_TEMPLATE = 'I am currently looking at this part of the code from `{filePath}`. '
+
+export function populateCurrentEditorSelectedContextTemplate(code: string, filePath: string): string {
+    const context = isMarkdownFile(filePath)
+        ? populateMarkdownContextTemplate(code, filePath)
+        : populateCodeContextTemplate(code, filePath)
+    return CURRENT_EDITOR_SELECTED_CODE_TEMPLATE.replace(/{filePath}/g, filePath) + context
+}
+
 const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown'])
 
 export function isMarkdownFile(filePath: string): boolean {

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
   - `/r` or `/reset` to reset chat
   - `/s` or `/search` to perform codebase context search
 - Adds usage metrics to the experimental chat predictions feature [pull/51474](https://github.com/sourcegraph/sourcegraph/pull/51474)
-- Add highlighted code to end of prompt automatically [pull/tbc]()
+- Add highlighted code to end of prompt automatically [pull/51585](https://github.com/sourcegraph/sourcegraph/pull/51585)
 
 ### Fixed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
   - `/r` or `/reset` to reset chat
   - `/s` or `/search` to perform codebase context search
 - Adds usage metrics to the experimental chat predictions feature [pull/51474](https://github.com/sourcegraph/sourcegraph/pull/51474)
+- Add highlighted code to end of prompt automatically [pull/tbc]()
 
 ### Fixed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
   - `/r` or `/reset` to reset chat
   - `/s` or `/search` to perform codebase context search
 - Adds usage metrics to the experimental chat predictions feature [pull/51474](https://github.com/sourcegraph/sourcegraph/pull/51474)
-- Add highlighted code to end of prompt automatically [pull/51585](https://github.com/sourcegraph/sourcegraph/pull/51585)
+- Add highlighted code to context message automatically [pull/51585](https://github.com/sourcegraph/sourcegraph/pull/51585)
 
 ### Fixed
 


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1683316126807689

Add selected text from editor automatically to the end of the prompt when detected.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

To test, you can highlight text from your editor, and then ask cody about the selected text without copying and pasting the code to the chat box:
<img width="1521" alt="Screenshot 2023-05-08 at 10 09 12 AM" src="https://user-images.githubusercontent.com/68532117/236887366-b4541802-7763-465e-9b63-f9c5485ce24f.png">
