### PR TITLE
FetchRepoPerms should use InstallationAccessToken

### DIFF
--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -161,7 +161,7 @@ func ProvidersFromConfig(
 		enableGithubInternalRepoVisibility = ef.EnableGithubInternalRepoVisibility
 	}
 
-	initResult := github.NewAuthzProviders(db, gitHubConns, cfg.SiteConfig().AuthProviders, enableGithubInternalRepoVisibility)
+	initResult := github.NewAuthzProviders(ctx, db, gitHubConns, cfg.SiteConfig().AuthProviders, enableGithubInternalRepoVisibility)
 	initResult.Append(gitlab.NewAuthzProviders(db, cfg.SiteConfig(), gitLabConns))
 	initResult.Append(bitbucketserver.NewAuthzProviders(bitbucketServerConns))
 	initResult.Append(perforce.NewAuthzProviders(perforceConns))

--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"time"
@@ -9,6 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	eauth "github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github/auth"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -31,6 +34,7 @@ type ExternalConnection struct {
 // desired, callers should use `(*Provider).ValidateConnection` directly to get warnings related
 // to connection issues.
 func NewAuthzProviders(
+	ctx context.Context,
 	db database.DB,
 	conns []*ExternalConnection,
 	authProviders []schema.AuthProviders,
@@ -57,7 +61,7 @@ func NewAuthzProviders(
 
 	for _, c := range conns {
 		// Initialize authz (permissions) provider.
-		p, err := newAuthzProvider(db, c)
+		p, err := newAuthzProvider(ctx, db, c)
 		if err != nil {
 			initResults.InvalidConnections = append(initResults.InvalidConnections, extsvc.TypeGitHub)
 			initResults.Problems = append(initResults.Problems, err.Error())
@@ -102,6 +106,7 @@ func NewAuthzProviders(
 // newAuthzProvider instantiates a provider, or returns nil if authorization is disabled.
 // Errors returned are "serious problems".
 func newAuthzProvider(
+	ctx context.Context,
 	db database.DB,
 	c *ExternalConnection,
 ) (*Provider, error) {
@@ -123,10 +128,23 @@ func newAuthzProvider(
 		c.Authorization.GroupsCacheTTL = -1
 	}
 
+	if ghaDetails := c.GitHubConnection.GitHubAppDetails; ghaDetails != nil {
+		auther, err := auth.FromConnection(ctx, c.GitHubConnection.GitHubConnection)
+		if err == nil {
+			ttl := time.Duration(c.Authorization.GroupsCacheTTL) * time.Hour
+			return NewProvider(c.GitHubConnection.URN, ProviderOptions{
+				GitHubURL:      baseURL,
+				BaseAuther:     auther,
+				GroupsCacheTTL: ttl,
+				DB:             db,
+			}), nil
+		}
+	}
+
 	ttl := time.Duration(c.Authorization.GroupsCacheTTL) * time.Hour
 	return NewProvider(c.GitHubConnection.URN, ProviderOptions{
 		GitHubURL:      baseURL,
-		BaseToken:      c.Token,
+		BaseAuther:     &eauth.OAuthBearerToken{Token: c.Token},
 		GroupsCacheTTL: ttl,
 		DB:             db,
 	}), nil
@@ -135,6 +153,6 @@ func newAuthzProvider(
 // ValidateAuthz validates the authorization fields of the given GitHub external
 // service config.
 func ValidateAuthz(c *types.GitHubConnection) error {
-	_, err := newAuthzProvider(nil, &ExternalConnection{GitHubConnection: c})
+	_, err := newAuthzProvider(context.Background(), nil, &ExternalConnection{GitHubConnection: c})
 	return err
 }

--- a/enterprise/internal/authz/github/authz_test.go
+++ b/enterprise/internal/authz/github/authz_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 func TestNewAuthzProviders(t *testing.T) {
+	ctx := context.Background()
 	db := database.NewMockDB()
 	t.Run("no authorization", func(t *testing.T) {
 		initResults := NewAuthzProviders(
+			ctx,
 			db,
 			[]*ExternalConnection{
 				{
@@ -45,6 +47,7 @@ func TestNewAuthzProviders(t *testing.T) {
 	t.Run("no matching auth provider", func(t *testing.T) {
 		t.Cleanup(licensing.TestingSkipFeatureChecks())
 		initResults := NewAuthzProviders(
+			ctx,
 			db,
 			[]*ExternalConnection{
 				{
@@ -79,6 +82,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("default case", func(t *testing.T) {
 			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
+			ctx,
 				db,
 				[]*ExternalConnection{
 					{
@@ -109,6 +113,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("license does not have ACLs feature", func(t *testing.T) {
 			t.Cleanup(licensing.MockCheckFeatureError("failed"))
 			initResults := NewAuthzProviders(
+			ctx,
 				db,
 				[]*ExternalConnection{
 					{
@@ -138,6 +143,7 @@ func TestNewAuthzProviders(t *testing.T) {
 		t.Run("groups cache enabled, but not allowGroupsPermissionsSync", func(t *testing.T) {
 			t.Cleanup(licensing.TestingSkipFeatureChecks())
 			initResults := NewAuthzProviders(
+			ctx,
 				db,
 				[]*ExternalConnection{
 					{
@@ -178,6 +184,7 @@ func TestNewAuthzProviders(t *testing.T) {
 				return []string{"read:org"}, nil
 			}
 			initResults := NewAuthzProviders(
+				ctx,
 				db,
 				[]*ExternalConnection{
 					{

--- a/enterprise/internal/authz/github/github.go
+++ b/enterprise/internal/authz/github/github.go
@@ -45,7 +45,7 @@ type ProviderOptions struct {
 	GitHubClient *github.V3Client
 	GitHubURL    *url.URL
 
-	BaseToken      string
+	BaseAuther     auth.Authenticator
 	GroupsCacheTTL time.Duration
 	IsApp          bool
 	DB             database.DB
@@ -55,7 +55,7 @@ func NewProvider(urn string, opts ProviderOptions) *Provider {
 	if opts.GitHubClient == nil {
 		apiURL, _ := github.APIRoot(opts.GitHubURL)
 		opts.GitHubClient = github.NewV3Client(log.Scoped("provider.github.v3", "provider github client"),
-			urn, apiURL, &auth.OAuthBearerToken{Token: opts.BaseToken}, nil)
+			urn, apiURL, opts.BaseAuther, nil)
 	}
 
 	codeHost := extsvc.NewCodeHost(opts.GitHubURL, extsvc.TypeGitHub)


### PR DESCRIPTION
GitHub App connections weren't using the correct credentials. This sets up providers with GitHub App credentials if it is created from a GitHub App connection and not a normal token.

## Test plan

Unit tests still passing 🤞 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
