### PR TITLE
Cody: rendering issue

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -362,26 +362,25 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         if (!interaction) {
             return
         }
+
         this.isMessageInProgress = true
         this.transcript.addInteraction(interaction)
 
-        this.showTab('chat')
-
         // Check whether or not to connect to LLM backend for responses
         // Ex: performing fuzzy / context-search does not require responses from LLM backend
-        const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
-
-        switch (recipeId) {
-            case 'context-search':
-                this.onCompletionEnd()
-                break
-            default:
-                this.sendTranscript()
-                this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
-                await this.saveTranscriptToChatHistory()
+        if (recipeId === 'context-search') {
+            this.onCompletionEnd()
+            return
         }
 
-        logEvent(`CodyVSCodeExtension:recipe:${recipe.id}:executed`)
+        this.sendTranscript()
+        this.showTab('chat')
+
+        const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
+        this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
+
+        void this.saveTranscriptToChatHistory()
+        void logEvent(`CodyVSCodeExtension:recipe:${recipe.id}:executed`)
     }
 
     private async runRecipeForSuggestion(recipeId: string, humanChatInput: string = ''): Promise<void> {


### PR DESCRIPTION

We previously run `this.sendTranscript()` before we create the prompt `const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))` but moving `this.sendTranscript()` seems to cause lags between displaying user message and assistant's reply, and I'm not sure why 🤔 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Start dev env from this branch and compare its rendering time with the one from current release.
