### PR TITLE
batches: clear credential error after adding a new one

### DIFF
--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react'
 
+import { ApolloError } from '@apollo/client'
 import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline } from '@mdi/js'
 import classNames from 'classnames'
 
@@ -36,13 +37,16 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
     refetchAll,
     userID,
 }) => {
+    const [checkCredError, setCheckCredError] = useState<ApolloError | undefined>()
     const ExternalServiceIcon = defaultExternalServices[node.externalServiceKind].icon
     const codeHostDisplayName = defaultExternalServices[node.externalServiceKind].defaultDisplayName
 
-    const [checkCred, { data: checkCredData, loading: checkCredLoading, error: checkCredError }] = useLazyQuery<
+    const [checkCred, { data: checkCredData, loading: checkCredLoading }] = useLazyQuery<
         CheckBatchChangesCredentialResult,
         CheckBatchChangesCredentialVariables
-    >(CHECK_BATCH_CHANGES_CREDENTIAL, {})
+    >(CHECK_BATCH_CHANGES_CREDENTIAL, {
+        onError: err => setCheckCredError(err),
+    })
 
     const buttonReference = useRef<HTMLButtonElement | null>(null)
 
@@ -66,6 +70,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
     }, [])
     const afterAction = useCallback(() => {
         setOpenModal(undefined)
+        setCheckCredError(undefined)
         buttonReference.current?.focus()
         refetchAll()
     }, [refetchAll, buttonReference])


### PR DESCRIPTION
Some days ago, someone reported an issue they ran into when updating their Batch Changes credentials. They had an expired credential, and after updating it with a new (and valid) one, they still got the error `Credential is not authorized`.

This error went away when they refreshed the page.

#### Before

https://github.com/sourcegraph/sourcegraph/assets/25608335/efbdf138-f08b-4752-a397-9d8563bab69a

#### After

https://github.com/sourcegraph/sourcegraph/assets/25608335/99d39218-6b13-4653-9d21-e5a7a7572512

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Add a credential to Batch Changes.
* Revoke the credential on your code host.
* Check for the credential's validity - it should appear as unauthorized.
* Remove the token and add a new (and valid) credential.
* The `unauthorized` error should not be shown once the new credential has been added.