### PR TITLE
Cody: Fix useContext none setting and add type for winkJS

### DIFF
--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -31,14 +31,14 @@ export class CodebaseContext {
 
     public async getContextMessages(query: string, options: ContextSearchOptions): Promise<ContextMessage[]> {
         switch (this.config.useContext) {
-            case 'embeddings' || 'blended':
+            case 'keyword':
+                return this.getKeywordContextMessages(query, options)
+            case 'none':
+                return []
+            default:
                 return this.embeddings
                     ? this.getEmbeddingsContextMessages(query, options)
                     : this.getKeywordContextMessages(query, options)
-            case 'keyword':
-                return this.getKeywordContextMessages(query, options)
-            default:
-                return this.getEmbeddingsContextMessages(query, options)
         }
     }
 

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
@@ -31,6 +31,18 @@ const fileExtRipgrepParams = [
     '1M',
 ]
 
+interface RipgrepStreamData {
+    value: {
+        type: string
+        data: {
+            path: {
+                text: string
+            }
+            stats: { bytes_searched: number }
+        }
+    }
+}
+
 /**
  * Term represents a single term in the keyword search.
  * - A term is uniquely defined by its stem.
@@ -75,8 +87,8 @@ export function userQueryToKeywordQuery(query: string): Term[] {
         }
         origWords.push(...winkUtils.string.tokenize0(chunk))
     }
-    const filteredWords = winkUtils.tokens.removeWords(origWords) as string[]
-    const terms: { [stem: string]: Term } = {}
+    const filteredWords = winkUtils.tokens.removeWords(origWords)
+    const terms = new Map<string, Term>()
     for (const word of filteredWords) {
         // Ignore ASCII-only strings of length 2 or less
         if (word.length <= 2) {
@@ -93,20 +105,22 @@ export function userQueryToKeywordQuery(query: string): Term[] {
             }
         }
 
-        const stem = winkUtils.string.stem(word)
-        if (terms[stem]) {
-            terms[stem].originals.push(word)
-            terms[stem].count++
-        } else {
-            terms[stem] = {
+        const stem = (winkUtils.string.stem(word) as string) || ''
+        if (!terms.has(stem)) {
+            terms.set(stem, {
                 stem,
                 originals: [word],
                 prefix: longestCommonPrefix(word.toLowerCase(), stem),
                 count: 1,
-            }
+            })
+        }
+        const term = terms.get(stem)
+        if (term) {
+            term.originals.push(word)
+            term.count++
         }
     }
-    return [...Object.values(terms)]
+    return [...terms.values()]
 }
 
 export class LocalKeywordContextFetcher implements KeywordContextFetcher {
@@ -186,14 +200,14 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
                     .pipe(StreamValues.withParser())
                     .on('data', data => {
                         try {
-                            switch (data.value.type) {
+                            const typedData = data as RipgrepStreamData
+                            switch (typedData.value.type) {
                                 case 'end':
-                                    if (!fileTermCounts[data.value.data.path.text]) {
-                                        fileTermCounts[data.value.data.path.text] = {} as any
+                                    if (!fileTermCounts[typedData.value.data.path.text]) {
+                                        fileTermCounts[typedData.value.data.path.text] = { bytesSearched: 0 }
                                     }
-                                    fileTermCounts[data.value.data.path.text].bytesSearched =
-                                        data.value.data.stats.bytes_searched
-
+                                    fileTermCounts[typedData.value.data.path.text].bytesSearched =
+                                        typedData.value.data.stats.bytes_searched
                                     break
                             }
                         } catch (error) {

--- a/client/cody/src/wink-nlp-utils.d.ts
+++ b/client/cody/src/wink-nlp-utils.d.ts
@@ -1,1 +1,14 @@
-declare module 'wink-nlp-utils'
+declare module 'wink-nlp-utils' {
+    declare namespace winkUtils {
+        namespace string {
+            function tokenize0(s: string): string[]
+            function stem(word: string): string | undefined
+        }
+
+        namespace tokens {
+            function removeWords(words: string[]): string[]
+        }
+    }
+
+    export default winkUtils
+}


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/52125

This PR includes a fix to https://github.com/sourcegraph/sourcegraph/issues/52125 where setting `cody.useContext` to `none` works the same as setting it to `blend` or `embeddings`.
- This fix should also help users who run into issues with local keyword fetcher causing machine to freeze in large repo, where they can turn off `keyword search` by setting it to `none` 

Also add types for WinkJS and data returned by ripgrep

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Set cody.useContext to none to confirm no context is included for Cody except the currently opened file:
![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/8aaf113b-0fa0-4cb3-ae97-e17329de7650)
