### PR TITLE
own: fix broken unit test

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -809,7 +809,7 @@ func TestCommitOwnershipSignals(t *testing.T) {
 								"reasons": [
 									{
 										"title": "recent contributor",
-										"description": "Owner is associated because they are have contributed to this file in the last 90 days."
+										"description": "Owner is associated because they have contributed to this file in the last 90 days."
 									}
 								]
 							}


### PR DESCRIPTION
Seems like lack of merge queue bit us. This PR will unblock main. 

Test Plan:

Ran bazel test //enterprise/cmd/frontend/internal/own/resolvers:resolvers_test locally and it passes now.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
