### PR TITLE
app: rename 'Sourcegraph App' -> 'Sourcegraph'

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -62,7 +62,7 @@ func Main(services []sgservice.Service, config Config, args []string) {
 
 	app := cli.NewApp()
 	app.Name = filepath.Base(args[0])
-	app.Usage = "The Sourcegraph App"
+	app.Usage = "The Sourcegraph app"
 	app.Version = version.Version()
 	app.Flags = []cli.Flag{
 		&cli.PathFlag{

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -15,7 +15,7 @@ fn create_system_tray_menu() -> SystemTrayMenu {
     SystemTrayMenu::new()
         .add_item(CustomMenuItem::new(
             "open".to_string(),
-            "Open Sourcegraph App",
+            "Open Sourcegraph",
         ))
         .add_item(CustomMenuItem::new("cody".to_string(), "Show Cody"))
         .add_native_item(SystemTrayMenuItem::Separator)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,12 +21,7 @@
           {
             "name": "../.bin/sourcegraph-backend",
             "sidecar": true,
-            "args": [
-              "--cacheDir",
-              "$APPCONFIG",
-              "--configDir",
-              "$APPLOCALDATA"
-            ]
+            "args": ["--cacheDir", "$APPCONFIG", "--configDir", "$APPLOCALDATA"]
           }
         ],
         "open": "^(vscode:|https?:)|com.sourcegraph.cody/.*.log$"
@@ -46,16 +41,8 @@
       "deb": {
         "depends": []
       },
-      "externalBin": [
-        "../.bin/sourcegraph-backend"
-      ],
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
+      "externalBin": ["../.bin/sourcegraph-backend"],
+      "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
       "identifier": "com.sourcegraph.cody",
       "longDescription": "",
       "macOS": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "Sourcegraph App",
+    "productName": "Sourcegraph",
     "version": "1.0.0"
   },
   "tauri": {
@@ -21,7 +21,12 @@
           {
             "name": "../.bin/sourcegraph-backend",
             "sidecar": true,
-            "args": ["--cacheDir", "$APPCONFIG", "--configDir", "$APPLOCALDATA"]
+            "args": [
+              "--cacheDir",
+              "$APPCONFIG",
+              "--configDir",
+              "$APPLOCALDATA"
+            ]
           }
         ],
         "open": "^(vscode:|https?:)|com.sourcegraph.cody/.*.log$"
@@ -41,8 +46,16 @@
       "deb": {
         "depends": []
       },
-      "externalBin": ["../.bin/sourcegraph-backend"],
-      "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+      "externalBin": [
+        "../.bin/sourcegraph-backend"
+      ],
+      "icon": [
+        "icons/32x32.png",
+        "icons/128x128.png",
+        "icons/128x128@2x.png",
+        "icons/icon.icns",
+        "icons/icon.ico"
+      ],
       "identifier": "com.sourcegraph.cody",
       "longDescription": "",
       "macOS": {


### PR DESCRIPTION
Naming conventions for now:

* `Sourcegraph App` (capital A) is the product name; when we need to distinguish the app from e.g. an enterprise version of the product, we use `Sourcegraph App`.
* `the Sourcegraph app` (lowercase A) is to be used in general documentation strings or when writing about it in english, in a context where we do not need to distinguish it from our other product lines.
* `Sourcegraph` is to be used in places where it is obvious it is an app, e.g. `Sourcegraph.app` instead of `Sourcegraph App.app`, or if we were to start distributing it in say an app store.

## Test plan

N/A, rename only