### PR TITLE
[github app] move the auth provider message below app fields

### DIFF
--- a/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
+++ b/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
@@ -41,11 +41,11 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
             return [clientID, clientSecret]
         }
         return ['REDACTED', 'REDACTED']
-    }, [data, loading, reveal])
+    }, [data, loading, reveal, app?.clientID])
 
     const providerJson = useMemo(() => {
         // typescript compiler is not smart enough to know that app is not null
-        const url = app !== null ? app.baseURL : null
+        const url = app?.baseURL ?? null
         return JSON.stringify(
             {
                 type: 'github',
@@ -56,7 +56,7 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
             null,
             4
         )
-    }, [clientSecret, app])
+    }, [clientID, clientSecret, app?.baseURL])
 
     if (error) {
         return (

--- a/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
+++ b/client/web/src/components/gitHubApps/AuthProviderMessage.tsx
@@ -31,19 +31,20 @@ const AuthProviderJSON: FC<Props> = ({ app, id }) => {
         }
     )
 
-    const clientSecret = useMemo(() => {
+    const [clientID, clientSecret] = useMemo(() => {
         if (loading) {
-            return 'LOADING...'
+            return ['LOADING...', 'LOADING...']
         }
         if (reveal && data) {
-            return data?.gitHubApp?.clientSecret || 'NO CLIENT SECRET FOUND'
+            const clientID = app?.clientID ?? 'NO CLIENT ID'
+            const clientSecret = data?.gitHubApp?.clientSecret || 'NO CLIENT SECRET FOUND'
+            return [clientID, clientSecret]
         }
-        return 'REDACTED'
+        return ['REDACTED', 'REDACTED']
     }, [data, loading, reveal])
 
     const providerJson = useMemo(() => {
         // typescript compiler is not smart enough to know that app is not null
-        const clientID = app !== null ? app.clientID : null
         const url = app !== null ? app.baseURL : null
         return JSON.stringify(
             {

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -152,7 +152,6 @@ export const GitHubAppPage: FC<Props> = ({
                             </Tooltip>
                         </span>
                     </div>
-                    <AuthProviderMessage app={app} id={appID} />
                     <Container className="mt-3 mb-3">
                         <Grid columnCount={2} templateColumns="auto 1fr" spacing={[0.6, 2]}>
                             <span className="font-weight-bold">GitHub App Name</span>
@@ -164,6 +163,7 @@ export const GitHubAppPage: FC<Props> = ({
                             <span className="font-weight-bold">AppID</span>
                             <span>{app.appID}</span>
                         </Grid>
+                        <AuthProviderMessage app={app} id={appID} />
 
                         <hr className="mt-4 mb-4" />
 


### PR DESCRIPTION
## Screenshots

### Before
<img width="935" alt="Screenshot 2023-05-12 at 17 23 01" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/ef226115-2e23-4022-898f-5b0fc3f54d94">


### After

<img width="941" alt="Screenshot 2023-05-12 at 17 22 34" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/03145af9-5690-48ef-ad01-a98472202c41">

## Test plan

Tested locally, only UI changes here
