### PR TITLE
Cody: Remove system notification from non-actions

### DIFF
--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -11,6 +11,7 @@ export class ExplainCodeDetailed implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -11,6 +11,7 @@ export class ExplainCodeHighLevel implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -11,6 +11,7 @@ export class FindCodeSmells implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -16,6 +16,7 @@ export class GenerateDocstring implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -16,6 +16,7 @@ export class GenerateTest implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -42,8 +42,6 @@ export class GitHistory implements Recipe {
                 args: ['log', '-n5', logFormat, '--', selection.fileName],
                 rawDisplayText: `What changed in ${name} in the last 5 commits`,
             })
-        } else {
-            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
         }
         const selectedLabel = await context.editor.showQuickPick(items.map(e => e.label))
         if (!selectedLabel) {

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -42,6 +42,8 @@ export class GitHistory implements Recipe {
                 args: ['log', '-n5', logFormat, '--', selection.fileName],
                 rawDisplayText: `What changed in ${name} in the last 5 commits`,
             })
+        } else {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
         }
         const selectedLabel = await context.editor.showQuickPick(items.map(e => e.label))
         if (!selectedLabel) {

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -16,6 +16,7 @@ export class ImproveVariableNames implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return Promise.resolve(null)
         }
 

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -13,6 +13,7 @@ export class TranslateToLanguage implements Recipe {
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()
         if (!selection) {
+            await context.editor.showWarningMessage('No code selected. Please select some code and try again.')
             return null
         }
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
+- False alert on empty selection []()
+
 ### Changed
 
 ## [0.1.0]

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- False alert on empty selection [pull/51714](https://github.com/sourcegraph/sourcegraph/pull/51714)
+- Remove system alerts from non-actionable items [pull/51714](https://github.com/sourcegraph/sourcegraph/pull/51714)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,9 +8,13 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- Remove system alerts from non-actionable items [pull/51714](https://github.com/sourcegraph/sourcegraph/pull/51714)
-
 ### Changed
+
+## [0.1.1]
+
+### Fixed
+
+- Remove system alerts from non-actionable items [pull/51714](https://github.com/sourcegraph/sourcegraph/pull/51714)
 
 ## [0.1.0]
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- False alert on empty selection []()
+- False alert on empty selection [pull/51714](https://github.com/sourcegraph/sourcegraph/pull/51714)
 
 ### Changed
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Sourcegraph Cody",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -43,8 +43,7 @@ export class VSCodeEditor implements Editor {
         }
         const selection = activeEditor.selection
         if (!selection || selection?.start.isEqual(selection.end)) {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            vscode.window.showErrorMessage('No code selected. Please select some code and try again.')
+            console.error('No code selected. Please select some code and try again.')
             return null
         }
         return this.createActiveTextEditorSelection(activeEditor, selection)
@@ -122,7 +121,7 @@ export class VSCodeEditor implements Editor {
 
         if (activeEditor.document.getText(selection) !== selectedText) {
             // TODO: Be robust to this.
-            await vscode.window.showErrorMessage(
+            await vscode.window.showInformationMessage(
                 'The selection changed while Cody was working. The text will not be edited.'
             )
             return

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -43,7 +43,6 @@ export class VSCodeEditor implements Editor {
         }
         const selection = activeEditor.selection
         if (!selection || selection?.start.isEqual(selection.end)) {
-            console.error('No code selected. Please select some code and try again.')
             return null
         }
         return this.createActiveTextEditorSelection(activeEditor, selection)

--- a/client/cody/src/secret-storage.ts
+++ b/client/cody/src/secret-storage.ts
@@ -7,7 +7,7 @@ export async function getAccessToken(secretStorage: SecretStorage): Promise<stri
         return (await secretStorage.get(CODY_ACCESS_TOKEN_SECRET)) || null
     } catch (error) {
         await secretStorage.delete(CODY_ACCESS_TOKEN_SECRET)
-        void vscode.window.showErrorMessage(`Failed to retreive access token for Cody: ${error}`)
+        console.error(`Failed to retreive access token for Cody: ${error}`)
         return null
     }
 }


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/51349
RE: https://sourcegraph.slack.com/archives/C04MZPE4JKD/p1683724897212539?thread_ts=1683723327.455849&cid=C04MZPE4JKD

PR to remove system notifications from non-actionable items, eg error messages as system pop up from background process etc

System notification should be handled by actionable functions individually. 

VS code UX guideline: https://code.visualstudio.com/api/ux-guidelines/notifications

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Local dev.