### PR TITLE
ranking: Use correct graph key

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/coordinator.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/coordinator.go
@@ -37,7 +37,7 @@ func (s *store) Coordinate(
 		graphKey,
 		derivativeGraphKey,
 		now,
-		graphKey,
+		derivativeGraphKey,
 	)); err != nil {
 		return err
 	}


### PR DESCRIPTION
I believe we're hitting the `ON CONFLICT` clause all the time because the `WHERE` clause does not prevent it. This should calm down Cloud SQL insights a bit.

## Test plan

Existing unit tests.