### PR TITLE
llm-proxy: add mode that allows dev licenses only

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "productsubscription",
@@ -12,5 +12,16 @@ go_library(
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",
         "@com_github_sourcegraph_log//:log",
+        "@org_golang_x_exp//slices",
+    ],
+)
+
+go_test(
+    name = "productsubscription_test",
+    srcs = ["productsubscription_test.go"],
+    embed = [":productsubscription"],
+    deps = [
+        "//enterprise/cmd/llm-proxy/internal/dotcom",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription_test.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription_test.go
@@ -1,0 +1,87 @@
+package productsubscription
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/dotcom"
+)
+
+func TestNewActor(t *testing.T) {
+	type args struct {
+		s               dotcom.ProductSubscriptionState
+		devLicensesOnly bool
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantEnabled bool
+	}{
+		{
+			name: "not dev only",
+			args: args{
+				dotcom.ProductSubscriptionState{
+					LlmProxyAccess: dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccess{
+						LLMProxyAccessFields: dotcom.LLMProxyAccessFields{
+							Enabled: true,
+							RateLimit: &dotcom.LLMProxyAccessFieldsRateLimitLLMProxyRateLimit{
+								Limit:           10,
+								IntervalSeconds: 10,
+							},
+						},
+					},
+				},
+				false,
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "dev only, not a dev license",
+			args: args{
+				dotcom.ProductSubscriptionState{
+					LlmProxyAccess: dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccess{
+						LLMProxyAccessFields: dotcom.LLMProxyAccessFields{
+							Enabled: true,
+							RateLimit: &dotcom.LLMProxyAccessFieldsRateLimitLLMProxyRateLimit{
+								Limit:           10,
+								IntervalSeconds: 10,
+							},
+						},
+					},
+				},
+				true,
+			},
+			wantEnabled: false,
+		},
+		{
+			name: "dev only, is a dev license",
+			args: args{
+				dotcom.ProductSubscriptionState{
+					LlmProxyAccess: dotcom.ProductSubscriptionStateLlmProxyAccessLLMProxyAccess{
+						LLMProxyAccessFields: dotcom.LLMProxyAccessFields{
+							Enabled: true,
+							RateLimit: &dotcom.LLMProxyAccessFieldsRateLimitLLMProxyRateLimit{
+								Limit:           10,
+								IntervalSeconds: 10,
+							},
+						},
+					},
+					ActiveLicense: &dotcom.ProductSubscriptionStateActiveLicenseProductLicense{
+						Info: &dotcom.ProductSubscriptionStateActiveLicenseProductLicenseInfo{
+							Tags: []string{"dev"},
+						},
+					},
+				},
+				true,
+			},
+			wantEnabled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act := NewActor(nil, "", tt.args.s, tt.args.devLicensesOnly)
+			assert.Equal(t, act.AccessEnabled, tt.wantEnabled)
+		})
+	}
+}

--- a/enterprise/cmd/llm-proxy/internal/dotcom/operations.go
+++ b/enterprise/cmd/llm-proxy/internal/dotcom/operations.go
@@ -58,6 +58,11 @@ func (v *CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProduc
 	return v.ProductSubscriptionState.LlmProxyAccess
 }
 
+// GetActiveLicense returns CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProductSubscription.ActiveLicense, and is useful for accessing the field via an interface.
+func (v *CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProductSubscription) GetActiveLicense() *ProductSubscriptionStateActiveLicenseProductLicense {
+	return v.ProductSubscriptionState.ActiveLicense
+}
+
 func (v *CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProductSubscription) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -91,6 +96,8 @@ type __premarshalCheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTok
 	IsArchived bool `json:"isArchived"`
 
 	LlmProxyAccess ProductSubscriptionStateLlmProxyAccessLLMProxyAccess `json:"llmProxyAccess"`
+
+	ActiveLicense *ProductSubscriptionStateActiveLicenseProductLicense `json:"activeLicense"`
 }
 
 func (v *CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProductSubscription) MarshalJSON() ([]byte, error) {
@@ -108,6 +115,7 @@ func (v *CheckAccessTokenDotcomDotcomQueryProductSubscriptionByAccessTokenProduc
 	retval.Uuid = v.ProductSubscriptionState.Uuid
 	retval.IsArchived = v.ProductSubscriptionState.IsArchived
 	retval.LlmProxyAccess = v.ProductSubscriptionState.LlmProxyAccess
+	retval.ActiveLicense = v.ProductSubscriptionState.ActiveLicense
 	return &retval, nil
 }
 
@@ -213,6 +221,11 @@ func (v *ListProductSubscriptionFields) GetLlmProxyAccess() ProductSubscriptionS
 	return v.ProductSubscriptionState.LlmProxyAccess
 }
 
