### PR TITLE
own: add GraphQL resolver for recent view signal.

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -11,6 +11,7 @@ import {
     CodeownersFileEntryFields,
     OwnerFields,
     RecentContributorOwnershipSignalFields,
+    RecentViewOwnershipSignalFields,
 } from '../../../graphql-operations'
 import { PersonLink } from '../../../person/PersonLink'
 
@@ -21,7 +22,7 @@ interface Props {
     reasons: OwnershipReason[]
 }
 
-type OwnershipReason = CodeownersFileEntryFields | RecentContributorOwnershipSignalFields
+type OwnershipReason = CodeownersFileEntryFields | RecentContributorOwnershipSignalFields | RecentViewOwnershipSignalFields
 
 export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons }) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(false)

--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -22,7 +22,10 @@ interface Props {
     reasons: OwnershipReason[]
 }
 
-type OwnershipReason = CodeownersFileEntryFields | RecentContributorOwnershipSignalFields | RecentViewOwnershipSignalFields
+type OwnershipReason =
+    | CodeownersFileEntryFields
+    | RecentContributorOwnershipSignalFields
+    | RecentViewOwnershipSignalFields
 
 export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons }) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(false)

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -44,6 +44,11 @@ export const FETCH_OWNERS = gql`
         description
     }
 
+    fragment RecentViewOwnershipSignalFields on RecentViewOwnershipSignal {
+        title
+        description
+    }
+
     query FetchOwnership($repo: ID!, $revision: String!, $currentPath: String!) {
         node(id: $repo) {
             ... on Repository {
@@ -57,6 +62,7 @@ export const FETCH_OWNERS = gql`
                                 reasons {
                                     ...CodeownersFileEntryFields
                                     ...RecentContributorOwnershipSignalFields
+                                    ...RecentViewOwnershipSignalFields
                                 }
                             }
                         }

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -61,6 +61,7 @@ type OwnershipReasonResolver interface {
 	SimpleOwnReasonResolver
 	ToCodeownersFileEntry() (CodeownersFileEntryResolver, bool)
 	ToRecentContributorOwnershipSignal() (RecentContributorOwnershipSignalResolver, bool)
+	ToRecentViewOwnershipSignal() (RecentViewOwnershipSignalResolver, bool)
 }
 
 type SimpleOwnReasonResolver interface {
@@ -76,6 +77,11 @@ type CodeownersFileEntryResolver interface {
 }
 
 type RecentContributorOwnershipSignalResolver interface {
+	Title() (string, error)
+	Description() (string, error)
+}
+
+type RecentViewOwnershipSignalResolver interface {
 	Title() (string, error)
 	Description() (string, error)
 }

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -88,14 +88,29 @@ enum OwnershipReasonType {
 }
 
 """
-A union of all the different ownership reasons
+A union of all the different ownership reasons.
 """
-union OwnershipReason = CodeownersFileEntry | RecentContributorOwnershipSignal
+union OwnershipReason = CodeownersFileEntry | RecentContributorOwnershipSignal | RecentViewOwnershipSignal
 
 """
-A signal derived from recent code contributors
+A signal derived from recent code contributors.
 """
 type RecentContributorOwnershipSignal {
+    """
+    Descriptive title to display in the UI for the determination.
+    """
+    title: String!
+
+    """
+    More detailed description to display in the UI for the determination.
+    """
+    description: String!
+}
+
+"""
+A signal derived from recent code file views.
+"""
+type RecentViewOwnershipSignal {
     """
     Descriptive title to display in the UI for the determination.
     """

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -33,6 +33,16 @@ func NewPersonResolver(db database.DB, name, email string, includeUserInfo bool)
 	}
 }
 
