### PR TITLE
bazel: disable the github action reporter for the bundlesize check

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -2094,7 +2094,7 @@ build_test(
     ],
 )
 
-bundlesize_bin.bundlesize_binary(
+bundlesize_bin.bundlesize_test(
     name = "bundlesize-report",
     args = [
         "--config",
@@ -2105,6 +2105,7 @@ bundlesize_bin.bundlesize_binary(
         ":bundle-enterprise",
     ],
     env = {
+        "INTERNAL_SKIP_CACHE": "true",
         "WEB_BUNDLE_PATH": "$(rootpath //client/web:bundle-enterprise)",
     },
 )

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -2099,7 +2099,6 @@ bundlesize_bin.bundlesize_binary(
     args = [
         "--config",
         "$(location bundlesize.config.js)",
-        "--enable-github-checks",
     ],
     data = [
         "bundlesize.config.js",

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -103,17 +103,6 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 	cmds = append(cmds, bazelTestCmds...)
 
-	// Run commands
-	runTargets := []string{
-		"//client/web:bundlesize-report",
-	}
-	bazelRunCmd := bazelCmd(fmt.Sprintf("run %s", strings.Join(runTargets, " ")))
-	cmds = append(cmds,
-		bazelAnnouncef("bazel run %s", strings.Join(runTargets, " ")),
-		bk.Cmd(bazelRunCmd),
-		bazelAnnouncef("✅"),
-	)
-
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(":bazel: Tests",
 			cmds...,


### PR DESCRIPTION
## Context

Disabling the GitHub action reporter for the `bundlesize` check because it's flaky and converting the bundlesize target to test so that it fails in Bazel.

The third-party cache issue should not fail the test because it's covered by `catch` statements in the code. See [srcs](https://github.com/siddharthkp/bundlesize2/blob/5d5b61387d59e7aaf63e1b662c6b0b6a6592203c/cli/src/pipeline/cache.js#L19). The culprit of failures was [the GitHub reporter error handler](https://github.com/siddharthkp/bundlesize2/blob/5d5b61387d59e7aaf63e1b662c6b0b6a6592203c/cli/src/reporters/github.js#L22-L26).

## Test plan

CI
