### PR TITLE
nix: unset CC and CXX for ibazel as well

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,6 +37,7 @@ let
     exec ${pkgs.bazel_6}/bin/bazel "$@"
   '');
   bazel-watcher = pkgs.writeShellScriptBin "ibazel" ''
+    ${pkgs.lib.optionalString pkgs.hostPlatform.isMacOS "unset CC CXX"}
     exec ${pkgs.bazel-watcher}/bin/ibazel \
       ${pkgs.lib.optionalString pkgs.hostPlatform.isLinux "-bazel_path=${pkgs.bazel_6}/bin/bazel"} "$@"
   '';


### PR DESCRIPTION
We only did this for bazel but not ibazel. Found this due to having bazel build work for me but not ibazel.

Test Plan: sg run syntax-highlighter works on nix darwin