### PR TITLE
feat: add a message for auth provider config for github apps

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -322,6 +322,7 @@ ts_project(
         "src/components/fuzzyFinder/HighlightedLink.tsx",
         "src/components/fuzzyFinder/LazyFuzzyFinder.tsx",
         "src/components/gitHubApps/AddGitHubAppPage.tsx",
+        "src/components/gitHubApps/AuthProviderMessage.tsx",
         "src/components/gitHubApps/GitHubAppCard.tsx",
         "src/components/gitHubApps/GitHubAppPage.tsx",
         "src/components/gitHubApps/GitHubAppsPage.tsx",

--- a/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
+++ b/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
@@ -31,14 +31,6 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
         }
     )
 
-    if (error) {
-        return (
-            <Alert variant="danger" className="m-3">
-                Error fetching GitHub App client secret: {error.message}
-            </Alert>
-        )
-    }
-
     const clientSecret = useMemo(() => {
         if (loading) {
             return 'LOADING...'
@@ -64,6 +56,14 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
             4
         )
     }, [clientSecret, app])
+
+    if (error) {
+        return (
+            <Alert variant="danger" className="m-3">
+                Error fetching GitHub App client secret: {error.message}
+            </Alert>
+        )
+    }
 
     return (
         <>

--- a/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
+++ b/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
@@ -4,7 +4,7 @@ import { mdiEye, mdiEyeOffOutline } from '@mdi/js'
 import { parse as parseJSONC } from 'jsonc-parser'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { Icon, Button, Alert, Text, Link } from '@sourcegraph/wildcard'
+import { Icon, Button, Alert, Text, Link, Code } from '@sourcegraph/wildcard'
 
 import {
     GitHubAppByIDResult,
@@ -67,7 +67,7 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
 
     return (
         <>
-            <code>{providerJson}</code>
+            <Code>{providerJson}</Code>
             <br />
             <Button className="mt-2" size="sm" variant="secondary" onClick={() => setReveal(!reveal)}>
                 <Icon aria-hidden={true} svgPath={reveal ? mdiEyeOffOutline : mdiEye} className="mr-1" />
@@ -78,12 +78,14 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
 }
 
 export const AuthProviderMessage: FC<Props> = ({ app, id }) => {
+    const { data, loading, error } = useQuery<SiteResult, SiteVariables>(SITE_SETTINGS_QUERY, {
+        skip: !app || !id,
+    })
+    const siteConfig = useMemo(() => (data ? parseJSONC(data.site.configuration.effectiveContents) : null), [data])
+
     if (!app || !id) {
         return null
     }
-
-    const { data, loading, error } = useQuery<SiteResult, SiteVariables>(SITE_SETTINGS_QUERY, {})
-    const siteConfig = useMemo(() => (data ? parseJSONC(data.site.configuration.effectiveContents) : null), [data])
 
     const hasProvider = siteConfig?.['auth.providers'].find(
         (provider: { type: string; url: string; clientID: string }) =>
@@ -107,7 +109,7 @@ export const AuthProviderMessage: FC<Props> = ({ app, id }) => {
             <Text>
                 Add the following configuration to the{' '}
                 <Link to="/site-admin/configuration">
-                    <code>"auth.providers"</code> list in site-config
+                    <Code>"auth.providers"</Code> list in site-config
                 </Link>{' '}
                 to make sure that users can login and sync permissions via the GitHub app:
             </Text>

--- a/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
+++ b/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
@@ -1,0 +1,117 @@
+import { FC, useMemo, useState } from 'react'
+
+import { mdiEye, mdiEyeOffOutline } from '@mdi/js'
+import { parse as parseJSONC } from 'jsonc-parser'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { Icon, Button, Alert, Text, Link } from '@sourcegraph/wildcard'
+
+import {
+    GitHubAppByIDResult,
+    GitHubAppClientSecretResult,
+    GitHubAppClientSecretVariables,
+    SiteResult,
+    SiteVariables,
+} from '../../graphql-operations'
+
+import { GITHUB_APP_CLIENT_SECRET_QUERY, SITE_SETTINGS_QUERY } from './backend'
+
+interface Props {
+    app: GitHubAppByIDResult['gitHubApp']
+    id: string
+}
+
+const AuthProviderJSON: FC<Props> = ({ app, id }) => {
+    const [reveal, setReveal] = useState(false)
+    const { data, loading, error } = useQuery<GitHubAppClientSecretResult, GitHubAppClientSecretVariables>(
+        GITHUB_APP_CLIENT_SECRET_QUERY,
+        {
+            variables: { id },
+            skip: !reveal,
+        }
+    )
+
+    if (error) {
+        return (
+            <Alert variant="danger" className="m-3">
+                Error fetching GitHub App client secret: {error.message}
+            </Alert>
+        )
+    }
+
+    const clientSecret = useMemo(() => {
+        if (loading) {
+            return 'LOADING...'
+        }
+        if (reveal && data) {
+            return data?.gitHubApp?.clientSecret || 'NO CLIENT SECRET FOUND'
+        }
+        return 'REDACTED'
+    }, [data, loading, reveal])
+
+    const providerJson = useMemo(() => {
+        // typescript compiler is not smart enough to know that app is not null
+        const clientID = app !== null ? app.clientID : null
+        const url = app !== null ? app.baseURL : null
+        return JSON.stringify(
+            {
+                type: 'github',
+                clientID,
+                clientSecret,
+                url,
+            },
+            null,
+            4
+        )
+    }, [clientSecret, app])
+
+    return (
+        <>
+            <code>{providerJson}</code>
+            <br />
+            <Button className="mt-2" size="sm" variant="secondary" onClick={() => setReveal(!reveal)}>
+                <Icon aria-hidden={true} svgPath={reveal ? mdiEyeOffOutline : mdiEye} className="mr-1" />
+                {reveal ? 'Hide' : 'Reveal secret'}
+            </Button>
+        </>
+    )
+}
+
+export const AuthProviderMessage: FC<Props> = ({ app, id }) => {
+    if (!app || !id) {
+        return null
+    }
+
+    const { data, loading, error } = useQuery<SiteResult, SiteVariables>(SITE_SETTINGS_QUERY, {})
+    const siteConfig = useMemo(() => (data ? parseJSONC(data.site.configuration.effectiveContents) : null), [data])
+
+    const hasProvider = siteConfig?.['auth.providers'].find(
+        (provider: { type: string; url: string; clientID: string }) =>
+            provider.type === 'github' && provider.url === app.baseURL && provider.clientID === app.clientID
+    )
+
+    if (!siteConfig || hasProvider || loading) {
+        return null
+    }
+
+    if (error) {
+        return (
+            <Alert variant="danger" className="m-3">
+                Error fetching site configuration: {error.message}
+            </Alert>
+        )
+    }
+
+    return (
+        <Alert variant="warning" className="mt-4 mb-4">
+            <Text>
+                Add the following configuration to the{' '}
+                <Link to="/site-admin/configuration">
+                    <code>"auth.providers"</code> list in site-config
+                </Link>{' '}
+                to make sure that users can login and sync permissions via the GitHub app:
+            </Text>
+            <AuthProviderJSON app={app} id={id} />
+        </Alert>
+    )
+}

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -129,7 +129,6 @@ export const GitHubAppPage: FC<Props> = ({
                                         onClick={onDelete}
                                         disabled={deleteLoading}
                                         variant="danger"
-                                        size="sm"
                                     >
                                         <Icon aria-hidden={true} svgPath={mdiDelete} />
                                         {' Delete'}

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -28,6 +28,7 @@ import { ExternalServiceNode } from '../externalServices/ExternalServiceNode'
 import { ConnectionList, SummaryContainer, ConnectionSummary } from '../FilteredConnection/ui'
 import { PageTitle } from '../PageTitle'
 
+import { AuthProviderMessage } from './AuthProviderMessage'
 import { GITHUB_APP_BY_ID_QUERY } from './backend'
 
 import styles from './GitHubAppCard.module.scss'
@@ -124,6 +125,7 @@ export const GitHubAppPage: FC<Props> = ({
                             </span>
                         </span>
                     </span>
+                    <AuthProviderMessage app={app} id={appID} />
                     <hr />
 
                     <div className="mt-4">

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -56,9 +56,6 @@ export const GitHubAppPage: FC<Props> = ({
 
     const app = useMemo(() => data?.gitHubApp, [data])
 
-    // TODO - make an actual GraphQL request to do it here...
-    const refreshFromGH = (): void => {}
-
     if (!appID) {
         return null
     }
@@ -100,9 +97,6 @@ export const GitHubAppPage: FC<Props> = ({
                         headingElement="h2"
                         actions={
                             <>
-                                <Button onClick={refreshFromGH} variant="info" className="ml-auto">
-                                    <Icon inline={true} svgPath={mdiRefresh} aria-hidden={true} /> Refresh from GitHub
-                                </Button>
                                 <ButtonLink to={app.appURL} variant="info" className="ml-2">
                                     <Icon inline={true} svgPath={mdiGithub} aria-hidden={true} /> Edit
                                 </ButtonLink>

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -26,6 +26,7 @@ export const GITHUB_APP_BY_ID_QUERY = gql`
         gitHubApp(id: $id) {
             id
             appID
+            baseURL
             name
             slug
             appURL
@@ -49,6 +50,26 @@ export const GITHUB_APP_BY_ID_QUERY = gql`
                     ...ListExternalServiceFields
                 }
                 totalCount
+            }
+        }
+    }
+`
+
+export const GITHUB_APP_CLIENT_SECRET_QUERY = gql`
+    query GitHubAppClientSecret($id: ID!) {
+        gitHubApp(id: $id) {
+            id
+            clientSecret
+        }
+    }
+`
+
+export const SITE_SETTINGS_QUERY = gql`
+    query SiteConfigForApps {
+        site {
+            id
+            configuration {
+                effectiveContents
             }
         }
     }

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -67,6 +67,7 @@ export const GITHUB_APP_CLIENT_SECRET_QUERY = gql`
 export const SITE_SETTINGS_QUERY = gql`
     query SiteConfigForApps {
         site {
+            __typename
             id
             configuration {
                 effectiveContents

--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -37,6 +37,7 @@ type GitHubAppResolver interface {
 	BaseURL() string
 	AppURL() string
 	ClientID() string
+	ClientSecret() string
 	Logo() string
 	CreatedAt() gqlutil.DateTime
 	UpdatedAt() gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -64,6 +64,10 @@ type GitHubApp implements Node {
     """
     clientID: String!
     """
+    The client secret of the GitHub App
+    """
+    clientSecret: String!
+    """
     The logo URL of the GitHub App
     """
     logo: String!

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
@@ -137,6 +137,11 @@ func newServeMux(db edb.EnterpriseDB, prefix string, cache *rcache.Cache) http.H
 	})
 
 	r.Path(prefix + "/redirect").Methods("GET").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// 🚨 SECURITY: only site admins can setup github apps
+		if err := checkSiteAdmin(db, w, req); err != nil {
+			return
+		}
+
 		query := req.URL.Query()
 		state := query.Get("state")
 		code := query.Get("code")

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -180,6 +180,10 @@ func (r *gitHubAppResolver) ClientID() string {
 	return r.app.ClientID
 }
 
+func (r *gitHubAppResolver) ClientSecret() string {
+	return r.app.ClientSecret
+}
+
 func (r *gitHubAppResolver) Logo() string {
 	return r.app.Logo
 }


### PR DESCRIPTION
## Description

GitHub Apps are distributed with OAuth credentials for users to sign in with. We need to add an auth provider for each github app. Modifying the site config automatically is not really an option, because:
1. A lot of customers use site config from a file, which would override any changes that we make
2. Modifying the site config on the backend is really hard, since it's jsonc and we want to keep any comments. E.g. we cannot just json.Marshal a struct in Go
3. Even if we could do the above, we only allow 1 auth provider per url. So we cannot have more than one `https://github.com` auth providers. Letting the site admin decide what to do in that case seems like the best bet.

This PR adds a feature that shows to the site admin the configuration that needs to be added to the site configuration instead. We rely on the site-admin to do it manually. Given the constraints above, this was the quickest way to make it functional with the least amount of friction.

## Screenshots

<img width="922" alt="Screenshot 2023-05-10 at 14 50 46" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/3fd33906-75f9-4b7c-9598-89ed97a733d7">

![Screenshot 2023-05-10 at 14 50 56](https://github.com/sourcegraph/sourcegraph/assets/9974711/5d45d4af-4fd1-45b7-8ab9-e1db5815483d)

## Test plan

Tested locally. Most of the changes are in the UI.
