### PR TITLE
codeintel: Fix nil pointer in summary resolver when repos are deleted

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/store/coverage.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/coverage.go
@@ -72,11 +72,15 @@ func (s *store) RepositoryIDsWithConfiguration(ctx context.Context, offset, limi
 
 const repositoriesWithConfigurationQuery = `
 SELECT
-	repository_id,
-	available_indexers,
+	r.id,
+	cai.available_indexers,
 	COUNT(*) OVER() AS count
-FROM cached_available_indexers
-WHERE available_indexers != '{}'::jsonb
+FROM cached_available_indexers cai
+JOIN repo r ON r.id = cai.repository_id
+WHERE
+	available_indexers != '{}'::jsonb AND
+	r.deleted_at IS NULL AND
+	r.blocked IS NULL
 ORDER BY num_events DESC
 LIMIT %s
 OFFSET %s

--- a/enterprise/internal/codeintel/uploads/internal/store/summary.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/summary.go
@@ -301,7 +301,7 @@ WITH
 -- perform below.
 candidates_from_uploads AS (
 	SELECT u.repository_id
-	FROM lsif_uploads u
+	FROM lsif_uploads_with_repository_name u
 	WHERE
 		u.state = 'failed' AND
 		NOT EXISTS (


### PR DESCRIPTION
Ensure we don't return ids/aggregate data for repositories that have been deleted since the calculation.

## Test plan

Existing unit tests.