### PR TITLE
Add additional field resolver for the most recent token

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
@@ -35,7 +35,7 @@ import { prettyInterval } from './utils'
 
 interface Props {
     productSubscriptionID: Scalars['ID']
-    sourcegraphAccessTokens: string[]
+    currentSourcegraphAccessToken: string | null
     accessTokenError?: Error
     viewerCanAdminister: boolean
     refetchSubscription: () => void
@@ -45,7 +45,7 @@ interface Props {
 export const CodyServicesSection: React.FunctionComponent<Props> = ({
     productSubscriptionID,
     viewerCanAdminister,
-    sourcegraphAccessTokens,
+    currentSourcegraphAccessToken,
     accessTokenError,
     refetchSubscription,
     llmProxyAccess,
@@ -99,18 +99,18 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
             <Container className="mb-3">
                 <H4>Access token</H4>
                 <Text className="mb-2">Access tokens can be used for LLM-proxy access - coming soon!</Text>
-                {sourcegraphAccessTokens.length > 0 && (
+                {currentSourcegraphAccessToken && (
                     <CopyableText
                         label="Access token"
                         secret={true}
                         flex={true}
-                        text={sourcegraphAccessTokens[0]}
+                        text={currentSourcegraphAccessToken}
                         className="mb-2"
                     />
                 )}
                 {accessTokenError && <ErrorAlert error={accessTokenError} className="mb-0" />}
 
-                {sourcegraphAccessTokens.length > 0 && (
+                {currentSourcegraphAccessToken && (
                     <>
                         <H4>Completions</H4>
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -176,7 +176,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                 {llmProxyManagementUI && (
                     <CodyServicesSection
                         viewerCanAdminister={true}
-                        sourcegraphAccessTokens={productSubscription.sourcegraphAccessTokens}
+                        currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
                         accessTokenError={errorForPath(error, accessTokenPath)}
                         llmProxyAccess={productSubscription.llmProxyAccess}
                         productSubscriptionID={productSubscription.id}

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/backend.ts
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/backend.ts
@@ -85,7 +85,7 @@ export const DOTCOM_PRODUCT_SUBSCRIPTION = gql`
                     licenseKey
                     createdAt
                 }
-                sourcegraphAccessTokens
+                currentSourcegraphAccessToken
                 llmProxyAccess {
                     ...LLMProxyAccessFields
                 }

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/utils.ts
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/utils.ts
@@ -38,4 +38,4 @@ export function errorForPath(error: ApolloError | undefined, path: (string | num
     return error?.graphQLErrors.find(error => isEqual(error.path, path))
 }
 
-export const accessTokenPath = ['dotcom', 'productSubscription', 'sourcegraphAccessTokens']
+export const accessTokenPath = ['dotcom', 'productSubscription', 'currentSourcegraphAccessToken']

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -111,7 +111,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
             {llmProxyManagementUI && (
                 <CodyServicesSection
                     viewerCanAdminister={false}
-                    sourcegraphAccessTokens={productSubscription.sourcegraphAccessTokens}
+                    currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
                     accessTokenError={errorForPath(error, accessTokenPath)}
                     llmProxyAccess={productSubscription.llmProxyAccess}
                     productSubscriptionID={productSubscription.id}

--- a/client/web/src/enterprise/user/productSubscriptions/backend.ts
+++ b/client/web/src/enterprise/user/productSubscriptions/backend.ts
@@ -34,7 +34,7 @@ export const USER_PRODUCT_SUBSCRIPTION = gql`
         isArchived
         url
         urlForSiteAdmin
-        sourcegraphAccessTokens
+        currentSourcegraphAccessToken
         llmProxyAccess {
             ...LLMProxyAccessFields
         }

--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -45,6 +45,7 @@ type ProductSubscription interface {
 	IsArchived() bool
 	URL(context.Context) (string, error)
 	URLForSiteAdmin(context.Context) *string
+	CurrentSourcegraphAccessToken(context.Context) (*string, error)
 	SourcegraphAccessTokens(context.Context) ([]string, error)
 }
 

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -265,9 +265,14 @@ type ProductSubscription implements Node {
         first: Int
     ): ProductLicenseConnection!
     """
+    The most preferable Sourcegraph access token to use for authenticating as the
+    subscription holder with managed Sourcegraph services.
+    Null only if creating a token failed, for example when no active license exists.
+    """
+    currentSourcegraphAccessToken: String
+    """
     Available access tokens for authenticating as the subscription holder with managed
     Sourcegraph services.
-    Empty only if creating a token failed, for example when no active license exists.
     """
     sourcegraphAccessTokens: [String!]!
     """


### PR DESCRIPTION
Instead of relying purely on the ordering, this makes it more explicit. The main driver for this is though that we don't want to error out if some of the keys in the list still exist, but the UI depends on that. This is a simple fix for it so that the proxy can list all the valid tokens alright from dotcom.

## Test plan

Verified things still work alright. 