### PR TITLE
own: fix user resolving as unknown if email is not associated

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -366,8 +366,12 @@ func computeRecentContributorSignals(ctx context.Context, db edb.EnterpriseDB, p
 		user, err := identifyUser(ctx, db, author.AuthorEmail)
 		if err == nil {
 			// if we don't get an error (meaning we can match) we will add it to the resolver, otherwise use the contributor data
+			em := author.AuthorEmail
 			res.resolvedOwner = &codeowners.Person{
-				User: user,
+				User:         user,
+				Email:        author.AuthorEmail,
+				PrimaryEmail: &em,
+				Handle:       author.AuthorName,
 			}
 		}
 		results = append(results, &res)

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -369,7 +369,7 @@ func computeRecentContributorSignals(ctx context.Context, db edb.EnterpriseDB, p
 			em := author.AuthorEmail
 			res.resolvedOwner = &codeowners.Person{
 				User:         user,
-				Email:        author.AuthorEmail,
+				Email:        em,
 				PrimaryEmail: &em,
 				Handle:       author.AuthorName,
 			}


### PR DESCRIPTION
Fix some users resolving as "unknown" due to missing email address.

## Test plan

After fix, loading the contributors panel shows users properly associated instead of "unknown"
<img width="446" alt="image" src="https://user-images.githubusercontent.com/5090588/236923316-4230da0b-e97c-4110-864e-707ebc2a0ed9.png">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
