### PR TITLE
Cody JetBrains: get the plugin working with no dirty changes

### DIFF
--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
@@ -244,11 +244,13 @@ public class SettingsComponent implements Disposable {
     }
 
     public boolean areChatPredictionsEnabled() {
-        return areChatPredictionsEnabledCheckBox.isSelected();
+        return areChatPredictionsEnabledCheckBox != null && areChatPredictionsEnabledCheckBox.isSelected();
     }
 
     public void setAreChatPredictionsEnabled(boolean value) {
-        areChatPredictionsEnabledCheckBox.setSelected(value);
+        if (areChatPredictionsEnabledCheckBox != null) {
+            areChatPredictionsEnabledCheckBox.setSelected(value);
+        }
     }
 
     private void setDotcomSettingsEnabled(boolean enable) {

--- a/client/jetbrains-shared/.gitignore
+++ b/client/jetbrains-shared/.gitignore
@@ -1,0 +1,40 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+*.jar
+!gradle-wrapper.jar
+
+# User local IDEA configuration files
+.idea/
+
+# IntelliJ project
+*.iml
+
+# Build output & caches for IntelliJ plugin development
+build/
+idea-sandbox/
+.gradle/
+
+## File-based project format:
+*.iws
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# JavaScript resources
+src/main/resources/dist/*
+
+# VSCode langserver artifacts
+/bin/


### PR DESCRIPTION
Previously, I wasn't able to configure the Sourcegraph instance URL because the JetBrains plugin crashed with a NullPointerException. After I got the plugin running, I had dirty changes in the git worktree from files that should have been gitignored.

## Test plan

- Run `./gradlew :runIde`
- Verify that you can change Cody settings
- Verify that there is no dirty git state
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
