### PR TITLE
llmproxy: Allow casing variations of Bearer in auth header

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/auth/auth.go
+++ b/enterprise/cmd/llm-proxy/internal/auth/auth.go
@@ -25,9 +25,11 @@ func (a *Authenticator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	typ := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 	if len(typ) != 2 {
 		response.JSONError(a.Logger, w, http.StatusBadRequest, errors.New("token type missing in Authorization header"))
+		return
 	}
 	if strings.ToLower(typ[0]) != "bearer" {
 		response.JSONError(a.Logger, w, http.StatusBadRequest, errors.Newf("invalid token type %s", typ[0]))
+		return
 	}
 
 	token := r.Header.Get("Authorization")[len("Bearer "):]


### PR DESCRIPTION
Usually, these are case insensitive, so adding a check, and some more checks that don't hide invalid header errors behind a "this token was not found" errors.

## Test plan

verified the split works in go playground