### PR TITLE
Improve Cody Web Chat UI

### DIFF
--- a/client/cody-ui/src/chat/Transcript.module.css
+++ b/client/cody-ui/src/chat/Transcript.module.css
@@ -1,5 +1,6 @@
 .container {
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
 }

--- a/client/cody-ui/src/chat/TranscriptItem.module.css
+++ b/client/cody-ui/src/chat/TranscriptItem.module.css
@@ -64,16 +64,20 @@
     line-height: 150%;
 }
 
+.content p {
+    word-break: break-word;
+}
+
 .content pre {
     padding: calc(var(--spacing) * 0.5);
     overflow-x: auto;
 }
 
-.content>div:first-child>*:first-child {
+.content > div:first-child > *:first-child {
     margin-top: 0;
 }
 
-.content>div:first-child>*:last-child {
+.content > div:first-child > *:last-child {
     margin-bottom: 0;
 }
 

--- a/client/web/src/cody/components/ChatUI/ChatUi.module.scss
+++ b/client/web/src/cody/components/ChatUI/ChatUi.module.scss
@@ -28,6 +28,7 @@
 .transcript-item p > code {
     /* Our syntax highlighter emits colors intended for dark backgrounds only. */
     background-color: var(--code-background);
+    word-break: break-all;
 }
 
 .transcript-item pre {
@@ -76,7 +77,6 @@
 
 .input-row {
     position: sticky;
-    bottom: 0;
     padding: 0.8rem 1rem;
     border-top: 1px solid var(--border-color);
     background-color: var(--input-bg);

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -16,7 +16,8 @@ import styles from './ChatUi.module.scss'
 export const SCROLL_THRESHOLD = 100
 
 export const ChatUI = (): JSX.Element => {
-    const { submitMessage, editMessage, messageInProgress, transcript, getChatContext } = useChatStoreState()
+    const { submitMessage, editMessage, messageInProgress, transcript, getChatContext, transcriptId } =
+        useChatStoreState()
 
     const [formInput, setFormInput] = useState('')
     const [inputHistory, setInputHistory] = useState<string[] | []>([])
@@ -24,6 +25,7 @@ export const ChatUI = (): JSX.Element => {
 
     return (
         <Chat
+            key={transcriptId}
             messageInProgress={messageInProgress}
             messageBeingEdited={messageBeingEdited}
             setMessageBeingEdited={setMessageBeingEdited}
@@ -88,7 +90,7 @@ export const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
 
 export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path }) => <>{path}</>
 
-interface AutoResizableTextAreaProps extends ChatUITextAreaProps {}
+interface AutoResizableTextAreaProps extends ChatUITextAreaProps { }
 
 export const AutoResizableTextArea: React.FC<AutoResizableTextAreaProps> = ({
     value,

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -90,7 +90,7 @@ export const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
 
 export const FileLink: React.FunctionComponent<FileLinkProps> = ({ path }) => <>{path}</>
 
-interface AutoResizableTextAreaProps extends ChatUITextAreaProps { }
+interface AutoResizableTextAreaProps extends ChatUITextAreaProps {}
 
 export const AutoResizableTextArea: React.FC<AutoResizableTextAreaProps> = ({
     value,


### PR DESCRIPTION
Fix a bunch of things in Cody Web UI:
1. Input box overlaps the last chat message.
2. `<code>` in message overflows.
3. Switching to the old chat doesn't scroll down to the latest message.

## Test plan

- visit cody web chat