### PR TITLE
Cody: Fix auth view

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -12,6 +12,7 @@ import {
     SEARCH_EMBEDDINGS_QUERY,
     LOG_EVENT_MUTATION,
     REPOSITORY_EMBEDDING_EXISTS_QUERY,
+    CURRENT_USER_ID_VERIFICATION_STATUS_QUERY,
 } from './queries'
 
 interface APIResponse<T> {
@@ -21,6 +22,10 @@ interface APIResponse<T> {
 
 interface CurrentUserIdResponse {
     currentUser: { id: string } | null
+}
+
+interface CurrentUserIdVerificationStatusResponse {
+    currentUser: { id: string; hasVerifiedEmail: boolean } | null
 }
 
 interface RepositoryIdResponse {
@@ -81,6 +86,17 @@ export class SourcegraphGraphQLAPIClient {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdResponse>>(CURRENT_USER_ID_QUERY, {}).then(response =>
             extractDataOrError(response, data =>
                 data.currentUser ? data.currentUser.id : new Error('current user not found')
+            )
+        )
+    }
+
+    public async getCurrentUserIDAndVerificationStatus(): Promise<{ id: string; hasVerifiedEmail: boolean } | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdVerificationStatusResponse>>(
+            CURRENT_USER_ID_VERIFICATION_STATUS_QUERY,
+            {}
+        ).then(response =>
+            extractDataOrError(response, data =>
+                data.currentUser ? data.currentUser : new Error('current user not found')
             )
         )
     }

--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -12,7 +12,7 @@ import {
     SEARCH_EMBEDDINGS_QUERY,
     LOG_EVENT_MUTATION,
     REPOSITORY_EMBEDDING_EXISTS_QUERY,
-    CURRENT_USER_ID_VERIFICATION_STATUS_QUERY,
+    AUTH_STATUS_QUERY,
 } from './queries'
 
 interface APIResponse<T> {
@@ -90,13 +90,17 @@ export class SourcegraphGraphQLAPIClient {
         )
     }
 
-    public async getCurrentUserIDAndVerificationStatus(): Promise<{ id: string; hasVerifiedEmail: boolean } | Error> {
+    public async getAuthStatus(): Promise<
+        { id: string; hasVerifiedEmail: boolean; requiresVerifiedEmail: boolean } | Error
+    > {
         return this.fetchSourcegraphAPI<APIResponse<CurrentUserIdVerificationStatusResponse>>(
-            CURRENT_USER_ID_VERIFICATION_STATUS_QUERY,
+            AUTH_STATUS_QUERY,
             {}
         ).then(response =>
             extractDataOrError(response, data =>
-                data.currentUser ? data.currentUser : new Error('current user not found')
+                data.currentUser
+                    ? { ...data.currentUser, requiresVerifiedEmail: data.site.requiresVerifiedEmailForCody }
+                    : new Error('current user not found')
             )
         )
     }

--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -26,6 +26,7 @@ interface CurrentUserIdResponse {
 
 interface CurrentUserIdVerificationStatusResponse {
     currentUser: { id: string; hasVerifiedEmail: boolean } | null
+    site: { requiresVerifiedEmailForCody: boolean }
 }
 
 interface RepositoryIdResponse {

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,6 +5,14 @@ query CurrentUser {
     }
 }`
 
+export const CURRENT_USER_ID_VERIFICATION_STATUS_QUERY = `
+query CurrentUser {
+    currentUser {
+        id
+		hasVerifiedEmail
+    }
+}`
+
 export const REPOSITORY_ID_QUERY = `
 query Repository($name: String!) {
 	repository(name: $name) {

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -5,8 +5,12 @@ query CurrentUser {
     }
 }`
 
-export const CURRENT_USER_ID_VERIFICATION_STATUS_QUERY = `
+// TODO: We can only query these fields on dotcom ... instrospection query?
+export const AUTH_STATUS_QUERY = `
 query CurrentUser {
+	site {
+		requiresVerifiedEmailForCody
+	}
     currentUser {
         id
 		hasVerifiedEmail

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -29,14 +29,18 @@ import { LocalStorage } from '../services/LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, SecretStorage } from '../services/SecretStorageProvider'
 import { TestSupport } from '../test-support'
 
-import { ConfigurationSubsetForWebview, DOTCOM_URL, ExtensionMessage, WebviewMessage } from './protocol'
+import { AuthStatus, ConfigurationSubsetForWebview, DOTCOM_URL, ExtensionMessage, WebviewMessage } from './protocol'
 
-export async function isValidLogin(
+export async function getAuthStatus(
     config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
-): Promise<boolean> {
+): Promise<AuthStatus> {
     const client = new SourcegraphGraphQLAPIClient(config)
-    const userId = await client.getCurrentUserId()
-    return !isError(userId)
+    const data = await client.getCurrentUserIDAndVerificationStatus()
+    return Promise.resolve(
+        isError(data)
+            ? { loggedIn: false, hasVerifiedEmail: false }
+            : { loggedIn: true, hasVerifiedEmail: data.hasVerifiedEmail }
+    )
 }
 
 type Config = Pick<
@@ -171,19 +175,19 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 await this.executeRecipe(message.recipe)
                 break
             case 'settings': {
-                const isValid = await isValidLogin({
+                const authStatus = await getAuthStatus({
                     serverEndpoint: message.serverEndpoint,
                     accessToken: message.accessToken,
                     customHeaders: this.config.customHeaders,
                 })
                 // activate when user has valid login
-                await vscode.commands.executeCommand('setContext', 'cody.activated', isValid)
-                if (isValid) {
+                await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus)
+                if (authStatus.loggedIn) {
                     await updateConfiguration('serverEndpoint', message.serverEndpoint)
                     await this.secretStorage.store(CODY_ACCESS_TOKEN_SECRET, message.accessToken)
                     this.sendEvent('auth', 'login')
                 }
-                void this.webview?.postMessage({ type: 'login', isValid })
+                void this.webview?.postMessage({ type: 'login', authStatus })
                 break
             }
             case 'event':
@@ -274,7 +278,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 this.transcript.addErrorAsAssistantResponse(err)
                 // Log users out on unauth error
                 if (statusCode && statusCode >= 400 && statusCode <= 410) {
-                    void this.sendLogin(false)
+                    void this.sendLogin({ loggedIn: false, hasVerifiedEmail: statusCode != 403 })
                     void this.clearAndRestartSession()
                 }
                 this.onCompletionEnd()
@@ -497,13 +501,16 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     /**
      * Save Login state to webview
      */
-    public async sendLogin(isValid: boolean): Promise<void> {
+    public async sendLogin(authStatus: AuthStatus): Promise<void> {
         this.sendEvent('token', 'Set')
-        await vscode.commands.executeCommand('setContext', 'cody.activated', isValid)
-        if (isValid) {
+        await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.loggedIn)
+        if (authStatus.loggedIn) {
             this.sendEvent('auth', 'login')
         }
-        void this.webview?.postMessage({ type: 'login', isValid })
+        void this.webview?.postMessage({
+            type: 'login',
+            authStatus,
+        })
     }
 
     /**
@@ -561,7 +568,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             void this.updateCodebaseContext()
             // check if new configuration change is valid or not
             // log user out if config is invalid
-            const isAuthed = await isValidLogin({
+            const authStatus = await getAuthStatus({
                 serverEndpoint: this.config.serverEndpoint,
                 accessToken: this.config.accessToken,
                 customHeaders: this.config.customHeaders,
@@ -569,9 +576,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             const configForWebview: ConfigurationSubsetForWebview = {
                 debug: this.config.debug,
                 serverEndpoint: this.config.serverEndpoint,
-                hasAccessToken: isAuthed,
+                hasAccessToken: authStatus.loggedIn,
             }
-            void vscode.commands.executeCommand('setContext', 'cody.activated', isAuthed)
+            void vscode.commands.executeCommand('setContext', 'cody.activated', authStatus)
             void this.webview?.postMessage({ type: 'config', config: configForWebview })
         }
 

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -28,7 +28,7 @@ export type WebviewMessage =
 export type ExtensionMessage =
     | { type: 'showTab'; tab: string }
     | { type: 'config'; config: ConfigurationSubsetForWebview }
-    | { type: 'login'; isValid: boolean }
+    | { type: 'login'; authStatus: AuthStatus }
     | { type: 'history'; messages: UserLocalHistory | null }
     | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean }
     | { type: 'debug'; message: string }
@@ -45,3 +45,12 @@ export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debu
 }
 
 export const DOTCOM_URL = new URL('https://sourcegraph.com')
+
+/**
+ * The status of a users authentication, whether they're logged in and have a
+ * verified email.
+ */
+export interface AuthStatus {
+    loggedIn: boolean
+    hasVerifiedEmail: boolean
+}

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -8,9 +8,7 @@ import { View } from '../../webviews/NavBar'
  * A message sent from the webview to the extension host.
  */
 export type WebviewMessage =
-    | {
-          command: 'initialized'
-      }
+    | { command: 'initialized' }
     | { command: 'event'; event: string; value: string }
     | { command: 'submit'; text: string; submitType: 'user' | 'suggestion' }
     | { command: 'executeRecipe'; recipe: string }
@@ -42,6 +40,7 @@ export type ExtensionMessage =
  */
 export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debug' | 'serverEndpoint'> {
     hasAccessToken: boolean
+    hasVerifiedEmail: boolean
 }
 
 export const DOTCOM_URL = new URL('https://sourcegraph.com')

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 
-import { ChatViewProvider, isValidLogin } from './chat/ChatViewProvider'
+import { ChatViewProvider, getAuthStatus } from './chat/ChatViewProvider'
 import { DOTCOM_URL } from './chat/protocol'
 import { CodyCompletionItemProvider } from './completions'
 import { CompletionsDocumentProvider } from './completions/docprovider'
@@ -196,13 +196,13 @@ const register = async (
                 const token = new URLSearchParams(uri.query).get('code')
                 if (token && token.length > 8) {
                     await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, token)
-                    const isAuthed = await isValidLogin({
+                    const authStatus = await getAuthStatus({
                         serverEndpoint: DOTCOM_URL.href,
                         accessToken: token,
                         customHeaders: config.customHeaders,
                     })
-                    await chatProvider.sendLogin(isAuthed)
-                    void vscode.window.showInformationMessage('Token has been retreived and updated successfully')
+                    await chatProvider.sendLogin(authStatus)
+                    void vscode.window.showInformationMessage('Token has been retrieved and updated successfully')
                 }
             },
         })

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -50,11 +50,11 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 }
                 case 'config':
                     setConfig(message.config)
-                    setView(message.config.hasAccessToken ? 'chat' : 'login')
+                    setView(message.config.hasVerifiedEmail ? 'chat' : 'login')
                     break
                 case 'login':
                     setAuthStatus(message.authStatus)
-                    setView(message.authStatus.loggedIn && message.authStatus.hasVerifiedEmail ? 'chat' : 'login')
+                    setView(message.authStatus.hasVerifiedEmail ? 'chat' : 'login')
                     break
                 case 'showTab':
                     if (message.tab === 'chat') {
@@ -101,6 +101,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
 
     const onLogout = useCallback(() => {
         vscodeAPI.postMessage({ command: 'removeToken' })
+        setAuthStatus(undefined)
         setView('login')
     }, [vscodeAPI])
 
@@ -108,41 +109,45 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         return <LoadingPage />
     }
 
+    // Authed View
     return (
         <div className="outer-container">
             <Header />
-            {view === 'login' && (
+            {!authStatus?.loggedIn || !authStatus?.hasVerifiedEmail ? (
                 <Login onLogin={onLogin} authStatus={authStatus} serverEndpoint={config?.serverEndpoint} />
-            )}
-            {view !== 'login' && <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />}
-            {view === 'debug' && config?.debug && <Debug debugLog={debugLog} />}
-            {view === 'history' && (
-                <UserHistory
-                    userHistory={userHistory}
-                    setUserHistory={setUserHistory}
-                    setInputHistory={setInputHistory}
-                    setView={setView}
-                    vscodeAPI={vscodeAPI}
-                />
-            )}
-            {view === 'recipes' && <Recipes vscodeAPI={vscodeAPI} />}
-            {view === 'settings' && <Settings onLogout={onLogout} serverEndpoint={config?.serverEndpoint} />}
-            {view === 'chat' && errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
-            {view === 'chat' && (
-                <Chat
-                    messageInProgress={messageInProgress}
-                    messageBeingEdited={messageBeingEdited}
-                    setMessageBeingEdited={setMessageBeingEdited}
-                    transcript={transcript}
-                    contextStatus={contextStatus}
-                    formInput={formInput}
-                    setFormInput={setFormInput}
-                    inputHistory={inputHistory}
-                    setInputHistory={setInputHistory}
-                    vscodeAPI={vscodeAPI}
-                    suggestions={suggestions}
-                    setSuggestions={setSuggestions}
-                />
+            ) : (
+                <>
+                    <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />
+                    {view === 'debug' && config?.debug && <Debug debugLog={debugLog} />}
+                    {view === 'history' && (
+                        <UserHistory
+                            userHistory={userHistory}
+                            setUserHistory={setUserHistory}
+                            setInputHistory={setInputHistory}
+                            setView={setView}
+                            vscodeAPI={vscodeAPI}
+                        />
+                    )}
+                    {view === 'recipes' && <Recipes vscodeAPI={vscodeAPI} />}
+                    {view === 'settings' && <Settings onLogout={onLogout} serverEndpoint={config?.serverEndpoint} />}
+                    {errorMessages && <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />}
+                    {view === 'chat' && (
+                        <Chat
+                            messageInProgress={messageInProgress}
+                            messageBeingEdited={messageBeingEdited}
+                            setMessageBeingEdited={setMessageBeingEdited}
+                            transcript={transcript}
+                            contextStatus={contextStatus}
+                            formInput={formInput}
+                            setFormInput={setFormInput}
+                            inputHistory={inputHistory}
+                            setInputHistory={setInputHistory}
+                            vscodeAPI={vscodeAPI}
+                            suggestions={suggestions}
+                            setSuggestions={setSuggestions}
+                        />
+                    )}
+                </>
             )}
         </div>
     )

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -6,6 +6,8 @@ import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { ChatHistory, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
+import { AuthStatus } from '../src/chat/protocol'
+
 import { Chat } from './Chat'
 import { Debug } from './Debug'
 import { Header } from './Header'
@@ -24,7 +26,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
     const [messageBeingEdited, setMessageBeingEdited] = useState<boolean>(false)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
-    const [isValidLogin, setIsValidLogin] = useState<boolean>()
+    const [authStatus, setAuthStatus] = useState<AuthStatus>()
     const [formInput, setFormInput] = useState('')
     const [inputHistory, setInputHistory] = useState<string[] | []>([])
     const [userHistory, setUserHistory] = useState<ChatHistory | null>(null)
@@ -51,8 +53,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     setView(message.config.hasAccessToken ? 'chat' : 'login')
                     break
                 case 'login':
-                    setIsValidLogin(message.isValid)
-                    setView(message.isValid ? 'chat' : 'login')
+                    setAuthStatus(message.authStatus)
+                    setView(message.authStatus.loggedIn && message.authStatus.hasVerifiedEmail ? 'chat' : 'login')
                     break
                 case 'showTab':
                     if (message.tab === 'chat') {
@@ -91,7 +93,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
             if (!token || !endpoint) {
                 return
             }
-            setIsValidLogin(undefined)
+            setAuthStatus(undefined)
             vscodeAPI.postMessage({ command: 'settings', serverEndpoint: endpoint, accessToken: token })
         },
         [vscodeAPI]
@@ -110,7 +112,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         <div className="outer-container">
             <Header />
             {view === 'login' && (
-                <Login onLogin={onLogin} isValidLogin={isValidLogin} serverEndpoint={config?.serverEndpoint} />
+                <Login onLogin={onLogin} authStatus={authStatus} serverEndpoint={config?.serverEndpoint} />
             )}
             {view !== 'login' && <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />}
             {view === 'debug' && config?.debug && <Debug debugLog={debugLog} />}

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -6,16 +6,18 @@ import { VSCodeTextField, VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import { renderCodyMarkdown } from '@sourcegraph/cody-shared/src/chat/markdown'
 import { CODY_TERMS_MARKDOWN } from '@sourcegraph/cody-ui/src/terms'
 
+import { AuthStatus } from '../src/chat/protocol'
+
 import styles from './Login.module.css'
 
 interface LoginProps {
-    isValidLogin?: boolean
+    authStatus?: AuthStatus
     onLogin: (token: string, endpoint: string) => void
     serverEndpoint?: string
 }
 
 export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>> = ({
-    isValidLogin,
+    authStatus,
     onLogin,
     serverEndpoint,
 }) => {
@@ -34,9 +36,14 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     return (
         <div className={styles.container}>
-            {isValidLogin === false && (
+            {authStatus?.loggedIn === false && (
                 <p className={styles.error}>
                     Invalid credentials. Please check the Sourcegraph instance URL and access token.
+                </p>
+            )}
+            {authStatus?.loggedIn === true && authStatus?.hasVerifiedEmail === false && (
+                <p className={styles.error}>
+                    Email not verified. Please add a verified email to your Sourcegraph instance account.
                 </p>
             )}
             <section className={styles.section}>

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -27,7 +27,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     const onSubmit = useCallback<React.FormEventHandler>(
         event => {
             event.preventDefault()
-            if (endpoint) {
+            if (endpoint && token) {
                 onLogin(token, endpoint)
             }
         },
@@ -36,14 +36,13 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     return (
         <div className={styles.container}>
-            {authStatus?.loggedIn === false && (
+            {authStatus && (
                 <p className={styles.error}>
-                    Invalid credentials. Please check the Sourcegraph instance URL and access token.
-                </p>
-            )}
-            {authStatus?.loggedIn === true && authStatus?.hasVerifiedEmail === false && (
-                <p className={styles.error}>
-                    Email not verified. Please add a verified email to your Sourcegraph instance account.
+                    {!authStatus.loggedIn
+                        ? 'Invalid credentials. Please check the Sourcegraph instance URL and access token.'
+                        : !authStatus?.hasVerifiedEmail
+                        ? 'Email not verified. Please add a verified email to your Sourcegraph instance account.'
+                        : null}
                 </p>
             )}
             <section className={styles.section}>
@@ -51,20 +50,19 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                 <form className={styles.wrapper} onSubmit={onSubmit}>
                     <VSCodeTextField
                         id="endpoint"
-                        value={endpoint || ''}
+                        value={endpoint}
                         className={styles.input}
-                        placeholder="https://example.sourcegraph.com"
-                        onInput={(e: any) => setEndpoint(e.target.value)}
+                        placeholder="https://sourcegraph.com"
+                        onInput={e => setEndpoint((e.target as HTMLInputElement).value)}
                     >
                         Sourcegraph Instance URL
                     </VSCodeTextField>
                     <VSCodeTextField
                         id="accessToken"
                         value={token}
-                        placeholder=""
                         className={styles.input}
                         type={TextFieldType.password}
-                        onInput={(e: any) => setToken(e.target.value)}
+                        onInput={e => setToken((e.target as HTMLInputElement).value)}
                     >
                         Access Token (
                         <a href="https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token">docs</a>)
@@ -77,7 +75,6 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             <div className={styles.divider} />
             <section className={styles.section}>
                 <h2 className={styles.sectionHeader}>Everyone Else</h2>
-
                 <p className={styles.openMessage}>
                     Cody for open source code is available to all users with a Sourcegraph.com account
                 </p>


### PR DESCRIPTION
Updated so that a user is considered `authed` only when`authStatus.hasVerifiedEmail === true`: `await vscode.commands.executeCommand('setContext', 'cody.activated', authStatus.hasVerifiedEmail)` (When `cody.activated` is set to true, it will activate all the commands for the users on the right conditions). 

While I was working on this, I discovered another bug - see this loom for the UI bug where unauthed users can see visit the `chat` view and `history` view in our current version: 
https://www.loom.com/share/002035051d0341a6833fa8c79db0036e

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See this loom for the fixed version: https://www.loom.com/share/1b013db11a9841b8a42689e922818d8d