### PR TITLE
cody: guardrails debug command

### DIFF
--- a/client/cody-shared/BUILD.bazel
+++ b/client/cody-shared/BUILD.bazel
@@ -56,6 +56,8 @@ ts_project(
         "src/editor/withPreselectedOptions.ts",
         "src/embeddings/client.ts",
         "src/embeddings/index.ts",
+        "src/guardrails/client.ts",
+        "src/guardrails/index.ts",
         "src/hallucinations-detector/index.ts",
         "src/intent-detector/client.ts",
         "src/intent-detector/index.ts",

--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -8,6 +8,7 @@ export interface Configuration {
     experimentalSuggest: boolean
     experimentalChatPredictions: boolean
     experimentalInline: boolean
+    experimentalGuardrails: boolean
     customHeaders: Record<string, string>
 }
 

--- a/client/cody-shared/src/guardrails/client.ts
+++ b/client/cody-shared/src/guardrails/client.ts
@@ -1,0 +1,54 @@
+import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+import { isError } from '../utils'
+
+import { Guardrails, RepositoryAttribution } from '.'
+
+export class SourcegraphGuardrailsClient implements Guardrails {
+    constructor(private client: SourcegraphGraphQLAPIClient) {}
+
+    public async searchAttribution(snippet: string): Promise<RepositoryAttribution[] | Error> {
+        // TODO(keegancsmith) adjust implementation to respect line count thresholds and to handle resultLimitHit.
+        const query = `type:file select:repo content:${goEscapeString(snippet)}`
+        const results = await this.client.searchTypeRepo(query)
+        if (isError(results)) {
+            return results
+        }
+        return results.repositories
+    }
+}
+
+function goEscapeString(str: string): string {
+    // TODO(keegancsmith) verify correct, this is blind copy pasta from cody
+    let escaped = ''
+    for (const c of str) {
+        switch (c) {
+            case '\n':
+                escaped += '\\n'
+                break
+            case '\t':
+                escaped += '\\t'
+                break
+            case '\r':
+                escaped += '\\r'
+                break
+            case '\v':
+                escaped += '\\v'
+                break
+            case '\b':
+                escaped += '\\b'
+                break
+            case '\f':
+                escaped += '\\f'
+                break
+            case '\\':
+                escaped += '\\\\'
+                break
+            case '"':
+                escaped += '\\"'
+                break
+            default:
+                escaped += c
+        }
+    }
+    return `"${escaped}"`
+}

--- a/client/cody-shared/src/guardrails/index.ts
+++ b/client/cody-shared/src/guardrails/index.ts
@@ -1,0 +1,7 @@
+export interface RepositoryAttribution {
+    name: string
+}
+
+export interface Guardrails {
+    searchAttribution(snippet: string): Promise<RepositoryAttribution[] | Error>
+}

--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -13,6 +13,7 @@ import {
     LEGACY_SEARCH_EMBEDDINGS_QUERY,
     LOG_EVENT_MUTATION,
     REPOSITORY_EMBEDDING_EXISTS_QUERY,
+    SEARCH_TYPE_REPO_QUERY,
     CURRENT_USER_ID_AND_VERIFIED_EMAIL_QUERY,
 } from './queries'
 
@@ -45,6 +46,10 @@ interface EmbeddingsMultiSearchResponse {
     embeddingsMultiSearch: EmbeddingsSearchResults
 }
 
+interface SearchTypeRepoResponse {
+    search: { results: { results: { name: string }[] } }
+}
+
 interface LogEventResponse {}
 
 export interface EmbeddingsSearchResult {
@@ -59,6 +64,10 @@ export interface EmbeddingsSearchResult {
 export interface EmbeddingsSearchResults {
     codeResults: EmbeddingsSearchResult[]
     textResults: EmbeddingsSearchResult[]
+}
+
+export interface SearchTypeRepoResults {
+    repositories: { name: string }[]
 }
 
 interface IsContextRequiredForChatQueryResponse {
@@ -194,6 +203,16 @@ export class SourcegraphGraphQLAPIClient {
             codeResultsCount,
             textResultsCount,
         }).then(response => extractDataOrError(response, data => data.embeddingsSearch))
+    }
+
+    public async searchTypeRepo(query: string): Promise<SearchTypeRepoResults | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<SearchTypeRepoResponse>>(SEARCH_TYPE_REPO_QUERY, {
+            query,
+        }).then(response =>
+            extractDataOrError(response, data => ({
+                repositories: data.search.results.results,
+            }))
+        )
     }
 
     public async isContextRequiredForQuery(query: string): Promise<boolean | Error> {

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -68,6 +68,19 @@ query LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int
 	}
 }`
 
+export const SEARCH_TYPE_REPO_QUERY = `
+query SearchTypeRepo($query: String!) {
+	search(query: $query, version: V3) {
+        results {
+            results {
+                ... on Repository {
+                    name
+                }
+            }
+        }
+	}
+}`
+
 export const IS_CONTEXT_REQUIRED_QUERY = `
 query IsContextRequiredForChatQuery($query: String!) {
 	isContextRequiredForChatQuery(query: $query)

--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -46,6 +46,7 @@ ts_project(
         "src/rg.ts",
         "src/services/CodeLensProvider.ts",
         "src/services/DecorationProvider.ts",
+        "src/services/GuardrailsProvider.ts",
         "src/services/InlineController.ts",
         "src/services/LocalStorageProvider.ts",
         "src/services/SecretStorageProvider.ts",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -182,6 +182,11 @@
         "category": "Cody Inline Assist",
         "enablement": "!commentThreadIsEmpty",
         "icon": "$(sync~spin)"
+      },
+      {
+        "command": "cody.guardrails.debug",
+        "title": "Cody: Guardrails Debug Attribution",
+        "enablement": "config.cody.debug && config.cody.experimental.guardrails && editorHasSelection"
       }
     ],
     "keybindings": [
@@ -297,6 +302,10 @@
         {
           "command": "cody.focus",
           "when": "!cody.activated"
+        },
+        {
+          "command": "cody.guardrails.debug",
+          "when": "config.cody.debug && config.cody.experimental.guardrails && editorHasSelection"
         }
       ],
       "view/title": [
@@ -386,6 +395,10 @@
           "order": 6,
           "type": "boolean",
           "markdownDescription": "Enables Cody Inline Assist, an inline way to explicitly ask questions and propose modifications to code.",
+          "default": false
+        },
+        "cody.experimental.guardrails": {
+          "type": "boolean",
           "default": false
         },
         "cody.customHeaders": {

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -20,6 +20,7 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         experimentalSuggest: config.get('cody.experimental.suggestions', false),
         experimentalChatPredictions: config.get('cody.experimental.chatPredictions', false),
         experimentalInline: config.get('cody.experimental.inline', false),
+        experimentalGuardrails: config.get('cody.experimental.guardrails', false),
         customHeaders: config.get<object>('cody.customHeaders', {}) as Record<string, string>,
     }
 }

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -3,6 +3,8 @@ import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
 import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
