### PR TITLE
Observability: deduplicate attributes

### DIFF
--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -285,15 +285,13 @@ func (op *Operation) With(ctx context.Context, err *error, args Args) (context.C
 		elapsedMs := since.Milliseconds()
 		defaultFinishFields := []attribute.KeyValue{attribute.Float64("count", count), attribute.Float64("elapsed", elapsed)}
 		finishAttrs := mergeAttrs(defaultFinishFields, finishArgs.Attrs)
-
-		attrs := mergeAttrs(defaultFinishFields, finishAttrs)
 		metricLabels := mergeLabels(op.metricLabels, args.MetricLabelValues, finishArgs.MetricLabelValues)
 
 		if multi := new(ErrCollector); err != nil && errors.As(*err, &multi) {
 			if multi.errs == nil {
 				err = nil
 			}
-			attrs = append(attrs, multi.extraAttrs...)
+			finishAttrs = append(finishAttrs, multi.extraAttrs...)
 		}
 
 		var (
@@ -312,7 +310,7 @@ func (op *Operation) With(ctx context.Context, err *error, args Args) (context.C
 
 		op.emitMetrics(metricsErr, count, elapsed, metricLabels)
 
-		op.finishTrace(traceErr, tr, attrs)
+		op.finishTrace(traceErr, tr, finishAttrs)
 	}
 }
 


### PR DESCRIPTION
We were duplicating fields in the "done" event in the observability package. This fixes it. 

## Test plan

Before: 

<img width="286" alt="Screenshot 2023-05-17 at 14 06 30" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/c5de54a8-8bf6-484e-b38c-c66dfb866d74">

After:

<img width="207" alt="Screenshot 2023-05-17 at 14 17 42" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/078efa93-30c3-4c7a-b69e-fdd13fd1d647">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
