### PR TITLE
Revert "Cody: respect the trace=1 URL param for Cody completions"

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/browserClient.ts
@@ -15,11 +15,6 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
         if (this.config.accessToken) {
             headersInstance.set('Authorization', `token ${this.config.accessToken}`)
         }
-        const parameters = new URLSearchParams(window.location.search)
-        const trace = parameters.get('trace')
-        if (trace) {
-            headersInstance.set('X-Sourcegraph-Should-Trace', 'true')
-        }
         fetchEventSource(this.completionsEndpoint, {
             method: 'POST',
             headers: Object.fromEntries(headersInstance.entries()),


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#51839

I think this will likely break non-web clients since it refers to the window and this is in shared code. Reverting preemptively to figure out how to do this better