### PR TITLE
Give `BaseActionContainer` a more flexible title heading style

### DIFF
--- a/client/web/src/repo/settings/components/ActionContainer.tsx
+++ b/client/web/src/repo/settings/components/ActionContainer.tsx
@@ -3,23 +3,27 @@ import * as React from 'react'
 import classNames from 'classnames'
 
 import { asError } from '@sourcegraph/common'
-import { Button, ButtonProps, H4, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
+import { Button, ButtonProps, Heading, Tooltip, ErrorAlert, HeadingElement } from '@sourcegraph/wildcard'
 
 import styles from './ActionContainer.module.scss'
 
 export const BaseActionContainer: React.FunctionComponent<
     React.PropsWithChildren<{
         title: React.ReactNode
+        titleAs?: HeadingElement
+        titleStyleAs?: HeadingElement
         description: React.ReactNode
         action?: React.ReactNode
         details?: React.ReactNode
         className?: string
     }>
-> = ({ title, description, action, details, className }) => (
+> = ({ title, description, action, details, className, titleAs = 'h4', titleStyleAs = titleAs }) => (
     <div className={classNames(styles.actionContainer, className)}>
         <div className={styles.row}>
             <div>
-                <H4 className={styles.title}>{title}</H4>
+                <Heading as={titleAs} styleAs={titleStyleAs} className={styles.title}>
+                    {title}
+                </Heading>
                 {description}
             </div>
             {action && <div className={styles.btnContainer}>{action}</div>}
@@ -30,6 +34,8 @@ export const BaseActionContainer: React.FunctionComponent<
 
 interface Props {
     title: React.ReactNode
+    titleAs?: HeadingElement
+    titleStyleAs?: HeadingElement
     description: React.ReactNode
     buttonVariant?: ButtonProps['variant']
     buttonLabel: React.ReactNode
@@ -71,6 +77,8 @@ export class ActionContainer extends React.PureComponent<Props, State> {
         return (
             <BaseActionContainer
                 title={this.props.title}
+                titleAs={this.props.titleAs}
+                titleStyleAs={this.props.titleStyleAs}
                 description={this.props.description}
                 className={this.props.className}
                 action={


### PR DESCRIPTION
# Description

`BaseActionContainer` uses an [`H4` component](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bbfce81a35562d84386862e854ef6b35b555a92a/-/blob/client/wildcard/src/components/Typography/Heading/H4.tsx) to style its title, which makes it pretty inflexible both in visual and semantic layout.

Replace the `H4` component with a [`Heading` component](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@bbfce81a35562d84386862e854ef6b35b555a92a/-/blob/client/wildcard/src/components/Typography/Heading/Heading.tsx) that defaults to the `H4` heading level.

Add two new properties  that can be used to customize the title heading:
- `titleAs` to change the semantic heading level (defaults to `'h4'`)
- `titleStyleAs` to change  the visual heading level (defaults to `titleAs`)

Example usage:
```typescript
    return (
        <ActionContainer
            title={title}
            titleAs="h3" // new property - elevate the heading level to fit the page layout
            description={<div>{description}</div>}
            buttonLabel={buttonLabel}
            buttonDisabled={buttonDisabled || props.disabled}
            buttonSubtitle={props.disabledReason}
            flashText="Added to queue"
            info={info}
            run={run}
        />
    )
```

# Test plan
- [ ] Verify that [existing usages of `BaseActionContainer` and `ActionContainer`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40bbfce81+file:.*%5C.tsx%24+/%3C%28Base%29%3FActionContainer/&patternType=standard&sm=1&groupBy=repo) continue to render using `h4` elements
- [ ] Verify that changing the heading level using `titleAs` changes the rendered element
- [ ] Verify that changing the visual heading level using `titleStyleAs` renders a look that looks like the desired heading level
