### PR TITLE
nix: pass through NIX_LD and NIX_LD_LIBRARY_PATH from cargo-bazel

### DIFF
--- a/dev/nix/001-rules-rust-cargo-bazel-env.patch
+++ b/dev/nix/001-rules-rust-cargo-bazel-env.patch
@@ -1,5 +1,5 @@
 diff --git a/src/lockfile.rs b/src/lockfile.rs
-index 1ff96f43..53c01882 100644
+index 8f9ebd83..b4842c70 100644
 --- a/src/lockfile.rs
 +++ b/src/lockfile.rs
 @@ -131,7 +131,7 @@ impl Digest {
@@ -7,7 +7,20 @@ index 1ff96f43..53c01882 100644
 
      pub fn bin_version(binary: &Path) -> Result<String> {
 -        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT")];
-+        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT"), OsStr::new("LD_LIBRARY_PATH")];
++        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT"), OsStr::new("NIX_LD_LIBRARY_PATH"), OsStr::new("NIX_LD")];
          let env = std::env::vars_os().filter(|(var, _)| safe_vars.contains(&var.as_os_str()));
 
          let output = Command::new(binary)
+diff --git a/src/metadata.rs b/src/metadata.rs
+index c84bfbb8..9ef2d13d 100644
+--- a/src/metadata.rs
++++ b/src/metadata.rs
+@@ -150,6 +150,8 @@ impl Cargo {
+                 "sparse".into(),
+             );
+         }
++        map.insert("NIX_LD".into(), env::var("NIX_LD").unwrap_or_default());
++        map.insert("NIX_LD_LIBRARY_PATH".into(), env::var("NIX_LD_LIBRARY_PATH").unwrap_or_default());
+         Ok(map)
+     }
+ }

--- a/dev/nix/001-rules-rust-cargo-bazel-env.patch
+++ b/dev/nix/001-rules-rust-cargo-bazel-env.patch
@@ -7,7 +7,7 @@ index 8f9ebd83..b4842c70 100644
 
      pub fn bin_version(binary: &Path) -> Result<String> {
 -        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT")];
-+        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT"), OsStr::new("NIX_LD_LIBRARY_PATH"), OsStr::new("NIX_LD")];
++        let safe_vars = [OsStr::new("HOMEDRIVE"), OsStr::new("PATHEXT"), OsStr::new("NIX_LD_LIBRARY_PATH"), OsStr::new("NIX_LD"), OsStr::new("LD_LIBRARY_PATH")];
          let env = std::env::vars_os().filter(|(var, _)| safe_vars.contains(&var.as_os_str()));
 
          let output = Command::new(binary)
@@ -15,12 +15,13 @@ diff --git a/src/metadata.rs b/src/metadata.rs
 index c84bfbb8..9ef2d13d 100644
 --- a/src/metadata.rs
 +++ b/src/metadata.rs
-@@ -150,6 +150,8 @@ impl Cargo {
+@@ -151,6 +150,9 @@ impl Cargo {
                  "sparse".into(),
              );
          }
 +        map.insert("NIX_LD".into(), env::var("NIX_LD").unwrap_or_default());
 +        map.insert("NIX_LD_LIBRARY_PATH".into(), env::var("NIX_LD_LIBRARY_PATH").unwrap_or_default());
++        map.insert("LD_LIBRARY_PATH".into(), env::var("LD_LIBRARY_PATH").unwrap_or_default());
          Ok(map)
      }
  }


### PR DESCRIPTION
When using nix-ld instead of symlinking /lib64/ld-linux-x86-64.so.2 to glibc's ld.so, we need to pass through NIX_LD and NIX_LD_LIBRARY_PATH for it to work. cargo-bazel doesnt pass through stuff by default, so we have to do it ourselves

## Test plan

N/A, nix stuff