### PR TITLE
ci: enable auto retry on "tests"

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -91,6 +91,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 		bk.Agent("queue", "bazel"),
 		bk.Key("bazel-tests"),
 		bk.ArtifactPaths("./bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/*.log"),
+		bk.AutomaticRetry(1), // TODO @jhchabran flaky stuff are breaking builds
 	}
 
 	// Test commands


### PR DESCRIPTION
Retrying is usually very very fast (<60s) so this will make it better for folks while we hunt down the flaky tests.

Test plan: ci

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
