### PR TITLE
docs: change batch changes server-side to beta

### DIFF
--- a/doc/batch_changes/explanations/index.md
+++ b/doc/batch_changes/explanations/index.md
@@ -7,4 +7,4 @@ The following articles explain different parts of [Sourcegraph Batch Changes](..
 - [Batch Changes design](batch_changes_design.md)
 - [How `src` executes a batch spec](how_src_executes_a_batch_spec.md)
 - [Re-executing batch specs multiple times](reexecuting_batch_specs_multiple_times.md)
-- <span class="badge badge-experimental">Experimental</span> [Running batch changes server-side](server_side.md)
+- <span class="badge badge-beta">Beta</span> [Running batch changes server-side](server_side.md)


### PR DESCRIPTION
noticed that it's marked as beta on the page itself, but not on the index


## Test plan

- N/A