### PR TITLE
llm-proxy: ignore context cancelled error, improve trace propagation in logs

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//enterprise/cmd/llm-proxy/internal/limiter",
         "//internal/goroutine",
+        "//internal/trace",
         "//lib/errors",
         "@com_github_go_redsync_redsync_v4//:redsync",
         "@com_github_sourcegraph_conc//pool",

--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//enterprise/cmd/llm-proxy/internal/actor",
         "//enterprise/cmd/llm-proxy/internal/dotcom",
         "//enterprise/internal/llm-proxy",
+        "//internal/trace",
         "//lib/errors",
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",


### PR DESCRIPTION
Cancellation only happens if the worker is asked to stop - in Cloud Run this is a frequent occurrence as instances are regularly spun up and down based on traffic.

## Test plan

n/a