### PR TITLE
fix unnecessary re-renders of components

### DIFF
--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -264,12 +264,13 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
         },
         render: ({ resolvedRev: { commitID }, match, repoHeaderContributionsLifecycleProps, ...context }: any) => (
             <>
-                <RepositoryDocumentationPage
+                const memoizedRepositoryDocumentationPage = React.useMemo(() => <RepositoryDocumentationPage
                     {...context}
                     match={match}
                     commitID={commitID}
                     pathID={match.params.pathID ? '/' + decodeURIComponent(match.params.pathID) : '/'}
-                />
+                />, [context, match, commitID, match.params.pathID]);
+                <>{memoizedRepositoryDocumentationPage}
                 <ActionItemsBar
                     useActionItemsBar={context.useActionItemsBar}
                     location={context.location}


### PR DESCRIPTION
**Root Cause:**
Unnecessary re-rendering of components due to state changes in the search box on every keystroke.

**Resolution:**
1. Use the React useMemo hook to prevent unnecessary re-renders of components. This will ensure that the components only re-render when the props they depend on change.
