### PR TITLE
Tracing: remove deprecated methods

### DIFF
--- a/cmd/sitemap/graphql.go
+++ b/cmd/sitemap/graphql.go
@@ -72,7 +72,7 @@ func (c *graphQLClient) requestGraphQL(ctx context.Context, queryName string, qu
 			// not a generic http.RoundTripper.
 			httpcli.ExternalTransportOpt,
 			httpcli.NewErrorResilientTransportOpt(
-				// httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts)),
+				httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts)),
 				httpcli.ExpJitterDelay(graphQLRetryDelayBase, graphQLRetryDelayMax),
 			),
 			httpcli.TracedTransportOpt,

--- a/cmd/sitemap/graphql.go
+++ b/cmd/sitemap/graphql.go
@@ -72,7 +72,7 @@ func (c *graphQLClient) requestGraphQL(ctx context.Context, queryName string, qu
 			// not a generic http.RoundTripper.
 			httpcli.ExternalTransportOpt,
 			httpcli.NewErrorResilientTransportOpt(
-				httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts)),
+				// httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts)),
 				httpcli.ExpJitterDelay(graphQLRetryDelayBase, graphQLRetryDelayMax),
 			),
 			httpcli.TracedTransportOpt,

--- a/enterprise/internal/database/BUILD.bazel
+++ b/enterprise/internal/database/BUILD.bazel
@@ -55,10 +55,10 @@ go_library(
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
-        "@com_github_opentracing_opentracing_go//log",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -3,12 +3,13 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 
@@ -235,7 +236,7 @@ func (s *permsStore) Done(err error) error {
 func (s *permsStore) LoadUserPermissions(ctx context.Context, userID int32) (p []authz.Permission, err error) {
 	ctx, save := s.observe(ctx, "LoadUserPermissions", "")
 	defer func() {
-		tracingFields := []otlog.Field{}
+		tracingFields := []attribute.KeyValue{}
 		for _, perm := range p {
 			tracingFields = append(tracingFields, perm.TracingFields()...)
 		}
@@ -267,7 +268,7 @@ WHERE user_external_account_id = %s;
 func (s *permsStore) LoadRepoPermissions(ctx context.Context, repoID int32) (p []authz.Permission, err error) {
 	ctx, save := s.observe(ctx, "LoadRepoPermissions", "")
 	defer func() {
-		tracingFields := []otlog.Field{}
+		tracingFields := []attribute.KeyValue{}
 		for _, perm := range p {
 			tracingFields = append(tracingFields, perm.TracingFields()...)
 		}
@@ -368,7 +369,7 @@ func (s *permsStore) SetRepoPerms(ctx context.Context, repoID int32, userIDs []a
 func (s *permsStore) setUserRepoPermissions(ctx context.Context, p []authz.Permission, entity authz.PermissionEntity, source authz.PermsSource, replacePerms bool) (_ *database.SetPermissionsResult, err error) {
 	ctx, save := s.observe(ctx, "setUserRepoPermissions", "")
 	defer func() {
-		f := []otlog.Field{}
+		f := []attribute.KeyValue{}
 		for _, permission := range p {
 			f = append(f, permission.TracingFields()...)
 		}
@@ -825,8 +826,8 @@ func (s *permsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.
 	ctx, save := s.observe(ctx, "loadUserPendingPermissionsIDs", "")
 	defer func() {
 		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
+			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
+			attribute.String("Query.Args", fmt.Sprintf("%q", q.Args())),
 		)
 	}()
 
@@ -843,8 +844,8 @@ func (s *permsStore) loadExistingUserPendingPermissionsBatch(ctx context.Context
 	ctx, save := s.observe(ctx, "loadExistingUserPendingPermissionsBatch", "")
 	defer func() {
 		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
+			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
+			attribute.String("Query.Args", fmt.Sprintf("%q", q.Args())),
 		)
 	}()
 
@@ -1228,7 +1229,7 @@ func (s *permsStore) DeleteAllUserPermissions(ctx context.Context, userID int32)
 		defer func() { err = txs.Done(err) }()
 	}
 
-	defer func() { save(&err, otlog.Int32("userID", userID)) }()
+	defer func() { save(&err, attribute.Int("userID", int(userID))) }()
 
 	// first delete from the unified table
 	if err = txs.execute(ctx, sqlf.Sprintf(`DELETE FROM user_repo_permissions WHERE user_id = %d`, userID)); err != nil {
@@ -1268,7 +1269,7 @@ AND bind_id IN (%s)`,
 
 func (s *permsStore) execute(ctx context.Context, q *sqlf.Query, vs ...any) (err error) {
 	ctx, save := s.observe(ctx, "execute", "")
-	defer func() { save(&err, otlog.Object("q", q)) }()
+	defer func() { save(&err, attribute.String("q", q.Query(sqlf.PostgresBindVar))) }()
 
 	var rows *sql.Rows
 	rows, err = s.Query(ctx, q)
@@ -1345,8 +1346,8 @@ AND bind_id = %s
 	ctx, save := s.observe(ctx, "load", "")
 	defer func() {
 		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
+			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
+			attribute.String("Query.Args", fmt.Sprintf("%q", q.Args())),
 		)
 	}()
 	var rows *sql.Rows
@@ -1391,8 +1392,8 @@ AND permission = %s
 	ctx, save := s.observe(ctx, "load", "")
 	defer func() {
 		save(&err,
-			otlog.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
-			otlog.Object("Query.Args", q.Args()),
+			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
+			attribute.String("Query.Args", fmt.Sprintf("%q", q.Args())),
 		)
 	}()
 	var rows *sql.Rows
@@ -1787,17 +1788,17 @@ WHERE perms.repo_id IN
 	return m, nil
 }
 
-func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...otlog.Field)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
+func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...attribute.KeyValue)) {
 	began := s.clock()
 	tr, ctx := trace.New(ctx, "database.PermsStore."+family, title)
 
-	return ctx, func(err *error, fs ...otlog.Field) {
+	return ctx, func(err *error, attrs ...attribute.KeyValue) {
 		now := s.clock()
 		took := now.Sub(began)
 
-		fs = append(fs, otlog.String("Duration", took.String()))
+		attrs = append(attrs, attribute.Stringer("Duration", took))
 
-		tr.LogFields(fs...) //nolint:staticcheck // TODO when updating the observation package
+		tr.AddEvent("finish", attrs...)
 
 		success := err == nil || *err == nil
 		if !success {

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1788,7 +1788,7 @@ WHERE perms.repo_id IN
 	return m, nil
 }
 
-func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...attribute.KeyValue)) {
+func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...attribute.KeyValue)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
 	began := s.clock()
 	tr, ctx := trace.New(ctx, "database.PermsStore."+family, title)
 

--- a/internal/authz/BUILD.bazel
+++ b/internal/authz/BUILD.bazel
@@ -20,12 +20,11 @@ go_library(
         "//internal/api",
         "//internal/collections",
         "//internal/extsvc",
-        "//internal/trace",
         "//internal/types",
         "//lib/errors",
-        "@com_github_opentracing_opentracing_go//log",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/internal/authz/perms.go
+++ b/internal/authz/perms.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/collections"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -99,16 +98,15 @@ const (
 )
 
 // TracingFields returns tracing fields for the opentracing log.
-func (p *Permission) TracingFields() []otlog.Field {
-	fs := []otlog.Field{
-		otlog.Int32("SrcPermissions.UserID", p.UserID),
-		otlog.Int32("SrcPermissions.RepoID", p.RepoID),
-		otlog.Int32("SrcPermissions.ExternalAccountID", p.ExternalAccountID),
-		otlog.String("SrcPermissions.CreatedAt", p.CreatedAt.String()),
-		otlog.String("SrcPermissions.UpdatedAt", p.UpdatedAt.String()),
-		otlog.String("SrcPermissions.Source", string(p.Source)),
+func (p *Permission) TracingFields() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("SrcPermissions.UserID", int(p.UserID)),
+		attribute.Int("SrcPermissions.RepoID", int(p.RepoID)),
+		attribute.Int("SrcPermissions.ExternalAccountID", int(p.ExternalAccountID)),
+		attribute.Stringer("SrcPermissions.CreatedAt", p.CreatedAt),
+		attribute.Stringer("SrcPermissions.UpdatedAt", p.UpdatedAt),
+		attribute.String("SrcPermissions.Source", string(p.Source)),
 	}
-	return fs
 }
 
 // RepoPermissions declares which users have access to a given repository
@@ -123,22 +121,22 @@ type RepoPermissions struct {
 }
 
 // TracingFields returns tracing fields for the opentracing log.
-func (p *RepoPermissions) TracingFields() []otlog.Field {
-	fs := []otlog.Field{
-		otlog.Int32("RepoPermissions.RepoID", p.RepoID),
-		trace.Stringer("RepoPermissions.Perm", p.Perm),
+func (p *RepoPermissions) TracingFields() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Int("RepoPermissions.RepoID", int(p.RepoID)),
+		attribute.Stringer("RepoPermissions.Perm", p.Perm),
 	}
 
 	if p.UserIDs != nil {
-		fs = append(fs,
-			otlog.Int("RepoPermissions.UserIDs.Count", len(p.UserIDs)),
-			otlog.Int("RepoPermissions.PendingUserIDs.Count", len(p.PendingUserIDs)),
-			otlog.String("RepoPermissions.UpdatedAt", p.UpdatedAt.String()),
-			otlog.String("RepoPermissions.SyncedAt", p.SyncedAt.String()),
+		attrs = append(attrs,
+			attribute.Int("RepoPermissions.UserIDs.Count", len(p.UserIDs)),
+			attribute.Int("RepoPermissions.PendingUserIDs.Count", len(p.PendingUserIDs)),
+			attribute.Stringer("RepoPermissions.UpdatedAt", p.UpdatedAt),
+			attribute.Stringer("RepoPermissions.SyncedAt", p.SyncedAt),
 		)
 	}
 
-	return fs
+	return attrs
 }
 
 // UserGrantPermissions defines the structure to grant pending permissions to a user.
@@ -157,16 +155,16 @@ type UserGrantPermissions struct {
 }
 
 // TracingFields returns tracing fields for the opentracing log.
-func (p *UserGrantPermissions) TracingFields() []otlog.Field {
-	fs := []otlog.Field{
-		otlog.Int32("UserGrantPermissions.UserID", p.UserID),
-		otlog.Int32("UserGrantPermissions.UserExternalAccountID", p.UserExternalAccountID),
-		otlog.String("UserPendingPermissions.ServiceType", p.ServiceType),
-		otlog.String("UserPendingPermissions.ServiceID", p.ServiceID),
-		otlog.String("UserPendingPermissions.AccountID", p.AccountID),
+func (p *UserGrantPermissions) TracingFields() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Int("UserGrantPermissions.UserID", int(p.UserID)),
+		attribute.Int("UserGrantPermissions.UserExternalAccountID", int(p.UserExternalAccountID)),
+		attribute.String("UserPendingPermissions.ServiceType", p.ServiceType),
+		attribute.String("UserPendingPermissions.ServiceID", p.ServiceID),
+		attribute.String("UserPendingPermissions.AccountID", p.AccountID),
 	}
 
-	return fs
+	return attrs
 }
 
 // UserPendingPermissions defines permissions that a not-yet-created user has to
@@ -205,22 +203,22 @@ func (p *UserPendingPermissions) GenerateSortedIDsSlice() []int32 {
 }
 
 // TracingFields returns tracing fields for the opentracing log.
-func (p *UserPendingPermissions) TracingFields() []otlog.Field {
-	fs := []otlog.Field{
-		otlog.Int64("UserPendingPermissions.ID", p.ID),
-		otlog.String("UserPendingPermissions.ServiceType", p.ServiceType),
-		otlog.String("UserPendingPermissions.ServiceID", p.ServiceID),
-		otlog.String("UserPendingPermissions.BindID", p.BindID),
-		trace.Stringer("UserPendingPermissions.Perm", p.Perm),
-		otlog.String("UserPendingPermissions.Type", string(p.Type)),
+func (p *UserPendingPermissions) TracingFields() []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Int64("UserPendingPermissions.ID", p.ID),
+		attribute.String("UserPendingPermissions.ServiceType", p.ServiceType),
+		attribute.String("UserPendingPermissions.ServiceID", p.ServiceID),
+		attribute.String("UserPendingPermissions.BindID", p.BindID),
+		attribute.Stringer("UserPendingPermissions.Perm", p.Perm),
+		attribute.String("UserPendingPermissions.Type", string(p.Type)),
 	}
 
 	if p.IDs != nil {
-		fs = append(fs,
-			otlog.Int("UserPendingPermissions.IDs.Count", len(p.IDs)),
-			otlog.String("UserPendingPermissions.UpdatedAt", p.UpdatedAt.String()),
+		attrs = append(attrs,
+			attribute.Int("UserPendingPermissions.IDs.Count", len(p.IDs)),
+			attribute.Stringer("UserPendingPermissions.UpdatedAt", p.UpdatedAt),
 		)
 	}
 
-	return fs
+	return attrs
 }

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -132,7 +132,6 @@ go_library(
         "@com_github_json_iterator_go//:go",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
-        "@com_github_opentracing_opentracing_go//log",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/types"
 
@@ -428,9 +428,10 @@ func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccoun
 			tr.SetError(err)
 		}
 
-		tr.LogFields( //nolint:staticcheck // TODO unpack the object
-			otlog.Object("opt", opt),
-			otlog.Int("accounts.count", len(acct)),
+		tr.AddEvent(
+			"done",
+			attribute.String("opt", fmt.Sprintf("%#v", opt)),
+			attribute.Int("accounts.count", len(acct)),
 		)
 
 		tr.Finish()

--- a/internal/extsvc/BUILD.bazel
+++ b/internal/extsvc/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//internal/jsonc",
         "//lib/errors",
         "//schema",
-        "@com_github_opentracing_opentracing_go//log",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_time//rate",
     ],
 )

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/time/rate"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -110,11 +110,11 @@ func NewEncryptedConfig(cipher, keyID string, key encryption.Key) *EncryptableCo
 }
 
 // TracingFields returns tracing fields for the opentracing log.
-func (s *Accounts) TracingFields() []otlog.Field {
-	return []otlog.Field{
-		otlog.String("Accounts.ServiceType", s.ServiceType),
-		otlog.String("Accounts.Perm", s.ServiceID),
-		otlog.Int("Accounts.AccountIDs.Count", len(s.AccountIDs)),
+func (s *Accounts) TracingFields() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("Accounts.ServiceType", s.ServiceType),
+		attribute.String("Accounts.Perm", s.ServiceID),
+		attribute.Int("Accounts.AccountIDs.Count", len(s.AccountIDs)),
 	}
 }
 

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -383,7 +383,7 @@ func (op *Operation) finishTrace(err *error, tr *trace.Trace, logFields []otlog.
 		tr.SetError(*err)
 	}
 
-	tr.AddEvent("done", trace.OTLogFieldsToOTelAttrs(logFields)...) //nolint:staticcheck // TODO when updating the observation package
+	tr.AddEvent("done", trace.OTLogFieldsToOTelAttrs(logFields)...)
 	tr.Finish()
 }
 

--- a/internal/trace/otel_bridge.go
+++ b/internal/trace/otel_bridge.go
@@ -64,7 +64,7 @@ func (e *bridgeFieldEncoder) emitCommon(key string, value interface{}) {
 	e.pairs = append(e.pairs, otTagToOTelAttr(key, value))
 }
 
-func otLogFieldsToOTelAttrs(fields []otlog.Field) []attribute.KeyValue {
+func OTLogFieldsToOTelAttrs(fields []otlog.Field) []attribute.KeyValue {
 	encoder := &bridgeFieldEncoder{}
 	for _, field := range fields {
 		field.Marshal(encoder)

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opentracing/opentracing-go/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -87,15 +86,4 @@ func (t *Trace) SetErrorIfNotContext(err error) {
 func (t *Trace) Finish() {
 	t.nettraceTrace.Finish()
 	t.oteltraceSpan.End()
-}
-
-/////////////////////
-// Deprecated APIs //
-/////////////////////
-
-// Deprecated: Use AddEvent(...) instead.
-//
-// LogFields logs fields to the opentracing.Span as well as the nettrace.Trace.
-func (t *Trace) LogFields(fields ...log.Field) {
-	t.AddEvent("LogFields", OTLogFieldsToOTelAttrs(fields)...)
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -97,11 +97,5 @@ func (t *Trace) Finish() {
 //
 // LogFields logs fields to the opentracing.Span as well as the nettrace.Trace.
 func (t *Trace) LogFields(fields ...log.Field) {
-	t.AddEvent("LogFields", otLogFieldsToOTelAttrs(fields)...)
+	t.AddEvent("LogFields", OTLogFieldsToOTelAttrs(fields)...)
 }
-
-// Deprecated: Use SetAttributes(...) instead.
-//
-// TagFields adds fields to the opentracing.Span as tags
-// as well as logs to the nettrace.Trace.
-func (t *Trace) TagFields(fields ...log.Field) { t.SetAttributes(otLogFieldsToOTelAttrs(fields)...) }

--- a/internal/uploadhandler/upload_handler.go
+++ b/internal/uploadhandler/upload_handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	sglog "github.com/sourcegraph/log"
 
@@ -86,15 +87,16 @@ func (h *UploadHandler[T]) handleEnqueue(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			return nil, statusCode, err
 		}
-		trace.Log( //nolint:staticcheck // Need to convert this to attribute.* methods, might be not so easy with metadata
-			log.Int("uploadID", uploadState.uploadID),
-			log.Int("numParts", uploadState.numParts),
-			log.Int("numUploadedParts", len(uploadState.uploadedParts)),
-			log.Bool("multipart", uploadState.multipart),
-			log.Bool("suppliedIndex", uploadState.suppliedIndex),
-			log.Int("index", uploadState.index),
-			log.Bool("done", uploadState.done),
-			log.Object("metadata", uploadState.metadata),
+		trace.AddEvent(
+			"finished constructUploadState",
+			attribute.Int("uploadID", uploadState.uploadID),
+			attribute.Int("numParts", uploadState.numParts),
+			attribute.Int("numUploadedParts", len(uploadState.uploadedParts)),
+			attribute.Bool("multipart", uploadState.multipart),
+			attribute.Bool("suppliedIndex", uploadState.suppliedIndex),
+			attribute.Int("index", uploadState.index),
+			attribute.Bool("done", uploadState.done),
+			attribute.String("metadata", fmt.Sprintf("%#v", uploadState.metadata)),
 		)
 
 		if uploadHandlerFunc := h.selectUploadHandlerFunc(uploadState); uploadHandlerFunc != nil {


### PR DESCRIPTION
This does the minimum amount of work needed to remove the deprecated methods on `trace.Trace`. We still rely on the `otlog.Field` type heavily in the observation package, so to minimize the surface area of the change, I exported the `OTLogFieldsToOTelAttrs` field so we can start to push the opentelemetry attribute types upwards in the stack more incrementally.

## Test plan

It compiles + existing tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
