### PR TITLE
app: Disable autosyncing repos in the current working directory

### DIFF
--- a/internal/service/servegit/service.go
+++ b/internal/service/servegit/service.go
@@ -24,8 +24,6 @@ func (c *Config) Load() {
 	// We bypass BaseConfig since it doesn't handle variables being empty.
 	if src, ok := os.LookupEnv("SRC"); ok {
 		c.CWDRoot = src
-	} else if pwd, err := os.Getwd(); err == nil {
-		c.CWDRoot = pwd
 	}
 
 	c.ServeConfig.Load()


### PR DESCRIPTION
One feedback we've gotten was that it's surprising for users that repositories are added automatically when starting app from the commandline. If the repos are really large it can also lead to performance issues.

This commit removes the logic to automatically use the current working directory as "root" dir.

Note: I'd like to bring this functionality back via an explicit parameter passed to the command, but that requires some more tinkering (especially considering the differences between running the dev and prod versions).


## Test plan

Run `sg start app` and notice the `warn` message about not syncing local repos. Opening the app and going to the "Repositories" page doesn't list any "autogenerated" local repos.
