### PR TITLE
Revert "ci: remove bundlesize run target (#51626)"

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -103,19 +103,14 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 	cmds = append(cmds, bazelTestCmds...)
 
-	// DISABLED: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919
-	// this command makes an external request to https://bundlesize-cache.vercel.app
-	// which is not acceptable for such a task.
-	// TODO: @jhchabran
-	//
 	// Run commands
-	// runTargets := []string{
-	// 	"//client/web:bundlesize-report",
-	// }
-	// bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
+	runTargets := []string{
+		"//client/web:bundlesize-report",
+	}
+	bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
 	cmds = append(cmds,
-		// bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
-		// bk.Cmd(bazelRunCmd),
+		bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
+		bk.Cmd(bazelRunCmd),
 		bazelAnnouncef("✅"),
 	)
 


### PR DESCRIPTION
This reverts commit e73073e99fdeeca43fd4ec6156b3b0b479ead6ec.

Let's monitor the behavior of this task. If it happens again, we disable it, and I'll dig further. But I'm sure I saw successful Bazel builds with the bundlesize cache error. [The Slack thread](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919).

## Test plan

CI
