### PR TITLE
Cody: Tweak "connect to App" feature and remove experimental flag

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -9,7 +9,6 @@ export interface Configuration {
     experimentalSuggest: boolean
     experimentalChatPredictions: boolean
     experimentalInline: boolean
-    experimentalConnectToApp: boolean
     customHeaders: Record<string, string>
 }
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -390,10 +390,6 @@
           "markdownDescription": "Enables inline chat with cody inside the code editor window",
           "default": false
         },
-        "cody.experimental.connectToApp": {
-          "type": "boolean",
-          "default": false
-        },
         "cody.customHeaders": {
           "order": 8,
           "type": "object",

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -50,7 +50,6 @@ type Config = Pick<
     | 'accessToken'
     | 'useContext'
     | 'experimentalChatPredictions'
-    | 'experimentalConnectToApp'
 >
 
 export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
@@ -585,7 +584,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             })
 
             // Ensure local app detector is running
-            if (this.config.experimentalConnectToApp && !isAuthed) {
+            if (!isAuthed) {
                 this.localAppDetector.start()
             } else {
                 this.localAppDetector.stop()
@@ -595,7 +594,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 debug: this.config.debug,
                 serverEndpoint: this.config.serverEndpoint,
                 hasAccessToken: isAuthed,
-                experimentalConnectToApp: this.config.experimentalConnectToApp,
             }
             void vscode.commands.executeCommand('setContext', 'cody.activated', isAuthed)
             void this.webview?.postMessage({ type: 'config', config: configForWebview })

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -42,8 +42,7 @@ export type ExtensionMessage =
 /**
  * The subset of configuration that is visible to the webview.
  */
-export interface ConfigurationSubsetForWebview
-    extends Pick<Configuration, 'debug' | 'serverEndpoint' | 'experimentalConnectToApp'> {
+export interface ConfigurationSubsetForWebview extends Pick<Configuration, 'debug' | 'serverEndpoint'> {
     hasAccessToken: boolean
 }
 

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -21,7 +21,6 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         experimentalSuggest: config.get('cody.experimental.suggestions', false),
         experimentalChatPredictions: config.get('cody.experimental.chatPredictions', false),
         experimentalInline: config.get('cody.experimental.inline', false),
-        experimentalConnectToApp: config.get('cody.experimental.connectToApp', false),
         customHeaders: config.get<object>('cody.customHeaders', {}) as Record<string, string>,
     }
 }

--- a/client/cody/src/local-app-detector.ts
+++ b/client/cody/src/local-app-detector.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import { homedir, platform, type } from 'os'
+import { homedir, platform } from 'os'
 
 import { Disposable } from 'vscode'
 

--- a/client/cody/src/local-app-detector.ts
+++ b/client/cody/src/local-app-detector.ts
@@ -61,9 +61,6 @@ export class LocalAppDetector implements Disposable {
     }
 
     public start(): void {
-        console.log('platform', platform())
-        console.log('type', type())
-
         if (this.intervalHandle !== undefined) {
             return
         }

--- a/client/cody/src/local-app-detector.ts
+++ b/client/cody/src/local-app-detector.ts
@@ -3,9 +3,9 @@ import { homedir } from 'os'
 
 import { Disposable } from 'vscode'
 
-const INTERVAL = 5000
+const INTERVAL = 10000
 
-const LOCAL_APP_LOCATIONS = ['~/Library/Application Support/sourcegraph', '~/Applications/Sourcegraph App.app']
+const LOCAL_APP_LOCATIONS = ['~/Library/Application Support/sourcegraph']
 
 async function pathExists(path: string): Promise<boolean> {
     path = expandHomeDir(path)

--- a/client/cody/webviews/App.story.tsx
+++ b/client/cody/webviews/App.story.tsx
@@ -46,7 +46,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 debug: true,
                 hasAccessToken: true,
                 serverEndpoint: 'https://example.com',
-                experimentalConnectToApp: false,
             },
         })
         return () => {}

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -18,10 +18,7 @@ import { UserHistory } from './UserHistory'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<Pick<
-        Configuration,
-        'debug' | 'serverEndpoint' | 'experimentalConnectToApp'
-    > | null>(null)
+    const [config, setConfig] = useState<Pick<Configuration, 'debug' | 'serverEndpoint'> | null>(null)
     const [debugLog, setDebugLog] = useState<string[]>([])
     const [view, setView] = useState<View | undefined>()
     const [messageInProgress, setMessageInProgress] = useState<ChatMessage | null>(null)
@@ -123,7 +120,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     serverEndpoint={config?.serverEndpoint}
                     isAppInstalled={isAppInstalled}
                     vscodeAPI={vscodeAPI}
-                    enableConnectToApp={config?.experimentalConnectToApp}
                 />
             )}
             {view !== 'login' && <NavBar view={view} setView={setView} devMode={Boolean(config?.debug)} />}

