### PR TITLE
ci: install asdf deps on Publish Executor step

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,7 +15,7 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" ]]; then
     asdf install golang
   elif [[ "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
     echo "pipeline-upload step: skipping asdf install"
-  elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" ]]; then
+  elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" && ! "${BUILDKITE_STEP_KEY:-""}" =~  "Publishexecutorimage" ]]; then
     echo "publish image step: skipping asdf install"
   else
     echo "running normal install"


### PR DESCRIPTION
`aws` is missing on `Publish Exeuctor Image` steps because the `asdf` install step is skipped
## Test plan
```
sourcegraph on  main [$!?] via 🐹 v1.19.8 took 5s
❯ BUILDKITE_GROUP_KEY="Publishimages" BUILDKITE_STEP_KEY="packerwhitecheckmarkPublishexecutoriage" .buildkite/hooks/pre-command
~~~ Preparing asdf dependencies
publish image step: skipping asdf install

sourcegraph on  main [$!?] via 🐹 v1.19.8
❯ BUILDKITE_GROUP_KEY="Publishimages" BUILDKITE_STEP_KEY="packerwhitecheckmarkPublishexecutorimage" .buildkite/hooks/pre-command
~~~ Preparing asdf dependencies
running normal install
asdf install
fd plugin is not installed
shfmt plugin is not installed
shellcheck plugin is not installed
kubectl plugin is not installed
github-cli plugin is not installed
packer plugin is not installed
trivy plugin is not installed
kustomize plugin is not installed
awscli plugin is not installed
python plugin is not installed
rust plugin is not installed```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
