### PR TITLE
Remove unused subscriptions RBAC role

### DIFF
--- a/client/web/src/rbac/constants.ts
+++ b/client/web/src/rbac/constants.ts
@@ -3,7 +3,3 @@
 export const BatchChangesReadPermission = 'BATCH_CHANGES#READ'
 
 export const BatchChangesWritePermission = 'BATCH_CHANGES#WRITE'
-
-export const SubscriptionsReadPermission = 'SUBSCRIPTIONS#READ'
-
-export const SubscriptionsWritePermission = 'SUBSCRIPTIONS#WRITE'

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9700,10 +9700,6 @@ enum PermissionNamespace {
     This represents the Batch Changes namespace.
     """
     BATCH_CHANGES
-    """
-    This represents the subscriptions namespace.
-    """
-    SUBSCRIPTIONS
 }
 
 """

--- a/internal/rbac/constants.go
+++ b/internal/rbac/constants.go
@@ -5,7 +5,3 @@ package rbac
 const BatchChangesReadPermission string = "BATCH_CHANGES#READ"
 
 const BatchChangesWritePermission string = "BATCH_CHANGES#WRITE"
-
-const SubscriptionsReadPermission string = "SUBSCRIPTIONS#READ"
-
-const SubscriptionsWritePermission string = "SUBSCRIPTIONS#WRITE"

--- a/internal/rbac/schema.yaml
+++ b/internal/rbac/schema.yaml
@@ -3,7 +3,3 @@ namespaces:
     actions:
       - READ
       - WRITE
-  - name: SUBSCRIPTIONS
-    actions:
-      - READ
-      - WRITE

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -874,8 +874,7 @@ func (n PermissionNamespace) String() string {
 // Valid checks if a namespace is valid and supported by the Sourcegraph RBAC system.
 func (n PermissionNamespace) Valid() bool {
 	switch n {
-	case BatchChangesNamespace,
-		SubscriptionsNamespace:
+	case BatchChangesNamespace:
 		return true
 	default:
 		return false
@@ -884,7 +883,6 @@ func (n PermissionNamespace) Valid() bool {
 
 // BatchChangesNamespace represents the Batch Changes namespace.
 const BatchChangesNamespace PermissionNamespace = "BATCH_CHANGES"
-const SubscriptionsNamespace PermissionNamespace = "SUBSCRIPTIONS"
 
 type Permission struct {
 	ID        int32


### PR DESCRIPTION
Not used at the moment, was a leftover in a PR that I forgot to remove.



## Test plan


CI. Just unused constants. 