### PR TITLE
Send publicArgument not Arugment

### DIFF
--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job.go
@@ -300,7 +300,7 @@ func buildBigQueryObject(event *database.Event, metadata *instanceMetadata) *big
 		URL:               "", // omitting URL intentionally
 		Source:            event.Source,
 		Timestamp:         event.Timestamp.Format(time.RFC3339),
-		PublicArgument:    string(event.Argument),
+		PublicArgument:    string(event.PublicArgument),
 		Version:           event.Version, // sending event Version since these events could be scraped from the past
 		SiteID:            metadata.SiteID,
 		LicenseKey:        metadata.LicenseKey,

--- a/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/enterprise/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -502,7 +502,7 @@ func TestBuildBigQueryObject(t *testing.T) {
 		URL:              "https://sourcegraph.com/search",
 		UserID:           5,
 		AnonymousUserID:  "anonymous",
-		Argument:         json.RawMessage("argument"),
+		PublicArgument:   json.RawMessage("public_argument"),
 		Source:           "src",
 		Version:          "1.1.1",
 		Timestamp:        atTime,
@@ -539,7 +539,7 @@ func TestBuildBigQueryObject(t *testing.T) {
 		FeatureFlags:      `{"testflag":true}`,
 		CohortID:          valast.Addr("cohort1").(*string),
 		Referrer:          "reff",
-		PublicArgument:    "argument",
+		PublicArgument:    "public_argument",
 		DeviceID:          valast.Addr("devid").(*string),
 		InsertID:          valast.Addr("insertid").(*string),
 	}).Equal(t, got)


### PR DESCRIPTION
update to send publicArguments and not the private field arguements
## Test plan
test locally to ensure publicArguements is being sent now