### PR TITLE
Cody: Fix release script

### DIFF
--- a/client/cody/scripts/release.ts
+++ b/client/cody/scripts/release.ts
@@ -17,7 +17,7 @@ const { version } = require('../package.json')
  * Build and publish the extension with the updated package name using the tokens stored in the
  * pipeline to run commands in pnpm and allows all events to activate the extension
  */
-const isPreRelease = semver.minor(version) % 2 !== 0 ? '--pre-release' : ''
+const isPreRelease = semver.prerelease(version) !== null ? '--pre-release' : ''
 
 // Tokens are stored in CI pipeline
 const tokens = {


### PR DESCRIPTION
Seems like `0.1.0` is detected as prerelease by this logic: https://buildkite.com/sourcegraph/sourcegraph/builds/218113#0188055e-1537-40fb-bad1-1d51729c100e

I don't really understand the logic anyways but this makes more sense.

## Test plan

Tested by adding `console.log` and changing the version to `0.1.0-dev` 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
