### PR TITLE
cody: don't treat npm packages as hallucinated file paths

### DIFF
--- a/client/cody-shared/src/hallucinations-detector/index.test.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.test.ts
@@ -63,6 +63,18 @@ describe('Hallucinations detector', () => {
                 input: 'pattern/foo/bar/*.ts',
                 output: [],
             },
+            {
+                input: 'remix-run/react',
+                output: [{ fullMatch: 'remix-run/react', pathMatch: 'remix-run/react' }],
+            },
+            {
+                input: '`@remix-run/react`',
+                output: [],
+            },
+            {
+                input: '@remix-run/react',
+                output: [],
+            },
         ]
         for (const { input, output } of cases) {
             const actualOutput = findFilePaths(input)

--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -84,7 +84,7 @@ export function findFilePaths(line: string): { fullMatch: string; pathMatch: str
     return matches
 }
 
-const filePathCharacters = '[\\*\\w\\/\\._-]'
+const filePathCharacters = '[\\@\\*\\w\\/\\._-]'
 
 const filePathRegexpParts = [
     // File path can start with a `, ", ', or a whitespace
@@ -98,9 +98,24 @@ const filePathRegexpParts = [
 const filePathRegexp = new RegExp(filePathRegexpParts.join(''), 'g')
 
 function isFilePathLike(fullMatch: string, pathMatch: string): boolean {
+    if (
+        fullMatch.length >= 1 &&
+        (['"', "'", '`'].includes(fullMatch.charAt(0)) ||
+            ['"', "'", '`'].includes(fullMatch.charAt(fullMatch.length - 1)))
+    ) {
+        if (!fullMatch.endsWith(fullMatch.charAt(0))) {
+            // unbalanced delimiters
+            return false
+        }
+    }
+
     const parts = pathMatch.split(/[/\\]/)
     if (pathMatch.includes('*')) {
         // Probably a glob pattern
+        return false
+    }
+    if (parts.length === 2 && pathMatch.startsWith('@')) {
+        // Probably an npm package
         return false
     }
 


### PR DESCRIPTION
User reported the following misrendering in a Cody response message:

```
The imports are specific, importing only what is needed. For example, useLoaderData is imported instead of the entire @ <span class="token-file token-hallucinated">remix-run/react library.
```

The original string was:
```
`@remix-run/react`
```

Our hallucination detector was parsing out the following:
```
{
  fullMatch: "remix-run/react`",
  pathMatch: "remix-run"
}
```

Updates the detector to:
1. Do not treat 2-part paths that begin with `@` as file paths, since these are likely npm packages.
2. Check for balanced delimiters if the fullMatch begins with `'`, `"`, or <code>`</code>

## Test plan

Added unit tests. Verified locally.