### PR TITLE
batches: automatically delete branches when changeset is merged/closed with site config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added the ability to block auto-indexing scheduling and inference via the `codeintel_autoindexing_exceptions` Postgres table. [#51578](https://github.com/sourcegraph/sourcegraph/pull/51578)
 - When an admin has configured rollout windows for Batch Changes changesets, the configuration details are now visible to all users on the Batch Changes settings page. [#50479](https://github.com/sourcegraph/sourcegraph/pull/50479)
 - Added support for regular expressions in`exclude` repositories for GitLab code host connections. [#51862](https://github.com/sourcegraph/sourcegraph/pull/51862)
+- Branches created by Batch Changes will now be automatically deleted on the code host upon merging or closing a changeset if the new `batchChanges.autoDeleteBranch` site setting is enabled. [#XXXXX](https://github.com/sourcegraph/sourcegraph/issues/XXXXX)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added the ability to block auto-indexing scheduling and inference via the `codeintel_autoindexing_exceptions` Postgres table. [#51578](https://github.com/sourcegraph/sourcegraph/pull/51578)
 - When an admin has configured rollout windows for Batch Changes changesets, the configuration details are now visible to all users on the Batch Changes settings page. [#50479](https://github.com/sourcegraph/sourcegraph/pull/50479)
 - Added support for regular expressions in`exclude` repositories for GitLab code host connections. [#51862](https://github.com/sourcegraph/sourcegraph/pull/51862)
-- Branches created by Batch Changes will now be automatically deleted on the code host upon merging or closing a changeset if the new `batchChanges.autoDeleteBranch` site setting is enabled. [#XXXXX](https://github.com/sourcegraph/sourcegraph/issues/XXXXX)
+- Branches created by Batch Changes will now be automatically deleted on the code host upon merging or closing a changeset if the new `batchChanges.autoDeleteBranch` site setting is enabled. [#52055](https://github.com/sourcegraph/sourcegraph/pull/52055)
 
 ### Changed
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -148,3 +148,27 @@ To enable forks, update the site configuration to include:
   "batchChanges.enforceForks": true
 }
 ```
+
+## Automatically delete branches on merge/close
+
+<span class="badge badge-note">Sourcegraph 5.0.5+</span>
+
+Sourcegraph can be configured to automatically delete branches created for Batch Changes changesets when changesets are merged or closed by enabling the `batchChanges.autoDeleteBranch` site configuration option.
+
+When enabled, Batch Changes will override any setting on the repository on the code host itself and attempt to remove the source branch of the changeset when the changeset is merged or closed. This is useful for keeping repositories clean of stale branches.
+
+Not every code host supports this in the same way; some code host APIs expose a property on the changeset which can be toggled to enable this behavior, while others require a separate API call to delete the branch after the changeset is merged/closed.
+
+For those that support a changeset property, Batch Changes will automatically set the property to match the site config setting. The property will be updated whenever the changeset is updated, so that the settings stay in sync.
+
+For those that require a separate API call, Batch Changes will only be able to delete the branch if the changeset is merged/closed _using Sourcegraph_. If the changeset is merged/closed on the code host itself, Batch Changes will not be able to delete the branch.
+
+Refer to the table below to see the levels with which each code host is supported:
+
+Code Host | Changeset property or separate API call? | Support on merge | Support on close
+--------- | --------- | :-: | :-:
+Azure DevOps | Changeset property | ✓ | ✗
+Bitbucket Cloud | Changeset property | ✓ | ✓
+Bitbucket Server | API call | ✓ | ✓
+GitHub | API call | ✓ | ✓
+GitLab | Changeset property | ✓ | ✓

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -16,6 +16,7 @@
     * [Rollout windows](../../admin/config/batch_changes.md#rollout-windows), which control the rate at which Batch Changes will publish changesets on code hosts.
     * [Forks](../../admin/config/batch_changes.md#forks), which push branches created by Batch Changes onto forks of the upstream repository instead than the repository itself.
     * [Outgoing webhooks](../../admin/config/webhooks/outgoing.md), which publish events related to batch changes and changesets to enable deeper integrations with your other tools and systems.
+    * [Auto-delete branch on merge/close](../../admin/config/batch_changes.md#automatically-delete-branches-on-merge-close), which automatically deletes branches created by Batch Changes when changesets are merged or closed.
 
 #### Disable Batch Changes
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).

--- a/enterprise/internal/batches/sources/BUILD.bazel
+++ b/enterprise/internal/batches/sources/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//enterprise/internal/batches/sources/bitbucketcloud",
         "//enterprise/internal/batches/store",
         "//enterprise/internal/batches/types",
+        "//internal/conf",
         "//internal/database",
         "//internal/errcode",
         "//internal/extsvc",

--- a/enterprise/internal/batches/sources/BUILD.bazel
+++ b/enterprise/internal/batches/sources/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//enterprise/internal/batches/store",
         "//enterprise/internal/batches/types",
         "//internal/api",
+        "//internal/conf",
         "//internal/database",
         "//internal/errcode",
         "//internal/extsvc",

--- a/enterprise/internal/batches/sources/azuredevops.go
+++ b/enterprise/internal/batches/sources/azuredevops.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 
 	adobatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
@@ -411,20 +410,11 @@ func (s AzureDevOpsSource) setChangesetMetadata(ctx context.Context, repo *azure
 
 func (s AzureDevOpsSource) changesetToPullRequestInput(cs *Changeset) azuredevops.CreatePullRequestInput {
 
-	var closeSourceBranch bool
-
-	if conf.Get().BatchChangesAutoDeleteBranch {
-		closeSourceBranch = true
-	} else {
-		closeSourceBranch = false
-	}
-
 	input := azuredevops.CreatePullRequestInput{
 		Title:         cs.Title,
 		Description:   cs.Body,
 		SourceRefName: cs.HeadRef,
 		TargetRefName: cs.BaseRef,
-		AutoComplete:  closeSourceBranch,
 	}
 
 	// If we're forking, then we need to set the source repository as well.

--- a/enterprise/internal/batches/sources/azuredevops.go
+++ b/enterprise/internal/batches/sources/azuredevops.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 
 	adobatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
@@ -409,11 +410,21 @@ func (s AzureDevOpsSource) setChangesetMetadata(ctx context.Context, repo *azure
 }
 
 func (s AzureDevOpsSource) changesetToPullRequestInput(cs *Changeset) azuredevops.CreatePullRequestInput {
+
+	var closeSourceBranch bool
+
+	if conf.Get().BatchChangesAutoDeleteBranch {
+		closeSourceBranch = true
+	} else {
+		closeSourceBranch = false
+	}
+
 	input := azuredevops.CreatePullRequestInput{
 		Title:         cs.Title,
 		Description:   cs.Body,
 		SourceRefName: cs.HeadRef,
 		TargetRefName: cs.BaseRef,
+		AutoComplete:  closeSourceBranch,
 	}
 
 	// If we're forking, then we need to set the source repository as well.

--- a/enterprise/internal/batches/sources/azuredevops.go
+++ b/enterprise/internal/batches/sources/azuredevops.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -105,8 +104,6 @@ func (s AzureDevOpsSource) LoadChangeset(ctx context.Context, cs *Changeset) err
 // exists, *Changeset will be populated and the return value will be true.
 func (s AzureDevOpsSource) CreateChangeset(ctx context.Context, cs *Changeset) (bool, error) {
 	input := s.changesetToPullRequestInput(cs)
-	fmt.Printf("input from create: %v", input)
-
 	return s.createChangeset(ctx, cs, input)
 }
 
@@ -175,6 +172,14 @@ func (s AzureDevOpsSource) CloseChangeset(ctx context.Context, cs *Changeset) er
 		return errors.Wrap(err, "abandoning pull request")
 	}
 
+	// TODO: We ought to check the AutoDeleteBranch setting here and delete the branch if
+	// it's set, but we don't have all the necessary details of the head ref here in order
+	// to perform that update, so currently we only honor the setting on "completion" aka
+	// merge. In order to accomplish this, we would need to issue a POST request to update
+	// the ref and supply its name and old Object ID (which we don't have) and then
+	// "0000000000000000000000000000000000000000" as the new Object ID. See
+	// https://learn.microsoft.com/en-us/rest/api/azure/devops/git/refs/update-refs?view=azure-devops-rest-7.0&tabs=HTTP#gitrefupdate
+
 	return errors.Wrap(s.setChangesetMetadata(ctx, repo, &updated, cs), "setting Azure DevOps changeset metadata")
 }
 
@@ -215,8 +220,12 @@ func (s AzureDevOpsSource) UpdateChangeset(ctx context.Context, cs *Changeset) e
 // ReopenChangeset will reopen the Changeset on the source, if it's closed.
 // If not, it's a noop.
 func (s AzureDevOpsSource) ReopenChangeset(ctx context.Context, cs *Changeset) error {
+	deleteSourceBranch := conf.Get().BatchChangesAutoDeleteBranch
 	input := azuredevops.PullRequestUpdateInput{
 		Status: &azuredevops.PullRequestStatusActive,
+		CompletionOptions: &azuredevops.PullRequestCompletionOptions{
+			DeleteSourceBranch: deleteSourceBranch,
+		},
 	}
 	repo := cs.TargetRepo.Metadata.(*azuredevops.Repository)
 	args, err := s.createCommonPullRequestArgs(*repo, *cs)
@@ -270,9 +279,11 @@ func (s AzureDevOpsSource) MergeChangeset(ctx context.Context, cs *Changeset, sq
 		mergeStrategy = &ms
 	}
 
+	deleteSourceBranch := conf.Get().BatchChangesAutoDeleteBranch
 	updated, err := s.client.CompletePullRequest(ctx, args, azuredevops.PullRequestCompleteInput{
-		CommitID:      cs.SyncState.HeadRefOid,
-		MergeStrategy: mergeStrategy,
+		CommitID:           cs.SyncState.HeadRefOid,
+		MergeStrategy:      mergeStrategy,
+		DeleteSourceBranch: deleteSourceBranch,
 	})
 	if err != nil {
 		if errcode.IsNotFound(err) {
@@ -413,22 +424,16 @@ func (s AzureDevOpsSource) setChangesetMetadata(ctx context.Context, repo *azure
 }
 
 func (s AzureDevOpsSource) changesetToPullRequestInput(cs *Changeset) azuredevops.CreatePullRequestInput {
-
+	deleteSourceBranch := conf.Get().BatchChangesAutoDeleteBranch
 	input := azuredevops.CreatePullRequestInput{
 		Title:         cs.Title,
 		Description:   cs.Body,
 		SourceRefName: cs.HeadRef,
 		TargetRefName: cs.BaseRef,
+		CompletionOptions: &azuredevops.PullRequestCompletionOptions{
+			DeleteSourceBranch: deleteSourceBranch,
+		},
 	}
-
-	if conf.Get().BatchChangesAutoDeleteBranch {
-		input.CompletionOptions = &azuredevops.PullRequestCompletionOptions{
-			DeleteSourceBranch: true,
-		}
-	}
-
-	fmt.Printf("input from CTPR: %v", input)
-	fmt.Printf("completion options: %v", input.CompletionOptions)
 
 	// If we're forking, then we need to set the source repository as well.
 	if cs.RemoteRepo != cs.TargetRepo {
@@ -441,16 +446,20 @@ func (s AzureDevOpsSource) changesetToPullRequestInput(cs *Changeset) azuredevop
 }
 
 func (s AzureDevOpsSource) changesetToUpdatePullRequestInput(cs *Changeset, targetRefChanged bool) azuredevops.PullRequestUpdateInput {
-	targetRed := gitdomain.EnsureRefPrefix(cs.BaseRef)
+	targetRef := gitdomain.EnsureRefPrefix(cs.BaseRef)
 	if targetRefChanged {
 		return azuredevops.PullRequestUpdateInput{
-			TargetRefName: &targetRed,
+			TargetRefName: &targetRef,
 		}
 	}
 
+	deleteSourceBranch := conf.Get().BatchChangesAutoDeleteBranch
 	return azuredevops.PullRequestUpdateInput{
 		Title:       &cs.Title,
 		Description: &cs.Body,
+		CompletionOptions: &azuredevops.PullRequestCompletionOptions{
+			DeleteSourceBranch: deleteSourceBranch,
+		},
 	}
 }
 

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -142,6 +142,7 @@ func (s BitbucketCloudSource) CloseChangeset(ctx context.Context, cs *Changeset)
 
 // UpdateChangeset can update Changesets.
 func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset) error {
+
 	opts := s.changesetToPullRequestInput(cs)
 	targetRepo := cs.TargetRepo.Metadata.(*bitbucketcloud.Repo)
 
@@ -150,6 +151,8 @@ func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset
 	// it'll override it's value to it's empty value. We always want to retain the reviewers assigned to a pull
 	// request when updating a pull request.
 	opts.Reviewers = pr.Reviewers
+
+	opts.CloseSourceBranch = conf.Get().BatchChangesAutoDeleteBranch
 
 	updated, err := s.client.UpdatePullRequest(ctx, targetRepo, pr.ID, opts)
 	if err != nil {
@@ -321,7 +324,6 @@ func (s BitbucketCloudSource) changesetToPullRequestInput(cs *Changeset) bitbuck
 	destBranch := gitdomain.AbbreviateRef(cs.BaseRef)
 
 	var closeSourceBranch bool
-
 	if conf.Get().BatchChangesAutoDeleteBranch {
 		closeSourceBranch = true
 	} else {

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -152,7 +152,9 @@ func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset
 	// request when updating a pull request.
 	opts.Reviewers = pr.Reviewers
 
-	opts.CloseSourceBranch = conf.Get().BatchChangesAutoDeleteBranch
+	if conf.Get().BatchChangesAutoDeleteBranch {
+		opts.CloseSourceBranch = true
+	}
 
 	updated, err := s.client.UpdatePullRequest(ctx, targetRepo, pr.ID, opts)
 	if err != nil {
@@ -326,8 +328,6 @@ func (s BitbucketCloudSource) changesetToPullRequestInput(cs *Changeset) bitbuck
 	var closeSourceBranch bool
 	if conf.Get().BatchChangesAutoDeleteBranch {
 		closeSourceBranch = true
-	} else {
-		closeSourceBranch = false
 	}
 
 	opts := bitbucketcloud.PullRequestInput{

--- a/enterprise/internal/batches/sources/bitbucketcloud.go
+++ b/enterprise/internal/batches/sources/bitbucketcloud.go
@@ -142,7 +142,6 @@ func (s BitbucketCloudSource) CloseChangeset(ctx context.Context, cs *Changeset)
 
 // UpdateChangeset can update Changesets.
 func (s BitbucketCloudSource) UpdateChangeset(ctx context.Context, cs *Changeset) error {
-
 	opts := s.changesetToPullRequestInput(cs)
 	targetRepo := cs.TargetRepo.Metadata.(*bitbucketcloud.Repo)
 
@@ -324,11 +323,7 @@ func (s BitbucketCloudSource) setChangesetMetadata(ctx context.Context, repo *bi
 
 func (s BitbucketCloudSource) changesetToPullRequestInput(cs *Changeset) bitbucketcloud.PullRequestInput {
 	destBranch := gitdomain.AbbreviateRef(cs.BaseRef)
-
-	var closeSourceBranch bool
-	if conf.Get().BatchChangesAutoDeleteBranch {
-		closeSourceBranch = true
-	}
+	closeSourceBranch := conf.Get().BatchChangesAutoDeleteBranch
 
 	opts := bitbucketcloud.PullRequestInput{
 		Title:             cs.Title,

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -152,10 +152,9 @@ func (s BitbucketServerSource) CloseChangeset(ctx context.Context, c *Changeset)
 	}
 
 	if conf.Get().BatchChangesAutoDeleteBranch {
-		err := s.client.DeleteSourceBranch(ctx, pr, bitbucketserver.DeleteSourceBranchInput{
+		if err := s.client.DeleteBranch(ctx, pr.ToRef.Repository.Project.Key, pr.ToRef.Repository.Slug, bitbucketserver.DeleteBranchInput{
 			Name: pr.FromRef.ID,
-		})
-		if err != nil {
+		}); err != nil {
 			return errors.Wrap(err, "deleting source branch")
 		}
 	}
@@ -298,10 +297,9 @@ func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset,
 	}
 
 	if conf.Get().BatchChangesAutoDeleteBranch {
-		err := s.client.DeleteSourceBranch(ctx, pr, bitbucketserver.DeleteSourceBranchInput{
+		if err := s.client.DeleteBranch(ctx, pr.ToRef.Repository.Project.Key, pr.ToRef.Repository.Slug, bitbucketserver.DeleteBranchInput{
 			Name: pr.FromRef.ID,
-		})
-		if err != nil {
+		}); err != nil {
 			return errors.Wrap(err, "deleting source branch")
 		}
 	}

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -284,6 +285,83 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 			}
 
 			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			err = bbsSrc.CloseChangeset(ctx, tc.cs)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil {
+				return
+			}
+
+			pr := tc.cs.Changeset.Metadata.(*bitbucketserver.PullRequest)
+			testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), pr)
+		})
+	}
+}
+
+func TestBitbucketServerSource_CloseChangeset_DeleteSourceBranch(t *testing.T) {
+	// Repository used: https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing
+	//
+	// This test can be updated with `-update BitbucketServerSource_CloseChangeset_DeleteSourceBranch`,
+	// provided this PR is open: https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/168/overview
+
+	pr := &bitbucketserver.PullRequest{ID: 168, Version: 1}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+	pr.FromRef.ID = "refs/heads/delete-me"
+
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "BitbucketServerSource_CloseChangeset_DeleteSourceBranch_" + strings.ReplaceAll(tc.name, " ", "_")
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Updating fixtures: %t", update(tc.name))
+
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			conf.Mock(&conf.Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					BatchChangesAutoDeleteBranch: true,
+				},
+			})
+			defer conf.Mock(nil)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &types.ExternalService{
+				Kind: extsvc.KindBitbucketServer,
+				Config: extsvc.NewUnencryptedConfig(marshalJSON(t, &schema.BitbucketServerConnection{
+					Url:   "https://bitbucket.sgdev.org",
+					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				})),
+			}
+
+			ctx := context.Background()
+			bbsSrc, err := NewBitbucketServerSource(ctx, svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", "https://bitbucket.sgdev.org")
 
 			err = bbsSrc.CloseChangeset(ctx, tc.cs)
 			if have, want := fmt.Sprint(err), tc.err; have != want {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -177,9 +177,14 @@ func (s GitHubSource) CloseChangeset(ctx context.Context, c *Changeset) error {
 		return err
 	}
 
+	owner, repo, err := github.SplitRepositoryNameWithOwner(pr.RepoWithOwner)
+	if err != nil {
+		return err
+	}
+
 	deleteBranch := conf.Get().BatchChangesAutoDeleteBranch
 	if deleteBranch {
-		err := s.client.DeleteRef(ctx, pr.RepoWithOwner, pr.Title, pr.HeadRefName)
+		err := s.client.DeleteRef(ctx, owner, repo, pr.HeadRefName)
 		if err != nil {
 			return err
 		}

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -119,7 +119,7 @@ func (s *GitLabSource) CreateChangeset(ctx context.Context, c *Changeset) (bool,
 	}
 
 	var removeSource bool
-	if conf.Get().BatchChangesAutoDeleteBranch == true {
+	if conf.Get().BatchChangesAutoDeleteBranch {
 		removeSource = true
 	} else {
 		removeSource = false

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CloseChangeset_DeleteSourceBranch_success
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CloseChangeset_DeleteSourceBranch_success
@@ -1,0 +1,55 @@
+{
+  "id": 168,
+  "version": 1,
+  "title": "PR to be deleted",
+  "description": "",
+  "state": "DECLINED",
+  "open": false,
+  "closed": true,
+  "createdDate": 1684292333177,
+  "updatedDate": 1684292383182,
+  "fromRef": {
+   "id": "refs/heads/delete-me",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "milton",
+    "emailAddress": "dev@sourcegraph.com",
+    "id": 1,
+    "displayName": "milton",
+    "active": true,
+    "slug": "milton",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/168"
+    }
+   ]
+  }
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/GitLabSource_CreateChangeset_no-remove-source-branch
+++ b/enterprise/internal/batches/sources/testdata/golden/GitLabSource_CreateChangeset_no-remove-source-branch
@@ -1,0 +1,41 @@
+{
+  "id": 224166702,
+  "iid": 12,
+  "project_id": 40370047,
+  "source_project_id": 40370047,
+  "SourceProjectNamespace": "",
+  "SourceProjectName": "",
+  "title": "This is a test PR",
+  "description": "This is the description of the test PR",
+  "state": "opened",
+  "created_at": "2023-05-17T02:37:18.003Z",
+  "updated_at": "2023-05-17T02:37:18.003Z",
+  "merged_at": null,
+  "closed_at": null,
+  "head_pipeline": null,
+  "labels": [],
+  "source_branch": "test-pr-3",
+  "target_branch": "main",
+  "web_url": "https://gitlab.com/batch-changes-testing/batch-changes-test-repo/-/merge_requests/12",
+  "work_in_progress": false,
+  "draft": false,
+  "force_remove_source_branch": false,
+  "author": {
+   "id": 11440943,
+   "name": "Kelli Rockwell",
+   "username": "courier-new",
+   "email": "",
+   "state": "active",
+   "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/11440943/avatar.png",
+   "web_url": "https://gitlab.com/courier-new",
+   "identities": null
+  },
+  "diff_refs": {
+   "base_sha": "",
+   "head_sha": "",
+   "start_sha": ""
+  },
+  "Notes": null,
+  "Pipelines": null,
+  "ResourceStateEvents": null
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/GitLabSource_CreateChangeset_yes-remove-source-branch
+++ b/enterprise/internal/batches/sources/testdata/golden/GitLabSource_CreateChangeset_yes-remove-source-branch
@@ -1,0 +1,41 @@
+{
+  "id": 224166704,
+  "iid": 13,
+  "project_id": 40370047,
+  "source_project_id": 40370047,
+  "SourceProjectNamespace": "",
+  "SourceProjectName": "",
+  "title": "This is a test PR",
+  "description": "This is the description of the test PR",
+  "state": "opened",
+  "created_at": "2023-05-17T02:37:19.37Z",
+  "updated_at": "2023-05-17T02:37:19.37Z",
+  "merged_at": null,
+  "closed_at": null,
+  "head_pipeline": null,
+  "labels": [],
+  "source_branch": "test-pr-4",
+  "target_branch": "main",
+  "web_url": "https://gitlab.com/batch-changes-testing/batch-changes-test-repo/-/merge_requests/13",
+  "work_in_progress": false,
+  "draft": false,
+  "force_remove_source_branch": true,
+  "author": {
+   "id": 11440943,
+   "name": "Kelli Rockwell",
+   "username": "courier-new",
+   "email": "",
+   "state": "active",
+   "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/11440943/avatar.png",
+   "web_url": "https://gitlab.com/courier-new",
+   "identities": null
+  },
+  "diff_refs": {
+   "base_sha": "",
+   "head_sha": "",
+   "start_sha": ""
+  },
+  "Notes": null,
+  "Pipelines": null,
+  "ResourceStateEvents": null
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/GithubSource_CloseChangeset_DeleteSourceBranch_success
+++ b/enterprise/internal/batches/sources/testdata/golden/GithubSource_CloseChangeset_DeleteSourceBranch_success
@@ -1,0 +1,264 @@
+{
+  "ID": "PR_kwDODS5xec4waMkR",
+  "Title": "This is a test PR",
+  "Body": "This is the description of the test PR",
+  "State": "CLOSED",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/468",
+  "HeadRefOid": "a5955a89096304d07531f7467b269b1bcf2727c7",
+  "BaseRefOid": "58dd8da9d9099a823c814c528b29b72c9b2ac98b",
+  "HeadRefName": "test-pr-10",
+  "BaseRefName": "master",
+  "Number": 468,
+  "Author": {
+   "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+   "Login": "LawnGnome",
+   "URL": "https://github.com/LawnGnome"
+  },
+  "BaseRepository": {
+   "ID": "MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=",
+   "Name": "automation-testing",
+   "Owner": {
+    "Login": "sourcegraph"
+   }
+  },
+  "HeadRepository": {
+   "ID": "MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=",
+   "Name": "automation-testing",
+   "Owner": {
+    "Login": "sourcegraph"
+   }
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+    "Login": "LawnGnome",
+    "URL": "https://github.com/LawnGnome"
+   },
+   {
+    "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+    "Login": "courier-new",
+    "URL": "https://github.com/courier-new"
+   }
+  ],
+  "Labels": {
+   "Nodes": []
+  },
+  "TimelineItems": [
+   {
+    "Type": "PullRequestCommit",
+    "Item": {
+     "Commit": {
+      "OID": "a5955a89096304d07531f7467b269b1bcf2727c7",
+      "Message": "Test branch.",
+      "MessageHeadline": "Test branch.",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/a5955a89096304d07531f7467b269b1bcf2727c7",
+      "Committer": {
+       "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+       "Email": "adam@adamharvey.name",
+       "Name": "Adam Harvey",
+       "User": {
+        "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+        "Login": "LawnGnome",
+        "URL": "https://github.com/LawnGnome"
+       }
+      },
+      "CommittedDate": "2021-12-30T22:56:31Z",
+      "PushedDate": "2021-12-30T22:56:37Z"
+     }
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+      "Login": "LawnGnome",
+      "URL": "https://github.com/LawnGnome"
+     },
+     "CreatedAt": "2021-12-30T23:02:46Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-5829292407"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-02-03T20:14:42Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-02-03T20:15:12Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-8435938069"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:32:21Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:36:41Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-9263776785"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:40:30Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:40:47Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-9263793435"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:42:37Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:44:38Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-9263807970"
+    }
+   },
+   {
+    "Type": "ReopenedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:49:43Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466\u0026v=4",
+      "Login": "courier-new",
+      "URL": "https://github.com/courier-new"
+     },
+     "CreatedAt": "2023-05-17T01:50:02Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/468#event-9263832101"
+    }
+   }
+  ],
+  "Commits": {
+   "Nodes": [
+    {
+     "Commit": {
+      "OID": "a5955a89096304d07531f7467b269b1bcf2727c7",
+      "CheckSuites": {
+       "Nodes": [
+        {
+         "ID": "CS_kwDODS5xec8AAAABHeqoTA",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "CS_kwDODS5xec8AAAABHeqoUA",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "CS_kwDODS5xec8AAAABHeqoVA",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "CS_kwDODS5xec8AAAADA7bFkw",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "CS_kwDODS5xec8AAAADA7bFlw",
+         "Status": "QUEUED",
+         "Conclusion": "",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        }
+       ]
+      },
+      "Status": {
+       "State": "",
+       "Contexts": null
+      },
+      "CommittedDate": "2021-12-30T22:56:31Z"
+     }
+    }
+   ]
+  },
+  "IsDraft": false,
+  "CreatedAt": "2021-12-30T22:57:42Z",
+  "UpdatedAt": "2023-05-17T01:50:02Z"
+ }

--- a/enterprise/internal/batches/sources/testdata/golden/GitlabSource_LoadChangeset_found
+++ b/enterprise/internal/batches/sources/testdata/golden/GitlabSource_LoadChangeset_found
@@ -19,6 +19,7 @@
   "web_url": "https://gitlab.com/sourcegraph/sourcegraph/-/merge_requests/2",
   "work_in_progress": false,
   "draft": false,
+  "force_remove_source_branch": false,
   "author": {
    "id": 3294801,
    "name": "Ryan Blunden",

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CloseChangeset_DeleteSourceBranch_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CloseChangeset_DeleteSourceBranch_success.yaml
@@ -1,0 +1,119 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/168/decline?version=1
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":0,"expectedVersion":1,"pullRequest":{"id":168,"version":0,"title":"PR
+      to be deleted","state":"OPEN","open":true,"closed":false,"createdDate":1684292333177,"updatedDate":1684292333177,"fromRef":{"id":"refs/heads/delete-me","displayId":"delete-me","latestCommit":"82a998a3e58c042bc7926f073356aa96c9f96c50","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"archived":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"archived":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","active":true,"displayName":"milton","id":1,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/168"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 17 May 2023 02:59:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@1W6FCFYx179x2963536x0'
+      X-Asessionid:
+      - flcnww
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/168/decline?version=0
+    method: POST
+  response:
+    body: '{"id":168,"version":1,"title":"PR to be deleted","state":"DECLINED","open":false,"closed":true,"createdDate":1684292333177,"updatedDate":1684292383182,"closedDate":1684292383182,"fromRef":{"id":"refs/heads/delete-me","displayId":"delete-me","latestCommit":"82a998a3e58c042bc7926f073356aa96c9f96c50","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"archived":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2046f48cd2633f58f1a4c2aa7b5b1b613e34a24c","type":"BRANCH","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"archived":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","active":true,"displayName":"milton","id":1,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/168"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 17 May 2023 02:59:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - x-ausername,x-auserid,cookie,accept-encoding
+      X-Arequestid:
+      - '@1W6FCFYx179x2963537x0'
+      X-Asessionid:
+      - 41294z
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: |
+      {"name":"refs/heads/delete-me"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/branch-utils/latest/projects/SOUR/repos/automation-testing/branches
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 17 May 2023 02:59:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - X-AUSERNAME
+      - X-AUSERID
+      - Cookie
+      X-Arequestid:
+      - '@1W6FCFYx179x2963538x0'
+      X-Asessionid:
+      - 894vxq
+      X-Auserid:
+      - "1"
+      X-Ausername:
+      - milton
+      X-Content-Type-Options:
+      - nosniff
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/GitLabSource_CreateChangeset_no-remove-source-branch.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/GitLabSource_CreateChangeset_no-remove-source-branch.yaml
@@ -1,0 +1,292 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"source_branch":"test-pr-3","target_branch":"main","title":"This is a
+      test PR","description":"This is the description of the test PR"}'
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests
+    method: POST
+  response:
+    body: '{"id":224166702,"iid":12,"project_id":40370047,"title":"This is a test
+      PR","description":"This is the description of the test PR","state":"opened","created_at":"2023-05-17T02:37:18.003Z","updated_at":"2023-05-17T02:37:18.003Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"test-pr-3","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":11440943,"username":"courier-new","name":"Kelli
+      Rockwell","state":"active","avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/11440943/avatar.png","web_url":"https://gitlab.com/courier-new"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":40370047,"target_project_id":40370047,"labels":[],"draft":false,"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","sha":"ee9d62f8f653057d13cdaecb129681bdab520fbe","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":null,"reference":"!12","references":{"short":"!12","relative":"!12","full":"batch-changes-testing/batch-changes-test-repo!12"},"web_url":"https://gitlab.com/batch-changes-testing/batch-changes-test-repo/-/merge_requests/12","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7c887a4a79de945c-SJC
+      Content-Length:
+      - "1846"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:18 GMT
+      Etag:
+      - W/"b7a779c1a573487835da374710f9e543"
+      Gitlab-Lb:
+      - fe-33-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=hnwBAkzR5ZGimWClYWhzZyFtDnL%2BD0qOSIwpcY4h5qw9zr8putt2T626tW3N0LsgdVw8uG6oAq49tLtG4CynKSEIRMlKzNBQgDTFFY76eIOYJk3OEDToz%2F9GPyc%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"4569d2d4cfd4dd8e522fe5b38d772fc1","version":"1"}'
+      X-Request-Id:
+      - 4569d2d4cfd4dd8e522fe5b38d772fc1
+      X-Runtime:
+      - "0.486591"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/12/notes?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a4e6d61945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:18 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-08-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/notes?activity_filter=all_notes&id=40370047&noteable_id=12&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/notes?activity_filter=all_notes&id=40370047&noteable_id=12&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=bGOh3afeMCQGr0AKWGQwWjEej7ASOacCQoI8%2B4ne4Bq6mksteiH8dI7iSgKFhSkMLHFi%2Fo7wNKYbKWXiCQCwK%2FZ9aSjRVh6wgcBHc8gFDCoCAOoxW3HPtysfR5E%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"a02986e021b6ab14973847971c49cedc","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - a02986e021b6ab14973847971c49cedc
+      X-Runtime:
+      - "0.073266"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/12/resource_state_events?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a509f23945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-13-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/resource_state_events?eventable_id=12&id=40370047&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/resource_state_events?eventable_id=12&id=40370047&page=1&per_page=20>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=iCC%2FnN0%2Fhg8UTOu84WuAPJrlXUYZPsNai0BRXq2sRORPg7lMXpfwpy2uqzvheNeoCq8kl43kYL0nqqxGNFwdmJ%2Fl9grhH15KwHpvCNRYCQaEBUfGJdOerKqup4Y%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"113d9aea35e7b8c9e876771fdb7806a6","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 113d9aea35e7b8c9e876771fdb7806a6
+      X-Runtime:
+      - "0.068255"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/12/pipelines?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a51d865945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-19-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/pipelines?id=40370047&merge_request_iid=12&page=1&per_page=15>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/12/pipelines?id=40370047&merge_request_iid=12&page=1&per_page=15>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=sOYyWG61zkoD%2Fr5kh1lP4hFVaRYf90LYkT%2BMOw%2BH7O9ZgnnksMHKDHaERdOLMQ6b7x5X4u6IEJQNxCaH2MdbTQboWEq6KVAYDmHcoA3%2BdpwnyaR0A3LR2MwR6Go%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"700f092ff0e2954106cc9f82ac1d20cd","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "15"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 700f092ff0e2954106cc9f82ac1d20cd
+      X-Runtime:
+      - "0.068695"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/GitLabSource_CreateChangeset_yes-remove-source-branch.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/GitLabSource_CreateChangeset_yes-remove-source-branch.yaml
@@ -1,0 +1,292 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"source_branch":"test-pr-4","target_branch":"main","title":"This is a
+      test PR","description":"This is the description of the test PR","remove_source_branch":true}'
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests
+    method: POST
+  response:
+    body: '{"id":224166704,"iid":13,"project_id":40370047,"title":"This is a test
+      PR","description":"This is the description of the test PR","state":"opened","created_at":"2023-05-17T02:37:19.370Z","updated_at":"2023-05-17T02:37:19.370Z","merged_by":null,"merge_user":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"main","source_branch":"test-pr-4","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":11440943,"username":"courier-new","name":"Kelli
+      Rockwell","state":"active","avatar_url":"https://gitlab.com/uploads/-/system/user/avatar/11440943/avatar.png","web_url":"https://gitlab.com/courier-new"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":40370047,"target_project_id":40370047,"labels":[],"draft":false,"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"checking","detailed_merge_status":"preparing","sha":"ac5346012ad196d62c4acf4d5c06e04d2f7c051e","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":true,"reference":"!13","references":{"short":"!13","relative":"!13","full":"batch-changes-testing/batch-changes-test-repo!13"},"web_url":"https://gitlab.com/batch-changes-testing/batch-changes-test-repo/-/merge_requests/13","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"squash_on_merge":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":false,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":true,"changes_count":null,"latest_build_started_at":null,"latest_build_finished_at":null,"first_deployed_to_production_at":null,"pipeline":null,"head_pipeline":null,"diff_refs":null,"merge_error":null,"user":{"can_merge":true}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7c887a5329d0945c-SJC
+      Content-Length:
+      - "1846"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:19 GMT
+      Etag:
+      - W/"c74cac4b635763889859b106702943f1"
+      Gitlab-Lb:
+      - fe-36-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=65wsSjvo%2F85BEaL82V5qJOx6Ur9nw0ntKJjcqzT9SG6nhXWy%2Fg1kh6nVitoGipT123gJ70P9sktxYc%2FAEgxJWwRaHO2BwjvdkPa1gHPxQsgxRXAri%2FLIktuvOUs%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"2133bff13528f1c25e43a46b39790555","version":"1"}'
+      X-Request-Id:
+      - 2133bff13528f1c25e43a46b39790555
+      X-Runtime:
+      - "0.241559"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/13/notes?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a557bc7945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-04-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/notes?activity_filter=all_notes&id=40370047&noteable_id=13&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/notes?activity_filter=all_notes&id=40370047&noteable_id=13&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=YzTEr74jVG2fNhMkAePPKuqp0jzHxA4xIpg43EbrGR2f%2B%2FVsQmZ1Kv7hMbTYcG8ZjUFQSmkZzK0fsWAE%2BGOCUiG8aUo3JNEK4Y6Hl%2FxqUsCG3EBgk112lqqTpPk%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"a6af0306d675d6c6ed2803ffb104ad29","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - a6af0306d675d6c6ed2803ffb104ad29
+      X-Runtime:
+      - "0.069445"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/13/resource_state_events?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a56bcdd945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:19 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/resource_state_events?eventable_id=13&id=40370047&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/resource_state_events?eventable_id=13&id=40370047&page=1&per_page=20>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=8Kjv8vtHirzW3Ohcevnde2Kfm%2F2CC5bsHTVyVG9DZs37SkNCBdB5FWYvGvJTGW9ePPa65jaON1EVsDjdPXFZ%2BEt9h6oArDNZY%2Fczsv%2BTAslJGXZRaBvcLeei2xY%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"4caab4d6097547af21379f127626d758","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 4caab4d6097547af21379f127626d758
+      X-Runtime:
+      - "0.072582"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/40370047/merge_requests/13/pipelines?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - MISS
+      Cf-Ray:
+      - 7c887a581e44945c-SJC
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 May 2023 02:37:20 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Gitlab-Lb:
+      - fe-16-lb-gprd
+      Gitlab-Sv:
+      - localhost
+      Link:
+      - <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/pipelines?id=40370047&merge_request_iid=13&page=1&per_page=15>;
+        rel="first", <https://gitlab.com/api/v4/projects/40370047/merge_requests/13/pipelines?id=40370047&merge_request_iid=13&page=1&per_page=15>;
+        rel="last"
+      Nel:
+      - '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=vcpR8h78zt%2B091MFKVu2jeW%2B6ElheT2gdFv0OIM5RprIGAZQqvl5wJH6lYIORtp%2FGGPWAOjD96%2FZi19JONJXPmacL%2BigyXpV9%2ByOrEvIVqF0eC7uLseEBNKPKP8%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin, Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Meta:
+      - '{"correlation_id":"efc8d68257c097f957d6197ffa8c8954","version":"1"}'
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "15"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - efc8d68257c097f957d6197ffa8c8954
+      X-Runtime:
+      - "0.066014"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/GithubSource_CloseChangeset_DeleteSourceBranch_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/GithubSource_CloseChangeset_DeleteSourceBranch_success.yaml
@@ -1,0 +1,160 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer
+      {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment
+      review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit
+      {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment timelineItems on
+      PullRequestTimelineItems {\n  ... on AssignedEvent {\n    actor {\n      ...actor\n    }\n    assignee
+      {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ClosedEvent {\n    actor
+      {\n      ...actor\n    }\n    createdAt\n    url\n  }\n  ... on IssueComment
+      {\n    databaseId\n    author {\n      ...actor\n    }\n    authorAssociation\n    body\n    createdAt\n    editor
+      {\n      ...actor\n    }\n    url\n    updatedAt\n    includesCreatedEdit\n    publishedAt\n  }\n  ...
+      on RenamedTitleEvent {\n    actor {\n      ...actor\n    }\n    previousTitle\n    currentTitle\n    createdAt\n  }\n  ...
+      on MergedEvent {\n    actor {\n      ...actor\n    }\n    mergeRefName\n    url\n    commit
+      {\n      ...commit\n    }\n    createdAt\n  }\n  ... on PullRequestReview {\n    ...review\n  }\n  ...
+      on PullRequestReviewThread {\n    comments(last: 100) {\n      nodes {\n        databaseId\n        author
+      {\n          ...actor\n        }\n        authorAssociation\n        editor
+      {\n          ...actor\n        }\n        commit {\n          ...commit\n        }\n        body\n        state\n        url\n        createdAt\n        updatedAt\n        includesCreatedEdit\n      }\n    }\n  }\n  ...
+      on ReopenedEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on ReviewDismissedEvent {\n    actor {\n      ...actor\n    }\n    review {\n      ...review\n    }\n    dismissalMessage\n    createdAt\n  }\n  ...
+      on ReviewRequestRemovedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReviewRequestedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReadyForReviewEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on UnassignedEvent {\n    actor {\n      ...actor\n    }\n    assignee {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on LabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on UnlabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on PullRequestCommit {\n    commit {\n      ...commit\n    }\n  }\n  \n  ...
+      on ConvertToDraftEvent {\n    actor {\n\t  ...actor\n\t}\n\tcreatedAt\n  }\n\n}\n\nfragment
+      actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label
+      {\n  name\n  color\n  description\n  id\n}\n\nfragment commitWithChecks on Commit
+      {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last:
+      20) {\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last:
+      20) {\n        nodes {\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment
+      prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment
+      repo on Repository {\n  id\n  name\n  owner {\n    login\n  }\n}\n\nfragment
+      pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  isDraft\n  author
+      {\n    ...actor\n  }\n  baseRepository {\n    ...repo\n  }\n  headRepository
+      {\n    ...repo\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first:
+      100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes
+      {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT,
+      CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW,
+      PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT,
+      REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT,
+      READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    nodes
+      {\n      __typename\n      ...timelineItems\n    }\n  }\n}\nmutation\tClosePullRequest($input:ClosePullRequestInput!)
+      {\n  closePullRequest(input:$input) {\n    pullRequest {\n      ... pr\n    }\n  }\n}","variables":{"input":{"pullRequestId":"PR_kwDODS5xec4waMkR"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"closePullRequest":{"pullRequest":{"id":"PR_kwDODS5xec4waMkR","title":"This
+      is a test PR","body":"This is the description of the test PR","state":"CLOSED","url":"https://github.com/sourcegraph/automation-testing/pull/468","number":468,"createdAt":"2021-12-30T22:57:42Z","updatedAt":"2023-05-17T01:50:02Z","headRefOid":"a5955a89096304d07531f7467b269b1bcf2727c7","baseRefOid":"58dd8da9d9099a823c814c528b29b72c9b2ac98b","headRefName":"test-pr-10","baseRefName":"master","isDraft":false,"author":{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"},"baseRepository":{"id":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","name":"automation-testing","owner":{"login":"sourcegraph"}},"headRepository":{"id":"MDEwOlJlcG9zaXRvcnkyMjExNDc1MTM=","name":"automation-testing","owner":{"login":"sourcegraph"}},"participants":{"nodes":[{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"},{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"}]},"labels":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"a5955a89096304d07531f7467b269b1bcf2727c7","status":null,"checkSuites":{"nodes":[{"id":"CS_kwDODS5xec8AAAABHeqoTA","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"CS_kwDODS5xec8AAAABHeqoUA","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"CS_kwDODS5xec8AAAABHeqoVA","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"CS_kwDODS5xec8AAAADA7bFkw","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}},{"id":"CS_kwDODS5xec8AAAADA7bFlw","status":"QUEUED","conclusion":null,"checkRuns":{"nodes":[]}}]},"committedDate":"2021-12-30T22:56:31Z"}}]},"timelineItems":{"pageInfo":{"hasNextPage":false,"endCursor":"Y3Vyc29yOnYyOpPPAAABiCdmZRABqjkyNjM4MzIxMDE="},"nodes":[{"__typename":"PullRequestCommit","commit":{"oid":"a5955a89096304d07531f7467b269b1bcf2727c7","message":"Test
+      branch.","messageHeadline":"Test branch.","committedDate":"2021-12-30T22:56:31Z","pushedDate":"2021-12-30T22:56:37Z","url":"https://github.com/sourcegraph/automation-testing/commit/a5955a89096304d07531f7467b269b1bcf2727c7","committer":{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","email":"adam@adamharvey.name","name":"Adam
+      Harvey","user":{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"}}}},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"},"createdAt":"2021-12-30T23:02:46Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-5829292407"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-02-03T20:14:42Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-02-03T20:15:12Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-8435938069"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:32:21Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:36:41Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-9263776785"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:40:30Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:40:47Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-9263793435"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:42:37Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:44:38Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-9263807970"},{"__typename":"ReopenedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:49:43Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/8942601?u=d2ce1e7fb6b3178eefa92abc9e8a7eb835597466&v=4","login":"courier-new","url":"https://github.com/courier-new"},"createdAt":"2023-05-17T01:50:02Z","url":"https://github.com/sourcegraph/automation-testing/pull/468#event-9263832101"}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 May 2023 01:50:03 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - F9B7:8788:745CCD5:785EE4F:646432C9
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "231"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/test-pr-10
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Security-Policy:
+      - default-src 'none'
+      Date:
+      - Wed, 17 May 2023 01:50:03 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - F9B7:8788:745CF13:785F08B:646432CA
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "16"
+      X-Xss-Protection:
+      - "0"
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/goware/urlx"
 	"github.com/sourcegraph/log"
-	"golang.org/x/oauth2"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -20,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/oauth2"
 )
 
 const (

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/goware/urlx"
 	"github.com/sourcegraph/log"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -18,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"golang.org/x/oauth2"
 )
 
 const (

--- a/internal/extsvc/azuredevops/pull_requests.go
+++ b/internal/extsvc/azuredevops/pull_requests.go
@@ -38,12 +38,6 @@ func (c *client) AbandonPullRequest(ctx context.Context, args PullRequestCommonA
 // CreatePullRequest creates a new PR with the specified properties, returns the newly created PR.
 // NOTE: this API needs repository ID specified not repository Name in OrgProjectRepoArgs.
 func (c *client) CreatePullRequest(ctx context.Context, args OrgProjectRepoArgs, input CreatePullRequestInput) (PullRequest, error) {
-	if conf.Get().BatchChangesAutoDeleteBranch {
-		input.CompletionOptions = &PullRequestCompletionOptions{
-			DeleteSourceBranch: true,
-		}
-	}
-
 	data, err := json.Marshal(&input)
 	if err != nil {
 		return PullRequest{}, errors.Wrap(err, "marshalling request")

--- a/internal/extsvc/azuredevops/pull_requests.go
+++ b/internal/extsvc/azuredevops/pull_requests.go
@@ -95,7 +95,6 @@ func (c *client) GetPullRequestStatuses(ctx context.Context, args PullRequestCom
 //
 // Warning: If you are setting the TargetRefName in the PullRequestUpdateInput, it will be the only thing to get updated (bug in the ADO API).
 func (c *client) UpdatePullRequest(ctx context.Context, args PullRequestCommonArgs, input PullRequestUpdateInput) (PullRequest, error) {
-
 	reqURL := url.URL{Path: fmt.Sprintf("%s/%s/_apis/git/repositories/%s/pullrequests/%s", args.Org, args.Project, args.RepoNameOrID, args.PullRequestID)}
 
 	data, err := json.Marshal(input)

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -90,6 +90,7 @@ type CreatePullRequestInput struct {
 	Reviewers     []Reviewer `json:"reviewers"`
 	ForkSource    *ForkRef   `json:"forkSource"`
 	IsDraft       bool       `json:"isDraft"`
+	AutoComplete  bool       `json:"autoComplete"`
 }
 
 type ForkRef struct {

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -83,14 +83,14 @@ type Ref struct {
 }
 
 type CreatePullRequestInput struct {
-	SourceRefName string     `json:"sourceRefName"`
-	TargetRefName string     `json:"targetRefName"`
-	Title         string     `json:"title"`
-	Description   string     `json:"description"`
-	Reviewers     []Reviewer `json:"reviewers"`
-	ForkSource    *ForkRef   `json:"forkSource"`
-	IsDraft       bool       `json:"isDraft"`
-	AutoComplete  bool       `json:"autoComplete"`
+	SourceRefName     string                        `json:"sourceRefName"`
+	TargetRefName     string                        `json:"targetRefName"`
+	Title             string                        `json:"title"`
+	Description       string                        `json:"description"`
+	Reviewers         []Reviewer                    `json:"reviewers"`
+	ForkSource        *ForkRef                      `json:"forkSource"`
+	IsDraft           bool                          `json:"isDraft"`
+	CompletionOptions *PullRequestCompletionOptions `json:"completionOptions"`
 }
 
 type ForkRef struct {

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -161,6 +161,10 @@ type PullRequestUpdateInput struct {
 	// ADO does not seem to support updating Source ref name, only TargetRefName which needs to be explicitly enabled.
 }
 
+type PullRequestAbandonInput struct {
+	DeleteSourceBranch bool
+}
+
 type PullRequestStatus string
 type PullRequestMergeStrategy string
 
@@ -171,13 +175,14 @@ type PullRequestMergeOptions struct {
 }
 
 type PullRequestCompleteInput struct {
-	CommitID      string                    `json:"commitId"`
-	MergeStrategy *PullRequestMergeStrategy `json:"mergeStrategy"`
+	CommitID           string
+	MergeStrategy      *PullRequestMergeStrategy
+	DeleteSourceBranch bool
 }
 
 type PullRequestCompletionOptions struct {
-	MergeStrategy      PullRequestMergeStrategy `json:"mergeStrategy"`
-	DeleteSourceBranch bool                     `json:"deleteSourceBranch"`
+	MergeStrategy      PullRequestMergeStrategy `json:"mergeStrategy,omitempty"`
+	DeleteSourceBranch bool                     `json:"deleteSourceBranch,omitempty"`
 	MergeCommitMessage string                   `json:"mergeCommitMessage"`
 }
 

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -161,10 +161,6 @@ type PullRequestUpdateInput struct {
 	// ADO does not seem to support updating Source ref name, only TargetRefName which needs to be explicitly enabled.
 }
 
-type PullRequestAbandonInput struct {
-	DeleteSourceBranch bool
-}
-
 type PullRequestStatus string
 type PullRequestMergeStrategy string
 

--- a/internal/extsvc/bitbucketcloud/pull_requests.go
+++ b/internal/extsvc/bitbucketcloud/pull_requests.go
@@ -23,7 +23,7 @@ type PullRequestInput struct {
 	// If SourceRepo is provided, only FullName is actually used.
 	SourceRepo        *Repo
 	DestinationBranch *string
-	CloseSourceBranch bool
+	CloseSourceBranch bool `json:"close_source_branch"`
 }
 
 // CreatePullRequest opens a new pull request.
@@ -200,10 +200,11 @@ func (input *PullRequestInput) MarshalJSON() ([]byte, error) {
 	}
 
 	type request struct {
-		Title       string  `json:"title"`
-		Description string  `json:"description,omitempty"`
-		Source      source  `json:"source"`
-		Destination *source `json:"destination,omitempty"`
+		Title             string  `json:"title"`
+		Description       string  `json:"description,omitempty"`
+		Source            source  `json:"source"`
+		Destination       *source `json:"destination,omitempty"`
+		CloseSourceBranch bool    `json:"close_source_branch,omitempty"`
 	}
 
 	req := request{
@@ -212,6 +213,7 @@ func (input *PullRequestInput) MarshalJSON() ([]byte, error) {
 		Source: source{
 			Branch: branch{Name: input.SourceBranch},
 		},
+		CloseSourceBranch: input.CloseSourceBranch,
 	}
 	if input.SourceRepo != nil {
 		req.Source.Repository = &repository{

--- a/internal/extsvc/bitbucketcloud/pull_requests.go
+++ b/internal/extsvc/bitbucketcloud/pull_requests.go
@@ -23,6 +23,7 @@ type PullRequestInput struct {
 	// If SourceRepo is provided, only FullName is actually used.
 	SourceRepo        *Repo
 	DestinationBranch *string
+	CloseSourceBranch bool
 }
 
 // CreatePullRequest opens a new pull request.

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -724,6 +724,16 @@ func (c *Client) ReopenPullRequest(ctx context.Context, pr *PullRequest) error {
 	return err
 }
 
+func (c *Client) DeleteSourceBranch(ctx context.Context, pr *PullRequest) error {
+	path := fmt.Sprintf(
+		"rest/branch-utils/latest/projects/%s/repos/%s/branches",
+		pr.ToRef.Repository.Project.Key,
+		pr.ToRef.Repository.Slug,
+	)
+	_, err := c.send(ctx, "DELETE", path, nil, nil, pr)
+	return err
+}
+
 // LoadPullRequestActivities loads the given PullRequest's timeline of activities,
 // returning an error in case of failure.
 func (c *Client) LoadPullRequestActivities(ctx context.Context, pr *PullRequest) (err error) {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -697,7 +697,7 @@ func (c *Client) ReopenPullRequest(ctx context.Context, pr *PullRequest) error {
 	return err
 }
 
-type DeleteSourceBranchInput struct {
+type DeleteBranchInput struct {
 	// Don't actually delete the ref name, just do a dry run
 	DryRun bool `json:"dryRun,omitempty"`
 	// Commit ID that the provided ref name is expected to point to. Should the ref point
@@ -708,11 +708,12 @@ type DeleteSourceBranchInput struct {
 	Name string `json:"name,omitempty"`
 }
 
-func (c *Client) DeleteSourceBranch(ctx context.Context, pr *PullRequest, input DeleteSourceBranchInput) error {
+// DeleteBranch deletes a branch on the given repo.
+func (c *Client) DeleteBranch(ctx context.Context, projectKey, repoSlug string, input DeleteBranchInput) error {
 	path := fmt.Sprintf(
 		"rest/branch-utils/latest/projects/%s/repos/%s/branches",
-		pr.ToRef.Repository.Project.Key,
-		pr.ToRef.Repository.Slug,
+		projectKey,
+		repoSlug,
 	)
 
 	resp, err := c.send(ctx, "DELETE", path, nil, input, nil)

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1579,7 +1579,9 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 		return newHttpResponseState(resp.StatusCode, resp.Header), nil
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(result)
+	if resp.StatusCode != http.StatusNoContent {
+		err = json.NewDecoder(resp.Body).Decode(result)
+	}
 	return newHttpResponseState(resp.StatusCode, resp.Header), err
 }
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -799,7 +799,7 @@ func (c *V3Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 
 func (c *V3Client) DeleteRef(ctx context.Context, owner, repo string, ref string) error {
 	//
-	if _, err := c.delete(ctx, "repos/"+owner+"/"+repo+"/git/refs/"+ref); err != nil {
+	if _, err := c.delete(ctx, "repos/"+owner+"/"+repo+"/git/refs/heads/"+ref); err != nil {
 		return err
 	}
 	return nil

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -797,6 +797,14 @@ func (c *V3Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 	return convertRestRepo(restRepo), nil
 }
 
+func (c *V3Client) DeleteRef(ctx context.Context, owner, repo string, ref string) error {
+	//
+	if _, err := c.delete(ctx, "repos/"+owner+"/"+repo+"/git/refs/"+ref); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetAppInstallation gets information of a GitHub App installation.
 //
 // API docs: https://docs.github.com/en/rest/reference/apps#get-an-installation-for-the-authenticated-app

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -797,9 +797,9 @@ func (c *V3Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 	return convertRestRepo(restRepo), nil
 }
 
-func (c *V3Client) DeleteRef(ctx context.Context, owner, repo string, ref string) error {
-	//
-	if _, err := c.delete(ctx, "repos/"+owner+"/"+repo+"/git/refs/heads/"+ref); err != nil {
+// DeleteBranch deletes the given branch from the given repository.
+func (c *V3Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
+	if _, err := c.delete(ctx, "repos/"+owner+"/"+repo+"/git/refs/heads/"+branch); err != nil {
 		return err
 	}
 	return nil

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -657,6 +657,13 @@ func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).Fork(ctx, owner, repo, org, forkName)
 }
 
+// To delete branch
+func (c *V4Client) DeleteRef(ctx context.Context, owner, repo string, ref string) error {
+	// Unfortunately, the GraphQL API doesn't provide a mutation to deleting a branch so we have to fall back to the REST API.
+	logger := c.log.Scoped("Delete", "temporary client for deleting a branch")
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteRef(ctx, owner, repo, ref)
+}
+
 type RecentCommittersParams struct {
 	// Repository name
 	Name string

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -659,7 +659,7 @@ func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 
 // DeleteBranch deletes the given branch from the given repository.
 func (c *V4Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
-	// Unfortunately, the GraphQL API doesn't provide a mutation to deleting a branch as
+	// Unfortunately, the GraphQL API doesn't provide a mutation to delete a ref/branch as
 	// of May 2023, so we have to fall back to the REST API.
 	logger := c.log.Scoped("DeleteBranch", "temporary client for deleting a branch")
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteBranch(ctx, owner, repo, branch)

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -661,7 +661,7 @@ func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 func (c *V4Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
 	// Unfortunately, the GraphQL API doesn't provide a mutation to deleting a branch as
 	// of May 2023, so we have to fall back to the REST API.
-	logger := c.log.Scoped("Delete", "temporary client for deleting a branch")
+	logger := c.log.Scoped("DeleteBranch", "temporary client for deleting a branch")
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteBranch(ctx, owner, repo, branch)
 }
 

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -657,11 +657,12 @@ func (c *V4Client) Fork(ctx context.Context, owner, repo string, org *string, fo
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).Fork(ctx, owner, repo, org, forkName)
 }
 
-// To delete branch
-func (c *V4Client) DeleteRef(ctx context.Context, owner, repo string, ref string) error {
-	// Unfortunately, the GraphQL API doesn't provide a mutation to deleting a branch so we have to fall back to the REST API.
+// DeleteBranch deletes the given branch from the given repository.
+func (c *V4Client) DeleteBranch(ctx context.Context, owner, repo, branch string) error {
+	// Unfortunately, the GraphQL API doesn't provide a mutation to deleting a branch as
+	// of May 2023, so we have to fall back to the REST API.
 	logger := c.log.Scoped("Delete", "temporary client for deleting a branch")
-	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteRef(ctx, owner, repo, ref)
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteBranch(ctx, owner, repo, branch)
 }
 
 type RecentCommittersParams struct {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -107,11 +107,12 @@ var (
 )
 
 type CreateMergeRequestOpts struct {
-	SourceBranch    string `json:"source_branch"`
-	TargetBranch    string `json:"target_branch"`
-	TargetProjectID int    `json:"target_project_id,omitempty"`
-	Title           string `json:"title"`
-	Description     string `json:"description,omitempty"`
+	SourceBranch       string `json:"source_branch"`
+	TargetBranch       string `json:"target_branch"`
+	TargetProjectID    int    `json:"target_project_id,omitempty"`
+	Title              string `json:"title"`
+	Description        string `json:"description,omitempty"`
+	RemoveSourceBranch bool   `json:"remove_source_branch,omitempty"`
 	// TODO: other fields at
 	// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr as needed.
 }

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -245,7 +245,7 @@ func (c *Client) UpdateMergeRequest(ctx context.Context, project *Project, mr *M
 		return MockUpdateMergeRequest(c, ctx, project, mr, opts)
 	}
 
-	if conf.Get().BatchChangesAutoDeleteBranch == true {
+	if conf.Get().BatchChangesAutoDeleteBranch {
 		opts.RemoveSourceBranch = true
 	} else {
 		opts.RemoveSourceBranch = false

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Masterminds/semver"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -243,12 +242,6 @@ const (
 func (c *Client) UpdateMergeRequest(ctx context.Context, project *Project, mr *MergeRequest, opts UpdateMergeRequestOpts) (*MergeRequest, error) {
 	if MockUpdateMergeRequest != nil {
 		return MockUpdateMergeRequest(c, ctx, project, mr, opts)
-	}
-
-	if conf.Get().BatchChangesAutoDeleteBranch {
-		opts.RemoveSourceBranch = true
-	} else {
-		opts.RemoveSourceBranch = false
 	}
 
 	data, err := json.Marshal(opts)

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -27,26 +27,27 @@ const (
 )
 
 type MergeRequest struct {
-	ID                     ID `json:"id"`
-	IID                    ID `json:"iid"`
-	ProjectID              ID `json:"project_id"`
-	SourceProjectID        ID `json:"source_project_id"`
-	SourceProjectNamespace string
-	SourceProjectName      string
-	Title                  string            `json:"title"`
-	Description            string            `json:"description"`
-	State                  MergeRequestState `json:"state"`
-	CreatedAt              Time              `json:"created_at"`
-	UpdatedAt              Time              `json:"updated_at"`
-	MergedAt               *Time             `json:"merged_at"`
-	ClosedAt               *Time             `json:"closed_at"`
-	HeadPipeline           *Pipeline         `json:"head_pipeline"`
-	Labels                 []string          `json:"labels"`
-	SourceBranch           string            `json:"source_branch"`
-	TargetBranch           string            `json:"target_branch"`
-	WebURL                 string            `json:"web_url"`
-	WorkInProgress         bool              `json:"work_in_progress"`
-	Draft                  bool              `json:"draft"`
+	ID                      ID `json:"id"`
+	IID                     ID `json:"iid"`
+	ProjectID               ID `json:"project_id"`
+	SourceProjectID         ID `json:"source_project_id"`
+	SourceProjectNamespace  string
+	SourceProjectName       string
+	Title                   string            `json:"title"`
+	Description             string            `json:"description"`
+	State                   MergeRequestState `json:"state"`
+	CreatedAt               Time              `json:"created_at"`
+	UpdatedAt               Time              `json:"updated_at"`
+	MergedAt                *Time             `json:"merged_at"`
+	ClosedAt                *Time             `json:"closed_at"`
+	HeadPipeline            *Pipeline         `json:"head_pipeline"`
+	Labels                  []string          `json:"labels"`
+	SourceBranch            string            `json:"source_branch"`
+	TargetBranch            string            `json:"target_branch"`
+	WebURL                  string            `json:"web_url"`
+	WorkInProgress          bool              `json:"work_in_progress"`
+	Draft                   bool              `json:"draft"`
+	ForceRemoveSourceBranch bool              `json:"force_remove_source_branch"`
 	// We only get a partial User object back from the REST API. For example, it lacks
 	// `Email` and `Identities`. If we need more, we need to issue an additional API
 	// request. Otherwise, we should use a different type here.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2340,7 +2340,7 @@ type SiteConfiguration struct {
 	AuthzEnforceForSiteAdmins bool `json:"authz.enforceForSiteAdmins,omitempty"`
 	// AuthzRefreshInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
 	AuthzRefreshInterval int `json:"authz.refreshInterval,omitempty"`
-	// BatchChangesAutoDeleteBranch description: Override code host specific setting and automatically delete batch change branches when a batch change is merged or closed.
+	// BatchChangesAutoDeleteBranch description: Automatically delete branches created for Batch Changes changesets when the changeset is merged or closed, for supported code hosts. Overrides any setting on the repository on the code host itself.
 	BatchChangesAutoDeleteBranch bool `json:"batchChanges.autoDeleteBranch,omitempty"`
 	// BatchChangesChangesetsRetention description: How long changesets will be retained after they have been detached from a batch change.
 	BatchChangesChangesetsRetention string `json:"batchChanges.changesetsRetention,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2340,6 +2340,8 @@ type SiteConfiguration struct {
 	AuthzEnforceForSiteAdmins bool `json:"authz.enforceForSiteAdmins,omitempty"`
 	// AuthzRefreshInterval description: Time interval (in seconds) of how often each component picks up authorization changes in external services.
 	AuthzRefreshInterval int `json:"authz.refreshInterval,omitempty"`
+	// BatchChangesAutoDeleteBranch description: Override code host specific setting and automatically delete batch change branches when a batch change is merged or closed.
+	BatchChangesAutoDeleteBranch bool `json:"batchChanges.autoDeleteBranch,omitempty"`
 	// BatchChangesChangesetsRetention description: How long changesets will be retained after they have been detached from a batch change.
 	BatchChangesChangesetsRetention string `json:"batchChanges.changesetsRetention,omitempty"`
 	// BatchChangesDisableWebhooksWarning description: Hides Batch Changes warnings about webhooks not being configured.
@@ -2606,6 +2608,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "auth.userOrgMap")
 	delete(m, "authz.enforceForSiteAdmins")
 	delete(m, "authz.refreshInterval")
+	delete(m, "batchChanges.autoDeleteBranch")
 	delete(m, "batchChanges.changesetsRetention")
 	delete(m, "batchChanges.disableWebhooksWarning")
 	delete(m, "batchChanges.enabled")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -569,7 +569,7 @@
       "default": false
     },
     "batchChanges.autoDeleteBranch": {
-      "description": "Override code host specific setting and automatically delete batch change branches when a batch change is merged or closed.",
+      "description": "Automatically delete branches created for Batch Changes changesets when the changeset is merged or closed, for supported code hosts. Overrides any setting on the repository on the code host itself.",
       "type": "boolean",
       "group": "BatchChanges",
       "default": false

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -568,6 +568,12 @@
       "group": "BatchChanges",
       "default": false
     },
+    "batchChanges.autoDeleteBranch": {
+      "description": "Override code host specific setting and automatically delete batch change branches when a batch change is merged or closed.",
+      "type": "boolean",
+      "group": "BatchChanges",
+      "default": false
+    },
     "batchChanges.rolloutWindows": {
       "description": "Specifies specific windows, which can have associated rate limits, to be used when reconciling published changesets (creating or updating). All days and times are handled in UTC.",
       "type": "array",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/50354.

This adds a new site setting, `batchChanges.autoDeleteBranch`, which, when enabled, will have Sourcegraph attempt to delete the branches for any changesets it has created when the changesets are merged or closed.

Ideally, this functionality would be opt-in per batch change or even per changeset operation, so there's room for future iteration here. This PR merely provides the groundwork to enable this functionality and exposes it via a global site config setting so that customers can start taking advantage of it immediately.

Code hosts offer varying levels of support for this. Several provide a 1st-party solution to this via a property on the changeset itself that can be toggled. But a few don't. For those, Sourcegraph must instead issue a secondary API call to delete the branch after it closes or merges the changeset. This does mean that on those code hosts, if the changeset is merged or closed _on the code host itself_, we won't have any control over whether or not the branch is deleted. I've tried to make this explicitly clear in the docs.

We introduce this logic at the Batch Changes `Source` layer, where we have consolidated other logic about the ways Batch Changes should interact with code host API methods. Generally speaking, the approach takes one of the following forms:

- If a code host supports this natively with a flag on the changeset, great! At any point when we would **create** or **update** the properties of a changeset on the code host, we check the setting in site config and make sure to send its updated value along in the payload, ensuring the flag always stays closely synced with the setting on Sourcegraph.
- If a code host does not support this natively, at any point when we **close** or **merge** a changeset on the code host, we check the setting in site config and, on successful close/merge, we send a follow-up request to delete the branch associated with the changeset.

## Test plan

Wherever we already had VCR integration tests set up for Batch Changes `Source`s, I wrote additional tests to cover toggling the flag or the additional API calls. Two code hosts don't have any VCR test set ups, so for those I only manually tested with the code hosts. I'd love to add VCR testing for them but just don't have the time right now.

Code host | Test strategy
---------- | -------------
Azure DevOps | Manual testing
Bitbucket Server | Additional VCR tests added, manual testing
Bitbucket Cloud | Manual testing
GitHub | Additional VCR tests added, manual testing
GitLab | Additional VCR tests added, manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
