### PR TITLE
executor: Watch Job Status

### DIFF
--- a/doc/admin/executors/deploy_executors_kubernetes.md
+++ b/doc/admin/executors/deploy_executors_kubernetes.md
@@ -74,7 +74,7 @@ Kubernetes.
 
 | API Groups | Resources          | Verbs                     | Reason                                                                                    |
 |------------|--------------------|---------------------------|-------------------------------------------------------------------------------------------|
-| `batch`    | `jobs`             | `create`, `delete`, `get` | Executors create Job pods to run processes. Once Jobs are completed, they are cleaned up. |
+| `batch`    | `jobs`             | `create`, `delete`, `get`, `list`, `watch` | Executors create Job pods to run processes. Once Jobs are completed, they are cleaned up. |
 |            | `pods`, `pods/log` | `get`, `list`, `watch`    | Executors need to look up and steam logs from the Job Pods.                               |
 
 See

--- a/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/watch",
         "@io_k8s_client_go//kubernetes/fake",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_client_go//rest",

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/sourcegraph/log"
 	"golang.org/x/sync/errgroup"
@@ -139,20 +138,25 @@ func (c *KubernetesCommand) FindPod(ctx context.Context, namespace string, name 
 
 // WaitForJobToComplete waits for the job with the given name to complete.
 func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace string, name string) error {
-	for {
-		// Eventually `ActiveDeadlineSeconds` will kill the job.
-		job, err := c.getJob(ctx, namespace, name)
-		if err != nil {
-			return errors.Wrap(err, "retrieving job")
+	watch, err := c.Clientset.BatchV1().Jobs(namespace).Watch(ctx, metav1.ListOptions{Watch: true, FieldSelector: "metadata.name=" + name})
+	if err != nil {
+		return errors.Wrap(err, "watching job")
+	}
+	defer watch.Stop()
+	// No need to add a timer. If the job exceeds the deadline, it will fail.
+	for event := range watch.ResultChan() {
+		job, ok := event.Object.(*batchv1.Job)
+		if !ok {
+			return errors.New("unexpected object type")
 		}
-		if job.Status.Active == 0 && job.Status.Succeeded > 0 {
+		if job.Status.Succeeded > 0 {
 			return nil
-		} else if job.Status.Failed > 0 {
+		}
+		if job.Status.Failed > 0 {
 			return ErrKubernetesJobFailed
-		} else {
-			time.Sleep(100 * time.Millisecond)
 		}
 	}
+	return nil
 }
 
 // ErrKubernetesJobFailed is returned when a Kubernetes job fails.

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -156,6 +156,7 @@ func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace 
 			return ErrKubernetesJobFailed
 		}
 	}
+	// Wont happen
 	return nil
 }
 

--- a/enterprise/cmd/executor/internal/worker/runner/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/worker/runner/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/watch",
         "@io_k8s_client_go//kubernetes/fake",
         "@io_k8s_client_go//testing",
     ],

--- a/enterprise/cmd/executor/kubernetes/batches/executor-batches.Role.yml
+++ b/enterprise/cmd/executor/kubernetes/batches/executor-batches.Role.yml
@@ -12,6 +12,8 @@ rules:
       - get
       - create
       - delete
+      - watch
+      - list
   - apiGroups:
       - ""
     resources:

--- a/enterprise/cmd/executor/kubernetes/codeintel/executor-codeintel.Role.yml
+++ b/enterprise/cmd/executor/kubernetes/codeintel/executor-codeintel.Role.yml
@@ -12,6 +12,8 @@ rules:
       - get
       - create
       - delete
+      - watch
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Came out of customer partnership.

Noticed the executor was getting rate limited by K8s when getting job status. We not use the native K8s API to stream the job status instead of hitting the API every x amount of time.

## Test plan

Updated tests and tested locally.
