### PR TITLE
sg: build syntax-highlighter via bazel

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -29,6 +29,11 @@ import (
 const MAX_CONCURRENT_BUILD_PROCS = 4
 
 func Commands(ctx context.Context, parentEnv map[string]string, verbose bool, cmds ...Command) error {
+	if len(cmds) == 0 {
+		// Exit early if there are no commands to run.
+		return nil
+	}
+
 	chs := make([]<-chan struct{}, 0, len(cmds))
 	monitor := &changeMonitor{}
 	for _, cmd := range cmds {

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -956,6 +956,17 @@ bazelCommands:
       SRC_PROF_HTTP: 127.0.0.1:3551
   searcher:
     target: //cmd/searcher
+  syntax-highlighter:
+    target: //docker-images/syntax-highlighter:syntect_server
+    env:
+      # Environment copied from Dockerfile
+      WORKERS: "1"
+      ROCKET_ENV: "production"
+      ROCKET_LIMITS: "{json=10485760}"
+      ROCKET_SECRET_KEY: "SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA="
+      ROCKET_KEEP_ALIVE: "0"
+      ROCKET_PORT: "9238"
+      QUIET: "true"
   github-proxy:
     target: //cmd/github-proxy
   frontend:
@@ -1060,10 +1071,10 @@ commandsets:
       - oss-gitserver-1
       - github-proxy
       - searcher
+      - syntax-highlighter
     commands:
       - oss-web
       - caddy
-      - syntax-highlighter
       - zoekt-index-0
       - zoekt-index-1
       - zoekt-web-0
@@ -1112,12 +1123,12 @@ commandsets:
       - gitserver-1
       - searcher
       - symbols
+      - syntax-highlighter
       - github-proxy
     commands:
       - web
       - blobstore
       - docsite
-      - syntax-highlighter
       - zoekt-index-0
       - zoekt-index-1
       - zoekt-web-0
@@ -1204,6 +1215,7 @@ commandsets:
       - gitserver-1
       - searcher
       - symbols
+      - syntax-highlighter
       - github-proxy
       - codeintel-worker
       - codeintel-executor
@@ -1211,7 +1223,6 @@ commandsets:
       - web
       - blobstore
       - docsite
-      - syntax-highlighter
       - zoekt-index-0
       - zoekt-index-1
       - zoekt-web-0


### PR DESCRIPTION
Kill docker with fire in our sg start.

Test Plan: sg run syntax-highlighter works. Then sg start and view a file to confirm there is functional syntax highlighting.