### PR TITLE
cody: the ugliest possible guardrails UX

### DIFF
--- a/client/cody-shared/src/guardrails/index.ts
+++ b/client/cody-shared/src/guardrails/index.ts
@@ -42,7 +42,7 @@ export async function annotateAttribution(guardrails: Guardrails, text: string):
             })
 
             // TODO(keegancsmith) escape msg?
-            return `${token.raw}\n> ${msg}\n`
+            return `${token.raw}\n<div title="guardrails">🛡️ ${msg}</div>`
         })
     )
     return parts.join('')

--- a/client/cody-shared/src/guardrails/index.ts
+++ b/client/cody-shared/src/guardrails/index.ts
@@ -1,7 +1,49 @@
+import { parseMarkdown } from '../chat/markdown'
+import { isError } from '../utils'
+
 export interface RepositoryAttribution {
     name: string
 }
 
 export interface Guardrails {
     searchAttribution(snippet: string): Promise<RepositoryAttribution[] | Error>
+}
+
+/**
+ * Returns markdown text with attribution information added in.
+ *
+ * @param guardrails client to use to lookup if a snippet of codes attributions
+ * @param text markdown text
+ */
+export async function annotateAttribution(guardrails: Guardrails, text: string): Promise<string> {
+    const tokens = parseMarkdown(text)
+    const parts = await Promise.all(
+        tokens.map(async token => {
+            if (token.type !== 'code') {
+                return token.raw
+            }
+
+            const msg = await guardrails.searchAttribution(token.text).then(result => {
+                if (isError(result)) {
+                    return `guardrails attribution search failed: ${result.message}`
+                }
+
+                const count = result.length
+                if (count === 0) {
+                    return 'no matching repositories found'
+                }
+
+                const summary = result.slice(0, count < 5 ? count : 5).map(repo => repo.name)
+                if (count > 5) {
+                    summary.push('...')
+                }
+
+                return `found ${count} matching repositories ${summary.join(', ')}`
+            })
+
+            // TODO(keegancsmith) escape msg?
+            return `${token.raw}\n> ${msg}\n`
+        })
+    )
+    return parts.join('')
 }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -99,6 +99,7 @@ const register = async (
         chatClient,
         intentDetector,
         codebaseContext,
+        guardrails,
         editor,
         secretStorage,
         localStorage,


### PR DESCRIPTION
So many TODOs litered around, but makes it easier to incrementally improve and stop me from overindexing on trying to make things better before sharing my TS code.

This is not good enough yet for end users at all, everything is hidden behind the configuration experimentalGuardrails.

Test Plan: Got cody to echo back some code I know exists in our corpus and it told me it had a hit. Otherwise got cody to generate code and it told me we had no hits.

<img width="763" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/187831/4b27ef82-212a-45da-8c1b-afef79de9bde">

<img width="766" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/187831/3ce8ff68-cbb2-4295-85d5-20e97f9ee90c">

Based on #52146 
Part of #51361 