### PR TITLE
batches: change SSBC to beta in explanations page

### DIFF
--- a/doc/batch_changes/explanations/index.md
+++ b/doc/batch_changes/explanations/index.md
@@ -7,4 +7,4 @@ The following articles explain different parts of [Sourcegraph Batch Changes](..
 - [Batch Changes design](batch_changes_design.md)
 - [How `src` executes a batch spec](how_src_executes_a_batch_spec.md)
 - [Re-executing batch specs multiple times](reexecuting_batch_specs_multiple_times.md)
-- <span class="badge badge-experimental">Experimental</span> [Running batch changes server-side](server_side.md)
+- <span class="badge badge-beta">Beta</span> [Running batch changes server-side](server_side.md)


### PR DESCRIPTION
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="851" alt="CleanShot 2023-05-12 at 18 51 16@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/ec97f19c-0b5e-4394-95f7-e2a1e86ed6b2">

Visit `/help/batch_changes/explanations` SSBC should be displayed with the Beta tag.