### PR TITLE
Default to allowing Perforce code hosts

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1545,7 +1545,7 @@ export const codeHostExternalServices: Record<string, AddExternalServiceOptions>
     ...(window.context?.experimentalFeatures?.goPackages === 'enabled' ? { goModules: GO_MODULES } : {}),
     ...(window.context?.experimentalFeatures?.jvmPackages === 'enabled' ? { jvmPackages: JVM_PACKAGES } : {}),
     ...(window.context?.experimentalFeatures?.npmPackages === 'enabled' ? { npmPackages: NPM_PACKAGES } : {}),
-    ...(window.context?.experimentalFeatures?.perforce === 'enabled' ? { perforce: PERFORCE } : {}),
+    ...(window.context?.experimentalFeatures?.perforce !== 'disabled' ? { perforce: PERFORCE } : {}),
     ...(window.context?.experimentalFeatures?.pagure === 'enabled' ? { pagure: PAGURE } : {}),
 }
 


### PR DESCRIPTION
Unless explicitly disabled in `experimentalFeatures`

## Test plan

Navigate to `Site configuration` and confirm that `perforce` is not in `experimentalFeatures`

<img width="491" alt="no Perforce in experimentalFeatures" src="https://github.com/sourcegraph/sourcegraph/assets/129280/5ac904a1-7e0d-4082-a68c-0c7d51131e6b">

Then add a code host and confirm that Perforce is an option in the list of code hosts

<img width="929" alt="Perforce in code hosts" src="https://github.com/sourcegraph/sourcegraph/assets/129280/d35ec4aa-eca7-4a57-ab77-7e75e4a1bbdb">

