### PR TITLE
App: Fix redirect after app sign-in

### DIFF
--- a/cmd/frontend/internal/auth/userpasswd/app.go
+++ b/cmd/frontend/internal/auth/userpasswd/app.go
@@ -106,13 +106,14 @@ func AppSignInMiddleware(db database.DB, handler func(w http.ResponseWriter, r *
 		// Success. Redirect to search or to "redirect" param if present.
 		redirect := r.URL.Query().Get("redirect")
 		u := r.URL
-		u.RawQuery = ""
 		if redirect != "" {
-			path, err := url.QueryUnescape(redirect)
+			redirectUrl, err := url.Parse(redirect)
 			if err == nil {
-				u.Path = path
+				u.Path = redirectUrl.Path
+				u.RawQuery = redirectUrl.RawQuery
 			}
 		} else {
+			u.RawQuery = ""
 			u.Path = "/search"
 		}
 		http.Redirect(w, r, u.String(), http.StatusTemporaryRedirect)


### PR DESCRIPTION
Fix the App sign-in middleware when:

- the app is launching with a deep link using a sourcegraph:// scheme url
- and the app contains a query param

The proposed fix is to parse the redirect URL so that we can assign the `Path` and the `RawQuery` parts of the destination URL. This method handles the parts of the URL properly so we don't need to call QueryUnescape.

This is in the middleware that is used for the Tauri sign-in link.

This keeps the original behavior where we only set the path/query part of the URL and we don't modify the scheme and host because it should always local redirect.

## Test plan

- Test launching App with deep links with and without query params