### PR TITLE
Embeddings: VZEROALL after using 256-bit registers

### DIFF
--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -48,6 +48,10 @@ reduce:
 	// Store the reduced sum
 	VMOVD X0, R8
 
+	// For the remainder of the function, we do not use vector instructions.
+	// Zero the registers to avoid the SSE penalty.
+	VZEROALL
+
 // In tailloop, we add to the dot product one at a time
 tailloop:
 	CMPQ DX, $0


### PR DESCRIPTION
Leaving the upper bits uncleared will lead to a performance penalty for any SSE instructions for the duration of the program. It is considered [best practice](https://john-h-k.github.io/VexTransitionPenalties.html) to clear the upper bits after using AVX instructions. 

Thanks to @kiroma for [pointing this out](https://github.com/sourcegraph/sourcegraph/pull/51372#issuecomment-1542358436)!

## Test plan

Existing tests, run on a test server that supports AVX2. Re-ran benchmarks to ensure there is no regression.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
