### PR TITLE
Spec compliant Retry-After headers

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/limiter/error.go
+++ b/enterprise/cmd/llm-proxy/internal/limiter/error.go
@@ -22,7 +22,7 @@ func (e RateLimitExceededError) WriteResponse(w http.ResponseWriter) {
 	// Rate limit exceeded, write well known headers and return correct status code.
 	w.Header().Set("x-ratelimit-limit", strconv.Itoa(e.Limit))
 	w.Header().Set("x-ratelimit-remaining", strconv.Itoa(max(e.Limit-e.Used, 0)))
-	w.Header().Set("retry-after", e.RetryAfter.Format(time.RFC3339))
+	w.Header().Set("retry-after", e.RetryAfter.Format(time.RFC1123))
 	http.Error(w, e.Error(), http.StatusTooManyRequests)
 }
 

--- a/enterprise/internal/completions/streaming/stream.go
+++ b/enterprise/internal/completions/streaming/stream.go
@@ -173,6 +173,6 @@ func respondRateLimited(w http.ResponseWriter, err RateLimitExceededError) {
 	// Rate limit exceeded, write well known headers and return correct status code.
 	w.Header().Set("x-ratelimit-limit", strconv.Itoa(err.Limit))
 	w.Header().Set("x-ratelimit-remaining", strconv.Itoa(max(err.Limit-err.Used, 0)))
-	w.Header().Set("retry-after", err.RetryAfter.Format(time.RFC3339))
+	w.Header().Set("retry-after", err.RetryAfter.Format(time.RFC1123))
 	http.Error(w, err.Error(), http.StatusTooManyRequests)
 }


### PR DESCRIPTION
This header should use RFC1123 as the format, as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After.

## Test plan

Renders correctly.