### PR TITLE
'undeprecate' single-service main entrypoints

### DIFF
--- a/cmd/blobstore/main.go
+++ b/cmd/blobstore/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -15,5 +15,5 @@ func main() {
 	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -8,5 +8,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -8,5 +8,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/sourcegraph-oss/osscmd/osscmd.go
+++ b/cmd/sourcegraph-oss/osscmd/osscmd.go
@@ -21,10 +21,8 @@ func MainOSS(services []service.Service, args []string) {
 	svcmain.Main(services, config, args)
 }
 
-// DeprecatedSingleServiceMainOSS is called from the `main` function of a command in the OSS build
+// SingleServiceMainOSS is called from the `main` function of a command in the OSS build
 // to start a single service (such as frontend or gitserver).
-//
-// DEPRECATED: See svcmain.DeprecatedSingleServiceMain documentation for more info.
-func DeprecatedSingleServiceMainOSS(service service.Service) {
-	svcmain.DeprecatedSingleServiceMain(service, config, true, true)
+func SingleServiceMainOSS(service service.Service) {
+	svcmain.SingleServiceMain(service, config, true, true)
 }

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -8,5 +8,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	osscmd.DeprecatedSingleServiceMainOSS(shared.Service)
+	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/enterprise/cmd/embeddings/main.go
+++ b/enterprise/cmd/embeddings/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -15,5 +15,5 @@ func main() {
 	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/gitserver/main.go
+++ b/enterprise/cmd/gitserver/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/llm-proxy/main.go
+++ b/enterprise/cmd/llm-proxy/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	svcmain.DeprecatedSingleServiceMain(shared.Service, svcmain.Config{}, true, false)
+	svcmain.SingleServiceMain(shared.Service, svcmain.Config{}, true, false)
 }

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
+++ b/enterprise/cmd/sourcegraph/enterprisecmd/enterprisecmd.go
@@ -16,12 +16,10 @@ func MainEnterprise(services []service.Service, args []string) {
 	svcmain.Main(services, config, args)
 }
 
-// DeprecatedSingleServiceMainEnterprise is called from the `main` function of a command in the
+// SingleServiceMainEnterprise is called from the `main` function of a command in the
 // enterprise (non-OSS) build to start a single service (such as frontend or gitserver).
-//
-// DEPRECATED: See svcmain.DeprecatedSingleServiceMain documentation for more info.
-func DeprecatedSingleServiceMainEnterprise(service service.Service) {
-	svcmain.DeprecatedSingleServiceMain(service, config, true, true)
+func SingleServiceMainEnterprise(service service.Service) {
+	svcmain.SingleServiceMain(service, config, true, true)
 }
 
 func init() {

--- a/enterprise/cmd/sourcegraph/enterprisecmd/executorcmd/executorcmd.go
+++ b/enterprise/cmd/sourcegraph/enterprisecmd/executorcmd/executorcmd.go
@@ -12,10 +12,8 @@ import (
 
 var config = svcmain.Config{}
 
-// DeprecatedSingleServiceMainEnterprise is called from the `main` function of a command in the
+// SingleServiceMainEnterprise is called from the `main` function of a command in the
 // enterprise (non-OSS) build to start a single service (such as frontend or gitserver).
-//
-// DEPRECATED: See svcmain.DeprecatedSingleServiceMain documentation for more info.
-func DeprecatedSingleServiceMainEnterprise(service service.Service) {
-	svcmain.DeprecatedSingleServiceMain(service, config, false, false)
+func SingleServiceMainEnterprise(service service.Service) {
+	svcmain.SingleServiceMain(service, config, false, false)
 }

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -6,5 +6,5 @@ import (
 )
 
 func main() {
-	enterprisecmd.DeprecatedSingleServiceMainEnterprise(shared.Service)
+	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -96,12 +96,9 @@ func Main(services []sgservice.Service, config Config, args []string) {
 	}
 }
 
-// DeprecatedSingleServiceMain is called from the `main` function of a command to start a single
+// SingleServiceMain is called from the `main` function of a command to start a single
 // service (such as frontend or gitserver).
-//
-// DEPRECATED: Building per-service commands (i.e., a separate binary for frontend, gitserver, etc.)
-// is deprecated.
-func DeprecatedSingleServiceMain(svc sgservice.Service, config Config, validateConfig, useConfPackage bool) {
+func SingleServiceMain(svc sgservice.Service, config Config, validateConfig, useConfPackage bool) {
 	liblog := log.Init(log.Resource{
 		Name:       env.MyName,
 		Version:    version.Version(),


### PR DESCRIPTION
Renaming main entrypoints which are confusingly marked as "deprecated", yet are not deprecated from what I've been informed :shrug: 

## Test plan

No logic changes, just renaming functions
