### PR TITLE
App: Change the app data path and split for dev/release 

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/sourcegraph/log"
@@ -64,9 +65,14 @@ func Init(logger log.Logger) {
 	// This defaults to an internal hostname.
 	setDefaultEnv(logger, "SRC_FRONTEND_INTERNAL", "localhost:3090")
 
+	time.Sleep(10 * time.Second)
+	appPath := "sg-app"
+	if version.IsDev(version.Version()) {
+		appPath = fmt.Sprintf("%s-dev", appPath)
+	}
 	cacheDir, err := os.UserCacheDir()
 	if err == nil {
-		cacheDir = filepath.Join(cacheDir, "sourcegraph-sp")
+		cacheDir = filepath.Join(cacheDir, appPath)
 		err = os.MkdirAll(cacheDir, 0700)
 	}
 	if err != nil {
@@ -81,7 +87,7 @@ func Init(logger log.Logger) {
 
 	configDir, err := os.UserConfigDir()
 	if err == nil {
-		configDir = filepath.Join(configDir, "sourcegraph-sp")
+		configDir = filepath.Join(configDir, appPath)
 		err = os.MkdirAll(configDir, 0700)
 	}
 	if err != nil {

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/sourcegraph/log"
@@ -65,7 +64,6 @@ func Init(logger log.Logger) {
 	// This defaults to an internal hostname.
 	setDefaultEnv(logger, "SRC_FRONTEND_INTERNAL", "localhost:3090")
 
-	time.Sleep(10 * time.Second)
 	appPath := "sg-app"
 	if version.IsDev(version.Version()) {
 		appPath = fmt.Sprintf("%s-dev", appPath)

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -64,7 +64,7 @@ func Init(logger log.Logger) {
 	// This defaults to an internal hostname.
 	setDefaultEnv(logger, "SRC_FRONTEND_INTERNAL", "localhost:3090")
 
-	appPath := "sg-app"
+	appPath := "sourcegraph"
 	if version.IsDev(version.Version()) {
 		appPath = fmt.Sprintf("%s-dev", appPath)
 	}


### PR DESCRIPTION
This updates the Sourcegraph App's data.  There are 2 purposes: 

1. Avoid any conflicts with the original march release. 
2. Versioning is handled differently when running in dev mode and it can cause data inconsistency when switching between the dev and release apps if they point to the same db.
## Test plan
Run `sg start app` verify app starts and creates  `sg-app-dev` folder with database
Build release version `./enterprise/dev/app/build-release.sh` verify app starts and creates `sg-app` folder with database.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
