### PR TITLE
cody > keyword context: ignore ASCII-only keywords of length 2 or less

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -103,5 +103,6 @@ ts_project(
     tsconfig = ":tsconfig",
     deps = [
         ":cody",
+        "//:node_modules/@types/node",
     ],
 )

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.test.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.test.ts
@@ -1,6 +1,131 @@
-import { regexForTerms, userQueryToKeywordQuery } from './local-keyword-context-fetcher'
+import * as assert from 'assert'
+
+import { Term, regexForTerms, userQueryToKeywordQuery } from './local-keyword-context-fetcher'
 
 describe('keyword context', () => {
+    it('userQueryToKeywordQuery', () => {
+        const cases: { query: string; expected: Term[] }[] = [
+            {
+                query: 'Where is auth in Sourcegraph?',
+                expected: [
+                    {
+                        count: 1,
+                        originals: ['Where'],
+                        prefix: 'where',
+                        stem: 'where',
+                    },
+                    {
+                        count: 1,
+                        originals: ['auth'],
+                        prefix: 'auth',
+                        stem: 'auth',
+                    },
+                    {
+                        count: 1,
+                        originals: ['Sourcegraph'],
+                        prefix: 'sourcegraph',
+                        stem: 'sourcegraph',
+                    },
+                ],
+            },
+            {
+                query: `Explain the following code at a high level:
+uint32_t PackUInt32(const Color& color) {
+  uint32_t result = 0;
+  result |= static_cast<uint32_t>(color.r * 255 + 0.5f) << 24;
+  result |= static_cast<uint32_t>(color.g * 255 + 0.5f) << 16;
+  result |= static_cast<uint32_t>(color.b * 255 + 0.5f) << 8;
+  result |= static_cast<uint32_t>(color.a * 255 + 0.5f);
+  return result;
+}
+`,
+                expected: [
+                    {
+                        count: 4,
+                        originals: ['255', '255', '255', '255'],
+                        prefix: '255',
+                        stem: '255',
+                    },
+                    {
+                        count: 1,
+                        originals: ['Explain'],
+                        prefix: 'explain',
+                        stem: 'explain',
+                    },
+                    {
+                        count: 1,
+                        originals: ['following'],
+                        prefix: 'follow',
+                        stem: 'follow',
+                    },
+                    {
+                        count: 1,
+                        originals: ['code'],
+                        prefix: 'code',
+                        stem: 'code',
+                    },
+                    {
+                        count: 1,
+                        originals: ['high'],
+                        prefix: 'high',
+                        stem: 'high',
+                    },
+                    {
+                        count: 1,
+                        originals: ['level'],
+                        prefix: 'level',
+                        stem: 'level',
+                    },
+                    {
+                        count: 6,
+                        originals: ['uint32_t', 'uint32_t', 'uint32_t', 'uint32_t', 'uint32_t', 'uint32_t'],
+                        prefix: 'uint',
+                        stem: 'uinty2_t',
+                    },
+                    {
+                        count: 1,
+                        originals: ['PackUInt32'],
+                        prefix: 'packuint',
+                        stem: 'packuinty2',
+                    },
+                    {
+                        count: 1,
+                        originals: ['const'],
+                        prefix: 'const',
+                        stem: 'const',
+                    },
+                    {
+                        count: 6,
+                        originals: ['Color', 'color', 'color', 'color', 'color', 'color'],
+                        prefix: 'color',
+                        stem: 'color',
+                    },
+                    {
+                        count: 6,
+                        originals: ['result', 'result', 'result', 'result', 'result', 'result'],
+                        prefix: 'result',
+                        stem: 'result',
+                    },
+                    {
+                        count: 4,
+                        originals: ['static_cast', 'static_cast', 'static_cast', 'static_cast'],
+                        prefix: 'static_cast',
+                        stem: 'static_cast',
+                    },
+                    {
+                        count: 1,
+                        originals: ['return'],
+                        prefix: 'return',
+                        stem: 'return',
+                    },
+                ],
+            },
+        ]
+        for (const testcase of cases) {
+            const actual = userQueryToKeywordQuery(testcase.query)
+            assert.deepStrictEqual(actual, testcase.expected)
+        }
+    })
     it('query to regex', () => {
         const trials: {
             userQuery: string

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
@@ -18,7 +18,7 @@ const fileExtRipgrepParams = ['-Tmarkdown', '-Tyaml', '-Tjson', '-g', '!*.lock',
  * For example, if the original is "cody" and the stem is "codi", the prefix is "cod"
  * - The count is the number of times the keyword appears in the document/query.
  */
-interface Term {
+export interface Term {
     stem: string
     originals: string[]
     prefix: string
@@ -57,6 +57,21 @@ export function userQueryToKeywordQuery(query: string): Term[] {
     const filteredWords = winkUtils.tokens.removeWords(origWords) as string[]
     const terms: { [stem: string]: Term } = {}
     for (const word of filteredWords) {
+        // Ignore ASCII-only strings of length 2 or less
+        if (word.length <= 2) {
+            let skip = true
+            for (let i = 0; i < word.length; i++) {
+                if (word.charCodeAt(i) >= 128) {
+                    // non-ASCII
+                    skip = false
+                    break
+                }
+            }
+            if (skip) {
+                continue
+            }
+        }
+
         const stem = winkUtils.string.stem(word)
         if (terms[stem]) {
             terms[stem].originals.push(word)


### PR DESCRIPTION
Customer bug report:
* [Original report](https://sourcegraph.slack.com/archives/C010U8N6X9A/p1683322690473349?thread_ts=1683297985.821049&cid=C010U8N6X9A)
* Keyword context was taking too long
* `ps aux` revealed several long-running ripgrep jobs, including several for 1- or 2-character queries, which must have had a lot of results

This filters out keywords that are 2 characters or less and composed only of ASCII characters.

Note: in my first initial attempt to address the issue, I thought that batching the keyword query into a single ripgrep invocation would be faster. This turned out not to be the case, I believe because it resulted in more string processing done within the node process.

## Test plan

Tested locally + unit test