### PR TITLE
batches: surface batch change feature availability in JS context `LicenseInfo`

### DIFF
--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -13,10 +13,10 @@ var PostAuthMiddleware func(http.Handler) http.Handler
 // the given license plan. It mirrors the type licensing.FeatureBatchChanges.
 type FeatureBatchChanges struct {
 	// If true, there is no limit to the number of changesets that can be created.
-	Unrestricted bool
+	Unrestricted bool `json:"unrestricted"`
 	// Maximum number of changesets that can be created per batch change.
 	// If Unrestricted is true, this is ignored.
-	MaxNumChangesets int
+	MaxNumChangesets int `json:"maxNumChangesets"`
 }
 
 // LicenseInfo contains information about the legitimate usage of the current

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -9,15 +9,26 @@ import (
 // middleware. The client is authenticated when PostAuthMiddleware is called.
 var PostAuthMiddleware func(http.Handler) http.Handler
 
+// FeatureBatchChanges describes if and how the Batch Changes feature is available on
+// the given license plan. It mirrors the type licensing.FeatureBatchChanges.
+type FeatureBatchChanges struct {
+	// If true, there is no limit to the number of changesets that can be created.
+	Unrestricted bool
+	// Maximum number of changesets that can be created per batch change.
+	// If Unrestricted is true, this is ignored.
+	MaxNumChangesets int
+}
+
 // LicenseInfo contains information about the legitimate usage of the current
 // license on the instance.
 type LicenseInfo struct {
 	CurrentPlan string `json:"currentPlan"`
 
-	CodeScaleLimit         string   `json:"codeScaleLimit"`
-	CodeScaleCloseToLimit  bool     `json:"codeScaleCloseToLimit"`
-	CodeScaleExceededLimit bool     `json:"codeScaleExceededLimit"`
-	KnownLicenseTags       []string `json:"knownLicenseTags"`
+	CodeScaleLimit         string               `json:"codeScaleLimit"`
+	CodeScaleCloseToLimit  bool                 `json:"codeScaleCloseToLimit"`
+	CodeScaleExceededLimit bool                 `json:"codeScaleExceededLimit"`
+	KnownLicenseTags       []string             `json:"knownLicenseTags"`
+	BatchChanges           *FeatureBatchChanges `json:"batchChanges"`
 }
 
 var GetLicenseInfo = func(isSiteAdmin bool) *LicenseInfo { return nil }

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -170,6 +170,12 @@ type JSContext struct {
 
 	Branding *schema.Branding `json:"branding"`
 
+	// BatchChangesEnabled is true if:
+	// * Batch Changes is NOT disabled by a flag in the site config
+	// * Batch Changes is NOT limited to admins-only, or it is, but the user issuing
+	//   the request is an admin and thus can access batch changes
+	// It does NOT reflect whether or not the site license has batch changes available.
+	// Use LicenseInfo for that.
 	BatchChangesEnabled                bool                                `json:"batchChangesEnabled"`
 	BatchChangesDisableWebhooksWarning bool                                `json:"batchChangesDisableWebhooksWarning"`
 	BatchChangesWebhookLogsEnabled     bool                                `json:"batchChangesWebhookLogsEnabled"`

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -85,6 +85,22 @@ func Init(
 			}
 		}
 
+		bcFeature := &licensing.FeatureBatchChanges{}
+		if err := licensing.Check(bcFeature); err == nil {
+			if bcFeature.Unrestricted {
+				licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
+					Unrestricted: true,
+					// Superceded by being unrestricted
+					MaxNumChangesets: -1,
+				}
+			} else {
+				max := int(bcFeature.MaxNumChangesets)
+				licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
+					MaxNumChangesets: max,
+				}
+			}
+		}
+
 		// returning this only makes sense on dotcom
 		if envvar.SourcegraphDotComMode() {
 			for _, plan := range licensing.AllPlans {

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -85,22 +85,6 @@ func Init(
 			}
 		}
 
-		bcFeature := &licensing.FeatureBatchChanges{}
-		if err := licensing.Check(bcFeature); err == nil {
-			if bcFeature.Unrestricted {
-				licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
-					Unrestricted: true,
-					// Superceded by being unrestricted
-					MaxNumChangesets: -1,
-				}
-			} else {
-				max := int(bcFeature.MaxNumChangesets)
-				licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
-					MaxNumChangesets: max,
-				}
-			}
-		}
-
 		// returning this only makes sense on dotcom
 		if envvar.SourcegraphDotComMode() {
 			for _, plan := range licensing.AllPlans {
@@ -110,6 +94,22 @@ func Init(
 				licenseInfo.KnownLicenseTags = append(licenseInfo.KnownLicenseTags, feature.FeatureName())
 			}
 			licenseInfo.KnownLicenseTags = append(licenseInfo.KnownLicenseTags, licensing.MiscTags...)
+		} else {
+			bcFeature := &licensing.FeatureBatchChanges{}
+			if err := licensing.Check(bcFeature); err == nil {
+				if bcFeature.Unrestricted {
+					licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
+						Unrestricted: true,
+						// Superceded by being unrestricted
+						MaxNumChangesets: -1,
+					}
+				} else {
+					max := int(bcFeature.MaxNumChangesets)
+					licenseInfo.BatchChanges = &hooks.FeatureBatchChanges{
+						MaxNumChangesets: max,
+					}
+				}
+			}
 		}
 
 		return licenseInfo


### PR DESCRIPTION
License info was recently added to the JS Context, which makes a lot of sense given it's pretty much guaranteed to be constant over the lifetime of a user's visit to Sourcegraph and it's useful to make the very earliest of rendering decisions when the web app loads.

One such decision is whether or not to display the Batch Changes tab in the nav bar, or whether or not to show the main Batch Changes list page when visiting that part of the web app. Not properly handling this decision was what led to https://github.com/sourcegraph/sourcegraph/issues/49714, a bug which Becca is working on fixes for. This PR attempts to enable a part of that fix -- namely, that if a site has a license that explicitly does *not* include Batch Changes in its provisions, we should not show the Batch Changes list page, only the "Getting Started" page. It does so by surfacing the Batch Changes feature configuration in that JS Context `LicenseInfo` object.

This PR is just the backend changes; Becca's got the corresponding frontend ones incoming.

What's also notable about this is that it would allow us to refactor away from the somewhat outdated, redundant frontend logic around [assessing the license](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/batches/useBatchChangesLicense.ts?L33) and the `maxUnlicensedChangesets` property on the GraphQL schema that we query and rely on in a couple other places in the frontend in order to inform users when they're about to take an action that would exceed their license capabilities. 🙂

## Test plan

### No Batch Changes:

- Mock a license plan without the Batch Changes feature included
- Load the frontend web app
- `console.log(window.context.licenseInfo)`
- Observe presence of property `batchChanges: null`

### Dotcom

- Run `sg start dotcom`
- Load the frontend web app
- `console.log(window.context.licenseInfo)`
- Observe presence of property `batchChanges: null`

### Limited Batch Changes

- Mock a license plan with Batch Changes included with a `MaxNumChangesets` set
- Load the frontend web app
- `console.log(window.context.licenseInfo)`
- Observe presence of property `batchChanges: { maxNumChangesets: 10, unrestricted: false}`

### Unlimited Batch Changes

- Mock a license plan with Batch Changes included with `Unrestricted: true` set
- Load the frontend web app
- `console.log(window.context.licenseInfo)`
- Observe presence of property `batchChanges: { maxNumChangesets: -1, unrestricted: true}`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
