### PR TITLE
llmproxy: check token size before auth

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -21,6 +21,7 @@ var (
 	minUpdateInterval = 10 * time.Minute
 
 	defaultUpdateInterval = 24 * time.Hour
+	tokenLength           = 68
 )
 
 type Source struct {
@@ -49,7 +50,7 @@ func (s *Source) Name() string { return llmproxy.ProductSubscriptionActorSourceN
 
 func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 	// "sgs_" is productSubscriptionAccessTokenPrefix
-	if token == "" || !strings.HasPrefix(token, "sgs_") {
+	if token == "" || !strings.HasPrefix(token, "sgs_") || len(token) != tokenLength {
 		return nil, actor.ErrNotFromSource{}
 	}
 

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -53,8 +53,12 @@ func (s *Source) Name() string { return llmproxy.ProductSubscriptionActorSourceN
 
 func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 	// "sgs_" is productSubscriptionAccessTokenPrefix
-	if token == "" || !strings.HasPrefix(token, "sgs_") || len(token) != tokenLength {
+	if token == "" || !strings.HasPrefix(token, "sgs_") {
 		return nil, actor.ErrNotFromSource{}
+	}
+
+	if len(token) != tokenLength {
+		return nil, errors.New("invalid token format")
 	}
 
 	data, hit := s.cache.Get(token)

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/productsubscription.go
@@ -17,11 +17,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+// product subscription tokens are always a prefix of 4 characters (sgs_)
+// followed by a 64-character hex-encoded SHA256 hash
+const tokenLength = 4 + 64
+
 var (
 	minUpdateInterval = 10 * time.Minute
 
 	defaultUpdateInterval = 24 * time.Hour
-	tokenLength           = 68
 )
 
 type Source struct {

--- a/enterprise/cmd/llm-proxy/shared/main_test.go
+++ b/enterprise/cmd/llm-proxy/shared/main_test.go
@@ -80,7 +80,7 @@ func TestAuthenticateEndToEnd(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
-		r.Header.Set("Authorization", "Bearer sgs_abc123")
+		r.Header.Set("Authorization", "Bearer sgs_abc1228e23e789431f08cd15e9be20e69b8694c2dff701b81d16250a4a861f37")
 		(&auth.Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
@@ -105,7 +105,7 @@ func TestAuthenticateEndToEnd(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
-		r.Header.Set("Authorization", "Bearer sgs_abc123")
+		r.Header.Set("Authorization", "Bearer sgs_abc1228e23e789431f08cd15e9be20e69b8694c2dff701b81d16250a4a861f37")
 		(&auth.Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
@@ -126,7 +126,7 @@ func TestAuthenticateEndToEnd(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
-		r.Header.Set("Authorization", "Bearer sgs_abc123")
+		r.Header.Set("Authorization", "Bearer sgs_abc1228e23e789431f08cd15e9be20e69b8694c2dff701b81d16250a4a861f37")
 		(&auth.Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
@@ -168,7 +168,7 @@ func TestAuthenticateEndToEnd(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
-		r.Header.Set("Authorization", "Bearer sgs_abc123")
+		r.Header.Set("Authorization", "Bearer sgs_abc1228e23e789431f08cd15e9be20e69b8694c2dff701b81d16250a4a861f37")
 		(&auth.Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),


### PR DESCRIPTION
Before we pass the token along, we enforce a size check to make sure we don't cache any bogus. 

## Test plan
I've updated the unittests and all checks passed.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
