### PR TITLE
pnpm: remove update notifier message

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -16,3 +16,6 @@ public-hoist-pattern[]=global
 public-hoist-pattern[]=*eslint*
 
 auto-install-peers=true
+
+# We manage the version of pnpm so the update warnings based on NPM is inaccurate.
+update-notifier=false


### PR DESCRIPTION
Having a bit fat dialog printed everytime I run pnpm install is a bit annoying. I believe we manage the version used, so we don't actually want to be using the latest on NPM. IE this dialog was misleading.

Test Plan: pnpm install didn't show the upgrade dialog.
