### PR TITLE
Embeddings: add an AVX512 implementation of Dot

### DIFF
--- a/enterprise/internal/embeddings/dot.go
+++ b/enterprise/internal/embeddings/dot.go
@@ -1,40 +1,58 @@
 package embeddings
 
+import "github.com/sourcegraph/sourcegraph/internal/env"
+
+var (
+	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
+
+	// dotArch is a dot product function that is architecture-optimized. Its
+	// inputs must be of equal length and that length must be a multiple of 64.
+	// The default implementation will work on all architectures, but it may
+	// be overridden if a more efficient method is available.
+	dotArch = func(a, b []int8) int32 {
+		sum := int32(0)
+
+		count := len(a)
+		if count > len(b) {
+			// Do this ahead of time so the compiler doesn't need to bounds check
+			// every time we index into b.
+			panic("mismatched vector lengths")
+		}
+
+		for i := 0; i+3 < count; i += 4 {
+			m0 := int32(a[i]) * int32(b[i])
+			m1 := int32(a[i+1]) * int32(b[i+1])
+			m2 := int32(a[i+2]) * int32(b[i+2])
+			m3 := int32(a[i+3]) * int32(b[i+3])
+			sum += (m0 + m1 + m2 + m3)
+		}
+
+		return sum
+	}
+)
+
 // Dot computes the dot product of the two vectors:
 // sum_i(a_i * b_i) for i in [0, len(a)).
 //
 // Precondition: len(a) == len(b)
 func Dot(a, b []int8) int32 {
-	if haveDotArch {
-		return dotArch(a, b)
-	}
-	return dotPortable(a, b)
-}
-
-func dotPortable(a, b []int8) int32 {
-	similarity := int32(0)
-
-	count := len(a)
-	if count > len(b) {
-		// Do this ahead of time so the compiler doesn't need to bounds check
-		// every time we index into b.
-		panic("mismatched vector lengths")
+	if len(a) != len(b) {
+		panic("mismatched lengths")
 	}
 
-	i := 0
-	for ; i+3 < count; i += 4 {
-		m0 := int32(a[i]) * int32(b[i])
-		m1 := int32(a[i+1]) * int32(b[i+1])
-		m2 := int32(a[i+2]) * int32(b[i+2])
-		m3 := int32(a[i+3]) * int32(b[i+3])
-		similarity += (m0 + m1 + m2 + m3)
+	// dotArch requires 64-byte chunks.
+	rem := len(a) % 64
+	blockA := a[:len(a)-rem]
+	blockB := b[:len(b)-rem]
+
+	sum := dotArch(blockA, blockB)
+
+	// add the remaining elements separately
+	for i := len(a) - rem; i < len(a); i++ {
+		sum += int32(a[i]) * int32(b[i])
 	}
 
-	for ; i < count; i++ {
-		similarity += int32(a[i]) * int32(b[i])
-	}
-
-	return similarity
+	return sum
 }
 
 func DotFloat32(row []float32, query []float32) float32 {

--- a/enterprise/internal/embeddings/dot_amd64.go
+++ b/enterprise/internal/embeddings/dot_amd64.go
@@ -4,46 +4,23 @@ package embeddings
 
 import (
 	"github.com/klauspost/cpuid/v2"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-var (
-	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
-	hasAVX2     = cpuid.CPU.Has(cpuid.AVX2)
-	haveDotArch = simdEnabled && hasAVX2
-	hasVNNI     = cpuid.CPU.Supports(
-		cpuid.AVX512F,    // VPXORQ, VPSUBD, VPBROADCASTD
-		cpuid.AVX512BW,   // VMOVDQU8, VADDB, VPSRLDQ
-		cpuid.AVX512VNNI, // VPDPBUSD
+func init() {
+	hasAVX2 := cpuid.CPU.Has(cpuid.AVX2)
+	hasVNNI := cpuid.CPU.Supports(
+		cpuid.AVX512F,    // required by VPXORQ, VPSUBD, VPBROADCASTD
+		cpuid.AVX512BW,   // required by VMOVDQU8, VADDB, VPSRLDQ
+		cpuid.AVX512VNNI, // required by VPDPBUSD
 	)
-)
 
-func dotArch(a []int8, b []int8) int32 {
-	if len(a) != len(b) {
-		panic("mismatched lengths")
+	if simdEnabled && hasVNNI {
+		dotArch = dotVNNI
+	} else if simdEnabled && hasAVX2 {
+		dotArch = dotAVX2
 	}
-
-	if len(a) == 0 {
-		return 0
-	}
-
-	if hasVNNI {
-		rem := len(a) % 64
-		blockA := a[:len(a)-rem]
-		blockB := b[:len(b)-rem]
-
-		sum := dotVNNI(blockA, blockB)
-
-		for i := len(a) - rem; i < len(a); i++ {
-			sum += int32(a[i]) * int32(b[i])
-		}
-
-		return sum
-	}
-	return int32(dotAVX2(a, b))
 }
 
-func dotAVX2(a, b []int8) int64
+func dotAVX2(a, b []int8) int32
 
 func dotVNNI(a, b []int8) int32

--- a/enterprise/internal/embeddings/dot_amd64.go
+++ b/enterprise/internal/embeddings/dot_amd64.go
@@ -12,6 +12,11 @@ var (
 	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
 	hasAVX2     = cpuid.CPU.Has(cpuid.AVX2)
 	haveDotArch = simdEnabled && hasAVX2
+	hasVNNI     = cpuid.CPU.Supports(
+		cpuid.AVX512F,    // VPXORQ, VPSUBD, VPBROADCASTD
+		cpuid.AVX512BW,   // VMOVDQU8, VADDB, VPSRLDQ
+		cpuid.AVX512VNNI, // VPDPBUSD
+	)
 )
 
 func dotArch(a []int8, b []int8) int32 {
@@ -23,7 +28,22 @@ func dotArch(a []int8, b []int8) int32 {
 		return 0
 	}
 
+	if hasVNNI {
+		rem := len(a) % 64
+		blockA := a[:len(a)-rem]
+		blockB := b[:len(b)-rem]
+
+		sum := dotVNNI(blockA, blockB)
+
+		for i := len(a) - rem; i < len(a); i++ {
+			sum += int32(a[i]) * int32(b[i])
+		}
+
+		return sum
+	}
 	return int32(dotAVX2(a, b))
 }
 
 func dotAVX2(a, b []int8) int64
+
+func dotVNNI(a, b []int8) int32

--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-TEXT ·dotAVX2(SB), NOSPLIT, $0-56
+TEXT ·dotAVX2(SB), NOSPLIT, $0-52
 	// Offsets based on slice header offsets.
 	// To check, use `GOARCH=amd64 go vet`
 	MOVQ a_base+0(FP), AX
@@ -48,30 +48,9 @@ reduce:
 	// Store the reduced sum
 	VMOVD X0, R8
 
-	// For the remainder of the function, we do not use vector instructions.
-	// Zero the registers to avoid the SSE penalty.
-	VZEROALL
-
-// In tailloop, we add to the dot product one at a time
-tailloop:
-	CMPQ DX, $0
-	JE end
-
-	// Load values from the input slices
-	MOVBQSX (AX), R9
-	MOVBQSX (BX), R10
-
-	// Multiply and accumulate
-	IMULQ R9, R10
-	ADDQ R10, R8
-
-	INCQ AX
-	INCQ BX
-	DECQ DX
-	JMP tailloop
-
 end:
-	MOVQ R8, ret+48(FP)
+	MOVL R8, ret+48(FP)
+	VZEROALL
 	RET
 
 // dotVNNI calculates the dot product of two slices using AVX512 VNNI

--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -69,7 +69,7 @@ TEXT ·dotVNNI(SB), NOSPLIT, $0-52
 	VPXORQ Z0, Z0, Z0 // positive
 	VPXORQ Z1, Z1, Z1 // negative
 
-	// Fill Z3 with 128
+	// Fill Z2 with 128
 	MOVD $0x80808080, R9
 	VPBROADCASTD R9, Z2
 
@@ -98,9 +98,12 @@ blockloop:
 	JMP blockloop
 
 reduce:
+    // Subtract the overshoot from our calculated dot product
 	VPSUBD Z1, Z0, Z0 // Z0 -= Z1
 
-    // Sum Z0 horizontally
+    // Sum Z0 horizontally. There is no horizontal sum instruction, so instead
+    // we sum the upper and lower halves of Z0, fold it in half again, and
+    // repeat until we are down to 1 element that contains the final sum.
     VEXTRACTI64X4 $1, Z0, Y1
     VPADDD Y0, Y1, Y0
 

--- a/enterprise/internal/embeddings/dot_amd64.s
+++ b/enterprise/internal/embeddings/dot_amd64.s
@@ -88,6 +88,9 @@ blockloop:
 	// to compensate by so we can subtract it from the sum at the end.
 	//
 	// Effectively, we are calculating SUM((Z3 + 128) · Z4) - 128 * SUM(Z4).
+    //
+    // The idea for this comes from this doc:
+    // https://www.intel.com/content/www/us/en/docs/onednn/developer-guide-reference/2023-0/nuances-of-int8-computations.html#DOXID-DEV-GUIDE-INT8-COMPUTATIONS-1DG-I8-COMP-S12
 
 	VPADDB Z3, Z2, Z3   // add 128 to Z3, making it unsigned
 	VPDPBUSD Z4, Z3, Z0 // Z0 += Z3 dot Z4

--- a/enterprise/internal/embeddings/dot_arm64.go
+++ b/enterprise/internal/embeddings/dot_arm64.go
@@ -4,36 +4,13 @@ package embeddings
 
 import (
 	"github.com/klauspost/cpuid/v2"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-var (
-	simdEnabled   = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
-	hasDotProduct = cpuid.CPU.Supports(cpuid.ASIMD, cpuid.ASIMDDP)
-	haveDotArch   = simdEnabled && hasDotProduct
-)
-
-func dotArch(a []int8, b []int8) int32 {
-	if len(a) != len(b) {
-		panic("mismatched lengths")
+func init() {
+	hasDotProduct := cpuid.CPU.Supports(cpuid.ASIMD, cpuid.ASIMDDP)
+	if simdEnabled && hasDotProduct {
+		dotArch = dotSIMD
 	}
-
-	if len(a) == 0 {
-		return 0
-	}
-
-	rem := len(a) % 16
-	blockA := a[:len(a)-rem]
-	blockB := b[:len(b)-rem]
-
-	sum := int32(dotSIMD(blockA, blockB))
-
-	for i := len(a) - rem; i < len(a); i++ {
-		sum += int32(a[i]) * int32(b[i])
-	}
-
-	return sum
 }
 
-func dotSIMD(a, b []int8) int64
+func dotSIMD(a, b []int8) int32

--- a/enterprise/internal/embeddings/dot_arm64.s
+++ b/enterprise/internal/embeddings/dot_arm64.s
@@ -6,7 +6,7 @@
 //
 // The vectors must be of the same length, and that length
 // must be a multiple of 16.
-TEXT ·dotSIMD(SB), NOSPLIT, $0-56
+TEXT ·dotSIMD(SB), NOSPLIT, $0-52
 	// Offsets based on slice header offsets.
 	// To check, use `GOARCH=arm64 go vet`
 	MOVD a_base+0(FP), R4
@@ -17,8 +17,6 @@ TEXT ·dotSIMD(SB), NOSPLIT, $0-56
 
 	// Zero V0, which will store 4 packed 32-bit sums
 	VEOR V0.B16, V0.B16, V0.B16
-
-#define BLOCKSIZE $16
 
 blockloop:
 	CMP R4, R6


### PR DESCRIPTION
This adds a dot product implementation that uses [AVX512 VNNI instructions](https://iq.opengenus.org/avx512-vnni/). These instructions specifically exist to accelerate ML workloads. This yields a ~30% improvement in embeddings/s compared to the AVX2 implementation.

In the second commit, I cleaned up and simplified the implementations a bit since we now have 4 different implementations of the dot product (native go, arm64, amd64 with AVX2, and amd64 with AVX512-VNNI 🤯). Some comments inline for each of the changes.

```
goos: linux
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings
cpu: Intel(R) Xeon(R) Platinum 8481C CPU @ 2.70GHz
                                  │ /tmp/avx2.txt │            /tmp/vnni.txt            │
                                  │    sec/op     │   sec/op     vs base                │
SimilaritySearch/numWorkers=1-44      150.5m ± 3%   119.4m ± 1%  -20.67% (p=0.000 n=10)
SimilaritySearch/numWorkers=2-44      81.08m ± 6%   61.66m ± 1%  -23.95% (p=0.000 n=10)
SimilaritySearch/numWorkers=4-44      45.54m ± 2%   33.94m ± 4%  -25.48% (p=0.000 n=10)
SimilaritySearch/numWorkers=8-44      26.02m ± 1%   19.22m ± 3%  -26.15% (p=0.000 n=10)
SimilaritySearch/numWorkers=16-44     17.05m ± 0%   14.08m ± 2%  -17.42% (p=0.000 n=10)
geomean                               47.69m        36.81m       -22.80%

                                  │ /tmp/avx2.txt │            /tmp/vnni.txt             │
                                  │ embeddings/s  │ embeddings/s  vs base                │
SimilaritySearch/numWorkers=1-44      6.644M ± 3%    8.375M ± 1%  +26.05% (p=0.000 n=10)
SimilaritySearch/numWorkers=2-44      12.33M ± 5%    16.22M ± 1%  +31.49% (p=0.000 n=10)
SimilaritySearch/numWorkers=4-44      21.96M ± 2%    29.47M ± 4%  +34.18% (p=0.000 n=10)
SimilaritySearch/numWorkers=8-44      38.43M ± 1%    52.04M ± 3%  +35.40% (p=0.000 n=10)
SimilaritySearch/numWorkers=16-44     58.65M ± 0%    71.03M ± 2%  +21.10% (p=0.000 n=10)
geomean                               20.97M         27.16M       +29.53%

                                  │    /tmp/avx2.txt    │                /tmp/vnni.txt                │
                                  │ embeddings/s/worker │ embeddings/s/worker  vs base                │
SimilaritySearch/numWorkers=1-44            6.644M ± 3%           8.375M ± 1%  +26.05% (p=0.000 n=10)
SimilaritySearch/numWorkers=2-44            6.167M ± 5%           8.109M ± 1%  +31.49% (p=0.000 n=10)
SimilaritySearch/numWorkers=4-44            5.490M ± 2%           7.366M ± 4%  +34.18% (p=0.000 n=10)
SimilaritySearch/numWorkers=8-44            4.804M ± 1%           6.504M ± 3%  +35.40% (p=0.000 n=10)
SimilaritySearch/numWorkers=16-44           3.666M ± 0%           4.439M ± 2%  +21.10% (p=0.000 n=10)
geomean                                     5.243M                6.791M       +29.53%
```

## Test plan

Updated tests to run on cases larger than 64, add an additional "random ints" test to augment the more opaque quicktests. Manually ran tests and benchmarks on a GCE instance with AVX512-VNNI available. This is not enabled by default, and can be disabled easily by unsetting an environment variable, so the risk is low.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
