### PR TITLE
Tracing: remove trace.Tag

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -346,6 +346,7 @@ go_library(
         "@com_github_stretchr_testify//require",
         "@com_github_throttled_throttled_v2//:throttled",
         "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/log"
@@ -193,7 +194,7 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
-	tr, _ := trace.New(ctx, "DynamicFilters", "", trace.Tag{Key: "resolver", Value: "SearchResultsResolver"})
+	tr, _ := trace.New(ctx, "DynamicFilters", "", attribute.String("resolver", "SearchResultsResolver"))
 	defer tr.Finish()
 
 	var filters streaming.SearchFilters

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -24,9 +24,9 @@ type Trace struct {
 }
 
 // New returns a new Trace with the specified family and title.
-func New(ctx context.Context, family, title string, tags ...Tag) (*Trace, context.Context) {
+func New(ctx context.Context, family, title string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
 	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
-	return tr.New(ctx, family, title, tags...)
+	return tr.New(ctx, family, title, attrs...)
 }
 
 // SetAttributes sets kv as attributes of the Span.


### PR DESCRIPTION
One more for ya.

`trace.Tag` is only used in the `trace.New()` function, after which it is immediately translated to opentelemetry attributes. Let's reduce the number of types we have to deal with and just use attributes directly. 

Stacked on https://github.com/sourcegraph/sourcegraph/pull/52088

## Test plan

CI.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
