### PR TITLE
cody: check whether email is verified when accessing cody

### DIFF
--- a/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
+++ b/client/jetbrains/webview/src/sourcegraph-api-access/api-gateway.ts
@@ -25,6 +25,7 @@ export const siteVersionAndUserQuery = gql`
             siteAdmin
             url
             settingsURL
+            hasVerifiedEmail
             organizations {
                 nodes {
                     id

--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -42,6 +42,7 @@ export const currentAuthStateQuery = gql`
             viewerCanAdminister
             tosAccepted
             searchable
+            hasVerifiedEmail
             emails {
                 email
                 verified

--- a/client/shared/src/testing/integration/graphQlResults.ts
+++ b/client/shared/src/testing/integration/graphQlResults.ts
@@ -21,6 +21,7 @@ export const currentUserMock = {
     searchable: true,
     emails: [{ email: 'felix@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
+    hasVerifiedEmail: true,
     permissions: {
         __typename: 'PermissionConnection',
         nodes: [

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -202,6 +202,7 @@ ts_project(
         "src/cody/stores/chat.ts",
         "src/cody/stores/editor.ts",
         "src/cody/stores/sidebar.ts",
+        "src/cody/useIsCodyEnabled.tsx",
         "src/cody/widgets/CodyRecipesWidget.tsx",
         "src/cody/widgets/components/Recipe.tsx",
         "src/cody/widgets/components/RecipeAction.tsx",

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -53,8 +53,8 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({ authe
         eventLogger.logPageView('CodyChat')
     }, [])
 
-    if (!enabled || !authenticatedUser) {
-        return null
+    if (!enabled) {
+        return <PageTitle title="Cody AI Chat" />
     }
 
     return (

--- a/client/web/src/cody/search/CodySearchPage.tsx
+++ b/client/web/src/cody/search/CodySearchPage.tsx
@@ -14,6 +14,7 @@ import { BrandLogo } from '../../components/branding/BrandLogo'
 import { useURLSyncedString } from '../../hooks/useUrlSyncedString'
 import { eventLogger } from '../../tracking/eventLogger'
 import { CodyIcon } from '../components/CodyIcon'
+import { useIsCodyEnabled } from '../useIsCodyEnabled'
 
 import { translateToQuery } from './translateToQuery'
 
@@ -29,6 +30,8 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
     useEffect(() => {
         eventLogger.logPageView('CodySearch')
     }, [])
+
+    const enabled = useIsCodyEnabled()
 
     const navigate = useNavigate()
 
@@ -106,7 +109,7 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
         <div className={classNames('d-flex flex-column align-items-center px-3', searchPageStyles.searchPage)}>
             <BrandLogo className={searchPageStyles.logo} isLightTheme={isLightTheme} variant="logo" />
             <div className="text-muted mt-3 mr-sm-2 pr-2 text-center">Searching millions of public repositories</div>
-            {window.context?.codyEnabled ? (
+            {enabled.search ? (
                 <SearchInput
                     value={input}
                     onChange={onInputChange}

--- a/client/web/src/cody/stores/chat.ts
+++ b/client/web/src/cody/stores/chat.ts
@@ -13,6 +13,7 @@ import { isErrorLike } from '@sourcegraph/common'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 import { CodeMirrorEditor } from '../components/CodeMirrorEditor'
+import { useIsCodyEnabled } from '../useIsCodyEnabled'
 
 import { EditorStore, useEditorStore } from './editor'
 
@@ -330,6 +331,7 @@ export const useChatStore = ({
     setIsCodySidebarOpen?: (state: boolean | undefined) => void
 }): CodyChatStore => {
     const store = useChatStoreState()
+    const enabled = useIsCodyEnabled()
 
     const onEvent = useCallback(
         (eventName: 'submit' | 'reset' | 'error') => {
@@ -362,12 +364,12 @@ export const useChatStore = ({
 
     const { initializeClient, config: currentConfig } = store
     useEffect(() => {
-        if (!window.context?.codyEnabled || isEqual(config, currentConfig)) {
+        if (!(enabled.chat || enabled.sidebar) || isEqual(config, currentConfig)) {
             return
         }
 
         void initializeClient(config, editorStateRef, onEvent)
-    }, [config, initializeClient, currentConfig, editorStateRef, onEvent])
+    }, [config, initializeClient, currentConfig, editorStateRef, onEvent, enabled.chat, enabled.sidebar])
 
     return store
 }

--- a/client/web/src/cody/stores/sidebar.ts
+++ b/client/web/src/cody/stores/sidebar.ts
@@ -2,6 +2,8 @@ import create from 'zustand'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 
+import { useIsCodyEnabled } from '../useIsCodyEnabled'
+
 interface CodySidebarSizeStore {
     size: number
     onResize: (size: number) => void
@@ -37,5 +39,7 @@ export function useCodySidebarStore(): Omit<CodySidebarSizeStore, 'size'> & Cody
 export function useCodySidebarSize(): number {
     const size = useCodySidebarSizeStore(store => store.size)
     const { isOpen } = useCodySidebarStore()
-    return isOpen && window.context?.codyEnabled ? size : 0
+    const enabled = useIsCodyEnabled()
+
+    return isOpen && enabled.sidebar ? size : 0
 }

--- a/client/web/src/cody/useIsCodyEnabled.tsx
+++ b/client/web/src/cody/useIsCodyEnabled.tsx
@@ -23,7 +23,6 @@ export const useIsCodyEnabled = (): { chat: boolean; sidebar: boolean; search: b
         !window.context?.currentUser?.siteAdmin &&
         !window.context?.currentUser?.hasVerifiedEmail
     ) {
-        console.log(window.context?.currentUser?.hasVerifiedEmail)
         return notEnabled
     }
 

--- a/client/web/src/cody/useIsCodyEnabled.tsx
+++ b/client/web/src/cody/useIsCodyEnabled.tsx
@@ -1,0 +1,36 @@
+import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
+
+const notEnabled = {
+    chat: false,
+    sidebar: false,
+    search: false,
+    editorRecipes: false,
+}
+
+export const useIsCodyEnabled = (): { chat: boolean; sidebar: boolean; search: boolean; editorRecipes: boolean } => {
+    const [chatEnabled] = useFeatureFlag('cody-web-chat')
+    const [searchEnabled] = useFeatureFlag('cody-web-search')
+    const [sidebarEnabled] = useFeatureFlag('cody-web-sidebar')
+    const [editorRecipesEnabled] = useFeatureFlag('cody-web-editor-recipes')
+    const [allEnabled] = useFeatureFlag('cody-web-all')
+
+    if (!window.context?.codyEnabled) {
+        return notEnabled
+    }
+
+    if (
+        window.context?.sourcegraphDotComMode &&
+        !window.context?.currentUser?.siteAdmin &&
+        !window.context?.currentUser?.hasVerifiedEmail
+    ) {
+        console.log(window.context?.currentUser?.hasVerifiedEmail)
+        return notEnabled
+    }
+
+    return {
+        chat: chatEnabled || allEnabled,
+        sidebar: sidebarEnabled || allEnabled,
+        search: searchEnabled || allEnabled,
+        editorRecipes: (editorRecipesEnabled && sidebarEnabled) || allEnabled,
+    }
+}

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -60,6 +60,7 @@ const authUser: AuthenticatedUser = {
         ] as AuthenticatedUser['organizations']['nodes'],
     },
     viewerCanAdminister: true,
+    hasVerifiedEmail: true,
     databaseID: 0,
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -21,6 +21,7 @@ export const mockUser: AuthenticatedUser = {
         __typename: 'OrgConnection',
         nodes: [],
     },
+    hasVerifiedEmail: true,
     session: { __typename: 'Session', canSignOut: true },
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.story.tsx
@@ -12,6 +12,7 @@ import {
     GetIngestedCodeownersResult,
     GetIngestedCodeownersVariables,
     RepositoryFields,
+    RepositoryType,
 } from '../../graphql-operations'
 
 import { GET_INGESTED_CODEOWNERS_QUERY } from './graphqlQueries'
@@ -48,6 +49,7 @@ const repo: RepositoryFields = {
         abbrevName: 'main',
     },
     metadata: [],
+    sourceType: RepositoryType.GIT_REPOSITORY,
 }
 
 const empyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCodeownersVariables> = {

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -82,6 +82,7 @@ const authUser: AuthenticatedUser = {
         ] as OrgAreaOrganizationFields[],
     },
     viewerCanAdminister: true,
+    hasVerifiedEmail: true,
     databaseID: 0,
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -28,6 +28,9 @@ export type FeatureFlagName =
     | 'llm-proxy-management-ui'
     | 'cody-web-chat'
     | 'cody-web-search'
+    | 'cody-web-sidebar'
+    | 'cody-web-all'
+    | 'cody-web-editor-recipes'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -80,6 +80,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 tosAccepted: true,
                 url: '/users/test',
                 settingsURL: '/users/test/settings',
+                hasVerifiedEmail: true,
                 organizations: {
                     nodes: [
                         {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -55,6 +55,7 @@ export type SourcegraphContextCurrentUser = Pick<
     | 'emails'
     | 'latestSettings'
     | 'permissions'
+    | 'hasVerifiedEmail'
 >
 
 /**

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -27,6 +27,7 @@ import { BatchChangesNavItem } from '../batches/BatchChangesNavItem'
 import { CodeMonitoringLogo } from '../code-monitoring/CodeMonitoringLogo'
 import { CodeMonitoringProps } from '../codeMonitoring'
 import { CodyLogo } from '../cody/components/CodyLogo'
+import { useIsCodyEnabled } from '../cody/useIsCodyEnabled'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { useFuzzyFinderFeatureFlags } from '../components/fuzzyFinder/FuzzyFinderFeatureFlag'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
@@ -153,8 +154,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     const showSearchContext = searchContextsEnabled && !isSourcegraphDotCom
     const showCodeMonitoring = codeMonitoringEnabled
     const showSearchNotebook = notebooksEnabled
-    const showCody = window.context?.codyEnabled
-    const [showCodyChat] = useFeatureFlag('cody-web-chat')
+    const codyEnabled = useIsCodyEnabled()
 
     const [isSentinelEnabled] = useFeatureFlag('sentinel')
     // TODO: Include isSourcegraphDotCom in subsequent PR
@@ -181,7 +181,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
         const items: (NavDropdownItem | false)[] = [
             !!showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
             ownEnabled && { path: EnterprisePageRoutes.Own, content: 'Own' },
-            showCody && {
+            codyEnabled.search && {
                 path: EnterprisePageRoutes.CodySearch,
                 content: (
                     <>
@@ -191,7 +191,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
             },
         ]
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
-    }, [ownEnabled, showSearchContext, showCody])
+    }, [ownEnabled, showSearchContext, codyEnabled.search])
 
     const { fuzzyFinderNavbar } = useFuzzyFinderFeatureFlags()
 
@@ -233,7 +233,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             </NavLink>
                         </NavItem>
                     )}
-                    {showCody && showCodyChat && !!props.authenticatedUser && (
+                    {codyEnabled.chat && (
                         <NavItem icon={CodyLogo}>
                             <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Cody}>
                                 Cody AI

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -35,6 +35,7 @@ import { CodeIntelligenceProps } from '../codeintel'
 import { CodySidebar } from '../cody/sidebar'
 import { useChatStore } from '../cody/stores/chat'
 import { useCodySidebarStore } from '../cody/stores/sidebar'
+import { useIsCodyEnabled } from '../cody/useIsCodyEnabled'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
@@ -153,6 +154,8 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     const { repoName, revision, rawRevision, filePath, commitRange, position, range } = parseBrowserRepoURL(
         location.pathname + location.search + location.hash
     )
+
+    const codyEnabled = useIsCodyEnabled()
 
     const resolvedRevisionOrError = useObservable(
         useMemo(
@@ -348,7 +351,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
 
     return (
         <>
-            {window.context?.codyEnabled &&
+            {codyEnabled.sidebar &&
                 focusCodyShortcut?.keybindings.map((keybinding, index) => (
                     <Shortcut
                         key={index}
@@ -372,7 +375,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         telemetryService={props.telemetryService}
                     />
 
-                    {window.context?.codyEnabled ? (
+                    {codyEnabled.sidebar ? (
                         <RepoHeaderContributionPortal
                             position="right"
                             priority={1}
@@ -488,7 +491,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                     </Suspense>
                 </div>
 
-                {window.context?.codyEnabled && isCodySidebarOpen && (
+                {codyEnabled.sidebar && isCodySidebarOpen && (
                     <Panel
                         className="cody-sidebar-panel"
                         position="right"

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -27,6 +27,7 @@ import { AbsoluteRepoFile, ModeSpec, parseQueryAndHash } from '@sourcegraph/shar
 import { useLocalStorage } from '@sourcegraph/wildcard'
 
 import { useEditorStore } from '../../cody/stores/editor'
+import { useIsCodyEnabled } from '../../cody/useIsCodyEnabled'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { ExternalLinkFields, Scalars } from '../../graphql-operations'
 import { BlameHunkData } from '../blame/useBlameHunks'
@@ -272,6 +273,8 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         [customHistoryAction]
     )
 
+    const codyEnabled = useIsCodyEnabled()
+
     const extensions = useMemo(
         () => [
             // Log uncaught errors that happen in callbacks that we pass to
@@ -288,7 +291,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             }),
             scipSnapshot(blobInfo.snapshotData),
             codeFoldingExtension(),
-            window.context?.codyEnabled ? codyWidgetExtension() : [],
+            codyEnabled.editorRecipes ? codyWidgetExtension() : [],
             navigateToLineOnAnyClick ? navigateToLineOnAnyClickExtension : tokenSelectionExtension(),
             syntaxHighlight.of(blobInfo),
             languageSupport.of(blobInfo),

--- a/cmd/frontend/backend/mocks_temp.go
+++ b/cmd/frontend/backend/mocks_temp.go
@@ -1179,6 +1179,10 @@ type MockUserEmailsService struct {
 	// AddFunc is an instance of a mock function object controlling the
 	// behavior of the method Add.
 	AddFunc *UserEmailsServiceAddFunc
+	// CurrentActorHasVerifiedEmailFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// CurrentActorHasVerifiedEmail.
+	CurrentActorHasVerifiedEmailFunc *UserEmailsServiceCurrentActorHasVerifiedEmailFunc
 	// HasVerifiedEmailFunc is an instance of a mock function object
 	// controlling the behavior of the method HasVerifiedEmail.
 	HasVerifiedEmailFunc *UserEmailsServiceHasVerifiedEmailFunc
@@ -1214,8 +1218,13 @@ func NewMockUserEmailsService() *MockUserEmailsService {
 				return
 			},
 		},
-		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+		CurrentActorHasVerifiedEmailFunc: &UserEmailsServiceCurrentActorHasVerifiedEmailFunc{
 			defaultHook: func(context.Context) (r0 bool, r1 error) {
+				return
+			},
+		},
+		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -1262,8 +1271,13 @@ func NewStrictMockUserEmailsService() *MockUserEmailsService {
 				panic("unexpected invocation of MockUserEmailsService.Add")
 			},
 		},
-		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+		CurrentActorHasVerifiedEmailFunc: &UserEmailsServiceCurrentActorHasVerifiedEmailFunc{
 			defaultHook: func(context.Context) (bool, error) {
+				panic("unexpected invocation of MockUserEmailsService.CurrentActorHasVerifiedEmail")
+			},
+		},
+		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (bool, error) {
 				panic("unexpected invocation of MockUserEmailsService.HasVerifiedEmail")
 			},
 		},
@@ -1307,6 +1321,9 @@ func NewMockUserEmailsServiceFrom(i UserEmailsService) *MockUserEmailsService {
 	return &MockUserEmailsService{
 		AddFunc: &UserEmailsServiceAddFunc{
 			defaultHook: i.Add,
+		},
+		CurrentActorHasVerifiedEmailFunc: &UserEmailsServiceCurrentActorHasVerifiedEmailFunc{
+			defaultHook: i.CurrentActorHasVerifiedEmail,
 		},
 		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
 			defaultHook: i.HasVerifiedEmail,
@@ -1440,28 +1457,137 @@ func (c UserEmailsServiceAddFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
+// UserEmailsServiceCurrentActorHasVerifiedEmailFunc describes the behavior
+// when the CurrentActorHasVerifiedEmail method of the parent
+// MockUserEmailsService instance is invoked.
+type UserEmailsServiceCurrentActorHasVerifiedEmailFunc struct {
+	defaultHook func(context.Context) (bool, error)
+	hooks       []func(context.Context) (bool, error)
+	history     []UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall
+	mutex       sync.Mutex
+}
+
+// CurrentActorHasVerifiedEmail delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockUserEmailsService) CurrentActorHasVerifiedEmail(v0 context.Context) (bool, error) {
+	r0, r1 := m.CurrentActorHasVerifiedEmailFunc.nextHook()(v0)
+	m.CurrentActorHasVerifiedEmailFunc.appendCall(UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// CurrentActorHasVerifiedEmail method of the parent MockUserEmailsService
+// instance is invoked and the hook queue is empty.
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CurrentActorHasVerifiedEmail method of the parent MockUserEmailsService
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) PushHook(hook func(context.Context) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) nextHook() func(context.Context) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) appendCall(r0 UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall objects describing
+// the invocations of this function.
+func (f *UserEmailsServiceCurrentActorHasVerifiedEmailFunc) History() []UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall {
+	f.mutex.Lock()
+	history := make([]UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall is an object that
+// describes an invocation of method CurrentActorHasVerifiedEmail on an
+// instance of MockUserEmailsService.
+type UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserEmailsServiceCurrentActorHasVerifiedEmailFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // UserEmailsServiceHasVerifiedEmailFunc describes the behavior when the
 // HasVerifiedEmail method of the parent MockUserEmailsService instance is
 // invoked.
 type UserEmailsServiceHasVerifiedEmailFunc struct {
-	defaultHook func(context.Context) (bool, error)
-	hooks       []func(context.Context) (bool, error)
+	defaultHook func(context.Context, int32) (bool, error)
+	hooks       []func(context.Context, int32) (bool, error)
 	history     []UserEmailsServiceHasVerifiedEmailFuncCall
 	mutex       sync.Mutex
 }
 
 // HasVerifiedEmail delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserEmailsService) HasVerifiedEmail(v0 context.Context) (bool, error) {
-	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0)
-	m.HasVerifiedEmailFunc.appendCall(UserEmailsServiceHasVerifiedEmailFuncCall{v0, r0, r1})
+func (m *MockUserEmailsService) HasVerifiedEmail(v0 context.Context, v1 int32) (bool, error) {
+	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0, v1)
+	m.HasVerifiedEmailFunc.appendCall(UserEmailsServiceHasVerifiedEmailFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the HasVerifiedEmail
 // method of the parent MockUserEmailsService instance is invoked and the
 // hook queue is empty.
-func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context) (bool, error)) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context, int32) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -1470,7 +1596,7 @@ func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Context) (bool, error)) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Context, int32) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1479,19 +1605,19 @@ func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context) (bool, error) {
+	f.SetDefaultHook(func(context.Context, int32) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *UserEmailsServiceHasVerifiedEmailFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context) (bool, error) {
+	f.PushHook(func(context.Context, int32) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *UserEmailsServiceHasVerifiedEmailFunc) nextHook() func(context.Context) (bool, error) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) nextHook() func(context.Context, int32) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1528,6 +1654,9 @@ type UserEmailsServiceHasVerifiedEmailFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -1539,7 +1668,7 @@ type UserEmailsServiceHasVerifiedEmailFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c UserEmailsServiceHasVerifiedEmailFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/cmd/frontend/backend/mocks_temp.go
+++ b/cmd/frontend/backend/mocks_temp.go
@@ -1215,7 +1215,7 @@ func NewMockUserEmailsService() *MockUserEmailsService {
 			},
 		},
 		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
-			defaultHook: func(context.Context, int32) (r0 bool, r1 error) {
+			defaultHook: func(context.Context) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -1263,7 +1263,7 @@ func NewStrictMockUserEmailsService() *MockUserEmailsService {
 			},
 		},
 		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
-			defaultHook: func(context.Context, int32) (bool, error) {
+			defaultHook: func(context.Context) (bool, error) {
 				panic("unexpected invocation of MockUserEmailsService.HasVerifiedEmail")
 			},
 		},
@@ -1444,24 +1444,24 @@ func (c UserEmailsServiceAddFuncCall) Results() []interface{} {
 // HasVerifiedEmail method of the parent MockUserEmailsService instance is
 // invoked.
 type UserEmailsServiceHasVerifiedEmailFunc struct {
-	defaultHook func(context.Context, int32) (bool, error)
-	hooks       []func(context.Context, int32) (bool, error)
+	defaultHook func(context.Context) (bool, error)
+	hooks       []func(context.Context) (bool, error)
 	history     []UserEmailsServiceHasVerifiedEmailFuncCall
 	mutex       sync.Mutex
 }
 
 // HasVerifiedEmail delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserEmailsService) HasVerifiedEmail(v0 context.Context, v1 int32) (bool, error) {
-	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0, v1)
-	m.HasVerifiedEmailFunc.appendCall(UserEmailsServiceHasVerifiedEmailFuncCall{v0, v1, r0, r1})
+func (m *MockUserEmailsService) HasVerifiedEmail(v0 context.Context) (bool, error) {
+	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0)
+	m.HasVerifiedEmailFunc.appendCall(UserEmailsServiceHasVerifiedEmailFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the HasVerifiedEmail
 // method of the parent MockUserEmailsService instance is invoked and the
 // hook queue is empty.
-func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context, int32) (bool, error)) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context) (bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -1470,7 +1470,7 @@ func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Context, int32) (bool, error)) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Context) (bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1479,19 +1479,19 @@ func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Conte
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int32) (bool, error) {
+	f.SetDefaultHook(func(context.Context) (bool, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *UserEmailsServiceHasVerifiedEmailFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int32) (bool, error) {
+	f.PushHook(func(context.Context) (bool, error) {
 		return r0, r1
 	})
 }
 
-func (f *UserEmailsServiceHasVerifiedEmailFunc) nextHook() func(context.Context, int32) (bool, error) {
+func (f *UserEmailsServiceHasVerifiedEmailFunc) nextHook() func(context.Context) (bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1528,9 +1528,6 @@ type UserEmailsServiceHasVerifiedEmailFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 int32
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 bool
@@ -1542,7 +1539,7 @@ type UserEmailsServiceHasVerifiedEmailFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c UserEmailsServiceHasVerifiedEmailFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this

--- a/cmd/frontend/backend/mocks_temp.go
+++ b/cmd/frontend/backend/mocks_temp.go
@@ -1179,6 +1179,9 @@ type MockUserEmailsService struct {
 	// AddFunc is an instance of a mock function object controlling the
 	// behavior of the method Add.
 	AddFunc *UserEmailsServiceAddFunc
+	// HasVerifiedEmailFunc is an instance of a mock function object
+	// controlling the behavior of the method HasVerifiedEmail.
+	HasVerifiedEmailFunc *UserEmailsServiceHasVerifiedEmailFunc
 	// RemoveFunc is an instance of a mock function object controlling the
 	// behavior of the method Remove.
 	RemoveFunc *UserEmailsServiceRemoveFunc
@@ -1208,6 +1211,11 @@ func NewMockUserEmailsService() *MockUserEmailsService {
 	return &MockUserEmailsService{
 		AddFunc: &UserEmailsServiceAddFunc{
 			defaultHook: func(context.Context, int32, string) (r0 error) {
+				return
+			},
+		},
+		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -1254,6 +1262,11 @@ func NewStrictMockUserEmailsService() *MockUserEmailsService {
 				panic("unexpected invocation of MockUserEmailsService.Add")
 			},
 		},
+		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (bool, error) {
+				panic("unexpected invocation of MockUserEmailsService.HasVerifiedEmail")
+			},
+		},
 		RemoveFunc: &UserEmailsServiceRemoveFunc{
 			defaultHook: func(context.Context, int32, string) error {
 				panic("unexpected invocation of MockUserEmailsService.Remove")
@@ -1294,6 +1307,9 @@ func NewMockUserEmailsServiceFrom(i UserEmailsService) *MockUserEmailsService {
 	return &MockUserEmailsService{
 		AddFunc: &UserEmailsServiceAddFunc{
 			defaultHook: i.Add,
+		},
+		HasVerifiedEmailFunc: &UserEmailsServiceHasVerifiedEmailFunc{
+			defaultHook: i.HasVerifiedEmail,
 		},
 		RemoveFunc: &UserEmailsServiceRemoveFunc{
 			defaultHook: i.Remove,
@@ -1422,6 +1438,117 @@ func (c UserEmailsServiceAddFuncCall) Args() []interface{} {
 // invocation.
 func (c UserEmailsServiceAddFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// UserEmailsServiceHasVerifiedEmailFunc describes the behavior when the
+// HasVerifiedEmail method of the parent MockUserEmailsService instance is
+// invoked.
+type UserEmailsServiceHasVerifiedEmailFunc struct {
+	defaultHook func(context.Context, int32) (bool, error)
+	hooks       []func(context.Context, int32) (bool, error)
+	history     []UserEmailsServiceHasVerifiedEmailFuncCall
+	mutex       sync.Mutex
+}
+
+// HasVerifiedEmail delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUserEmailsService) HasVerifiedEmail(v0 context.Context, v1 int32) (bool, error) {
+	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0, v1)
+	m.HasVerifiedEmailFunc.appendCall(UserEmailsServiceHasVerifiedEmailFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the HasVerifiedEmail
+// method of the parent MockUserEmailsService instance is invoked and the
+// hook queue is empty.
+func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context, int32) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// HasVerifiedEmail method of the parent MockUserEmailsService instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserEmailsServiceHasVerifiedEmailFunc) PushHook(hook func(context.Context, int32) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserEmailsServiceHasVerifiedEmailFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserEmailsServiceHasVerifiedEmailFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int32) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *UserEmailsServiceHasVerifiedEmailFunc) nextHook() func(context.Context, int32) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserEmailsServiceHasVerifiedEmailFunc) appendCall(r0 UserEmailsServiceHasVerifiedEmailFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserEmailsServiceHasVerifiedEmailFuncCall
+// objects describing the invocations of this function.
+func (f *UserEmailsServiceHasVerifiedEmailFunc) History() []UserEmailsServiceHasVerifiedEmailFuncCall {
+	f.mutex.Lock()
+	history := make([]UserEmailsServiceHasVerifiedEmailFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserEmailsServiceHasVerifiedEmailFuncCall is an object that describes an
+// invocation of method HasVerifiedEmail on an instance of
+// MockUserEmailsService.
+type UserEmailsServiceHasVerifiedEmailFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserEmailsServiceHasVerifiedEmailFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserEmailsServiceHasVerifiedEmailFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // UserEmailsServiceRemoveFunc describes the behavior when the Remove method

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6114,6 +6114,11 @@ type User implements Node & SettingsSubject & Namespace {
     """
     emails: [UserEmail!]!
     """
+    Whether the user has a verified email or not.
+    Only the user and site admins can access this field.
+    """
+    requiresVerifiedEmailForCody: Boolean!
+    """
     The user's verified primary email address (if any).
     On dotcom only the user and site admins can access this field.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6119,11 +6119,6 @@ type User implements Node & SettingsSubject & Namespace {
     """
     hasVerifiedEmail: Boolean!
     """
-    Whether the user is required to have a verified email to access Cody.
-    """
-    requiresVerifiedEmailForCody: Boolean!
-
-    """
     The user's verified primary email address (if any).
     On dotcom only the user and site admins can access this field.
     """
@@ -6227,6 +6222,11 @@ type User implements Node & SettingsSubject & Namespace {
     Null, if not overwritten.
     """
     codeCompletionsQuotaOverride: Int
+    """
+    Whether users are required to have a verified email in order to access Cody.
+    """
+    requiresVerifiedEmailForCody: Boolean!
+
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6117,7 +6117,12 @@ type User implements Node & SettingsSubject & Namespace {
     Whether the user has a verified email or not.
     Only the user and site admins can access this field.
     """
+    hasVerifiedEmail: Boolean!
+    """
+    Whether the user is required to have a verified email to access Cody.
+    """
     requiresVerifiedEmailForCody: Boolean!
+
     """
     The user's verified primary email address (if any).
     On dotcom only the user and site admins can access this field.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6222,11 +6222,6 @@ type User implements Node & SettingsSubject & Namespace {
     Null, if not overwritten.
     """
     codeCompletionsQuotaOverride: Int
-    """
-    Whether users are required to have a verified email in order to access Cody.
-    """
-    requiresVerifiedEmailForCody: Boolean!
-
 }
 
 """
@@ -7037,6 +7032,11 @@ type Site implements SettingsSubject {
     The quota of code completions requests allowed per user in a day. Null, if unlimited.
     """
     perUserCodeCompletionsQuota: Int
+
+    """
+    Whether users are required to have a verified email in order to access Cody.
+    """
+    requiresVerifiedEmailForCody: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -503,3 +503,13 @@ func (r *siteResolver) PerUserCodeCompletionsQuota() *int32 {
 	}
 	return nil
 }
+
+func (r *siteResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
+	// We only require this on dotcom
+	if !envvar.SourcegraphDotComMode() {
+		return false
+	}
+
+	isAdmin := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil
+	return !isAdmin
+}

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -17,6 +17,17 @@ import (
 
 var timeNow = time.Now
 
+func (r *UserResolver) RequiresVerifiedEmailForCody(ctx context.Context) (bool, error) {
+	// We only require this on dotcom
+	if !envvar.SourcegraphDotComMode() {
+		return false, nil
+	}
+	// 🚨 SECURITY: Only the authenticated user and site admins can check
+	// whether the user has a verified email. That's checked in here.
+	emails := backend.NewUserEmailsService(r.db, r.logger)
+	return emails.HasVerifiedEmail(ctx, r.user.ID)
+}
+
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {
 	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
 	// emails on Sourcegraph.com.

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -17,16 +17,6 @@ import (
 
 var timeNow = time.Now
 
-func (r *UserResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
-	// We only require this on dotcom
-	if !envvar.SourcegraphDotComMode() {
-		return false
-	}
-
-	isAdmin := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil
-	return !isAdmin
-}
-
 func (r *UserResolver) HasVerifiedEmail(ctx context.Context) (bool, error) {
 	// 🚨 SECURITY: In the UserEmailsService we check that only the
 	// authenticated user and site admins can check

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -106,6 +106,7 @@ type CurrentUser struct {
 	ViewerCanAdminister bool       `json:"viewerCanAdminister"`
 	TosAccepted         bool       `json:"tosAccepted"`
 	Searchable          bool       `json:"searchable"`
+	HasVerifiedEmail    bool       `json:"hasVerifiedEmail"`
 
 	Organizations  *UserOrganizationsConnection `json:"organizations"`
 	Session        *UserSession                 `json:"session"`
@@ -418,6 +419,11 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		return nil
 	}
 
+	hasVerifiedEmail, err := userResolver.HasVerifiedEmail(ctx)
+	if err != nil {
+		return nil
+	}
+
 	return &CurrentUser{
 		GraphQLTypename:     "User",
 		AvatarURL:           userResolver.AvatarURL(),
@@ -436,6 +442,7 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		Username:            userResolver.Username(),
 		ViewerCanAdminister: canAdminister,
 		Permissions:         resolveUserPermissions(ctx, userResolver),
+		HasVerifiedEmail:    hasVerifiedEmail,
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/completions/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/backend",
         "//cmd/frontend/enterprise",
         "//enterprise/cmd/frontend/internal/completions/resolvers",
         "//enterprise/internal/codeintel",

--- a/enterprise/cmd/frontend/internal/completions/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/BUILD.bazel
@@ -6,11 +6,11 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/backend",
         "//cmd/frontend/enterprise",
         "//enterprise/cmd/frontend/internal/completions/resolvers",
         "//enterprise/internal/codeintel",
         "//enterprise/internal/completions/streaming",
+        "//internal/cody",
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/observation",

--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
@@ -24,9 +25,36 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	logger := log.Scoped("completions", "")
-	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler { return streaming.NewCompletionsStreamHandler(logger, db) }
-	enterpriseServices.NewCodeCompletionsHandler = func() http.Handler { return streaming.NewCodeCompletionsHandler(logger, db) }
-	enterpriseServices.CompletionsResolver = resolvers.NewCompletionsResolver(db)
+
+	enterpriseServices.NewCompletionsStreamHandler = func() http.Handler {
+		completionsHandler := streaming.NewCompletionsStreamHandler(logger, db)
+		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, completionsHandler)
+	}
+	enterpriseServices.NewCodeCompletionsHandler = func() http.Handler {
+		codeCompletionsHandler := streaming.NewCodeCompletionsHandler(logger, db)
+		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, codeCompletionsHandler)
+	}
+	enterpriseServices.CompletionsResolver = resolvers.NewCompletionsResolver(db, observationCtx.Logger)
 
 	return nil
+}
+
+func requireVerifiedEmailMiddleware(db database.DB, logger log.Logger, next http.Handler) http.Handler {
+	emails := backend.NewUserEmailsService(db, logger)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		verified, err := emails.HasVerifiedEmail(r.Context())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if !verified {
+			// Report HTTP 403 Forbidden if user has no verified email address.
+			code := http.StatusForbidden
+			http.Error(w, "No verified email address found.", code)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -41,7 +41,7 @@ func Init(
 
 func requireVerifiedEmailMiddleware(db database.DB, logger log.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := cody.RequiresVerifiedEmail(r.Context(), db, logger); err != nil {
+		if err := cody.CheckVerifiedEmailRequirement(r.Context(), db, logger); err != nil {
 			// Report HTTP 403 Forbidden if user has no verified email address.
 			http.Error(w, err.Error(), http.StatusForbidden)
 			return

--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/cody"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -41,23 +40,10 @@ func Init(
 }
 
 func requireVerifiedEmailMiddleware(db database.DB, logger log.Logger, next http.Handler) http.Handler {
-	emails := backend.NewUserEmailsService(db, logger)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !envvar.SourcegraphDotComMode() {
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		verified, err := emails.CurrentActorHasVerifiedEmail(r.Context())
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if !verified {
+		if err := cody.RequiresVerifiedEmail(r.Context(), db, logger); err != nil {
 			// Report HTTP 403 Forbidden if user has no verified email address.
-			code := http.StatusForbidden
-			http.Error(w, "No verified email address found.", code)
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 

--- a/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/resolvers",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/backend",
         "//cmd/frontend/graphqlbackend",
         "//enterprise/internal/completions/streaming",
         "//enterprise/internal/completions/types",
@@ -13,5 +14,6 @@ go_library(
         "//internal/database",
         "//internal/redispool",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/completions/resolvers",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/backend",
         "//cmd/frontend/graphqlbackend",
         "//enterprise/internal/completions/streaming",
         "//enterprise/internal/completions/types",

--- a/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -34,7 +34,7 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 		return "", errors.New("cody experimental feature flag is not enabled for current user")
 	}
 
-	if err := cody.RequiresVerifiedEmail(ctx, c.db, c.logger); err != nil {
+	if err := cody.CheckVerifiedEmailRequirement(ctx, c.db, c.logger); err != nil {
 		return "", err
 	}
 

--- a/enterprise/cmd/frontend/internal/embeddings/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/embeddings/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/backend",
         "//cmd/frontend/enterprise",
         "//enterprise/cmd/frontend/internal/embeddings/resolvers",
         "//enterprise/internal/codeintel",

--- a/enterprise/cmd/frontend/internal/embeddings/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/embeddings/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/backend",
         "//cmd/frontend/enterprise",
         "//enterprise/cmd/frontend/internal/embeddings/resolvers",
         "//enterprise/internal/codeintel",

--- a/enterprise/cmd/frontend/internal/embeddings/init.go
+++ b/enterprise/cmd/frontend/internal/embeddings/init.go
@@ -3,6 +3,7 @@ package embeddings
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
@@ -27,6 +28,7 @@ func Init(
 	contextDetectionEmbeddingsStore := contextdetection.NewContextDetectionEmbeddingJobsStore(db)
 	gitserverClient := gitserver.NewClient()
 	embeddingsClient := embeddings.NewClient()
-	enterpriseServices.EmbeddingsResolver = resolvers.NewResolver(db, gitserverClient, embeddingsClient, repoEmbeddingsStore, contextDetectionEmbeddingsStore)
+	emails := backend.NewUserEmailsService(db, observationCtx.Logger)
+	enterpriseServices.EmbeddingsResolver = resolvers.NewResolver(db, gitserverClient, embeddingsClient, repoEmbeddingsStore, contextDetectionEmbeddingsStore, emails)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/embeddings/init.go
+++ b/enterprise/cmd/frontend/internal/embeddings/init.go
@@ -3,7 +3,6 @@ package embeddings
 import (
 	"context"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
@@ -17,7 +16,7 @@ import (
 )
 
 func Init(
-	ctx context.Context,
+	_ context.Context,
 	observationCtx *observation.Context,
 	db database.DB,
 	_ codeintel.Services,
@@ -28,7 +27,15 @@ func Init(
 	contextDetectionEmbeddingsStore := contextdetection.NewContextDetectionEmbeddingJobsStore(db)
 	gitserverClient := gitserver.NewClient()
 	embeddingsClient := embeddings.NewClient()
-	emails := backend.NewUserEmailsService(db, observationCtx.Logger)
-	enterpriseServices.EmbeddingsResolver = resolvers.NewResolver(db, gitserverClient, embeddingsClient, repoEmbeddingsStore, contextDetectionEmbeddingsStore, emails)
+
+	enterpriseServices.EmbeddingsResolver = resolvers.NewResolver(
+		db,
+		observationCtx.Logger,
+		gitserverClient,
+		embeddingsClient,
+		repoEmbeddingsStore,
+		contextDetectionEmbeddingsStore,
+	)
+
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/embeddings/resolvers",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/backend",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//enterprise/internal/embeddings",

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
         "//lib/errors",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_graph_gophers_graphql_go//relay",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -57,7 +57,7 @@ func (r *Resolver) EmbeddingsSearch(ctx context.Context, args graphqlbackend.Emb
 		return nil, errors.New("cody experimental feature flag is not enabled for current user")
 	}
 
-	if err := cody.RequiresVerifiedEmail(ctx, r.db, r.logger); err != nil {
+	if err := cody.CheckVerifiedEmailRequirement(ctx, r.db, r.logger); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graph
 		return false, errors.New("cody experimental feature flag is not enabled for current user")
 	}
 
-	if err := cody.RequiresVerifiedEmail(ctx, r.db, r.logger); err != nil {
+	if err := cody.CheckVerifiedEmailRequirement(ctx, r.db, r.logger); err != nil {
 		return false, err
 	}
 

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -6,10 +6,14 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/cody",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//cmd/frontend/backend",
+        "//cmd/frontend/envvar",
         "//internal/actor",
         "//internal/conf",
         "//internal/conf/deploy",
+        "//internal/database",
         "//internal/featureflag",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//cmd/frontend/backend",
         "//cmd/frontend/envvar",
         "//internal/actor",
+        "//internal/auth",
         "//internal/conf",
         "//internal/conf/deploy",
         "//internal/database",

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//internal/conf/deploy",
         "//internal/database",
         "//internal/featureflag",
+        "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/internal/cody/feature_flag.go
+++ b/internal/cody/feature_flag.go
@@ -2,10 +2,10 @@ package cody
 
 import (
 	"context"
-	"errors"
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/internal/cody/feature_flag.go
+++ b/internal/cody/feature_flag.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -14,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // IsCodyEnabled determines if cody is enabled for the actor in the given context.

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -57668,6 +57668,9 @@ type MockUserEmailsStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *UserEmailsStoreHandleFunc
+	// HasVerifiedEmailFunc is an instance of a mock function object
+	// controlling the behavior of the method HasVerifiedEmail.
+	HasVerifiedEmailFunc *UserEmailsStoreHasVerifiedEmailFunc
 	// ListByUserFunc is an instance of a mock function object controlling
 	// the behavior of the method ListByUser.
 	ListByUserFunc *UserEmailsStoreListByUserFunc
@@ -57736,6 +57739,11 @@ func NewMockUserEmailsStore() *MockUserEmailsStore {
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
 			defaultHook: func() (r0 basestore.TransactableHandle) {
+				return
+			},
+		},
+		HasVerifiedEmailFunc: &UserEmailsStoreHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -57826,6 +57834,11 @@ func NewStrictMockUserEmailsStore() *MockUserEmailsStore {
 				panic("unexpected invocation of MockUserEmailsStore.Handle")
 			},
 		},
+		HasVerifiedEmailFunc: &UserEmailsStoreHasVerifiedEmailFunc{
+			defaultHook: func(context.Context, int32) (bool, error) {
+				panic("unexpected invocation of MockUserEmailsStore.HasVerifiedEmail")
+			},
+		},
 		ListByUserFunc: &UserEmailsStoreListByUserFunc{
 			defaultHook: func(context.Context, UserEmailsListOptions) ([]*UserEmail, error) {
 				panic("unexpected invocation of MockUserEmailsStore.ListByUser")
@@ -57897,6 +57910,9 @@ func NewMockUserEmailsStoreFrom(i UserEmailsStore) *MockUserEmailsStore {
 		},
 		HandleFunc: &UserEmailsStoreHandleFunc{
 			defaultHook: i.Handle,
+		},
+		HasVerifiedEmailFunc: &UserEmailsStoreHasVerifiedEmailFunc{
+			defaultHook: i.HasVerifiedEmail,
 		},
 		ListByUserFunc: &UserEmailsStoreListByUserFunc{
 			defaultHook: i.ListByUser,
@@ -58804,6 +58820,117 @@ func (c UserEmailsStoreHandleFuncCall) Args() []interface{} {
 // invocation.
 func (c UserEmailsStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// UserEmailsStoreHasVerifiedEmailFunc describes the behavior when the
+// HasVerifiedEmail method of the parent MockUserEmailsStore instance is
+// invoked.
+type UserEmailsStoreHasVerifiedEmailFunc struct {
+	defaultHook func(context.Context, int32) (bool, error)
+	hooks       []func(context.Context, int32) (bool, error)
+	history     []UserEmailsStoreHasVerifiedEmailFuncCall
+	mutex       sync.Mutex
+}
+
+// HasVerifiedEmail delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUserEmailsStore) HasVerifiedEmail(v0 context.Context, v1 int32) (bool, error) {
+	r0, r1 := m.HasVerifiedEmailFunc.nextHook()(v0, v1)
+	m.HasVerifiedEmailFunc.appendCall(UserEmailsStoreHasVerifiedEmailFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the HasVerifiedEmail
+// method of the parent MockUserEmailsStore instance is invoked and the hook
+// queue is empty.
+func (f *UserEmailsStoreHasVerifiedEmailFunc) SetDefaultHook(hook func(context.Context, int32) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// HasVerifiedEmail method of the parent MockUserEmailsStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UserEmailsStoreHasVerifiedEmailFunc) PushHook(hook func(context.Context, int32) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UserEmailsStoreHasVerifiedEmailFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UserEmailsStoreHasVerifiedEmailFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int32) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *UserEmailsStoreHasVerifiedEmailFunc) nextHook() func(context.Context, int32) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UserEmailsStoreHasVerifiedEmailFunc) appendCall(r0 UserEmailsStoreHasVerifiedEmailFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UserEmailsStoreHasVerifiedEmailFuncCall
+// objects describing the invocations of this function.
+func (f *UserEmailsStoreHasVerifiedEmailFunc) History() []UserEmailsStoreHasVerifiedEmailFuncCall {
+	f.mutex.Lock()
+	history := make([]UserEmailsStoreHasVerifiedEmailFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UserEmailsStoreHasVerifiedEmailFuncCall is an object that describes an
+// invocation of method HasVerifiedEmail on an instance of
+// MockUserEmailsStore.
+type UserEmailsStoreHasVerifiedEmailFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UserEmailsStoreHasVerifiedEmailFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UserEmailsStoreHasVerifiedEmailFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // UserEmailsStoreListByUserFunc describes the behavior when the ListByUser

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -51,6 +51,7 @@ type UserEmailsStore interface {
 	GetInitialSiteAdminInfo(ctx context.Context) (email string, tosAccepted bool, err error)
 	GetLatestVerificationSentEmail(ctx context.Context, email string) (*UserEmail, error)
 	GetPrimaryEmail(ctx context.Context, id int32) (email string, verified bool, err error)
+	HasVerifiedEmail(ctx context.Context, id int32) (bool, error)
 	GetVerifiedEmails(ctx context.Context, emails ...string) ([]*UserEmail, error)
 	ListByUser(ctx context.Context, opt UserEmailsListOptions) ([]*UserEmail, error)
 	Remove(ctx context.Context, userID int32, email string) error
@@ -110,6 +111,13 @@ func (s *userEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email 
 		return "", false, err
 	}
 	return email, verified, nil
+}
+
+// HasVerifiedEmail returns whether the user with the given ID has a verified email.
+func (s *userEmailsStore) HasVerifiedEmail(ctx context.Context, id int32) (bool, error) {
+	q := sqlf.Sprintf("SELECT true FROM user_emails WHERE user_id = %s AND verified_at IS NOT NULL LIMIT 1", id)
+	verified, ok, err := basestore.ScanFirstBool(s.Query(ctx, q))
+	return ok && verified, err
 }
 
 // SetPrimaryEmail sets the primary email for a user.


### PR DESCRIPTION
This fixes #51453 by ensuring that on sourcegraph.com users can only access the Cody-relevant endpoints/resolvers if they have >1 verified email.

It does this by 
- adding a helper to the `cody` package
- changing the endpoints/resolvers to check whether verified-email-is-required and user-has-verified-email

This also adds two new GraphQL fields:

```graphql
user {
 # [...]
 hasVerifiedEmail
}
site {
 # [...]
 requiresVerifiedEmailForCody
}
```

Both of them can then be used in clients (VS Code, web) to check whether `site.requiresVerifiedEmailForCody && user.hasVerifiedEmail`.

They should check, otherwise the user will run into an error. Client changes will be made in follow-up PRs.

## Test plan

Existing and new unit tests

#### Prep

1. Create user: `sg db add-user --username test-user-1 --password 123456789101112`
1. Unset site-admin bit: `psql -c "update users set site_admin = false where username = 'test-user-1';"`
1. Unverify email: `psql -c "update user_emails set verified_at = NULL where email = 'test-user-1@sourcegraph.com';"`
1. Login with user and create access token

#### Test

1. Start sourcegraph in dotcom mode: `sg start dotcom`
2. Confirm that all endpoints error:

    Completions stream:
    ```
    curl 'https://sourcegraph.test:3443/.api/completions/stream' \
      -H 'Authorization: token sgp_b3fc2922cb697080210467ac1e727d8d936b0afc' \
      --data-raw $'{"messages":[{"speaker":"human","text":"Testing"}],"temperature":0.2,"maxTokensToSample":1000,"topK":-1,"topP":-1}' \
      --compressed
    ```
    -> prints `cody requires a verified email address`

    Code completions:
    ```
    curl 'https://sourcegraph.test:3443/.api/completions/code' \
      -H 'Authorization: token sgp_b3fc2922cb697080210467ac1e727d8d936b0afc' \
      --data-raw $'{"messages":[{"speaker":"human","text":"Testing"}],"temperature":0.2,"maxTokensToSample":1000,"topK":-1,"topP":-1}' \
      --compressed

    ```
    -> prints `cody requires a verified email address`

    GraphQL completions:
    ```
    curl 'https://sourcegraph.test:3443/.api/graphql' \
      -H 'Authorization: token sgp_b3fc2922cb697080210467ac1e727d8d936b0afc' \
      --data-raw $'{"query":"query($input:CompletionsInput\u0021) {\\n  completions(input: $input)\\n}","variables":{"input":{"messages":[{"speaker":"HUMAN","text":"hello"}],"temperature":0.2,"maxTokensToSample":1000,"topK":-1,"topP":-1}}}' \
      --compressed
    ```
    -> prints `{"errors":[{"message":"cody requires a verified email address","path":["completions"]}],"data":null}`


3. Verify email: `psql -c "update user_emails set verified_at = now() where email = 'test-user-1@sourcegraph.com';"`
4. Retry requests: all work

