### PR TITLE
llm-proxy: improve tracing

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
@@ -15,6 +15,10 @@ go_library(
         "@com_github_go_redsync_redsync_v4//:redsync",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )
 

--- a/enterprise/cmd/llm-proxy/internal/auth/auth.go
+++ b/enterprise/cmd/llm-proxy/internal/auth/auth.go
@@ -33,6 +33,7 @@ func (a *Authenticator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		response.JSONError(a.Logger, w, http.StatusUnauthorized, err)
 
 		err := a.EventLogger.LogEvent(
+			r.Context(),
 			events.Event{
 				Name:       llmproxy.EventNameUnauthorized,
 				Source:     "anonymous",
@@ -54,6 +55,7 @@ func (a *Authenticator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 
 		err := a.EventLogger.LogEvent(
+			r.Context(),
 			events.Event{
 				Name:       llmproxy.EventNameAccessDenied,
 				Source:     act.Source.Name(),

--- a/enterprise/cmd/llm-proxy/internal/events/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/events/BUILD.bazel
@@ -10,5 +10,9 @@ go_library(
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@com_google_cloud_go_bigquery//:bigquery",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//codes",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -88,8 +88,13 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 
 	// Instrumentation layers
 	handler = requestLogger(obctx.Logger.Scoped("requests", "HTTP requests"), handler)
-	handler = instrumentation.HTTPMiddleware("llm-proxy", handler,
-		otelhttp.WithPublicEndpoint())
+	var otelhttpOpts []otelhttp.Option
+	if !config.InsecureDev {
+		// Outside of dev, we're probably running as a standalone service, so treat
+		// incoming spans as links
+		otelhttpOpts = append(otelhttpOpts, otelhttp.WithPublicEndpoint())
+	}
+	handler = instrumentation.HTTPMiddleware("llm-proxy", handler, otelhttpOpts...)
 
 	// Collect request client for downstream handlers. Outside of dev, we always set up
 	// Cloudflare in from of LLM-proxy. This comes first.
@@ -139,6 +144,7 @@ func rateLimit(logger log.Logger, eventLogger events.Logger, cache limiter.Redis
 		err := l.TryAcquire(r.Context())
 		if err != nil {
 			loggerErr := eventLogger.LogEvent(
+				r.Context(),
 				events.Event{
 					Name:       llmproxy.EventNameRateLimited,
 					Source:     act.Source.Name(),


### PR DESCRIPTION
Realized our traces in deployed environments are currently a bit uninformative. This PR sets up some tracing with vanilla OpenTelemetry and makes sure they get propagated in the right places:

1. Forwarding requests to upstream now get connected traces
2. Logging events now takes a context for connecting traces

In dev, I've also toggled off the linking functionality of otelhttp so that we get connected traces instead in Jaeger.

## Test plan

<img width="1621" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/a4d27415-5ff6-45e6-85af-d085fe3f5df0">

<img width="1162" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/b5f86b2b-f49e-460b-8de8-12d714928ecc">


