### PR TITLE
Cody: Fix Inline Assist empty file issue

### DIFF
--- a/client/cody-shared/src/chat/recipes/fixup.ts
+++ b/client/cody-shared/src/chat/recipes/fixup.ts
@@ -86,8 +86,9 @@ export class Fixup implements Recipe {
     Do not move code from outside the selection into the selection in your reply.
     Do not remove code inside the <selection> tags that might be being used by the code outside the <selection> tags.
     It is OK to provide some commentary within the replacement <selection>.
-    Only return provide me the replacement <selection> and nothing else.
-    If it doesn't make sense, you do not need to provide <selection>.
+    It is not acceptable to enclose the rewritten replacement with markdowns.
+    Only provide me with the replacement <selection> and nothing else.
+    If it doesn't make sense, you do not need to provide <selection>. Instead, tell me how I can help you to understand my request.
 
     \`\`\`
     {truncateTextStart}<selection>{selectedText}</selection>{truncateFollowingText}

--- a/client/cody/src/services/InlineController.ts
+++ b/client/cody/src/services/InlineController.ts
@@ -221,10 +221,11 @@ export class InlineController {
         // Stop tracking for file changes to perfotm replacement
         this.isInProgress = false
         // Perform edits
-        await activeEditor.edit(edit => {
-            edit.replace(selection, replacement)
-        })
         const startLine = selection.start.line
+        await activeEditor.edit(edit => {
+            edit.delete(selection)
+            edit.insert(new vscode.Position(startLine, 0), replacement + '\n')
+        })
         const newLineCount = replacement.split('\n').length - 2
         // Highlight from the start line to the length of the replacement content
         const newRange = new vscode.Range(startLine, 0, startLine + newLineCount, 0)


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/51904

Cody Inline Assist currently hangs when working on empty files. I believe this happens during the replacement step because there is nothing to replace, while selecting an empty space before starting the task works as shown in this [video](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1683949225579829?thread_ts=1683935338.445299&cid=C04MSD3DP5L).

I am able to resolve the issue locally by `deleting` the code that was selected originally (including empty lines) before inserting the code returned by Cody to the original starting line instead of using the `replace` method.

<img width="1165" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/0bc55884-14c5-4bb5-b3b2-b2665586099c">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

See loom for the fix: https://www.loom.com/share/68f80c3d79ba4277a6ce0f03ff4cfb53