### PR TITLE
frontend: handle http.ErrAbortHandler in HandlerWithErrorReturn

### DIFF
--- a/cmd/frontend/internal/handlerutil/handler.go
+++ b/cmd/frontend/internal/handlerutil/handler.go
@@ -33,6 +33,14 @@ func (h HandlerWithErrorReturn) ServeHTTP(w http.ResponseWriter, r *http.Request
 	// Handle when h.Handler panics.
 	defer func() {
 		if e := recover(); e != nil {
+			// ErrAbortHandler is a sentinal error which is used to stop an
+			// http handler but not report the error. In practice we have only
+			// seen this used by httputil.ReverseProxy when the server goes
+			// down.
+			if e == http.ErrAbortHandler {
+				return
+			}
+
 			log15.Error("panic in HandlerWithErrorReturn.Handler", "error", e)
 			stack := make([]byte, 1024*1024)
 			n := runtime.Stack(stack, false)


### PR DESCRIPTION
I was investigating a panic in production and the root cause was the debugproxies reverse proxy failing due to the connection being closed. In that case reverse proxy panics with ErrAbortHandler. According to the documentation this is an intentional panic error that indicates to stop processing and not report the error. As such we do the same in our top-level error middleware.

Test Plan: I didn't try trigger the code path, instead I am relying on CI to ensure nothing breaks. Will attach this PR to the error reported in google cloud. If this error every happens again it will show up as this PR and we know this was not the solution.

https://console.cloud.google.com/errors/detail/CNDKmOfsxpa1CA?project=sourcegraph-dev