### PR TITLE
Refactor: Make introducing directory/repo graphQL API easy

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -195,7 +195,7 @@ func (r *ownResolver) ownershipConnection(
 ) (*ownershipConnectionResolver, error) {
 	// 1. Order ownerships for deterministic pagination:
 
-	// TODO: Introduce deterministic ordering based on priority of signals.
+	// TODO(#51636): Introduce deterministic ordering based on priority of signals.
 	sort.Slice(ownerships, func(i, j int) bool {
 		iText := ownerships[i].resolvedOwner.Identifier()
 		jText := ownerships[j].resolvedOwner.Identifier()

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
@@ -104,89 +105,21 @@ func (r *ownResolver) GitBlobOwnership(
 	if err := areOwnEndpointsAvailable(ctx); err != nil {
 		return nil, err
 	}
-	cursor, err := graphqlutil.DecodeCursor(args.After)
+
+	// Evaluate CODEOWNERS rules.
+	ownerships, err := r.computeCodeowners(ctx, blob)
 	if err != nil {
 		return nil, err
 	}
-	repo := blob.Repository()
-	repoID, repoName := repo.IDInt32(), repo.RepoName()
-	commitID := api.CommitID(blob.Commit().OID())
-	ownService := r.ownService()
-	rs, err := ownService.RulesetForRepo(ctx, repoName, repoID, commitID)
+
+	// Retrieve recent contributors signals.
+	contribResolvers, err := computeRecentContributorSignals(ctx, r.db, blob.Path(), blob.Repository().IDInt32())
 	if err != nil {
 		return nil, err
 	}
-	// No ruleset found.
-	if rs == nil {
-		return &ownershipConnectionResolver{db: r.db}, nil
-	}
+	ownerships = append(ownerships, contribResolvers...)
 
-	var total int
-	var next *string
-
-	var ownerships []graphqlbackend.OwnershipResolver
-	var resolvedOwners []codeowners.ResolvedOwner
-
-	rule := rs.Match(blob.Path())
-	// No match found.
-	if rule != nil {
-		owners := rule.GetOwner()
-		sort.Slice(owners, func(i, j int) bool {
-			iText := ownerText(owners[i])
-			jText := ownerText(owners[j])
-			return iText < jText
-		})
-		total = len(owners)
-		for cursor != "" && len(owners) > 0 && ownerText(owners[0]) != cursor {
-			owners = owners[1:]
-		}
-		if args.First != nil && len(owners) > int(*args.First) {
-			cursor := ownerText(owners[*args.First])
-			next = &cursor
-			owners = owners[:*args.First]
-		}
-		resolvedOwners, err = ownService.ResolveOwnersWithType(ctx, owners)
-		if err != nil {
-			return nil, err
-		}
-		ownerships = make([]graphqlbackend.OwnershipResolver, 0, len(resolvedOwners))
-		for _, ro := range resolvedOwners {
-
-			res := &codeownersFileEntryResolver{
-				db:              r.db,
-				gitserverClient: r.gitserver,
-				source:          rs.GetSource(),
-				repo:            blob.Repository(),
-				matchLineNumber: rule.GetLineNumber(),
-			}
-
-			reasons := []graphqlbackend.OwnershipReasonResolver{
-				&ownershipReasonResolver{res},
-			}
-
-			ownerships = append(ownerships, &ownershipResolver{
-				db:            r.db,
-				resolvedOwner: ro,
-				reasons:       reasons,
-			})
-		}
-	}
-
-	contribResolvers, err := computeRecentContributorSignals(ctx, r.db, blob.Path(), repoID)
-	if err != nil {
-		return nil, err
-	}
-	for _, resolver := range contribResolvers {
-		ownerships = append(ownerships, resolver)
-	}
-	total += len(contribResolvers)
-
-	return &ownershipConnectionResolver{
-		db:             r.db,
-		total:          total,
-		next:           next,
-		ownerships:     ownerships,
-	}, nil
+	return r.ownershipConnection(args, ownerships)
 }
 
 func (r *ownResolver) PersonOwnerField(_ *graphqlbackend.PersonResolver) string {
@@ -214,11 +147,95 @@ func (r *ownResolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
 	}
 }
 
+// computeCodeowners evaluates the codeowners file (if any) against given file (blob)
+// and returns resolvers for identified owners.
+func (r *ownResolver) computeCodeowners(ctx context.Context, blob *graphqlbackend.GitTreeEntryResolver) ([]*ownershipResolver, error) {
+	repo := blob.Repository()
+	repoID, repoName := repo.IDInt32(), repo.RepoName()
+	commitID := api.CommitID(blob.Commit().OID())
+	var ownerships []*ownershipResolver
+	rs, err := r.ownService().RulesetForRepo(ctx, repoName, repoID, commitID)
+	if err != nil {
+		return nil, err
+	}
+	var rule *codeownerspb.Rule
+	if rs != nil {
+		rule = rs.Match(blob.Path())
+	}
+	if rule != nil {
+		owners := rule.GetOwner()
+		resolvedOwners, err := r.ownService().ResolveOwnersWithType(ctx, owners)
+		if err != nil {
+			return nil, err
+		}
+		for _, ro := range resolvedOwners {
+			res := &codeownersFileEntryResolver{
+				db:              r.db,
+				gitserverClient: r.gitserver,
+				source:          rs.GetSource(),
+				repo:            blob.Repository(),
+				matchLineNumber: rule.GetLineNumber(),
+			}
+			ownerships = append(ownerships, &ownershipResolver{
+				db:            r.db,
+				resolvedOwner: ro,
+				reasons: []graphqlbackend.OwnershipReasonResolver{
+					&ownershipReasonResolver{res},
+				},
+			})
+		}
+	}
+	return ownerships, nil
+}
+
+// ownershipConnection handles ordering and pagination of given set of ownerships.
+func (r *ownResolver) ownershipConnection(
+	args graphqlbackend.ListOwnershipArgs,
+	ownerships []*ownershipResolver,
+) (*ownershipConnectionResolver, error) {
+	// 1. Order ownerships for deterministic pagination:
+
+	// TODO: Introduce deterministic ordering based on priority of signals.
+	sort.Slice(ownerships, func(i, j int) bool {
+		iText := ownerships[i].resolvedOwner.Identifier()
+		jText := ownerships[j].resolvedOwner.Identifier()
+		return iText < jText
+	})
+	total := len(ownerships)
+
+	// 2. Apply pagination from the parameter & compute next cursor:
+	cursor, err := graphqlutil.DecodeCursor(args.After)
+	if err != nil {
+		return nil, err
+	}
+	for cursor != "" && len(ownerships) > 0 && ownerships[0].resolvedOwner.Identifier() != cursor {
+		ownerships = ownerships[1:]
+	}
+	var next *string
+	if args.First != nil && len(ownerships) > int(*args.First) {
+		c := ownerships[*args.First].resolvedOwner.Identifier()
+		next = &c
+		ownerships = ownerships[:*args.First]
+	}
+
+	// 3. Assemble the connection resolver object:
+	var rs []graphqlbackend.OwnershipResolver
+	for _, o := range ownerships {
+		rs = append(rs, o)
+	}
+	return &ownershipConnectionResolver{
+		db:         r.db,
+		total:      total,
+		next:       next,
+		ownerships: rs,
+	}, nil
+}
+
 type ownershipConnectionResolver struct {
-	db             edb.EnterpriseDB
-	total          int
-	next           *string
-	ownerships     []graphqlbackend.OwnershipResolver
+	db         edb.EnterpriseDB
+	total      int
+	next       *string
+	ownerships []graphqlbackend.OwnershipResolver
 }
 
 func (r *ownershipConnectionResolver) TotalCount(_ context.Context) (int32, error) {

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -185,7 +185,6 @@ func (r *ownResolver) GitBlobOwnership(
 		db:             r.db,
 		total:          total,
 		next:           next,
-		resolvedOwners: resolvedOwners,
 		ownerships:     ownerships,
 	}, nil
 }
@@ -219,7 +218,6 @@ type ownershipConnectionResolver struct {
 	db             edb.EnterpriseDB
 	total          int
 	next           *string
-	resolvedOwners []codeowners.ResolvedOwner
 	ownerships     []graphqlbackend.OwnershipResolver
 }
 

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -635,6 +635,12 @@ func TestOwnership_WithSignals(t *testing.T) {
 							blob(path: $currentPath) {
 								ownership {
 									nodes {
+										owner {
+											...on Person {
+												displayName
+												email
+											}
+										}
 										reasons {
 											...CodeownersFileEntryFields
 											... on RecentContributorOwnershipSignal {
@@ -656,6 +662,10 @@ func TestOwnership_WithSignals(t *testing.T) {
 						"ownership": {
 							"nodes": [
 								{
+									"owner": {
+										"displayName": "js-owner",
+										"email": ""
+									},
 									"reasons": [
 										{
 											"title": "codeowners",
@@ -669,6 +679,10 @@ func TestOwnership_WithSignals(t *testing.T) {
 									]
 								},
 								{
+									"owner": {
+										"displayName": "santa claus",
+										"email": "santa@northpole.com"
+									},
 									"reasons": [
 										{
 											"title": "recent contributor",


### PR DESCRIPTION
Part of #50800

Refactoring of graph QL resolver for ownership - no behavior changes.

This makes it easier to implement similar API for tree resolver (directory) and commit resolver (repo view), because the same components that are extracted here can be directly reused. At the end of the day pagination for connection and signal computation can work the same for all views.

Includes the following:

- Extract `computeCodeowners` similar to `computeRecentContributorSignals`,
- Extract `ownershipConnection` that handles ordering and pagination for both code owners and signals,
- _nit_ Remove `resolvedOwners` from the connection object - it was not needed.

Caveat: Filed [#51636](https://github.com/sourcegraph/sourcegraph/issues/51636) to track ordering improvements. For now the connection ordering is identifier based and alphabetical. This needs to be improved for better UX.

## Test plan

Extend the signals test to make sure the refactoring does not break identity of owner for signals.
