### PR TITLE
codeintel: Fix background job context auth

### DIFF
--- a/enterprise/cmd/worker/internal/codeintel/lsifuploadstore_expirer.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifuploadstore_expirer.go
@@ -32,13 +32,15 @@ func (j *lsifuploadstoreExpirer) Config() []env.Config {
 }
 
 func (j *lsifuploadstoreExpirer) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
-	uploadStore, err := lsifuploadstore.New(context.Background(), observationCtx, lsifuploadstoreExpirerConfigInst.LSIFUploadStoreConfig)
+	ctx := context.Background()
+
+	uploadStore, err := lsifuploadstore.New(ctx, observationCtx, lsifuploadstoreExpirerConfigInst.LSIFUploadStoreConfig)
 	if err != nil {
 		observationCtx.Logger.Fatal("Failed to create upload store", log.Error(err))
 	}
 
 	return []goroutine.BackgroundRoutine{
-		uploadstore.NewExpirer(context.Background(), uploadStore, lsifuploadstoreExpirerConfigInst.prefix, lsifuploadstoreExpirerConfigInst.maxAge, lsifuploadstoreExpirerConfigInst.interval),
+		uploadstore.NewExpirer(ctx, uploadStore, lsifuploadstoreExpirerConfigInst.prefix, lsifuploadstoreExpirerConfigInst.maxAge, lsifuploadstoreExpirerConfigInst.interval),
 	}, nil
 }
 

--- a/enterprise/internal/codeintel/autoindexing/internal/background/scheduler/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/scheduler/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//enterprise/internal/codeintel/policies",
         "//enterprise/internal/codeintel/policies/shared",
         "//enterprise/internal/codeintel/uploads/shared",
+        "//internal/actor",
         "//internal/api",
         "//internal/codeintel/dependencies",
         "//internal/conf",

