### PR TITLE
sg: add graphql lint to linters

### DIFF
--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -48,6 +48,13 @@ var Targets = []Target{
 		},
 	},
 	{
+		Name:        "graphql",
+		Description: "Checks the graphql code for linting errors [bazel]",
+		Checks: []*linter{
+			onlyLocal(bazelTest("graphql schema lint (bazel)", "//cmd/frontend/graphqlbackend:graphql_schema_lint_test")),
+		},
+	},
+	{
 		Name:        "docs",
 		Description: "Documentation checks",
 		Checks: []*linter{
@@ -135,6 +142,15 @@ func runCheck(name string, check check.CheckAction[*repo.State]) *linter {
 	return &linter{
 		Name:  name,
 		Check: check,
+	}
+}
+
+func bazelTest(name, target string) *linter {
+	return &linter{
+		Name: name,
+		Check: func(ctx context.Context, out *std.Output, args *repo.State) error {
+			return root.Run(run.Cmd(ctx, "bazel", "test", target)).StreamLines(out.Write)
+		},
 	}
 }
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -429,6 +429,15 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
+### sg lint graphql
+
+Checks the graphql code for linting errors [bazel].
+
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
 ### sg lint docs
 
 Documentation checks.


### PR DESCRIPTION
We recently removed the graphql linter from the ci pipeline as an explicit step and integrated it to be part of bazel. There is still a need to lint graphql explicitly, thus we add it to the sg linters that one can run
## Test plan
Tested locally and green ci
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
