### PR TITLE
ci: retry once backend integ tests for the time being

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -501,8 +501,6 @@ func addGoBuild(pipeline *bk.Pipeline) {
 }
 
 // Adds backend integration tests step.
-//
-// Runtime: ~5m
 func backendIntegrationTests(candidateImageTag string, imageDep string) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
 		for _, enableGRPC := range []bool{true, false} {
@@ -514,6 +512,7 @@ func backendIntegrationTests(candidateImageTag string, imageDep string) operatio
 				description,
 				// Run tests against the candidate server image
 				bk.DependsOn(candidateImageStepKey(imageDep)),
+				bk.AutomaticRetry(1), // TODO: @jhchabran, flaky, investigate
 				bk.Env("IMAGE",
 					images.DevRegistryImage("server", candidateImageTag)),
 				bk.Env("SG_FEATURE_FLAG_GRPC", strconv.FormatBool(enableGRPC)),


### PR DESCRIPTION
Backend integrations tests have been flaking a lot recently, seems to be bitbucket related. For now this will avoid breaking builds too often. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

ci 
