### PR TITLE
feat: add github apps section to site admin sidebar

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -9,7 +9,7 @@ import {
     analyticsGroup,
     configurationGroup as ossConfigurationGroup,
     maintenanceGroup as ossMaintenanceGroup,
-    repositoriesGroup,
+    repositoriesGroup as ossRepositoriesGroup,
     usersGroup as ossUsersGroup,
 } from '../../site-admin/sidebaritems'
 import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar'
@@ -157,6 +157,17 @@ const usersGroup: SiteAdminSideBarGroup = {
             label: 'Permissions',
             to: '/site-admin/permissions-syncs',
         },
+    ],
+}
+
+const repositoriesGroup: SiteAdminSideBarGroup = {
+    ...ossRepositoriesGroup,
+    items: [
+        {
+            label: 'GitHub Apps',
+            to: '/site-admin/github-apps',
+        },
+        ...ossRepositoriesGroup.items,
     ],
 }
 


### PR DESCRIPTION
## Description

Based on [latest design](https://www.figma.com/file/Jw8oRpyNfPfYcgD8ZkCnnh/GitHub-App?type=design&node-id=1-2&t=GhVecOrCihtAZw76-0), sidebar should contain the github apps section.

## Screenshot

<img width="245" alt="Screenshot 2023-05-11 at 18 09 53" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/a4d74998-a621-49be-9db8-ddd7b59d1439">


## Test plan

Tested locally, small UI change.
