### PR TITLE
productsubscription: separate read-only and read-write service accounts

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account.go
@@ -8,16 +8,53 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
-// featureFlagProductSubscriptionsServiceAccount is a feature flag that should be
-// set on service accounts that can read product subscriptions.
-const featureFlagProductSubscriptionsServiceAccount = "product-subscriptions-service-account"
+const (
+	// featureFlagProductSubscriptionsServiceAccount is a feature flag that should be
+	// set on service accounts that can read AND write product subscriptions.
+	featureFlagProductSubscriptionsServiceAccount = "product-subscriptions-service-account"
+
+	// featureFlagProductSubscriptionsReaderServiceAccount is a feature flag that should be
+	// set on service accounts that can only read product subscriptions.
+	featureFlagProductSubscriptionsReaderServiceAccount = "product-subscriptions-reader-service-account"
+)
+
+// 🚨 SECURITY: Use this to check if access to a subscription query or mutation
+// is authorized for service accounts and site admins.
+func serviceAccountOrSiteAdmin(
+	ctx context.Context,
+	db database.DB,
+	// requiresWriterServiceAccount, if true, requires "product-subscriptions-service-account",
+	// otherwise just "product-subscriptions-reader-service-account" is sufficient.
+	requiresWriterServiceAccount bool,
+) error {
+	return serviceAccountOrOwnerOrSiteAdmin(ctx, db, nil, requiresWriterServiceAccount)
+}
 
 // 🚨 SECURITY: Use this to check if access to a subscription query or mutation
 // is authorized for service accounts, the owning user, and site admins.
