### PR TITLE
Cody: Do not require selection for chat message

### DIFF
--- a/client/cody-shared/src/chat/recipes/fixup.ts
+++ b/client/cody-shared/src/chat/recipes/fixup.ts
@@ -13,7 +13,7 @@ export class Fixup implements Recipe {
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         // TODO: Prompt the user for additional direction.
 
-        const selection = context.editor.getActiveTextEditorSelection()
+        const selection = context.editor.getActiveTextEditorSelection(true)
         if (!selection) {
             await context.editor.showWarningMessage('Select some code to fixup.')
             return null

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -18,7 +18,7 @@ export interface ActiveTextEditorVisibleContent {
 export interface Editor {
     getWorkspaceRootPath(): string | null
     getActiveTextEditor(): ActiveTextEditor | null
-    getActiveTextEditorSelection(): ActiveTextEditorSelection | null
+    getActiveTextEditorSelection(requireSelection?: boolean): ActiveTextEditorSelection | null
 
     /**
      * Gets the active text editor's selection, or the entire file if the selected range is empty.

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -53,7 +53,7 @@ export class MockEditor implements Editor {
         return this.mocks.getWorkspaceRootPath?.() ?? null
     }
 
-    public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {
+    public getActiveTextEditorSelection(_requireSelection: boolean): ActiveTextEditorSelection | null {
         return this.mocks.getActiveTextEditorSelection?.() ?? null
     }
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
+- Fixes an issue when using cody without selecting text. [pull/51713](https://github.com/sourcegraph/sourcegraph/pull/51713)
+
 ### Changed
 
 ## [0.1.0]

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -36,15 +36,17 @@ export class VSCodeEditor implements Editor {
         return activeEditor && activeEditor.document.uri.scheme === 'file' ? activeEditor : null
     }
 
-    public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {
+    public getActiveTextEditorSelection(requireSelection: boolean = false): ActiveTextEditorSelection | null {
         const activeEditor = this.getActiveTextEditorInstance()
         if (!activeEditor) {
             return null
         }
         const selection = activeEditor.selection
         if (!selection || selection?.start.isEqual(selection.end)) {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            vscode.window.showErrorMessage('No code selected. Please select some code and try again.')
+            if (requireSelection) {
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                vscode.window.showErrorMessage('No code selected. Please select some code and try again.')
+            }
             return null
         }
         return this.createActiveTextEditorSelection(activeEditor, selection)


### PR DESCRIPTION
Fixes an issue when using cody without selecting text.

## Test plan

<img width="1164" alt="Screenshot 2023-05-10 at 15 35 10" src="https://github.com/sourcegraph/sourcegraph/assets/458591/455a9e36-1ab6-4286-88e5-5b22dade432c">
<img width="509" alt="Screenshot 2023-05-10 at 15 35 01" src="https://github.com/sourcegraph/sourcegraph/assets/458591/4fedcd69-8762-4a0e-959f-49c1fdff578d">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
