### PR TITLE
httptrace: do not mutate shared logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Could not set "permissions.syncOldestUsers" or "permissions.syncOldestRepos" to zero. [#51255](https://github.com/sourcegraph/sourcegraph/pull/51255)
 - GitLab code host connections will disable repo-centric repository permission syncs when the authentication provider is set as "oauth". This prevents repo-centric permission sync from getting incorrect data. [#51452](https://github.com/sourcegraph/sourcegraph/pull/51452)
 - Code intelligence background jobs did not correctly use an internal context, causing SCIP data to sometimes be prematurely deleted. [#51591](https://github.com/sourcegraph/sourcegraph/pull/51591)
+- Slow request logs now have the correct trace and span IDs attached if a trace is present on the request. [#51826](https://github.com/sourcegraph/sourcegraph/pull/51826)
 
 ### Removed
 


### PR DESCRIPTION
Previously, every slow request would be logged with the first trace ID that the middleware encounters. This change ensures we make a copy of the base logger first before creating new loggers with additional fields.

Detected by @michaellzc who noticed all slow requests were being logged with the same executor request, even when they weren't :)

## Test plan

n/a
