### PR TITLE
Revert "Revert "ci: remove bundlesize run target (#51626)" (#51695)"

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -103,14 +103,19 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 	cmds = append(cmds, bazelTestCmds...)
 
+	// DISABLED: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919
+	// this command makes an external request to https://bundlesize-cache.vercel.app
+	// which is not acceptable for such a task.
+	// TODO: @jhchabran
+	//
 	// Run commands
-	runTargets := []string{
-		"//client/web:bundlesize-report",
-	}
-	bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
+	// runTargets := []string{
+	// 	"//client/web:bundlesize-report",
+	// }
+	// bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
 	cmds = append(cmds,
-		bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
-		bk.Cmd(bazelRunCmd),
+		// bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
+		// bk.Cmd(bazelRunCmd),
 		bazelAnnouncef("✅"),
 	)
 


### PR DESCRIPTION
This reverts commit ed8fe4cdafb41eb2ca04cccc1bec2bc7a58879fc.

This is happening again https://buildkite.com/sourcegraph/sourcegraph/builds/218174#018805f1-361d-4d49-9e2e-fd6258311a8a

```
/root/buildkite/build/sourcegraph/node_modules/.pnpm/node-fetch@2.6.7/node_modules/node-fetch/lib/index.js:273
				return Body.Promise.reject(new FetchError(`invalid json response body at ${_this2.url} reason: ${err.message}`, 'invalid-json'));
				                           ^
FetchError: invalid json response body at https://bundlesize-github-reporter.vercel.app/ reason: Unexpected token A in JSON at position 0
    at /root/buildkite/build/sourcegraph/node_modules/.pnpm/node-fetch@2.6.7/node_modules/node-fetch/lib/index.js:273:32
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  type: 'invalid-json'
}
 ELIFECYCLE  Command failed with exit code 1.
🚨 Error: The command exited with status 1
```

@valerybugakov am I overlooking something? This doesn't look unrelated anymore 🤔 

<img width="1171" alt="Screenshot 2023-05-10 at 16 07 59" src="https://github.com/sourcegraph/sourcegraph/assets/458591/5b8cf575-81db-49a5-b510-c1a876c29e63">

## Test plan

- CI green

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