--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -3,7 +3,6 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import { VSCodeWrapper } from './utils/VSCodeApi'
 
 interface ConnectAppProps {
-    isAppInstalled: boolean
     vscodeAPI: VSCodeWrapper
 }
 
@@ -20,15 +19,9 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = props => {
         <p>
             <VSCodeButton
                 type="button"
-                onClick={() =>
-                    openLink(
-                        props.isAppInstalled
-                            ? 'sourcegraph://user/settings/tokens/new/callback?requestFrom=CODY'
-                            : 'https://about.sourcegraph.com/app'
-                    )
-                }
+                onClick={() => openLink('sourcegraph://user/settings/tokens/new/callback?requestFrom=CODY')}
             >
-                {props.isAppInstalled ? 'Connect Sourcegraph App' : 'Get Sourcegraph App'}
+                Connect Sourcegraph App
             </VSCodeButton>
         </p>
     )

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -17,7 +17,6 @@ interface LoginProps {
     serverEndpoint?: string
     isAppInstalled: boolean
     vscodeAPI: VSCodeWrapper
-    enableConnectToApp?: boolean
 }
 
 export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>> = ({
@@ -26,7 +25,6 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     serverEndpoint,
     isAppInstalled,
     vscodeAPI,
-    enableConnectToApp,
 }) => {
     const [token, setToken] = useState<string>('')
     const [endpoint, setEndpoint] = useState(serverEndpoint)
@@ -91,7 +89,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
                         Continue with Sourcegraph.com
                     </VSCodeButton>
                 </a>
-                {enableConnectToApp && <ConnectApp isAppInstalled={isAppInstalled} vscodeAPI={vscodeAPI} />}
+                {isAppInstalled && <ConnectApp vscodeAPI={vscodeAPI} />}
             </section>
             <div
                 className={styles.terms}

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -2,6 +2,10 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
 import './Settings.css'
 
+import { useMemo } from 'react'
+
+import { LOCAL_APP_URL } from '../src/chat/protocol'
+
 interface SettingsProps {
     onLogout: () => void
     serverEndpoint?: string
@@ -10,15 +14,18 @@ interface SettingsProps {
 export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsProps>> = ({
     onLogout,
     serverEndpoint,
-}) => (
-    <div className="inner-container">
-        <div className="non-transcript-container">
-            <div className="settings">
-                {serverEndpoint && <p>🟢 Connected to {serverEndpoint}</p>}
-                <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
-                    Logout
-                </VSCodeButton>
+}) => {
+    const isLocalApp = useMemo(() => serverEndpoint === LOCAL_APP_URL.toString(), [serverEndpoint])
+    return (
+        <div className="inner-container">
+            <div className="non-transcript-container">
+                <div className="settings">
+                    {serverEndpoint && <p>🟢 Connected to {isLocalApp ? 'Sourcegraph App' : serverEndpoint}</p>}
+                    <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
+                        Logout
+                    </VSCodeButton>
+                </div>
             </div>
         </div>
-    </div>
-)
+    )
+}

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -2,10 +2,6 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
 import './Settings.css'
 
-import { useMemo } from 'react'
-
-import { LOCAL_APP_URL } from '../src/chat/protocol'
-
 interface SettingsProps {
     onLogout: () => void
     serverEndpoint?: string
@@ -14,18 +10,15 @@ interface SettingsProps {
 export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsProps>> = ({
     onLogout,
     serverEndpoint,
-}) => {
-    const isLocalApp = useMemo(() => serverEndpoint === LOCAL_APP_URL.toString(), [serverEndpoint])
-    return (
-        <div className="inner-container">
-            <div className="non-transcript-container">
-                <div className="settings">
-                    {serverEndpoint && <p>🟢 Connected to {isLocalApp ? 'Sourcegraph App' : serverEndpoint}</p>}
-                    <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
-                        Logout
-                    </VSCodeButton>
-                </div>
+}) => (
+    <div className="inner-container">
+        <div className="non-transcript-container">
+            <div className="settings">
+                {serverEndpoint && <p>🟢 Connected to {serverEndpoint}</p>}
+                <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
+                    Logout
+                </VSCodeButton>
             </div>
         </div>
-    )
-}
+    </div>
+)


### PR DESCRIPTION
Change the App button behavior in the Cody VSCE:

- Show "Connect to Sourcegraph App" always when App is detected as being installed, without being behind a feature flag. (This detects new upcoming releases of App only)
- Do not show any App download CTA when it's not installed. We will re-add the App download CTA when we have a release of App that we're ready to share more widely.

This removes the "experimental.connectToApp" settings flag in the Cody extension.

Also, improve the App detector, changing the known App locations to be per-platform (supporting mac for now).

## Test plan

- Without App installed, check that Cody VSCode behavior is unchanged.
- Install a new build of App
- Check that "Connect to Sourcegraph App" button appears and that it works
