### PR TITLE
Cody: Release notes recipe fix

### DIFF
--- a/client/cody-shared/src/chat/recipes/generate-release-notes.ts
+++ b/client/cody-shared/src/chat/recipes/generate-release-notes.ts
@@ -19,12 +19,12 @@ export class ReleaseNotes implements Recipe {
         const logFormat = '--pretty="Commit author: %an%nCommit message: %s%nChange description:%b%n"'
 
         // check for tags first
-        const gitTagCommand = spawnSync('git', ['tag'], { cwd: dirPath })
+        const gitTagCommand = spawnSync('git', ['tag', '--sort=-creatordate'], { cwd: dirPath })
         const gitTagOutput = gitTagCommand.stdout.toString().trim()
         let tagsPromptText = ''
 
         if (gitTagOutput) {
-            const tags = gitTagOutput.split(/\r?\n/).reverse()
+            const tags = gitTagOutput.split(/\r?\n/)
             for (const tag of tags.slice(0, 3)) {
                 quickPickItems.push({
                     label: tag,


### PR DESCRIPTION
This PR fixes a minor issue with implementing the release notes recipe. I assumed that the git tag command shows the recipe in the sorted order of creation date, but it doesn't, so I have added that to the git command. It was noticed here, too, in #51834 
