### PR TITLE
batch: Update postgres max num parameters

### DIFF
--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -21,8 +21,8 @@ import (
 type Inserter struct {
 	db                   dbutil.DB
 	numColumns           int
-	maxBatchSize         int
-	batch                []any
+	maxNumValues         int
+	values               []any
 	cumulativeValueSizes []int
 	queryPrefix          string
 	querySuffix          string
@@ -170,7 +170,7 @@ func NewInserterWithReturn(
 	returningScanner ReturningScanner,
 ) *Inserter {
 	numColumns := len(columnNames)
-	maxBatchSize := GetMaxBatchSize(numColumns, maxNumParameters)
+	maxNumValues := int(maxNumParameters/numColumns) * numColumns
 	queryPrefix := makeQueryPrefix(tableName, columnNames)
 	querySuffix := makeQuerySuffix(numColumns, maxNumParameters)
 	onConflictSuffix := makeOnConflictSuffix(onConflictClause)
@@ -180,9 +180,9 @@ func NewInserterWithReturn(
 	return &Inserter{
 		db:                   db,
 		numColumns:           numColumns,
-		maxBatchSize:         maxBatchSize,
-		batch:                make([]any, 0, maxBatchSize),
-		cumulativeValueSizes: make([]int, 0, maxBatchSize),
+		maxNumValues:         maxNumValues,
+		values:               make([]any, 0, maxNumValues),
+		cumulativeValueSizes: make([]int, 0, maxNumValues),
 		queryPrefix:          queryPrefix,
 		querySuffix:          querySuffix,
 		onConflictSuffix:     onConflictSuffix,
@@ -193,7 +193,7 @@ func NewInserterWithReturn(
 			log.String("tableName", tableName),
 			log.String("columnNames", strings.Join(columnNames, ",")),
 			log.Int("numColumns", numColumns),
-			log.Int("maxBatchSize", maxBatchSize),
+			log.Int("maxNumValues", maxNumValues),
 		},
 	}
 }
@@ -224,10 +224,10 @@ func (i *Inserter) Insert(ctx context.Context, values ...any) error {
 		valueSizes = append(valueSizes, currentCumulativeValueSize)
 	}
 
-	i.batch = append(i.batch, values...)
+	i.values = append(i.values, values...)
 	i.cumulativeValueSizes = append(i.cumulativeValueSizes, valueSizes...)
 
-	if len(i.batch) >= i.maxBatchSize {
+	if len(i.values) >= i.maxNumValues {
 		// Flush full batch
 		return i.Flush(ctx)
 	}
@@ -236,7 +236,7 @@ func (i *Inserter) Insert(ctx context.Context, values ...any) error {
 }
 
 // Flush ensures that all queued rows are inserted. This method must be invoked at the end
-// of insertion to ensure that all records are flushed to the underlying Execable.
+// of insertion to ensure that all records are flushed to the underlying db connection.
 func (i *Inserter) Flush(ctx context.Context) (err error) {
 	i.checkInvariants()
 	defer i.checkInvariants()
@@ -278,8 +278,8 @@ func (i *Inserter) Flush(ctx context.Context) (err error) {
 var checkBatchInserterInvariants = false
 
 func (i *Inserter) checkInvariants() {
-	if checkBatchInserterInvariants && len(i.batch) != len(i.cumulativeValueSizes) {
-		panic(fmt.Sprintf("broken invariant: len(i.batch) != len(i.cumulativeValueSizes): %d != %d", len(i.batch), len(i.cumulativeValueSizes)))
+	if checkBatchInserterInvariants && len(i.values) != len(i.cumulativeValueSizes) {
+		panic(fmt.Sprintf("broken invariant: len(i.batch) != len(i.cumulativeValueSizes): %d != %d", len(i.values), len(i.cumulativeValueSizes)))
 	}
 }
 
@@ -287,27 +287,27 @@ func (i *Inserter) checkInvariants() {
 // insert statement. The returned values are the oldest values submitted to the batch (in order).
 // This method additionally returns the total (approximate) size of the batch being inserted.
 func (i *Inserter) pop() (batch []any, payloadSize int) {
-	if len(i.batch) == 0 {
+	if len(i.values) == 0 {
 		return nil, 0
 	}
 
-	if len(i.batch) < i.maxBatchSize {
+	if len(i.values) < i.maxNumValues {
 		// Grab size before overwriting it
 		payloadSize = i.cumulativeValueSizes[len(i.cumulativeValueSizes)-1]
 
 		// Use entire batch. This allows us to cleanly reset the sizes we were tracking for value
 		// payloads by just cutting the length of the slice back to zero.
-		batch, i.batch = i.batch, i.batch[:0]
+		batch, i.values = i.values, i.values[:0]
 		i.cumulativeValueSizes = i.cumulativeValueSizes[:0]
 		return batch, payloadSize
 	}
 
 	// Grab size before altering containing slice
-	payloadSize = i.cumulativeValueSizes[i.maxBatchSize-1]
+	payloadSize = i.cumulativeValueSizes[i.maxNumValues-1]
 
-	// Extract partial batch along with the size tracking data for each elemetn
-	batch, i.batch = i.batch[:i.maxBatchSize], i.batch[i.maxBatchSize:]
-	i.cumulativeValueSizes = i.cumulativeValueSizes[i.maxBatchSize:]
+	// Extract partial batch along with the size tracking data for each element
+	batch, i.values = i.values[:i.maxNumValues], i.values[i.maxNumValues:]
+	i.cumulativeValueSizes = i.cumulativeValueSizes[i.maxNumValues:]
 
 	for idx := range i.cumulativeValueSizes {
 		// Remove the size of the batch we've just extracted from every value remaining in the slice.
@@ -348,12 +348,6 @@ const MaxNumPostgresParameters = 32767
 // in a single insert statement.
 const MaxNumSQLiteParameters = 999
 
-// GetMaxBatchSize returns the number of rows that can be inserted into a single table with the
-// given number of columns via a single insert statement.
-func GetMaxBatchSize(numColumns, maxNumParameters int) int {
-	return (maxNumParameters / numColumns) * numColumns
-}
-
 // makeQueryPrefix creates the prefix of the batch insert statement (up to `VALUES `) using the
 // given table and column names.
 func makeQueryPrefix(tableName string, columnNames []string) string {
@@ -375,7 +369,7 @@ var (
 // _full_ rows that can be inserted in one insert statement.
 //
 // If a fewer number of rows should be inserted (due to flushing a partial batch), then the caller
-// slice the appropriate nubmer of rows from the beginning of the string. The suffix constructed
+// slice the appropriate number of rows from the beginning of the string. The suffix constructed
 // here is done so with this use case in mind (each placeholder is 5 digits), so finding the right
 // substring index is efficient.
 //

--- a/internal/database/batch/batch.go
+++ b/internal/database/batch/batch.go
@@ -342,7 +342,7 @@ func (i *Inserter) makeQuery(numValues int) string {
 
 // MaxNumPostgresParameters is the maximum number of placeholder variables allowed by Postgres
 // in a single insert statement.
-const MaxNumPostgresParameters = 32767
+const MaxNumPostgresParameters = 65535
 
 // MaxNumSQLiteParameters is the maximum number of placeholder variables allowed by SQLite
 // in a single insert statement.

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -48,6 +48,39 @@ func TestBatchInserter(t *testing.T) {
 	}
 }
 
+func TestBatchInserterThin(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbtest.NewDB(logger, t)
+	setupTestTableThin(t, db)
+
+	tableSizeFactor := 2
+	var expectedValues [][]any
+	for i := 0; i < MaxNumPostgresParameters*tableSizeFactor; i++ {
+		expectedValues = append(expectedValues, []any{i})
+	}
+	testInsertThin(t, db, expectedValues)
+
+	rows, err := db.Query("SELECT col1 from batch_inserter_test_thin")
+	if err != nil {
+		t.Fatalf("unexpected error querying data: %s", err)
+	}
+	defer rows.Close()
+
+	var values [][]any
+	for rows.Next() {
+		var v1 int
+		if err := rows.Scan(&v1); err != nil {
+			t.Fatalf("unexpected error scanning data: %s", err)
+		}
+
+		values = append(values, []any{v1})
+	}
+
+	if diff := cmp.Diff(expectedValues, values); diff != "" {
+		t.Errorf("unexpected table contents (-want +got):\n%s", diff)
+	}
+}
+
 func TestBatchInserterWithReturn(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := dbtest.NewDB(logger, t)
@@ -163,6 +196,18 @@ func setupTestTable(t testing.TB, db *sql.DB) {
 	}
 }
 
+func setupTestTableThin(t testing.TB, db *sql.DB) {
+	createTableQuery := `
+		CREATE TABLE batch_inserter_test_thin (
+			id SERIAL,
+			col1 integer NOT NULL UNIQUE
+		)
+	`
+	if _, err := db.Exec(createTableQuery); err != nil {
+		t.Fatalf("unexpected error creating test table: %s", err)
+	}
+}
+
 func makeTestValues(tableSizeFactor, payloadSize int) [][]any {
 	var expectedValues [][]any
 	for i := 0; i < MaxNumPostgresParameters*tableSizeFactor; i++ {
@@ -191,6 +236,21 @@ func testInsert(t testing.TB, db *sql.DB, expectedValues [][]any) {
 	ctx := context.Background()
 
 	inserter := NewInserter(ctx, db, "batch_inserter_test", MaxNumPostgresParameters, "col1", "col2", "col3", "col4", "col5")
+	for _, values := range expectedValues {
+		if err := inserter.Insert(ctx, values...); err != nil {
+			t.Fatalf("unexpected error inserting values: %s", err)
+		}
+	}
+
+	if err := inserter.Flush(ctx); err != nil {
+		t.Fatalf("unexpected error flushing: %s", err)
+	}
+}
+
+func testInsertThin(t testing.TB, db *sql.DB, expectedValues [][]any) {
+	ctx := context.Background()
+
+	inserter := NewInserter(ctx, db, "batch_inserter_test_thin", MaxNumPostgresParameters, "col1")
 	for _, values := range expectedValues {
 		if err := inserter.Insert(ctx, values...); err != nil {
 			t.Fatalf("unexpected error inserting values: %s", err)

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -22,7 +22,8 @@ func TestBatchInserter(t *testing.T) {
 	db := dbtest.NewDB(logger, t)
 	setupTestTable(t, db)
 
-	expectedValues := makeTestValues(2, 0)
+	tableSizeFactor := 2
+	expectedValues := makeTestValues(tableSizeFactor, 0)
 	testInsert(t, db, expectedValues)
 
 	rows, err := db.Query("SELECT col1, col2, col3, col4, col5 from batch_inserter_test")


### PR DESCRIPTION
There's an extended Postgres write protocol that allows us to send 2x as much in a batch inserter call.

## Test plan

Updated unit tests.