### PR TITLE
(fix) add repo meta create & update user-friendly error message

### DIFF
--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -105,7 +105,7 @@ func (s *repoKVPStore) Update(ctx context.Context, repoID api.RepoID, kvp KeyVal
 	var updated KeyValuePair
 	err := row.Scan(&kvp.Key, &kvp.Value)
 	if errors.Is(err, sql.ErrNoRows) {
-		return updated, errors.Newf(`Metadata key "%s" does not exist for the given repository.`, kvp.Key)
+		return updated, errors.Newf(`metadata key %q does not exist for the given repository`, kvp.Key)
 	}
 	return updated, err
 }

--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -105,7 +105,7 @@ func (s *repoKVPStore) Update(ctx context.Context, repoID api.RepoID, kvp KeyVal
 	var updated KeyValuePair
 	err := row.Scan(&kvp.Key, &kvp.Value)
 	if errors.Is(err, sql.ErrNoRows) {
-		return updated, errors.Newf(`Repo metadata key "%s" does not exist for the given repository.`, kvp.Key)
+		return updated, errors.Newf(`Metadata key "%s" does not exist for the given repository.`, kvp.Key)
 	}
 	return updated, err
 }

--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -48,19 +49,14 @@ func (s *repoKVPStore) Create(ctx context.Context, repoID api.RepoID, kvp KeyVal
 	q := `
 	INSERT INTO repo_kvps (repo_id, key, value)
 	VALUES (%s, %s, %s)
-	ON CONFLICT DO NOTHING
 	`
 
-	result, err := s.ExecResult(ctx, sqlf.Sprintf(q, repoID, kvp.Key, kvp.Value))
-	if err != nil {
-		return errors.Wrap(err, "executing SQL query")
-	}
-	nrows, err := result.RowsAffected()
-	if err != nil {
-		return errors.Wrap(err, "getting rows affected")
-	}
-	if nrows == 0 {
-		return errors.Newf(`Repo metadata key "%s" already exists for the given repository.`, kvp.Key)
+	if err := s.Exec(ctx, sqlf.Sprintf(q, repoID, kvp.Key, kvp.Value)); err != nil {
+		var e *pgconn.PgError
+		if errors.As(err, &e) && e.Code == "23505" {
+			return errors.Newf(`Repo metadata key "%s" already exists for the given repository.`, kvp.Key)
+		}
+		return err
 	}
 
 	return nil

--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -54,7 +54,7 @@ func (s *repoKVPStore) Create(ctx context.Context, repoID api.RepoID, kvp KeyVal
 	if err := s.Exec(ctx, sqlf.Sprintf(q, repoID, kvp.Key, kvp.Value)); err != nil {
 		var e *pgconn.PgError
 		if errors.As(err, &e) && e.Code == "23505" {
-			return errors.Newf(`Repo metadata key "%s" already exists for the given repository.`, kvp.Key)
+			return errors.Newf(`Metadata key "%s" already exists for the given repository.`, kvp.Key)
 		}
 		return err
 	}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

## Test plan
- `sg start`
- Enable `repository-metadata` feature flag
- Open any repo meta settings page, ex: https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/settings/metadata
- Try to add duplicate key

## Screenshots
| Description | Before | After |
| --: | --: | :-- |
| Create duplicate key | <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/03f05ff5-8bb8-4632-8c69-06963c530954"> | <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/8b70dd30-a428-482b-b31c-bc0e28d773b9"> |
| Update non-existing key-value pair. This is mainly used by `src repos update-metadata` command  | <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/3de8ebf2-3d25-4154-b1b8-dc66a662f72e"> | <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/48bc3182-d682-44ff-9885-a0e5a6720f90"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
