### PR TITLE
Observation: add an option to use OTel attrs rather than Opentracing fields

### DIFF
--- a/cmd/frontend/internal/highlight/highlight.go
+++ b/cmd/frontend/internal/highlight/highlight.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
@@ -336,15 +335,15 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		filetypeQuery.Engine = EngineSyntect
 	}
 
-	ctx, errCollector, trace, endObservation := getHighlightOp().WithErrorsAndLogger(ctx, &err, observation.Args{LogFields: []otlog.Field{
-		otlog.String("revision", p.Metadata.Revision),
-		otlog.String("repo", p.Metadata.RepoName),
-		otlog.String("fileExtension", filepath.Ext(p.Filepath)),
-		otlog.String("filepath", p.Filepath),
-		otlog.Int("sizeBytes", len(p.Content)),
-		otlog.Bool("highlightLongLines", p.HighlightLongLines),
-		otlog.Bool("disableTimeout", p.DisableTimeout),
-		otlog.String("syntaxEngine", filetypeQuery.Engine.String()),
+	ctx, errCollector, trace, endObservation := getHighlightOp().WithErrorsAndLogger(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("revision", p.Metadata.Revision),
+		attribute.String("repo", p.Metadata.RepoName),
+		attribute.String("fileExtension", filepath.Ext(p.Filepath)),
+		attribute.String("filepath", p.Filepath),
+		attribute.Int("sizeBytes", len(p.Content)),
+		attribute.Bool("highlightLongLines", p.HighlightLongLines),
+		attribute.Bool("disableTimeout", p.DisableTimeout),
+		attribute.Stringer("syntaxEngine", filetypeQuery.Engine),
 	}})
 	defer endObservation(1, observation.Args{})
 


### PR DESCRIPTION
This adds an additional `Attrs` field to the `observation.Args` type that can be used instead of `LogFields`. Before they are actually used, `LogFields` and `Attrs` will be merged, so right now, using either one will work fine.

This allows us to incrementally remove more dependencies on the opentracing log fields rather than having to convert every usage of `Args.LogFields` at once, which would be intense.

There are two commits in this PR. The first adds the new field, marks the old one as deprecated, and updates the dependents of `LogFields` to also respect `Attrs`. The second commit is an example migration of `LogFields` to `Attrs`.

## Test plan

Unit tests. The change itself is pretty minimal. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
