### PR TITLE
mark adminanalytics tests as flaky.

### DIFF
--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -33,9 +33,9 @@ go_library(
 go_test(
     name = "adminanalytics_test",
     timeout = "short",
-    flaky = True,
     srcs = ["users_test.go"],
     embed = [":adminanalytics"],
+    flaky = True,
     tags = [
         # Test requires localhost for database
         "requires-network",

--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 go_test(
     name = "adminanalytics_test",
     timeout = "short",
+    flaky = True,
     srcs = ["users_test.go"],
     embed = [":adminanalytics"],
     tags = [


### PR DESCRIPTION
Test plan:
CI.

There was a timeout for `//internal/adminanalytics:adminanalytics_test` tests in [this build](https://buildkite.com/sourcegraph/sourcegraph/builds/218450#01880a27-66ac-42fa-911a-d4a76702618a/31-1453).
