### PR TITLE
set ctx timeout to 10 min for update check

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -765,7 +765,7 @@ var telemetryHTTPProxy = env.Get("TELEMETRY_HTTP_PROXY", "", "if set, HTTP proxy
 
 // check performs an update check and updates the global state.
 func check(logger log.Logger, db database.DB) {
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	updateBodyFunc := updateBody


### PR DESCRIPTION
We have been seeing frequent context timeouts for the update check. See https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22sourcegraph-dev%22%0Aresource.labels.location%3D%22us-central1-f%22%0Aresource.labels.cluster_name%3D%22cloud%22%0Aresource.labels.namespace_name%3D%22prod%22%0Alabels.k8s-pod%2Fapp%3D%22sourcegraph-frontend%22%20severity%3E%3DDEFAULT%20%22updatecheck%20failed%22;timeRange=2023-05-12T03:55:24.000Z%2F2023-05-12T05:57:24.000Z;pinnedLogId=2023-05-12T10:25:36.922524862Z%2F37n5oit90d8387cj;cursorTimestamp=2023-05-12T05:37:48.960572018Z?project=sourcegraph-dev

Slack thread: https://sourcegraph.slack.com/archives/CMBA8F926/p1683827240597409
## Test plan
Deploy and see if the with a longer timeouts pings are persisted
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
