### PR TITLE
Use time-safe comparison for webhook secrets

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/bitbucketcloud.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net/http"
@@ -159,7 +160,7 @@ func (h *BitbucketCloudWebhook) parseEvent(r *http.Request) (interface{}, *types
 		}
 
 		if secret := con.WebhookSecret; secret != "" {
-			if r.FormValue("secret") == secret {
+			if subtle.ConstantTimeCompare([]byte(r.FormValue("secret")), []byte(secret)) == 1 {
 				extSvc = e
 				break
 			}

--- a/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/gitlab.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net/http"
@@ -331,7 +332,7 @@ func validateGitLabSecret(ctx context.Context, extSvc *types.ExternalService, se
 	// number of webhooks in an external service should be small enough that a
 	// linear search like this is sufficient.
 	for _, webhook := range config.Webhooks {
-		if webhook.Secret == secret {
+		if subtle.ConstantTimeCompare([]byte(webhook.Secret), []byte(secret)) == 1 {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
This PR resolves an issue where a timing attack would be possible to retrieve webhook secrets. By using a constant-time comparison, regardless whether the client provided secret is correct or not, the comparison takes the same amount of time. 

Closes https://github.com/sourcegraph/security-issues/issues/346

## Test plan
CI tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
