### PR TITLE
sg: run generate buf only with changes

### DIFF
--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -52,7 +52,6 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
-
 	// Always run in CI
 	if os.Getenv("CI") == "true" {
 		return proto.Generate(ctx, verbose)
@@ -70,5 +69,4 @@ func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
 	}
 	// Run buf gen by default
 	return proto.Generate(ctx, verbose)
-
 }

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/golang"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/proto"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var allGenerateTargets = generateTargets{
@@ -48,5 +53,16 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
+	// Don't run buf gen if no .proto files changed or not in CI
+	out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
+	if err != nil {
+		return &generate.Report{Err: errors.Wrap(err, "git diff failed")} // should never happen
+	}
+	if !strings.Contains(string(out), ".proto") && os.Getenv("CI") != "true" {
+		std.Out.WriteNoticef("Skipping buf as no .proto files changed or not in CI")
+		return &generate.Report{Output: "No .proto files changed or not in CI"}
+
+	}
+
 	return proto.Generate(ctx, verbose)
 }

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"os/exec"
-	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
@@ -50,17 +48,5 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
-	out, err := exec.Command("git", "diff", "--name-only", "origin/master...").Output()
-	if err != nil {
-		panic(err)
-	}
-
-	// Check if output contains any .proto files
-	if strings.Contains(string(out), ".proto") {
-		println("Diff contains .proto changes!")
-		return proto.Generate(ctx, verbose)
-	} else {
-		println("No .proto changes found")
-		return nil
-	}
+	return proto.Generate(ctx, verbose)
 }

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os/exec"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
@@ -48,5 +50,17 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
-	return proto.Generate(ctx, verbose)
+	out, err := exec.Command("git", "diff", "--name-only", "origin/master...").Output()
+	if err != nil {
+		panic(err)
+	}
+
+	// Check if output contains any .proto files
+	if strings.Contains(string(out), ".proto") {
+		println("Diff contains .proto changes!")
+		return proto.Generate(ctx, verbose)
+	} else {
+		println("No .proto changes found")
+		return nil
+	}
 }

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -2,16 +2,12 @@ package main
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/buf"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/golang"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/proto"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var allGenerateTargets = generateTargets{
@@ -52,14 +48,5 @@ func generateGoRunner(ctx context.Context, args []string) *generate.Report {
 }
 
 func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
-	// Check if output contains any .proto files
-	out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
-	if err != nil {
-		errors.Errorf("failed to run git diff: %v", err)
-	}
-	if strings.Contains(string(out), ".proto") || os.Getenv("CI") == "true" {
-		return proto.Generate(ctx, verbose)
-	} else {
-		return nil
-	}
+	return proto.Generate(ctx, verbose)
 }

--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/golang"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/generate/proto"
-	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -59,10 +58,7 @@ func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
 		return &generate.Report{Err: errors.Wrap(err, "git diff failed")} // should never happen
 	}
 	if !strings.Contains(string(out), ".proto") && os.Getenv("CI") != "true" {
-		std.Out.WriteNoticef("Skipping buf as no .proto files changed or not in CI")
-		return &generate.Report{Output: "No .proto files changed or not in CI"}
-
+		return &generate.Report{Output: "No .proto files changed or not in CI. Skippping buf gen."}
 	}
-
 	return proto.Generate(ctx, verbose)
 }

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -73,17 +71,6 @@ func runGenerateAndReport(ctx context.Context, t generate.Target, args []string)
 	_, err := root.RepositoryRoot()
 	if err != nil {
 		return err
-	}
-	// Don't run buf gen if no .proto files changed or not in CI
-	if t.Name == "buf" {
-		out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
-		if err != nil {
-			return errors.Errorf("failed to run git diff: %v", err)
-		}
-		if !strings.Contains(string(out), ".proto") && os.Getenv("CI") != "true" {
-			std.Out.WriteNoticef("Skipping %q as no .proto files changed or not in CI", t.Name)
-			return nil
-		}
 	}
 	std.Out.WriteNoticef("Running target %q (%s)", t.Name, t.Help)
 	report := t.Runner(ctx, args)

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -64,16 +64,20 @@ sg --verbose generate ... # Enable verbose output
 			std.Out.WriteFailuref("unrecognized command %q provided", cmd.Args().First())
 			return flag.ErrHelp
 		}
-		out, err := exec.Command("git", "diff", "--name-only", "origin/master...").Output()
-		if err != nil {
-			panic(err)
+		// Get the index of the go target
+		var ind int
+		for i, t := range allGenerateTargets {
+			if t.Name == "go" {
+				ind = i
+			}
 		}
 		// Check if output contains any .proto files
-		if strings.Contains(string(out), ".proto") {
+		out, _ := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
+		if strings.Contains(string(out), ".proto") || os.Getenv("CI") == "true" {
 			return allGenerateTargets.RunAll(cmd.Context)
-
 		} else {
-			return generateTargets.RunAll(cmd.Context)
+			_ = runGenerateAndReport(cmd.Context, allGenerateTargets[ind], []string{})
+			return nil
 		}
 	},
 	Subcommands: allGenerateTargets.Commands(),

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -5,8 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -64,24 +62,7 @@ sg --verbose generate ... # Enable verbose output
 			std.Out.WriteFailuref("unrecognized command %q provided", cmd.Args().First())
 			return flag.ErrHelp
 		}
