### PR TITLE
Start implementing ownership unification Bag

### DIFF
--- a/enterprise/internal/own/BUILD.bazel
+++ b/enterprise/internal/own/BUILD.bazel
@@ -32,6 +32,9 @@ go_test(
         "service_test.go",
     ],
     embed = [":own"],
+    tags = [
+        "requires-network",
+    ],
     deps = [
         "//enterprise/internal/database",
         "//enterprise/internal/own/codeowners",

--- a/enterprise/internal/own/BUILD.bazel
+++ b/enterprise/internal/own/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "own",
-    srcs = ["service.go"],
+    srcs = [
+        "ownref.go",
+        "service.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/own",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
@@ -23,7 +26,10 @@ go_library(
 go_test(
     name = "own_test",
     timeout = "short",
-    srcs = ["service_test.go"],
+    srcs = [
+        "ownref_test.go",
+        "service_test.go",
+    ],
     embed = [":own"],
     deps = [
         "//enterprise/internal/database",
@@ -34,10 +40,12 @@ go_test(
         "//internal/authz",
         "//internal/conf",
         "//internal/database",
+        "//internal/database/dbtest",
         "//internal/gitserver",
         "//internal/types",
         "//lib/errors",
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/internal/own/BUILD.bazel
+++ b/enterprise/internal/own/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//internal/errcode",
         "//internal/gitserver",
         "//internal/types",
+        "//lib/errors",
     ],
 )
 

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -29,9 +29,6 @@ type Reference struct {
 	// handle is either a sourcegraph or code-host handle,
 	// and can be considered within or outside of
 	handle string
-	// contributorName is specific to recent contributions signal,
-	// and contains whatever is found in commit author's name.
-	contributorName string
 	// email can be found in a CODEOWNERS entry, but can also
 	// be a commit author email, which means it can be a code-host specific
 	// email generated for the purpose of merging a pull-request.
@@ -71,9 +68,30 @@ func searchExample(db database.EnterpriseDB) error {
 	// Then for given file we have owner matches (translated to references here):
 	ownerReferences := []Reference{
 		// Some possible matching entries:
-		{email: "john.doe@sourcegraph.com"}, // email entry in CODEOWNERS
-		{handle: "jdoe"},                    // @eseliger entry in CODEOWNERS
-		{userID: 42},                        // Erik's user ID from assigned ownership
+		// email entry in CODEOWNERS
+		{
+			email: "john.doe@sourcegraph.com",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		// @jdoe entry in CODEOWNERS
+		{
+			handle: "jdoe",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		{
+			handle: "jdoe.sourcegraph",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		{userID: 42}, // John Doe's user ID from assigned ownership
 	}
 	var matches bool
 	for _, ref := range ownerReferences {
@@ -137,8 +155,7 @@ func resolutionExample(db database.EnterpriseDB) error {
 		},
 		// Contributor email contains github username, we can figure this out based on github code host.
 		{
-			contributorName: "John Doe",
-			email:           "githubusername@users.noreply.github.com",
+			email: "githubusername@users.noreply.github.com",
 			// alternative:  "userID+userName@users.noreply.github.com",
 			// repo context where the commit is from
 			repoContext: &repoContext{

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -33,7 +33,7 @@ type Reference struct {
 	// UserID indicates identifying a specific user.
 	UserID int32
 	// Handle is either a sourcegraph or code-host handle,
-	// and can be considered within or outside of
+	// and can be considered within or outside of the repo context.
 	Handle string
 	// Email can be found in a CODEOWNERS entry, but can also
 	// be a commit author email, which means it can be a code-host specific

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -86,8 +86,8 @@ type Bag interface {
 // that can be referred to by given text (name or email alike).
 // This can be used in search to find relevant owners by different identifiers
 // that the database reveals.
-// TODO: Search by verified email.
-// TODO: Search by code host handle.
+// TODO(#52140): Search by verified email.
+// TODO(#52141): Search by code host handle.
 func ByTextReference(ctx context.Context, db database.EnterpriseDB, text string) (Bag, error) {
 	text = strings.TrimPrefix(text, "@")
 	var b bag
@@ -143,7 +143,7 @@ func (refs userReferences) containsEmail(email string) bool {
 	return false
 }
 
-// TODO: Introduce matching on linked code host handles.
+// TODO(#52142): Introduce matching on linked code host handles.
 func (refs userReferences) containsHandle(handle string) bool {
 	handle = strings.TrimPrefix(handle, "@")
 	if u := refs.user; u != nil && u.Username == handle {
@@ -161,7 +161,7 @@ func (refs userReferences) containsUserID(userID int32) bool {
 
 // Contains at this point returns true
 //   - if email reference matches the primary email,
-//     TODO: Match also other verified emails
+//     TODO(#52143): Match also other verified emails
 //   - if user ID matches the ID if the user in the bag,
 func (b bag) Contains(ref Reference) bool {
 	for _, userRefs := range b {

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -162,6 +162,7 @@ func (refs userReferences) containsUserID(userID int32) bool {
 // Contains at this point returns true
 //   - if email reference matches the primary email,
 //     TODO(#52143): Match also other verified emails
+//   - if handle reference matches the user handle,
 //   - if user ID matches the ID if the user in the bag,
 func (b bag) Contains(ref Reference) bool {
 	for _, userRefs := range b {

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -1,0 +1,173 @@
+package own
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/own/codeowners"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+// repoContext allows us to anchor an author reference to a repo where it stems from.
+// For instance a handle from a CODEOWNERS file comes from github.com/sourcegraph/sourcegraph.
+// This is important for resolving namespaced owner names
+// (like CODEOWNERS file can refer to team handle "own"), while the name in the database is "sourcegraph/own"
+// because it was pulled from github, and by convention organiziation name is prepended.
+type repoContext struct {
+	name         api.RepoName
+	codehostKind string
+}
+
+// Reference is whatever we get from a data source, like a commit,
+// CODEOWNERS entry or file view.
+type Reference struct {
+	// repoContext is present if given owner reference is associated
+	// with specific repository.
+	repoContext *repoContext
+	// userID indicates identifying a specific user.
+	userID int
+	// handle is either a sourcegraph or code-host handle,
+	// and can be considered within or outside of
+	handle string
+	// contributorName is specific to recent contributions signal,
+	// and contains whatever is found in commit author's name.
+	contributorName string
+	// email can be found in a CODEOWNERS entry, but can also
+	// be a commit author email, which means it can be a code-host specific
+	// email generated for the purpose of merging a pull-request.
+	email string
+}
+
+// Bag is a collection of platonic forms or identities of owners
+// (teams, people or otherwise). It is pre-seeded with database information
+// based on the search query using `ByTextReference`, and used to match owner
+// references found.
+type Bag interface {
+
+	// Contains answers true if given bag contains an owner form
+	// that the given reference points at in some way.
+	Contains(ref Reference) bool
+}
+
+// ByTextReference returns a Bag of all the forms (users, persons, teams)
+// that can be referred to by given text (name or email alike).
+// This can be used in search to find relevant owners by different identifiers
+// that the database reveals.
+func ByTextReference(context.Context, database.EnterpriseDB, string) (Bag, error) {
+	return nil, nil
+}
+
+// Example: Implement search for f:has.owner(eseliger)
+func searchExample(db database.EnterpriseDB) error {
+	ctx := context.Background()
+	ownerSearchTerm := "jdoe"
+	// Do this at first during search and hold references to all the known entities
+	// that can be referred to by given search term
+	bag, err := ByTextReference(ctx, db, ownerSearchTerm)
+	if err != nil {
+		return err
+	}
+
+	// Then for given file we have owner matches (translated to references here):
+	ownerReferences := []Reference{
+		// Some possible matching entries:
+		{email: "john.doe@sourcegraph.com"}, // email entry in CODEOWNERS
+		{handle: "jdoe"},                    // @eseliger entry in CODEOWNERS
+		{userID: 42},                        // Erik's user ID from assigned ownership
+	}
+	var matches bool
+	for _, ref := range ownerReferences {
+		if bag.Contains(ref) {
+			matches = true
+		}
+	}
+	if matches {
+		// Great! We're selecting the result of filtering.
+	}
+	return nil
+}
+
+// Clusters is a set of associated references with the use of a database.
+// The way it works is that:
+// 1. references are first added as leads,
+// 2. database is used to resolve set of different references,
+// 3. then the same references can be looked up and resolved to concrete people or teams.
+type Clusters interface {
+	// Add a reference to enrich the data set
+	Add(ref Reference)
+
+	// Resolve all the added references, and cluster by owner identity.
+	Resolve(context.Context, database.EnterpriseDB) error
+
+	// Look up resolved references. If two references evaluate to a single
+	// resolved owner, the result for them is guaranteed to be the same,
+	// and different resolved owners are guaranteed to have different Identifier().
+	Lookup(ref Reference) codeowners.ResolvedOwner
+}
+
+// Example: resolution for file/repo/directory ownership
+func resolutionExample(db database.EnterpriseDB) error {
+	ctx := context.Background()
+	// here are some signals and owner data that is returned for given
+	// file or directory:
+	ownerReferences := []Reference{
+		// email entry in CODEOWNERS
+		{
+			email: "john.doe@sourcegraph.com",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		// user handle entry in CODEOWNERS
+		{
+			handle: "johndoe",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		// team handle in CODEOWNERS - we know it's a team because of github code host and / in the name
+		{
+			handle: "sourcegraph/own",
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		// Contributor email contains github username, we can figure this out based on github code host.
+		{
+			contributorName: "John Doe",
+			email:           "githubusername@users.noreply.github.com",
+			// alternative:  "userID+userName@users.noreply.github.com",
+			// repo context where the commit is from
+			repoContext: &repoContext{
+				name:         "github.com/sourcegraph/sourcegraph",
+				codehostKind: "github",
+			},
+		},
+		{userID: 42}, // John's user ID from assigned ownership
+		{userID: 42}, // User ID originating from recent viewer signal.
+	}
+	var cls Clusters = nil // construct somehow
+	for _, r := range ownerReferences {
+		cls.Add(r)
+	}
+	if err := cls.Resolve(ctx, db); err != nil {
+		return err
+	}
+	// iterate through ownership and signals found again to group
+	grouped := map[string][]Reference{}
+	for _, r := range ownerReferences {
+		// Here we iterate through references, but in the ownership blob/repo/dir
+		// resolver each reference will be attached to a signal, so we'll be able
+		// to group these, like so:
+		o := cls.Lookup(r)
+		rs := grouped[o.Identifier()]
+		rs = append(rs, r)
+		grouped[o.Identifier()] = rs
+	}
+	// We have a map of references by resolved owner identity. In resolver
+	// we're likely also accumulating the resolved owner with signals.
+	return nil
+}

--- a/enterprise/internal/own/ownref_test.go
+++ b/enterprise/internal/own/ownref_test.go
@@ -138,3 +138,56 @@ func TestBagNoUser(t *testing.T) {
 		})
 	}
 }
+
+func TestBagUserFoundNoMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	ctx := context.Background()
+	user, err := db.Users().Create(ctx, database.NewUser{
+		Email:           "john.doe@example.com",
+		Username:        "jdoe",
+		EmailIsVerified: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bag, err := ByTextReference(ctx, db, "jdoe")
+	if err != nil {
+		t.Fatalf("ByTextReference: %s", err)
+	}
+	// Check test is valid by verifying user can be found by handle.
+	r := Reference{Handle: "jdoe"}
+	if !bag.Contains(r) {
+		t.Fatalf("validation: Contains(%s), want true, got false", r)
+	}
+	for name, r := range map[string]Reference{
+		"email entry in CODEOWNERS": {
+			Email: "jdoe@example.com",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"different handle entry in CODEOWNERS": {
+			Handle: "anotherhandle",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"user ID from assigned ownership": {
+			UserID: user.ID + 1, // different user ID
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if bag.Contains(r) {
+				t.Errorf("bag.Contains(%s), want false, got true", r)
+			}
+		})
+	}
+}

--- a/enterprise/internal/own/ownref_test.go
+++ b/enterprise/internal/own/ownref_test.go
@@ -1,0 +1,140 @@
+package own
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+
+	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+)
+
+func TestSearchFilteringExample(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+	logger := logtest.Scoped(t)
+	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	ctx := context.Background()
+	user, err := db.Users().Create(ctx, database.NewUser{
+		Email:           "john.doe@example.com",
+		Username:        "jdoe",
+		EmailIsVerified: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Imagine this is search with filter `file:has.owner(jdoe)`.
+	ownerSearchTerm := "jdoe"
+
+	// Do this at first during search and hold references to all the known entities
+	// that can be referred to by given search term
+	bag, err := ByTextReference(ctx, db, ownerSearchTerm)
+	if err != nil {
+		t.Fatalf("ByTextReference: %s", err)
+	}
+
+	// Then for given file we have owner matches (translated to references here):
+	ownerReferences := map[string]Reference{
+		// Some possible matching entries:
+		// email entry in CODEOWNERS
+		"email entry in CODEOWNERS": {
+			Email: "john.doe@example.com",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"jdoe entry in CODEOWNERS": {
+			Handle: "jdoe",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"@jdoe entry in CODEOWNERS": {
+			Handle: "@jdoe",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"user ID from assigned ownership": {
+			UserID: user.ID,
+		},
+	}
+	for name, r := range ownerReferences {
+		t.Run(name, func(t *testing.T) {
+			if !bag.Contains(r) {
+				t.Errorf("bag.Contains(%s), want true, got false", r)
+			}
+		})
+	}
+}
+
+func TestBagNoUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	t.Parallel()
+	logger := logtest.Scoped(t)
+
+	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	ctx := context.Background()
+	bag, err := ByTextReference(ctx, db, "userdoesnotexist")
+	if err != nil {
+		t.Fatalf("ByTextReference: %s", err)
+	}
+	for name, r := range map[string]Reference{
+		"same handle matches even when there is no user": {
+			Handle: "userdoesnotexist",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"same handle with @ matches even when there is no user": {
+			Handle: "@userdoesnotexist",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !bag.Contains(r) {
+				t.Errorf("bag.Contains(%s), want true, got false", r)
+			}
+		})
+	}
+	for name, r := range map[string]Reference{
+		"email entry in CODEOWNERS": {
+			Email: "john.doe@example.com",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"different handle entry in CODEOWNERS": {
+			Handle: "anotherhandle",
+			RepoContext: &RepoContext{
+				Name:         "github.com/sourcegraph/sourcegraph",
+				CodehostKind: "github",
+			},
+		},
+		"user ID from assigned ownership": {
+			UserID: 42,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if bag.Contains(r) {
+				t.Errorf("bag.Contains(%s), want false, got true", r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #52139

This pull-request merges a primitive `Bag` implementation from API spike: #52070.

The bag supports the search filtering use case (aka `file:has.owner(@handle)`). Here's how:

1. Try pulling the user from the database by username.
2. Pull other data points (primary email for now) from the database.
3. Put the above in a `Bag`.
4. Allow `References` from signals and CODEOWNERS to be looked up in the `Bag`.

This implementations intentionally has plenty gaps (keeping PR size sane 💡), but follow-up improvements are listed in tracking issue #52139.

## Test plan

Add tests with database - positive and negative test cases.
