### PR TITLE
drift autofix: Support partial application

### DIFF
--- a/internal/database/migration/cliutil/BUILD.bazel
+++ b/internal/database/migration/cliutil/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "downgrade.go",
         "downto.go",
         "drift.go",
+        "drift_autofix.go",
         "drift_schema.go",
         "drift_util.go",
         "help.go",

--- a/internal/database/migration/cliutil/drift.go
+++ b/internal/database/migration/cliutil/drift.go
@@ -16,8 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-const maxAutofixAttempts = 3
-
 func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, development bool, expectedSchemaFactories ...ExpectedSchemaFactory) *cli.Command {
 	defaultVersion := ""
 	if development {
@@ -143,36 +141,15 @@ func Drift(commandName string, factory RunnerFactory, outFactory OutputFactory, 
 			return err
 		}
 		schema := schemas["public"]
+
 		summaries := drift.CompareSchemaDescriptions(schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
 
-		var autofixErr error
 		if autofixFlag.Get(cmd) {
-			for attempts := maxAutofixAttempts; attempts > 0 && len(summaries) > 0 && autofixErr == nil; attempts-- {
-				allStatements := []string{}
-				for _, summary := range summaries {
-					if statements, ok := summary.Statements(); ok {
-						allStatements = append(allStatements, statements...)
-					}
-				}
-				if len(allStatements) == 0 {
-					out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "No autofix to apply"))
-					break
-				}
-
-				autofixErr = store.RunDDLStatements(ctx, allStatements)
-				if autofixErr != nil {
-					out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure, "Failed to apply autofix: %s", autofixErr))
-				} else {
-					out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Successfully applied autofix"))
-					out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "Re-checking drift"))
-				}
-
-				schemas, err := store.Describe(ctx)
-				if err != nil {
-					return err
-				}
-				schema := schemas["public"]
-				summaries = drift.CompareSchemaDescriptions(schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
+			summaries, err = attemptAutofix(ctx, out, store, summaries, func(schema descriptions.SchemaDescription) []drift.Summary {
+				return drift.CompareSchemaDescriptions(schemaName, version, canonicalize(schema), canonicalize(expectedSchema))
+			})
+			if err != nil {
+				return err
 			}
 		}
 

--- a/internal/database/migration/cliutil/drift_autofix.go
+++ b/internal/database/migration/cliutil/drift_autofix.go
@@ -1,0 +1,57 @@
+package cliutil
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/migration/drift"
+	descriptions "github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const maxAutofixAttempts = 3
+
+// attemptAutofix tries to apply the suggestions in the given diff summary on the store.
+// Multiple attempts to apply drift may occur, and partial recovery of the schema may be
+// applied. New drift may be found after an attempted autofix.
+//
+// This function returns a fresh drift description of the target schema if any SQL queries
+// modifying the Postgres catalog have been attempted. This function returns an error only
+// on failure to describe the current schema, not on failure to apply the drift.
+func attemptAutofix(
+	ctx context.Context,
+	out *output.Output,
+	store Store,
+	summaries []drift.Summary,
+	compareDescriptionAgainstTarget func(descriptions.SchemaDescription) []drift.Summary,
+) ([]drift.Summary, error) {
+	var autofixErr error
+	for attempts := maxAutofixAttempts; attempts > 0 && len(summaries) > 0 && autofixErr == nil; attempts-- {
+		allStatements := []string{}
+		for _, summary := range summaries {
+			if statements, ok := summary.Statements(); ok {
+				allStatements = append(allStatements, statements...)
+			}
+		}
+		if len(allStatements) == 0 {
+			out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "No autofix to apply"))
+			break
+		}
+
+		autofixErr = store.RunDDLStatements(ctx, allStatements)
+		if autofixErr != nil {
+			out.WriteLine(output.Linef(output.EmojiFailure, output.StyleFailure, "Failed to apply autofix: %s", autofixErr))
+		} else {
+			out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Successfully applied autofix"))
+			out.WriteLine(output.Linef(output.EmojiInfo, output.StyleReset, "Re-checking drift"))
+		}
+
+		schemas, err := store.Describe(ctx)
+		if err != nil {
+			return nil, err
+		}
+		schema := schemas["public"]
+		summaries = compareDescriptionAgainstTarget(schema)
+	}
+
+	return summaries, nil
+}

--- a/internal/database/migration/drift/compare_indexes.go
+++ b/internal/database/migration/drift/compare_indexes.go
@@ -35,7 +35,7 @@ func compareIndexesCallbackFor(table schemas.TableDescription) func(_ *schemas.I
 			expectedIndex,
 			*index,
 		).withStatements(
-			expectedIndex.DropStatement(),
+			expectedIndex.DropStatement(table),
 			expectedIndex.CreateStatement(table),
 		)
 	}
@@ -50,7 +50,7 @@ func compareIndexesCallbackAdditionalFor(table schemas.TableDescription) func(_ 
 				fmt.Sprintf("Unexpected index %q.%q", table.GetName(), index.GetName()),
 				"drop the index",
 			).withStatements(
-				index.DropStatement(),
+				index.DropStatement(table),
 			))
 		}
 

--- a/internal/database/migration/schemas/description.go
+++ b/internal/database/migration/schemas/description.go
@@ -282,7 +282,11 @@ func (d IndexDescription) CreateStatement(table TableDescription) string {
 	return fmt.Sprintf("%s;", d.IndexDefinition)
 }
 
-func (d IndexDescription) DropStatement() string {
+func (d IndexDescription) DropStatement(table TableDescription) string {
+	if d.ConstraintType == "u" || d.ConstraintType == "p" {
+		return fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s;", table.Name, d.Name)
+	}
+
 	return fmt.Sprintf("DROP INDEX IF EXISTS %s;", d.GetName())
 }
 

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -293,7 +293,7 @@ func (s *Store) RunDDLStatements(ctx context.Context, statements []string) (err 
 	defer func() { err = tx.Done(err) }()
 
 	for _, statement := range statements {
-		if err := tx.Exec(ctx, sqlf.Sprintf(statement)); err != nil {
+		if err := tx.Exec(ctx, sqlf.Sprintf(strings.ReplaceAll(statement, "%", "%%"))); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Allow partial auto-fixing of migration differences. Change error output.

Drive-by: fix error where `%` characters were not rendered properly via sqlf for DDL statements.
Another drive-by: fix error with dropping unique indexes not being droppable as indexes.

## Test plan

Tested locally. Jerked my database up *real bad* (worse than I tried actually lol) and got 'er back up hummin just fine thank you.