### PR TITLE
llmproxy: Make dotcom API URL configurable

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/dotcom/dotcom.go
+++ b/enterprise/cmd/llm-proxy/internal/dotcom/dotcom.go
@@ -4,14 +4,22 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/Khan/genqlient/graphql"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-const endpoint = "https://sourcegraph.com/.api/graphql"
+var endpoint = env.Get("LLM_PROXY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
+
+func init() {
+	// Poor mans startup verify check.
+	mustParseURL(endpoint)
+}
 
 // NewClient returns a new GraphQL client for the Sourcegraph.com API authenticated
 // with the given Sourcegraph access token.
@@ -74,4 +82,12 @@ type tokenAuthTransport struct {
 func (t *tokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", t.token))
 	return t.wrapped.RoundTrip(req)
+}
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse URL %q: %s", s, err.Error()))
+	}
+	return u
 }

--- a/enterprise/cmd/llm-proxy/shared/config.go
+++ b/enterprise/cmd/llm-proxy/shared/config.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -12,6 +13,7 @@ type Config struct {
 	Address string
 
 	Dotcom struct {
+		URL         string
 		AccessToken string
 	}
 
@@ -27,7 +29,17 @@ type Config struct {
 func (c *Config) Load() {
 	c.Address = c.Get("LLM_PROXY_ADDR", ":9992", "Address to serve LLM proxy on.")
 	c.Dotcom.AccessToken = c.Get("LLM_PROXY_DOTCOM_ACCESS_TOKEN", "", "The Sourcegraph.com access token to be used.")
+	c.Dotcom.URL = c.Get("LLM_PROXY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
 	c.Anthropic.AccessToken = c.Get("LLM_PROXY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 	c.AllowAnonymous = c.GetBool("LLM_PROXY_ALLOW_ANONYMOUS", "false", "Allow anonymous access to LLM proxy.")
 	c.SourcesSyncInterval = c.GetInterval("LLM_PROXY_SOURCES_SYNC_INTERVAL", "2m", "The interval at which to sync actor sources.")
+}
+
+func (c *Config) Validate() error {
+	_, err := url.Parse(c.Dotcom.URL)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -47,7 +47,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		productsubscription.NewSource(
 			obctx.Logger,
 			rcache.New("product-subscriptions"),
-			dotcom.NewClient(config.Dotcom.AccessToken)),
+			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken)),
 	}
 
 	// Set up our handler chain, which is run from the bottom up

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1123,6 +1123,7 @@ commandsets:
       - zoekt-web-0
       - zoekt-web-1
       - caddy
+  # If you modify this command set, please consider also updating the dotcom runset.
   enterprise: &enterprise_set
     requiresDevPrivate: true
     checks:
@@ -1157,7 +1158,32 @@ commandsets:
       EXTSVC_CONFIG_FILE: ''
 
   dotcom:
-    <<: *enterprise_set
+    # This is 95% the enterprise runset, with the addition of LLM-proxy.
+    requiresDevPrivate: true
+    checks:
+      - docker
+      - redis
+      - postgres
+      - git
+    commands:
+      - frontend
+      - worker
+      - repo-updater
+      - web
+      - gitserver-0
+      - gitserver-1
+      - searcher
+      - symbols
+      - caddy
+      - docsite
+      - syntax-highlighter
+      - github-proxy
+      - zoekt-index-0
+      - zoekt-index-1
+      - zoekt-web-0
+      - zoekt-web-1
+      - blobstore
+      - llm-proxy
     env:
       SOURCEGRAPHDOTCOM_MODE: true
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -396,6 +396,11 @@ commands:
 
       go build -gcflags="$GCFLAGS" -o .bin/llm-proxy github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy
     checkBinary: .bin/llm-proxy
+    env:
+      LLM_PROXY_ANTHROPIC_ACCESS_TOKEN: foobar
+      LLM_PROXY_DOTCOM_ACCESS_TOKEN: foobar
+      LLM_PROXY_DOTCOM_API_URL: https://sourcegraph.test:3443/.api/graphql
+      SRC_LOG_LEVEL: dbug
     watch:
       - lib
       - internal
@@ -1426,9 +1431,6 @@ commandsets:
       - redis
     commands:
       - llm-proxy
-    env:
-      LLM_PROXY_ANTHROPIC_ACCESS_TOKEN: foobar
-      LLM_PROXY_DOTCOM_ACCESS_TOKEN: foobar
 
 tests:
   # These can be run with `sg test [name]`


### PR DESCRIPTION
This helps with local dev :)

## Test plan

Verified it can talk to a dev dotcom instance. 