### PR TITLE
llmproxy: Add some basic request logging

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -59,7 +59,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		Next:    handler,
 	}
 	handler = instrumentation.HTTPMiddleware("llm-proxy", handler)
-	handler = httpLogger(obctx.Logger.Scoped("HTTP API", ""), handler)
+	handler = httpLogger(obctx.Logger.Scoped("httpAPI", ""), handler)
 
 	// Initialize our server
 	server := httpserver.NewFromAddr(config.Address, &http.Server{


### PR DESCRIPTION
This felt useful, we can also experiment with metrics a bit once we have this. (I know technically specifically this metric we also get from google, but we don't in dev for example)

## Test plan

Logs render alright.