### PR TITLE
sitemap: fix compile error after update to NewRetryPolicy

### DIFF
--- a/cmd/sitemap/graphql.go
+++ b/cmd/sitemap/graphql.go
@@ -72,7 +72,7 @@ func (c *graphQLClient) requestGraphQL(ctx context.Context, queryName string, qu
 			// not a generic http.RoundTripper.
 			httpcli.ExternalTransportOpt,
 			httpcli.NewErrorResilientTransportOpt(
-				httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts)),
+				httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts), 2*time.Second),
 				httpcli.ExpJitterDelay(graphQLRetryDelayBase, graphQLRetryDelayMax),
 			),
 			httpcli.TracedTransportOpt,


### PR DESCRIPTION
Seems like NewRetryPolicy was changed but the new argument wasn't added.

This fixes that.

(VS Code complained)

## Test plan

- VS Code
