### PR TITLE
Prepare for support for OpenAI based code completions

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/httpapi/openai.go
+++ b/enterprise/cmd/llm-proxy/internal/httpapi/openai.go
@@ -58,7 +58,7 @@ func newOpenAIHandler(logger log.Logger, eventLogger events.Logger, accessToken 
 				return 0
 			}
 
-			// Otherwise, we have to parse the event stream from anthropic.
+			// Otherwise, we have to parse the event stream.
 			dec := openai.NewDecoder(r)
 			var finalCompletion string
 			// Consume all the messages, but we only care about the last completion data.

--- a/enterprise/cmd/llm-proxy/internal/httpapi/upstream.go
+++ b/enterprise/cmd/llm-proxy/internal/httpapi/upstream.go
@@ -123,6 +123,9 @@ func makeUpstreamHandler[ReqT any](logger log.Logger, eventLogger events.Logger,
 		if upstreamStatusCode >= 200 && upstreamStatusCode < 300 {
 			// Pass reader to response transformer to capture token counts.
 			completionCharacterCount = respParser(body, &responseBuf)
+
+		} else if upstreamStatusCode >= 500 {
+			logger.Error("error from upstream", log.String("url", upstreamAPIURL), log.Int("status_code", upstreamStatusCode))
 		}
 	})
 }

--- a/enterprise/internal/completions/client/anthropic/anthropic.go
+++ b/enterprise/internal/completions/client/anthropic/anthropic.go
@@ -22,8 +22,10 @@ func NewClient(cli httpcli.Doer, accessToken string, model string) types.Complet
 	}
 }
 
