### PR TITLE
Update tracking issue syncer

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -27,7 +27,7 @@ on:
     - unlabeled
 jobs:
   sync-tracking-issues:
-    if: github.repository == 'sourcegraph/sourcegraph'
+    if: github.repository == 'sourcegraph/sourcegraph' || 'sourcegraph/security'
     runs-on: ubuntu-latest
     steps:
       - uses: docker://sourcegraph/tracking-issue:latest


### PR DESCRIPTION
The security team will start using tracking issues in `sourcegraph/security` and changes to issues on that repo should trigger the workflow.
## Test plan
Manual test.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
