### PR TITLE
Revert hallucination detector changes

### DIFF
--- a/client/cody-shared/src/hallucinations-detector/index.test.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.test.ts
@@ -17,9 +17,9 @@ This is a cool/awesome test.
 
 const expectedHighlightedTokensText = `# Title
 
-This is \`<span class="token-file token-hallucinated">/some/hallucinated/file/path</span>\`. Hosted on github.com/sourcegraph.
+This is  <span class="token-file token-hallucinated">\`/some/hallucinated/file/path\`</span> . Hosted on github.com/sourcegraph.
 
-Quoted "<span class="token-file token-not-hallucinated">file/path.js</span>". Unquoted hallucinated <span class="token-file token-hallucinated">file/path/Class.java</span> file.
+Quoted  <span class="token-file token-not-hallucinated">"file/path.js"</span> . Unquoted hallucinated <span class="token-file token-hallucinated">file/path/Class.java</span> file.
 
 This is a cool/awesome test.
 

--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -81,14 +81,14 @@ async function detectTokens(
 function highlightLine(line: string, tokens: HighlightedToken[]): string {
     let highlightedLine = line
     for (const token of tokens) {
-        highlightedLine = highlightedLine.replaceAll(token.innerValue, getHighlightedTokenHTML(token))
+        highlightedLine = highlightedLine.replaceAll(token.outerValue, getHighlightedTokenHTML(token))
     }
     return highlightedLine
 }
 
 function getHighlightedTokenHTML(token: HighlightedToken): string {
     const isHallucinatedClassName = token.isHallucinated ? 'hallucinated' : 'not-hallucinated'
-    return `<span class="token-${token.type} token-${isHallucinatedClassName}">${token.innerValue}</span>`
+    return ` <span class="token-${token.type} token-${isHallucinatedClassName}">${token.outerValue.trim()}</span> `
 }
 
 export function findFilePaths(line: string): { fullMatch: string; pathMatch: string }[] {

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 - UI bug that capped buttons at 300px max-width with visible border [pull/51726](https://github.com/sourcegraph/sourcegraph/pull/51726)
 - Add error message on top of Cody's response instead of overriding it [pull/51762](https://github.com/sourcegraph/sourcegraph/pull/51762)
+- Fixes an issue where file where the hallucination detection was not working properly [pull/51785](https://github.com/sourcegraph/sourcegraph/pull/51785)
 
 ### Changed
 


### PR DESCRIPTION
Fixes #51768

When working on #51576 I was trying to fix some issues where the hallucination detection logic highlighting was not working well and later, based on Rok's input, noticed that this was causing a regression.

The problem? I forgot to push my revert 😭 

<img width="896" alt="Screenshot 2023-05-11 at 12 29 47" src="https://github.com/sourcegraph/sourcegraph/assets/458591/af334243-7a30-4f4b-af90-ec8f5e2bc86e">

So here's the revert for the changes in #51576

## Test plan

<img width="556" alt="Screenshot 2023-05-11 at 12 31 03" src="https://github.com/sourcegraph/sourcegraph/assets/458591/c7ce8465-2ac7-4b49-b205-3555c433942a">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
