### PR TITLE
Cody: respect the trace=1 URL param for Cody completions

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
@@ -15,6 +15,11 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
         if (this.config.accessToken) {
             headersInstance.set('Authorization', `token ${this.config.accessToken}`)
         }
+        const parameters = new URLSearchParams(window.location.search)
+        const trace = parameters.get('trace')
+        if (trace) {
+            headersInstance.set('X-Sourcegraph-Should-Trace', 'true')
+        }
         fetchEventSource(this.completionsEndpoint, {
             method: 'POST',
             headers: Object.fromEntries(headersInstance.entries()),


### PR DESCRIPTION
I frequently find myself wanting to view a trace of Cody's response for ad-hoc measurements, debugging, and exploratory hacking. However, AFAICT, there is no way right now to get a trace for a Cody query. 

This makes Cody in the web UI respect the `trace=1` URL parameter that is used for search. A URL pointing to the trace ID is the set on the response header of the `stream` request (just as we do with search queries).

The traces aren't terribly useful right now, but I plan to follow up by adding useful information like token sizes, logs whenever we stream a message, etc.

## Test plan

<img width="1274" alt="Screenshot 2023-05-11 at 14 04 47" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/4dbffc22-4430-4b6c-841d-0a3652199e32">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