+import { Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
+import { SourcegraphGuardrailsClient } from '@sourcegraph/cody-shared/src/guardrails/client'
 import { IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
 import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
 import { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
@@ -18,6 +20,7 @@ interface ExternalServices {
     codebaseContext: CodebaseContext
     chatClient: ChatClient
     completionsClient: SourcegraphCompletionsClient
+    guardrails: Guardrails
 
     /** Update configuration for all of the services in this interface. */
     onConfigurationChange: (newConfig: ExternalServicesConfiguration) => void
@@ -53,11 +56,14 @@ export async function configureExternalServices(
         new LocalKeywordContextFetcher(rgPath, editor)
     )
 
+    const guardrails = new SourcegraphGuardrailsClient(client)
+
     return {
         intentDetector: new SourcegraphIntentDetectorClient(client),
         codebaseContext,
         chatClient: new ChatClient(completions),
         completionsClient: completions,
+        guardrails,
         onConfigurationChange: newConfig => {
             client.onConfigurationChange(newConfig)
             completions.onConfigurationChange(newConfig)

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -13,6 +13,7 @@ import { VSCodeEditor } from './editor/vscode-editor'
 import { logEvent, updateEventLogger } from './event-logger'
 import { configureExternalServices } from './external-services'
 import { getRgPath } from './rg'
+import { GuardrailsProvider } from './services/GuardrailsProvider'
 import { InlineController } from './services/InlineController'
 import { LocalStorage } from './services/LocalStorageProvider'
 import {
@@ -87,6 +88,7 @@ const register = async (
         codebaseContext,
         chatClient,
         completionsClient,
+        guardrails,
         onConfigurationChange: externalServicesOnDidConfigurationChange,
     } = await configureExternalServices(initialConfig, rgPath, editor)
 
@@ -237,6 +239,15 @@ const register = async (
                 return [new vscode.Range(0, 0, lineCount - 1, 0)]
             },
         }
+    }
+
+    if (initialConfig.experimentalGuardrails) {
+        const guardrailsProvider = new GuardrailsProvider(guardrails, editor)
+        disposables.push(
+            vscode.commands.registerCommand('cody.guardrails.debug', async () => {
+                await guardrailsProvider.debugEditorSelection()
+            })
+        )
     }
 
     return {

--- a/client/cody/src/services/GuardrailsProvider.ts
+++ b/client/cody/src/services/GuardrailsProvider.ts
@@ -1,0 +1,35 @@
+import { Editor } from '@sourcegraph/cody-shared/src/editor'
+import { Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
+import { isError } from '@sourcegraph/cody-shared/src/utils'
+
+export class GuardrailsProvider {
+    // TODO(keegancsmith) this provider should create the client since the guardrails client requires a dotcom graphql connection.
+    constructor(private client: Guardrails, private editor: Editor) {}
+
+    public async debugEditorSelection(): Promise<void> {
+        const snippet = this.editor.getActiveTextEditorSelection()?.selectedText
+        if (snippet === undefined) {
+            return
+        }
+
+        const msg = await this.client.searchAttribution(snippet).then(result => {
+            if (isError(result)) {
+                return `guardrails attribution search failed: ${result.message}`
+            }
+
+            const count = result.length
+            if (count === 0) {
+                return 'no matching repositories found'
+            }
+
+            const summary = result.slice(0, count < 5 ? count : 5).map(repo => repo.name)
+            if (count > 5) {
+                summary.push('...')
+            }
+
+            return `found ${count} matching repositories ${summary.join(', ')}`
+        })
+
+        await this.editor.showWarningMessage(msg)
+    }
+}


### PR DESCRIPTION
This provides some basic infrastructure for guardrails that will be built on top of. Initially the only command exposed is a debug command which will send off the selected code for attribution. The implementation of attribution is naive. The intention is to get some a basic shape of how things fit together to be further improved.

If you can provide guidance on where things live that would be great, I am a noob.

Test Plan: run cody with debug and experimental.guardrails turned on. Then select some code and run the guardrails debug command. Observe hits. Then create some unique looking text and run attribution against that. Get no hits.

https://github.com/sourcegraph/sourcegraph/assets/187831/838426d3-5239-4bd5-975a-26066cb33f5d

Part of #51361 