### PR TITLE
tiny refactoring: remove duplicated auth code

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -323,10 +323,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 	token1GQLID := graphql.ID("QWNjZXNzVG9rZW46MQ==")
 
 	t.Run("authenticated as user", func(t *testing.T) {
-		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: false}, nil)
 		db := database.NewMockDB()
-		db.UsersFunc.SetDefaultReturn(users)
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
 
 		RunTests(t, []*Test{
@@ -355,7 +352,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		const differentSiteAdminUID = 234
 
 		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil)
 		db := database.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
@@ -384,11 +381,9 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 
 	t.Run("unauthenticated", func(t *testing.T) {
 		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, database.ErrNoCurrentUser)
-		users.GetByIDFunc.SetDefaultReturn(&types.User{Username: "username"}, nil)
 		db := database.NewMockDB()
-		db.UsersFunc.SetDefaultReturn(users)
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
+		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), nil)
 		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -266,11 +266,12 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 }
 
 func TestCreateSavedSearch(t *testing.T) {
-	ctx := context.Background()
 	key := int32(1)
 
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true, ID: key}, nil)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: key})
 
 	ss := database.NewMockSavedSearchStore()
 	ss.CreateFunc.SetDefaultHook(func(_ context.Context, newSavedSearch *types.SavedSearch) (*types.SavedSearch, error) {
@@ -332,11 +333,11 @@ func TestCreateSavedSearch(t *testing.T) {
 }
 
 func TestUpdateSavedSearch(t *testing.T) {
-	ctx := context.Background()
-
 	key := int32(1)
 	users := database.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true, ID: key}, nil)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: key})
 
 	ss := database.NewMockSavedSearchStore()
 	ss.UpdateFunc.SetDefaultHook(func(ctx context.Context, savedSearch *types.SavedSearch) (*types.SavedSearch, error) {
@@ -510,11 +511,11 @@ func TestUpdateSavedSearchPermissions(t *testing.T) {
 }
 
 func TestDeleteSavedSearch(t *testing.T) {
-	ctx := context.Background()
-
 	key := int32(1)
 	users := database.NewMockUserStore()
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true, ID: key}, nil)
+	users.GetByIDFunc.SetDefaultReturn(&types.User{SiteAdmin: true, ID: key}, nil)
+
+	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: key})
 
 	ss := database.NewMockSavedSearchStore()
 	ss.GetByIDFunc.SetDefaultReturn(&api.SavedQuerySpecAndConfig{

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -507,10 +507,6 @@ func TestUpdateUser(t *testing.T) {
 	})
 
 	t.Run("bad avatarURL", func(t *testing.T) {
-		users := database.NewMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
-		db.UsersFunc.SetDefaultReturn(users)
-
 		tests := []struct {
 			name      string
 			avatarURL string
@@ -530,9 +526,9 @@ func TestUpdateUser(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(
-					context.Background(),
+					actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
 					&updateUserArgs{
-						User:      MarshalUserID(1),
+						User:      MarshalUserID(2),
 						AvatarURL: &test.avatarURL,
 					},
 				)

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -458,7 +458,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 
 		t.Cleanup(func() { permssync.MockSchedulePermsSync = nil })
 		trueVal := true
-		_, err := r.ScheduleUserPermissionsSync(context.Background(), &graphqlbackend.UserPermissionsSyncArgs{
+		_, err := r.ScheduleUserPermissionsSync(actor.WithActor(context.Background(), &actor.Actor{UID: 123}), &graphqlbackend.UserPermissionsSyncArgs{
 			User:    graphqlbackend.MarshalUserID(userID),
 			Options: &struct{ InvalidateCaches *bool }{InvalidateCaches: &trueVal},
 		})
@@ -1540,8 +1540,9 @@ func TestResolver_UserPermissionsInfo(t *testing.T) {
 		}
 	})
 
+	userID := int32(9999)
 	users := database.NewStrictMockUserStore()
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: userID, SiteAdmin: true}, nil)
 	users.GetByIDFunc.SetDefaultHook(func(_ context.Context, id int32) (*types.User, error) {
 		return &types.User{ID: id}, nil
 	})
@@ -1573,7 +1574,8 @@ func TestResolver_UserPermissionsInfo(t *testing.T) {
 			name: "get permissions information",
 			gqlTests: []*graphqlbackend.Test{
 				{
-					Schema: mustParseGraphQLSchema(t, db),
+					Context: actor.WithActor(context.Background(), &actor.Actor{UID: userID}),
+					Schema:  mustParseGraphQLSchema(t, db),
 					Query: `
 				{
 					currentUser {
@@ -1960,6 +1962,7 @@ query {
 func TestResolverPermissionsSyncJobs(t *testing.T) {
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
+		users.GetByIDFunc.SetDefaultReturn(&types.User{}, nil)
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
@@ -1977,6 +1980,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 	t.Run("authenticated as non-admin with current user's ID as userID filter", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
@@ -1993,6 +1997,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 	t.Run("authenticated as non-admin with different user's ID as userID filter", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
@@ -2009,6 +2014,7 @@ func TestResolverPermissionsSyncJobs(t *testing.T) {
 	t.Run("authenticated as admin with different user's ID as userID filter", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -362,7 +362,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 
 	t.Run("authenticated as non-admin and not the same user", func(t *testing.T) {
 		users := database.NewStrictMockUserStore()
-		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 123}, nil)
+		users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 123}, nil)
 
 		db := edb.NewStrictMockEnterpriseDB()
 		db.UsersFunc.SetDefaultReturn(users)
@@ -377,7 +377,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 	})
 
 	users := database.NewStrictMockUserStore()
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 123, SiteAdmin: true}, nil)
+	users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 123, SiteAdmin: true}, nil)
 
 	db := edb.NewStrictMockEnterpriseDB()
 	db.UsersFunc.SetDefaultReturn(users)

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account_test.go
@@ -58,10 +58,11 @@ func TestServiceAccountOrOwnerOrSiteAdmin(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			db := database.NewMockDB()
 			mockUsers := database.NewMockUserStore()
-			mockUsers.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{
-				ID:        actorID,
-				SiteAdmin: tc.actorSiteAdmin,
-			}, nil)
+
+			user := &types.User{ID: actorID, SiteAdmin: tc.actorSiteAdmin}
+			mockUsers.GetByCurrentAuthUserFunc.SetDefaultReturn(user, nil)
+			mockUsers.GetByIDFunc.SetDefaultReturn(user, nil)
+
 			db.UsersFunc.SetDefaultReturn(mockUsers)
 
 			ctx := featureflag.WithFlags(context.Background(),

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
@@ -95,7 +95,6 @@ func TestSearchContextsStarDefaultPermissions(t *testing.T) {
 
 	users := database.NewMockUserStore()
 	users.GetByIDFunc.SetDefaultReturn(&types.User{Username: username}, nil)
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: userID, Username: username}, nil)
 
 	searchContextSpec := "test"
 	graphqlSearchContextID := marshalSearchContextID(searchContextSpec)
@@ -139,8 +138,9 @@ func TestSearchContextsStarDefaultPermissions(t *testing.T) {
 	}
 
 	// User is admin, trying to set things for another user
-	users.GetByIDFunc.SetDefaultReturn(&types.User{Username: username, SiteAdmin: true}, nil)
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{Username: username, SiteAdmin: true}, nil)
+	users.GetByIDFunc.SetDefaultReturn(&types.User{ID: userID, Username: username, SiteAdmin: true}, nil)
+	// Create a new context with actor so that the user cached on actor is not reused
+	ctx = actor.WithActor(ctx, &actor.Actor{UID: userID})
 
 	_, err = (&Resolver{db: db}).SetDefaultSearchContext(ctx, graphqlbackend.SetDefaultSearchContextArgs{SearchContextID: graphqlSearchContextID, UserID: graphqlUserID2})
 	if err != nil {

--- a/internal/auth/site_admin.go
+++ b/internal/auth/site_admin.go
@@ -69,14 +69,7 @@ func (e *InsufficientAuthorizationError) Unauthorized() bool { return true }
 // Returns an error without the name of the given user.
 func CheckSiteAdminOrSameUser(ctx context.Context, db database.DB, subjectUserID int32) error {
 	a := actor.FromContext(ctx)
-	if a.IsInternal() || (a.IsAuthenticated() && a.UID == subjectUserID) {
-		return nil
-	}
-	isSiteAdminErr := CheckCurrentUserIsSiteAdmin(ctx, db)
-	if isSiteAdminErr == nil {
-		return nil
-	}
-	return ErrMustBeSiteAdminOrSameUser
+	return CheckSiteAdminOrSameUserFromActor(a, db, subjectUserID)
 }
 
 // CheckSameUser returns an error if the user is not the user specified by


### PR DESCRIPTION
The body of `CheckSiteAdminOrSameUser` is the same as in `CheckSiteAdminOrSameUserFromActor`, except that the latter expects an `actor.Actor` to be passed in and the former pulls it from the context.


## Test plan

- Existing tests