### PR TITLE
mvu: handle missing 'auto_upgrade' column in versions table

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -3973,6 +3973,14 @@ def go_dependencies():
         version = "v1.10.1",
     )
     go_repository(
+        name = "com_github_jackc_pgerrcode",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/jackc/pgerrcode",
+        sum = "h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=",
+        version = "v0.0.0-20220416144525-469b46aa5efa",
+    )
+
+    go_repository(
         name = "com_github_jackc_pgio",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/jackc/pgio",
@@ -6334,13 +6342,13 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
+        patch_args = ["-p1"],
         patches = [
             "//third_party/com_github_sourcegraph_zoekt:zoekt_archive_index.patch",
             "//third_party/com_github_sourcegraph_zoekt:zoekt_git_index.patch",
             "//third_party/com_github_sourcegraph_zoekt:zoekt_webserver.patch",
             "//third_party/com_github_sourcegraph_zoekt:zoekt_indexserver.patch",
         ],
-        patch_args = ["-p1"],
         sum = "h1:lCxBFbLdzt0m789CNyYWEqPURhta69aRA9ixPyWilvI=",
         version = "v0.0.0-20230503105159-f818d968ddad",
     )

--- a/go.mod
+++ b/go.mod
@@ -263,7 +263,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/go-redsync/redsync/v4 v4.8.1
+require (
+	github.com/go-redsync/redsync/v4 v4.8.1
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
+)
 
 require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
@@ -297,7 +300,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -297,6 +297,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1382,6 +1382,8 @@ github.com/jackc/pgconn v1.9.0/go.mod h1:YctiPyvzfU11JFxoXokUOOKQXQmDMoJL9vJzHH8
 github.com/jackc/pgconn v1.9.1-0.20210724152538-d89c8390a530/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
 github.com/jackc/pgconn v1.10.1 h1:DzdIHIjG1AxGwoEEqS+mGsURyjt4enSmqzACXvVzOT8=
 github.com/jackc/pgconn v1.10.1/go.mod h1:4z2w8XhRbP1hYxkpTuBjTS3ne3J48K83+u0zoyvg2pI=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
+github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=

--- a/internal/version/upgradestore/BUILD.bazel
+++ b/internal/version/upgradestore/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "//internal/database/basestore",
         "//lib/errors",
         "@com_github_jackc_pgconn//:pgconn",
-        "@com_github_jackc_pgerrcode//:go_default_library",
+        "@com_github_jackc_pgerrcode//:pgerrcode",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_masterminds_semver//:semver",
     ],

--- a/internal/version/upgradestore/BUILD.bazel
+++ b/internal/version/upgradestore/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//internal/database/basestore",
         "//lib/errors",
         "@com_github_jackc_pgconn//:pgconn",
+        "@com_github_jackc_pgerrcode//:go_default_library",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_masterminds_semver//:semver",
     ],

--- a/internal/version/upgradestore/store.go
+++ b/internal/version/upgradestore/store.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -145,6 +146,14 @@ func isMissingRelation(err error) bool {
 // GetAutoUpgrade gets the current value of versions.version and versions.auto_upgrade in the frontend database.
 func (s *store) GetAutoUpgrade(ctx context.Context) (version string, enabled bool, err error) {
 	if err = s.db.QueryRow(ctx, sqlf.Sprintf(getAutoUpgradeQuery)).Scan(&version, &enabled); err != nil {
+		var pgerr *pgconn.PgError
+		if errors.As(err, &pgerr) {
+			if pgerr.Code == pgerrcode.UndefinedColumn {
+				if err = s.db.QueryRow(ctx, sqlf.Sprintf(getAutoUpgradeFallbackQuery)).Scan(&version); err != nil {
+					return "", false, errors.Wrap(err, "failed to get frontend version from fallback")
+				}
+			}
+		}
 		return "", false, errors.Wrap(err, "failed to get frontend version and auto_upgrade state")
 	}
 	return version, enabled, nil
@@ -152,6 +161,10 @@ func (s *store) GetAutoUpgrade(ctx context.Context) (version string, enabled boo
 
 const getAutoUpgradeQuery = `
 SELECT version, auto_upgrade FROM versions WHERE service = 'frontend'
+`
+
+const getAutoUpgradeFallbackQuery = `
+SELECT version FROM versions WHERE service = 'frontend'
 `
 
 // SetAutoUpgrade sets the value of versions.auto_upgrade in the frontend database.

--- a/internal/version/upgradestore/store.go
+++ b/internal/version/upgradestore/store.go
@@ -140,7 +140,7 @@ func isMissingRelation(err error) bool {
 		return false
 	}
 
-	return pgErr.Code == "42P01"
+	return pgErr.Code == pgerrcode.UndefinedTable
 }
 
 // GetAutoUpgrade gets the current value of versions.version and versions.auto_upgrade in the frontend database.


### PR DESCRIPTION
This column was first added in 5.0.0, so trying to run a migrator from a version containing https://github.com/sourcegraph/sourcegraph/pull/48787 (no tagged release yet) or later on an instance pre-5.0.0 would result in `checking auto upgrade: failed to get frontend version and auto_upgrade state: ERROR: column \"auto_upgrade\" does not exist (SQLSTATE 42703)`

## Test plan

Tested locally on a full upgrade from 3.33.0 to 5.0.1
