### PR TITLE
Remove note about builtin auth for managed instances

### DIFF
--- a/doc/admin/config/authorization_and_authentication.md
+++ b/doc/admin/config/authorization_and_authentication.md
@@ -17,7 +17,7 @@ Sourcegraph supports username/password auth by default and SAML, OAuth, HTTP Pro
 }
 ```
 
-For users using any of the other authentication mechanisms, removing `builtin` as an authentication mechanism is best practice. (Customers in a managed instance environment will need to leave `builtin` enabled for Sourcegraph employee access. Consult with your Customer Engineer for more info.)
+For users using any of the other authentication mechanisms, removing `builtin` as an authentication mechanism is best practice.
 
 > NOTE: If Sourcegraph is running on a free license all users will be created as site admins. Learn more about license settings on our [pricing page](https://about.sourcegraph.com/pricing).
 


### PR DESCRIPTION
I believe enabling builtin auth is no longer required for MI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Doc update.
