### PR TITLE
cody: change logic for cody-web-all

### DIFF
--- a/client/web/src/cody/useIsCodyEnabled.tsx
+++ b/client/web/src/cody/useIsCodyEnabled.tsx
@@ -26,10 +26,14 @@ export const useIsCodyEnabled = (): { chat: boolean; sidebar: boolean; search: b
         return notEnabled
     }
 
+    if (!allEnabled) {
+        return notEnabled
+    }
+
     return {
-        chat: chatEnabled || allEnabled,
-        sidebar: sidebarEnabled || allEnabled,
-        search: searchEnabled || allEnabled,
-        editorRecipes: (editorRecipesEnabled && sidebarEnabled) || allEnabled,
+        chat: chatEnabled,
+        sidebar: sidebarEnabled,
+        search: searchEnabled,
+        editorRecipes: (editorRecipesEnabled && sidebarEnabled),
     }
 }


### PR DESCRIPTION
this changes the behaviour of the `cody-web-all` feature flag to enable more fine grained control on the subsequent flags `cody-web-chat`, `cody-web-sidebar`, `cody-web-search`, and `cody-web-editor-recipes`


if `cody-web-all` is `false`, it will turn off all features. 

if `cody-web-all` is `true`, it will use each subsequent flag's boolean value to determine if the feature is on or off.

this was raised in [conversation](https://sourcegraph.slack.com/archives/C04MZPE4JKD/p1684189294232839?thread_ts=1684181007.730419&cid=C04MZPE4JKD) when we were confused on what the difference `cody-web-chat` and `cody-web-sidebar` was and how to enable the features

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
