### PR TITLE
Add handling for 429 Retry-After errors in httpcli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix.
 - The commit message defined in a batch spec will now be quoted when git is invoked, i.e. `git commit -m "commit message"`, to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash. This may mean that previous escaping strategies will behave differently.
+- 429 errors from external services Sourcegraph talks to are only retried automatically if the Retry-After header doesn't indicate that a retry would be useless. The time grace period can be configured using `SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION` and `SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION`. [#51743](https://github.com/sourcegraph/sourcegraph/pull/51743)
 
 ### Fixed
 

--- a/internal/httpcli/BUILD.bazel
+++ b/internal/httpcli/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "@com_github_puerkitobio_rehttp//:rehttp",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@io_k8s_utils//strings/slices",
     ],
 )

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -638,7 +638,7 @@ func NewRetryPolicy(max int, retryAfterMaxSleepDuration time.Duration) rehttp.Re
 						// Check if the date is either in the past, or if within the next
 						// retryAfterMaxSleepDuration we would get access again.
 						in := time.Until(after)
-						return in < 0 || in < retryAfterMaxSleepDuration
+						return in <= retryAfterMaxSleepDuration
 					}
 				}
 

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -846,7 +846,7 @@ func TestRetryAfter(t *testing.T) {
 		})
 		t.Run("Exceeds configured limit", func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Add("retry-after", now.Add(2*time.Second).Format(time.RFC1123)) // 2 seconds is larger than the 1s we give the retry policy below.
+				w.Header().Add("retry-after", now.Add(5*time.Second).Format(time.RFC1123)) // 5 seconds is larger than the 1s we give the retry policy below.
 				w.WriteHeader(http.StatusTooManyRequests)
 			}))
 

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/PuerkitoBio/rehttp"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -478,7 +479,7 @@ func TestLoggingMiddleware(t *testing.T) {
 
 		// Check log entries for logged fields about retries
 		logEntries := exportLogs()
-		assert.Len(t, logEntries, 2) // should have a scope debug log, and the entry we want
+		require.Len(t, logEntries, 2) // should have a scope debug log, and the entry we want
 		entry := logEntries[1]
 		assert.Contains(t, entry.Scope, "httpcli")
 		assert.NotEmpty(t, entry.Fields["error"])

--- a/internal/httpcli/client_test.go
+++ b/internal/httpcli/client_test.go
@@ -346,7 +346,7 @@ func TestErrorResilience(t *testing.T) {
 				ContextErrorMiddleware,
 			),
 			NewErrorResilientTransportOpt(
-				NewRetryPolicy(20),
+				NewRetryPolicy(20, time.Second),
 				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
 			),
 		).Doer()
@@ -369,7 +369,7 @@ func TestErrorResilience(t *testing.T) {
 				ContextErrorMiddleware,
 			),
 			NewErrorResilientTransportOpt(
-				NewRetryPolicy(0), // zero retries
+				NewRetryPolicy(0, time.Second), // zero retries
 				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
 			),
 		).Doer()
