### PR TITLE
Revert "completions: Fixup schema validation (#52024)"

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -545,7 +545,7 @@ type Completions struct {
 	// AccessToken description: The access token used to authenticate with the external completions provider.
 	AccessToken string `json:"accessToken"`
 	// ChatModel description: The model used for chat completions.
-	ChatModel string `json:"chatModel"`
+	ChatModel string `json:"chatModel,omitempty"`
 	// CompletionModel description: The model used for code completion.
 	CompletionModel string `json:"completionModel,omitempty"`
 	// Enabled description: Toggles whether completions are enabled.
@@ -553,7 +553,7 @@ type Completions struct {
 	// Endpoint description: The endpoint under which to reach the provider. Currently only used for provider type LLM proxy.
 	Endpoint string `json:"endpoint,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
-	Model string `json:"model,omitempty"`
+	Model string `json:"model"`
 	// PerUserCodeCompletionsDailyLimit description: If > 0, enables the maximum number of code completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
 	PerUserCodeCompletionsDailyLimit int `json:"perUserCodeCompletionsDailyLimit,omitempty"`
 	// PerUserDailyLimit description: If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2335,7 +2335,7 @@
     "completions": {
       "description": "Configuration for the completions service.",
       "type": "object",
-      "required": ["enabled", "chatModel", "accessToken", "provider"],
+      "required": ["enabled", "model", "accessToken", "provider"],
       "properties": {
         "enabled": {
           "description": "Toggles whether completions are enabled.",


### PR DESCRIPTION
This broke FS based updates, seems like we enforce the schema again, I thought we stopped doing that at some point. 

This reverts commit c2045704d85269d13744254011c3ce1844fa9816.



## Test plan

N/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
