### PR TITLE
client: remove unused decoration* vars from stream API

### DIFF
--- a/client/jetbrains/webview/src/search/App.tsx
+++ b/client/jetbrains/webview/src/search/App.tsx
@@ -193,7 +193,6 @@ export const App: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
                     patternType: nextSearch.patternType,
                     trace: undefined,
                     sourcegraphURL: instanceURL + '.api',
-                    decorationContextLines: 0,
                     displayLimit: 200,
                 }
             ).subscribe((searchResults: AggregateStreamingSearchResults) => {

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -472,8 +472,6 @@ export interface StreamSearchOptions {
     featureOverrides?: string[]
     searchMode?: SearchMode
     sourcegraphURL?: string
-    decorationKinds?: string[]
-    decorationContextLines?: number
     displayLimit?: number
     chunkMatches?: boolean
     enableRepositoryMetadata?: boolean
@@ -487,8 +485,6 @@ function initiateSearchStream(
         caseSensitive,
         trace,
         featureOverrides,
-        decorationKinds,
-        decorationContextLines,
         searchMode = SearchMode.Precise,
         displayLimit = 1500,
         sourcegraphURL = '',
@@ -504,9 +500,6 @@ function initiateSearchStream(
             ['v', version],
             ['t', patternType as string],
             ['sm', searchMode.toString()],
-            ['dl', '0'],
-            ['dk', (decorationKinds || ['html']).join('|')],
-            ['dc', (decorationContextLines || '1').toString()],
             ['display', displayLimit.toString()],
             ['cm', chunkMatches ? 't' : 'f'],
         ]


### PR DESCRIPTION
The backend never used these variables. See related PR https://github.com/sourcegraph/sourcegraph/pull/51564/

Test Plan: CI