@@ -387,7 +387,7 @@ func TestErrorResilience(t *testing.T) {
 	t.Run("no such host", func(t *testing.T) {
 		// spy on policy so we see what decisions it makes
 		retries := 0
-		policy := NewRetryPolicy(5) // smaller retries for faster failures
+		policy := NewRetryPolicy(5, time.Second) // smaller retries for faster failures
 		wrapped := func(a rehttp.Attempt) bool {
 			if policy(a) {
 				retries++
@@ -493,7 +493,7 @@ func TestLoggingMiddleware(t *testing.T) {
 				NewLoggingMiddleware(logger),
 			),
 			NewErrorResilientTransportOpt(
-				NewRetryPolicy(20),
+				NewRetryPolicy(20, time.Second),
 				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
 			),
 		).Doer()
@@ -653,4 +653,287 @@ type bogusTransport struct{}
 
 func (t bogusTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	panic("should not be called")
+}
+
+func TestRetryAfter(t *testing.T) {
+	t.Run("Not set", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+
+		t.Cleanup(srv.Close)
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// spy on policy so we see what decisions it makes
+		retries := 0
+		policy := NewRetryPolicy(5, time.Second) // smaller retries for faster failures
+		wrapped := func(a rehttp.Attempt) bool {
+			if policy(a) {
+				retries++
+				return true
+			}
+			return false
+		}
+
+		cli, _ := NewFactory(
+			NewMiddleware(
+				ContextErrorMiddleware,
+			),
+			NewErrorResilientTransportOpt(
+				wrapped,
+				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+			),
+		).Doer()
+
+		res, err := cli.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.StatusCode != 429 {
+			t.Fatalf("want status code 429, got: %d", res.StatusCode)
+		}
+
+		if want := 5; retries != want {
+			t.Fatalf("expected %d retries, got %d", want, retries)
+		}
+	})
+	t.Run("Format seconds", func(t *testing.T) {
+		t.Run("Within configured limit", func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("retry-after", "1") // 1 second is smaller than the 2s we give the retry policy below.
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// spy on policy so we see what decisions it makes
+			retries := 0
+			policy := NewRetryPolicy(5, 2*time.Second) // smaller retries for faster failures
+			wrapped := func(a rehttp.Attempt) bool {
+				if policy(a) {
+					retries++
+					return true
+				}
+				return false
+			}
+
+			cli, _ := NewFactory(
+				NewMiddleware(
+					ContextErrorMiddleware,
+				),
+				NewErrorResilientTransportOpt(
+					wrapped,
+					rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+				),
+			).Doer()
+
+			res, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode != 429 {
+				t.Fatalf("want status code 429, got: %d", res.StatusCode)
+			}
+
+			if want := 5; retries != want {
+				t.Fatalf("expected %d retries, got %d", want, retries)
+			}
+		})
+		t.Run("Exceeds configured limit", func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("retry-after", "2") // 2 seconds is larger than the 1s we give the retry policy below.
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// spy on policy so we see what decisions it makes
+			retries := 0
+			policy := NewRetryPolicy(5, time.Second) // smaller retries for faster failures
+			wrapped := func(a rehttp.Attempt) bool {
+				if policy(a) {
+					retries++
+					return true
+				}
+				return false
+			}
+
+			cli, _ := NewFactory(
+				NewMiddleware(
+					ContextErrorMiddleware,
+				),
+				NewErrorResilientTransportOpt(
+					wrapped,
+					rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+				),
+			).Doer()
+
+			res, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode != 429 {
+				t.Fatalf("want status code 429, got: %d", res.StatusCode)
+			}
+
+			if want := 0; retries != want {
+				t.Fatalf("expected %d retries, got %d", want, retries)
+			}
+		})
+	})
+	t.Run("Format Date", func(t *testing.T) {
+		now := time.Now()
+		t.Run("Within configured limit", func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("retry-after", now.Add(time.Second).Format(time.RFC1123)) // 1 second is smaller than the 2s we give the retry policy below.
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// spy on policy so we see what decisions it makes
+			retries := 0
+			policy := NewRetryPolicy(5, 2*time.Second) // smaller retries for faster failures
+			wrapped := func(a rehttp.Attempt) bool {
+				if policy(a) {
+					retries++
+					return true
+				}
+				return false
+			}
+
+			cli, _ := NewFactory(
+				NewMiddleware(
+					ContextErrorMiddleware,
+				),
+				NewErrorResilientTransportOpt(
+					wrapped,
+					rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+				),
+			).Doer()
+
+			res, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode != 429 {
+				t.Fatalf("want status code 429, got: %d", res.StatusCode)
+			}
+
+			if want := 5; retries != want {
+				t.Fatalf("expected %d retries, got %d", want, retries)
+			}
+		})
+		t.Run("Exceeds configured limit", func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("retry-after", now.Add(2*time.Second).Format(time.RFC1123)) // 2 seconds is larger than the 1s we give the retry policy below.
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+
+			t.Cleanup(srv.Close)
+
+			req, err := http.NewRequest("GET", srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// spy on policy so we see what decisions it makes
+			retries := 0
+			policy := NewRetryPolicy(5, time.Second) // smaller retries for faster failures
+			wrapped := func(a rehttp.Attempt) bool {
+				if policy(a) {
+					retries++
+					return true
+				}
+				return false
+			}
+
+			cli, _ := NewFactory(
+				NewMiddleware(
+					ContextErrorMiddleware,
+				),
+				NewErrorResilientTransportOpt(
+					wrapped,
+					rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+				),
+			).Doer()
+
+			res, err := cli.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if res.StatusCode != 429 {
+				t.Fatalf("want status code 429, got: %d", res.StatusCode)
+			}
+
+			if want := 0; retries != want {
+				t.Fatalf("expected %d retries, got %d", want, retries)
+			}
+		})
+	})
+	t.Run("Invalid retry-after header", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("retry-after", "unparseable")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+
+		t.Cleanup(srv.Close)
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// spy on policy so we see what decisions it makes
+		retries := 0
+		policy := NewRetryPolicy(5, 2*time.Second) // smaller retries for faster failures
+		wrapped := func(a rehttp.Attempt) bool {
+			if policy(a) {
+				retries++
+				return true
+			}
+			return false
+		}
+
+		cli, _ := NewFactory(
+			NewMiddleware(
+				ContextErrorMiddleware,
+			),
+			NewErrorResilientTransportOpt(
+				wrapped,
+				rehttp.ExpJitterDelay(50*time.Millisecond, 5*time.Second),
+			),
+		).Doer()
+
+		res, err := cli.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if res.StatusCode != 429 {
+			t.Fatalf("want status code 429, got: %d", res.StatusCode)
+		}
+
+		if want := 5; retries != want {
+			t.Fatalf("expected %d retries, got %d", want, retries)
+		}
+	})
 }


### PR DESCRIPTION
This PR adds some basic handling of the Retry-After for 429 errors. Right now, we retry every 429 error, regardless of if the Retry-After header tells us to wait another hour, where 20 retry attempts would not help at all. We do that by parsing the header and checking if within the next 3s we would regain access. If so, we keep trying, otherwise, we stop retrying.

## Test plan

Verified that with a valid retry-after header this correctly stops retrying. Also added a test suite for all the possible cases around 429 errors.