### PR TITLE
Updating Cody's widget wording and icon

### DIFF
--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiTranslate } from '@mdi/js'
+import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiSwapHorizontal } from '@mdi/js'
 
 import { TranslateToLanguage } from '@sourcegraph/cody-shared/src/chat/recipes/translate'
 
@@ -27,7 +27,7 @@ export const CodyRecipesWidget: React.FC<{}> = () => {
                 <RecipeAction title="A docstring" onClick={() => void executeRecipe('generate-docstring')} />
             </Recipe>
 
-            <Recipe title="Translate" icon={mdiTranslate}>
+            <Recipe title="Transpile" icon={mdiSwapHorizontal}>
                 {TranslateToLanguage.options.map(language => (
                     <RecipeAction
                         key={language}

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 
-import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiSwapHorizontal } from '@mdi/js'
+import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiShuffleVariant } from '@mdi/js'
 
 import { TranslateToLanguage } from '@sourcegraph/cody-shared/src/chat/recipes/translate'
 
@@ -27,7 +27,7 @@ export const CodyRecipesWidget: React.FC<{}> = () => {
                 <RecipeAction title="A docstring" onClick={() => void executeRecipe('generate-docstring')} />
             </Recipe>
 
-            <Recipe title="Transpile" icon={mdiSwapHorizontal}>
+            <Recipe title="Transpile" icon={mdiShuffleVariant}>
                 {TranslateToLanguage.options.map(language => (
                     <RecipeAction
                         key={language}


### PR DESCRIPTION
Enhancing Cody's widget by refining the wording and icon. Our research discovered that about 1/3 of users thought that "Translate" initially meant translating into a different spoken language, not a coding language. The wording will be amended to "transpiling," which is the correct definition. Also, the icon to better illustrates the recipe action.

<img width="623" alt="Screenshot 2023-05-16 at 7 15 11 PM" src="https://github.com/sourcegraph/sourcegraph/assets/64257673/ba1cb379-33fc-4f78-8fc4-8cbac2553031">

## Test plan
- Open Cody's widget in the File view and confirm that the wording and the icon it's updated.