-func serviceAccountOrOwnerOrSiteAdmin(ctx context.Context, db database.DB, ownerUserID *int32) error {
-	// Check if the user is a service account.
-	if featureflag.FromContext(ctx).GetBoolOr(featureFlagProductSubscriptionsServiceAccount, false) {
-		return nil
+func serviceAccountOrOwnerOrSiteAdmin(
+	ctx context.Context,
+	db database.DB,
+	ownerUserID *int32,
+	// requiresWriterServiceAccount, if true, requires "product-subscriptions-service-account",
+	// otherwise just "product-subscriptions-reader-service-account" is sufficient.
+	requiresWriterServiceAccount bool,
+) error {
+	// Check if the user is has the prerequisite service account.
+	serviceAccountIsWriter := featureflag.FromContext(ctx).GetBoolOr(featureFlagProductSubscriptionsServiceAccount, false)
+	if requiresWriterServiceAccount {
+		// 🚨 SECURITY: Require the more strict featureFlagProductSubscriptionsServiceAccount
+		// if requiresWriterServiceAccount=true
+		if serviceAccountIsWriter {
+			return nil
+		}
+		// Otherwise, fall through to check if actor is owner or site admin.
+	} else {
+		// If requiresWriterServiceAccount==false, then just
+		// featureFlagProductSubscriptionsReaderServiceAccount is sufficient.
+		if serviceAccountIsWriter || featureflag.FromContext(ctx).GetBoolOr(featureFlagProductSubscriptionsReaderServiceAccount, false) {
+			return nil
+		}
 	}
 
 	// If ownerUserID is specified, the user must be the owner, or a site admin.

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account_test.go
@@ -19,9 +19,19 @@ func TestServiceAccountOrOwnerOrSiteAdmin(t *testing.T) {
 		name           string
 		featureFlags   map[string]bool
 		actorSiteAdmin bool
-		ownerUserID    *int32
-		wantErr        autogold.Value
+
+		ownerUserID            *int32
+		serviceAccountCanWrite bool
+
+		wantErr autogold.Value
 	}{
+		{
+			name: "reader service account",
+			featureFlags: map[string]bool{
+				featureFlagProductSubscriptionsReaderServiceAccount: true,
+			},
+			wantErr: nil,
+		},
 		{
 			name: "service account",
 			featureFlags: map[string]bool{
@@ -54,8 +64,27 @@ func TestServiceAccountOrOwnerOrSiteAdmin(t *testing.T) {
 			name:    "not a site admin, not accessing a user-specific resource",
 			wantErr: autogold.Expect("must be site admin"),
 		},
+		{
+			name: "service account needs writer flag",
+			featureFlags: map[string]bool{
+				featureFlagProductSubscriptionsReaderServiceAccount: true,
+			},
+			serviceAccountCanWrite: true,
+			wantErr:                autogold.Expect("must be site admin"),
+		},
+		{
+			name: "service account fulfills writer flag",
+			featureFlags: map[string]bool{
+				featureFlagProductSubscriptionsServiceAccount: true,
+			},
+			serviceAccountCanWrite: true,
+			wantErr:                nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
 			db := database.NewMockDB()
 			mockUsers := database.NewMockUserStore()
 
@@ -72,6 +101,7 @@ func TestServiceAccountOrOwnerOrSiteAdmin(t *testing.T) {
 				actor.WithActor(ctx, &actor.Actor{UID: actorID}),
 				db,
 				tc.ownerUserID,
+				tc.serviceAccountCanWrite,
 			)
 			if tc.wantErr != nil {
 				require.Error(t, err)

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -59,7 +59,7 @@ func productSubscriptionByDBID(ctx context.Context, db database.DB, id string) (
 		return nil, err
 	}
 	// 🚨 SECURITY: Only site admins and the subscription account's user may view a product subscription.
-	if err := serviceAccountOrOwnerOrSiteAdmin(ctx, db, &v.UserID); err != nil {
+	if err := serviceAccountOrOwnerOrSiteAdmin(ctx, db, &v.UserID, false); err != nil {
 		return nil, err
 	}
 	return &productSubscription{v: v, db: db}, nil
@@ -226,8 +226,8 @@ func (r ProductSubscriptionLicensingResolver) CreateProductSubscription(ctx cont
 }
 
 func (r ProductSubscriptionLicensingResolver) UpdateProductSubscription(ctx context.Context, args *graphqlbackend.UpdateProductSubscriptionArgs) (*graphqlbackend.EmptyResponse, error) {
-	// 🚨 SECURITY: Only site admins may update product subscriptions.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
+	// 🚨 SECURITY: Only site admins or the service accounts may update product subscriptions.
+	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
 		return nil, err
 	}
 
@@ -281,7 +281,7 @@ func (r ProductSubscriptionLicensingResolver) ProductSubscriptions(ctx context.C
 
 	// 🚨 SECURITY: Users may only list their own product subscriptions. Site admins may list
 	// licenses for all users, or for any other user.
-	if err := serviceAccountOrOwnerOrSiteAdmin(ctx, r.DB, accountUserID); err != nil {
+	if err := serviceAccountOrOwnerOrSiteAdmin(ctx, r.DB, accountUserID, false); err != nil {
 		return nil, err
 	}
 	var opt dbSubscriptionsListOptions

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql.go
@@ -20,7 +20,7 @@ func defaultAccessToken(rawToken []byte) string {
 // given access token.
 func (r ProductSubscriptionLicensingResolver) ProductSubscriptionByAccessToken(ctx context.Context, args *graphqlbackend.ProductSubscriptionByAccessTokenArgs) (graphqlbackend.ProductSubscription, error) {
 	// 🚨 SECURITY: Only specific entities may use this functionality.
-	if err := serviceAccountOrOwnerOrSiteAdmin(ctx, r.DB, nil); err != nil {
+	if err := serviceAccountOrSiteAdmin(ctx, r.DB, false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds a read-only tier of service accounts for `productsubscription`, again implemented by feature flag:

- `product-subscriptions-service-account` (existing flag in use): read AND write
- `product-subscriptions-reader-service-account` (new flag): read-only

The read/write account can now also make updates to product subscriptions, currently only LLM-proxy access traits. This will be useful for automated provisioning i.e. https://github.com/sourcegraph/controller/pull/637


## Test plan

Unit test on auth checks
