### PR TITLE
executors: Flip order when creating block device

### DIFF
--- a/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
@@ -138,16 +138,8 @@ func setupLoopDevice(
 		return "", "", "", errors.Wrap(err, "failed to close backing file")
 	}
 
-	// Create an ext4 file system in the device backing file.
-	out, err := commandLogger(ctx, cmdRunner, handle, "mkfs.ext4", blockDeviceFile)
-	if err != nil {
-		return "", "", "", errors.Wrapf(err, "failed to create ext4 filesystem in backing file: %q", out)
-	}
-
-	fmt.Fprintf(handle, "Wrote ext4 filesystem to backing file %q\n", blockDeviceFile)
-
 	// Create a loop device pointing to our block device.
-	out, err = commandLogger(ctx, cmdRunner, handle, "losetup", "--find", "--show", blockDeviceFile)
+	out, err := commandLogger(ctx, cmdRunner, handle, "losetup", "--find", "--show", blockDeviceFile)
 	if err != nil {
 		return "", "", "", errors.Wrapf(err, "failed to create loop device: %q", out)
 	}
@@ -163,6 +155,14 @@ func setupLoopDevice(
 		}
 	}()
 	fmt.Fprintf(handle, "Created loop device at %q backed by %q\n", blockDevice, blockDeviceFile)
+
+	// Create an ext4 file system in the device backing file.
+	out, err = commandLogger(ctx, cmdRunner, handle, "mkfs.ext4", blockDevice)
+	if err != nil {
+		return "", "", "", errors.Wrapf(err, "failed to create ext4 filesystem in backing file: %q", out)
+	}
+
+	fmt.Fprintf(handle, "Wrote ext4 filesystem to %q\n", blockDevice)
 
 	// Mount the loop device at a temporary directory so we can write the workspace contents to it.
 	tmpMountDir, err = mountLoopDevice(ctx, cmdRunner, blockDevice, handle)

--- a/enterprise/cmd/executor/internal/worker/workspace/firecracker_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/firecracker_test.go
@@ -41,10 +41,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -65,10 +65,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -167,10 +167,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -194,10 +194,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -275,10 +275,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -314,10 +314,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -354,10 +354,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -442,10 +442,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach
@@ -490,10 +490,10 @@ func TestNewFirecrackerWorkspace(t *testing.T) {
 			},
 			mockFunc: func(logger *workspace.MockLogger, filesStore *workspace.MockFilesStore, cmdRunner *workspace.MockCmdRunner, cmd *workspace.MockCommand, tempDir string) {
 				logger.LogEntryFunc.SetDefaultReturn(workspace.NewMockLogEntry())
-				// mkfs.ext4
-				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --find
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte(tempDir), nil)
+				// mkfs.ext4
+				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// mount
 				cmdRunner.CombinedOutputFunc.PushReturn([]byte{}, nil)
 				// losetup --detach


### PR DESCRIPTION
Found in [thread](https://sourcegraph.slack.com/archives/C02MR5PPMKJ/p1684321940550879).

We should create the block device (`losetup`) first from the file, then use `mkfs.ext4` on the created block device.

## Test plan

Updated existing tests.

![Screenshot 2023-05-17 at 12 23 25](https://github.com/sourcegraph/sourcegraph/assets/38407415/2ce44984-d1d1-4916-bc6b-6cbaa72a7d8e)