+func NewPersonResolverFromUser(db database.DB, email string, user *types.User) *PersonResolver {
+	return &PersonResolver{
+		db:    db,
+		user:  user,
+		email: email,
+		// We don't need to query for user.
+		includeUserInfo: false,
+	}
+}
+
 // resolveUser resolves the person to a user (using the email address). Not all persons can be
 // resolved to a user.
 func (r *PersonResolver) resolveUser(ctx context.Context) (*types.User, error) {

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
 	"github.com/sourcegraph/log"
 
@@ -47,6 +48,8 @@ var (
 	_ graphqlbackend.OwnershipReasonResolver                  = &ownershipReasonResolver{}
 	_ graphqlbackend.RecentContributorOwnershipSignalResolver = &recentContributorOwnershipSignal{}
 	_ graphqlbackend.SimpleOwnReasonResolver                  = &recentContributorOwnershipSignal{}
+	_ graphqlbackend.RecentViewOwnershipSignalResolver        = &recentViewOwnershipSignal{}
+	_ graphqlbackend.SimpleOwnReasonResolver                  = &recentViewOwnershipSignal{}
 	_ graphqlbackend.SimpleOwnReasonResolver                  = &codeownersFileEntryResolver{}
 )
 
@@ -87,6 +90,13 @@ func (o *ownershipReasonResolver) ToRecentContributorOwnershipSignal() (graphqlb
 	return nil, false
 }
 
+func (o *ownershipReasonResolver) ToRecentViewOwnershipSignal() (graphqlbackend.RecentViewOwnershipSignalResolver, bool) {
+	if res, ok := o.resolver.(*recentViewOwnershipSignal); ok {
+		return res, true
+	}
+	return nil, false
+}
+
 func ownerText(o *codeownerspb.Owner) string {
 	if o == nil {
 		return ""
@@ -118,6 +128,13 @@ func (r *ownResolver) GitBlobOwnership(
 		return nil, err
 	}
 	ownerships = append(ownerships, contribResolvers...)
+
+	// Retrieve recent view signals.
+	viewerResolvers, err := computeRecentViewSignals(ctx, r.logger, r.db, blob.Path(), repoID)
+	if err != nil {
+		return nil, err
+	}
+	ownerships = append(ownerships, viewerResolvers...)
 
 	return r.ownershipConnection(args, ownerships)
 }
@@ -360,7 +377,7 @@ func (g *recentContributorOwnershipSignal) Title() (string, error) {
 }
 
 func (g *recentContributorOwnershipSignal) Description() (string, error) {
-	return "Owner is associated because they are have contributed to this file in the last 90 days.", nil
+	return "Owner is associated because they have contributed to this file in the last 90 days.", nil
 }
 
 func computeRecentContributorSignals(ctx context.Context, db edb.EnterpriseDB, path string, repoID api.RepoID) (results []*ownershipResolver, err error) {
@@ -378,7 +395,7 @@ func computeRecentContributorSignals(ctx context.Context, db edb.EnterpriseDB, p
 			},
 			reasons: []graphqlbackend.OwnershipReasonResolver{&ownershipReasonResolver{&recentContributorOwnershipSignal{}}},
 		}
-		user, err := identifyUser(ctx, db, author.AuthorEmail)
+		user, err := db.Users().GetByVerifiedEmail(ctx, author.AuthorEmail)
 		if err == nil {
 			// if we don't get an error (meaning we can match) we will add it to the resolver, otherwise use the contributor data
 			em := author.AuthorEmail
@@ -394,6 +411,64 @@ func computeRecentContributorSignals(ctx context.Context, db edb.EnterpriseDB, p
 	return results, nil
 }
 
-func identifyUser(ctx context.Context, db database.DB, email string) (*types.User, error) {
-	return db.Users().GetByVerifiedEmail(ctx, email)
+type recentViewOwnershipSignal struct {
+	total int32
+}
+
+func (v *recentViewOwnershipSignal) Title() (string, error) {
+	return "recent view", nil
+}
+
+func (v *recentViewOwnershipSignal) Description() (string, error) {
+	return "Owner is associated because they have viewed this file in the last 90 days.", nil
+}
+
+func computeRecentViewSignals(ctx context.Context, logger log.Logger, db edb.EnterpriseDB, path string, repoID api.RepoID) (results []*ownershipResolver, err error) {
+	summaries, err := db.RecentViewSignal().List(ctx, database.ListRecentViewSignalOpts{Path: path, RepoID: repoID})
+	if err != nil {
+		return nil, errors.Wrap(err, "list recent view signals")
+	}
+
+	fetchedUsers := make(map[int32]*types.User)
+	userEmails := make(map[int32]string)
+
+	for _, summary := range summaries {
+		var user *types.User
+		var email string
+		userID := summary.UserID
+		if fetchedUser, found := fetchedUsers[userID]; found {
+			user = fetchedUser
+			email = userEmails[userID]
+		} else {
+			userFromDB, err := db.Users().GetByID(ctx, userID)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting user")
+			}
+			primaryEmail, _, err := db.UserEmails().GetPrimaryEmail(ctx, userID)
+			if err != nil {
+				if errcode.IsNotFound(err) {
+					logger.Warn("Cannot find a primary email", log.Int32("userID", userID))
+				} else {
+					return nil, errors.Wrap(err, "getting user primary email")
+				}
+			}
+			user = userFromDB
+			email = primaryEmail
+			fetchedUsers[userID] = userFromDB
+			userEmails[userID] = primaryEmail
+		}
+		// TODO(sashaostrikov): what to do if email here is empty
+		res := ownershipResolver{
+			db: db,
+			resolvedOwner: &codeowners.Person{
+				User:         user,
+				Email:        email,
+				PrimaryEmail: &email,
+				Handle:       user.Username,
+			},
+			reasons: []graphqlbackend.OwnershipReasonResolver{&ownershipReasonResolver{&recentViewOwnershipSignal{}}},
+		}
+		results = append(results, &res)
+	}
+	return results, nil
 }

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -121,6 +121,7 @@ func TestBlobOwnershipPanelQueryPersonUnresolved(t *testing.T) {
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.RecentContributionSignalsFunc.SetDefaultReturn(database.NewMockRecentContributionSignalStore())
+	db.RecentViewSignalFunc.SetDefaultReturn(database.NewMockRecentViewSignalStore())
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
 	backend.Mocks.Repos.ResolveRev = func(_ context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
@@ -220,6 +221,7 @@ func TestBlobOwnershipPanelQueryIngested(t *testing.T) {
 	fakeDB := fakedb.New()
 	db := database.NewMockDB()
 	db.RecentContributionSignalsFunc.SetDefaultReturn(database.NewMockRecentContributionSignalStore())
+	db.RecentViewSignalFunc.SetDefaultReturn(database.NewMockRecentViewSignalStore())
 	fakeDB.Wire(db)
 	repoID := api.RepoID(1)
 	own := fakeOwnService{
@@ -331,6 +333,7 @@ func TestBlobOwnershipPanelQueryTeamResolved(t *testing.T) {
 	db.UsersFunc.SetDefaultReturn(fakeDB.UserStore)
 	db.CodeownersFunc.SetDefaultReturn(enterprisedb.NewMockCodeownersStore())
 	db.RecentContributionSignalsFunc.SetDefaultReturn(database.NewMockRecentContributionSignalStore())
+	db.RecentViewSignalFunc.SetDefaultReturn(database.NewMockRecentViewSignalStore())
 	own := own.NewService(git, db)
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
@@ -501,6 +504,7 @@ func TestOwnershipPagination(t *testing.T) {
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	db.RecentContributionSignalsFunc.SetDefaultReturn(database.NewMockRecentContributionSignalStore())
+	db.RecentViewSignalFunc.SetDefaultReturn(database.NewMockRecentViewSignalStore())
 	repos.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
 	backend.Mocks.Repos.ResolveRev = func(_ context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
 		return "42", nil

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -582,8 +582,9 @@ func TestOwnership_WithSignals(t *testing.T) {
 
 	recentContribStore := database.NewMockRecentContributionSignalStore()
 	santaEmail := "santa@northpole.com"
+	santaName := "santa claus"
 	recentContribStore.FindRecentAuthorsFunc.SetDefaultReturn([]database.RecentContributorSummary{{
-		AuthorName:        "santa claus",
+		AuthorName:        santaName,
 		AuthorEmail:       santaEmail,
 		ContributionCount: 5,
 	}}, nil)
@@ -618,7 +619,7 @@ func TestOwnership_WithSignals(t *testing.T) {
 				},
 			}),
 	}
-	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
+	ctx := userCtx(fakeDB.AddUser(types.User{Username: santaName, DisplayName: santaName, SiteAdmin: true}))
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
@@ -706,16 +707,20 @@ func TestOwnership_WithSignals(t *testing.T) {
 									},
 									"reasons": [
 										{
-											"title": "recent contributor",
-											"description": "Owner is associated because they have contributed to this file in the last 90 days."
+											"title": "recent view",
+											"description": "Owner is associated because they have viewed this file in the last 90 days."
 										}
 									]
 								},
 								{
+									"owner": {
+										"displayName": "santa claus",
+										"email": "santa@northpole.com"
+									},
 									"reasons": [
 										{
-											"title": "recent view",
-											"description": "Owner is associated because they have viewed this file in the last 90 days."
+											"title": "recent contributor",
+											"description": "Owner is associated because they have contributed to this file in the last 90 days."
 										}
 									]
 								}

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -41908,6 +41908,540 @@ func (c RecentContributionSignalStoreWithTransactFuncCall) Results() []interface
 	return []interface{}{c.Result0}
 }
 
+// MockRecentViewSignalStore is a mock implementation of the
+// RecentViewSignalStore interface (from the package
+// github.com/sourcegraph/sourcegraph/internal/database) used for unit
+// testing.
+type MockRecentViewSignalStore struct {
+	// BuildAggregateFromEventsFunc is an instance of a mock function object
+	// controlling the behavior of the method BuildAggregateFromEvents.
+	BuildAggregateFromEventsFunc *RecentViewSignalStoreBuildAggregateFromEventsFunc
+	// InsertFunc is an instance of a mock function object controlling the
+	// behavior of the method Insert.
+	InsertFunc *RecentViewSignalStoreInsertFunc
+	// InsertPathsFunc is an instance of a mock function object controlling
+	// the behavior of the method InsertPaths.
+	InsertPathsFunc *RecentViewSignalStoreInsertPathsFunc
+	// ListFunc is an instance of a mock function object controlling the
+	// behavior of the method List.
+	ListFunc *RecentViewSignalStoreListFunc
+}
+
+// NewMockRecentViewSignalStore creates a new mock of the
+// RecentViewSignalStore interface. All methods return zero values for all
+// results, unless overwritten.
+func NewMockRecentViewSignalStore() *MockRecentViewSignalStore {
+	return &MockRecentViewSignalStore{
+		BuildAggregateFromEventsFunc: &RecentViewSignalStoreBuildAggregateFromEventsFunc{
+			defaultHook: func(context.Context, []*Event) (r0 error) {
+				return
+			},
+		},
+		InsertFunc: &RecentViewSignalStoreInsertFunc{
+			defaultHook: func(context.Context, int32, int, int) (r0 error) {
+				return
+			},
+		},
+		InsertPathsFunc: &RecentViewSignalStoreInsertPathsFunc{
+			defaultHook: func(context.Context, int32, map[int]int) (r0 error) {
+				return
+			},
+		},
+		ListFunc: &RecentViewSignalStoreListFunc{
+			defaultHook: func(context.Context, ListRecentViewSignalOpts) (r0 []RecentViewSummary, r1 error) {
+				return
+			},
+		},
+	}
+}
+
+// NewStrictMockRecentViewSignalStore creates a new mock of the
+// RecentViewSignalStore interface. All methods panic on invocation, unless
+// overwritten.
+func NewStrictMockRecentViewSignalStore() *MockRecentViewSignalStore {
+	return &MockRecentViewSignalStore{
+		BuildAggregateFromEventsFunc: &RecentViewSignalStoreBuildAggregateFromEventsFunc{
+			defaultHook: func(context.Context, []*Event) error {
+				panic("unexpected invocation of MockRecentViewSignalStore.BuildAggregateFromEvents")
+			},
+		},
+		InsertFunc: &RecentViewSignalStoreInsertFunc{
+			defaultHook: func(context.Context, int32, int, int) error {
+				panic("unexpected invocation of MockRecentViewSignalStore.Insert")
+			},
+		},
+		InsertPathsFunc: &RecentViewSignalStoreInsertPathsFunc{
+			defaultHook: func(context.Context, int32, map[int]int) error {
+				panic("unexpected invocation of MockRecentViewSignalStore.InsertPaths")
+			},
+		},
+		ListFunc: &RecentViewSignalStoreListFunc{
+			defaultHook: func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error) {
+				panic("unexpected invocation of MockRecentViewSignalStore.List")
+			},
+		},
+	}
+}
+
+// NewMockRecentViewSignalStoreFrom creates a new mock of the
+// MockRecentViewSignalStore interface. All methods delegate to the given
+// implementation, unless overwritten.
+func NewMockRecentViewSignalStoreFrom(i RecentViewSignalStore) *MockRecentViewSignalStore {
+	return &MockRecentViewSignalStore{
+		BuildAggregateFromEventsFunc: &RecentViewSignalStoreBuildAggregateFromEventsFunc{
+			defaultHook: i.BuildAggregateFromEvents,
+		},
+		InsertFunc: &RecentViewSignalStoreInsertFunc{
+			defaultHook: i.Insert,
+		},
+		InsertPathsFunc: &RecentViewSignalStoreInsertPathsFunc{
+			defaultHook: i.InsertPaths,
+		},
+		ListFunc: &RecentViewSignalStoreListFunc{
+			defaultHook: i.List,
+		},
+	}
+}
+
+// RecentViewSignalStoreBuildAggregateFromEventsFunc describes the behavior
+// when the BuildAggregateFromEvents method of the parent
+// MockRecentViewSignalStore instance is invoked.
+type RecentViewSignalStoreBuildAggregateFromEventsFunc struct {
+	defaultHook func(context.Context, []*Event) error
+	hooks       []func(context.Context, []*Event) error
+	history     []RecentViewSignalStoreBuildAggregateFromEventsFuncCall
+	mutex       sync.Mutex
+}
+
+// BuildAggregateFromEvents delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockRecentViewSignalStore) BuildAggregateFromEvents(v0 context.Context, v1 []*Event) error {
+	r0 := m.BuildAggregateFromEventsFunc.nextHook()(v0, v1)
+	m.BuildAggregateFromEventsFunc.appendCall(RecentViewSignalStoreBuildAggregateFromEventsFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// BuildAggregateFromEvents method of the parent MockRecentViewSignalStore
+// instance is invoked and the hook queue is empty.
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) SetDefaultHook(hook func(context.Context, []*Event) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// BuildAggregateFromEvents method of the parent MockRecentViewSignalStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) PushHook(hook func(context.Context, []*Event) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, []*Event) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, []*Event) error {
+		return r0
+	})
+}
+
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) nextHook() func(context.Context, []*Event) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) appendCall(r0 RecentViewSignalStoreBuildAggregateFromEventsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RecentViewSignalStoreBuildAggregateFromEventsFuncCall objects describing
+// the invocations of this function.
+func (f *RecentViewSignalStoreBuildAggregateFromEventsFunc) History() []RecentViewSignalStoreBuildAggregateFromEventsFuncCall {
+	f.mutex.Lock()
+	history := make([]RecentViewSignalStoreBuildAggregateFromEventsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RecentViewSignalStoreBuildAggregateFromEventsFuncCall is an object that
+// describes an invocation of method BuildAggregateFromEvents on an instance
+// of MockRecentViewSignalStore.
+type RecentViewSignalStoreBuildAggregateFromEventsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []*Event
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RecentViewSignalStoreBuildAggregateFromEventsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RecentViewSignalStoreBuildAggregateFromEventsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RecentViewSignalStoreInsertFunc describes the behavior when the Insert
+// method of the parent MockRecentViewSignalStore instance is invoked.
+type RecentViewSignalStoreInsertFunc struct {
+	defaultHook func(context.Context, int32, int, int) error
+	hooks       []func(context.Context, int32, int, int) error
+	history     []RecentViewSignalStoreInsertFuncCall
+	mutex       sync.Mutex
+}
+
+// Insert delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockRecentViewSignalStore) Insert(v0 context.Context, v1 int32, v2 int, v3 int) error {
+	r0 := m.InsertFunc.nextHook()(v0, v1, v2, v3)
+	m.InsertFunc.appendCall(RecentViewSignalStoreInsertFuncCall{v0, v1, v2, v3, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the Insert method of the
+// parent MockRecentViewSignalStore instance is invoked and the hook queue
+// is empty.
+func (f *RecentViewSignalStoreInsertFunc) SetDefaultHook(hook func(context.Context, int32, int, int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// Insert method of the parent MockRecentViewSignalStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *RecentViewSignalStoreInsertFunc) PushHook(hook func(context.Context, int32, int, int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RecentViewSignalStoreInsertFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int32, int, int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RecentViewSignalStoreInsertFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int32, int, int) error {
+		return r0
+	})
+}
+
+func (f *RecentViewSignalStoreInsertFunc) nextHook() func(context.Context, int32, int, int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RecentViewSignalStoreInsertFunc) appendCall(r0 RecentViewSignalStoreInsertFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RecentViewSignalStoreInsertFuncCall objects
+// describing the invocations of this function.
+func (f *RecentViewSignalStoreInsertFunc) History() []RecentViewSignalStoreInsertFuncCall {
+	f.mutex.Lock()
+	history := make([]RecentViewSignalStoreInsertFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RecentViewSignalStoreInsertFuncCall is an object that describes an
+// invocation of method Insert on an instance of MockRecentViewSignalStore.
+type RecentViewSignalStoreInsertFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RecentViewSignalStoreInsertFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RecentViewSignalStoreInsertFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RecentViewSignalStoreInsertPathsFunc describes the behavior when the
+// InsertPaths method of the parent MockRecentViewSignalStore instance is
+// invoked.
+type RecentViewSignalStoreInsertPathsFunc struct {
+	defaultHook func(context.Context, int32, map[int]int) error
+	hooks       []func(context.Context, int32, map[int]int) error
+	history     []RecentViewSignalStoreInsertPathsFuncCall
+	mutex       sync.Mutex
+}
+
+// InsertPaths delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockRecentViewSignalStore) InsertPaths(v0 context.Context, v1 int32, v2 map[int]int) error {
+	r0 := m.InsertPathsFunc.nextHook()(v0, v1, v2)
+	m.InsertPathsFunc.appendCall(RecentViewSignalStoreInsertPathsFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the InsertPaths method
+// of the parent MockRecentViewSignalStore instance is invoked and the hook
+// queue is empty.
+func (f *RecentViewSignalStoreInsertPathsFunc) SetDefaultHook(hook func(context.Context, int32, map[int]int) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// InsertPaths method of the parent MockRecentViewSignalStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *RecentViewSignalStoreInsertPathsFunc) PushHook(hook func(context.Context, int32, map[int]int) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RecentViewSignalStoreInsertPathsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, int32, map[int]int) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RecentViewSignalStoreInsertPathsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, int32, map[int]int) error {
+		return r0
+	})
+}
+
+func (f *RecentViewSignalStoreInsertPathsFunc) nextHook() func(context.Context, int32, map[int]int) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RecentViewSignalStoreInsertPathsFunc) appendCall(r0 RecentViewSignalStoreInsertPathsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RecentViewSignalStoreInsertPathsFuncCall
+// objects describing the invocations of this function.
+func (f *RecentViewSignalStoreInsertPathsFunc) History() []RecentViewSignalStoreInsertPathsFuncCall {
+	f.mutex.Lock()
+	history := make([]RecentViewSignalStoreInsertPathsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RecentViewSignalStoreInsertPathsFuncCall is an object that describes an
+// invocation of method InsertPaths on an instance of
+// MockRecentViewSignalStore.
+type RecentViewSignalStoreInsertPathsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 map[int]int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RecentViewSignalStoreInsertPathsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RecentViewSignalStoreInsertPathsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RecentViewSignalStoreListFunc describes the behavior when the List method
+// of the parent MockRecentViewSignalStore instance is invoked.
+type RecentViewSignalStoreListFunc struct {
+	defaultHook func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error)
+	hooks       []func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error)
+	history     []RecentViewSignalStoreListFuncCall
+	mutex       sync.Mutex
+}
+
+// List delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockRecentViewSignalStore) List(v0 context.Context, v1 ListRecentViewSignalOpts) ([]RecentViewSummary, error) {
+	r0, r1 := m.ListFunc.nextHook()(v0, v1)
+	m.ListFunc.appendCall(RecentViewSignalStoreListFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the List method of the
+// parent MockRecentViewSignalStore instance is invoked and the hook queue
+// is empty.
+func (f *RecentViewSignalStoreListFunc) SetDefaultHook(hook func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// List method of the parent MockRecentViewSignalStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *RecentViewSignalStoreListFunc) PushHook(hook func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RecentViewSignalStoreListFunc) SetDefaultReturn(r0 []RecentViewSummary, r1 error) {
+	f.SetDefaultHook(func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RecentViewSignalStoreListFunc) PushReturn(r0 []RecentViewSummary, r1 error) {
+	f.PushHook(func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error) {
+		return r0, r1
+	})
+}
+
+func (f *RecentViewSignalStoreListFunc) nextHook() func(context.Context, ListRecentViewSignalOpts) ([]RecentViewSummary, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RecentViewSignalStoreListFunc) appendCall(r0 RecentViewSignalStoreListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of RecentViewSignalStoreListFuncCall objects
+// describing the invocations of this function.
+func (f *RecentViewSignalStoreListFunc) History() []RecentViewSignalStoreListFuncCall {
+	f.mutex.Lock()
+	history := make([]RecentViewSignalStoreListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RecentViewSignalStoreListFuncCall is an object that describes an
+// invocation of method List on an instance of MockRecentViewSignalStore.
+type RecentViewSignalStoreListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ListRecentViewSignalOpts
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []RecentViewSummary
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RecentViewSignalStoreListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RecentViewSignalStoreListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // MockRepoStatisticsStore is a mock implementation of the
 // RepoStatisticsStore interface (from the package
 // github.com/sourcegraph/sourcegraph/internal/database) used for unit

--- a/mockgen.temp.yaml
+++ b/mockgen.temp.yaml
@@ -80,6 +80,7 @@
     - RolePermissionStore
     - RepoStatisticsStore
     - RecentContributionSignalStore
+    - RecentViewSignalStore
 - filename: internal/gitserver/mocks_temp.go
   path: github.com/sourcegraph/sourcegraph/internal/gitserver
   interfaces:


### PR DESCRIPTION
Test plan:
GraphQL tests updated.

Part of https://github.com/sourcegraph/sourcegraph/issues/51464