### PR TITLE
Cody: Render chat input immediately

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 - UI bug that capped buttons at 300px max-width with visible border [pull/51726](https://github.com/sourcegraph/sourcegraph/pull/51726)
 - Add error message on top of Cody's response instead of overriding it [pull/51762](https://github.com/sourcegraph/sourcegraph/pull/51762)
+- Fixed an issue where chat input messages where not rendered in the UI immediately [pull/](https://github.com/sourcegraph/sourcegraph/pull/
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 - UI bug that capped buttons at 300px max-width with visible border [pull/51726](https://github.com/sourcegraph/sourcegraph/pull/51726)
 - Add error message on top of Cody's response instead of overriding it [pull/51762](https://github.com/sourcegraph/sourcegraph/pull/51762)
-- Fixed an issue where chat input messages where not rendered in the UI immediately [pull/](https://github.com/sourcegraph/sourcegraph/pull/
+- Fixed an issue where chat input messages where not rendered in the UI immediately [pull/51783](https://github.com/sourcegraph/sourcegraph/pull/51783)
 
 ### Changed
 

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -372,18 +372,20 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             this.showTab('chat')
         }
 
-        // Check whether or not to connect to LLM backend for responses
-        // Ex: performing fuzzy / context-search does not require responses from LLM backend
-        const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
-
         switch (recipeId) {
             case 'context-search':
                 this.onCompletionEnd()
                 break
-            default:
+            default: {
                 this.sendTranscript()
+
+                // Check whether or not to connect to LLM backend for responses
+                // Ex: performing fuzzy / context-search does not require responses from LLM backend
+                const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
+
                 this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
                 await this.saveTranscriptToChatHistory()
+            }
         }
 
         logEvent(`CodyVSCodeExtension:recipe:${recipe.id}:executed`)

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -372,6 +372,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             this.showTab('chat')
         }
 
+        // Check whether or not to connect to LLM backend for responses
+        // Ex: performing fuzzy / context-search does not require responses from LLM backend
         switch (recipeId) {
             case 'context-search':
                 this.onCompletionEnd()
@@ -379,10 +381,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             default: {
                 this.sendTranscript()
 
-                // Check whether or not to connect to LLM backend for responses
-                // Ex: performing fuzzy / context-search does not require responses from LLM backend
                 const prompt = await this.transcript.toPrompt(getPreamble(this.codebaseContext.getCodebase()))
-
                 this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
                 await this.saveTranscriptToChatHistory()
             }


### PR DESCRIPTION
Fixes #51760

Changes in #51077 made it so that we now block on the prompt creation before showing the chat input in the UI. The issue is that the prompt requires _context_ which come from embeddings that are hosted on a different machine so this `await` was causing a network roundtrip. 

## Test plan

- verified that fuzzy/ context search still works
- made sure there is no more input delay when sending a chat message

https://github.com/sourcegraph/sourcegraph/assets/458591/15329207-0357-444a-8002-7a200a8f0c67




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
