### PR TITLE
llmproxy: Fix panic in rate limiter

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -127,9 +127,8 @@ func rateLimit(logger log.Logger, eventLogger events.Logger, cache limiter.Redis
 		l := act.Limiter(cache)
 
 		err := l.TryAcquire(r.Context())
-
 		if err != nil {
-			err := eventLogger.LogEvent(
+			loggerErr := eventLogger.LogEvent(
 				events.Event{
 					Name:       llmproxy.EventNameRateLimited,
 					Source:     act.Source.Name(),
@@ -139,8 +138,8 @@ func rateLimit(logger log.Logger, eventLogger events.Logger, cache limiter.Redis
 					},
 				},
 			)
-			if err != nil {
-				logger.Error("failed to log event", log.Error(err))
+			if loggerErr != nil {
+				logger.Error("failed to log event", log.Error(loggerErr))
 			}
 
 			var rateLimitExceeded limiter.RateLimitExceededError
@@ -155,6 +154,7 @@ func rateLimit(logger log.Logger, eventLogger events.Logger, cache limiter.Redis
 			}
 
 			response.JSONError(logger, w, http.StatusInternalServerError, err)
+			return
 		}
 
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
This fixes an issue in the rate limiter where we overwrote err and thus called err.Error() on a nil error if logging didn't fail. Also added a missing return statement.

## Test plan

Verified no more panics when rate limited.