### PR TITLE
bzl: fix backcompat errors when applying patch

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -117,7 +117,8 @@ func bazelBackCompatTest(targets ...string) func(*bk.Pipeline) {
 		bk.Agent("queue", "bazel"),
 
 		// Generate a patch that backports the migration from the new code into the old one.
-		bk.Cmd("git diff origin/ci/backcompat-v5.0.0..HEAD -- migrations/ > dev/backcompat/patches/back_compat_migrations.patch"),
+		// Ignore space is because of https://github.com/bazelbuild/bazel/issues/17376
+		bk.Cmd("git diff --ignore-space-at-eol origin/ci/backcompat-v5.0.0..HEAD -- migrations/ > dev/backcompat/patches/back_compat_migrations.patch"),
 	}
 
 	bazelCmd := bazelCmd(fmt.Sprintf("test %s", strings.Join(targets, " ")))


### PR DESCRIPTION
It seems we've been hitting https://github.com/bazelbuild/bazel/issues/17376 with the changes from https://github.com/sourcegraph/sourcegraph/pull/51748 

Adding `--ignore-space-at-eol` to the `git diff` command fixes it, which in our context here, is fine. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested on the branch where the issue was appearing. 