### PR TITLE
Cody: Generate app scaffold

### DIFF
--- a/client/cody-shared/src/chat/recipes/generate-app-scaffold.ts
+++ b/client/cody-shared/src/chat/recipes/generate-app-scaffold.ts
@@ -1,0 +1,91 @@
+import * as os from 'os'
+
+import { Interaction } from '../transcript/interaction'
+
+import { Recipe, RecipeContext, RecipeID } from './recipe'
+import { ScaffoldGenerator } from './scaffold'
+
+export class AppScaffold extends ScaffoldGenerator implements Recipe {
+    public id: RecipeID = 'app-scaffold'
+
+    public async getInteraction(_humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        const dirPath = context.editor.getWorkspaceRootPath()
+        if (!dirPath) {
+            return Promise.resolve(null)
+        }
+
+        // get the root path where the app scaffold will be saved
+        const rootPath = os.homedir()
+        if (!rootPath) {
+            return null
+        }
+
+        const rawDisplayText = 'Generating the scaffold of the selected app'
+
+        const quickPickItems = [
+            {
+                label: 'React App',
+            },
+        ]
+
+        const selectedLabel = await context.editor.showQuickPick(quickPickItems.map(e => e.label))
+        if (!selectedLabel) {
+            return null
+        }
+        const appName = await context.editor.showInputBox('Enter the app name')
+
+        if (!appName) {
+            const emptyAppNameMessage = 'No app name provided to generate scaffold'
+            return new Interaction(
+                { speaker: 'human', displayText: rawDisplayText },
+                {
+                    speaker: 'assistant',
+                    prefix: emptyAppNameMessage,
+                    text: emptyAppNameMessage,
+                },
+                Promise.resolve([])
+            )
+        }
+
+        let generatorStatus = false
+        let messsage = ''
+        switch (selectedLabel) {
+            case 'React App':
+                // eslint-disable-next-line no-case-declarations
+                const res = this.generateReactApp(rootPath, appName.trim())
+                generatorStatus = res.generatorStatus
+                messsage = res.generatorMessage
+                break
+            default:
+                messsage = 'Generation unsuccessful'
+        }
+
+        let assistantResponsePrefix = 'The app scaffold has been generated successfully'
+
+        // if app generation is unsucessful return the message, with the steps to fix error
+        if (!generatorStatus) {
+            assistantResponsePrefix = 'There were some errors while generating the selected app scaffold'
+            const promptMessage = `You encountered this error messages ${messsage} while generating the ${selectedLabel}.\nSummarise the actual errors first.\nReturn a response for possible suggestioons to fix the error in stepwise format.`
+
+            return new Interaction(
+                { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
+                {
+                    speaker: 'assistant',
+                    prefix: assistantResponsePrefix,
+                    text: assistantResponsePrefix,
+                },
+                Promise.resolve([])
+            )
+        }
+
+        return new Interaction(
+            { speaker: 'human', displayText: rawDisplayText },
+            {
+                speaker: 'assistant',
+                prefix: assistantResponsePrefix,
+                text: assistantResponsePrefix,
+            },
+            Promise.resolve([])
+        )
+    }
+}

--- a/client/cody-shared/src/chat/recipes/recipe.ts
+++ b/client/cody-shared/src/chat/recipes/recipe.ts
@@ -27,6 +27,7 @@ export type RecipeID =
     | 'release-notes'
     | 'inline-chat'
     | 'next-questions'
+    | 'app-scaffold'
 
 export interface Recipe {
     id: RecipeID

--- a/client/cody-shared/src/chat/recipes/scaffold.ts
+++ b/client/cody-shared/src/chat/recipes/scaffold.ts
@@ -1,0 +1,52 @@
+import { execSync } from 'child_process'
+
+interface Scaffold {
+    scaffold_name: string
+    dependencies: string[]
+    command: string
+}
+
+interface ScaffoldStatus {
+    generatorStatus: boolean
+    generatorMessage: string
+}
+
+export class ScaffoldGenerator {
+    public generateReactApp(rootPath: string, appName: string): ScaffoldStatus {
+        let status = false
+        let message = ''
+        const react: Scaffold = {
+            scaffold_name: 'React app generator',
+            dependencies: ['node -v', 'npx -v', 'npm -v'],
+            command: 'npx create-react-app',
+        }
+
+        // check for the dependencies first
+        for (const dependency of react.dependencies) {
+            try {
+                execSync(dependency, { cwd: rootPath })
+                status = true
+            } catch (error) {
+                status = false
+                message = error
+            }
+        }
+
+        // if all the dependency are present then run create command
+        if (status) {
+            try {
+                execSync(`${react.command} ${appName}`, { cwd: rootPath })
+                message = 'React app generated successfully'
+                status = true
+            } catch (error) {
+                status = false
+                message = error
+            }
+        }
+
+        return {
+            generatorStatus: status,
+            generatorMessage: message,
+        }
+    }
+}

--- a/client/cody-shared/src/chat/recipes/vscode-recipes.ts
+++ b/client/cody-shared/src/chat/recipes/vscode-recipes.ts
@@ -4,6 +4,7 @@ import { ExplainCodeDetailed } from './explain-code-detailed'
 import { ExplainCodeHighLevel } from './explain-code-high-level'
 import { FindCodeSmells } from './find-code-smells'
 import { Fixup } from './fixup'
+import { AppScaffold } from './generate-app-scaffold'
 import { GenerateDocstring } from './generate-docstring'
 import { ReleaseNotes } from './generate-release-notes'
 import { GenerateTest } from './generate-test'
@@ -44,6 +45,7 @@ function init(): void {
         new NextQuestions(),
         new ContextSearch(),
         new ReleaseNotes(),
+        new AppScaffold(),
     ]
 
     for (const recipe of recipes) {

--- a/client/cody/webviews/Recipes.tsx
+++ b/client/cody/webviews/Recipes.tsx
@@ -18,6 +18,7 @@ export const recipesList = {
     fixup: 'Fixup code from inline instructions',
     'context-search': 'Codebase context search',
     'release-notes': 'Generate release notes',
+    'app-scaffold': 'Generate app scaffold',
 }
 
 export const Recipes: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {


### PR DESCRIPTION
This PR is for issue #50226. 

An attempt to generate most of the app scaffold with Cody. Developing an app scaffold can involve many steps; each developer has their requirements. It's good to consider the app's starting point with some options for the common dependencies. With this idea, I have implemented a small scaffold of React app in this PR. 
The current implementation involves the following steps:
1. Quick pick to select the app type
2. Provide the app name
3. Once the user selects the first two, it generates the scaffold by checking all dependencies and then generating the scaffold in the user's root.
4. If the scaffold generation is successful, then it returns the success message with some of the steps to start the app, else if it's unsuccessful, it returns the possible way to debug for the user and try again.

I have tried to think of the code implementation as it is easily extensible, like the one for Recipes, so I have used individual classes, interfaces and methods.

If this implementation is fine, I can include a few scaffolds in this PR:
1. React app
2. Angular app
3. Python apps Flask/Django

Input required:
1. Which more apps scaffold should we have the beginning as a starting point?

## Test plan
- Tested it on Mac, and it works completely fine
