### PR TITLE
mvu: notify when a newer migrator version is released

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -820,6 +820,7 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--file="<value>"`: The target schema description file.
+* `--ignore-migrator-update`: Ignore the running migrator not being the latest version. It is recommended to use the latest migrator version.
 * `--schema, --db="<value>"`: The target `schema` to compare. Possible values are 'frontend', 'codeintel' and 'codeinsights'
 * `--skip-version-check`: Skip validation of the instance's current version.
 * `--version="<value>"`: The target schema version. Can be a version (e.g. 5.0.2) or resolvable as a git revlike on the Sourcegraph repository (e.g. a branch, tag or commit hash).

--- a/internal/database/migration/cliutil/downgrade.go
+++ b/internal/database/migration/cliutil/downgrade.go
@@ -65,8 +65,18 @@ func Downgrade(
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		if err := isAirgapped(ctx); err != nil {
-			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, err.Error()))
+		airgapped := isAirgapped(ctx)
+		if airgapped != nil {
+			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, airgapped.Error()))
+		}
+
+		if airgapped == nil {
+			latest, hasUpdate, err := checkForMigratorUpdate(ctx)
+			if err != nil {
+				out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "Failed to check for migrator update: %s. Continuing...", err))
+			} else if hasUpdate {
+				out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, "A new migrator version is available (%s), please consider using it instead.", latest))
+			}
 		}
 
 		from, ok := oobmigration.NewVersionFromString(fromFlag.Get(cmd))

--- a/internal/database/migration/cliutil/downgrade.go
+++ b/internal/database/migration/cliutil/downgrade.go
@@ -2,6 +2,7 @@ package cliutil
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/urfave/cli/v2"
 
@@ -53,6 +54,11 @@ func Downgrade(
 		Usage:    "Skip comparison of the instance's current schema against the expected version's schema.",
 		Required: false,
 	}
+	ignoreMigratorUpdateCheckFlag := &cli.BoolFlag{
+		Name:     "ignore-migrator-update",
+		Usage:    "Ignore the running migrator not being the latest version. It is recommended to use the latest migrator version.",
+		Required: false,
+	}
 	dryRunFlag := &cli.BoolFlag{
 		Name:     "dry-run",
 		Usage:    "Print the downgrade plan but do not execute it.",
@@ -75,7 +81,12 @@ func Downgrade(
 			if err != nil {
 				out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "Failed to check for migrator update: %s. Continuing...", err))
 			} else if hasUpdate {
-				out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, "A new migrator version is available (%s), please consider using it instead.", latest))
+				noticeStr := fmt.Sprintf("A newer migrator version is available (%s), please consider using it instead", latest)
+				if ignoreMigratorUpdateCheckFlag.Get(cmd) {
+					out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "%s. Continuing...", noticeStr))
+				} else {
+					return cli.Exit(fmt.Sprintf("%s %s%s or pass -ignore-migrator-update.%s", output.EmojiWarning, output.StyleWarning, noticeStr, output.StyleReset), 1)
+				}
 			}
 		}
 
@@ -148,6 +159,7 @@ func Downgrade(
 			privilegedHashesFlag,
 			skipVersionCheckFlag,
 			skipDriftCheckFlag,
+			ignoreMigratorUpdateCheckFlag,
 			dryRunFlag,
 			disableAnimation,
 		},

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -40,8 +40,18 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
-		if err := isAirgapped(ctx); err != nil {
-			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, err.Error()))
+		airgapped := isAirgapped(ctx)
+		if airgapped != nil {
+			out.WriteLine(output.Line(output.EmojiWarningSign, output.StyleYellow, airgapped.Error()))
+		}
+
+		if airgapped == nil {
+			latest, hasUpdate, err := checkForMigratorUpdate(ctx)
+			if err != nil {
+				out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "Failed to check for migrator update: %s. Continuing...", err))
+			} else if hasUpdate {
+				out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, "A new migrator version is available (%s), please consider using it instead.", latest))
+			}
 		}
 
 		schemaName := TranslateSchemaNames(schemaNameFlag.Get(cmd), out)

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -38,6 +38,11 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 		Usage:    "Skip validation of the instance's current version.",
 		Required: false,
 	}
+	ignoreMigratorUpdateCheckFlag := &cli.BoolFlag{
+		Name:     "ignore-migrator-update",
+		Usage:    "Ignore the running migrator not being the latest version. It is recommended to use the latest migrator version.",
+		Required: false,
+	}
 
 	action := makeAction(outFactory, func(ctx context.Context, cmd *cli.Context, out *output.Output) error {
 		airgapped := isAirgapped(ctx)
@@ -50,7 +55,12 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 			if err != nil {
 				out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "Failed to check for migrator update: %s. Continuing...", err))
 			} else if hasUpdate {
-				out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, "A new migrator version is available (%s), please consider using it instead.", latest))
+				noticeStr := fmt.Sprintf("A newer migrator version is available (%s), please consider using it instead", latest)
+				if ignoreMigratorUpdateCheckFlag.Get(cmd) {
+					out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "%s. Continuing...", noticeStr))
+				} else {
+					return cli.Exit(fmt.Sprintf("%s %s%s or pass -ignore-migrator-update.%s", output.EmojiWarning, output.StyleWarning, noticeStr, output.StyleReset), 1)
+				}
 			}
 		}
 
@@ -129,6 +139,7 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 			versionFlag,
 			fileFlag,
 			skipVersionCheckFlag,
+			ignoreMigratorUpdateCheckFlag,
 		},
 	}
 }

--- a/internal/database/migration/cliutil/upgrade.go
+++ b/internal/database/migration/cliutil/upgrade.go
@@ -2,6 +2,7 @@ package cliutil
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/urfave/cli/v2"
 
@@ -56,6 +57,11 @@ func Upgrade(
 		Usage:    "Skip comparison of the instance's current schema against the expected version's schema.",
 		Required: false,
 	}
+	ignoreMigratorUpdateCheckFlag := &cli.BoolFlag{
+		Name:     "ignore-migrator-update",
+		Usage:    "Ignore the running migrator not being the latest version. It is recommended to use the latest migrator version.",
+		Required: false,
+	}
 	dryRunFlag := &cli.BoolFlag{
 		Name:     "dry-run",
 		Usage:    "Print the upgrade plan but do not execute it.",
@@ -78,7 +84,12 @@ func Upgrade(
 			if err != nil {
 				out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "Failed to check for migrator update: %s. Continuing...", err))
 			} else if hasUpdate {
-				out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion, "A new migrator version is available (%s), please consider using it instead.", latest))
+				noticeStr := fmt.Sprintf("A newer migrator version is available (%s), please consider using it instead", latest)
+				if ignoreMigratorUpdateCheckFlag.Get(cmd) {
+					out.WriteLine(output.Linef(output.EmojiWarningSign, output.StyleYellow, "%s. Continuing...", noticeStr))
+				} else {
+					return cli.Exit(fmt.Sprintf("%s %s%s or pass -ignore-migrator-update.%s", output.EmojiWarning, output.StyleWarning, noticeStr, output.StyleReset), 1)
+				}
 			}
 		}
 
@@ -181,6 +192,7 @@ func Upgrade(
 			privilegedHashesFlag,
 			skipVersionCheckFlag,
 			skipDriftCheckFlag,
+			ignoreMigratorUpdateCheckFlag,
 			dryRunFlag,
 			disableAnimation,
 		},

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -240,7 +240,9 @@ func checkForMigratorUpdate(ctx context.Context) (latest string, hasUpdate bool,
 		return "", false, nil
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://github.com/sourcegraph/sourcegraph/releases/latest", nil)
+	timedCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(timedCtx, http.MethodHead, "https://github.com/sourcegraph/sourcegraph/releases/latest", nil)
 	resp, err := (&http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/database/migration/cliutil/util.go
+++ b/internal/database/migration/cliutil/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -19,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
@@ -230,4 +232,46 @@ func getSchemaJSONFilename(schemaName string) (string, error) {
 	}
 
 	return "", errors.Newf("unknown schema name %q", schemaName)
+}
+
+func checkForMigratorUpdate(ctx context.Context) (latest string, hasUpdate bool, err error) {
+	migratorVersion, migratorPatch, ok := oobmigration.NewVersionAndPatchFromString(version.Version())
+	if !ok || migratorVersion.Dev {
+		return "", false, nil
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://github.com/sourcegraph/sourcegraph/releases/latest", nil)
+	resp, err := (&http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}).Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		return "", false, errors.Newf("unexpected status code %d", resp.StatusCode)
+	}
+
+	location, err := resp.Location()
+	if err != nil {
+		return "", false, err
+	}
+
+	pathParts := strings.Split(location.Path, "/")
+	if len(pathParts) == 0 {
+		return "", false, errors.Newf("empty path in Location header URL: %s", location.String())
+	}
+	latest = pathParts[len(pathParts)-1]
+
+	latestVersion, latestPatch, ok := oobmigration.NewVersionAndPatchFromString(latest)
+	if !ok {
+		return "", false, errors.Newf("last section in path is an invalid format: %s", latest)
+	}
+
+	isMigratorOutOfDate := oobmigration.CompareVersions(latestVersion, migratorVersion) == oobmigration.VersionOrderBefore || (latestPatch > migratorPatch)
+
+	return latest, isMigratorOutOfDate, nil
 }

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -134,7 +134,7 @@ const (
 
 // CompareVersions returns the relationship between `a (op) b`.
 func CompareVersions(a, b Version) VersionOrder {
-	for _, pair := range [][2]int{
+	for _, pair := range [2][2]int{
 		{a.Major, b.Major},
 		{a.Minor, b.Minor},
 	} {


### PR DESCRIPTION
Notifies users when a newer version of migrator exists. If  `-ignore-migrator-update` is not set, this hard fails.

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/ae13818c-2c2d-4b55-91fd-55a7857523dc)

## Test plan

Ran locally, see screenshots
