### PR TITLE
Cody compeltions: Disregard whitespace in the completion prefix for the cache

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -103,6 +103,7 @@ ts_project(
     testonly = True,
     srcs = [
         "src/chat/ChatViewProvider.test.ts",
+        "src/completions/cache.test.ts",
         "src/completions/context.test.ts",
         "src/completions/provider.test.ts",
         "src/configuration.test.ts",

--- a/client/cody/src/completions/cache.test.ts
+++ b/client/cody/src/completions/cache.test.ts
@@ -1,0 +1,28 @@
+import { CompletionsCache } from './cache'
+
+describe('CompletionsCache', () => {
+    it('returns the cached completion items', () => {
+        const cache = new CompletionsCache()
+        cache.add([{ prefix: 'foo\n', content: 'bar', prompt: '' }])
+
+        expect(cache.get('foo\n')).toEqual([{ prefix: 'foo\n', content: 'bar', prompt: '' }])
+    })
+
+    it('returns the cached items when the prefix includes characters from the completion', () => {
+        const cache = new CompletionsCache()
+        cache.add([{ prefix: 'foo\n', content: 'bar', prompt: '' }])
+
+        expect(cache.get('foo\nb')).toEqual([{ prefix: 'foo\nb', content: 'ar', prompt: '' }])
+        expect(cache.get('foo\nba')).toEqual([{ prefix: 'foo\nba', content: 'r', prompt: '' }])
+    })
+
+    it('returns the cached items when the prefix has less whitespace', () => {
+        const cache = new CompletionsCache()
+        cache.add([{ prefix: 'foo \n  ', content: 'bar', prompt: '' }])
+
+        expect(cache.get('foo \n  ')).toEqual([{ prefix: 'foo \n  ', content: 'bar', prompt: '' }])
+        expect(cache.get('foo \n ')).toEqual([{ prefix: 'foo \n ', content: 'bar', prompt: '' }])
+        expect(cache.get('foo \n')).toEqual([{ prefix: 'foo \n', content: 'bar', prompt: '' }])
+        expect(cache.get('foo ')).toEqual(undefined)
+    })
+})

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -12,11 +12,12 @@ export class CompletionsCache {
     // to make sure the cache does not return undesired results for other files
     // in the same project.
     public get(prefix: string): Completion[] | undefined {
-        const results = this.cache.get(prefix)
+        const trimmedPrefix = trimEndAfterLastNewline(prefix)
+        const results = this.cache.get(trimmedPrefix)
         if (results) {
             return results.map(result => {
-                if (prefix.length === result.prefix.length) {
-                    return result
+                if (trimmedPrefix.length === trimEndAfterLastNewline(result.prefix).length) {
+                    return { ...result, prefix, content: result.content }
                 }
 
                 // Cached results can be created by appending characters from a
@@ -47,7 +48,7 @@ export class CompletionsCache {
             }
 
             for (let i = 0; i <= maxCharsAppended; i++) {
-                const key = completion.prefix + completion.content.slice(0, i)
+                const key = trimEndAfterLastNewline(completion.prefix) + completion.content.slice(0, i)
                 if (!this.cache.has(key)) {
                     this.cache.set(key, [completion])
                 } else {
@@ -57,4 +58,10 @@ export class CompletionsCache {
             }
         }
     }
+}
+
+function trimEndAfterLastNewline(text: string): string {
+    const lastNewlineIndex = text.lastIndexOf('\n')
+    const before = text.slice(0, lastNewlineIndex + 1)
+    return before + text.slice(lastNewlineIndex + 1).trimEnd()
 }


### PR DESCRIPTION
This fixes a bug that is currently present in the completions cache where a reduction of whitespace would cause to additional completion requests.

To reproduce the bug, imagine this scenario:

```ts
function foo() {
  |
```

With the curser at `|`.

We request completions and cache it with the prefix `function foo() {\n  `. Cool.

However, the unexpected behavior comes when you _remove some whitespace from the prefix_. So e.g. you Remove one backspace and make it:

```ts
function foo() {
 |
```

With the previous cache, this was resulting in a miss and a new completion being sent which led to some unexpected behavior, especially if the IDE inserts whitespace for you and you fix it by pressing backspace:


https://github.com/sourcegraph/sourcegraph/assets/458591/db9034a0-6545-4e2b-9af0-78bc02cc7863

To fix this, the cache now trims all whitespace _in the last line_ (leaving the total numbers of `\n` unchanged).


## Test plan

- Tested locally by reproducing the above steps
- Added unit tests to the cache

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
