### PR TITLE
own: don't return an error when trying to display the `PrimaryEmail` by not a site-admin or same user.

### DIFF
--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -46,10 +46,11 @@ func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error)
 
 func (r *UserResolver) PrimaryEmail(ctx context.Context) (*userEmailResolver, error) {
 	// 🚨 SECURITY: Only the authenticated user and site admins can list user's
-	// emails on Sourcegraph.com.
+	// emails on Sourcegraph.com. We don't return an error, but not showing the email
+	// either.
 	if envvar.SourcegraphDotComMode() {
 		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return nil, err
+			return nil, nil
 		}
 	}
 	ms, err := r.db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{


### PR DESCRIPTION
Test plan:
CI.

Addressing the issue found [here](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1684161082313599).