### PR TITLE
Cody web improvements

### DIFF
--- a/client/web/src/cody/components/HistoryList/HistoryList.tsx
+++ b/client/web/src/cody/components/HistoryList/HistoryList.tsx
@@ -92,9 +92,7 @@ const HistoryListItem: React.FunctionComponent<{
         [deleteHistoryItem, id]
     )
 
-    if (!lastMessage?.text) {
-        return null
-    }
+    const text = lastMessage?.text || 'Write your first message.'
 
     return (
         <button
@@ -131,8 +129,8 @@ const HistoryListItem: React.FunctionComponent<{
                 </Tooltip>
             </div>
             <Text className="mb-0 truncate text-body">
-                {lastMessage.text.slice(0, truncateMessageLength)}
-                {lastMessage.text.length > truncateMessageLength ? '...' : ''}
+                {text.slice(0, truncateMessageLength)}
+                {text.length > truncateMessageLength ? '...' : ''}
             </Text>
         </button>
     )

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { mdiClose, mdiFormatListBulleted, mdiPlus, mdiDelete } from '@mdi/js'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/src/icons/CodyLogo'
-import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
+import { Button, Icon, Tooltip, Badge } from '@sourcegraph/wildcard'
 
 import { ChatUI, ScrollDownButton } from '../components/ChatUI'
 import { HistoryList } from '../components/HistoryList'
@@ -96,6 +96,9 @@ export const CodySidebar = ({ onClose }: CodySidebarProps): JSX.Element => {
                     <div className="col-6 d-flex justify-content-center">
                         <CodyLogo />
                         {showHistory ? 'Chats' : 'Ask Cody'}
+                        <div className="ml-2">
+                            <Badge variant="info">Beta</Badge>
+                        </div>
                     </div>
                     <div className="col-3 d-flex justify-content-end p-0">
                         <Button variant="icon" aria-label="Close" onClick={onClose}>


### PR DESCRIPTION
- Add beta label to Ask Cody sidebar. 
<img width="636" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/22571395/1c695dd6-d7e7-4be0-9392-116bb1338406">

- Make empty conversations persistent in history; earlier they were not stored, and after reset, on page reload the chat will open the last conversation and not the new empty one. 
- Fixed chat history deletion. Was not happening due to race condition.

## Test plan

- visit /cody