### PR TITLE
Cody: Promote VS Code extension to beta

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Changed
 
+- Promote Cody from experimental to beta [pull/](https://github.com/sourcegraph/sourcegraph/)
 - Various improvements to the experimental completions feature
 
 ## [0.0.10]

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Changed
 
-- Promote Cody from experimental to beta [pull/](https://github.com/sourcegraph/sourcegraph/)
+- Promote Cody from experimental to beta [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 - Various improvements to the experimental completions feature
 
 ## [0.0.10]

--- a/client/cody/README.md
+++ b/client/cody/README.md
@@ -2,7 +2,7 @@
 
 Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
 
-**Status:** experimental ([join the open beta](https://docs.sourcegraph.com/cody))
+**Status:** beta ([join the open beta](https://docs.sourcegraph.com/cody))
 
 [**Full documentation**](https://docs.sourcegraph.com/cody)
 

--- a/client/cody/webviews/Header.tsx
+++ b/client/cody/webviews/Header.tsx
@@ -9,6 +9,6 @@ export const Header: React.FunctionComponent = () => (
         <div className={styles.logo}>
             <CodyColoredSvg />
         </div>
-        <VSCodeTag className={styles.tag}>experimental</VSCodeTag>
+        <VSCodeTag className={styles.tag}>beta</VSCodeTag>
     </div>
 )

--- a/client/web/src/enterprise/app/AppComingSoonPage.tsx
+++ b/client/web/src/enterprise/app/AppComingSoonPage.tsx
@@ -32,7 +32,7 @@ export const AppComingSoonPage: React.FC = () => {
             <Container className={classNames('mb-3', styles.container)}>
                 <section className={classNames('row', styles.section)}>
                     <div className={classNames('col-12 col-md-5', styles.text)}>
-                        <ProductStatusBadge status="experimental" className="mb-4 text-uppercase" />
+                        <ProductStatusBadge status="beta" className="mb-4 text-uppercase" />
                         <H2 as="h3" className="mb-4">
                             Cody
                         </H2>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
@@ -94,7 +94,7 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
     return (
         <>
             <H3>
-                Cody services <ProductStatusBadge status="experimental" />
+                Cody services <ProductStatusBadge status="beta" />
             </H3>
             <Container className="mb-3">
                 <H4>Access token</H4>

--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -46,7 +46,7 @@ As part of this service you will receive a number of benefits from our team, inc
   - [Adding repositories from all of your code hosts to Sourcegraph](../admin/external_service/index.md)
   - [Integrating your single sign-on provider with Sourcegraph](../admin/auth/index.md)
   - [Configuring Sourcegraph](../admin/config/index.md)
-  
+
 ### Access to all Sourcegraph features
 
 All Sourcegraph features are avilable on Sourcegraph Cloud instances out-of-the-box, including but not limited to:
@@ -176,11 +176,11 @@ To opt out of managed SMTP, please let your Sourcegraph Account team know when r
 
 To learn more about how the Sourcegraph team operates managed SMTP internally, refer to [our handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/managed-smtp/).
 
-### Cody 
+### Cody
 
-<aside class="experimental">
+<aside class="beta">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+<span class="badge badge-beta">Beta</span> This feature is beta and might change in the future. We've released it to provide a preview of functionality we're working on.
 </p>
 </aside>
 
@@ -204,7 +204,7 @@ Now that Cody is turned on on your Sourcegraph Cloud instance, any user can conf
 <img width="1369" alt="image" src="https://user-images.githubusercontent.com/25070988/227510686-4afcb1f9-a3a5-495f-b1bf-6d661ba53cce.png">
 
 5. In the Cody VS Code extension, set your instance URL and the access token
-    
+
 <img width="553" alt="image" src="https://user-images.githubusercontent.com/25070988/227510233-5ce37649-6ae3-4470-91d0-71ed6c68b7ef.png">
 
 You're all set!


### PR DESCRIPTION
Part-of #51445

I did a grep across the repo for "experimental" and replaced all labels that made sense. Speciifcally:

- This changes the label inside the VS Code extension
- Changes the labels inside the docs
- Changes the label inside the App "coming soon" upsell

cc @gwestersf 

## Test plan

<img width="387" alt="Screenshot 2023-05-09 at 16 05 13" src="https://github.com/sourcegraph/sourcegraph/assets/458591/ea248c00-90f0-466e-91e4-637b714aa4cf">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
