### PR TITLE
trace/internal: do not add tracing in policy transport

### DIFF
--- a/internal/httpcli/BUILD.bazel
+++ b/internal/httpcli/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//lib/errors",
         "//schema",
         "@com_github_gregjones_httpcache//:httpcache",
+        "@com_github_opentracing_contrib_go_stdlib//nethttp",
         "@com_github_opentracing_opentracing_go//:opentracing-go",
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_prometheus_client_golang//prometheus",

--- a/internal/trace/policy/BUILD.bazel
+++ b/internal/trace/policy/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/trace/policy",
     visibility = ["//:__subpackages__"],
     deps = [
-        "@com_github_opentracing_contrib_go_stdlib//nethttp",
         "@org_golang_google_grpc//metadata",
         "@org_uber_go_atomic//:atomic",
     ],

--- a/internal/trace/policy/policy.go
+++ b/internal/trace/policy/policy.go
@@ -73,7 +73,7 @@ type Transport struct {
 
 func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set(traceHeader, strconv.FormatBool(ShouldTrace(req.Context())))
-	return r.RoundTrip(req)
+	return r.RoundTripper.RoundTrip(req)
 }
 
 // requestWantsTrace returns true if a request is opting into tracing either

--- a/internal/trace/policy/policy.go
+++ b/internal/trace/policy/policy.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"go.uber.org/atomic"
 )
 
@@ -69,13 +68,12 @@ const (
 // Transport wraps an underlying HTTP RoundTripper, injecting the X-Sourcegraph-Should-Trace header
 // into outgoing requests whenever the shouldTraceKey context value is true.
 type Transport struct {
-	http.RoundTripper
+	RoundTripper http.RoundTripper
 }
 
 func (r *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set(traceHeader, strconv.FormatBool(ShouldTrace(req.Context())))
-	t := nethttp.Transport{RoundTripper: r.RoundTripper}
-	return t.RoundTrip(req)
+	return r.RoundTrip(req)
 }
 
 // requestWantsTrace returns true if a request is opting into tracing either


### PR DESCRIPTION
Policy transport shouldn't have tracing tucked away in it - moves the old OpenTracing thing here up into the transport option.

I originally thought we should remove it since otelhttp (added in https://github.com/sourcegraph/sourcegraph/pull/51847) should propagate the same thing via the propagators we initialize, but we might want to keep it in case anyone relies on context things it sets.

## Test plan

n/a - functionally the same 