### PR TITLE
fix a possible panic in multi-repo search

### DIFF
--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "dot_test.go",
         "index_storage_test.go",
         "similarity_search_test.go",
+        "types_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":embeddings"],

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -59,7 +59,10 @@ func (esrs *EmbeddingSearchResults) MergeTruncate(other EmbeddingSearchResults, 
 	self := *esrs
 	self = append(self, other...)
 	sort.Slice(self, func(i, j int) bool { return self[i].Score() > self[j].Score() })
-	*esrs = self[:max]
+	if len(self) > max {
+		self = self[:max]
+	}
+	*esrs = self
 }
 
 type EmbeddingSearchResult struct {

--- a/enterprise/internal/embeddings/types_test.go
+++ b/enterprise/internal/embeddings/types_test.go
@@ -1,0 +1,46 @@
+package embeddings
+
+import "testing"
+
+func TestEmbeddingsSearchResults(t *testing.T) {
+	t.Run("MergeTruncate", func(t *testing.T) {
+		cases := []struct {
+			a, b, expected EmbeddingSearchResults
+			max            int
+		}{{
+			EmbeddingSearchResults{{
+				FileName:     "test1",
+				ScoreDetails: SearchScoreDetails{Score: 100},
+			}, {
+				FileName:     "test2",
+				ScoreDetails: SearchScoreDetails{Score: 50},
+			}},
+			EmbeddingSearchResults{{
+				FileName:     "test3",
+				ScoreDetails: SearchScoreDetails{Score: 75},
+			}, {
+				FileName:     "test4",
+				ScoreDetails: SearchScoreDetails{Score: 25},
+			}},
+			EmbeddingSearchResults{{
+				FileName:     "test1",
+				ScoreDetails: SearchScoreDetails{Score: 75},
+			}, {
+				FileName:     "test3",
+				ScoreDetails: SearchScoreDetails{Score: 25},
+			}},
+			2,
+		}, {
+			EmbeddingSearchResults{},
+			EmbeddingSearchResults{},
+			EmbeddingSearchResults{},
+			2,
+		}}
+
+		for _, tc := range cases {
+			t.Run("", func(t *testing.T) {
+				tc.a.MergeTruncate(tc.b, tc.max)
+			})
+		}
+	})
+}


### PR DESCRIPTION
When max is larger than the number of results returned, this will panic with an out-of-bounds slice access.

Only observed during testing.

## Test plan

Added a test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
