### PR TITLE
[github app] GHA resolver now groups connections under installations

### DIFF
--- a/client/web/src/components/gitHubApps/GitHubAppCard.module.scss
+++ b/client/web/src/components/gitHubApps/GitHubAppCard.module.scss
@@ -14,7 +14,7 @@
 }
 
 .app-link {
-    color: var(--body-color)
+    color: var(--body-color);
 }
 
 .installation {
@@ -26,12 +26,12 @@
     }
 
     .list-group {
-        >li {
+        > li {
             border-top: var(--border-width) solid var(--border-color);
             padding: 1rem 0;
 
             &:first-child {
-                border-top: none
+                border-top: none;
             }
         }
     }

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -232,7 +232,7 @@ export const GitHubAppPage: FC<Props> = ({
                                                     className={styles.listGroup}
                                                     aria-label="Code Host Connections"
                                                 >
-                                                    {app.externalServices?.nodes?.map(node => (
+                                                    {installation.externalServices?.nodes?.map(node => (
                                                         <ExternalServiceNode
                                                             key={node.id}
                                                             node={node}
@@ -240,13 +240,13 @@ export const GitHubAppPage: FC<Props> = ({
                                                         />
                                                     ))}
                                                 </ConnectionList>
-                                                {app.externalServices && (
+                                                {installation.externalServices && (
                                                     <SummaryContainer className="mt-2" centered={true}>
                                                         <ConnectionSummary
                                                             noSummaryIfAllNodesVisible={false}
                                                             first={100}
                                                             centered={true}
-                                                            connection={app.externalServices}
+                                                            connection={installation.externalServices}
                                                             noun="code host connection"
                                                             pluralNoun="code host connections"
                                                             hasNextPage={false}

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -47,12 +47,12 @@ export const GITHUB_APP_BY_ID_QUERY = gql`
                     url
                     type
                 }
-            }
-            externalServices(first: 100) {
-                nodes {
-                    ...ListExternalServiceFields
+                externalServices(first: 100) {
+                    nodes {
+                        ...ListExternalServiceFields
+                    }
+                    totalCount
                 }
-                totalCount
             }
             webhook {
                 id

--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -6,7 +6,9 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // This file just contains stub GraphQL resolvers and data types for GitHub apps which merely
@@ -43,7 +45,6 @@ type GitHubAppResolver interface {
 	Logo() string
 	CreatedAt() gqlutil.DateTime
 	UpdatedAt() gqlutil.DateTime
-	ExternalServices(context.Context, *struct{ graphqlutil.ConnectionArgs }) *ComputedExternalServiceConnectionResolver
 	Installations(context.Context) []GitHubAppInstallation
 	Webhook(context.Context) WebhookResolver
 }
@@ -101,9 +102,11 @@ func (ghai GitHubAppInstallationAccount) Type() string {
 }
 
 type GitHubAppInstallation struct {
-	InstallID      int32
-	InstallURL     string
-	InstallAccount GitHubAppInstallationAccount
+	DB                      database.DB
+	InstallID               int32
+	InstallURL              string
+	InstallAccount          GitHubAppInstallationAccount
+	InstallExternalServices []*types.ExternalService
 }
 
 func (ghai GitHubAppInstallation) ID() int32 {
@@ -116,4 +119,8 @@ func (ghai GitHubAppInstallation) URL() string {
 
 func (ghai GitHubAppInstallation) Account() GitHubAppInstallationAccount {
 	return ghai.InstallAccount
+}
+
+func (ghai GitHubAppInstallation) ExternalServices(args *struct{ graphqlutil.ConnectionArgs }) *ComputedExternalServiceConnectionResolver {
+	return NewComputedExternalServiceConnectionResolver(ghai.DB, ghai.InstallExternalServices, args.ConnectionArgs)
 }

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -88,10 +88,6 @@ type GitHubApp implements Node {
     """
     updatedAt: DateTime!
     """
-    Fetches external services related to this GitHub App.
-    """
-    externalServices(first: Int): ExternalServiceConnection!
-    """
     Fetches a list of installation IDs for this GitHub App.
     """
     installations: [Installation!]!
@@ -139,4 +135,8 @@ type Installation {
     The account on which the App was installed
     """
     account: GitHubAccount!
+    """
+    The external services derived from this installation.
+    """
+    externalServices(first: Int): ExternalServiceConnection!
 }

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//cmd/frontend/auth",
         "//cmd/frontend/enterprise",
         "//cmd/frontend/graphqlbackend",
-        "//cmd/frontend/graphqlbackend/graphqlutil",
         "//enterprise/cmd/frontend/internal/repos/webhooks/resolvers",
         "//enterprise/internal/codeintel",
         "//enterprise/internal/database",

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/repos/webhooks/resolvers"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	ghauth "github.com/sourcegraph/sourcegraph/enterprise/internal/github_apps/auth"
@@ -320,30 +319,6 @@ func (r *gitHubAppResolver) UpdatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.app.UpdatedAt}
 }
 
-func (r *gitHubAppResolver) ExternalServices(ctx context.Context, args *struct{ graphqlutil.ConnectionArgs }) *graphqlbackend.ComputedExternalServiceConnectionResolver {
-	extsvcs, err := r.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{
-		Kinds: []string{extsvc.KindGitHub},
-	})
-	if err != nil {
-		return nil
-	}
-
-	var filteredExtsvc []*itypes.ExternalService
-	for _, es := range extsvcs {
-		parsed, err := extsvc.ParseEncryptableConfig(ctx, extsvc.KindGitHub, es.Config)
-		if err != nil {
-			continue
-		}
-		c := parsed.(*schema.GitHubConnection)
-		if c.GitHubAppDetails == nil || c.GitHubAppDetails.AppID != r.app.AppID || c.Url != r.app.BaseURL {
-			continue
-		}
-		filteredExtsvc = append(filteredExtsvc, es)
-	}
-
-	return graphqlbackend.NewComputedExternalServiceConnectionResolver(r.db, filteredExtsvc, args.ConnectionArgs)
-}
-
 func (r *gitHubAppResolver) Installations(ctx context.Context) (installations []graphqlbackend.GitHubAppInstallation) {
 	auther, err := ghauth.NewGitHubAppAuthenticator(int(r.AppID()), []byte(r.app.PrivateKey))
 	if err != nil {
@@ -362,8 +337,29 @@ func (r *gitHubAppResolver) Installations(ctx context.Context) (installations []
 		return nil
 	}
 
+	extsvcs, err := r.db.ExternalServices().List(ctx, database.ExternalServicesListOptions{
+		Kinds: []string{extsvc.KindGitHub},
+	})
+	if err != nil {
+		return nil
+	}
+
 	for _, install := range installs {
+		var installationExtsvcs []*itypes.ExternalService
+		for _, es := range extsvcs {
+			parsed, err := extsvc.ParseEncryptableConfig(ctx, extsvc.KindGitHub, es.Config)
+			if err != nil {
+				continue
+			}
+			c := parsed.(*schema.GitHubConnection)
+			if c.GitHubAppDetails == nil || c.GitHubAppDetails.AppID != r.app.AppID || c.Url != r.app.BaseURL || c.GitHubAppDetails.InstallationID != int(install.GetID()) {
+				continue
+			}
+			installationExtsvcs = append(installationExtsvcs, es)
+		}
+
 		installations = append(installations, graphqlbackend.GitHubAppInstallation{
+			DB:         r.db,
 			InstallID:  int32(*install.ID),
 			InstallURL: install.GetHTMLURL(),
 			InstallAccount: graphqlbackend.GitHubAppInstallationAccount{
@@ -372,6 +368,7 @@ func (r *gitHubAppResolver) Installations(ctx context.Context) (installations []
 				AccountURL:       install.Account.GetHTMLURL(),
 				AccountType:      install.Account.GetType(),
 			},
+			InstallExternalServices: installationExtsvcs,
 		})
 	}
 


### PR DESCRIPTION
Reworks the resolver so that connections are grouped under their respective installations.

## Test plan

Verified locally. Unit tests should still pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
