### PR TITLE
Cody: add RecipeID type + docs and small refactors

### DIFF
--- a/client/cody-cli/src/preamble.ts
+++ b/client/cody-cli/src/preamble.ts
@@ -17,6 +17,10 @@ I will answer questions, explain code, and generate code as concisely and clearl
 My responses will be formatted using Markdown syntax for code blocks without language specifiers.
 I will acknowledge when I don't know an answer or need more context.`
 
+/**
+ * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.
+ * Both messages contain an optional note about the current codebase if it's not null.
+ */
 export function getPreamble(codebase: string): Message[] {
     const preamble = [actions, rules]
     const preambleResponse = [answer]

--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -5,7 +5,7 @@ import { PrefilledOptions, withPreselectedOptions } from '../editor/withPreselec
 import { SourcegraphEmbeddingsSearchClient } from '../embeddings/client'
 import { SourcegraphIntentDetectorClient } from '../intent-detector/client'
 import { SourcegraphBrowserCompletionsClient } from '../sourcegraph-api/completions/browserClient'
-import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql/client'
+import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 import { isError } from '../utils'
 
 import { BotResponseMultiplexer } from './bot-response-multiplexer'
@@ -15,6 +15,7 @@ import { getRecipe } from './recipes/browser-recipes'
 import { Transcript, TranscriptJSON } from './transcript'
 import { ChatMessage } from './transcript/messages'
 import { reformatBotMessage } from './viewHelpers'
+import { RecipeID } from './recipes/recipe'
 
 export type { TranscriptJSON }
 export { Transcript }
@@ -35,7 +36,7 @@ export interface Client {
     readonly isMessageInProgress: boolean
     submitMessage: (text: string) => Promise<void>
     executeRecipe: (
-        recipeId: string,
+        recipeId: RecipeID,
         options?: {
             prefilledOptions?: PrefilledOptions
         }
@@ -87,7 +88,7 @@ export async function createClient({
     }
 
     async function executeRecipe(
-        recipeId: string,
+        recipeId: RecipeID,
         options?: {
             prefilledOptions?: PrefilledOptions
             humanChatInput?: string

--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -12,10 +12,10 @@ import { BotResponseMultiplexer } from './bot-response-multiplexer'
 import { ChatClient } from './chat'
 import { getPreamble } from './preamble'
 import { getRecipe } from './recipes/browser-recipes'
+import { RecipeID } from './recipes/recipe'
 import { Transcript, TranscriptJSON } from './transcript'
 import { ChatMessage } from './transcript/messages'
 import { reformatBotMessage } from './viewHelpers'
-import { RecipeID } from './recipes/recipe'
 
 export type { TranscriptJSON }
 export { Transcript }

--- a/client/cody-shared/src/chat/preamble.ts
+++ b/client/cody-shared/src/chat/preamble.ts
@@ -18,6 +18,10 @@ I will answer questions, explain code, and generate code as concisely and clearl
 My responses will be formatted using Markdown syntax for code blocks.
 I will acknowledge when I don't know an answer or need more context.`
 
+/**
+ * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.
+ * Both messages contain an optional note about the current codebase if it's not null.
+ */
 export function getPreamble(codebase: string | undefined): Message[] {
     const preamble = [actions, rules]
     const preambleResponse = [answer]

--- a/client/cody-shared/src/chat/recipes/browser-recipes.ts
+++ b/client/cody-shared/src/chat/recipes/browser-recipes.ts
@@ -5,16 +5,16 @@ import { FindCodeSmells } from './find-code-smells'
 import { GenerateDocstring } from './generate-docstring'
 import { GenerateTest } from './generate-test'
 import { ImproveVariableNames } from './improve-variable-names'
-import { Recipe } from './recipe'
+import { Recipe, RecipeID } from './recipe'
 import { TranslateToLanguage } from './translate'
 
-const registeredRecipes: { [id: string]: Recipe } = {}
+const registeredRecipes: { [id in RecipeID]?: Recipe } = {}
 
-export function registerRecipe(id: string, recipe: Recipe): void {
+export function registerRecipe(id: RecipeID, recipe: Recipe): void {
     registeredRecipes[id] = recipe
 }
 
-export function getRecipe(id: string): Recipe | null {
+export function getRecipe(id: RecipeID): Recipe | undefined {
     return registeredRecipes[id]
 }
 

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -10,10 +10,10 @@ import {
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ChatQuestion implements Recipe {
-    public id = 'chat-question'
+    public id: RecipeID = 'chat-question'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const truncatedText = truncateText(humanChatInput, MAX_HUMAN_INPUT_TOKENS)

--- a/client/cody-shared/src/chat/recipes/context-search.ts
+++ b/client/cody-shared/src/chat/recipes/context-search.ts
@@ -6,7 +6,7 @@ import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getFileExtension } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 /*
 This class implements the context-search recipe.
@@ -26,7 +26,7 @@ Functionality:
 */
 
 export class ContextSearch implements Recipe {
-    public id = 'context-search'
+    public id: RecipeID = 'context-search'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const query = humanChatInput || (await context.editor.showInputBox('Enter your search query here...')) || ''

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -3,10 +3,10 @@ import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ExplainCodeDetailed implements Recipe {
-    public id = 'explain-code-detailed'
+    public id: RecipeID = 'explain-code-detailed'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -3,10 +3,10 @@ import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ExplainCodeHighLevel implements Recipe {
-    public id = 'explain-code-high-level'
+    public id: RecipeID = 'explain-code-high-level'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -3,10 +3,10 @@ import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getNormalizedLanguageName } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class FindCodeSmells implements Recipe {
-    public id = 'find-code-smells'
+    public id: RecipeID = 'find-code-smells'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/fixup.ts
+++ b/client/cody-shared/src/chat/recipes/fixup.ts
@@ -6,10 +6,10 @@ import { BufferedBotResponseSubscriber } from '../bot-response-multiplexer'
 import { Interaction } from '../transcript/interaction'
 
 import { contentSanitizer } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class Fixup implements Recipe {
-    public id = 'fixup'
+    public id: RecipeID = 'fixup'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         // TODO: Prompt the user for additional direction.

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -8,10 +8,10 @@ import {
     getContextMessagesFromSelection,
     getFileExtension,
 } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class GenerateDocstring implements Recipe {
-    public id = 'generate-docstring'
+    public id: RecipeID = 'generate-docstring'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/generate-release-notes.ts
+++ b/client/cody-shared/src/chat/recipes/generate-release-notes.ts
@@ -4,10 +4,10 @@ import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ReleaseNotes implements Recipe {
-    public id = 'release-notes'
+    public id: RecipeID = 'release-notes'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const dirPath = context.editor.getWorkspaceRootPath()

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -8,10 +8,10 @@ import {
     getFileExtension,
     getContextMessagesFromSelection,
 } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class GenerateTest implements Recipe {
-    public id = 'generate-unit-test'
+    public id: RecipeID = 'generate-unit-test'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -5,10 +5,10 @@ import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class GitHistory implements Recipe {
-    public id = 'git-history'
+    public id: RecipeID = 'git-history'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const dirPath = context.editor.getWorkspaceRootPath()

--- a/client/cody-shared/src/chat/recipes/helpers.ts
+++ b/client/cody-shared/src/chat/recipes/helpers.ts
@@ -18,7 +18,7 @@ const EXTENSION_TO_LANGUAGE: { [key: string]: string } = {
 }
 
 export function getNormalizedLanguageName(extension: string): string {
-    return extension ? (EXTENSION_TO_LANGUAGE[extension] ?? extension.charAt(0).toUpperCase() + extension.slice(1)) : ''
+    return extension ? EXTENSION_TO_LANGUAGE[extension] ?? extension.charAt(0).toUpperCase() + extension.slice(1) : ''
 }
 
 export async function getContextMessagesFromSelection(

--- a/client/cody-shared/src/chat/recipes/helpers.ts
+++ b/client/cody-shared/src/chat/recipes/helpers.ts
@@ -18,14 +18,7 @@ const EXTENSION_TO_LANGUAGE: { [key: string]: string } = {
 }
 
 export function getNormalizedLanguageName(extension: string): string {
-    if (!extension) {
-        return ''
-    }
-    const language = EXTENSION_TO_LANGUAGE[extension]
-    if (language) {
-        return language
-    }
-    return extension.charAt(0).toUpperCase() + extension.slice(1)
+    return extension ? (EXTENSION_TO_LANGUAGE[extension] ?? extension.charAt(0).toUpperCase() + extension.slice(1)) : ''
 }
 
 export async function getContextMessagesFromSelection(

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -8,10 +8,10 @@ import {
     getContextMessagesFromSelection,
     getFileExtension,
 } from './helpers'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class ImproveVariableNames implements Recipe {
-    public id = 'improve-variable-names'
+    public id: RecipeID = 'improve-variable-names'
 
     public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.getActiveTextEditorSelectionOrEntireFile()

--- a/client/cody-shared/src/chat/recipes/inline-chat.ts
+++ b/client/cody-shared/src/chat/recipes/inline-chat.ts
@@ -7,10 +7,10 @@ import { Interaction } from '../transcript/interaction'
 
 import { ChatQuestion } from './chat-question'
 import { Fixup } from './fixup'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class InlineChat implements Recipe {
-    public id = 'inline-chat'
+    public id: RecipeID = 'inline-chat'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const selection = context.editor.controller?.selection

--- a/client/cody-shared/src/chat/recipes/next-questions.ts
+++ b/client/cody-shared/src/chat/recipes/next-questions.ts
@@ -7,10 +7,10 @@ import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
 import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class NextQuestions implements Recipe {
-    public id = 'next-questions'
+    public id: RecipeID = 'next-questions'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
         const promptPrefix = 'Assume I have an answer to the following request:'

--- a/client/cody-shared/src/chat/recipes/recipe.ts
+++ b/client/cody-shared/src/chat/recipes/recipe.ts
@@ -12,7 +12,23 @@ export interface RecipeContext {
     responseMultiplexer: BotResponseMultiplexer
 }
 
+export type RecipeID =
+    | 'chat-question'
+    | 'explain-code-detailed'
+    | 'explain-code-high-level'
+    | 'generate-unit-test'
+    | 'generate-docstring'
+    | 'improve-variable-names'
+    | 'translate-to-language'
+    | 'git-history'
+    | 'find-code-smells'
+    | 'fixup'
+    | 'context-search'
+    | 'release-notes'
+    | 'inline-chat'
+    | 'next-questions'
+
 export interface Recipe {
-    id: string
+    id: RecipeID
     getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null>
 }

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -3,10 +3,10 @@ import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
-import { Recipe, RecipeContext } from './recipe'
+import { Recipe, RecipeContext, RecipeID } from './recipe'
 
 export class TranslateToLanguage implements Recipe {
-    public id = 'translate-to-language'
+    public id: RecipeID = 'translate-to-language'
 
     public static options = languageNames
 

--- a/client/cody-shared/src/chat/recipes/vscode-recipes.ts
+++ b/client/cody-shared/src/chat/recipes/vscode-recipes.ts
@@ -11,16 +11,16 @@ import { GitHistory } from './git-log'
 import { ImproveVariableNames } from './improve-variable-names'
 import { InlineChat } from './inline-chat'
 import { NextQuestions } from './next-questions'
-import { Recipe } from './recipe'
+import { Recipe, RecipeID } from './recipe'
 import { TranslateToLanguage } from './translate'
 
-const registeredRecipes: { [id: string]: Recipe } = {}
+const registeredRecipes: { [id in RecipeID]?: Recipe } = {}
 
-export function registerRecipe(id: string, recipe: Recipe): void {
+export function registerRecipe(id: RecipeID, recipe: Recipe): void {
     registeredRecipes[id] = recipe
 }
 
-export function getRecipe(id: string): Recipe | null {
+export function getRecipe(id: RecipeID): Recipe | undefined {
     return registeredRecipes[id]
 }
 

--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -5,11 +5,15 @@ import { Interaction, InteractionJSON } from './interaction'
 import { ChatMessage } from './messages'
 
 export interface TranscriptJSON {
+    // This is the timestamp of the first interaction.
     id: string
     interactions: InteractionJSON[]
     lastInteractionTimestamp: string
 }
 
+/**
+ * A transcript of a conversation between a human and an assistant.
+ */
 export class Transcript {
     public static fromJSON(json: TranscriptJSON): Transcript {
         return new Transcript(
@@ -142,6 +146,11 @@ export class Transcript {
     }
 }
 
+/**
+ * Truncates the given prompt messages to fit within the available tokens budget.
+ * The truncation is done by removing the oldest pairs of messages first.
+ * No individual message will be truncated. We just remove pairs of messages if they exceed the available tokens budget.
+ */
 function truncatePrompt(messages: Message[], maxTokens: number): Message[] {
     const newPromptMessages = []
     let availablePromptTokensBudget = maxTokens
@@ -163,6 +172,9 @@ function truncatePrompt(messages: Message[], maxTokens: number): Message[] {
     return newPromptMessages.reverse()
 }
 
+/**
+ * Gives a rough estimate for the number of tokens used by the message.
+ */
 function estimateTokensUsage(message: Message): number {
     return Math.round((message.text || '').length / CHARS_PER_TOKEN)
 }

--- a/client/cody-shared/src/chat/transcript/interaction.ts
+++ b/client/cody-shared/src/chat/transcript/interaction.ts
@@ -87,4 +87,3 @@ export class Interaction {
         }
     }
 }
-

--- a/client/cody-shared/src/chat/transcript/interaction.ts
+++ b/client/cody-shared/src/chat/transcript/interaction.ts
@@ -12,23 +12,34 @@ export interface InteractionJSON {
 }
 
 export class Interaction {
-    private cachedContextFileNames: string[] = []
-    private context: Promise<ContextMessage[]>
+    private readonly humanMessage: InteractionMessage
+    private assistantMessage: InteractionMessage
     public readonly timestamp: string
+    private readonly context: Promise<ContextMessage[]>
+
+    // A sorted list of unique filenames of context files that will be set later.
+    private cachedContextFileNames: string[] = []
 
     constructor(
-        private humanMessage: InteractionMessage,
-        private assistantMessage: InteractionMessage,
+        humanMessage: InteractionMessage,
+        assistantMessage: InteractionMessage,
         context: Promise<ContextMessage[]>,
         timestamp: string = new Date().toISOString()
     ) {
+        this.humanMessage = humanMessage
+        this.assistantMessage = assistantMessage
         this.timestamp = timestamp
+
+        // This is some hacky behavior: returns a promise that resolves to the same array that was passed,
+        // but also caches the context file names in memory as a side effect.
         this.context = context.then(messages => {
+            // Extract the context file names from the context messages.
             const contextFileNames = messages
                 .map(message => message.fileName)
                 .filter((fileName): fileName is string => !!fileName)
 
-            // Cache the context files so we don't have to block the UI when calling `toChat` by waiting for the context to resolve.
+            // Cache the context files in memory, so we don't have to block the UI
+            // when calling `toChat` by waiting for the context to resolve.
             this.cachedContextFileNames = [...new Set<string>(contextFileNames)].sort((a, b) => a.localeCompare(b))
 
             return messages
@@ -56,9 +67,13 @@ export class Interaction {
         if (includeContext) {
             messages.unshift(...(await this.context))
         }
-        return messages.map(toPromptMessage)
+
+        return messages.map(message => ({ speaker: message.speaker, text: message.text }))
     }
 
+    /**
+     * Converts the interaction to chat message pair: one message from a human, one from an assistant.
+     */
     public toChat(): ChatMessage[] {
         return [this.humanMessage, { ...this.assistantMessage, contextFiles: this.cachedContextFileNames }]
     }
@@ -73,6 +88,3 @@ export class Interaction {
     }
 }
 
-function toPromptMessage(interactionOrContextMessage: InteractionMessage | ContextMessage): Message {
-    return { speaker: interactionOrContextMessage.speaker, text: interactionOrContextMessage.text }
-}

--- a/client/cody-shared/src/chat/transcript/messages.ts
+++ b/client/cody-shared/src/chat/transcript/messages.ts
@@ -4,6 +4,7 @@ import { TranscriptJSON } from '.'
 
 export interface ChatMessage extends Message {
     displayText?: string
+    // File names of context files
     contextFiles?: string[]
 }
 

--- a/client/cody-shared/src/prompt/prompt-mixin.ts
+++ b/client/cody-shared/src/prompt/prompt-mixin.ts
@@ -1,17 +1,24 @@
 import { InteractionMessage } from '../chat/transcript/messages'
 
-// Prompt mixins elaborate every prompt presented to the LLM. Add a prompt mixin to prompt for cross-cutting concerns relevant to multiple recipes.
+/**
+ * Prompt mixins elaborate every prompt presented to the LLM.
+ * Add a prompt mixin to prompt for cross-cutting concerns relevant to multiple recipes.
+ */
 export class PromptMixin {
-    private static mixins_: PromptMixin[] = []
+    private static mixins: PromptMixin[] = []
 
-    // Adds a prompt mixin to the global set.
+    /**
+     * Adds a prompt mixin to the global set.
+     */
     public static add(mixin: PromptMixin): void {
-        this.mixins_.push(mixin)
+        this.mixins.push(mixin)
     }
 
-    // Prepends all of the mixins to `humanMessage`. Modifies and returns `humanMessage`.
+    /**
+     * Prepends all mixins to `humanMessage`. Modifies and returns `humanMessage`.
+     */
     public static mixInto(humanMessage: InteractionMessage): InteractionMessage {
-        const mixins = this.mixins_.map(mixin => mixin.prompt).join('\n\n')
+        const mixins = this.mixins.map(mixin => mixin.prompt).join('\n\n')
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
             // Note we do not reflect them in displayText.
@@ -20,11 +27,15 @@ export class PromptMixin {
         return humanMessage
     }
 
-    // Creates a mixin with the given, fixed prompt to insert.
+    /**
+     * Creates a mixin with the given, fixed prompt to insert.
+     */
     constructor(private readonly prompt: string) {}
 }
 
-// Creates a prompt mixin to get Cody to reply in the given language, for example "en-AU" for "Australian English".
+/**
+ * Creates a prompt mixin to get Cody to reply in the given language, for example "en-AU" for "Australian English".
+ */
 export function languagePromptMixin(languageCode: string): PromptMixin {
     return new PromptMixin(
         `Unless instructed otherwise, reply in the language with RFC5646/ISO language code "${languageCode}".`

--- a/client/cody-shared/src/prompt/templates.ts
+++ b/client/cody-shared/src/prompt/templates.ts
@@ -6,14 +6,18 @@ const CODE_CONTEXT_TEMPLATE = `Use following code snippet from file \`{filePath}
 \`\`\``
 
 export function populateCodeContextTemplate(code: string, filePath: string): string {
-    const language = path.extname(filePath).slice(1)
-    return CODE_CONTEXT_TEMPLATE.replace('{filePath}', filePath).replace('{language}', language).replace('{text}', code)
+    return CODE_CONTEXT_TEMPLATE
+        .replace('{filePath}', filePath)
+        .replace('{language}', getExtension(filePath))
+        .replace('{text}', code)
 }
 
 const MARKDOWN_CONTEXT_TEMPLATE = 'Use the following text from file `{filePath}`:\n{text}'
 
 export function populateMarkdownContextTemplate(markdown: string, filePath: string): string {
-    return MARKDOWN_CONTEXT_TEMPLATE.replace('{filePath}', filePath).replace('{text}', markdown)
+    return MARKDOWN_CONTEXT_TEMPLATE
+        .replace('{filePath}', filePath)
+        .replace('{text}', markdown)
 }
 
 const CURRENT_EDITOR_CODE_TEMPLATE = 'I have the `{filePath}` file opened in my editor. '
@@ -37,6 +41,10 @@ export function populateCurrentEditorSelectedContextTemplate(code: string, fileP
 const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown'])
 
 export function isMarkdownFile(filePath: string): boolean {
-    const extension = path.extname(filePath).slice(1)
-    return MARKDOWN_EXTENSIONS.has(extension)
+    return MARKDOWN_EXTENSIONS.has(getExtension(filePath))
 }
+
+function getExtension(filePath: string): string {
+    return path.extname(filePath).slice(1)
+}
+

--- a/client/cody-shared/src/prompt/templates.ts
+++ b/client/cody-shared/src/prompt/templates.ts
@@ -6,8 +6,7 @@ const CODE_CONTEXT_TEMPLATE = `Use following code snippet from file \`{filePath}
 \`\`\``
 
 export function populateCodeContextTemplate(code: string, filePath: string): string {
-    return CODE_CONTEXT_TEMPLATE
-        .replace('{filePath}', filePath)
+    return CODE_CONTEXT_TEMPLATE.replace('{filePath}', filePath)
         .replace('{language}', getExtension(filePath))
         .replace('{text}', code)
 }
@@ -15,9 +14,7 @@ export function populateCodeContextTemplate(code: string, filePath: string): str
 const MARKDOWN_CONTEXT_TEMPLATE = 'Use the following text from file `{filePath}`:\n{text}'
 
 export function populateMarkdownContextTemplate(markdown: string, filePath: string): string {
-    return MARKDOWN_CONTEXT_TEMPLATE
-        .replace('{filePath}', filePath)
-        .replace('{text}', markdown)
+    return MARKDOWN_CONTEXT_TEMPLATE.replace('{filePath}', filePath).replace('{text}', markdown)
 }
 
 const CURRENT_EDITOR_CODE_TEMPLATE = 'I have the `{filePath}` file opened in my editor. '
@@ -47,4 +44,3 @@ export function isMarkdownFile(filePath: string): boolean {
 function getExtension(filePath: string): string {
     return path.extname(filePath).slice(1)
 }
-

--- a/client/cody-shared/src/prompt/truncation.ts
+++ b/client/cody-shared/src/prompt/truncation.ts
@@ -1,10 +1,16 @@
 import { CHARS_PER_TOKEN } from './constants'
 
+/**
+ * Truncates text to the given number of tokens, keeping the start of the text.
+ */
 export function truncateText(text: string, maxTokens: number): string {
     const maxLength = maxTokens * CHARS_PER_TOKEN
     return text.length <= maxLength ? text : text.slice(0, maxLength)
 }
 
+/**
+ * Truncates text to the given number of tokens, keeping the end of the text.
+ */
 export function truncateTextStart(text: string, maxTokens: number): string {
     const maxLength = maxTokens * CHARS_PER_TOKEN
     return text.length <= maxLength ? text : text.slice(-maxLength - 1)

--- a/client/cody-slack/src/slack/preamble.ts
+++ b/client/cody-slack/src/slack/preamble.ts
@@ -22,6 +22,10 @@ I will answer questions, explain code, and generate code as concisely and clearl
 My responses will be formatted using Markdown syntax for code blocks without language specifiers.
 I will acknowledge when I don't know an answer or need more context. I will use the Slack thread conversation history to answer your questions.`
 
+/**
+ * Creates and returns an array of two messages: one from a human, and the supposed response from the AI assistant.
+ * Both messages contain an optional note about the current codebase if it's not null.
+ */
 function getSlackPreamble(codebase: string): Message[] {
     const preamble = [actions, rules]
     const preambleResponse = [answer]

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -3,10 +3,10 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
-import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
 import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { getPreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { getRecipe } from '@sourcegraph/cody-shared/src/chat/recipes/vscode-recipes'
 import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { ChatMessage, ChatHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -3,6 +3,7 @@ import path from 'path'
 
 import * as vscode from 'vscode'
 
+import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
 import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
 import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { getPreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
@@ -363,7 +364,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.publishContextStatus()
     }
 
-    public async executeRecipe(recipeId: string, humanChatInput: string = '', showTab = true): Promise<void> {
+    public async executeRecipe(recipeId: RecipeID, humanChatInput: string = '', showTab = true): Promise<void> {
         if (this.isMessageInProgress) {
             this.sendErrorToWebview('Cannot execute multiple recipes. Please wait for the current recipe to finish.')
             return
@@ -411,7 +412,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         logEvent(`CodyVSCodeExtension:recipe:${recipe.id}:executed`)
     }
 
-    private async runRecipeForSuggestion(recipeId: string, humanChatInput: string = ''): Promise<void> {
+    private async runRecipeForSuggestion(recipeId: RecipeID, humanChatInput: string = ''): Promise<void> {
         const recipe = getRecipe(recipeId)
         if (!recipe) {
             return

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -1,5 +1,5 @@
-import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -1,3 +1,4 @@
+import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { ChatMessage, UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
@@ -13,7 +14,7 @@ export type WebviewMessage =
       }
     | { command: 'event'; event: string; value: string }
     | { command: 'submit'; text: string; submitType: 'user' | 'suggestion' }
-    | { command: 'executeRecipe'; recipe: string }
+    | { command: 'executeRecipe'; recipe: RecipeID }
     | { command: 'settings'; serverEndpoint: string; accessToken: string }
     | { command: 'removeToken' }
     | { command: 'removeHistory' }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
 import { ChatViewProvider, isValidLogin } from './chat/ChatViewProvider'

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 
+import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
 import { ChatViewProvider, isValidLogin } from './chat/ChatViewProvider'
@@ -110,7 +111,7 @@ const register = async (
     )
     disposables.push({ dispose: () => vscode.commands.executeCommand('setContext', 'cody.activated', false) })
 
-    const executeRecipe = async (recipe: string): Promise<void> => {
+    const executeRecipe = async (recipe: RecipeID): Promise<void> => {
         await vscode.commands.executeCommand('cody.chat.focus')
         await chatProvider.executeRecipe(recipe, '')
     }

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -1,6 +1,6 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
-import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 
 import { VSCodeWrapper } from './utils/VSCodeApi'
 

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -1,5 +1,7 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
+import { RecipeID } from '@sourcegraph/cody-shared/out/src/chat/recipes/recipe'
+
 import { VSCodeWrapper } from './utils/VSCodeApi'
 
 import styles from './Recipes.module.css'
@@ -19,7 +21,7 @@ export const recipesList = {
 }
 
 export const Recipes: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const onRecipeClick = (recipeID: string): void => {
+    const onRecipeClick = (recipeID: RecipeID): void => {
         vscodeAPI.postMessage({ command: 'executeRecipe', recipe: recipeID })
     }
 
@@ -32,7 +34,7 @@ export const Recipes: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({
                             key={key}
                             className={styles.recipeButton}
                             type="button"
-                            onClick={() => onRecipeClick(key)}
+                            onClick={() => onRecipeClick(key as RecipeID)}
                         >
                             {value}
                         </VSCodeButton>

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -119,7 +119,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({ authe
                         </Menu>
                     </div>
                     <div className={classNames('h-100 mb-4', styles.sidebar)}>
-                        <HistoryList trucateMessageLenght={60} />
+                        <HistoryList truncateMessageLength={60} />
                     </div>
                     {!isCTADismissed &&
                         (showVSCodeCTA ? (

--- a/client/web/src/cody/components/HistoryList/HistoryList.tsx
+++ b/client/web/src/cody/components/HistoryList/HistoryList.tsx
@@ -12,13 +12,13 @@ import { safeTimestampToDate, useChatStoreState } from '../../stores/chat'
 import styles from './HistoryList.module.scss'
 
 interface HistoryListProps {
-    trucateMessageLenght?: number
+    truncateMessageLength?: number
     onSelect?: (id: string) => void
     itemClassName?: string
 }
 
 export const HistoryList: React.FunctionComponent<HistoryListProps> = ({
-    trucateMessageLenght,
+    truncateMessageLength,
     onSelect,
     itemClassName,
 }) => {
@@ -44,7 +44,7 @@ export const HistoryList: React.FunctionComponent<HistoryListProps> = ({
                     transcript={transcript}
                     onSelect={onSelect}
                     className={itemClassName}
-                    truncateMessageLength={trucateMessageLenght}
+                    truncateMessageLength={truncateMessageLength}
                 />
             ))}
         </div>

--- a/client/web/src/cody/stores/chat.ts
+++ b/client/web/src/cody/stores/chat.ts
@@ -6,6 +6,7 @@ import create from 'zustand'
 
 import { Client, createClient, ClientInit, Transcript, TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/client'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { PrefilledOptions } from '@sourcegraph/cody-shared/src/editor/withPreselectedOptions'
 import { isErrorLike } from '@sourcegraph/common'
@@ -35,7 +36,7 @@ interface CodyChatStore {
     submitMessage: (text: string) => void
     editMessage: (text: string) => void
     executeRecipe: (
-        recipeId: string,
+        recipeId: RecipeID,
         options?: {
             prefilledOptions?: PrefilledOptions
         }
@@ -145,7 +146,7 @@ export const useChatStoreState = create<CodyChatStore>((set, get): CodyChatStore
     }
 
     const executeRecipe = async (
-        recipeId: string,
+        recipeId: RecipeID,
         options?: {
             prefilledOptions?: PrefilledOptions
         }


### PR DESCRIPTION
Housekeeping PR:

- Added `RecipeID` type to introduce some type safety and clarity around recipe IDs
- Added comments for parts that were not self-explanatory to me
- Refactored some parts of the TypeScript codebase that I didn't find idiomatic with the rest of our codebase

Why and why now?
→ I'm working on Cody for JetBrains, and wanted to copy&paste some code to Java, but some stuff took much time to figure out because of the lack of the docs. Recipe IDs were one of the most difficult to track, so I focused on making those stricter.

## Test plan

- CI passes
- I've tested Cody in VS Code, works fine