### PR TITLE
Fix firecracker VM name missing from ignite command

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -124,7 +124,11 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job types.Job) 
 
 	// Create the runner that will actually run the commands.
 	logger.Info("Setting up runner")
-	runtimeRunner, err := h.jobRuntime.NewRunner(ctx, commandLogger, runtime.RunnerOptions{Path: ws.Path(), DockerAuthConfig: job.DockerAuthConfig})
+	runtimeRunner, err := h.jobRuntime.NewRunner(
+		ctx,
+		commandLogger,
+		runtime.RunnerOptions{Path: ws.Path(), DockerAuthConfig: job.DockerAuthConfig, Name: name},
+	)
 	if err != nil {
 		return errors.Wrap(err, "creating runtime runner")
 	}

--- a/enterprise/cmd/executor/internal/worker/handler_test.go
+++ b/enterprise/cmd/executor/internal/worker/handler_test.go
@@ -487,6 +487,7 @@ func TestHandler_Handle(t *testing.T) {
 				require.Len(t, jobRuntime.PrepareWorkspaceFunc.History(), 1)
 				require.Len(t, jobWorkspace.RemoveFunc.History(), 1)
 				require.Len(t, jobRuntime.NewRunnerFunc.History(), 1)
+				assert.NotEmpty(t, jobRuntime.NewRunnerFunc.History()[0].Arg2.Name)
 				require.Len(t, jobRunner.TeardownFunc.History(), 1)
 				require.Len(t, jobRuntime.NewRunnerSpecsFunc.History(), 1)
 				require.Len(t, jobRuntime.NewRunnerSpecsFunc.History()[0].Arg1, 1)


### PR DESCRIPTION
The VM name wasn't being passed to the ignite command.

## Test plan

Added an assert to an existing test.