### PR TITLE
embeddings: fix out of bounds error

### DIFF
--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     srcs = [
         "context_detection_test.go",
         "repo_embedding_index_cache_test.go",
+        "search_test.go",
     ],
     embed = [":shared"],
     deps = [
@@ -68,6 +69,7 @@ go_test(
         "//internal/api",
         "//internal/database",
         "//internal/types",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -108,7 +108,7 @@ func filterAndHydrateContent(
 		startLine := max(0, min(len(lines), result.StartLine))
 		endLine := max(0, min(len(lines), result.EndLine))
 
-		content := strings.Join(lines[result.StartLine:result.EndLine], "\n")
+		content := strings.Join(lines[startLine:endLine], "\n")
 
 		var debugString string
 		if debug {

--- a/enterprise/cmd/embeddings/shared/search_test.go
+++ b/enterprise/cmd/embeddings/shared/search_test.go
@@ -1,0 +1,38 @@
+package shared
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func TestFilterAndHydrateContent_emptyFile(t *testing.T) {
+	// Set up test data
+	repoName := api.RepoName("example/repo")
+	revision := api.CommitID("abc123")
+	debug := false
+	unfiltered := []embeddings.SimilaritySearchResult{
+		{
+			RepoEmbeddingRowMetadata: embeddings.RepoEmbeddingRowMetadata{
+				FileName:  "file.txt",
+				StartLine: 5,
+				EndLine:   20,
+			},
+		},
+	}
+
+	// Define a mock readFile function that returns an empty string
+	readFile := func(ctx context.Context, repoName api.RepoName, revision api.CommitID, fileName string) ([]byte, error) {
+		return []byte{}, nil
+	}
+
+	filtered := filterAndHydrateContent(context.Background(), log.NoOp(), repoName, revision, readFile, debug, unfiltered)
+
+	if len(filtered) != 1 {
+		t.Errorf("Expected 1 filtered result, but got %d elements", len(filtered))
+	}
+}


### PR DESCRIPTION
Fixes a bug that was introduced in https://github.com/sourcegraph/sourcegraph/pull/51476

We calculated the correct bounds but failed to use them for "content".



## Test plan
- new unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
