### PR TITLE
llmproxy: switch default endpoint to completions.sourcegraph.com

### DIFF
--- a/enterprise/internal/completions/client/llmproxy/llmproxy.go
+++ b/enterprise/internal/completions/client/llmproxy/llmproxy.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	ProviderName    = "llmproxy"
-	DefaultEndpoint = "https://completions.sgdev.org/v1/completions/anthropic"
+	DefaultEndpoint = "https://completions.sourcegraph.com/v1/completions/anthropic"
 )
 
 type llmProxyAnthropicClient struct {


### PR DESCRIPTION
This is where the real prod goodness is

## Test plan

n/a