### PR TITLE
app: add loading spinner to app-shell

### DIFF
--- a/client/app-shell/index.html
+++ b/client/app-shell/index.html
@@ -14,34 +14,65 @@
         <meta name="viewport" content="width=device-width, viewport-fit=cover" />
         <meta name="referrer" content="origin-when-cross-origin" />
         <meta name="color-scheme" content="light dark" />
-
-        <meta
-            name="description"
-            content="Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review code. Find answers."
-        />
         <title>Sourcegraph</title>
-        <link
-            rel="search"
-            href="/opensearch.xml"
-            type="application/opensearchdescription+xml"
-            title="Sourcegraph Search"
-        />
-        <link rel="preload" href="/.assets/img/sourcegraph-mark.svg?v2" as="image" />
+
+        <style type="text/css">
+            :root {
+                --loading-spinner-outer-color: #5e6e8c;
+                --loading-spinner-inner-color: #ffffff;
+                --body-bg: #14171f;
+            }
+
+            @media (prefers-color-scheme: light) {
+                :root {
+                    --loading-spinner-outer-color: #a6b6d9;
+                    --loading-spinner-inner-color: #343a4d;
+                    --body-bg: #f9fafb;
+                }
+            }
+
+            @keyframes loading-spinner-spin {
+                0% {
+                    transform: rotate(0deg);
+                }
+                100% {
+                    transform: rotate(360deg);
+                }
+            }
+
+            body {
+                margin: 0;
+                background-color: var(--body-bg);
+            }
+
+            .loading-spinner {
+                margin: 0.125rem;
+                width: 1rem;
+                height: 1rem;
+                border-radius: 50%;
+                animation: loading-spinner-spin 1s linear infinite;
+                border: 2px solid var(--loading-spinner-outer-color, rgba(0, 0, 0, 0.3));
+                border-top: 2px solid var(--loading-spinner-inner-color, rgba(0, 0, 0, 1));
+            }
+
+            .container {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                height: 100vh;
+                width: 100vw;
+                overflow: hidden;
+            }
+        </style>
     </head>
 
     <body>
-        <div id="root"></div>
-        <noscript>
-            <p>
-                Sourcegraph is a web-based code search and navigation tool for dev teams. Search, navigate, and review
-                code. Find answers.
-            </p>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
 
-            <br />
-            <br />
-            <br />
-            You need to enable JavaScript to run this app.
-        </noscript>
+        <div class="container">
+            <div class="loading-spinner" aria-label="Loading" aria-live="polite"></div>
+        </div>
 
         <script type="module" src="/scripts/app-shell.js"></script>
     </body>


### PR DESCRIPTION
Adds a minimal copy of `LoadingSpinner` to the app shell HTML so the page isn't blank.

## Test plan

Build release version of App to test. (Dev version doesn't use app shell.)

https://github.com/sourcegraph/sourcegraph/assets/206864/b0c8c31d-9f55-41f4-b973-556625564261

