### PR TITLE
Propagate tracing information

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -467,6 +468,7 @@ func TracedTransportOpt(cli *http.Client) error {
 	}
 
 	cli.Transport = &policy.Transport{RoundTripper: cli.Transport}
+	cli.Transport = otelhttp.NewTransport(cli.Transport)
 	return nil
 }
 


### PR DESCRIPTION
Previously, we were not propagating the parent trace ID across HTTP requests. This didn't used to be the case -- I'm honestly not sure when/how this changed, but it's been broken for at least a couple of months.

This wraps internal requests with the Opentelemetry transport, which will pass along the tracing information so that we can effectively connect traces across multiple services together.

## Test plan

Previously, this trace did not show the embeddings service:
![Uploading Screenshot 2023-05-11 at 17.01.08.png…]()


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
