### PR TITLE
Cody: Open chat tab on reset

### DIFF
--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -169,7 +169,10 @@ const register = async (
         vscode.commands.registerCommand('cody.focus', () => vscode.commands.executeCommand('cody.chat.focus')),
         vscode.commands.registerCommand('cody.settings', () => chatProvider.setWebviewView('settings')),
         vscode.commands.registerCommand('cody.history', () => chatProvider.setWebviewView('history')),
-        vscode.commands.registerCommand('cody.interactive.clear', () => chatProvider.clearAndRestartSession()),
+        vscode.commands.registerCommand('cody.interactive.clear', async () => {
+            await chatProvider.clearAndRestartSession()
+            chatProvider.setWebviewView('chat')
+        }),
         vscode.commands.registerCommand('cody.recipe.explain-code', () => executeRecipe('explain-code-detailed')),
         vscode.commands.registerCommand('cody.recipe.explain-code-high-level', () =>
             executeRecipe('explain-code-high-level')


### PR DESCRIPTION
This fixes a UX gripe that I have after we changed the icons a bit.

I always click the chat history icon when I want to clear the chat threads only to find out this icon now goes to the history:

<img width="564" alt="Screenshot 2023-05-11 at 12 20 50" src="https://github.com/sourcegraph/sourcegraph/assets/458591/73b3364d-067c-48b8-8e24-143912985049">

I realize the issue quickly and then press the other button to reset the chat tab but that does not give me any UI feedback which is really confusing me. 

This PR makes it so that the reset tab also opens that chat window. 

## Test plan


https://github.com/sourcegraph/sourcegraph/assets/458591/eb4c4d8b-d412-4f4a-84c2-ab85bb769603



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
