### PR TITLE
ci: rework job labels and icons 

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@
 steps:
   - group: "Pipeline setup"
     steps:
-      - label: ':hammer_and_wrench: :pipeline: Generate pipeline'
+      - label: ':bazel::pipeline: Generate pipeline'
         key: 'pipeline-gen'
         agents: { queue: bazel }
         # Prioritize generating pipelines so that jobs can get generated and queued up as soon

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -14,7 +14,6 @@ const (
 	// RunTypes should be defined by order of precedence.
 
 	PullRequest    RunType = iota // pull request build
-	BazelExpBranch                // branch that runs specific bazel steps
 	WolfiExpBranch                // branch that only builds wolfi images
 
 	// Nightly builds - must be first because they take precedence
@@ -152,10 +151,6 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "main-dry-run/",
 		}
-	case BazelExpBranch:
-		return &RunTypeMatcher{
-			Branch: "bzl/",
-		}
 	case WolfiExpBranch:
 		return &RunTypeMatcher{
 			Branch: "wolfi/",
@@ -192,8 +187,6 @@ func (t RunType) String() string {
 	switch t {
 	case PullRequest:
 		return "Pull request"
-	case BazelExpBranch:
-		return "Bazel Exp Branch"
 	case WolfiExpBranch:
 		return "Wolfi Exp Branch"
 	case ReleaseNightly:

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -16,91 +16,109 @@ The default run type.
 
 - Pipeline for `Go` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Client` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
   - **Pipeline setup**: Trigger async
 
 - Pipeline for `GraphQL` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 
 - Pipeline for `DatabaseSchema` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `Docs` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Dockerfiles` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `ExecutorVMImage` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `CIScripts` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `Terraform` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `SVG` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Shell` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `DockerImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `WolfiPackages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `WolfiBaseImages` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
 
 - Pipeline for `Protobuf` changes:
   - **Metadata**: Pipeline metadata
-  - **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+  - Ensure buildfiles are up to date
+  - Tests
+  - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
-
-### Bazel Exp Branch
-
-The run type for branches matching `bzl/`.
-You can create a build of this run type for your changes using:
-
-```sh
-sg ci build bzl
-```
-
-Base pipeline (more steps might be included based on branch changes):
-
-- **Metadata**: Pipeline metadata
-- **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
 
 ### Wolfi Exp Branch
 
@@ -177,7 +195,9 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build syntax-highlighter, Build Docker images, Build Docker images, Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
-- **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+- Ensure buildfiles are up to date
+- Tests
+- BackCompat Tests
 - **Linters and static analysis**: Run sg lint
 - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
@@ -194,7 +214,9 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build syntax-highlighter, Build Docker images, Build Docker images, Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
-- **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+- Ensure buildfiles are up to date
+- Tests
+- BackCompat Tests
 - **Linters and static analysis**: Run sg lint
 - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
@@ -252,7 +274,9 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build syntax-highlighter, Build Docker images, Build Docker images, Build Docker images, Build executor image, Build executor binary
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
-- **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+- Ensure buildfiles are up to date
+- Tests
+- BackCompat Tests
 - **Linters and static analysis**: Run sg lint
 - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA
@@ -274,7 +298,9 @@ Base pipeline (more steps might be included based on branch changes):
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build syntax-highlighter, Build Docker images, Build Docker images, Build Docker images, Build executor image, Build executor binary
 - **Image security scans**: Scan symbols, Scan executor, Scan alpine-3.14, Scan postgres-12-alpine, Scan cadvisor, Scan codeinsights-db, Scan codeintel-db, Scan frontend, Scan github-proxy, Scan gitserver, Scan grafana, Scan indexed-searcher, Scan migrator, Scan node-exporter, Scan opentelemetry-collector, Scan postgres_exporter, Scan precise-code-intel-worker, Scan prometheus, Scan prometheus-gcp, Scan redis-cache, Scan redis-store, Scan redis_exporter, Scan repo-updater, Scan search-indexer, Scan searcher, Scan syntax-highlighter, Scan worker, Scan batcheshelper, Scan blobstore2, Scan bundled-executor, Scan dind, Scan embeddings, Scan executor-kubernetes, Scan executor-vm, Scan jaeger-agent, Scan jaeger-all-in-one, Scan llm-proxy, Scan sg
-- **Bazel**: Ensure buildfiles are up to date, Tests, BackCompat Tests
+- Ensure buildfiles are up to date
+- Tests
+- BackCompat Tests
 - **Linters and static analysis**: Run sg lint
 - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Integration tests for the Cody VS Code extension, ESLint (all), ESLint (web), Stylelint (all)
 - **Integration tests**: Backend integration tests (gRPC), Backend integration tests, Code Intel QA

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -253,7 +253,6 @@ This command is useful when:
 
 Supported run types when providing an argument for 'sg ci build [runtype]':
 
-* bzl - Bazel Exp Branch
 * wolfi - Wolfi Exp Branch
 * main-dry-run - Main dry run
 * docker-images-patch - Patch image

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -13,11 +13,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
-func BazelOperations() *operations.Set {
-	ops := operations.NewNamedSet("Bazel")
-	ops.Append(bazelConfigure())
-	ops.Append(bazelTest("//...", "//client/web:test"))
-	ops.Append(bazelBackCompatTest(
+func BazelOperations() []operations.Operation {
+	ops := []operations.Operation{}
+	ops = append(ops, bazelConfigure())
+	ops = append(ops, bazelTest("//...", "//client/web:test"))
+	ops = append(ops, bazelBackCompatTest(
 		"@sourcegraph_back_compat//cmd/...",
 		"@sourcegraph_back_compat//lib/...",
 		"@sourcegraph_back_compat//internal/...",

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -279,7 +279,7 @@ func bazelBuildCandidateDockerImages(apps []string, version string, tag string, 
 				// bk.AutomaticRetryStatus(3, 222),
 			)
 		}
-		pipeline.AddStep(":docker: :construction: Build Docker images", cmds...)
+		pipeline.AddStep(":bazel::docker: :construction: Build Docker images", cmds...)
 	}
 }
 
@@ -378,7 +378,7 @@ func bazelBuildCandidateDockerImage(app string, version string, tag string, rt r
 			// Retry in case of flakes when pushing
 			// bk.AutomaticRetryStatus(3, 222),
 		)
-		pipeline.AddStep(fmt.Sprintf(":docker: :construction: Build %s", app), cmds...)
+		pipeline.AddStep(fmt.Sprintf(":bazel::docker: :construction: Build %s", app), cmds...)
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -506,7 +506,7 @@ func addGoBuild(pipeline *bk.Pipeline) {
 func backendIntegrationTests(candidateImageTag string, imageDep string) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		for _, enableGRPC := range []bool{true, false} {
-			description := ":bazel:+:docker: :chains: Backend integration tests"
+			description := ":bazel::docker: :chains: Backend integration tests"
 			if enableGRPC {
 				description += " (gRPC)"
 			}
@@ -662,7 +662,7 @@ func triggerReleaseBranchHealthchecks(minimumUpgradeableVersion string) operatio
 
 func codeIntelQA(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
-		p.AddStep(":docker::brain: Code Intel QA",
+		p.AddStep(":bazel::docker::brain: Code Intel QA",
 			bk.SlackStepNotify(&bk.SlackStepNotifyConfigPayload{
 				Message:     ":alert: :noemi-handwriting: Code Intel QA Flake detected <@Noah S-C>",
 				ChannelName: "code-intel-buildkite",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -48,7 +48,7 @@ func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *oper
 	ops := operations.NewSet()
 
 	if opts.ForceBazel {
-		ops.Merge(BazelOperations())
+		ops.Append(BazelOperations()...)
 	}
 
 	// Simple, fast-ish linter checks
@@ -506,7 +506,7 @@ func addGoBuild(pipeline *bk.Pipeline) {
 func backendIntegrationTests(candidateImageTag string, imageDep string) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		for _, enableGRPC := range []bool{true, false} {
-			description := ":chains: Backend integration tests"
+			description := ":bazel:+:docker: :chains: Backend integration tests"
 			if enableGRPC {
 				description += " (gRPC)"
 			}
@@ -686,7 +686,7 @@ func codeIntelQA(candidateTag string) operations.Operation {
 
 func executorsE2E(candidateTag string) operations.Operation {
 	return func(p *bk.Pipeline) {
-		p.AddStep(":docker::packer: Executors E2E",
+		p.AddStep(":bazel::docker::packer: Executors E2E",
 			// Run tests against the candidate server image
 			bk.DependsOn(candidateImageStepKey("symbols")),
 			bk.Agent("queue", "bazel"),

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -97,8 +97,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	//
 	// PERF: Try to order steps such that slower steps are first.
 	switch c.RunType {
-	case runtype.BazelExpBranch:
-		ops.Merge(BazelOperations())
 	case runtype.WolfiExpBranch:
 		// Rebuild packages if package configs have changed
 		updatePackages := c.Diff.Has(changed.WolfiPackages)


### PR DESCRIPTION
Based on a suggestion from @valerybugakov to make it clearer about what was ported to Bazel or not, this reworks the jobs to make the distinction clearer.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 