### PR TITLE
ci: remove bundlesize run target

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -102,14 +102,19 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 	cmds = append(cmds, bazelTestCmds...)
 
+	// DISABLED: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919
+	// this command makes an external request to https://bundlesize-cache.vercel.app
+	// which is not acceptable for such a task.
+	// TODO: @jhchabran
+	//
 	// Run commands
-	runTargets := []string{
-		"//client/web:bundlesize-report",
-	}
-	bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
+	// runTargets := []string{
+	// 	"//client/web:bundlesize-report",
+	// }
+	// bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
 	cmds = append(cmds,
-		bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
-		bk.Cmd(bazelRunCmd),
+		// bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
+		// bk.Cmd(bazelRunCmd),
 		bazelAnnouncef("✅"),
 	)
 


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919 

The bundlesize task performs an external request and the API in question is down. We'll find a long term fix after, we all agree that this should not be happening in CI. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 