-		// Get the index of the go target
-		var ind int
-		for i, t := range allGenerateTargets {
-			if t.Name == "go" {
-				ind = i
-			}
-		}
-		// Check if output contains any .proto files
-		out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
-		if err != nil {
-			errors.Errorf("failed to run git diff: %v", err)
-		}
-		if strings.Contains(string(out), ".proto") || os.Getenv("CI") == "true" {
-			return allGenerateTargets.RunAll(cmd.Context)
-		} else {
-			_ = runGenerateAndReport(cmd.Context, allGenerateTargets[ind], []string{})
-			return nil
-		}
+		return allGenerateTargets.RunAll(cmd.Context)
 	},
 	Subcommands: allGenerateTargets.Commands(),
 }

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -62,7 +64,17 @@ sg --verbose generate ... # Enable verbose output
 			std.Out.WriteFailuref("unrecognized command %q provided", cmd.Args().First())
 			return flag.ErrHelp
 		}
-		return allGenerateTargets.RunAll(cmd.Context)
+		out, err := exec.Command("git", "diff", "--name-only", "origin/master...").Output()
+		if err != nil {
+			panic(err)
+		}
+		// Check if output contains any .proto files
+		if strings.Contains(string(out), ".proto") {
+			return allGenerateTargets.RunAll(cmd.Context)
+
+		} else {
+			return generateTargets.RunAll(cmd.Context)
+		}
 	},
 	Subcommands: allGenerateTargets.Commands(),
 }

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/urfave/cli/v2"
@@ -71,6 +73,17 @@ func runGenerateAndReport(ctx context.Context, t generate.Target, args []string)
 	_, err := root.RepositoryRoot()
 	if err != nil {
 		return err
+	}
+	// Don't run buf gen if no .proto files changed or not in CI
+	if t.Name == "buf" {
+		out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
+		if err != nil {
+			return errors.Errorf("failed to run git diff: %v", err)
+		}
+		if !strings.Contains(string(out), ".proto") && os.Getenv("CI") != "true" {
+			std.Out.WriteNoticef("Skipping %q as no .proto files changed or not in CI", t.Name)
+			return nil
+		}
 	}
 	std.Out.WriteNoticef("Running target %q (%s)", t.Name, t.Help)
 	report := t.Runner(ctx, args)

--- a/dev/sg/sg_generate.go
+++ b/dev/sg/sg_generate.go
@@ -72,7 +72,10 @@ sg --verbose generate ... # Enable verbose output
 			}
 		}
 		// Check if output contains any .proto files
-		out, _ := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
+		out, err := exec.Command("git", "diff", "--name-only", "main...HEAD").Output()
+		if err != nil {
+			errors.Errorf("failed to run git diff: %v", err)
+		}
 		if strings.Contains(string(out), ".proto") || os.Getenv("CI") == "true" {
 			return allGenerateTargets.RunAll(cmd.Context)
 		} else {


### PR DESCRIPTION
Adds a check to see if .proto files have changed, to determine if running `generate buf` is required. Will always run both in CI 

## Test plan

```
➜  sourcegraph git:(dt/sg_buf) ✗ go run ./dev/sg generate 
👉 Running target "buf" (Re-generate protocol buffer bindings using buf)
✅ Target "buf" done (7s)
👉 Running target "go" (Run go generate [packages...] on the codebase)
✅ 14/14 packages generated  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████  100%
ℹ️ go generate ./... (excluding doc/cli/references)
ℹ️ goimports -w
ℹ️ go mod tidy
✅ Target "go" done (21s)
➜  sourcegraph git:(dt/sg_buf) ✗ unset CI=true
➜  sourcegraph git:(dt/sg_buf) ✗ unset CI     
➜  sourcegraph git:(dt/sg_buf) ✗ go run ./dev/sg generate 
👉 Running target "go" (Run go generate [packages...] on the codebase)
✅ 14/14 packages generated  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████  100%
ℹ️ go generate ./... (excluding doc/cli/references)
ℹ️ goimports -w
ℹ️ go mod tidy
✅ Target "go" done (21s)
➜  sourcegraph git:(dt/sg_buf) ✗ gst
On branch dt/sg_buf
Your branch is up to date with 'origin/dt/sg_buf'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .proto
➜  sourcegraph git:(dt/sg_buf) ✗ ga .proto && gc "add test proto" 
[dt/sg_buf 4c1da4175a] add test proto
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 .proto
➜  sourcegraph git:(dt/sg_buf) go run ./dev/sg generate
👉 Running target "buf" (Re-generate protocol buffer bindings using buf)
✅ Target "buf" done (7s)
👉 Running target "go" (Run go generate [packages...] on the codebase)
✅ 14/14 packages generated  ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████  100%
ℹ️ go generate ./... (excluding doc/cli/references)
ℹ️ goimports -w
ℹ️ go mod tidy
✅ Target "go" done (21s)
➜  sourcegraph git:(dt/sg_buf) 
```
