### PR TITLE
Return the output of the sync command in VCSSyncer::Fetch 

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2724,9 +2724,13 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 	// when the cleanup happens, just that it does.
 	defer s.cleanTmpFiles(dir)
 
-	err = syncer.Fetch(ctx, remoteURL, dir, revspec)
+	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
 	if err != nil {
-		return errors.Wrapf(err, "failed to fetch repo %q", repo)
+		if output != nil {
+			return errors.Wrapf(err, "failed to fetch repo %q with output %q", repo, newURLRedactor(remoteURL).redact(string(output)))
+		} else {
+			return errors.Wrapf(err, "failed to fetch repo %q", repo)
+		}
 	}
 
 	removeBadRefs(ctx, dir)

--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -90,7 +90,7 @@ func (s *vcsPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	}
 
 	// The Fetch method is responsible for cleaning up temporary directories.
-	if err := s.Fetch(ctx, remoteURL, GitDir(bareGitDirectory), ""); err != nil {
+	if _, err := s.Fetch(ctx, remoteURL, GitDir(bareGitDirectory), ""); err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch repo for %s", remoteURL)
 	}
 
@@ -98,24 +98,24 @@ func (s *vcsPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	return exec.CommandContext(ctx, "git", "--version"), nil
 }
 
-func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) (err error) {
+func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error) {
 	var pkg reposource.Package
-	pkg, err = s.source.ParsePackageFromRepoName(api.RepoName(remoteURL.Path))
+	pkg, err := s.source.ParsePackageFromRepoName(api.RepoName(remoteURL.Path))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	name := pkg.PackageSyntax()
 
 	versions, err := s.versions(ctx, name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if revspec != "" {
-		return s.fetchRevspec(ctx, name, dir, versions, revspec)
+		return nil, s.fetchRevspec(ctx, name, dir, versions, revspec)
 	}
 
-	return s.fetchVersions(ctx, name, dir, versions)
+	return nil, s.fetchVersions(ctx, name, dir, versions)
 }
 
 // fetchRevspec fetches the given revspec if it's not contained in

--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -53,7 +53,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.Add("foo@0.0.1")
 
 	t.Run("one version from service", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, map[string]string{
@@ -76,7 +76,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	oneVersionOneDownload := map[string]int{"foo@0.0.1": 1, "foo@0.0.2": 1}
 
 	t.Run("two versions, service and config", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, allVersionsHaveRefs)
@@ -86,7 +86,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.Delete("foo@0.0.2")
 
 	t.Run("cached tag not re-downloaded (404 not found)", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.NoError(t, err)
 
 		// v0.0.2 is still present in the git repo because we didn't send a second download request.
@@ -98,7 +98,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsSource.download["foo@0.0.1"] = errors.New("401 unauthorized")
 
 	t.Run("cached tag not re-downloaded (401 unauthorized)", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		// v0.0.1 is still present in the git repo because we didn't send a second download request.
 		require.NoError(t, err)
 		s.assertRefs(t, dir, allVersionsHaveRefs)
@@ -113,7 +113,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	}
 
 	t.Run("service version deleted", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, onlyV2Refs)
@@ -123,7 +123,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	s.configDeps = []string{}
 
 	t.Run("all versions deleted", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.NoError(t, err)
 
 		s.assertRefs(t, dir, map[string]string{})
@@ -135,7 +135,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	depsService.Add("foo@0.0.2")
 	depsSource.Add("foo@0.0.2")
 	t.Run("error aggregation", func(t *testing.T) {
-		err := s.Fetch(ctx, remoteURL, dir, "")
+		_, err := s.Fetch(ctx, remoteURL, dir, "")
 		require.ErrorContains(t, err, "401 unauthorized")
 
 		// The foo@0.0.1 tag was not created because of the 401 error.
@@ -158,7 +158,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 	t.Run("lazy-sync version via revspec", func(t *testing.T) {
 		// the v0.0.3 tag should be created on-demand through the revspec parameter
 		// For context, see https://github.com/sourcegraph/sourcegraph/pull/38811
-		err := s.Fetch(ctx, remoteURL, dir, "v0.0.3^0")
+		_, err := s.Fetch(ctx, remoteURL, dir, "v0.0.3^0")
 		require.ErrorContains(t, err, "401 unauthorized") // v0.0.1 is still erroring
 		require.Equal(t, s.svc.(*fakeDepsService).upsertedDeps, []dependencies.MinimalPackageRepoRef{{
 			Scheme:   fakeVersionedPackage{}.Scheme(),
@@ -176,7 +176,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 
 	t.Run("lazy-sync error version via revspec", func(t *testing.T) {
 		// the v0.0.4 tag cannot be created on-demand because it returns a "0.0.4 not found" error
-		err := s.Fetch(ctx, remoteURL, dir, "v0.0.4^0")
+		_, err := s.Fetch(ctx, remoteURL, dir, "v0.0.4^0")
 		require.Nil(t, err)
 		// // the 0.0.4 error is silently ignored, we only return the error for v0.0.1.
 		// require.Equal(t, fmt.Sprint(err.Error()), "error pushing dependency {\"foo\" \"0.0.1\"}: 401 unauthorized")

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -24,7 +24,7 @@ type VCSSyncer interface {
 	// to lazily fetch package versions. More details at
 	// https://github.com/sourcegraph/sourcegraph/issues/37921#issuecomment-1184301885
 	// Beware that the revspec parameter can be any random user-provided string.
-	Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) error
+	Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error)
 	// RemoteShowCommand returns the command to be executed for showing remote.
 	RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error)
 }

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -81,13 +81,13 @@ func (s *GitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 }
 
 // Fetch tries to fetch updates of a Git repository.
-func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) error {
+func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
 	if output, err := runWith(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
-		return &GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
+		return nil, &GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
 	}
-	return nil
+	return nil, nil
 }
 
 // RemoteShowCommand returns the command to be executed for showing remote of a Git repository.

--- a/cmd/gitserver/server/vcs_syncer_mock_test.go
+++ b/cmd/gitserver/server/vcs_syncer_mock_test.go
@@ -45,7 +45,7 @@ func NewMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		FetchFunc: &VCSSyncerFetchFunc{
-			defaultHook: func(context.Context, *vcs.URL, GitDir, string) (r0 error) {
+			defaultHook: func(context.Context, *vcs.URL, GitDir, string) (o0 []byte, r0 error) {
 				return
 			},
 		},
@@ -77,7 +77,7 @@ func NewStrictMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		FetchFunc: &VCSSyncerFetchFunc{
-			defaultHook: func(context.Context, *vcs.URL, GitDir, string) error {
+			defaultHook: func(context.Context, *vcs.URL, GitDir, string) ([]byte, error) {
 				panic("unexpected invocation of MockVCSSyncer.Fetch")
 			},
 		},
@@ -235,23 +235,23 @@ func (c VCSSyncerCloneCommandFuncCall) Results() []interface{} {
 // VCSSyncerFetchFunc describes the behavior when the Fetch method of the
 // parent MockVCSSyncer instance is invoked.
 type VCSSyncerFetchFunc struct {
-	defaultHook func(context.Context, *vcs.URL, GitDir, string) error
-	hooks       []func(context.Context, *vcs.URL, GitDir, string) error
+	defaultHook func(context.Context, *vcs.URL, GitDir, string) ([]byte, error)
+	hooks       []func(context.Context, *vcs.URL, GitDir, string) ([]byte, error)
 	history     []VCSSyncerFetchFuncCall
 	mutex       sync.Mutex
 }
 
 // Fetch delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockVCSSyncer) Fetch(v0 context.Context, v1 *vcs.URL, v2 GitDir, v3 string) error {
-	r0 := m.FetchFunc.nextHook()(v0, v1, v2, v3)
+func (m *MockVCSSyncer) Fetch(v0 context.Context, v1 *vcs.URL, v2 GitDir, v3 string) ([]byte, error) {
+	_, r0 := m.FetchFunc.nextHook()(v0, v1, v2, v3)
 	m.FetchFunc.appendCall(VCSSyncerFetchFuncCall{v0, v1, v2, r0})
-	return r0
+	return nil, r0
 }
 
 // SetDefaultHook sets function that is called when the Fetch method of the
 // parent MockVCSSyncer instance is invoked and the hook queue is empty.
-func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, *vcs.URL, GitDir, string) error) {
+func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, *vcs.URL, GitDir, string) ([]byte, error)) {
 	f.defaultHook = hook
 }
 
@@ -259,7 +259,7 @@ func (f *VCSSyncerFetchFunc) SetDefaultHook(hook func(context.Context, *vcs.URL,
 // Fetch method of the parent MockVCSSyncer instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, *vcs.URL, GitDir, string) error) {
+func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, *vcs.URL, GitDir, string) ([]byte, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -268,19 +268,19 @@ func (f *VCSSyncerFetchFunc) PushHook(hook func(context.Context, *vcs.URL, GitDi
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *VCSSyncerFetchFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, *vcs.URL, GitDir, string) error {
-		return r0
+	f.SetDefaultHook(func(context.Context, *vcs.URL, GitDir, string) ([]byte, error) {
+		return nil, r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *VCSSyncerFetchFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, *vcs.URL, GitDir, string) error {
-		return r0
+	f.PushHook(func(context.Context, *vcs.URL, GitDir, string) ([]byte, error) {
+		return nil, r0
 	})
 }
 
-func (f *VCSSyncerFetchFunc) nextHook() func(context.Context, *vcs.URL, GitDir, string) error {
+func (f *VCSSyncerFetchFunc) nextHook() func(context.Context, *vcs.URL, GitDir, string) ([]byte, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 


### PR DESCRIPTION
Administrating Perforce depot syncing in Sourcegraph is made much easier by being able to examine the output of the `p4-fusion` command. See [PR 51598](https://github.com/sourcegraph/sourcegraph/pull/51598) for details.

This PR adds support for capturing the output when a background sync runs. Because it modifies the signature of `VSCSyncer`, it's being broken out into a separate PR.

## Test plan

existing tests updated to support the returned output

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
