### PR TITLE
Tracing: use opentelemetry attrs in observation package

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -57,7 +57,7 @@ func getHighlightOp() *observation.Operation {
 
 		highlightOp = obsvCtx.Operation(observation.Op{
 			Name:        "codeintel.syntax-highlight.Code",
-			LogFields:   []otlog.Field{},
+			Attrs:       []attribute.KeyValue{},
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour { return observation.EmitForHoney },
 		})
 	})

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/resolvers"
@@ -87,7 +88,7 @@ func newIndexConfigurationResolver(autoindexSvc AutoIndexingService, siteAdminCh
 }
 
 func (r *indexConfigurationResolver) Configuration(ctx context.Context) (_ *string, err error) {
-	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "configuration"))
+	defer r.errTracer.Collect(&err, attribute.String("indexConfigResolver.field", "configuration"))
 
 	configuration, exists, err := r.autoindexSvc.GetIndexConfigurationByRepositoryID(ctx, r.repositoryID)
 	if err != nil {

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
@@ -102,7 +102,7 @@ func (r *indexConfigurationResolver) Configuration(ctx context.Context) (_ *stri
 }
 
 func (r *indexConfigurationResolver) InferredConfiguration(ctx context.Context) (_ resolverstubs.InferredConfigurationResolver, err error) {
-	defer r.errTracer.Collect(&err, log.String("indexConfigResolver.field", "inferredConfiguration"))
+	defer r.errTracer.Collect(&err, attribute.String("indexConfigResolver.field", "inferredConfiguration"))
 
 	var limitErr error
 	configuration, _, err := r.autoindexSvc.InferIndexConfiguration(ctx, r.repositoryID, "", "", true)

--- a/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/configuration_policy_resolver.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/resolvers/gitresolvers"
@@ -42,9 +42,9 @@ func (r *configurationPolicyResolver) Repository(ctx context.Context) (_ resolve
 	}
 
 	defer r.errTracer.Collect(&err,
-		log.String("configurationPolicyResolver.field", "repository"),
-		log.Int("configurationPolicyID", r.configurationPolicy.ID),
-		log.Int("repoID", *r.configurationPolicy.RepositoryID),
+		attribute.String("configurationPolicyResolver.field", "repository"),
+		attribute.Int("configurationPolicyID", r.configurationPolicy.ID),
+		attribute.Int("repoID", *r.configurationPolicy.RepositoryID),
 	)
 
 	return gitresolvers.NewRepositoryFromID(ctx, r.repoStore, *r.configurationPolicy.RepositoryID)
@@ -56,9 +56,9 @@ func (r *configurationPolicyResolver) RepositoryPatterns() *[]string {
 
 func (r *configurationPolicyResolver) Type() (_ resolverstubs.GitObjectType, err error) {
 	defer r.errTracer.Collect(&err,
-		log.String("configurationPolicyResolver.field", "type"),
-		log.Int("configurationPolicyID", r.configurationPolicy.ID),
-		log.String("policyType", string(r.configurationPolicy.Type)),
+		attribute.String("configurationPolicyResolver.field", "type"),
+		attribute.Int("configurationPolicyID", r.configurationPolicy.ID),
+		attribute.String("policyType", string(r.configurationPolicy.Type)),
 	)
 
 	switch r.configurationPolicy.Type {

--- a/internal/observation/context.go
+++ b/internal/observation/context.go
@@ -87,10 +87,10 @@ func (c *Context) Operation(args Op) *Operation {
 		name:         args.Name,
 		kebabName:    kebabCase(args.Name),
 		metricLabels: args.MetricLabelValues,
-		attributes:   trace.OTLogFieldsToOTelAttrs(args.LogFields),
+		attributes:   args.Attrs,
 		errorFilter:  args.ErrorFilter,
 
-		Logger: logger.With(toLogFields(args.LogFields)...),
+		Logger: logger.With(attributesToLogFields(args.Attrs)...),
 	}
 }
 

--- a/internal/observation/context.go
+++ b/internal/observation/context.go
@@ -87,7 +87,7 @@ func (c *Context) Operation(args Op) *Operation {
 		name:         args.Name,
 		kebabName:    kebabCase(args.Name),
 		metricLabels: args.MetricLabelValues,
-		logFields:    args.LogFields,
+		attributes:   trace.OTLogFieldsToOTelAttrs(args.LogFields),
 		errorFilter:  args.ErrorFilter,
 
 		Logger: logger.With(toLogFields(args.LogFields)...),

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -178,16 +178,16 @@ func (f FinishFunc) OnCancel(ctx context.Context, count float64, args Args) {
 
 // ErrCollector represents multiple errors and additional log fields that arose from those errors.
 type ErrCollector struct {
-	errs        error
-	extraFields []otlog.Field
+	errs       error
+	extraAttrs []attribute.KeyValue
 }
 
 func NewErrorCollector() *ErrCollector { return &ErrCollector{errs: nil} }
 
-func (e *ErrCollector) Collect(err *error, fields ...otlog.Field) {
+func (e *ErrCollector) Collect(err *error, attrs ...attribute.KeyValue) {
 	if err != nil && *err != nil {
 		e.errs = errors.Append(e.errs, *err)
-		e.extraFields = append(e.extraFields, fields...)
+		e.extraAttrs = append(e.extraAttrs, attrs...)
 	}
 }
 
@@ -293,7 +293,7 @@ func (op *Operation) With(ctx context.Context, err *error, args Args) (context.C
 			if multi.errs == nil {
 				err = nil
 			}
-			logFields = append(logFields, trace.OTLogFieldsToOTelAttrs(multi.extraFields)...)
+			logFields = append(logFields, multi.extraAttrs...)
 		}
 
 		var (

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -55,8 +55,8 @@ type Op struct {
 	Description string
 	// MetricLabelValues that apply for every invocation of this operation.
 	MetricLabelValues []string
-	// LogFields that apply for every invocation of this operation.
-	LogFields []otlog.Field
+	// Attributes that apply for every invocation of this operation.
+	Attrs []attribute.KeyValue
 	// ErrorFilter returns true for any error that should be converted to nil
 	// for the purposes of metrics and tracing. If this field is not set then
 	// error values are unaltered.

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -275,7 +275,7 @@ func (op *Operation) With(ctx context.Context, err *error, args Args) (context.C
 		Logger:  logger,
 	}
 
-	if mergedFields := mergeLogFields(op.attributes, trace.OTLogFieldsToOTelAttrs(args.LogFields)); len(mergedFields) > 0 {
+	if mergedFields := mergeAttrs(op.attributes, trace.OTLogFieldsToOTelAttrs(args.LogFields)); len(mergedFields) > 0 {
 		trLogger.initWithTags(mergedFields...)
 	}
 
@@ -284,9 +284,9 @@ func (op *Operation) With(ctx context.Context, err *error, args Args) (context.C
 		elapsed := since.Seconds()
 		elapsedMs := since.Milliseconds()
 		defaultFinishFields := []attribute.KeyValue{attribute.Float64("count", count), attribute.Float64("elapsed", elapsed)}
-		finishLogFields := mergeLogFields(defaultFinishFields, trace.OTLogFieldsToOTelAttrs(finishArgs.LogFields))
+		finishLogFields := mergeAttrs(defaultFinishFields, trace.OTLogFieldsToOTelAttrs(finishArgs.LogFields))
 
-		logFields := mergeLogFields(defaultFinishFields, finishLogFields)
+		logFields := mergeAttrs(defaultFinishFields, finishLogFields)
 		metricLabels := mergeLabels(op.metricLabels, args.MetricLabelValues, finishArgs.MetricLabelValues)
 
 		if multi := new(ErrCollector); err != nil && errors.As(*err, &multi) {

--- a/internal/observation/util.go
+++ b/internal/observation/util.go
@@ -64,8 +64,8 @@ func mergeLabels(groups ...[]string) []string {
 	return labels
 }
 
-// mergeLogFields flattens slices of slices of log fields.
-func mergeLogFields(groups ...[]attribute.KeyValue) []attribute.KeyValue {
+// mergeAttrs flattens slices of slices of log fields.
+func mergeAttrs(groups ...[]attribute.KeyValue) []attribute.KeyValue {
 	size := 0
 	for _, group := range groups {
 		size += len(group)

--- a/internal/observation/util.go
+++ b/internal/observation/util.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"unicode"
 
-	otlog "github.com/opentracing/opentracing-go/log"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // commonAcronyms includes acronyms that malform the expected output of kebabCase
@@ -65,16 +65,16 @@ func mergeLabels(groups ...[]string) []string {
 }
 
 // mergeLogFields flattens slices of slices of log fields.
-func mergeLogFields(groups ...[]otlog.Field) []otlog.Field {
+func mergeLogFields(groups ...[]attribute.KeyValue) []attribute.KeyValue {
 	size := 0
 	for _, group := range groups {
 		size += len(group)
 	}
 
-	logFields := make([]otlog.Field, 0, size)
+	attrs := make([]attribute.KeyValue, 0, size)
 	for _, group := range groups {
-		logFields = append(logFields, group...)
+		attrs = append(attrs, group...)
 	}
 
-	return logFields
+	return attrs
 }


### PR DESCRIPTION
This migrates most of the interface of the observation package to use the opentelemetry attrs rather than the opentracing fields. The only remaining API surface that uses the opentracing fields is the Args struct, which is admittedly the most used piece. This PR knocks out the rest of the low-hanging fruit before tackling the tougher stuff.

## Test plan

It compiles. Not using any new translations, just moving bridge translations up the stack.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