+// GetActiveLicense returns ListProductSubscriptionFields.ActiveLicense, and is useful for accessing the field via an interface.
+func (v *ListProductSubscriptionFields) GetActiveLicense() *ProductSubscriptionStateActiveLicenseProductLicense {
+	return v.ProductSubscriptionState.ActiveLicense
+}
+
 func (v *ListProductSubscriptionFields) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -248,6 +261,8 @@ type __premarshalListProductSubscriptionFields struct {
 	IsArchived bool `json:"isArchived"`
 
 	LlmProxyAccess ProductSubscriptionStateLlmProxyAccessLLMProxyAccess `json:"llmProxyAccess"`
+
+	ActiveLicense *ProductSubscriptionStateActiveLicenseProductLicense `json:"activeLicense"`
 }
 
 func (v *ListProductSubscriptionFields) MarshalJSON() ([]byte, error) {
@@ -266,6 +281,7 @@ func (v *ListProductSubscriptionFields) __premarshalJSON() (*__premarshalListPro
 	retval.Uuid = v.ProductSubscriptionState.Uuid
 	retval.IsArchived = v.ProductSubscriptionState.IsArchived
 	retval.LlmProxyAccess = v.ProductSubscriptionState.LlmProxyAccess
+	retval.ActiveLicense = v.ProductSubscriptionState.ActiveLicense
 	return &retval, nil
 }
 
@@ -349,6 +365,11 @@ func (v *ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSub
 	return v.ListProductSubscriptionFields.ProductSubscriptionState.LlmProxyAccess
 }
 
+// GetActiveLicense returns ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSubscriptionConnectionNodesProductSubscription.ActiveLicense, and is useful for accessing the field via an interface.
+func (v *ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSubscriptionConnectionNodesProductSubscription) GetActiveLicense() *ProductSubscriptionStateActiveLicenseProductLicense {
+	return v.ListProductSubscriptionFields.ProductSubscriptionState.ActiveLicense
+}
+
 func (v *ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSubscriptionConnectionNodesProductSubscription) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -384,6 +405,8 @@ type __premarshalListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsPr
 	IsArchived bool `json:"isArchived"`
 
 	LlmProxyAccess ProductSubscriptionStateLlmProxyAccessLLMProxyAccess `json:"llmProxyAccess"`
+
+	ActiveLicense *ProductSubscriptionStateActiveLicenseProductLicense `json:"activeLicense"`
 }
 
 func (v *ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSubscriptionConnectionNodesProductSubscription) MarshalJSON() ([]byte, error) {
@@ -402,6 +425,7 @@ func (v *ListProductSubscriptionsDotcomDotcomQueryProductSubscriptionsProductSub
 	retval.Uuid = v.ListProductSubscriptionFields.ProductSubscriptionState.Uuid
 	retval.IsArchived = v.ListProductSubscriptionFields.ProductSubscriptionState.IsArchived
 	retval.LlmProxyAccess = v.ListProductSubscriptionFields.ProductSubscriptionState.LlmProxyAccess
+	retval.ActiveLicense = v.ListProductSubscriptionFields.ProductSubscriptionState.ActiveLicense
 	return &retval, nil
 }
 
@@ -454,6 +478,8 @@ type ProductSubscriptionState struct {
 	IsArchived bool `json:"isArchived"`
 	// LLM-proxy access granted to this subscription. Properties may be inferred from the active license, or be defined in overrides.
 	LlmProxyAccess ProductSubscriptionStateLlmProxyAccessLLMProxyAccess `json:"llmProxyAccess"`
+	// The currently active product license associated with this product subscription, if any.
+	ActiveLicense *ProductSubscriptionStateActiveLicenseProductLicense `json:"activeLicense"`
 }
 
 // GetId returns ProductSubscriptionState.Id, and is useful for accessing the field via an interface.
@@ -469,6 +495,38 @@ func (v *ProductSubscriptionState) GetIsArchived() bool { return v.IsArchived }
 func (v *ProductSubscriptionState) GetLlmProxyAccess() ProductSubscriptionStateLlmProxyAccessLLMProxyAccess {
 	return v.LlmProxyAccess
 }
+
+// GetActiveLicense returns ProductSubscriptionState.ActiveLicense, and is useful for accessing the field via an interface.
+func (v *ProductSubscriptionState) GetActiveLicense() *ProductSubscriptionStateActiveLicenseProductLicense {
+	return v.ActiveLicense
+}
+
+// ProductSubscriptionStateActiveLicenseProductLicense includes the requested fields of the GraphQL type ProductLicense.
+// The GraphQL type's documentation follows.
+//
+// A product license that was created on Sourcegraph.com.
+// FOR INTERNAL USE ONLY.
+type ProductSubscriptionStateActiveLicenseProductLicense struct {
+	// Information about this product license.
+	Info *ProductSubscriptionStateActiveLicenseProductLicenseInfo `json:"info"`
+}
+
+// GetInfo returns ProductSubscriptionStateActiveLicenseProductLicense.Info, and is useful for accessing the field via an interface.
+func (v *ProductSubscriptionStateActiveLicenseProductLicense) GetInfo() *ProductSubscriptionStateActiveLicenseProductLicenseInfo {
+	return v.Info
+}
+
+// ProductSubscriptionStateActiveLicenseProductLicenseInfo includes the requested fields of the GraphQL type ProductLicenseInfo.
+// The GraphQL type's documentation follows.
+//
+// Information about this site's product license (which activates certain Sourcegraph features).
+type ProductSubscriptionStateActiveLicenseProductLicenseInfo struct {
+	// Tags indicating the product plan and features activated by this license.
+	Tags []string `json:"tags"`
+}
+
+// GetTags returns ProductSubscriptionStateActiveLicenseProductLicenseInfo.Tags, and is useful for accessing the field via an interface.
+func (v *ProductSubscriptionStateActiveLicenseProductLicenseInfo) GetTags() []string { return v.Tags }
 
 // ProductSubscriptionStateLlmProxyAccessLLMProxyAccess includes the requested fields of the GraphQL type LLMProxyAccess.
 // The GraphQL type's documentation follows.
@@ -568,6 +626,11 @@ fragment ProductSubscriptionState on ProductSubscription {
 	llmProxyAccess {
 		... LLMProxyAccessFields
 	}
+	activeLicense {
+		info {
+			tags
+		}
+	}
 }
 fragment LLMProxyAccessFields on LLMProxyAccess {
 	enabled
@@ -627,6 +690,11 @@ fragment ProductSubscriptionState on ProductSubscription {
 	isArchived
 	llmProxyAccess {
 		... LLMProxyAccessFields
+	}
+	activeLicense {
+		info {
+			tags
+		}
 	}
 }
 fragment LLMProxyAccessFields on LLMProxyAccess {

--- a/enterprise/cmd/llm-proxy/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/llm-proxy/internal/dotcom/operations.graphql
@@ -14,6 +14,11 @@ fragment ProductSubscriptionState on ProductSubscription {
     llmProxyAccess {
         ...LLMProxyAccessFields
     }
+    activeLicense {
+        info {
+            tags
+        }
+    }
 }
 
 # CheckAccessToken returns traits of the product subscription associated with

--- a/enterprise/cmd/llm-proxy/shared/config.go
+++ b/enterprise/cmd/llm-proxy/shared/config.go
@@ -14,8 +14,9 @@ type Config struct {
 	Address string
 
 	Dotcom struct {
-		URL         string
-		AccessToken string
+		URL             string
+		AccessToken     string
+		DevLicensesOnly bool
 	}
 
 	Anthropic struct {
@@ -37,6 +38,8 @@ func (c *Config) Load() {
 	c.Address = c.Get("LLM_PROXY_ADDR", ":9992", "Address to serve LLM proxy on.")
 	c.Dotcom.AccessToken = c.Get("LLM_PROXY_DOTCOM_ACCESS_TOKEN", "", "The Sourcegraph.com access token to be used.")
 	c.Dotcom.URL = c.Get("LLM_PROXY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
+	c.Dotcom.DevLicensesOnly = c.GetBool("LLM_PROXY_DOTCOM_DEV_LICENSES_ONLY", "false", "Only allow tokens associated with active dev licenses to be used.")
+
 	c.Anthropic.AccessToken = c.Get("LLM_PROXY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 	c.AllowAnonymous = c.GetBool("LLM_PROXY_ALLOW_ANONYMOUS", "false", "Allow anonymous access to LLM proxy.")
 	c.SourcesSyncInterval = c.GetInterval("LLM_PROXY_SOURCES_SYNC_INTERVAL", "2m", "The interval at which to sync actor sources.")

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -57,7 +57,8 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		productsubscription.NewSource(
 			obctx.Logger,
 			rcache.New("product-subscriptions"),
-			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken)),
+			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
+			config.Dotcom.DevLicensesOnly),
 	}
 
 	// Set up our handler chain, which is run from the bottom up


### PR DESCRIPTION
Combat double-dipping of rate limits if someone finds the dev instance.

## Test plan

Unit tests