### PR TITLE
mvu: warn when migrator may be airgapped

### DIFF
--- a/internal/database/migration/cliutil/downgrade.go
+++ b/internal/database/migration/cliutil/downgrade.go
@@ -65,6 +65,10 @@ func Downgrade(
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
+		if err := isAirgapped(ctx); err != nil {
+			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, err.Error()))
+		}
+
 		from, ok := oobmigration.NewVersionFromString(fromFlag.Get(cmd))
 		if !ok {
 			return errors.New("bad format for -from")

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -40,6 +40,10 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
+		if err := isAirgapped(ctx); err != nil {
+			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, err.Error()))
+		}
+
 		schemaName := TranslateSchemaNames(schemaNameFlag.Get(cmd), out)
 		version := versionFlag.Get(cmd)
 		file := fileFlag.Get(cmd)

--- a/internal/database/migration/cliutil/drift_schema.go
+++ b/internal/database/migration/cliutil/drift_schema.go
@@ -77,11 +77,10 @@ func NewExplicitFileSchemaFactory(filename string) ExpectedSchemaFactory {
 
 // fetchSchema makes an HTTP GET request to the given URL and reads the schema description from the response.
 func fetchSchema(ctx context.Context, url string) (descriptions.SchemaDescription, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return descriptions.SchemaDescription{}, err
 	}
-	req = req.WithContext(ctx)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -68,6 +68,10 @@ func Upgrade(
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
+		if err := isAirgapped(ctx); err != nil {
+			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, err.Error()))
+		}
+
 		runner, err := runnerFactory(schemas.SchemaNames, schemas.Schemas)
 		if err != nil {
 			return errors.Wrap(err, "new runner")

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"flag"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -175,4 +176,37 @@ func outOfBandMigrationRunner(db database.DB) *oobmigration.Runner {
 
 func outOfBandMigrationRunnerWithStore(store *oobmigration.Store) *oobmigration.Runner {
 	return oobmigration.NewRunner(migratorObservationCtx, store, time.Second)
+}
+
+// checks if a known good version's schema can be reached through either Github
+// or GCS, to report whether the migrator may be operating in an airgapped environment.
+func isAirgapped(ctx context.Context) (err error) {
+	// known good version and filename in both GCS and Github
+	filename, _ := getSchemaJSONFilename("frontend")
+	const version = "v3.41.1"
+
+	timedCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	url := githubExpectedSchemaPath(filename, version)
+	req, _ := http.NewRequestWithContext(timedCtx, http.MethodHead, url, nil)
+	resp, gherr := http.DefaultClient.Do(req)
+	ghUnreachable := gherr != nil || resp.StatusCode != http.StatusOK
+
+	timedCtx, cancel = context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	url = gcsExpectedSchemaPath(filename, version)
+	req, _ = http.NewRequestWithContext(timedCtx, http.MethodHead, url, nil)
+	resp, gcserr := http.DefaultClient.Do(req)
+	gcsUnreachable := gcserr != nil || resp.StatusCode != http.StatusOK
+
+	switch {
+	case ghUnreachable && gcsUnreachable:
+		err = errors.New("Neither Github nor GCS reachable, some features may not work as expected")
+	case ghUnreachable:
+		err = errors.New("Github not reachable, GCS is reachable, some features may not work as expected")
+	case gcsUnreachable:
+		err = errors.New("Github is reachable, GCS not reachable, some features may not work as expected")
+	}
+
+	return err
 }

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -190,6 +190,9 @@ func isAirgapped(ctx context.Context) (err error) {
 	url := githubExpectedSchemaPath(filename, version)
 	req, _ := http.NewRequestWithContext(timedCtx, http.MethodHead, url, nil)
 	resp, gherr := http.DefaultClient.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	ghUnreachable := gherr != nil || resp.StatusCode != http.StatusOK
 
 	timedCtx, cancel = context.WithTimeout(ctx, time.Second*3)
@@ -197,6 +200,9 @@ func isAirgapped(ctx context.Context) (err error) {
 	url = gcsExpectedSchemaPath(filename, version)
 	req, _ = http.NewRequestWithContext(timedCtx, http.MethodHead, url, nil)
 	resp, gcserr := http.DefaultClient.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	gcsUnreachable := gcserr != nil || resp.StatusCode != http.StatusOK
 
 	switch {


### PR DESCRIPTION
Warns when the URLs for v3.41.1 frontend schema.json cant be resolved on either github, gcs or both. Closes #51179 

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/05cd177e-e7f0-4b57-b99c-66d57438e5d1)


## Test plan

Ran locally by changing the URLs in drift_schema.go so they fail to resolve

EDITING to nudge PR auditor 