### PR TITLE
llmproxy: Add allow list for upstream models

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/httpapi/anthropic.go
+++ b/enterprise/cmd/llm-proxy/internal/httpapi/anthropic.go
@@ -14,11 +14,12 @@ import (
 
 const anthropicAPIURL = "https://api.anthropic.com/v1/complete"
 
-func newAnthropicHandler(logger log.Logger, eventLogger events.Logger, accessToken string) http.Handler {
+func newAnthropicHandler(logger log.Logger, eventLogger events.Logger, accessToken string, allowedModels []string) http.Handler {
 	return makeUpstreamHandler(
 		logger,
 		eventLogger,
 		anthropicAPIURL,
+		allowedModels,
 		func(body *anthropicRequest) {
 			// Null the metadata field, we don't want to allow users to specify it:
 			body.Metadata = nil

--- a/enterprise/cmd/llm-proxy/internal/httpapi/handler.go
+++ b/enterprise/cmd/llm-proxy/internal/httpapi/handler.go
@@ -11,9 +11,11 @@ import (
 )
 
 type Config struct {
-	AnthropicAccessToken string
-	OpenAIAccessToken    string
-	OpenAIOrgID          string
+	AnthropicAccessToken   string
+	AnthropicAllowedModels []string
+	OpenAIAccessToken      string
+	OpenAIOrgID            string
+	OpenAIAllowedModels    []string
 }
 
 func NewHandler(logger log.Logger, eventLogger events.Logger, config *Config) http.Handler {
@@ -21,11 +23,12 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, config *Config) ht
 
 	// V1 service routes
 	v1router := r.PathPrefix("/v1").Subrouter()
+
 	if config.AnthropicAccessToken != "" {
-		v1router.Handle("/completions/anthropic", newAnthropicHandler(logger, eventLogger, config.AnthropicAccessToken)).Methods(http.MethodPost)
+		v1router.Handle("/completions/anthropic", newAnthropicHandler(logger, eventLogger, config.AnthropicAccessToken, config.AnthropicAllowedModels)).Methods(http.MethodPost)
 	}
 	if config.OpenAIAccessToken != "" {
-		v1router.Handle("/completions/openai", newOpenAIHandler(logger, eventLogger, config.OpenAIAccessToken, config.OpenAIOrgID)).Methods(http.MethodPost)
+		v1router.Handle("/completions/openai", newOpenAIHandler(logger, eventLogger, config.OpenAIAccessToken, config.OpenAIOrgID, config.OpenAIAllowedModels)).Methods(http.MethodPost)
 	}
 
 	return r

--- a/enterprise/cmd/llm-proxy/internal/httpapi/openai.go
+++ b/enterprise/cmd/llm-proxy/internal/httpapi/openai.go
@@ -14,11 +14,12 @@ import (
 
 const openAIURL = "https://api.openai.com/v1/chat/completions"
 
-func newOpenAIHandler(logger log.Logger, eventLogger events.Logger, accessToken string, orgID string) http.Handler {
+func newOpenAIHandler(logger log.Logger, eventLogger events.Logger, accessToken string, orgID string, allowedModels []string) http.Handler {
 	return makeUpstreamHandler(
 		logger,
 		eventLogger,
 		openAIURL,
+		allowedModels,
 		func(body *openaiRequest) {
 			// We don't want to let users generate multiple responses, as this would
 			// mess with rate limit counting.

--- a/enterprise/cmd/llm-proxy/shared/config.go
+++ b/enterprise/cmd/llm-proxy/shared/config.go
@@ -3,10 +3,12 @@ package shared
 import (
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Config struct {
@@ -25,12 +27,14 @@ type Config struct {
 	}
 
 	Anthropic struct {
-		AccessToken string
+		AllowedModels []string
+		AccessToken   string
 	}
 
 	OpenAI struct {
-		AccessToken string
-		OrgID       string
+		AllowedModels []string
+		AccessToken   string
+		OrgID         string
 	}
 
 	AllowAnonymous bool
@@ -62,8 +66,12 @@ func (c *Config) Load() {
 	c.Dotcom.DevLicensesOnly = c.GetBool("LLM_PROXY_DOTCOM_DEV_LICENSES_ONLY", "false", "Only allow tokens associated with active dev licenses to be used.")
 
 	c.Anthropic.AccessToken = c.Get("LLM_PROXY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
+	c.Anthropic.AllowedModels = splitMaybe(c.Get("LLM_PROXY_ANTHROPIC_ALLOWED_MODELS", "claude-v1,claude-v1.0,claude-v1.2,claude-v1.3,claude-instant-v1,claude-instant-v1.0", "The Anthropic access token to be used."))
+
 	c.OpenAI.AccessToken = c.GetOptional("LLM_PROXY_OPENAI_ACCESS_TOKEN", "The OpenAI access token to be used.")
 	c.OpenAI.OrgID = c.GetOptional("LLM_PROXY_OPENAI_ORG_ID", "The OpenAI organization to count billing towards. Setting this ensures we always use the correct negotiated terms.")
+	c.OpenAI.AllowedModels = splitMaybe(c.Get("LLM_PROXY_OPENAI_ALLOWED_MODELS", "gpt-4,gpt-3.5-turbo", "The Anthropic access token to be used."))
+
 	c.AllowAnonymous = c.GetBool("LLM_PROXY_ALLOW_ANONYMOUS", "false", "Allow anonymous access to LLM proxy.")
 	c.SourcesSyncInterval = c.GetInterval("LLM_PROXY_SOURCES_SYNC_INTERVAL", "2m", "The interval at which to sync actor sources.")
 
@@ -81,5 +89,22 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if c.Anthropic.AccessToken != "" && len(c.Anthropic.AllowedModels) == 0 {
+		c.AddError(errors.New("must provide allowed models for Anthropic"))
+	}
+
+	if c.OpenAI.AccessToken != "" && len(c.OpenAI.AllowedModels) == 0 {
+		c.AddError(errors.New("must provide allowed models for OpenAI"))
+	}
+
 	return nil
+}
+
+// splitMaybe splits on commas, but only returns at least one element if the input
+// is non-empty.
+func splitMaybe(input string) []string {
+	if input == "" {
+		return nil
+	}
+	return strings.Split(input, ",")
 }

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -67,9 +67,11 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	// Set up our handler chain, which is run from the bottom up. Application handlers
 	// come last.
 	handler := httpapi.NewHandler(obctx.Logger, eventLogger, &httpapi.Config{
-		AnthropicAccessToken: config.Anthropic.AccessToken,
-		OpenAIAccessToken:    config.OpenAI.AccessToken,
-		OpenAIOrgID:          config.OpenAI.OrgID,
+		AnthropicAccessToken:   config.Anthropic.AccessToken,
+		AnthropicAllowedModels: config.Anthropic.AllowedModels,
+		OpenAIAccessToken:      config.OpenAI.AccessToken,
+		OpenAIOrgID:            config.OpenAI.OrgID,
+		OpenAIAllowedModels:    config.OpenAI.AllowedModels,
 	})
 
 	// Authentication and rate-limting layers


### PR DESCRIPTION
We don't want to allow all models by default, as upstreams evolve they might add example models that we don't want to allow access to just yet (and just recently did with claude 100k, for example). For now, no additional config is required here, as I added some sensible defaults.

## Test plan

Verified the error is returned correctly. 