### PR TITLE
App: Add cli flags for cache and config dirs

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -57,22 +57,38 @@ func Main(services []sgservice.Service, config Config, args []string) {
 		),
 	)
 
-	runCommand := &cli.Command{
-		Name:  "run",
-		Usage: "Run the Sourcegraph App",
-		Action: func(ctx *cli.Context) error {
-			logger := log.Scoped("sourcegraph", "Sourcegraph")
-			singleprogram.Init(logger)
-			run(liblog, logger, services, config, true, true)
-			return nil
-		},
-	}
-
 	app := cli.NewApp()
 	app.Name = filepath.Base(args[0])
 	app.Usage = "The Sourcegraph App"
 	app.Version = version.Version()
-	app.Action = runCommand.Action
+	app.Flags = []cli.Flag{
+		&cli.PathFlag{
+			Name:        "cacheDir",
+			DefaultText: "OS default cache",
+			Usage:       "Which directory should be used to cache data",
+			EnvVars:     []string{"SRC_APP_CACHE"},
+			TakesFile:   false,
+			Action: func(ctx *cli.Context, p cli.Path) error {
+				return os.Setenv("SRC_APP_CACHE", p)
+			},
+		},
+		&cli.PathFlag{
+			Name:        "configDir",
+			DefaultText: "OS default config",
+			Usage:       "Directory where the configuration should be saved",
+			EnvVars:     []string{"SRC_APP_CONFIG"},
+			TakesFile:   false,
+			Action: func(ctx *cli.Context, p cli.Path) error {
+				return os.Setenv("SRC_APP_CONFIG", p)
+			},
+		},
+	}
+	app.Action = func(_ *cli.Context) error {
+		logger := log.Scoped("sourcegraph", "Sourcegraph")
+		singleprogram.Init(logger)
+		run(liblog, logger, services, config, true, true)
+		return nil
+	}
 
 	if err := app.Run(args); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-const AppDirectory = "sourcegraph"
+const appDirectory = "sourcegraph"
 
 func Init(logger log.Logger) {
 	if deploy.IsApp() {

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -239,11 +239,13 @@ func setupAppDir(root string, defaultDirFn func() (string, error)) (string, erro
 		return "", err
 	}
 
-	folder = AppDirectory
+	dir := AppDirectory
 	if version.IsDev(version.Version()) {
-		folder = fmt.Sprintf("%s-dev", folder)
+		dir = fmt.Sprintf("%s-dev", dir)
 	}
-	return folder, os.MkdirAll(folder, 0700)
+
+	path := filepath.Join(base, dir)
+	return path, os.MkdirAll(path, 0700)
 }
 
 // setDefaultEnv will set the environment variable if it is not set.

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -239,7 +239,7 @@ func setupAppDir(root string, defaultDirFn func() (string, error)) (string, erro
 		return "", err
 	}
 
-	dir := AppDirectory
+	dir := appDirectory
 	if version.IsDev(version.Version()) {
 		dir = fmt.Sprintf("%s-dev", dir)
 	}

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
+const AppDirectory = "sourcegraph-sp"
+
 func Init(logger log.Logger) {
 	if deploy.IsApp() {
 		fmt.Fprintln(os.Stderr, "✱ Sourcegraph App version:", version.Version())
@@ -64,18 +66,10 @@ func Init(logger log.Logger) {
 	// This defaults to an internal hostname.
 	setDefaultEnv(logger, "SRC_FRONTEND_INTERNAL", "localhost:3090")
 
-	appPath := "sourcegraph"
-	if version.IsDev(version.Version()) {
-		appPath = fmt.Sprintf("%s-dev", appPath)
-	}
-	cacheDir, err := os.UserCacheDir()
-	if err == nil {
-		cacheDir = filepath.Join(cacheDir, appPath)
-		err = os.MkdirAll(cacheDir, 0700)
-	}
+	cacheDir, err := setupAppDir(os.Getenv("SRC_APP_CACHE"), os.UserCacheDir)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "unable to make user cache directory:", err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stderr, "failed to setup cache directory. Please see log for more details")
+		logger.Fatal("failed to setup cache directory", log.Error(err))
 	}
 
 	setDefaultEnv(logger, "SRC_REPOS_DIR", filepath.Join(cacheDir, "repos"))
@@ -83,13 +77,10 @@ func Init(logger log.Logger) {
 	setDefaultEnv(logger, "SYMBOLS_CACHE_DIR", filepath.Join(cacheDir, "symbols"))
 	setDefaultEnv(logger, "SEARCHER_CACHE_DIR", filepath.Join(cacheDir, "searcher"))
 
-	configDir, err := os.UserConfigDir()
-	if err == nil {
-		configDir = filepath.Join(configDir, appPath)
-		err = os.MkdirAll(configDir, 0700)
-	}
+	configDir, err := setupAppDir(os.Getenv("SRC_APP_CONFIG"), os.UserConfigDir)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "unable to make user config directory:", err)
+		fmt.Fprintln(os.Stderr, "failed to setup user config directory. Please see log for more details")
+		logger.Fatal("failed to setup config directory", log.Error(err))
 		os.Exit(1)
 	}
 
@@ -237,6 +228,23 @@ exec docker run --rm -i \
     --entrypoint /usr/local/bin/universal-ctags \
     slimsag/ctags:latest@sha256:dd21503a3ae51524ab96edd5c0d0b8326d4baaf99b4238dfe8ec0232050af3c7 "$@"
 `
+
+func setupAppDir(root string, defaultDirFn func() (string, error)) (string, error) {
+	var base = root
+	var err error
+	if base == "" {
+		base, err = defaultDirFn()
+	}
+	if err != nil {
+		return "", err
+	}
+
+	folder = AppDirectory
+	if version.IsDev(version.Version()) {
+		folder = fmt.Sprintf("%s-dev", folder)
+	}
+	return folder, os.MkdirAll(folder, 0700)
+}
 
 // setDefaultEnv will set the environment variable if it is not set.
 func setDefaultEnv(logger log.Logger, k, v string) {

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-const AppDirectory = "sourcegraph-sp"
+const AppDirectory = "sourcegraph"
 
 func Init(logger log.Logger) {
 	if deploy.IsApp() {


### PR DESCRIPTION
Add flags to set the cache and config dirs for the app to use. These
flags are especially useful in testing scenarios or environments where
the user directory isn't available.

## Test plan
Local testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
