### PR TITLE
App: update site requires email verification and HasVerifiedEmail checks for App

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -505,6 +505,15 @@ func (r *siteResolver) PerUserCodeCompletionsQuota() *int32 {
 }
 
 func (r *siteResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
+	// App is typically forwarding Cody requests to dotcom.
+	// This section can be removed if dotcom stops requiring verified emails
+	if deploy.IsApp() {
+		// App users can specify their own keys
+		// if they use their own keys requests are not forwarded to dotcom
+		// which means a verified email is not needed
+		return conf.Get().Completions == nil
+	}
+
 	// We only require this on dotcom
 	if !envvar.SourcegraphDotComMode() {
 		return false

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -73,22 +73,20 @@ type UserResolver struct {
 
 // NewUserResolver returns a new UserResolver with given user object.
 func NewUserResolver(ctx context.Context, db database.DB, user *types.User) *UserResolver {
-	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
 		db:     db,
 		user:   user,
-		logger: logger,
+		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
 		actor:  actor.FromContext(ctx),
 	}
 }
 
 // newUserResolverFromActor returns a new UserResolver with given user object.
 func newUserResolverFromActor(a *actor.Actor, db database.DB, user *types.User) *UserResolver {
-	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
 		db:     db,
 		user:   user,
-		logger: logger,
+		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
 		actor:  a,
 	}
 }

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -62,6 +62,7 @@ func (r *schemaResolver) User(
 
 // UserResolver implements the GraphQL User type.
 type UserResolver struct {
+	HasVerifiedEmailResolver
 	logger log.Logger
 	db     database.DB
 	user   *types.User
@@ -73,21 +74,25 @@ type UserResolver struct {
 
 // NewUserResolver returns a new UserResolver with given user object.
 func NewUserResolver(ctx context.Context, db database.DB, user *types.User) *UserResolver {
+	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
-		db:     db,
-		user:   user,
-		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
-		actor:  actor.FromContext(ctx),
+		db:                       db,
+		user:                     user,
+		logger:                   logger,
+		actor:                    actor.FromContext(ctx),
+		HasVerifiedEmailResolver: newHasVerifiedEmailResolver(db, logger, user),
 	}
 }
 
 // newUserResolverFromActor returns a new UserResolver with given user object.
 func newUserResolverFromActor(a *actor.Actor, db database.DB, user *types.User) *UserResolver {
+	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
-		db:     db,
-		user:   user,
-		logger: log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username)),
-		actor:  a,
+		db:                       db,
+		user:                     user,
+		logger:                   logger,
+		actor:                    a,
+		HasVerifiedEmailResolver: newHasVerifiedEmailResolver(db, logger, user),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -62,7 +62,6 @@ func (r *schemaResolver) User(
 
 // UserResolver implements the GraphQL User type.
 type UserResolver struct {
-	HasVerifiedEmailResolver
 	logger log.Logger
 	db     database.DB
 	user   *types.User
@@ -76,11 +75,10 @@ type UserResolver struct {
 func NewUserResolver(ctx context.Context, db database.DB, user *types.User) *UserResolver {
 	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
-		db:                       db,
-		user:                     user,
-		logger:                   logger,
-		actor:                    actor.FromContext(ctx),
-		HasVerifiedEmailResolver: newHasVerifiedEmailResolver(db, logger, user),
+		db:     db,
+		user:   user,
+		logger: logger,
+		actor:  actor.FromContext(ctx),
 	}
 }
 
@@ -88,11 +86,10 @@ func NewUserResolver(ctx context.Context, db database.DB, user *types.User) *Use
 func newUserResolverFromActor(a *actor.Actor, db database.DB, user *types.User) *UserResolver {
 	logger := log.Scoped("userResolver", "resolves a specific user").With(log.String("user", user.Username))
 	return &UserResolver{
-		db:                       db,
-		user:                     user,
-		logger:                   logger,
-		actor:                    a,
-		HasVerifiedEmailResolver: newHasVerifiedEmailResolver(db, logger, user),
+		db:     db,
+		user:   user,
+		logger: logger,
+		actor:  a,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -27,7 +27,7 @@ var timeNow = time.Now
 
 func (r *UserResolver) HasVerifiedEmail(ctx context.Context) (bool, error) {
 	if deploy.IsApp() {
-		return r.hasDotcomVerifiedEmail(ctx)
+		return r.hasVerifiedEmailOnDotcom(ctx)
 	}
 
 	return r.hasVerifiedEmail(ctx)
@@ -40,8 +40,8 @@ func (r *UserResolver) hasVerifiedEmail(ctx context.Context) (bool, error) {
 	return backend.NewUserEmailsService(r.db, r.logger).HasVerifiedEmail(ctx, r.user.ID)
 }
 
-// hasDotcomVerifiedEmail - checks with sourcegraph.com to ensure the app user has verified email.
-func (r *UserResolver) hasDotcomVerifiedEmail(ctx context.Context) (bool, error) {
+// hasVerifiedEmailOnDotcom - checks with sourcegraph.com to ensure the app user has verified email.
+func (r *UserResolver) hasVerifiedEmailOnDotcom(ctx context.Context) (bool, error) {
 	// 🚨 SECURITY: This resolves HasVerifiedEmail only for App by
 	// sending the request to dotcom to check if a verified email exists for the user.
 	// Dotcom will ensure that only the authenticated user and site admins can check

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -36,7 +36,7 @@ type HasVerifiedEmailResolver interface {
 type dotcomUserHasVerifiedEmailResolver struct {
 }
 
-// HasVerifiedEmail - checks with sourcegraph.com to ensure user has verified email.
+// HasVerifiedEmail - checks with sourcegraph.com to ensure the app user has verified email.
 func (r *dotcomUserHasVerifiedEmailResolver) HasVerifiedEmail(ctx context.Context) (bool, error) {
 	// 🚨 SECURITY: This resolves HasVerifiedEmail only for App by
 	// sending the request to dotcom to check if a verified email exists for the user.
@@ -61,7 +61,7 @@ func (r *dotcomUserHasVerifiedEmailResolver) HasVerifiedEmail(ctx context.Contex
 	// If we have an app user with a dotcom authtoken ask dotcom if the user has a verified email
 	url := "https://sourcegraph.com/.api/graphql?AppHasVerifiedEmailCheck"
 	cli := httpcli.ExternalDoer
-	payload := strings.NewReader("{\"query\":\"query AppHasVerifiedEmailCheck{ currentUser { hasVerifiedEmail } }\",\"variables\":{}}")
+	payload := strings.NewReader(`{"query":"query AppHasVerifiedEmailCheck{ currentUser { hasVerifiedEmail } }","variables":{}}`)
 
 	// Send GraphQL request to sourcegraph.com to check if email is verified
 	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
@@ -94,6 +94,7 @@ func (r *dotcomUserHasVerifiedEmailResolver) HasVerifiedEmail(ctx context.Contex
 	if err := json.Unmarshal(b, &result); err != nil {
 		return false, errors.Wrap(err, "unable to unmarshal response")
 	}
+
 	return result.Data.CurrentUser.HasVerifiedEmail, nil
 }
 


### PR DESCRIPTION
This includes 2 work arounds to allow Cody to work in App due to the new verified email requirements on dotcom.

This updates the check for the site **RequiresVerifiedEmailForCody**  by checking if the App user supplied their own completions keys and if they did not the requests will be sent to dotcom so then yes verification is required.

This updates the User **HasVerifiedEmail** check in App by replacing the resolver with one that will send a new graphql request to dotcom to check the **HasVerifiedEmail** value 
## Test plan

App User without verified email
1. Create a new dotcom user & token 
2. Put token in App config & Remove Completions config from App
3. Verify that HasVerifiedEmail = `false` in window.context.currentUser in app ✅ 
4. Verify that cody chat does not work ✅ 

App User without verified email - self supplied keys
1. Create a new dotcom user & token 
2. Put token in App config & Add Completions config with keys
3. Verify that HasVerifiedEmail = `false` in window.context.currentUser in app ✅ 
4. Verify that cody chat works ✅ 

App User with verified email 
1. Create a new dotcom user & token 
2. Put token in App config & Add Completions config with keys
3. Verify that HasVerifiedEmail = `false` in window.context.currentUser in app ✅ 
4. Verify that cody chat does not work ✅ 
5. Click verification email to verify email
6. Verify that HasVerifiedEmail = `true` in window.context.currentUser in app ✅ 
7. Verify that cody chat does work ✅ 

Dotcom users 
1. run `sg start dotcom`
2. Create a new user
3. Verify there is no cody chat does not work ✅ 
4. Click verification email to verify email
5. Verify that cody chat does work ✅ 

Enterprise users 
1. run `sg start enterprise`
2. Create a new user - don't verify the email
3. Verify that cody chat does work ✅ 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
