### PR TITLE
Add temporary default value for completions model

### DIFF
--- a/enterprise/internal/completions/client/client.go
+++ b/enterprise/internal/completions/client/client.go
@@ -37,6 +37,11 @@ func GetCompletionsConfig() *schema.Completions {
 			completionsConfig.ChatModel = completionsConfig.Model
 		}
 
+		// TODO: Temporary workaround to fix instances where no completion model is set.
+		if completionsConfig.CompletionModel == "" {
+			completionsConfig.CompletionModel = "claude-instant-v1.0"
+		}
+
 		if completionsConfig.Provider == llmproxy.ProviderName && completionsConfig.Endpoint == "" {
 			completionsConfig.Endpoint = llmproxy.DefaultEndpoint
 		}


### PR DESCRIPTION
This adds a temporary value to fix some instances where the completion model is not set, as the client will not always send an override for that anymore soon.

## Test plan

Doesn't fail anymore when completions is not configured. 
I think the proper next step could be to disable the completions endpoint if not set, or something. Or perhaps a provider specific default. This is mostly to fix existing instances right now.