### PR TITLE
Cody VSCode: Add support for verified email check message when connected to app; and improve connected status message

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -37,6 +37,7 @@ import {
     DOTCOM_URL,
     ExtensionMessage,
     WebviewMessage,
+    isLocalApp,
     isLoggedIn,
 } from './protocol'
 
@@ -53,7 +54,7 @@ export async function getAuthStatus(
     }
 
     const client = new SourcegraphGraphQLAPIClient(config)
-    if (client.isDotCom()) {
+    if (client.isDotCom() || isLocalApp(config.serverEndpoint)) {
         const data = await client.getCurrentUserIdAndVerifiedEmail()
         return {
             showInvalidAccessTokenError: isError(data),

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -61,3 +61,7 @@ export interface AuthStatus {
 export function isLoggedIn(authStatus: AuthStatus): boolean {
     return authStatus.authenticated && (authStatus.requiresVerifiedEmail ? authStatus.hasVerifiedEmail : true)
 }
+
+export function isLocalApp(url: string): boolean {
+    return new URL(url).origin === LOCAL_APP_URL.origin
+}

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -192,7 +192,7 @@ const register = async (
                 if (token && token.length > 8) {
                     await secretStorage.store(CODY_ACCESS_TOKEN_SECRET, token)
                     const authStatus = await getAuthStatus({
-                        serverEndpoint: DOTCOM_URL.href,
+                        serverEndpoint,
                         accessToken: token,
                         customHeaders: config.customHeaders,
                     })

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -2,6 +2,8 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
 import './Settings.css'
 
+import { isLocalApp } from '../src/chat/protocol'
+
 interface SettingsProps {
     onLogout: () => void
     serverEndpoint?: string
@@ -14,7 +16,9 @@ export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsP
     <div className="inner-container">
         <div className="non-transcript-container">
             <div className="settings">
-                {serverEndpoint && <p>🟢 Connected to {serverEndpoint}</p>}
+                {serverEndpoint && (
+                    <p>🟢 Connected to {isLocalApp(serverEndpoint) ? 'Sourcegraph App' : serverEndpoint}</p>
+                )}
                 <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
                     Logout
                 </VSCodeButton>


### PR DESCRIPTION
### Show verified email message when connecting Cody extension to App

When connecting the Cody extension to App, it's expected to act similarly to dotcom in that requires an email address and if the user doesn't have a verified email address, it should show the same message.

This PR checks if we are connecting to App, and if so it will treat the email verification logic the same as if we were connecting to sourcegraph.com, so we also get the same error message for an unverified email.

Background info: App will basically proxy the request to dotcom so the response to `currentUser { id, hasVerifiedEmail }` will be similar to a dotcom response. The only difference, then, is that Cody extension holds an access token to App and App holds an access token to dotcom.

### Video

https://github.com/sourcegraph/sourcegraph/assets/602886/2d65e1f4-b8c8-4790-a476-b41fdfccb1ca


### Update "Connected to" display

This is a cosmetic change to show "Connected to Sourcegraph App" instead of "Connected to http://localhost:3080":

<img width="430" alt="Screenshot 2023-05-17 at 10 58 04 AM" src="https://github.com/sourcegraph/sourcegraph/assets/602886/86c52818-1dfe-4e93-976c-b3f0fc27d10e">


## Test plan

-  Connect App to a dotcom account 
-  Test Cody extension with an unverified email address in the dotcom account
-  Test Cody extension after verifying the email address in the dotcom account