### PR TITLE
llm-proxy: configure otel middleware with otelhttp.WithPublicEndpoint

### DIFF
--- a/enterprise/cmd/llm-proxy/shared/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/shared/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_googlecloudplatform_opentelemetry_operations_go_exporter_trace//:trace",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_contrib_detectors_gcp//:gcp",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:otelhttp",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//semconv/v1.7.0:v1_7_0",
         "@io_opentelemetry_go_otel_sdk//resource",

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/redigo"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/events"
 	llmproxy "github.com/sourcegraph/sourcegraph/enterprise/internal/llm-proxy"
@@ -79,7 +80,8 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 
 	// Instrumentation layers
 	handler = httpLogger(obctx.Logger.Scoped("httpAPI", ""), handler)
-	handler = instrumentation.HTTPMiddleware("llm-proxy", handler)
+	handler = instrumentation.HTTPMiddleware("llm-proxy", handler,
+		otelhttp.WithPublicEndpoint())
 
 	// Collect request client for downstream handlers. Outside of dev, we always set up
 	// Cloudflare in from of LLM-proxy. This comes first.


### PR DESCRIPTION
Connects to the incoming span as a **link** instead of as a parent span. Since llm-proxy is hosted in a separate project, using a parent span will show up as an error since it's expected that the span will show up, when in fact it never will.

## Test plan

n/a
