### PR TITLE
remove sensitive information from events

### DIFF
--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -1,6 +1,5 @@
 import { compatNavigate } from '@sourcegraph/common'
 import { SubmitSearchParameters } from '@sourcegraph/shared/src/search'
-import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 
 import { eventLogger } from '../tracking/eventLogger'

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -55,13 +55,9 @@ export function submitSearch({
         searchQueryParameter = searchQueryParameter + '&' + preserved
     }
 
-    const queryWithContext = appendContextFilter(query, selectedSearchContextSpec)
     eventLogger.log(
         'SearchSubmitted',
-        {
-            query: queryWithContext,
-            source,
-        },
+        { source },
         { source }
     )
 

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -55,11 +55,7 @@ export function submitSearch({
         searchQueryParameter = searchQueryParameter + '&' + preserved
     }
 
-    eventLogger.log(
-        'SearchSubmitted',
-        { source },
-        { source }
-    )
+    eventLogger.log('SearchSubmitted', { source }, { source })
 
     const state = {
         ...(typeof location.state === 'object' ? location.state : null),

--- a/client/web/src/site-admin/AccessRequestsPage/index.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/index.tsx
@@ -212,7 +212,7 @@ export const AccessRequestsPage: React.FunctionComponent = () => {
             if (!confirm('Are you sure you want to reject the selected access request?')) {
                 return
             }
-            eventLogger.log('AccessRequestRejected', { id })
+            eventLogger.log('AccessRequestRejected')
             rejectAccessRequest({
                 variables: {
                     id,
@@ -249,7 +249,7 @@ export const AccessRequestsPage: React.FunctionComponent = () => {
             if (!confirm('Are you sure you want to approve the selected access request?')) {
                 return
             }
-            eventLogger.log('AccessRequestApproved', { id })
+            eventLogger.log('AccessRequestApproved')
             async function createUserAndApproveRequest(): Promise<void> {
                 const username = await generateUsername(name)
                 const { data } = await createUser({


### PR DESCRIPTION
removes sensitive information within arguments for the following events `searchSubmitted`, `AccessRequestRejected`, `AccessRequestAccepted`

## Test plan
Tested locally
(shows before and after change 2023-05-06 -> before change, 2023-05-09 -> after change)
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/32119652/236986289-dc3333f1-dabc-4f6d-8549-39cad1258c22.png">
