### PR TITLE
Introduce ownership-assign RBAC

### DIFF
--- a/client/web/src/rbac/constants.ts
+++ b/client/web/src/rbac/constants.ts
@@ -3,3 +3,5 @@
 export const BatchChangesReadPermission = 'BATCH_CHANGES#READ'
 
 export const BatchChangesWritePermission = 'BATCH_CHANGES#WRITE'
+
+export const OwnershipAssignPermission = 'OWNERSHIP#ASSIGN'

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9731,6 +9731,11 @@ enum PermissionNamespace {
     This represents the Batch Changes namespace.
     """
     BATCH_CHANGES
+    """
+    Code ownership namespace used for permitting to assign ownership
+    within Sourcegraph.
+    """
+    OWNERSHIP
 }
 
 """

--- a/internal/rbac/constants.go
+++ b/internal/rbac/constants.go
@@ -4,3 +4,5 @@ package rbac
 const BatchChangesReadPermission string = "BATCH_CHANGES#READ"
 
 const BatchChangesWritePermission string = "BATCH_CHANGES#WRITE"
+
+const OwnershipAssignPermission string = "OWNERSHIP#ASSIGN"

--- a/internal/rbac/schema.yaml
+++ b/internal/rbac/schema.yaml
@@ -3,3 +3,6 @@ namespaces:
     actions:
       - READ
       - WRITE
+  - name: OWNERSHIP
+    actions:
+      - ASSIGN

--- a/internal/rbac/types/action.go
+++ b/internal/rbac/types/action.go
@@ -10,3 +10,4 @@ func (a NamespaceAction) String() string {
 
 const BatchChangesReadAction NamespaceAction = "READ"
 const BatchChangesWriteAction NamespaceAction = "WRITE"
+const OwnershipAssignAction NamespaceAction = "ASSIGN"

--- a/internal/rbac/types/namespace.go
+++ b/internal/rbac/types/namespace.go
@@ -10,11 +10,12 @@ func (n PermissionNamespace) String() string {
 }
 
 const BatchChangesNamespace PermissionNamespace = "BATCH_CHANGES"
+const OwnershipNamespace PermissionNamespace = "OWNERSHIP"
 
 // Valid checks if a namespace is valid and supported by Sourcegraph's RBAC system.
 func (n PermissionNamespace) Valid() bool {
 	switch n {
-	case BatchChangesNamespace:
+	case BatchChangesNamespace, OwnershipNamespace:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Closes #51915

Introduce `OWNERSHIP` RBAC namespace with single `ASSIGN` action:

<img width="1180" alt="Screenshot 2023-05-16 at 11 12 08 AM" src="https://github.com/sourcegraph/sourcegraph/assets/153410/a2b1033e-af94-451e-a263-a905a1b35c82">

In Go code, whether user has permission to promote owners can be checked with [CheckCurrentUserHasPermission](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@03da2be83dca2f60e973e893a69d8053658d7129/-/blob/internal/rbac/permission.go?L29):

```go
CheckCurrentUserHasPermission(ctx, db, "OWNERSHIP#ASSIGN")
```

## Test plan

Configuration change only - the current unit tests apply.
