### PR TITLE
svcmain: fixup logger updater

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -178,9 +178,7 @@ func run(
 	}
 
 	if oobConfig.Logging != nil {
-		go oobConfig.Logging.Watch(func() {
-			liblog.Update(oobConfig.Logging.SinksConfig)
-		})
+		go oobConfig.Logging.Watch(liblog.Update(oobConfig.Logging.SinksConfig))
 	}
 	if oobConfig.Tracing != nil {
 		tracer.Init(log.Scoped("tracer", "internal tracer package"), oobConfig.Tracing)


### PR DESCRIPTION
Regression I introduced in #52039: the logging configuration callback returns a callback that needs to be called 😬 

## Test plan

Configured sentry locally