### PR TITLE
cody: git-log recipe limits log to active file

### DIFF
--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process'
+import path from 'path'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
@@ -33,6 +34,15 @@ export class GitHistory implements Recipe {
                 rawDisplayText: 'What changed in my codebase in the last week?',
             },
         ]
+        const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
+        if (selection) {
+            const name = path.basename(selection.fileName)
+            items.push({
+                label: `Last 5 items for ${name}`,
+                args: ['log', '-n5', logFormat, '--', selection.fileName],
+                rawDisplayText: `What changed in ${name} in the last 5 commits`,
+            })
+        }
         const selectedLabel = await context.editor.showQuickPick(items.map(e => e.label))
         if (!selectedLabel) {
             return null


### PR DESCRIPTION
This seems like a more useful use of git log in a larger codebase.

Test Plan: clicked on the newly added option in the git log recipe and it summarised changes for the file. Compared to git log output of file to ensure the response made sense. Then compared it to the repository git log/etc just to make sure Cody was talking about the file.