### PR TITLE
[DRAFT] Enable OOB Migration checks for App

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/pubsub"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -37,17 +38,17 @@ var (
 	// non-cluster, non-docker-compose, and non-pure-docker installations what the latest
 	// version is. The version here _must_ be available at https://hub.docker.com/r/sourcegraph/server/tags/
 	// before landing in master.
-	latestReleaseDockerServerImageBuild = newPingResponse("5.0.3")
+	latestReleaseDockerServerImageBuild = newPingResponse(version.LatestReleaseBuild)
 
 	// latestReleaseKubernetesBuild is only used by sourcegraph.com to tell existing Sourcegraph
 	// cluster deployments what the latest version is. The version here _must_ be available in
 	// a tag at https://github.com/sourcegraph/deploy-sourcegraph before landing in master.
-	latestReleaseKubernetesBuild = newPingResponse("5.0.3")
+	latestReleaseKubernetesBuild = newPingResponse(version.LatestReleaseBuild)
 
 	// latestReleaseDockerComposeOrPureDocker is only used by sourcegraph.com to tell existing Sourcegraph
 	// Docker Compose or Pure Docker deployments what the latest version is. The version here _must_ be
 	// available in a tag at https://github.com/sourcegraph/deploy-sourcegraph-docker before landing in master.
-	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.0.3")
+	latestReleaseDockerComposeOrPureDocker = newPingResponse(version.LatestReleaseBuild)
 
 	// latestReleaseApp is only used by sourcegraph.com to tell existing Sourcegraph
 	// App instances what the latest version is. The version here _must_ be available for download/released

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -75,7 +75,7 @@ func InitDB(logger sglog.Logger) (*sql.DB, error) {
 		return nil, errors.Errorf("failed to connect to frontend database: %s", err)
 	}
 
-	if err := upgradestore.New(database.NewDB(logger, sqlDB)).UpdateServiceVersion(context.Background(), "frontend", version.Version()); err != nil {
+	if err := upgradestore.New(database.NewDB(logger, sqlDB)).UpdateServiceVersion(context.Background(), "frontend", version.MigrationEndVersion()); err != nil {
 		return nil, err
 	}
 

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -717,9 +717,7 @@ cc @${release.captainGitHubUsername}
                                 : `comby -in-place 'currentReleaseRevspec := ":[1]"' 'currentReleaseRevspec := "v${release.version.version}"' doc/_resources/templates/document.html`,
 
                             // Update references to Sourcegraph deployment versions
-                            `comby -in-place 'latestReleaseKubernetesBuild = newPingResponse(":[1]")' "latestReleaseKubernetesBuild = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
-                            `comby -in-place 'latestReleaseDockerServerImageBuild = newPingResponse(":[1]")' "latestReleaseDockerServerImageBuild = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
-                            `comby -in-place 'latestReleaseDockerComposeOrPureDocker = newPingResponse(":[1]")' "latestReleaseDockerComposeOrPureDocker = newPingResponse(\\"${release.version.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
+                            `comby -in-place 'LatestReleaseBuild = newPingResponse(":[1]")' "LatestReleaseBuild = newPingResponse(\\"${release.version.version}\\")" internal/version/version.go`,
 
                             // Support current release as the "previous release" going forward
                             notPatchRelease

--- a/internal/oobmigration/validate.go
+++ b/internal/oobmigration/validate.go
@@ -23,7 +23,7 @@ func ValidateOutOfBandMigrationRunner(ctx context.Context, db database.DB, runne
 		// Skip check in development environments
 		return nil
 	}
-	currentVersionSemver, err := semver.NewVersion(version.Version())
+	currentVersionSemver, err := semver.NewVersion(version.MigrationEndVersion())
 	if err != nil {
 		runner.logger.Warn("Skipping out-of-band migrations check", log.Error(err), log.String("version", version.Version()))
 		return nil

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -122,14 +122,6 @@ func Init(logger log.Logger) {
 	// Required because we set "executors.frontendURL": "http://host.docker.internal:3080" in site
 	// configuration.
 	setDefaultEnv(logger, "EXECUTOR_DOCKER_ADD_HOST_GATEWAY", "true")
-
-	// TODO(single-binary): HACK: This is a hack to workaround the fact that the 2nd time you run `sourcegraph`
-	// OOB migration validation fails:
-	//
-	// {"SeverityText":"FATAL","Timestamp":1675128552556359000,"InstrumentationScope":"sourcegraph","Caller":"svcmain/svcmain.go:143","Function":"github.com/sourcegraph/sourcegraph/internal/service/svcmain.run.func1","Body":"failed to start service","Resource":{"service.name":"sourcegraph","service.version":"0.0.196384-snapshot+20230131-6902ad","service.instance.id":"Stephens-MacBook-Pro.local"},"Attributes":{"service":"frontend","error":"failed to validate out of band migrations: Unfinished migrations. Please revert Sourcegraph to the previous version and wait for the following migrations to complete.\n  - migration 1 expected to be at 0.00% (at 100.00%)\n  - migration 13 expected to be at 0.00% (at 100.00%)\n  - migration 14 expected to be at 0.00% (at 100.00%)\n  - migration 15 expected to be at 0.00% (at 100.00%)\n  - migration 16 expected to be at 0.00% (at 100.00%)\n  - migration 17 expected to be at 0.00% (at 100.00%)\n  - migration 18 expected to be at 0.00% (at 100.00%)\n  - migration 19 expected to be at 0.00% (at 100.00%)\n  - migration 2 expected to be at 0.00% (at 100.00%)\n  - migration 20 expected to be at 0.00% (at 100.00%)\n  - migration 4 expected to be at 0.00% (at 100.00%)\n  - migration 5 expected to be at 0.00% (at 100.00%)\n  - migration 7 expected to be at 0.00% (at 100.00%)"}}
-	//
-	setDefaultEnv(logger, "SRC_DISABLE_OOBMIGRATION_VALIDATION", "1")
-
 	setDefaultEnv(logger, "EXECUTOR_USE_FIRECRACKER", "false")
 	// TODO(sqs): TODO(single-binary): Make it so we can run multiple executors in app mode. Right now, you
 	// need to change this to "batches" to use batch changes executors.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const LatestReleaseBuild = "5.0.3"
 const devVersion = "0.0.0+dev"                              // version string for unreleased development builds
 var devTimestamp = strconv.FormatInt(time.Now().Unix(), 10) // build timestamp for unreleased development builds
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Masterminds/semver"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -28,6 +31,21 @@ func init() {
 // Version returns the version string configured at build time.
 func Version() string {
 	return version
+}
+
+// MigrationEndVersion returns the version to be used as the end point of migrations.
+// For releases, this is the version string itself. For upcoming dev releases, and App
+// this is the last release version plus 1 minor version.
+func MigrationEndVersion() string {
+	if !deploy.IsApp() {
+		return Version()
+	}
+	v, err := semver.NewVersion(LatestReleaseBuild)
+	if err != nil {
+		return Version()
+	}
+	nextMinor := v.IncMinor()
+	return nextMinor.String()
 }
 
 // IsDev reports whether the version string is an unreleased development build.


### PR DESCRIPTION
wip,  I need to do more testing on this but wanted to get some eyes on it sooner to make sure I was going in the reasonable direction.

The goal is to get App working with OOB migrations.  The current issue today is that app's versioning `yyyy.mm.dd` is not compatible with oob migrations.  App having a large major version `2023` means that any migration with deprecated version in the future > 5.0  < 2023.5 will not run.  Additional the "first_version" gets set in the db with the app version which causes issues with the validation of previous oob migrations. 

## Test plan
WIP 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
