### PR TITLE
anthropic: include actual data that failed to be parsed as JSON

### DIFF
--- a/enterprise/internal/completions/streaming/anthropic/anthropic.go
+++ b/enterprise/internal/completions/streaming/anthropic/anthropic.go
@@ -182,7 +182,7 @@ func (a *anthropicClient) Stream(
 
 		var event types.ChatCompletionEvent
 		if err := json.Unmarshal(data, &event); err != nil {
-			return errors.Errorf("failed to decode event payload: %w", err)
+			return errors.Errorf("failed to decode event payload: %w - body: %s", err, string(data))
 		}
 
 		err = sendEvent(event)


### PR DESCRIPTION
Right now we get an opaque and helpless error message and impossible to figure out what's actually going on:


<img width="1112" alt="CleanShot 2023-05-12 at 14 38 38@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/74a3e9e3-7d65-47b9-a536-3ad825274d91">


## Test plan

CI
