### PR TITLE
Cody: catch error during secret getting

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -487,6 +487,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Save Login state to webview
      */
     public async sendLogin(isValid: boolean): Promise<void> {
+        this.sendEvent('token', 'Set')
         await vscode.commands.executeCommand('setContext', 'cody.activated', isValid)
         if (isValid) {
             this.sendEvent('auth', 'login')
@@ -572,6 +573,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      */
     public sendEvent(event: string, value: string): void {
         const isPrivateInstance = new URL(this.config.serverEndpoint).href !== DOTCOM_URL.href
+        const endpointUri = { serverEndpoint: this.config.serverEndpoint }
         switch (event) {
             case 'feedback':
                 // Only include context for dot com users with connected codebase
@@ -582,14 +584,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 )
                 break
             case 'token':
-                logEvent(`CodyVSCodeExtension:cody${value}AccessToken:clicked`)
+                logEvent(`CodyVSCodeExtension:cody${value}AccessToken:clicked`, endpointUri, endpointUri)
                 break
             case 'auth':
-                logEvent(`CodyVSCodeExtension:${value}:clicked`)
+                logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
                 break
             // aditya combine this with above statemenet for auth or click
             case 'click':
-                logEvent(`CodyVSCodeExtension:${value}:clicked`)
+                logEvent(`CodyVSCodeExtension:${value}:clicked`, endpointUri, endpointUri)
                 break
         }
     }

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -48,5 +48,6 @@ export async function updateConfiguration(configKey: string, configValue: string
 
 export const getFullConfig = async (secretStorage: SecretStorage): Promise<ConfigurationWithAccessToken> => {
     const config = getConfiguration(vscode.workspace.getConfiguration())
-    return { ...config, accessToken: await getAccessToken(secretStorage) }
+    const accessToken = (await getAccessToken(secretStorage)) || null
+    return { ...config, accessToken }
 }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -137,13 +137,11 @@ const register = async (
             logEvent('CodyVSCodeExtension:codyToggleEnabled:clicked')
         }),
         // Access token
+        // This is only used in configuration tests
         vscode.commands.registerCommand('cody.set-access-token', async (args: any[]) => {
-            const tokenInput = args?.length ? (args[0] as string) : await vscode.window.showInputBox()
-            if (tokenInput === undefined || tokenInput === '') {
-                return
+            if (args?.length && (args[0] as string)) {
+                await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, args[0])
             }
-            await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, tokenInput)
-            logEvent('CodyVSCodeExtension:codySetAccessToken:clicked')
         }),
         vscode.commands.registerCommand('cody.delete-access-token', async () => {
             await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
@@ -176,18 +174,13 @@ const register = async (
                 await workspaceConfig.update('cody.serverEndpoint', DOTCOM_URL.href, vscode.ConfigurationTarget.Global)
                 const token = new URLSearchParams(uri.query).get('code')
                 if (token && token.length > 8) {
-                    await context.secrets.store(CODY_ACCESS_TOKEN_SECRET, token)
+                    await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, token)
                     const isAuthed = await isValidLogin({
                         serverEndpoint: DOTCOM_URL.href,
                         accessToken: token,
                         customHeaders: config.customHeaders,
                     })
                     await chatProvider.sendLogin(isAuthed)
-                    logEvent(
-                        'CodyVSCodeExtension:codySetAccessToken:clicked',
-                        { serverEndpoint: config.serverEndpoint },
-                        { serverEndpoint: config.serverEndpoint }
-                    )
                     void vscode.window.showInformationMessage('Token has been retreived and updated successfully')
                 }
             },

--- a/client/cody/src/secret-storage.ts
+++ b/client/cody/src/secret-storage.ts
@@ -3,8 +3,13 @@ import * as vscode from 'vscode'
 export const CODY_ACCESS_TOKEN_SECRET = 'cody.access-token'
 
 export async function getAccessToken(secretStorage: SecretStorage): Promise<string | null> {
-    const token = await secretStorage.get(CODY_ACCESS_TOKEN_SECRET)
-    return token ?? null
+    try {
+        return (await secretStorage.get(CODY_ACCESS_TOKEN_SECRET)) || null
+    } catch (error) {
+        await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
+        void vscode.window.showErrorMessage(`Failed to retreive access token for Cody: ${error}`)
+        return null
+    }
 }
 
 export interface SecretStorage {


### PR DESCRIPTION
RE: https://github.com/sourcegraph/sourcegraph/issues/51573

Users have been reporting a similar issue where failing to retrieve access token from secret storage would stop Cody from initiating the webview. 

I was not able to reproduce the issue but in keegan's issue, he mentioned that deleting the token before registering the webview worked, so  I added try catch to the function where we retrieve the access token, and set to return `null` on errors and remove the corrupted token from their storage automatically.

Expected behavior:
- catch error and inform the user with the vscode system notification
- Remove corrupted token from secret storage
- Set token value to null so that it won't block the webview from starting


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Unit tests are passing.