### PR TITLE
chore: add a byline to feature flags page.

### DIFF
--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -29,6 +29,7 @@ import {
     Form,
 } from '@sourcegraph/wildcard'
 
+import { CreatedByAndUpdatedByInfoByline } from '../components/Byline/CreatedByAndUpdatedByInfoByline'
 import { Collapsible } from '../components/Collapsible'
 import { LoaderButton } from '../components/LoaderButton'
 import { PageTitle } from '../components/PageTitle'
@@ -169,7 +170,7 @@ export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<
                                 ...flagValue,
                             },
                         }).then(() => {
-                            navigate(`/site-admin/feature-flags/configuration/${flagName}`)
+                            navigate(0)
                         })
                     }
                 >
@@ -233,6 +234,17 @@ export const SiteAdminFeatureFlagConfigurationPage: FunctionComponent<
                               ]
                     }
                     className="mb-3"
+                    byline={
+                        featureFlagOrError &&
+                        !isErrorLike(featureFlagOrError) &&
+                        !isCreateFeatureFlag && (
+                            <CreatedByAndUpdatedByInfoByline
+                                createdAt={featureFlagOrError.createdAt}
+                                updatedAt={featureFlagOrError.updatedAt}
+                                noAuthor={true}
+                            />
+                        )
+                    }
                 />
                 {createFlagError && <ErrorAlert prefix="Error creating feature flag" error={createFlagError} />}
                 {updateFlagError && <ErrorAlert prefix="Error updating feature flag" error={updateFlagError} />}
@@ -281,6 +293,7 @@ interface FeatureFlagRolloutValue {
 interface CreateFeatureFlagOverrideResult {
     createFeatureFlagOverride: FeatureFlagOverride
 }
+
 interface CreateFeatureFlagOverrideVariables {
     namespace: string
     flagName: string

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -694,6 +694,8 @@ export function fetchFeatureFlags(): Observable<FeatureFlagFields[]> {
                     overrides {
                         ...OverrideFields
                     }
+                    createdAt
+                    updatedAt
                 }
                 ... on FeatureFlagRollout {
                     name
@@ -701,6 +703,8 @@ export function fetchFeatureFlags(): Observable<FeatureFlagFields[]> {
                     overrides {
                         ...OverrideFields
                     }
+                    createdAt
+                    updatedAt
                 }
             }
 

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -40,6 +41,12 @@ type FeatureFlagBooleanResolver struct {
 
 func (f *FeatureFlagBooleanResolver) Name() string { return f.inner.Name }
 func (f *FeatureFlagBooleanResolver) Value() bool  { return f.inner.Bool.Value }
+func (f *FeatureFlagBooleanResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: f.inner.CreatedAt}
+}
+func (f *FeatureFlagBooleanResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: f.inner.UpdatedAt}
+}
 func (f *FeatureFlagBooleanResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
 	overrides, err := f.db.FeatureFlags().GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {
@@ -56,6 +63,12 @@ type FeatureFlagRolloutResolver struct {
 
 func (f *FeatureFlagRolloutResolver) Name() string              { return f.inner.Name }
 func (f *FeatureFlagRolloutResolver) RolloutBasisPoints() int32 { return f.inner.Rollout.Rollout }
+func (f *FeatureFlagRolloutResolver) CreatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: f.inner.CreatedAt}
+}
+func (f *FeatureFlagRolloutResolver) UpdatedAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: f.inner.UpdatedAt}
+}
 func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
 	overrides, err := f.db.FeatureFlags().GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2291,6 +2291,15 @@ type FeatureFlagBoolean {
     Overrides that apply to the feature flag
     """
     overrides: [FeatureFlagOverride!]!
+    """
+    When the feature flag was created.
+    """
+    createdAt: DateTime!
+
+    """
+    When the feature flag was last updated.
+    """
+    updatedAt: DateTime!
 }
 
 """
@@ -2312,6 +2321,15 @@ type FeatureFlagRollout {
     Overrides that apply to the feature flag
     """
     overrides: [FeatureFlagOverride!]!
+    """
+    When the feature flag was created.
+    """
+    createdAt: DateTime!
+
+    """
+    When the feature flag was last updated.
+    """
+    updatedAt: DateTime!
 }
 
 """

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -110,7 +110,8 @@ func (f *featureFlagStore) UpdateFeatureFlag(ctx context.Context, flag *ff.Featu
 		SET
 			flag_type = %s,
 			bool_value = %s,
-			rollout = %s
+			rollout = %s,
+			updated_at = NOW()
 		WHERE flag_name = %s
 		RETURNING
 			flag_name,


### PR DESCRIPTION
This commit also fixes updating of `updatedAt` column of a `feature_flags` table and page reloading after feature flag is updated.

Test plan:
Local sg run and visual checks.

## Screenshots
| Before | After |
| :-- | :-- |
|<img width="911" alt="CleanShot 2023-05-10 at 6 51 36@2x" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/10d26e46-8692-42f0-b2ee-18cfe26395c2">|<img width="911" alt="CleanShot 2023-05-10 at 6 50 00@2x" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/877e8664-4848-421a-8a08-37abb41a6af6">|