### PR TITLE
Cody for JetBrains: Add preamble and streaming results

### DIFF
--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -87,7 +87,7 @@ class CodyToolWindowContent {
     private void sendMessage(@NotNull Project project) {
         // Build message
         EditorContext editorContext = EditorContextGetter.getEditorContext(project);
-        var chat = new Chat();
+        var chat = new Chat("", "https://sourcegraph.sourcegraph.com/", "TODO: API key");
         ArrayList<String> contextFiles = editorContext == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(editorContext.getCurrentFileContent()));
         ChatMessage humanMessage = ChatMessage.createHumanMessage(messageField.getText(), contextFiles);
         addMessage(humanMessage);

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -46,6 +46,7 @@ class CodyToolWindowContent implements UpdatableChat {
         controlsPanel.setLayout(new BoxLayout(controlsPanel, BoxLayout.X_AXIS));
         messageField = new JTextField();
         controlsPanel.add(messageField);
+        messageField.addActionListener(e -> sendMessage(project)); // TODO: Also disable the button while sending, then re-enable it
         JButton sendButton = new JButton("Send");
         sendButton.addActionListener(e -> sendMessage(project));
         controlsPanel.add(sendButton);
@@ -101,7 +102,7 @@ class CodyToolWindowContent implements UpdatableChat {
     private void sendMessage(@NotNull Project project) {
         // Build message
         EditorContext editorContext = EditorContextGetter.getEditorContext(project);
-        var chat = new Chat("", "https://sourcegraph.sourcegraph.com/", "TODO: API key");
+        var chat = new Chat("", "https://sourcegraph.com/", "TODO: API key");
         ArrayList<String> contextFiles = editorContext == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(editorContext.getCurrentFileContent()));
         ChatMessage humanMessage = ChatMessage.createHumanMessage(messageField.getText(), contextFiles);
         addMessage(humanMessage);

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.openapi.wm.ToolWindow;
@@ -16,11 +17,10 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.AdjustmentListener;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 
-class CodyToolWindowContent {
+class CodyToolWindowContent implements UpdatableChat {
     private final @NotNull JPanel contentPanel = new JPanel();
     private final @NotNull JPanel messagesPanel;
     private final @NotNull JTextField messageField;
@@ -62,25 +62,39 @@ class CodyToolWindowContent {
     }
 
     public void addMessage(@NotNull ChatMessage message) {
-        boolean isHuman = message.getSpeaker() == Speaker.HUMAN;
+        ApplicationManager.getApplication().invokeLater(() -> {
+            boolean isHuman = message.getSpeaker() == Speaker.HUMAN;
 
-        // Bubble panel
-        var bubblePanel = new JPanel();
-        bubblePanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
-        bubblePanel.setBorder(BorderFactory.createEmptyBorder(0, isHuman ? JBUIScale.scale(20) : 0, 0, !isHuman ? JBUIScale.scale(20) : 0));
+            // Bubble panel
+            var bubblePanel = new JPanel();
+            bubblePanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
+            bubblePanel.setBorder(BorderFactory.createEmptyBorder(0, isHuman ? JBUIScale.scale(20) : 0, 0, !isHuman ? JBUIScale.scale(20) : 0));
 
-        // Chat bubble
-        ChatBubble bubble = new ChatBubble(10, message);
-        bubblePanel.add(bubble, VerticalFlowLayout.TOP);
-        messagesPanel.add(bubblePanel);
-        messagesPanel.revalidate();
-        messagesPanel.repaint();
-
-        // Need this hacky solution to scroll all the way down after each message
-        SwingUtilities.invokeLater(() -> {
-            needScrollingDown = true;
+            // Chat bubble
+            ChatBubble bubble = new ChatBubble(10, message);
+            bubblePanel.add(bubble, VerticalFlowLayout.TOP);
+            messagesPanel.add(bubblePanel);
             messagesPanel.revalidate();
             messagesPanel.repaint();
+
+            // Need this hacky solution to scroll all the way down after each message
+            ApplicationManager.getApplication().invokeLater(() -> {
+                needScrollingDown = true;
+                messagesPanel.revalidate();
+                messagesPanel.repaint();
+            });
+        });
+    }
+
+    public void updateLastMessage(@NotNull ChatMessage message) {
+        ApplicationManager.getApplication().invokeLater(() -> {
+            if (messagesPanel.getComponentCount() > 0) {
+                JPanel lastBubblePanel = (JPanel) messagesPanel.getComponent(messagesPanel.getComponentCount() - 1);
+                ChatBubble lastBubble = (ChatBubble) lastBubblePanel.getComponent(0);
+                lastBubble.updateText(message.getDisplayText());
+                messagesPanel.revalidate();
+                messagesPanel.repaint();
+            }
         });
     }
 
@@ -92,23 +106,16 @@ class CodyToolWindowContent {
         ChatMessage humanMessage = ChatMessage.createHumanMessage(messageField.getText(), contextFiles);
         addMessage(humanMessage);
 
-        // Get and process assistant message
-        ChatMessage assistantMessage;
-        try {
-            assistantMessage = chat.sendMessage(humanMessage);
-        } catch (IOException e) {
-            if (e.getMessage().equals("Connection refused")) {
-                assistantMessage = ChatMessage.createAssistantMessage("I'm sorry, I can't connect to the server. Please make sure that the server is running and try again.");
-            } else {
-                assistantMessage = ChatMessage.createAssistantMessage("I'm sorry, I can't connect to the server. Please try again. The error message I got was: \"" + e.getMessage() + "\".");
-            }
-        } catch (InterruptedException e) {
-            assistantMessage = ChatMessage.createAssistantMessage("Okay, I've canceled that.");
-        }
-        addMessage(assistantMessage);
+        // Get assistant message
+        // Note: A separate thread is needed because it's a long-running task. If we did the back-end call
+        //       in the main thread and then waited, we wouldn't see the messages streamed back to us.
+        new Thread(() -> {
+            chat.sendMessage(humanMessage, "", this); // TODO: Use prefix
+        }).start();
     }
 
     public @NotNull JPanel getContentPanel() {
         return contentPanel;
     }
 }
+

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
@@ -1,0 +1,10 @@
+package com.sourcegraph.cody;
+
+import com.sourcegraph.cody.chat.ChatMessage;
+import org.jetbrains.annotations.NotNull;
+
+public interface UpdatableChat {
+    void addMessage(@NotNull ChatMessage message);
+
+    void updateLastMessage(@NotNull ChatMessage message);
+}

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -2,26 +2,39 @@ package com.sourcegraph.cody.chat;
 
 import com.sourcegraph.cody.completions.CompletionsInput;
 import com.sourcegraph.cody.completions.CompletionsService;
+import com.sourcegraph.cody.completions.Message;
 import com.sourcegraph.cody.completions.Speaker;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class Chat {
+    private final @Nullable String codebase;
+    private final @NotNull String instanceUrl;
+    private final @NotNull String accessToken;
+
+    public Chat(@Nullable String codebase, @NotNull String instanceUrl, @NotNull String accessToken) {
+        this.codebase = codebase;
+        this.instanceUrl = instanceUrl;
+        this.accessToken = accessToken;
+    }
+
     public @NotNull ChatMessage sendMessage(@NotNull ChatMessage humanMessage) throws IOException, InterruptedException {
-        // TODO: Use the prompt from VS Code
+        List<Message> preamble = Preamble.getPreamble(codebase);
+
+        // TODO: Use the context getting logic from VS Code
         var codeContext = "";
         if (humanMessage.getContextFiles().size() == 0) {
             codeContext = "I have no file open in the editor right now.";
         } else {
             codeContext = "Here is my current file\n" + humanMessage.getContextFiles().get(0);
         }
-        String preamble = "You are a software engineer who can write code according to instructions. You are given some code for extra context. You must not say anything other than the full code. You must output the full code snippet, and only the code snippet. You must not wrap the code snippet with markdown. You must double check you do not say anything other than the code.";
 
         var input = new CompletionsInput(new ArrayList<>(), 0.5f, 1000, -1, -1);
-        input.addMessage(Speaker.HUMAN, preamble);
-        input.addMessage(Speaker.ASSISTANT, "Ok.");
+        input.addMessages(preamble);
         input.addMessage(Speaker.HUMAN, codeContext);
         input.addMessage(Speaker.ASSISTANT, "Ok.");
         input.addMessage(Speaker.HUMAN, humanMessage.getText());
@@ -30,7 +43,7 @@ public class Chat {
         input.messages.forEach(System.out::println);
 
         // ConfigUtil.getAccessToken(project) TODO: Get the access token from the plugin config
-        String result = new CompletionsService("http://localhost:3080/.api/graphql", "").getCompletion(input); // TODO: Don't create this each time
+        String result = new CompletionsService(instanceUrl, accessToken).getCompletion(input); // TODO: Don't create this each time
 
         return ChatMessage.createAssistantMessage(result);
     }

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -1,28 +1,23 @@
 package com.sourcegraph.cody.chat;
 
-import com.sourcegraph.cody.completions.CompletionsInput;
-import com.sourcegraph.cody.completions.CompletionsService;
-import com.sourcegraph.cody.completions.Message;
-import com.sourcegraph.cody.completions.Speaker;
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.completions.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class Chat {
     private final @Nullable String codebase;
-    private final @NotNull String instanceUrl;
-    private final @NotNull String accessToken;
+    private final @NotNull CompletionsService completionsService;
 
     public Chat(@Nullable String codebase, @NotNull String instanceUrl, @NotNull String accessToken) {
         this.codebase = codebase;
-        this.instanceUrl = instanceUrl;
-        this.accessToken = accessToken;
+        completionsService = new CompletionsService(instanceUrl, accessToken);
     }
 
-    public @NotNull ChatMessage sendMessage(@NotNull ChatMessage humanMessage) throws IOException, InterruptedException {
+    public void sendMessage(@NotNull ChatMessage humanMessage, @Nullable String prefix, @NotNull UpdatableChat chat) {
         List<Message> preamble = Preamble.getPreamble(codebase);
 
         // TODO: Use the context getting logic from VS Code
@@ -43,8 +38,8 @@ public class Chat {
         input.messages.forEach(System.out::println);
 
         // ConfigUtil.getAccessToken(project) TODO: Get the access token from the plugin config
-        String result = new CompletionsService(instanceUrl, accessToken).getCompletion(input); // TODO: Don't create this each time
+        // TODO: Don't create this each time
 
-        return ChatMessage.createAssistantMessage(result);
+        completionsService.streamCompletion(input, new ChatUpdaterCallbacks(chat, prefix));
     }
 }

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
@@ -4,6 +4,7 @@ import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.cody.completions.Speaker;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -12,7 +13,7 @@ import java.awt.*;
 public class ChatBubble extends JPanel {
     private final int radius;
 
-    public ChatBubble(int radius, ChatMessage message) {
+    public ChatBubble(int radius, @NotNull ChatMessage message) {
         super();
 
         boolean isHuman = message.getSpeaker() == Speaker.HUMAN;
@@ -31,8 +32,13 @@ public class ChatBubble extends JPanel {
         this.add(textArea, BorderLayout.CENTER);
     }
 
+    public void updateText(@NotNull String newText) {
+        JTextArea textArea = (JTextArea) this.getComponent(0);
+        textArea.setText(newText);
+    }
+
     @Override
-    protected void paintComponent(Graphics g) {
+    protected void paintComponent(@NotNull Graphics g) {
         final Graphics2D g2d = (Graphics2D) g;
         g2d.setColor(getBackground());
         g2d.fillRoundRect(0, 0, this.getWidth() - 1, this.getHeight() - 1, this.radius, this.radius);

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Preamble.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/chat/Preamble.java
@@ -1,0 +1,53 @@
+package com.sourcegraph.cody.chat;
+
+import com.sourcegraph.cody.completions.Message;
+import com.sourcegraph.cody.completions.Speaker;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Preamble {
+
+    private static final String actions = "You are Cody, an AI-powered coding assistant created by Sourcegraph. You work inside a text editor. You have access to my currently open files. You perform the following actions:\n" +
+        "- Answer general programming questions.\n" +
+        "- Answer questions about the code that I have provided to you.\n" +
+        "- Generate code that matches a written description.\n" +
+        "- Explain what a section of code does.";
+
+    private static final String rules = "In your responses, obey the following rules:\n" +
+        "- Be as brief and concise as possible without losing clarity.\n" +
+        "- All code snippets have to be markdown-formatted, and placed in-between triple backticks like this ```.\n" +
+        "- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.\n" +
+        "- Only reference file names or URLs if you are sure they exist.";
+
+    private static final String answer = "Understood. I am Cody, an AI assistant made by Sourcegraph to help with programming tasks.\n" +
+        "I work inside a text editor. I have access to your currently open files in the editor.\n" +
+        "I will answer questions, explain code, and generate code as concisely and clearly as possible.\n" +
+        "My responses will be formatted using Markdown syntax for code blocks.\n" +
+        "I will acknowledge when I don't know an answer or need more context.";
+
+    public static List<Message> getPreamble(@Nullable String codebase) {
+        List<String> preamble = new ArrayList<>();
+        preamble.add(actions);
+        preamble.add(rules);
+
+        List<String> preambleResponse = new ArrayList<>();
+        preambleResponse.add(answer);
+
+        // If we have a codebase, add a preamble about it
+        if (codebase != null) {
+            String codebasePreamble = "You have access to the `" + codebase + "` repository. You are able to answer questions about the `" + codebase + "` repository. " +
+                "I will provide the relevant code snippets from the `" + codebase + "` repository when necessary to answer my questions.";
+
+            preamble.add(codebasePreamble);
+            preambleResponse.add("I have access to the `" + codebase + "` repository and can answer questions about its files.");
+        }
+
+        // Return this as a list of two items
+        List<Message> messages = new ArrayList<>();
+        messages.add(new Message(Speaker.HUMAN, String.join("\n\n", preamble)));
+        messages.add(new Message(Speaker.ASSISTANT, String.join("\n", preambleResponse)));
+        return messages;
+    }
+}

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/ChatUpdaterCallbacks.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/ChatUpdaterCallbacks.java
@@ -1,0 +1,72 @@
+package com.sourcegraph.cody.completions;
+
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.chat.ChatMessage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ChatUpdaterCallbacks implements CompletionsCallbacks {
+    private final UpdatableChat chat;
+    private final String prefix;
+    private boolean gotFirstMessage = false;
+
+    public ChatUpdaterCallbacks(@NotNull UpdatableChat chat, @Nullable String prefix) {
+        this.chat = chat;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void onSubscribed() {
+        System.out.println("Subscribed to completions.");
+    }
+
+    @Override
+    public void onData(@Nullable String data) {
+        if(data == null) {
+            return;
+        }
+        // print date/time and msg
+        System.out.println(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").format(LocalDateTime.now()) + " Data received by callback: " + data);
+        if (!gotFirstMessage) {
+            chat.addMessage(ChatMessage.createAssistantMessage(reformatBotMessage(data, prefix)));
+            gotFirstMessage = true;
+        } else {
+            chat.updateLastMessage(ChatMessage.createAssistantMessage(reformatBotMessage(data, prefix)));
+        }
+    }
+
+    @Override
+    public void onError(@NotNull Throwable error) {
+        if (error.getMessage().equals("Connection refused")) {
+            chat.addMessage(ChatMessage.createAssistantMessage("I'm sorry, I can't connect to the server. Please make sure that the server is running and try again."));
+        } else {
+            chat.addMessage(ChatMessage.createAssistantMessage("I'm sorry, something wet wrong. Please try again. The error message I got was: \"" + error.getMessage() + "\"."));
+        }
+        System.err.println("Error: " + error);
+    }
+
+    @Override
+    public void onComplete() {
+        System.out.println("Streaming completed.");
+    }
+
+    private static @NotNull String reformatBotMessage(@NotNull String text, @Nullable String prefix) {
+        String STOP_SEQUENCE_REGEXP = "(H|Hu|Hum|Huma|Human|Human:)$";
+        Pattern stopSequencePattern = Pattern.compile(STOP_SEQUENCE_REGEXP);
+
+        String reformattedMessage = (prefix != null ? prefix : "") + text.stripTrailing();
+
+        Matcher stopSequenceMatcher = stopSequencePattern.matcher(reformattedMessage);
+
+        if (stopSequenceMatcher.find()) {
+            reformattedMessage = reformattedMessage.substring(0, stopSequenceMatcher.start());
+        }
+
+        return reformattedMessage;
+    }
+}

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsCallbacks.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsCallbacks.java
@@ -1,0 +1,12 @@
+package com.sourcegraph.cody.completions;
+
+// Define a callback interface to handle events
+public interface CompletionsCallbacks {
+    void onSubscribed();
+
+    void onData(String data);
+
+    void onError(Throwable error);
+
+    void onComplete();
+}

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsInput.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsInput.java
@@ -25,4 +25,8 @@ public class CompletionsInput {
     public void addMessage(@NotNull Speaker speaker, @NotNull String text) {
         messages.add(new Message(speaker, text));
     }
+
+    public void addMessages(@NotNull List<Message> messages) {
+        this.messages.addAll(messages);
+    }
 }

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsService.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsService.java
@@ -9,11 +9,11 @@ import java.io.IOException;
 
 public class CompletionsService {
     private final String instanceUrl;
-    private final String token;
+    private final String accessToken;
 
-    public CompletionsService(@NotNull String instanceUrl, @NotNull String token) {
+    public CompletionsService(@NotNull String instanceUrl, @NotNull String accessToken) {
         this.instanceUrl = instanceUrl;
-        this.token = token;
+        this.accessToken = accessToken;
     }
 
     /**
@@ -26,7 +26,7 @@ public class CompletionsService {
         var variables = new JsonObject();
         variables.add("input", gson.toJsonTree(input));
 
-        var response = GraphQlClient.callGraphQLService(instanceUrl, token, null, query, variables);
+        var response = GraphQlClient.callGraphQLService(instanceUrl, accessToken, null, query, variables);
         return response
             .getBodyAsJson()
             .getAsJsonObject("data")

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsService.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsService.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.completions;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.sourcegraph.api.GraphQlClient;
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +21,9 @@ public class CompletionsService {
      * Sends a completions request to the Sourcegraph instance, and returns the response.
      */
     public String getCompletion(@NotNull CompletionsInput input) throws IOException, InterruptedException {
-        Gson gson = new Gson();
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Speaker.class, new SpeakerLowercaseSerializer())
+            .create();
 
         String query = "query completions($input: CompletionsInput!) { completions(input: $input) }";
         var variables = new JsonObject();
@@ -32,5 +35,18 @@ public class CompletionsService {
             .getAsJsonObject("data")
             .getAsJsonPrimitive("completions")
             .getAsString();
+    }
+
+    /**
+     * Sends a completions request to the Sourcegraph instance, and receives the response in a streaming fashion.
+     */
+    public void streamCompletion(@NotNull CompletionsInput input, @NotNull CompletionsCallbacks cb) {
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Speaker.class, new SpeakerLowercaseSerializer())
+            .create();
+
+        String body = gson.toJsonTree(input).getAsJsonObject().toString();
+        SSEClient sseClient = new SSEClient(instanceUrl + ".api/completions/stream", accessToken, body, cb);
+        sseClient.start();
     }
 }

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/SSEClient.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/SSEClient.java
@@ -1,0 +1,129 @@
+package com.sourcegraph.cody.completions;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+
+public class SSEClient {
+    private final String url;
+    private final String accessToken;
+    private final String body;
+    private final CompletionsCallbacks cb;
+
+    private InputStream inputStream;
+
+    public SSEClient(@NotNull String url, @NotNull String accessToken, @NotNull String body, @NotNull CompletionsCallbacks cb) {
+        this.url = url;
+        this.body = body;
+        this.accessToken = accessToken;
+        this.cb = cb;
+    }
+
+    public void start() {
+        try {
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(new URI(url))
+                .version(HttpClient.Version.HTTP_2)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .header("X-Sourcegraph-Should-Trace", "false")
+                .header("Accept", "text/event-stream")
+                .header("Cache-Control", "no-cache")
+                .header("Authorization", "token " + accessToken)
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+            HttpRequest request = requestBuilder.build();
+
+            HttpResponse<InputStream> response = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build()
+                .send(request, BodyHandlers.ofInputStream());
+
+            if (response.statusCode() == HttpStatus.SC_OK) {
+                cb.onSubscribed();
+                inputStream = response.body();
+                handleResponse(inputStream);
+            } else {
+                String result;
+                try (InputStream ignored = response.body()) {
+                    result = IOUtils.toString(response.body(), StandardCharsets.UTF_8);
+                }
+                cb.onError(new Error("Got error response " + response.statusCode() + ": " + result));
+            }
+        } catch (Exception e) {
+            if (e.getCause() instanceof InterruptedException) {
+                cb.onError(e); // TODO: Handle interruptions
+            } else {
+                cb.onError(e);
+            }
+        }
+    }
+
+    public void stopCurrentRequest() {
+        if (inputStream != null) {
+            try {
+                inputStream.close();
+            } catch (Exception e) {
+                System.err.println("Got error stopCurrentRequest: " + e.getMessage());
+            }
+        }
+    }
+
+    private void handleResponse(@NotNull InputStream inputStream) {
+        /*
+         * Streams go like this:
+         * event: completion
+         * data: Hello
+         *
+         * event: completion
+         * data: Hello, there
+         *
+         * event: done
+         * data:
+         */
+        String eventName = null;
+        try (BufferedInputStream in = IOUtils.buffer(inputStream)) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                String line;
+                StringBuilder messageBuilder = new StringBuilder();
+                while ((line = reader.readLine()) != null) {
+                    if (line.startsWith("data:")) {
+                        messageBuilder.append(line.substring(5));
+                    } else if (line.startsWith("event:")) {
+                        eventName = line.substring(6).trim();
+                    }
+                    if (line.trim().isEmpty() && messageBuilder.length() > 0) {
+                        String message = messageBuilder.toString();
+                        if (Objects.equals(eventName, "completion")) { // Completion
+                            JsonObject json = new Gson().fromJson(message, JsonObject.class);
+                            JsonPrimitive completion = json.getAsJsonPrimitive("completion");
+                            cb.onData(completion != null ? completion.getAsString().trim() : null);
+                        } else if (Objects.equals(eventName, "done")) { // Done
+                            stopCurrentRequest();
+                            cb.onComplete();
+                            return;
+                        }
+                        messageBuilder = new StringBuilder();
+                    }
+                }
+                if (messageBuilder.length() > 0) {
+                    System.out.println("Non-processed data: {}" + messageBuilder);
+                }
+            }
+        } catch (Exception e) {
+            cb.onError(e);
+        }
+    }
+}

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/SpeakerLowercaseSerializer.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/completions/SpeakerLowercaseSerializer.java
@@ -1,0 +1,15 @@
+package com.sourcegraph.cody.completions;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+public class SpeakerLowercaseSerializer implements JsonSerializer<Speaker> {
+    @Override
+    public JsonElement serialize(Speaker src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(src.name().toLowerCase());
+    }
+}


### PR DESCRIPTION
Two changes:
- Added the preamble (without the context part) copied from VS Code
- Now streaming the response so that it feels more responsive

[30-sec demo](https://www.loom.com/share/47a2c23d0b114814aaa8195f23c6334a)

## Test plan

- Tested it (see the Loom)
- Does not affect anything else
