### PR TITLE
app: add codesigning/notarization to releases

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -75,6 +75,14 @@ jobs:
           ./enterprise/dev/app/build-release.sh
         env:
           RELEASE_BUILD: 1
+          # For details on how code signing works, and where these secrets come from / how they
+          # were generated, see doc/dev/background-information/app/codesigning.md
+          CODESIGNING: 1
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/dev/background-information/app/codesigning.md
+++ b/doc/dev/background-information/app/codesigning.md
@@ -1,0 +1,41 @@
+
+# macOS code signing & notarization
+
+## How certificates are created
+
+You need only follow this process if the certificate is expired or we need to create a new one.
+
+1. You will need access to our https://developer.apple.com account; Apple 2FA is required for this so contact Stephen or Beyang for access.
+2. Follow [these steps](https://developer.apple.com/help/account/create-certificates/create-a-certificate-signing-request/#:~:text=Keychain%20Access%20on%20your%20Mac,Certificate%20from%20a%20Certificate%20Authority.) with your own name / email address to create a Certificate Signing Request file.
+3. From https://developer.apple.com you can create a new certificate, choose `Developer ID Application` as the type and upload your Certificate Signing Request file.
+4. Download the `.cer` file, double-click it. Then right-click on the `Developer ID Application: SOURCEGRAPH INC` entry -> export to create a `.p12` file
+5. You will be prompted to create a password for the file.
+6. As part of this process, you should create 1password artifacts:
+   1. A password entry titled `app: macOS signing .p12 password 2023-05-05`
+   2. A document titled `app: macOS signing .cer 2023-05-05` with the `.cer` file you downloaded
+   3. A document title `app: macOS signing .p12 2023-05-05` with the `.p12` you created
+
+Finally, you should base64 encode the `.p12` file:
+
+```
+openssl base64 -in Certificates.p12 -out cert.p12.base64
+```
+
+## How app-specific password is created
+
+1. Follow [these instructions](https://support.apple.com/en-ca/HT204397) from Apple.
+2. Create a 1password titled `app: macOS app-specific-password 2023-05-05` with the username and password you created.
+
+## Using certificates with Tauri
+
+Tauri has [documentation](https://tauri.app/v1/guides/distribution/sign-macos/) on how macOS code signing integrates with it. In specific, we must specify these env vars when running `pnpm tauri build`:
+
+```sh
+export APPLE_SIGNING_IDENTITY='Developer ID Application: SOURCEGRAPH INC (74A5FJ7P96)'
+export APPLE_CERTIFICATE=`cat cert.p12.base64`
+export APPLE_CERTIFICATE_PASSWORD='SECRET' # app: macOS signing .p12 password
+export APPLE_ID="stephen@sourcegraph.com"
+export APPLE_PASSWORD="SECRET" # app: macOS app-specific-password
+```
+
+The `APPLE_SIGNING_IDENTITY` value is the name of the certificate as reported by e.g. Keychain Access once imported, and should look something like what is shown above but may differ if the certificate was regenerated.

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -31,7 +31,7 @@ pre_codesign() {
     security create-keychain -p my_temporary_keychain_password my_temporary_keychain.keychain
     security set-keychain-settings my_temporary_keychain.keychain
     security unlock-keychain -p my_temporary_keychain_password my_temporary_keychain.keychain
-    security list-keychains -d user -s my_temporary_keychain.keychain $(security list-keychains -d user | sed 's/["]//g')
+    security list-keychains -d user -s my_temporary_keychain.keychain "$(security list-keychains -d user | sed 's/["]//g')"
 
     echo "$APPLE_CERTIFICATE" >cert.p12.base64
     base64 -d -i cert.p12.base64 -o cert.p12
@@ -39,7 +39,7 @@ pre_codesign() {
     security import ./cert.p12 -k my_temporary_keychain.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
     security set-key-partition-list -S apple-tool:,apple:, -s -k my_temporary_keychain_password -D "$APPLE_SIGNING_IDENTITY" -t private my_temporary_keychain.keychain
 
-    codesign --force -s "$APPLE_SIGNING_IDENTITY" --keychain my_temporary_keychain.keychain --deep .bin/sourcegraph-backend-aarch64-apple-darwin
+    codesign --force -s "$APPLE_SIGNING_IDENTITY" --keychain my_temporary_keychain.keychain --deep "$(pwd)/.bin/sourcegraph-backend-aarch64-apple-darwin"
 
     security delete-keychain my_temporary_keychain.keychain
     security list-keychains -d user -s login.keychain

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -22,19 +22,43 @@ bazel_build() {
   cp -vf "${out}" ".bin/sourcegraph-backend-${platform}"
 }
 
-create_version() {
-    local sha
-    # In a GitHub action this can result in an empty sha
-    sha=$(git rev-parse --short HEAD)
-    if [[ -z ${sha} ]]; then
-      sha=${GITHUB_SHA:-""}
-    fi
+pre_codesign() {
+  # Tauri won't code sign our sidecar sourcegraph-backend Go binary for us, so we need to do it on
+  # our own. https://github.com/tauri-apps/tauri/discussions/2269
+  # For details on code signing, see doc/dev/background-information/app/codesigning.md
+  if [[ ${PLATFORM_IS_MACOS} == 1 ]]; then
+    # We expect the same APPLE_ env vars that Tauri does here, see https://tauri.app/v1/guides/distribution/sign-macos
+    security create-keychain -p my_temporary_keychain_password my_temporary_keychain.keychain
+    security set-keychain-settings my_temporary_keychain.keychain
+    security unlock-keychain -p my_temporary_keychain_password my_temporary_keychain.keychain
+    security list-keychains -d user -s my_temporary_keychain.keychain $(security list-keychains -d user | sed 's/["]//g')
 
-    local build="insiders"
-    if [[ ${RELEASE_BUILD} == 1 ]]; then
-      build=${GITHUB_RUN_NUMBER:-"release"}
-    fi
-    echo "$(date '+%Y.%-m.%-d')+${build}.${sha}"
+    echo "$APPLE_CERTIFICATE" >cert.p12.base64
+    base64 -d -i cert.p12.base64 -o cert.p12
+
+    security import ./cert.p12 -k my_temporary_keychain.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+    security set-key-partition-list -S apple-tool:,apple:, -s -k my_temporary_keychain_password -D "$APPLE_SIGNING_IDENTITY" -t private my_temporary_keychain.keychain
+
+    codesign --force -s "$APPLE_SIGNING_IDENTITY" --keychain my_temporary_keychain.keychain --deep .bin/sourcegraph-backend-aarch64-apple-darwin
+
+    security delete-keychain my_temporary_keychain.keychain
+    security list-keychains -d user -s login.keychain
+  fi
+}
+
+create_version() {
+  local sha
+  # In a GitHub action this can result in an empty sha
+  sha=$(git rev-parse --short HEAD)
+  if [[ -z ${sha} ]]; then
+    sha=${GITHUB_SHA:-""}
+  fi
+
+  local build="insiders"
+  if [[ ${RELEASE_BUILD} == 1 ]]; then
+    build=${GITHUB_RUN_NUMBER:-"release"}
+  fi
+  echo "$(date '+%Y.%-m.%-d')+${build}.${sha}"
 }
 
 set_version() {
@@ -45,13 +69,12 @@ set_version() {
   fi
   export VERSION
 
-
   local tauri_conf
   local tmp
   tauri_conf="./src-tauri/tauri.conf.json"
   tmp=$(mktemp)
   echo "[Script] updating package version in '${tauri_conf}' to ${VERSION}"
-  jq --arg version "${VERSION}" '.package.version = $version' "${tauri_conf}" > "${tmp}"
+  jq --arg version "${VERSION}" '.package.version = $version' "${tauri_conf}" >"${tmp}"
   mv "${tmp}" ./src-tauri/tauri.conf.json
 }
 
@@ -59,6 +82,7 @@ set_platform() {
   # We need to determine the platform string for the sourcegraph-backend binary
   local arch=""
   local platform=""
+  local macos=0
   case "$(uname -m)" in
     "amd64")
       arch="x86_64"
@@ -68,25 +92,37 @@ set_platform() {
       ;;
     *)
       arch=$(uname -m)
+      ;;
   esac
 
   case "$(uname -s)" in
     "Darwin")
       platform="${arch}-apple-darwin"
+      macos=1
       ;;
     "Linux")
       platform="${arch}-unknown-linux-gnu"
       ;;
     *)
       platform="${arch}-unknown-unknown"
+      ;;
   esac
 
   export PLATFORM=${platform}
+  export PLATFORM_IS_MACOS=${macos}
 }
 
 set_platform
 set_version
 bazel_build "${PLATFORM}"
+if [[ ${CODESIGNING} == 1 ]]; then
+  # If on a macOS host, Tauri will invoke the base64 command as part of the code signing process.
+  # it expects the macOS base64 command, not the gnutils one provided by homebrew, so we prefer
+  # that one here:
+  export PATH="/usr/bin/:$PATH"
+
+  pre_codesign "${PLATFORM}"
+fi
 echo "[Tauri] Building Application (${VERSION})"]
 NODE_ENV=production pnpm run build-app-shell
 pnpm tauri build

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -128,7 +128,7 @@ if [[ ${CODESIGNING} == 1 ]]; then
   # that one here:
   export PATH="/usr/bin/:$PATH"
 
-  pre_codesign "${PLATFORM}" "${target_path}"
+  pre_codesign "${target_path}"
 fi
 echo "[Tauri] Building Application (${VERSION})"]
 NODE_ENV=production pnpm run build-app-shell

--- a/enterprise/dev/app/build-release.sh
+++ b/enterprise/dev/app/build-release.sh
@@ -118,9 +118,8 @@ set_platform() {
   export PLATFORM_IS_MACOS=${macos}
 }
 
-target_path=".bin/sourcegraph-backend-${PLATFORM}"
-
 set_platform
+target_path=".bin/sourcegraph-backend-${PLATFORM}"
 set_version
 bazel_build "${PLATFORM}" "${target_path}"
 if [[ ${CODESIGNING} == 1 ]]; then


### PR DESCRIPTION
This attempts to bundle all the codesigning logic I learned about into our new release pipeline, and also adds docs explaining how codesigning/notarization works.

## Test plan

We can merge once this branch is passing / producing valid signed builds: https://buildkite.com/sourcegraph/sourcegraph/builds?branch=app-release%2Fcodesign
