### PR TITLE
intellij plugin: handle case wherein remote for local branch does not correspond with sourcegraph remote

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -40,12 +40,16 @@ public class RepoUtil {
                 relativePath = relativePath.substring(relativePath.indexOf("/") + 1);
             }
 
-            // If the current branch doesn't exist on the remote, use the default branch.
-            remoteBranchName = Optional.ofNullable(getRemoteBranchName(project, file))
-                .orElse(ConfigUtil.getDefaultBranchName(project));
-
             remoteUrl = getRemoteRepoUrl(project, file);
             remoteUrl = doReplacements(project, remoteUrl);
+            
+            // If the current branch doesn't exist on the remote or if the remote
+            // for the current branch doesn't correspond with the sourcegraph remote,
+            // use the default branch for the project.
+            remoteBranchName = getRemoteBranchName(project, file)
+            if (remoteBranchName == null || !remoteUrl.contains(remoteBranchName)) {
+                remoteBranchName = ConfigUtil.getDefaultBranchName(project);
+            }
         } catch (Exception err) {
             String message;
             if (err instanceof PerforceAuthenticationException) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -46,7 +46,7 @@ public class RepoUtil {
             // If the current branch doesn't exist on the remote or if the remote
             // for the current branch doesn't correspond with the sourcegraph remote,
             // use the default branch for the project.
-            remoteBranchName = getRemoteBranchName(project, file)
+            remoteBranchName = getRemoteBranchName(project, file);
             if (remoteBranchName == null || !remoteUrl.contains(remoteBranchName)) {
                 remoteBranchName = ConfigUtil.getDefaultBranchName(project);
             }


### PR DESCRIPTION
If the remote for the current local branch is not the same as the sourcegraph remote, then we shouldn't expect that the remote branch is also replicated in the sourcegraph remote. In the likely case it is not, then the link copied from `Sourcegraph -> Copy Sourcegraph File Link` will be broken, since it will point to a non-existent branch in the sourcegraph remote. To fix, in this PR we try to detect this case and instead use the default branch for the project.

## Test plan

Build locally and verified the behavior is expected.
