### PR TITLE
Cody: add tracing to GraphQL requests

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -166,6 +166,7 @@ export class SourcegraphGraphQLAPIClient {
         if (this.config.accessToken) {
             headers.set('Authorization', `token ${this.config.accessToken}`)
         }
+        headers.set('X-Sourcegraph-Should-Trace', new URLSearchParams(window.location.search).get('trace') || 'false')
 
         const url = buildGraphQLUrl({ request: query, baseUrl: this.config.serverEndpoint })
         return fetch(url, {


### PR DESCRIPTION
This is a followup from https://github.com/sourcegraph/sourcegraph/pull/51839. This makes the Cody GraphQL requests (IsContextRequiredForQuery and EmbeddingsSearch) respect the `trace=1` URL parameter so we can pull the trace URL from the response header. #51839 just added support for the completions endpoint

## Test plan

<img width="1512" alt="Screenshot 2023-05-11 at 17 55 00" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/bb54aeb3-3a60-4e5c-b8d5-487b843fa782">
