### PR TITLE
llmproxy: Backport rate limiter fix from #51899

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/limiter/limiter.go
+++ b/enterprise/cmd/llm-proxy/internal/limiter/limiter.go
@@ -30,35 +30,25 @@ type StaticLimiter struct {
 func (l StaticLimiter) TryAcquire(ctx context.Context) error {
 	// Zero values implies no access - this is a fallback check, callers should
 	// be checking independently if access is granted.
-	if l.Identifier == "" || l.Limit == 0 || l.Interval == 0 {
+	if l.Identifier == "" || l.Limit <= 0 || l.Interval <= 0 {
 		return NoAccessError{}
 	}
 
-	// Check the current usage and increment the counter for the current user. If
-	// no record exists, redis will initialize it with 1.
-	currentUsage, err := l.Redis.Incr(l.Identifier)
+	// Check the current usage. If no record exists, redis will return 0.
+	currentUsage, err := l.Redis.GetInt(l.Identifier)
 	if err != nil {
-		return errors.Wrap(err, "failed to increase rate limit counter")
-	}
-
-	// Set expiry on the key. If existing TTL has not yet been set, or TTL is
-	// longer than the desired interval (indicates that the rate limit interval
-	// has changed and been shortened)
-	ttl, err := l.Redis.TTL(l.Identifier)
-	if err != nil {
-		return errors.Wrap(err, "failed to get TTL for rate limit counter")
-	}
-	intervalSeconds := int(l.Interval / time.Second)
-	if ttl < 0 || (l.UpdateRateLimitTTL && ttl > intervalSeconds) {
-		if err := l.Redis.Expire(l.Identifier, intervalSeconds); err != nil {
-			return errors.Wrap(err, "failed to set expiry for rate limit counter")
-		}
+		return errors.Wrap(err, "failed to read rate limit counter")
 	}
 
 	// If the usage exceeds the maximum, we return an error. Consumers can check if
 	// the error is of type RateLimitExceededError and extract additional information
 	// like the limit and the time by when they should retry.
-	if currentUsage > l.Limit {
+	if currentUsage >= l.Limit {
+		// Read TTL to compute the RetryAfter time.
+		ttl, err := l.Redis.TTL(l.Identifier)
+		if err != nil {
+			return errors.Wrap(err, "failed to get TTL for rate limit counter")
+		}
 		var now time.Time
 		if l.nowFunc != nil {
 			now = l.nowFunc()
@@ -72,6 +62,42 @@ func (l StaticLimiter) TryAcquire(ctx context.Context) error {
 			// on every check, even if the limit was reached.
 			Used:       min(currentUsage, l.Limit),
 			RetryAfter: now.Add(time.Duration(ttl) * time.Second),
+		}
+	}
+
+	// Now that we know that we want to let the user pass, let's increment the rate
+	// limit counter for the user.
+	// Note that the rate limiter _may_ allow slightly more requests than the configured
+	// limit, incrementing the rate limit counter and reading the usage futher up are currently
+	// not an atomic operation, because there is no good way to read the TTL in a transaction
+	// without a lua script.
+	// This approach could also slightly overcount the usage if redis requests after
+	// the INCR fail, but it will always recover safely.
+	// If Incr works but then everything else fails (eg ctx cancelled) the user spent
+	// a token without getting anything for it. This seems pretty rare and a fine trade-off
+	// since its just one token. The most likely reason this would happen is user cancelling
+	// the request and at that point its more likely to happen while the LLM is running than
+	// in this quick redis block.
+	// On the first request in the current time block, if the requests past Incr fail we don't
+	// yet have a deadline set. This means if the user comes back later we wouldn't of expired
+	// just one token. This seems fine. Note: this isn't an issue on subsequent requests in the
+	// same time block since the TTL would have been set.
+	if _, err := l.Redis.Incr(l.Identifier); err != nil {
+		return errors.Wrap(err, "failed to increment rate limit counter")
+	}
+
+	// Set expiry on the key. If the key didn't exist prior to the previous INCR,
+	// it will set the expiry of the key to one day.
+	// If it did exist before, it should have an expiry set already, so the TTL >= 0
+	// makes sure that we don't overwrite it and restart the 1h bucket.
+	ttl, err := l.Redis.TTL(l.Identifier)
+	if err != nil {
+		return errors.Wrap(err, "failed to get TTL for rate limit counter")
+	}
+	intervalSeconds := int(l.Interval / time.Second)
+	if ttl < 0 || (l.UpdateRateLimitTTL && ttl > intervalSeconds) {
+		if err := l.Redis.Expire(l.Identifier, intervalSeconds); err != nil {
+			return errors.Wrap(err, "failed to set expiry for rate limit counter")
 		}
 	}
 

--- a/enterprise/cmd/llm-proxy/internal/limiter/limiter_test.go
+++ b/enterprise/cmd/llm-proxy/internal/limiter/limiter_test.go
@@ -112,7 +112,7 @@ func TestStaticLimiterTryAcquire(t *testing.T) {
 			},
 			wantErr: autogold.Expect("you exceeded the rate limit for completions. Current usage: 10 out of 10 requests. Retry after 2000-01-01 00:01:00 +0000 UTC"),
 			wantStore: autogold.Expect(mockStore{"foobar": mockRedisEntry{
-				value: 11,
+				value: 10,
 				ttl:   60,
 			}}),
 		},

--- a/enterprise/cmd/llm-proxy/internal/limiter/store.go
+++ b/enterprise/cmd/llm-proxy/internal/limiter/store.go
@@ -8,6 +8,8 @@ import (
 type RedisStore interface {
 	// Incr increments a key's value, or initializes it to 1 if it does not exist
 	Incr(key string) (int, error)
+	// Get retrieves a key's value
+	GetInt(key string) (int, error)
 	// TTL provides seconds TTL on an existing key
 	TTL(key string) (int, error)
 	// Expire configures an existing key's TTL
@@ -30,6 +32,14 @@ func (m mockStore) Incr(key string) (int, error) {
 	}
 	entry.value++
 	m[key] = entry
+	return entry.value, nil
+}
+
+func (m mockStore) GetInt(key string) (int, error) {
+	entry, ok := m[key]
+	if !ok {
+		return 0, nil
+	}
 	return entry.value, nil
 }
 

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/redigo"
+	"github.com/gomodule/redigo/redis"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/events"
@@ -187,6 +188,14 @@ type prefixRedisStore struct {
 
 func (s *prefixRedisStore) Incr(key string) (int, error) {
 	return s.store.Incr(s.prefix + key)
+}
+
+func (s *prefixRedisStore) GetInt(key string) (int, error) {
+	i, err := s.store.Get(s.prefix + key).Int()
+	if err != nil && err != redis.ErrNil {
+		return 0, err
+	}
+	return i, nil
 }
 
 func (s *prefixRedisStore) TTL(key string) (int, error) {


### PR DESCRIPTION
This "backports" the fix from the above PR into the LLM Proxy rate limiter PR.

## Test plan

Verified locally. 