-const apiURL = "https://api.anthropic.com/v1/complete"
-const clientID = "sourcegraph/1.0"
+const (
+	apiURL   = "https://api.anthropic.com/v1/complete"
+	clientID = "sourcegraph/1.0"
+)
 
 type anthropicClient struct {
 	cli         httpcli.Doer

--- a/enterprise/internal/completions/client/llmproxy/llmproxy.go
+++ b/enterprise/internal/completions/client/llmproxy/llmproxy.go
@@ -26,7 +26,7 @@ func NewClient(cli httpcli.Doer, endpoint, accessToken string, model string) (ty
 		return nil, err
 	}
 
-	if strings.ToLower(model) == "gpt-4" {
+	if strings.HasPrefix(strings.ToLower(model), "gpt-") {
 		return openai.NewClient(llmProxyDoer(cli, llmProxyURL, accessToken, "/v1/completions/openai"), "", model), nil
 	}
 	if strings.HasPrefix(strings.ToLower(model), "claude-") {

--- a/enterprise/internal/completions/client/openai/openai.go
+++ b/enterprise/internal/completions/client/openai/openai.go
@@ -13,10 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const (
-	apiURL       = "https://api.openai.com/v1/chat/completions"
-	ProviderName = "openai"
-)
+const ProviderName = "openai"
 
 func NewClient(cli httpcli.Doer, accessToken string, model string) types.CompletionsClient {
 	return &openAIChatCompletionStreamClient{
@@ -26,21 +23,83 @@ func NewClient(cli httpcli.Doer, accessToken string, model string) types.Complet
 	}
 }
 
+const apiURL = "https://api.openai.com/v1/chat/completions"
+
 type openAIChatCompletionStreamClient struct {
 	cli         httpcli.Doer
 	accessToken string
 	model       string
 }
 
-func (a *openAIChatCompletionStreamClient) Complete(ctx context.Context, requestParams types.CompletionRequestParameters) (*types.CompletionResponse, error) {
-	return nil, errors.New("openAIChatCompletionStreamClient.Complete: unimplemented")
+func (c *openAIChatCompletionStreamClient) Complete(ctx context.Context, requestParams types.CompletionRequestParameters) (*types.CompletionResponse, error) {
+	resp, err := c.makeRequest(ctx, requestParams, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var response openaiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Choices) == 0 {
+		// Empty response.
+		return &types.CompletionResponse{}, nil
+	}
+
+	return &types.CompletionResponse{
+		Completion: response.Choices[0].Content,
+		StopReason: response.Choices[0].FinishReason,
+	}, nil
 }
 
-func (a *openAIChatCompletionStreamClient) Stream(
+func (c *openAIChatCompletionStreamClient) Stream(
 	ctx context.Context,
 	requestParams types.CompletionRequestParameters,
 	sendEvent types.SendCompletionEvent,
 ) error {
+	resp, err := c.makeRequest(ctx, requestParams, true)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	dec := NewDecoder(resp.Body)
+	var content string
+	for dec.Scan() {
+		if ctx.Err() != nil && ctx.Err() == context.Canceled {
+			return nil
+		}
+
+		data := dec.Data()
+		// Gracefully skip over any data that isn't JSON-like.
+		if !bytes.HasPrefix(data, []byte("{")) {
+			continue
+		}
+
+		var event openaiResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			return errors.Errorf("failed to decode event payload: %w - body: %s", err, string(data))
+		}
+
+		if len(event.Choices) > 0 {
+			content += event.Choices[0].Delta.Content
+			ev := types.CompletionResponse{
+				Completion: content,
+				StopReason: event.Choices[0].FinishReason,
+			}
+			err = sendEvent(ev)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return dec.Err()
+}
+
+func (c *openAIChatCompletionStreamClient) makeRequest(ctx context.Context, requestParams types.CompletionRequestParameters, stream bool) (*http.Response, error) {
 	if requestParams.TopK < 0 {
 		requestParams.TopK = 0
 	}
@@ -50,13 +109,17 @@ func (a *openAIChatCompletionStreamClient) Stream(
 
 	// TODO(sqs): make CompletionRequestParameters non-anthropic-specific
 	payload := openAIChatCompletionsRequestParameters{
-		Model:       a.model,
+		Model:       c.model,
 		Temperature: requestParams.Temperature,
 		TopP:        requestParams.TopP,
 		// TODO(sqs): map requestParams.TopK to openai
 		N:         1,
-		Stream:    true,
+		Stream:    stream,
 		MaxTokens: requestParams.MaxTokensToSample,
+		// TODO: Our clients are currently heavily biased towards Anthropic,
+		// so the stop sequences we send might not actually be very useful
+		// for OpenAI.
+		Stop: requestParams.StopSequences,
 	}
 	for _, m := range requestParams.Messages {
 		// TODO(sqs): map these 'roles' to openai system/user/assistant
@@ -66,6 +129,7 @@ func (a *openAIChatCompletionStreamClient) Stream(
 			role = "user"
 		case types.ASISSTANT_MESSAGE_SPEAKER:
 			role = "assistant"
+			//
 		default:
 			role = strings.ToLower(role)
 		}
@@ -77,71 +141,29 @@ func (a *openAIChatCompletionStreamClient) Stream(
 
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(reqBody))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+a.accessToken)
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
 
-	resp, err := a.cli.Do(req)
+	resp, err := c.cli.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return errors.Errorf("OpenAI API failed with: %s", string(respBody))
+		defer resp.Body.Close()
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, errors.Errorf("OpenAI API failed with status %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	dec := NewDecoder(resp.Body)
-	var content []string
-	for dec.Scan() {
-		if ctx.Err() != nil && ctx.Err() == context.Canceled {
-			return nil
-		}
-
-		data := dec.Data()
-
-		if bytes.Equal(data, doneBytes) {
-			return nil
-		}
-
-		if !bytes.HasPrefix(data, []byte("{")) {
-			continue
-		}
-
-		var event struct {
-			Choices []struct {
-				Delta struct {
-					Content string `json:"content"`
-				} `json:"delta"`
-				FinishReason *string `json:"finish_reason"`
-			} `json:"choices"`
-		}
-		if err := json.Unmarshal(data, &event); err != nil {
-			return errors.Errorf("failed to decode event payload: %w - body: %s", err, string(data))
-		}
-
-		if len(event.Choices) > 0 {
-			content = append(content, event.Choices[0].Delta.Content)
-			ev := types.CompletionResponse{Completion: strings.Join(content, "")}
-			if event.Choices[0].FinishReason != nil {
-				ev.StopReason = *event.Choices[0].FinishReason
-			}
-			err = sendEvent(ev)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return dec.Err()
+	return resp, nil
 }
 
 type openAIChatCompletionsRequestParameters struct {
@@ -162,4 +184,28 @@ type openAIChatCompletionsRequestParameters struct {
 type message struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
+}
+
+type openaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type openaiChoiceDelta struct {
+	Content string `json:"content"`
+}
+
+type openaiChoice struct {
+	Delta        openaiChoiceDelta `json:"delta"`
+	Role         string            `json:"role"`
+	Content      string            `json:"content"`
+	FinishReason string            `json:"finish_reason"`
+}
+
+type openaiResponse struct {
+	// Usage is only available for non-streaming requests.
+	Usage   openaiUsage    `json:"usage"`
+	Model   string         `json:"model"`
+	Choices []openaiChoice `json:"choices"`
 }


### PR DESCRIPTION
This adds the required backend functionality to support code completions with OpenAI. It does NOT implement code completions though, as the client has to craft and parse the queries and responses in a way that currently seems very specific to Anthropic. If someone is interested, this would be the next step to feature parity here. After this PR, using a GPT model like gpt-3.5-turbo can be used to ask for code completions. It returns a valid response to the VSCode extension, but the contents of it are not useful so nothing really shows up.

This PR is mostly to prepare the API ahead of the client because the client can ship any time.

## Test plan

Verified valid responses are returned E2E locally, through LLM Proxy.