### PR TITLE
[github apps] Add new code host connection screen for ghapps

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -327,6 +327,7 @@ ts_project(
         "src/components/gitHubApps/CreateGitHubAppPage.tsx",
         "src/components/gitHubApps/GitHubAppCard.tsx",
         "src/components/gitHubApps/GitHubAppPage.tsx",
+        "src/components/gitHubApps/GitHubAppSelector.tsx",
         "src/components/gitHubApps/GitHubAppsPage.tsx",
         "src/components/gitHubApps/backend.ts",
         "src/components/shared.tsx",

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -44,6 +44,10 @@ export const AddExternalServicePage: FC<Props> = ({
         telemetryService.logPageView('AddExternalService')
     }, [telemetryService])
 
+    useEffect(() => {
+        setConfig(externalService.defaultConfig)
+    }, [externalService.defaultConfig])
+
     const getExternalServiceInput = useCallback(
         (): AddExternalServiceInput => ({
             displayName,
@@ -99,7 +103,9 @@ export const AddExternalServicePage: FC<Props> = ({
                                 {...externalService}
                                 title={createdExternalService.displayName}
                                 shortDescription="Update this external service configuration to manage repository mirroring."
-                                to={`/site-admin/external-services/${createdExternalService.id}/edit`}
+                                to={`/site-admin/external-services/${encodeURIComponent(
+                                    createdExternalService.id
+                                )}/edit`}
                             />
                         </div>
                         <Alert variant="warning">
@@ -133,6 +139,7 @@ export const AddExternalServicePage: FC<Props> = ({
                             autoFocus={autoFocusForm}
                             externalServicesFromFile={externalServicesFromFile}
                             allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
+                            additionalFormComponent={externalService.additionalFormComponent}
                         />
                     </>
                 )}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -59,15 +59,13 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         const id = params.get('id')
         if (id) {
             let externalService = allExternalServices[id]
-            if (externalService) {
-                if (externalService.kind === ExternalServiceKind.GITHUB) {
-                    const appID = params.get('appID')
-                    const installationID = params.get('installationID')
-                    const baseURL = params.get('url')
-                    const org = params.get('org')
-                    if (externalService === codeHostExternalServices.ghapp) {
-                        externalService = gitHubAppConfig(baseURL, appID, installationID, org)
-                    }
+            if (externalService?.kind === ExternalServiceKind.GITHUB) {
+                const appID = params.get('appID')
+                const installationID = params.get('installationID')
+                const baseURL = params.get('url')
+                const org = params.get('org')
+                if (externalService === codeHostExternalServices.ghapp) {
+                    externalService = gitHubAppConfig(baseURL, appID, installationID, org)
                 }
             }
             return externalService

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 
 import { mdiInformation } from '@mdi/js'
 import { useLocation } from 'react-router-dom'
@@ -54,30 +54,37 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         setHasDismissedPrivacyWarning(true)
     }
 
-    const params = new URLSearchParams(search)
-    const id = params.get('id')
-    if (id) {
-        let externalService = allExternalServices[id]
-        if (externalService) {
-            if (externalService.kind === ExternalServiceKind.GITHUB) {
-                const appID = params.get('appID')
-                const installationID = params.get('installationID')
-                const baseURL = params.get('url')
-                const org = params.get('org')
-                if (appID && installationID && baseURL && org) {
-                    externalService = gitHubAppConfig(baseURL, appID, installationID, org)
+    const externalService = useMemo(() => {
+        const params = new URLSearchParams(search)
+        const id = params.get('id')
+        if (id) {
+            let externalService = allExternalServices[id]
+            if (externalService) {
+                if (externalService.kind === ExternalServiceKind.GITHUB) {
+                    const appID = params.get('appID')
+                    const installationID = params.get('installationID')
+                    const baseURL = params.get('url')
+                    const org = params.get('org')
+                    if (externalService === codeHostExternalServices.ghapp) {
+                        externalService = gitHubAppConfig(baseURL, appID, installationID, org)
+                    }
                 }
             }
-            return (
-                <AddExternalServicePage
-                    telemetryService={telemetryService}
-                    externalService={externalService}
-                    autoFocusForm={autoFocusForm}
-                    externalServicesFromFile={externalServicesFromFile}
-                    allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
-                />
-            )
+            return externalService
         }
+        return null
+    }, [search, codeHostExternalServices.ghapp])
+
+    if (externalService) {
+        return (
+            <AddExternalServicePage
+                telemetryService={telemetryService}
+                externalService={externalService}
+                autoFocusForm={autoFocusForm}
+                externalServicesFromFile={externalServicesFromFile}
+                allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
+            />
+        )
     }
 
     const licenseInfo = window.context.licenseInfo
@@ -189,10 +196,6 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
 }
 
 function getAddURL(id: string): string {
-    if (id === 'ghapp') {
-        return '../../github-apps'
-    }
-
     const parameters = new URLSearchParams()
     parameters.append('id', id)
     return `?${parameters.toString()}`

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useEffect, useState, useCallback, useMemo } from 'react'
 
-import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, ErrorAlert, PageHeader, Button, Label } from '@sourcegraph/wildcard'
+import { Container, ErrorAlert, PageHeader, ButtonLink } from '@sourcegraph/wildcard'
 
 import { AddExternalServiceInput } from '../../graphql-operations'
 import { CreatedByAndUpdatedByInfoByline } from '../Byline/CreatedByAndUpdatedByInfoByline'
@@ -94,13 +94,13 @@ export const ExternalServiceEditPage: FC<Props> = ({
 
     const path = useMemo(() => getBreadCrumbs(externalService, true), [externalService])
 
-    const externalServiceCategory = resolveExternalServiceCategory(externalService)
+    const externalServiceCategory = resolveExternalServiceCategory(externalService, ghApp)
 
     const combinedError = fetchError || updateExternalServiceError || fetchGHAppError
     const combinedLoading = fetchLoading || updateExternalServiceLoading || fetchGHAppLoading
 
     if (updated && !combinedLoading && externalService?.warning === null) {
-        return <Navigate to={`/site-admin/external-services/${externalService.id}`} replace={true} />
+        navigate(`/site-admin/external-services/${encodeURIComponent(externalService.id)}`, { replace: true })
     }
 
     return (
@@ -125,19 +125,14 @@ export const ExternalServiceEditPage: FC<Props> = ({
                         className="mb-3"
                         headingElement="h2"
                         actions={
-                            <Button onClick={() => navigate(-1)} variant="secondary">
+                            <ButtonLink
+                                to={`/site-admin/external-services/${encodeURIComponent(externalService.id)}`}
+                                variant="secondary"
+                            >
                                 Cancel
-                            </Button>
+                            </ButtonLink>
                         }
                     />
-                    {ghApp && (
-                        <Label>
-                            GitHub App:
-                            <Link className="ml-3" to={`/site-admin/github-apps/${ghApp.id}`}>
-                                {ghApp.name}
-                            </Link>
-                        </Label>
-                    )}
                     {externalServiceCategory && (
                         <ExternalServiceForm
                             input={{ ...externalService }}
@@ -154,6 +149,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
                             autoFocus={autoFocusForm}
                             externalServicesFromFile={externalServicesFromFile}
                             allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
+                            additionalFormComponent={externalServiceCategory.additionalFormComponent}
                         />
                     )}
                     <ExternalServiceWebhook externalService={externalService} className="mt-3" />

--- a/client/web/src/components/externalServices/ExternalServiceInformation.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceInformation.tsx
@@ -40,7 +40,9 @@ export const ExternalServiceInformation: FC<ExternalServiceInformationProps> = p
                     <tr>
                         <th className={styles.tableHeader}>GitHub App</th>
                         <td>
-                            <Link to={`/site-admin/github-apps/${gitHubApp.id}`}>{gitHubApp.name}</Link>
+                            <Link to={`/site-admin/github-apps/${encodeURIComponent(gitHubApp.id)}`}>
+                                {gitHubApp.name}
+                            </Link>
                         </td>
                     </tr>
                 )}

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -83,7 +83,9 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     <div>
                         <Icon as={IconComponent} aria-label="Code host logo" className="code-host-logo mr-2" />
                         <strong>
-                            <Link to={`/site-admin/external-services/${node.id}`}>{node.displayName}</Link>{' '}
+                            <Link to={`/site-admin/external-services/${encodeURIComponent(node.id)}`}>
+                                {node.displayName}
+                            </Link>{' '}
                             <small className="text-muted">
                                 ({node.repoCount} {pluralize('repository', node.repoCount, 'repositories')})
                             </small>
@@ -112,7 +114,7 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>
                         <Button
                             className="test-edit-external-service-button"
-                            to={`/site-admin/external-services/${node.id}/edit`}
+                            to={`/site-admin/external-services/${encodeURIComponent(node.id)}/edit`}
                             variant="secondary"
                             size="sm"
                             as={Link}

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -216,7 +216,9 @@ export const ExternalServicePage: FC<Props> = props => {
                                         <Tooltip content="Edit code host connection settings">
                                             <Button
                                                 className="test-edit-external-service-button"
-                                                to={`/site-admin/external-services/${externalService.id}/edit`}
+                                                to={`/site-admin/external-services/${encodeURIComponent(
+                                                    externalService.id
+                                                )}/edit`}
                                                 variant="primary"
                                                 size="sm"
                                                 as={Link}

--- a/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
+++ b/client/web/src/components/externalServices/__snapshots__/ExternalServiceForm.test.tsx.snap
@@ -5,35 +5,31 @@ exports[`ExternalServiceForm create GitHub 1`] = `
   <form
     class="external-service-form"
   >
-    <div
-      class="form-group"
+    <label
+      class="label w-100"
     >
-      <label
-        class="label label mb-0"
+      <p
+        class="mb-2"
       >
-        <div
-          class="mb-2"
-        >
-          Display name:
-        </div>
-        <div
-          class="container loader-input loaderInput"
-        >
-          <input
-            autocomplete="off"
-            autocorrect="off"
-            class="form-control with-invalid-icon"
-            id="test-external-service-form-display-name"
-            required=""
-            spellcheck="false"
-            type="text"
-            value="GitHub"
-          />
-        </div>
-      </label>
-    </div>
+        Display name
+      </p>
+      <div
+        class="container loader-input loaderInput mb-0"
+      >
+        <input
+          autocomplete="off"
+          autocorrect="off"
+          class="form-control with-invalid-icon"
+          id="test-external-service-form-display-name"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="GitHub"
+        />
+      </div>
+    </label>
     <div
-      class="form-group"
+      class="form-group mt-3"
     >
       DynamicallyImportedMonacoSettingsEditor
     </div>
@@ -53,35 +49,31 @@ exports[`ExternalServiceForm edit GitHub 1`] = `
   <form
     class="external-service-form"
   >
-    <div
-      class="form-group"
+    <label
+      class="label w-100"
     >
-      <label
-        class="label label mb-0"
+      <p
+        class="mb-2"
       >
-        <div
-          class="mb-2"
-        >
-          Display name:
-        </div>
-        <div
-          class="container loader-input loaderInput"
-        >
-          <input
-            autocomplete="off"
-            autocorrect="off"
-            class="form-control with-invalid-icon"
-            id="test-external-service-form-display-name"
-            required=""
-            spellcheck="false"
-            type="text"
-            value="GitHub"
-          />
-        </div>
-      </label>
-    </div>
+        Display name
+      </p>
+      <div
+        class="container loader-input loaderInput mb-0"
+      >
+        <input
+          autocomplete="off"
+          autocorrect="off"
+          class="form-control with-invalid-icon"
+          id="test-external-service-form-display-name"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="GitHub"
+        />
+      </div>
+    </label>
     <div
-      class="form-group"
+      class="form-group mt-3"
     >
       DynamicallyImportedMonacoSettingsEditor
     </div>
@@ -101,36 +93,32 @@ exports[`ExternalServiceForm edit GitHub, loading 1`] = `
   <form
     class="external-service-form"
   >
-    <div
-      class="form-group"
+    <label
+      class="label w-100"
     >
-      <label
-        class="label label mb-0"
+      <p
+        class="mb-2"
       >
-        <div
-          class="mb-2"
-        >
-          Display name:
-        </div>
-        <div
-          class="container loader-input loaderInput"
-        >
-          <input
-            autocomplete="off"
-            autocorrect="off"
-            class="form-control with-invalid-icon"
-            disabled=""
-            id="test-external-service-form-display-name"
-            required=""
-            spellcheck="false"
-            type="text"
-            value="GitHub"
-          />
-        </div>
-      </label>
-    </div>
+        Display name
+      </p>
+      <div
+        class="container loader-input loaderInput mb-0"
+      >
+        <input
+          autocomplete="off"
+          autocorrect="off"
+          class="form-control with-invalid-icon"
+          disabled=""
+          id="test-external-service-form-display-name"
+          required=""
+          spellcheck="false"
+          type="text"
+          value="GitHub"
+        />
+      </div>
+    </label>
     <div
-      class="form-group"
+      class="form-group mt-3"
     >
       DynamicallyImportedMonacoSettingsEditor
     </div>

--- a/client/web/src/components/externalServices/externalServices.test.tsx
+++ b/client/web/src/components/externalServices/externalServices.test.tsx
@@ -1,4 +1,9 @@
-import { gitHubAppConfig } from './externalServices'
+import React from 'react'
+
+import { ExternalServiceKind } from '../../graphql-operations'
+
+import { ExternalServiceFieldsWithConfig } from './backend'
+import { codeHostExternalServices, gitHubAppConfig, resolveExternalServiceCategory } from './externalServices'
 
 describe('gitHubAppConfig', () => {
     test('get config', () => {
@@ -13,5 +18,76 @@ describe('gitHubAppConfig', () => {
   "orgs": ["testUser"],
   "authorization": {}
 }`)
+    })
+
+    describe('resolveExternalServiceCategory', () => {
+        test('returns undefined with no external service', () => {
+            expect(resolveExternalServiceCategory()).toEqual(undefined)
+        })
+
+        test('parses config from JSONC if parsed config is not given', () => {
+            const externalService = {
+                config: '{"url": "https://github.com"}',
+                kind: ExternalServiceKind.GITHUB,
+            } as ExternalServiceFieldsWithConfig
+
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.github)
+        })
+
+        test('returns GITHUB_DOTCOM for github.com', () => {
+            const externalService = {
+                parsedConfig: { url: 'https://github.com' },
+                kind: ExternalServiceKind.GITHUB,
+            } as ExternalServiceFieldsWithConfig
+
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.github)
+        })
+
+        test('returns GHE if GITHUB kind and non-github.com URL', () => {
+            const externalService = {
+                parsedConfig: { url: 'https://gitlab.example.com' },
+                kind: ExternalServiceKind.GITHUB,
+            } as ExternalServiceFieldsWithConfig
+
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.ghe)
+        })
+
+        test('returns GitLab dotcom if GITLAB kind and gitlab.com URL', () => {
+            const externalService = {
+                kind: ExternalServiceKind.GITLAB,
+                parsedConfig: { url: 'https://gitlab.com' },
+            } as ExternalServiceFieldsWithConfig
+
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.gitlabcom)
+        })
+
+        test('returns GitLab category if GITLAB kind and non-gitlab.com URL', () => {
+            const externalService = {
+                kind: ExternalServiceKind.GITLAB,
+                parsedConfig: { url: 'https://gitlab.example.com' },
+            } as ExternalServiceFieldsWithConfig
+
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.gitlab)
+        })
+
+        test('returns GitHub App category if config contains gitHubAppDetails', () => {
+            const externalService = {
+                kind: ExternalServiceKind.GITHUB,
+                parsedConfig: {
+                    url: 'https://github.com',
+                    gitHubAppDetails: {
+                        appID: 1234,
+                        installationID: 5678,
+                        baseURL: 'https://github.com',
+                    },
+                },
+            } as ExternalServiceFieldsWithConfig
+            const gitHubApp = { id: '1234', name: 'test-app' }
+
+            expect(resolveExternalServiceCategory(externalService, gitHubApp)).toEqual({
+                ...codeHostExternalServices.ghapp,
+                additionalFormComponent: expect.anything(),
+            })
+        })
     })
 })

--- a/client/web/src/components/externalServices/externalServices.test.tsx
+++ b/client/web/src/components/externalServices/externalServices.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ExternalServiceKind } from '../../graphql-operations'
 
 import { ExternalServiceFieldsWithConfig } from './backend'

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1667,7 +1667,6 @@ export const resolveExternalServiceCategory = (
         // if config contains gitHubAppDetails, we should use GitHub App instead
         if (parsedConfig.gitHubAppDetails && gitHubApp) {
             externalServiceCategory = { ...codeHostExternalServices.ghapp }
-            console.log('parsedConfig', parsedConfig, gitHubApp)
             externalServiceCategory.additionalFormComponent = (
                 <GitHubAppSelector
                     disabled={true}

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 
 import { Edit, JSONPath, ModificationOptions, modify, parse as parseJSONC } from 'jsonc-parser'
 import AwsIcon from 'mdi-react/AwsIcon'
@@ -14,7 +14,6 @@ import LanguageRustIcon from 'mdi-react/LanguageRustIcon'
 import AzureDevOpsIcon from 'mdi-react/MicrosoftAzureDevopsIcon'
 import NpmIcon from 'mdi-react/NpmIcon'
 
-import { hasProperty } from '@sourcegraph/common'
 import { PerforceIcon, PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
 import { Link, Code, Text } from '@sourcegraph/wildcard'
 
@@ -38,12 +37,14 @@ import rubyPackagesSchemaJSON from '../../../../../schema/ruby-packages.schema.j
 import rustPackagesJSON from '../../../../../schema/rust-packages.schema.json'
 import {
     ExternalRepositoryFields,
-    ExternalServiceFields,
     ExternalServiceKind,
     ExternalServiceSyncJobState,
+    GitHubAppByAppIDResult,
 } from '../../graphql-operations'
 import { EditorAction } from '../../settings/EditorActionsGroup'
+import { GitHubAppSelector } from '../gitHubApps/GitHubAppSelector'
 
+import { ExternalServiceFieldsWithConfig } from './backend'
 import { GerritIcon } from './GerritIcon'
 
 /**
@@ -96,6 +97,11 @@ export interface AddExternalServiceOptions {
      * If present, denotes that we should show a status label, e.g. Beta or Experimental
      */
     status?: 'experimental' | 'beta'
+
+    /**
+     * If present, denotes that we should show additional fields on the form above the JSON
+     */
+    additionalFormComponent?: ReactNode
 }
 
 const defaultModificationOptions: ModificationOptions = {
@@ -190,6 +196,27 @@ const GitHubInstructions: React.FunctionComponent<{ isEnterprise: boolean }> = (
         <Text>
             See{' '}
             <Link rel="noopener noreferrer" target="_blank" to="/help/admin/external_service/github#configuration">
+                the docs for more options
+            </Link>
+            , or try one of the buttons below.
+        </Text>
+    </div>
+)
+
+const GitHubAppInstructions: React.FunctionComponent = () => (
+    <div>
+        <ol>
+            <li>
+                Choose a GitHub App to populate the initial JSON configuration in <Code>gitHubAppDetails</Code>.
+            </li>
+            <li>
+                If applicable, choose an associated installation. If your GitHub App has only one installation, this
+                will be pre-populated along with other GitHub App information in <Code>orgs</Code>.
+            </li>
+        </ol>
+        <Text>
+            See {/* TODO: proper docs link here */}
+            <Link rel="noopener noreferrer" target="_blank" to="">
                 the docs for more options
             </Link>
             , or try one of the buttons below.
@@ -351,6 +378,25 @@ const githubEditorActions = (isEnterprise: boolean): EditorAction[] => [
         },
     },
 ]
+
+const gitHubAppEditorActions = (isEnterprise: boolean): EditorAction[] => {
+    const actions = githubEditorActions(true).filter(
+        item =>
+            !['setURL', 'setAccessToken', 'addAffiliatedRepos', 'enablePermissions', 'addWebhooks'].includes(item.id)
+    )
+    return [
+        {
+            id: 'addAffiliatedRepos',
+            label: 'Add repositories affiliated with app installation',
+            run: (config: string) => {
+                const value = 'affiliated'
+                const edits = modify(config, ['repositoryQuery', -1], value, defaultModificationOptions)
+                return { edits, selectText: 'affiliated' }
+            },
+        },
+        ...actions,
+    ]
+}
 
 const gitlabEditorActions = (isSelfManaged: boolean): EditorAction[] => [
     ...(isSelfManaged
@@ -564,23 +610,25 @@ const GITHUB_ENTERPRISE: AddExternalServiceOptions = {
 const GITHUB_APP: AddExternalServiceOptions = {
     ...GITHUB_DOTCOM,
     title: 'GitHub App',
+    editorActions: gitHubAppEditorActions(false),
+    Instructions: () => <GitHubAppInstructions />,
+    additionalFormComponent: <GitHubAppSelector />,
 }
 export const gitHubAppConfig = (
-    baseURL: string,
-    appID: string,
-    installationID: string,
-    org: string
+    baseURL: string | null,
+    appID: string | null,
+    installationID: string | null,
+    org: string | null
 ): AddExternalServiceOptions => ({
-    ...GITHUB_DOTCOM,
-    title: 'GitHub App Installation',
+    ...GITHUB_APP,
     defaultConfig: `{
-  "url": "${decodeURI(baseURL)}",
+  "url": "${baseURL ? decodeURI(baseURL) : ''}",
   "gitHubAppDetails": {
-    "installationID": ${installationID},
-    "appID": ${appID},
-    "baseURL": "${baseURL}"
+    "installationID": ${installationID ?? -1},
+    "appID": ${appID ?? -1},
+    "baseURL": "${baseURL ?? ''}"
   },
-  "orgs": ["${org}"],
+  "orgs": ["${org ?? ''}"],
   "authorization": {}
 }`,
 })
@@ -1593,26 +1641,42 @@ export const EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES = new Set<ExternalServiceSyn
 ])
 
 export const resolveExternalServiceCategory = (
-    externalService?: ExternalServiceFields
+    externalService?: ExternalServiceFieldsWithConfig,
+    gitHubApp?: GitHubAppByAppIDResult['gitHubAppByAppID']
 ): AddExternalServiceOptions | undefined => {
     let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
     if (externalService && [ExternalServiceKind.GITHUB, ExternalServiceKind.GITLAB].includes(externalService.kind)) {
-        const parsedConfig: unknown = parseJSONC(externalService.config)
-        const url =
-            typeof parsedConfig === 'object' &&
-            parsedConfig !== null &&
-            hasProperty('url')(parsedConfig) &&
-            typeof parsedConfig.url === 'string' &&
-            isValidURL(parsedConfig.url)
-                ? new URL(parsedConfig.url)
-                : undefined
-        // We have no way of finding out whether an external service is GITHUB or GitHub.com or GitHub enterprise, so we need to guess based on the URL.
-        if (externalService.kind === ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
-            externalServiceCategory = codeHostExternalServices.ghe
+        let { parsedConfig } = externalService
+        if (!parsedConfig) {
+            parsedConfig = parseJSONC(externalService.config)
         }
-        // We have no way of finding out whether an external service is GITLAB or Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
-        if (externalService.kind === ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
-            externalServiceCategory = codeHostExternalServices.gitlab
+        if (!parsedConfig) {
+            return externalServiceCategory
+        }
+        if (parsedConfig.url) {
+            const url = isValidURL(parsedConfig.url) ? new URL(parsedConfig.url) : undefined
+            // We have no way of finding out whether an external service is GITHUB or GitHub.com or GitHub enterprise, so we need to guess based on the URL.
+            if (externalService.kind === ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
+                externalServiceCategory = codeHostExternalServices.ghe
+            }
+            // We have no way of finding out whether an external service is GITLAB or Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
+            if (externalService.kind === ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
+                externalServiceCategory = codeHostExternalServices.gitlab
+            }
+        }
+        // if config contains gitHubAppDetails, we should use GitHub App instead
+        if (parsedConfig.gitHubAppDetails && gitHubApp) {
+            externalServiceCategory = { ...codeHostExternalServices.ghapp }
+            console.log('parsedConfig', parsedConfig, gitHubApp)
+            externalServiceCategory.additionalFormComponent = (
+                <GitHubAppSelector
+                    disabled={true}
+                    gitHubApp={{
+                        ...parsedConfig.gitHubAppDetails,
+                        ...gitHubApp,
+                    }}
+                />
+            )
         }
     }
     return externalServiceCategory

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -90,11 +90,8 @@ export const GitHubAppPage: FC<Props> = ({
         try {
             const req = await fetch(`/.auth/githubapp/state?id=${app?.id}`)
             const state = await req.text()
-            window.open(
-                app.appURL.endsWith('/')
-                    ? app.appURL + 'installations/new?state=' + state
-                    : app.appURL + '/installations/new?state=' + state
-            )
+            const trailingSlash = app.appURL.endsWith('/') ? '' : '/'
+            window.location.assign(`${app.appURL}${trailingSlash}installations/new?state=${state}`)
         } catch (error) {
             handleError(error)
         }
@@ -216,7 +213,7 @@ export const GitHubAppPage: FC<Props> = ({
                                                     <ButtonLink
                                                         variant="primary"
                                                         className="ml-auto"
-                                                        to={`/site-admin/external-services/new?id=github&appID=${
+                                                        to={`/site-admin/external-services/new?id=ghapp&appID=${
                                                             app.appID
                                                         }&installationID=${installation.id}&url=${encodeURI(
                                                             app.baseURL

--- a/client/web/src/components/gitHubApps/GitHubAppSelector.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppSelector.tsx
@@ -101,8 +101,10 @@ export const GitHubAppSelector: React.FC<Props> = ({ disabled = false, gitHubApp
 
     return (
         <div className="d-flex flex-column">
-            <Label className="mt-2" id="github-app-label">
-                <Text className="mb-2">GitHub App</Text>
+            <Label className="mt-2">
+                <Text className="mb-2" id="github-app-label">
+                    GitHub App
+                </Text>
                 {disabled && id ? (
                     <Link to={`/site-admin/github-apps/${encodeURIComponent(id)}`}>{name}</Link>
                 ) : (
@@ -112,6 +114,7 @@ export const GitHubAppSelector: React.FC<Props> = ({ disabled = false, gitHubApp
                         onChange={onAppChange}
                         className="mb-0"
                         disabled={disabled}
+                        isCustomStyle={true}
                     >
                         <option value="">Choose a GitHub App</option>
                         {apps?.map(app => (
@@ -122,14 +125,17 @@ export const GitHubAppSelector: React.FC<Props> = ({ disabled = false, gitHubApp
                     </Select>
                 )}
             </Label>
-            <Label className="mt-2" id="installation-id-label">
-                <Text className="mb-2">Installation</Text>
+            <Label className="mt-2">
+                <Text className="mb-2" id="installation-id-label">
+                    Installation
+                </Text>
                 <Select
                     aria-labelledby="installation-id-label"
                     value={selectedInstallID}
                     onChange={onInstallationChange}
                     className="mb-0"
                     disabled={disabled || selectedApp?.installations.length === 1}
+                    isCustomStyle={true}
                 >
                     <option value={-1}>Choose a GitHub App</option>
                     {selectedApp?.installations?.map(installation => (

--- a/client/web/src/components/gitHubApps/GitHubAppSelector.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppSelector.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useMemo, useEffect } from 'react'
+
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import { useQuery } from '@sourcegraph/http-client'
+import { Alert, Label, Link, LoadingSpinner, Select, Text } from '@sourcegraph/wildcard'
+
+import { GitHubAppsWithInstallsResult, GitHubAppsWithInstallsVariables } from '../../graphql-operations'
+import { GitHubAppDetails } from '../externalServices/backend'
+
+import { GITHUB_APPS_WITH_INSTALLATIONS_QUERY } from './backend'
+
+interface GitHubApp extends GitHubAppDetails {
+    id?: string
+    name?: string
+}
+
+interface Props {
+    disabled?: boolean
+    gitHubApp?: GitHubApp
+}
+
+const parseQueryParams = (search: string, gitHubApp?: GitHubAppDetails): GitHubApp => {
+    if (gitHubApp) {
+        return gitHubApp
+    }
+
+    const urlParams = new URLSearchParams(search)
+    return {
+        baseURL: urlParams.get('url') ?? '',
+        appID: Number(urlParams.get('appID') ?? -1),
+        installationID: Number(urlParams.get('installationID') ?? -1),
+    }
+}
+
+export const GitHubAppSelector: React.FC<Props> = ({ disabled = false, gitHubApp }) => {
+    const navigate = useNavigate()
+    const { search } = useLocation()
+
+    const { data, loading, error } = useQuery<GitHubAppsWithInstallsResult, GitHubAppsWithInstallsVariables>(
+        GITHUB_APPS_WITH_INSTALLATIONS_QUERY,
+        {}
+    )
+    const apps = useMemo(() => data?.gitHubApps?.nodes ?? [], [data])
+
+    const { appID, baseURL, installationID, id, name } = parseQueryParams(search, gitHubApp)
+
+    const [selectedAppID, setSelectedAppID] = useState<string>(`${baseURL}|${appID}`)
+    const [selectedInstallID, setSelectedInstallID] = useState<number>(installationID)
+
+    const selectedApp = useMemo(() => {
+        const [baseURL, appID] = selectedAppID.split('|')
+        const app = apps?.find(a => a.baseURL === baseURL && a.appID === Number(appID))
+        if (app?.installations?.length === 1) {
+            setSelectedInstallID(app.installations[0].id)
+        }
+        return app
+    }, [apps, selectedAppID, setSelectedInstallID])
+
+    useEffect(() => {
+        if (disabled) {
+            return
+        }
+
+        const params = new URLSearchParams(search)
+        if (selectedApp) {
+            params.set('appID', String(selectedApp.appID))
+            params.set('url', selectedApp.baseURL)
+        } else {
+            params.delete('appID')
+            params.delete('url')
+        }
+        if (selectedApp && selectedInstallID >= 0) {
+            params.set('installationID', String(selectedInstallID))
+            const selectedInstallation = selectedApp.installations.find(item => item.id === selectedInstallID)
+            if (selectedInstallation) {
+                params.set('org', selectedInstallation.account.login)
+            }
+        } else {
+            params.delete('installationID')
+            params.delete('org')
+        }
+        navigate(`?${params.toString()}`)
+    }, [search, selectedApp, selectedInstallID, disabled, navigate])
+
+    const onAppChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        setSelectedAppID(event.target.value.trim())
+        setSelectedInstallID(-1)
+    }
+
+    const onInstallationChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        setSelectedInstallID(Number(event.target.value))
+    }
+
+    if (loading) {
+        return <LoadingSpinner />
+    }
+    if (error) {
+        return <Alert variant="danger">{error.message}</Alert>
+    }
+
+    return (
+        <div className="d-flex flex-column">
+            <Label className="mt-2" id="github-app-label">
+                <Text className="mb-2">GitHub App</Text>
+                {disabled && id ? (
+                    <Link to={`/site-admin/github-apps/${encodeURIComponent(id)}`}>{name}</Link>
+                ) : (
+                    <Select
+                        aria-labelledby="github-app-label"
+                        value={selectedAppID}
+                        onChange={onAppChange}
+                        className="mb-0"
+                        disabled={disabled}
+                    >
+                        <option value="">Choose a GitHub App</option>
+                        {apps?.map(app => (
+                            <option key={app.id} value={`${app.baseURL}|${app.appID}`}>
+                                {app.name}
+                            </option>
+                        ))}
+                    </Select>
+                )}
+            </Label>
+            <Label className="mt-2" id="installation-id-label">
+                <Text className="mb-2">Installation</Text>
+                <Select
+                    aria-labelledby="installation-id-label"
+                    value={selectedInstallID}
+                    onChange={onInstallationChange}
+                    className="mb-0"
+                    disabled={disabled || selectedApp?.installations.length === 1}
+                >
+                    <option value={-1}>Choose a GitHub App</option>
+                    {selectedApp?.installations?.map(installation => (
+                        <option key={installation.id} value={installation.id}>
+                            {installation.account.login}
+                        </option>
+                    ))}
+                </Select>
+            </Label>
+        </div>
+    )
+}

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -23,6 +23,29 @@ export const GITHUB_APPS_QUERY = gql`
     }
 `
 
+export const GITHUB_APPS_WITH_INSTALLATIONS_QUERY = gql`
+    query GitHubAppsWithInstalls {
+        gitHubApps {
+            nodes {
+                id
+                appID
+                name
+                baseURL
+                logo
+                installations {
+                    id
+                    account {
+                        login
+                        avatarURL
+                        url
+                        type
+                    }
+                }
+            }
+        }
+    }
+`
+
 export const GITHUB_APP_BY_ID_QUERY = gql`
     ${LIST_EXTERNAL_SERVICE_FRAGMENT}
     query GitHubAppByID($id: ID!) {

--- a/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
+++ b/client/web/src/repo/settings/components/ExternalServiceEntry.tsx
@@ -62,7 +62,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 {data && !redirectAfterExclusion ? (
                     <Alert variant="success">
                         Code host configuration updated. Please see the updated code host configuration{' '}
-                        <Link to={`/site-admin/external-services/${service.id}`}>here</Link>
+                        <Link to={`/site-admin/external-services/${encodeURIComponent(service.id)}`}>here</Link>
                     </Alert>
                 ) : (
                     <ExternalServiceCard
@@ -70,7 +70,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                         kind={service.kind}
                         title={service.displayName}
                         shortDescription="Update this code host configuration to manage repository mirroring."
-                        to={`/site-admin/external-services/${service.id}`}
+                        to={`/site-admin/external-services/${encodeURIComponent(service.id)}`}
                         toIcon={null}
                         bordered={false}
                     />
@@ -78,7 +78,7 @@ export const ExternalServiceEntry: FC<ExternalServiceEntryProps> = ({
                 {error && <ErrorAlert error={`Failed to exclude repository: ${renderError(error)}`} />}
                 {data && redirectAfterExclusion && (
                     <RedirectionAlert
-                        to={`/site-admin/external-services/${service.id}`}
+                        to={`/site-admin/external-services/${encodeURIComponent(service.id)}`}
                         messagePrefix="Code host configuration updated."
                     />
                 )}

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -182,15 +182,18 @@
       "properties": {
         "baseURL": {
           "description": "The base URL of the GitHub App.",
-          "type": "string"
+          "type": "string",
+          "pattern": "^https?://"
         },
         "appID": {
           "description": "The ID of the GitHub App.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1
         },
         "installationID": {
           "description": "The installation ID of this connection.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1
         }
       }
     },


### PR DESCRIPTION
## Description

Adds specific changes to support github app code host connections in create and edit code host connections screens.

Added:
- github app selector in the edit screen
- github app installation selector in edit screen
- github app instructions which are different than standard ghe instructions
- validation of JSON schema for code host connections and disabling the `Add connection` or `Update configuration` buttons at the bottom of the page if the JSONC doc does not adhere to the schema

## Video

[Loom video](https://www.loom.com/share/48898711281b4f369ba58613c5c26ff9)

## Test plan

Tested locally, only UI changes.