--- a/enterprise/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/store"
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -58,7 +59,7 @@ func NewScheduler(
 	})
 
 	return goroutine.NewPeriodicGoroutineWithMetrics(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.autoindexing-background-scheduler", "schedule autoindexing jobs in the background using defined or inferred configurations",
 		config.SchedulerInterval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {
@@ -200,7 +201,7 @@ func (b indexSchedulerJob) handleRepository(ctx context.Context, repositoryID, p
 
 func NewOnDemandScheduler(s store.Store, indexEnqueuer IndexEnqueuer, config *Config) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.autoindexing-ondemand-scheduler", "schedule autoindexing jobs for explicitly requested repo+revhash combinations",
 		config.OnDemandSchedulerInterval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/policies/internal/background/repository_matcher/BUILD.bazel
+++ b/enterprise/internal/codeintel/policies/internal/background/repository_matcher/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/policies/internal/store",
+        "//internal/actor",
         "//internal/conf",
         "//internal/env",
         "//internal/goroutine",

--- a/enterprise/internal/codeintel/policies/internal/background/repository_matcher/job.go
+++ b/enterprise/internal/codeintel/policies/internal/background/repository_matcher/job.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -22,7 +23,7 @@ func NewRepositoryMatcher(
 	}
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.policies-matcher", "match repositories to autoindexing+retention policies",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/sentinel/internal/background/downloader/BUILD.bazel
+++ b/enterprise/internal/codeintel/sentinel/internal/background/downloader/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//enterprise/internal/codeintel/sentinel/internal/store",
         "//enterprise/internal/codeintel/sentinel/shared",
+        "//internal/actor",
         "//internal/env",
         "//internal/goroutine",
         "//internal/lazyregexp",

--- a/enterprise/internal/codeintel/sentinel/internal/background/downloader/job.go
+++ b/enterprise/internal/codeintel/sentinel/internal/background/downloader/job.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/internal/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/shared"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -19,7 +20,7 @@ func NewCVEDownloader(store store.Store, observationCtx *observation.Context, co
 	metrics := newMetrics(observationCtx)
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.sentinel-cve-downloader", "Periodically syncs GitHub advisory records into Postgres.",
 		config.DownloaderInterval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/sentinel/internal/background/matcher/BUILD.bazel
+++ b/enterprise/internal/codeintel/sentinel/internal/background/matcher/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/sentinel/internal/store",
+        "//internal/actor",
         "//internal/env",
         "//internal/goroutine",
         "//internal/observation",

--- a/enterprise/internal/codeintel/sentinel/internal/background/matcher/job.go
+++ b/enterprise/internal/codeintel/sentinel/internal/background/matcher/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/sentinel/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -12,7 +13,7 @@ func NewCVEMatcher(store store.Store, observationCtx *observation.Context, confi
 	metrics := newMetrics(observationCtx)
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.sentinel-cve-matcher", "Matches SCIP indexes against known vulnerabilities.",
 		config.MatcherInterval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/shared/background/BUILD.bazel
+++ b/enterprise/internal/codeintel/shared/background/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/background",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
+        "//internal/actor",
         "//internal/goroutine",
         "//internal/metrics",
         "//internal/observation",

--- a/enterprise/internal/codeintel/shared/background/janitor_job.go
+++ b/enterprise/internal/codeintel/shared/background/janitor_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -85,7 +86,7 @@ func NewJanitorJob(ctx context.Context, opts JanitorOptions) goroutine.Backgroun
 	janitor := &janitor{opts: opts}
 
 	return goroutine.NewPeriodicGoroutineWithMetricsAndDynamicInterval(
-		ctx,
+		actor.WithInternalActor(ctx),
 		opts.Name,
 		opts.Description,
 		janitor.interval,

--- a/enterprise/internal/codeintel/shared/background/pipeline_job.go
+++ b/enterprise/internal/codeintel/shared/background/pipeline_job.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -99,7 +100,7 @@ func NewPipelineJob(ctx context.Context, opts PipelineOptions) goroutine.Backgro
 	pipeline := &pipeline{opts: opts}
 
 	return goroutine.NewPeriodicGoroutineWithMetricsAndDynamicInterval(
-		ctx,
+		actor.WithInternalActor(ctx),
 		opts.Name,
 		opts.Description,
 		pipeline.interval,

--- a/enterprise/internal/codeintel/uploads/internal/background/backfiller/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/background/backfiller/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/uploads/internal/store",
+        "//internal/actor",
         "//internal/api",
         "//internal/authz",
         "//internal/env",

--- a/enterprise/internal/codeintel/uploads/internal/background/backfiller/job_backfill.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/backfiller/job_backfill.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -19,7 +20,7 @@ func NewCommittedAtBackfiller(store store.Store, gitserverClient gitserver.Clien
 		batchSize:       config.BatchSize,
 	}
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.committed-at-backfiller", "backfills the committed_at column for code-intel uploads",
 		config.Interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/uploads/internal/background/commitgraph/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/background/commitgraph/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/uploads/internal/store",
+        "//internal/actor",
         "//internal/api",
         "//internal/authz",
         "//internal/database/locker",

--- a/enterprise/internal/codeintel/uploads/internal/background/commitgraph/job_commitgraph.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/commitgraph/job_commitgraph.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database/locker"
@@ -26,7 +27,7 @@ func NewCommitGraphUpdater(
 	}
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.commitgraph-updater", "updates the visibility commit graph for dirty repos",
 		config.Interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/uploads/internal/background/expirer/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/background/expirer/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//enterprise/internal/codeintel/policies/shared",
         "//enterprise/internal/codeintel/uploads/internal/store",
         "//enterprise/internal/codeintel/uploads/shared",
+        "//internal/actor",
         "//internal/api",
         "//internal/database",
         "//internal/env",

--- a/enterprise/internal/codeintel/uploads/internal/background/expirer/job_expirer.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/expirer/job_expirer.go
@@ -8,6 +8,7 @@ import (
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -32,7 +33,7 @@ func NewUploadExpirer(
 		policyMatcher: policies.NewMatcher(gitserverClient, policies.RetentionExtractor, true, false),
 	}
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.upload-expirer", "marks uploads as expired based on retention policies",
 		config.ExpirerInterval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/enterprise/internal/codeintel/uploads/internal/background/janitor/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/janitor/job_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -65,7 +66,7 @@ func newReconciler(
 	config *Config,
 	observationCtx *observation.Context,
 ) goroutine.BackgroundRoutine {
-	return background.NewJanitorJob(context.Background(), background.JanitorOptions{
+	return background.NewJanitorJob(context.Background()), background.JanitorOptions{
 		Name:        name,
 		Description: description,
 		Interval:    config.Interval,

--- a/enterprise/internal/codeintel/uploads/internal/background/janitor/job_reconciler.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/janitor/job_reconciler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/internal/store"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -66,7 +65,7 @@ func newReconciler(
 	config *Config,
 	observationCtx *observation.Context,
 ) goroutine.BackgroundRoutine {
-	return background.NewJanitorJob(context.Background()), background.JanitorOptions{
+	return background.NewJanitorJob(context.Background(), background.JanitorOptions{
 		Name:        name,
 		Description: description,
 		Interval:    config.Interval,

--- a/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
+++ b/internal/codeintel/dependencies/internal/background/job_cratesyncer.go
@@ -47,12 +47,14 @@ func NewCrateSyncer(
 	gitClient gitserver.Client,
 	extSvcStore ExternalServiceStore,
 ) goroutine.BackgroundRoutine {
+	ctx := actor.WithInternalActor(context.Background())
+
 	// By default, sync crates every 12h, but the user can customize this interval
 	// through site-admin configuration of the RUSTPACKAGES code host.
 	interval := time.Hour * 12
-	_, externalService, _ := singleRustExternalService(context.Background(), extSvcStore)
+	_, externalService, _ := singleRustExternalService(ctx, extSvcStore)
 	if externalService != nil {
-		config, err := rustPackagesConfig(context.Background(), externalService)
+		config, err := rustPackagesConfig(ctx, externalService)
 		if err == nil { // silently ignore config errors.
 			customInterval, err := time.ParseDuration(config.IndexRepositorySyncInterval)
 			if err == nil { // silently ignore duration decoding error.
@@ -74,7 +76,7 @@ func NewCrateSyncer(
 	}
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		ctx,
 		"codeintel.crates-syncer", "syncs the crates list from the index to dependency repos table",
 		interval,
 		goroutine.HandlerFunc(func(ctx context.Context) error {

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -30,7 +32,7 @@ func NewPackagesFilterApplicator(
 	}
 
 	return goroutine.NewPeriodicGoroutine(
-		context.Background(),
+		actor.WithInternalActor(context.Background()),
 		"codeintel.package-filter-applicator", "applies package repo filters to all package repo references to precompute their blocked status",
 		time.Second*5,
 		goroutine.HandlerFunc(job.handle))

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"


### PR DESCRIPTION
Ensure all code intel background jobs run with an internal context. All repos should be visible to the periodic jobs that synchronize, reconcile, and process data. User-level visibility is always considered at **retrieval** time.

## Test plan

Tested locally.