### PR TITLE
Pass repo & revision context from editor to context files

### DIFF
--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -71,7 +71,7 @@ export class ChatQuestion implements Recipe {
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
             populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName),
-            { fileName: visibleContent.fileName }
+            visibleContent
         )
     }
 
@@ -79,7 +79,7 @@ export class ChatQuestion implements Recipe {
         const truncatedContent = truncateText(selection.selectedText, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
             populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName),
-            { fileName: selection.fileName }
+            selection
         )
     }
 }

--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -30,7 +30,7 @@ export class ExplainCodeDetailed implements Recipe {
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
-                selection.fileName,
+                selection,
                 context.codebaseContext
             )
         )

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -30,7 +30,7 @@ export class ExplainCodeHighLevel implements Recipe {
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
-                selection.fileName,
+                selection,
                 context.codebaseContext
             )
         )

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -58,7 +58,7 @@ export class GenerateDocstring implements Recipe {
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
-                selection.fileName,
+                selection,
                 context.codebaseContext
             )
         )

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -42,7 +42,7 @@ export class GenerateTest implements Recipe {
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
-                selection.fileName,
+                selection,
                 context.codebaseContext
             )
         )

--- a/client/cody-shared/src/chat/recipes/helpers.ts
+++ b/client/cody-shared/src/chat/recipes/helpers.ts
@@ -25,7 +25,7 @@ export async function getContextMessagesFromSelection(
     selectedText: string,
     precedingText: string,
     followingText: string,
-    fileName: string,
+    { fileName, repoName, revision }: { fileName: string; repoName?: string; revision?: string },
     codebaseContext: CodebaseContext
 ): Promise<ContextMessage[]> {
     const selectedTextContext = await codebaseContext.getContextMessages(selectedText, {
@@ -35,7 +35,11 @@ export async function getContextMessagesFromSelection(
 
     return selectedTextContext.concat(
         [precedingText, followingText].flatMap(text =>
-            getContextMessageWithResponse(populateCodeContextTemplate(text, fileName), { fileName })
+            getContextMessageWithResponse(populateCodeContextTemplate(text, fileName), {
+                fileName,
+                repoName,
+                revision,
+            })
         )
     )
 }

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -42,7 +42,7 @@ export class ImproveVariableNames implements Recipe {
                 truncatedSelectedText,
                 truncatedPrecedingText,
                 truncatedFollowingText,
-                selection.fileName,
+                selection,
                 context.codebaseContext
             )
         )

--- a/client/cody-shared/src/chat/recipes/next-questions.ts
+++ b/client/cody-shared/src/chat/recipes/next-questions.ts
@@ -68,7 +68,7 @@ export class NextQuestions implements Recipe {
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
             populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName),
-            { fileName: visibleContent.fileName }
+            visibleContent
         )
     }
 }

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -1,10 +1,14 @@
 export interface ActiveTextEditor {
     content: string
     filePath: string
+    repoName?: string
+    revision?: string
 }
 
 export interface ActiveTextEditorSelection {
     fileName: string
+    repoName?: string
+    revision?: string
     precedingText: string
     selectedText: string
     followingText: string
@@ -13,6 +17,8 @@ export interface ActiveTextEditorSelection {
 export interface ActiveTextEditorVisibleContent {
     content: string
     fileName: string
+    repoName?: string
+    revision?: string
 }
 
 export interface InlineController {

--- a/client/web/src/cody/components/CodeMirrorEditor.ts
+++ b/client/web/src/cody/components/CodeMirrorEditor.ts
@@ -13,6 +13,14 @@ export class CodeMirrorEditor implements Editor {
         this.editorStoreRef = editorStoreRef
     }
 
+    public get repoName(): string | undefined {
+        return this.editorStoreRef.current.editor?.repo
+    }
+
+    public get revision(): string | undefined {
+        return this.editorStoreRef.current.editor?.revision
+    }
+
     public getWorkspaceRootPath(): string | null {
         return null
     }
@@ -23,7 +31,7 @@ export class CodeMirrorEditor implements Editor {
             return null
         }
 
-        return { content: editor.content, filePath: editor.filename }
+        return { content: editor.content, filePath: editor.filename, repoName: this.repoName, revision: this.revision }
     }
 
     public getActiveTextEditorSelection(): ActiveTextEditorSelection | null {
@@ -43,6 +51,8 @@ export class CodeMirrorEditor implements Editor {
 
             return {
                 fileName: editor.filename,
+                repoName: this.repoName,
+                revision: this.revision,
                 precedingText,
                 selectedText,
                 followingText,
@@ -65,6 +75,8 @@ export class CodeMirrorEditor implements Editor {
 
         return {
             fileName: editor.filename,
+            repoName: this.repoName,
+            revision: this.revision,
             precedingText: '',
             selectedText: editor.content,
             followingText: '',
@@ -82,6 +94,8 @@ export class CodeMirrorEditor implements Editor {
         const content = editor.view?.state.sliceDoc(from, to)
         return {
             fileName: editor.filename,
+            repoName: this.repoName,
+            revision: this.revision,
             content,
         }
     }

--- a/client/web/src/cody/stores/editor.ts
+++ b/client/web/src/cody/stores/editor.ts
@@ -5,6 +5,7 @@ export interface EditorStore {
     editor: null | {
         filename: string
         repo: string
+        revision: string
         content: string
         view: EditorView
     }

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -444,13 +444,14 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
                 ? {
                       view,
                       repo: props.blobInfo.repoName,
+                      revision: props.blobInfo.revision,
                       filename: props.blobInfo.filePath,
                       content: props.blobInfo.content,
                   }
                 : null,
         })
         return () => useEditorStore.setState({ editor: null })
-    }, [props.blobInfo.content, props.blobInfo.filePath, props.blobInfo.repoName])
+    }, [props.blobInfo.content, props.blobInfo.filePath, props.blobInfo.repoName, props.blobInfo.revision])
 
     return (
         <>


### PR DESCRIPTION
This PR passes down repo & revision info from the Code Mirror editor to context files. 

## Test plan

visit /github.com/sourcegraph/sourcegraph@40d1a42a8ecb88ee668da6a06d80a8bf13d1718a/-/blob/client/cody-shared/src/chat/client.ts and execute a recipe and then check context file lines for current file link.