### PR TITLE
Add trailing slashes to config samples

### DIFF
--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -107,9 +107,9 @@ For example, if your Perforce depot `//depot/Talkhouse` has different permission
 {
   // ...
   "depots": [
-    "//depot/Talkhouse/main-dev",
-    "//depot/Talkhouse/rel1.0/front",
-    "//depot/Talkhouse/rel1.0/back"
+    "//depot/Talkhouse/main-dev/",
+    "//depot/Talkhouse/rel1.0/front/",
+    "//depot/Talkhouse/rel1.0/back/"
   ]
 }
 ```
@@ -120,9 +120,9 @@ By configuring each subdirectory that has unique permissions, Sourcegraph is abl
 {
   // ...
   "depots": [
-    "//depot/Talkhouse/main-dev",
-    "//depot/Talkhouse/rel1.0",
-    "//depot/Talkhouse/rel1.0/back"
+    "//depot/Talkhouse/main-dev/",
+    "//depot/Talkhouse/rel1.0/",
+    "//depot/Talkhouse/rel1.0/back/"
   ]
 }
 ```


### PR DESCRIPTION
The code host configuration requires trailing slashed to the depot path specifications, but the docs page samples were missing the trailing slashes.

## Test plan

view docs page and see trailing slashes in samples