### PR TITLE
docs: add an example of commenting in own' docs

### DIFF
--- a/doc/own/index.md
+++ b/doc/own/index.md
@@ -59,6 +59,7 @@ The following snippet shows an example of a valid CODEOWNERS file.
 
 ```
 *.txt @text-team
+# this is a comment explaining why Alice owns this
 /build/logs/ alice@sourcegraph.com 
 /cmd/**/test @qa-team @user
 ```


### PR DESCRIPTION
Wasn't sure if comments were supported, got it confirmed by asking on Slack.

Test plan: CI



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
