### PR TITLE
perforce: Update regex to parse changelist and move to internal/perforce

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -277,6 +277,7 @@ go_library(
         "//internal/markdown",
         "//internal/observation",
         "//internal/oobmigration",
+        "//internal/perforce",
         "//internal/rcache",
         "//internal/repos",
         "//internal/repoupdater",

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -46,7 +46,7 @@ func parseP4FusionCommitSubject(subject string) (string, error) {
 // Either git-p4 or p4-fusion could be used to convert a perforce depot to a git repo. In which case the
 // [git-p4: depot-paths = "//test-perms/": change = 83725]
 // [p4-fusion: depot-paths = "//test-perms/": change = 80972]
-var gitP4Pattern = lazyregexp.New(`\[(?:git-p4|p4-fusion): depot-paths = "(.*?)"\: change = (\d+)\]`)
+var gitP4Pattern = lazyregexp.New(`\[(?:git-p4|p4-fusion): depot-paths? = "(.*?)"\: change = (\d+)\]`)
 
 func getP4ChangelistID(body string) (string, error) {
 	matches := gitP4Pattern.FindStringSubmatch(body)

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -21,7 +22,7 @@ func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, co
 		return nil, nil
 	}
 
-	changelistID, err := getP4ChangelistID(commitBody)
+	changelistID, err := perforce.GetP4ChangelistID(commitBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate perforceChangelistID")
 	}
@@ -40,20 +41,6 @@ func parseP4FusionCommitSubject(subject string) (string, error) {
 	if len(matches) != 3 {
 		return "", errors.Newf("failed to parse commit subject %q for commit converted by p4-fusion", subject)
 	}
-	return matches[2], nil
-}
-
-// Either git-p4 or p4-fusion could be used to convert a perforce depot to a git repo. In which case the
-// [git-p4: depot-paths = "//test-perms/": change = 83725]
-// [p4-fusion: depot-paths = "//test-perms/": change = 80972]
-var gitP4Pattern = lazyregexp.New(`\[(?:git-p4|p4-fusion): depot-paths? = "(.*?)"\: change = (\d+)\]`)
-
-func getP4ChangelistID(body string) (string, error) {
-	matches := gitP4Pattern.FindStringSubmatch(body)
-	if len(matches) != 3 {
-		return "", errors.Newf("failed to retrieve changelist ID from commit body: %q", body)
-	}
-
 	return matches[2], nil
 }
 

--- a/cmd/frontend/graphqlbackend/perforce_changelist_test.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist_test.go
@@ -17,7 +17,15 @@ func TestGetP4ChangelistID(t *testing.T) {
 			expectedChangeListID: "83725",
 		},
 		{
+			input:                `[git-p4: depot-path = "//test-perms/": change = 83725]`,
+			expectedChangeListID: "83725",
+		},
+		{
 			input:                `[p4-fusion: depot-paths = "//test-perms/": change = 80972]`,
+			expectedChangeListID: "80972",
+		},
+		{
+			input:                `[p4-fusion: depot-path = "//test-perms/": change = 80972]`,
 			expectedChangeListID: "80972",
 		},
 		{

--- a/cmd/frontend/graphqlbackend/perforce_changelist_test.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist_test.go
@@ -1,56 +1,8 @@
 package graphqlbackend
 
 import (
-	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
-
-func TestGetP4ChangelistID(t *testing.T) {
-	testCases := []struct {
-		input                string
-		expectedChangeListID string
-	}{
-		{
-			input:                `[git-p4: depot-paths = "//test-perms/": change = 83725]`,
-			expectedChangeListID: "83725",
-		},
-		{
-			input:                `[git-p4: depot-path = "//test-perms/": change = 83725]`,
-			expectedChangeListID: "83725",
-		},
-		{
-			input:                `[p4-fusion: depot-paths = "//test-perms/": change = 80972]`,
-			expectedChangeListID: "80972",
-		},
-		{
-			input:                `[p4-fusion: depot-path = "//test-perms/": change = 80972]`,
-			expectedChangeListID: "80972",
-		},
-		{
-			input:                "invalid string",
-			expectedChangeListID: "",
-		},
-		{
-			input:                "",
-			expectedChangeListID: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		result, err := getP4ChangelistID(tc.input)
-		if tc.expectedChangeListID != "" {
-			require.NoError(t, err)
-		} else {
-			require.Error(t, err)
-		}
-
-		if !reflect.DeepEqual(result, tc.expectedChangeListID) {
-			t.Errorf("getP4ChangelistID failed (%q) => got %q, want %q", tc.input, result, tc.expectedChangeListID)
-		}
-	}
-}
 
 func TestParseP4FusionCommitSubject(t *testing.T) {
 	testCases := []struct {

--- a/internal/perforce/BUILD.bazel
+++ b/internal/perforce/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "perforce",
+    srcs = ["changelist.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/perforce",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/lazyregexp",
+        "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "perforce_test",
+    srcs = ["changelist_test.go"],
+    embed = [":perforce"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -1,0 +1,20 @@
+package perforce
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Either git-p4 or p4-fusion could be used to convert a perforce depot to a git repo. In which case the
+// [git-p4: depot-paths = "//test-perms/": change = 83725]
+// [p4-fusion: depot-paths = "//test-perms/": change = 80972]
+var gitP4Pattern = lazyregexp.New(`\[(?:git-p4|p4-fusion): depot-paths? = "(.*?)"\: change = (\d+)\]`)
+
+func GetP4ChangelistID(body string) (string, error) {
+	matches := gitP4Pattern.FindStringSubmatch(body)
+	if len(matches) != 3 {
+		return "", errors.Newf("failed to retrieve changelist ID from commit body: %q", body)
+	}
+
+	return matches[2], nil
+}

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -5,7 +5,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// Either git-p4 or p4-fusion could be used to convert a perforce depot to a git repo. In which case the
+// Either git-p4 or p4-fusion could have been used to convert a perforce depot to a git repo. In
+// which case the which case the commit message would look like:
+//
 // [git-p4: depot-paths = "//test-perms/": change = 83725]
 // [p4-fusion: depot-paths = "//test-perms/": change = 80972]
 var gitP4Pattern = lazyregexp.New(`\[(?:git-p4|p4-fusion): depot-paths? = "(.*?)"\: change = (\d+)\]`)

--- a/internal/perforce/changelist_test.go
+++ b/internal/perforce/changelist_test.go
@@ -1,0 +1,53 @@
+package perforce
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetP4ChangelistID(t *testing.T) {
+	testCases := []struct {
+		input                string
+		expectedChangeListID string
+	}{
+		{
+			input:                `[git-p4: depot-paths = "//test-perms/": change = 83725]`,
+			expectedChangeListID: "83725",
+		},
+		{
+			input:                `[git-p4: depot-path = "//test-perms/": change = 83725]`,
+			expectedChangeListID: "83725",
+		},
+		{
+			input:                `[p4-fusion: depot-paths = "//test-perms/": change = 80972]`,
+			expectedChangeListID: "80972",
+		},
+		{
+			input:                `[p4-fusion: depot-path = "//test-perms/": change = 80972]`,
+			expectedChangeListID: "80972",
+		},
+		{
+			input:                "invalid string",
+			expectedChangeListID: "",
+		},
+		{
+			input:                "",
+			expectedChangeListID: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := GetP4ChangelistID(tc.input)
+		if tc.expectedChangeListID != "" {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+		}
+
+		if !reflect.DeepEqual(result, tc.expectedChangeListID) {
+			t.Errorf("getP4ChangelistID failed (%q) => got %q, want %q", tc.input, result, tc.expectedChangeListID)
+		}
+	}
+}


### PR DESCRIPTION
Part of #40330.

Two birds with one stone:

1. Update the regex to also check for `depot-path` along with the existing `depot-paths`, since the [git-p4 code](https://github.com/git/git/blob/5bc069e383539824fd3a0d897100d44bbe1f8a24/git-p4.py#L1018-L1041) seems to support this behaviour
2. Move this code to `internal/perforce` as I need to reuse this is another upcoming change related to perforce https://github.com/sourcegraph/sourcegraph/pull/51860

## Note to reviewers

Since the code changed and moved to a different location, I took care to make these changes as separate commits. Reviewing the commits one at a time will make the code change obvious.

## Test plan

Updated tests.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
