### PR TITLE
bazel: disable the bundlesize check outside of bazel

### DIFF
--- a/dev/ci/pnpm-build.sh
+++ b/dev/ci/pnpm-build.sh
@@ -18,8 +18,6 @@ pnpm run build --color
 
 # Only run bundlesize if intended and if there is valid a script provided in the relevant package.json
 if [ "$CHECK_BUNDLESIZE" ] && jq -e '.scripts.bundlesize' package.json >/dev/null; then
-  echo "--- bundlesize"
-  pnpm run bundlesize --enable-github-checks
   echo "--- bundlesize:web:upload"
   HONEYCOMB_API_KEY="$CI_HONEYCOMB_CLIENT_ENV_API_KEY" pnpm --filter @sourcegraph/observability-server run bundlesize:web:upload
 fi

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -103,19 +103,14 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 	cmds = append(cmds, bazelTestCmds...)
 
-	// DISABLED: https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919
-	// this command makes an external request to https://bundlesize-cache.vercel.app
-	// which is not acceptable for such a task.
-	// TODO: @jhchabran
-	//
 	// Run commands
-	// runTargets := []string{
-	// 	"//client/web:bundlesize-report",
-	// }
-	// bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
+	runTargets := []string{
+		"//client/web:bundlesize-report",
+	}
+	bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
 	cmds = append(cmds,
-		// bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
-		// bk.Cmd(bazelRunCmd),
+		bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
+		bk.Cmd(bazelRunCmd),
 		bazelAnnouncef("✅"),
 	)
 


### PR DESCRIPTION
## Context

Let's monitor the behavior of this task. If it happens again, we disable it, and I'll dig further. But I'm sure I saw successful Bazel builds with the bundlesize cache error. [The Slack thread](https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1683634881118919).

This PR also disables the bundlesize check outside of Bazel so that we run it only once per CI build.

## Test plan

CI
