### PR TITLE
Fix http header forwarding in proxy handler

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -122,7 +122,7 @@ func newServiceHandler(logger log.Logger, config *Config) http.Handler {
 	v1router := r.PathPrefix("/v1").Subrouter()
 	v1router.Handle("/completions/anthropic",
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			r, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/complete", r.Body)
+			ar, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/complete", r.Body)
 			if err != nil {
 				response.JSONError(logger, w, http.StatusInternalServerError, errors.Errorf("failed to create request: %s", err))
 				return
@@ -130,21 +130,25 @@ func newServiceHandler(logger log.Logger, config *Config) http.Handler {
 
 			// Mimic headers set by the official Anthropic client:
 			// https://sourcegraph.com/github.com/anthropics/anthropic-sdk-typescript@493075d70f50f1568a276ed0cb177e297f5fef9f/-/blob/src/index.ts
-			r.Header.Set("Cache-Control", "no-cache")
-			r.Header.Set("Accept", "application/json")
-			r.Header.Set("Content-Type", "application/json")
-			r.Header.Set("Client", "sourcegraph-llm-proxy/1.0")
-			r.Header.Set("X-API-Key", config.Anthropic.AccessToken)
+			ar.Header.Set("Cache-Control", "no-cache")
+			ar.Header.Set("Accept", "application/json")
+			ar.Header.Set("Content-Type", "application/json")
+			ar.Header.Set("Client", "sourcegraph-llm-proxy/1.0")
+			ar.Header.Set("X-API-Key", config.Anthropic.AccessToken)
 
-			resp, err := httpcli.ExternalDoer.Do(r)
+			resp, err := httpcli.ExternalDoer.Do(ar)
 			if err != nil {
 				response.JSONError(logger, w, http.StatusInternalServerError, errors.Errorf("failed to make request to Anthropic: %s", err))
 				return
 			}
 			defer func() { _ = resp.Body.Close() }()
 
+			for k, vv := range resp.Header {
+				for _, v := range vv {
+					w.Header().Add(k, v)
+				}
+			}
 			w.WriteHeader(resp.StatusCode)
-			_ = resp.Header.Write(w)
 
 			_, _ = io.Copy(w, resp.Body)
 		}),


### PR DESCRIPTION
The current approach wrote the headers to the body which is.. not exactly what we want. This fixes it.

## Test plan

Verified the response is now correct and parsable. 
