### PR TITLE
sg: ignore stdout/err for bazel syntax-highlighter

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -958,6 +958,8 @@ bazelCommands:
     target: //cmd/searcher
   syntax-highlighter:
     target: //docker-images/syntax-highlighter:syntect_server
+    ignoreStdout: true
+    ignoreStderr: true
     env:
       # Environment copied from Dockerfile
       WORKERS: "1"


### PR DESCRIPTION
This is what we do for the step pre-bazel command since it is quite noisy. We add support for bazelCommands to have the same setting.

Test Plan: sg run syntax-highlighter was quiet.