### PR TITLE
Running binaries with SANITY_CHECK=true immediately exits with a code zero

### DIFF
--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/blobstore/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/blobstore/main.go
+++ b/cmd/blobstore/main.go
@@ -4,8 +4,10 @@ package main // import "github.com/sourcegraph/sourcegraph/cmd/blobstore"
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/blobstore/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/frontend/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
         "//ui/assets",
         "//ui/assets/oss",
     ],

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 
 	_ "github.com/sourcegraph/sourcegraph/ui/assets/oss" // Select oss assets
 )
 
 func main() {
+	sanitycheck.Pass()
+
 	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}

--- a/cmd/github-proxy/BUILD.bazel
+++ b/cmd/github-proxy/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/github-proxy/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/gitserver/BUILD.bazel
+++ b/cmd/gitserver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/gitserver/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -4,8 +4,10 @@ package main // import "github.com/sourcegraph/sourcegraph/cmd/gitserver"
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/loadtest/BUILD.bazel
+++ b/cmd/loadtest/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     },
     deps = [
         "//internal/env",
+        "//internal/sanitycheck",
         "//lib/errors",
         "@com_github_inconshreveable_log15//:log15",
     ],

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -27,6 +28,7 @@ type GQLSearchVars struct {
 }
 
 func main() {
+	sanitycheck.Pass()
 	if err := run(); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/migrator/BUILD.bazel
+++ b/cmd/migrator/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/migrator/shared",
         "//internal/env",
+        "//internal/sanitycheck",
         "//internal/version",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/cmd/migrator/main.go
+++ b/cmd/migrator/main.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/migrator/shared"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 func main() {
+	sanitycheck.Pass()
 	liblog := log.Init(log.Resource{
 		Name:    env.MyName,
 		Version: version.Version(),

--- a/cmd/repo-updater/BUILD.bazel
+++ b/cmd/repo-updater/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/repo-updater/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/repo-updater/main.go
+++ b/cmd/repo-updater/main.go
@@ -5,8 +5,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/searcher/BUILD.bazel
+++ b/cmd/searcher/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/searcher/shared",
         "//cmd/sourcegraph-oss/osscmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -5,8 +5,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/shared"
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/server/shared",
+        "//internal/sanitycheck",
         "//ui/assets/oss",
     ],
 )

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/server/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 
 	_ "github.com/sourcegraph/sourcegraph/ui/assets/oss" // Select oss assets
 )
 
 func main() {
+	sanitycheck.Pass()
 	shared.Main()
 }

--- a/cmd/sourcegraph-oss/BUILD.bazel
+++ b/cmd/sourcegraph-oss/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//cmd/sourcegraph-oss/osscmd",
         "//cmd/symbols/shared",
         "//cmd/worker/shared",
+        "//internal/sanitycheck",
         "//internal/service",
         "//internal/service/servegit",
     ],

--- a/cmd/sourcegraph-oss/main.go
+++ b/cmd/sourcegraph-oss/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
 	symbols_shared "github.com/sourcegraph/sourcegraph/cmd/symbols/shared"
 	worker_shared "github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/servegit"
 )
@@ -31,5 +32,6 @@ var services = []service.Service{
 }
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.MainOSS(services, os.Args)
 }

--- a/cmd/symbols/BUILD.bazel
+++ b/cmd/symbols/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/sourcegraph-oss/osscmd",
         "//cmd/symbols/shared",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -5,8 +5,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/cmd/worker/BUILD.bazel
+++ b/cmd/worker/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//cmd/sourcegraph-oss/osscmd",
         "//cmd/worker/shared",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss/osscmd"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	osscmd.SingleServiceMainOSS(shared.Service)
 }

--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -50,6 +50,19 @@ fn not_found() -> JsonValue {
 
 #[launch]
 fn rocket() -> _ {
+    // Exits with a code zero if the environment variable SANITY_CHECK equals
+    // to "true". This enables testing that the current program is in a runnable
+    // state against the platform it's being executed on.
+    //
+    // See https://github.com/GoogleContainerTools/container-structure-test
+    match std::env::var("SANITY_CHECK") {
+        Ok(v) if v == "true" => {
+            println!("Sanity check passed, exiting without error");
+            std::process::exit(0)
+        },
+        _ => {},
+    };
+
     // load configurations on-startup instead of on-first-request.
     // TODO: load individual languages lazily on-request instead, currently
     // CONFIGURATIONS.get will load every configured configuration together.

--- a/enterprise/cmd/batcheshelper/BUILD.bazel
+++ b/enterprise/cmd/batcheshelper/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//enterprise/cmd/batcheshelper/log",
         "//enterprise/cmd/batcheshelper/run",
         "//enterprise/cmd/batcheshelper/util",
+        "//internal/sanitycheck",
         "//lib/batches",
         "//lib/batches/execution",
         "//lib/errors",

--- a/enterprise/cmd/batcheshelper/main.go
+++ b/enterprise/cmd/batcheshelper/main.go
@@ -12,12 +12,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/batcheshelper/log"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/batcheshelper/run"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/batcheshelper/util"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	batcheslib "github.com/sourcegraph/sourcegraph/lib/batches"
 	"github.com/sourcegraph/sourcegraph/lib/batches/execution"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func main() {
+	sanitycheck.Pass()
 	if err := doMain(); err != nil {
 		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)

--- a/enterprise/cmd/embeddings/BUILD.bazel
+++ b/enterprise/cmd/embeddings/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/cmd/embeddings/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/embeddings/main.go
+++ b/enterprise/cmd/embeddings/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/executor/BUILD.bazel
+++ b/enterprise/cmd/executor/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/env",
         "//internal/hostname",
         "//internal/logging",
+        "//internal/sanitycheck",
         "//internal/version",
         "@com_github_sourcegraph_log//:log",
         "@com_github_urfave_cli_v2//:cli",

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -14,10 +14,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
 func main() {
+	sanitycheck.Pass()
 	cfg := &config.Config{}
 	cfg.Load()
 

--- a/enterprise/cmd/frontend/BUILD.bazel
+++ b/enterprise/cmd/frontend/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/frontend/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
+        "//internal/sanitycheck",
         "//ui/assets",
         "//ui/assets/enterprise",
     ],

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 
 	_ "github.com/sourcegraph/sourcegraph/ui/assets/enterprise" // Select enterprise assets
 )
 
 func main() {
+	sanitycheck.Pass()
 	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}

--- a/enterprise/cmd/gitserver/BUILD.bazel
+++ b/enterprise/cmd/gitserver/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/gitserver/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/gitserver/main.go
+++ b/enterprise/cmd/gitserver/main.go
@@ -4,8 +4,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/llm-proxy/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//enterprise/cmd/llm-proxy/shared",
         "//internal/conf",
         "//internal/env",
+        "//internal/sanitycheck",
         "//internal/service/svcmain",
         "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_sourcegraph_log//:log",

--- a/enterprise/cmd/llm-proxy/main.go
+++ b/enterprise/cmd/llm-proxy/main.go
@@ -7,12 +7,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/service/svcmain"
 )
 
 var sentryDSN = env.Get("LLM_PROXY_SENTRY_DSN", "", "Sentry DSN")
 
 func main() {
+	sanitycheck.Pass()
 	svcmain.SingleServiceMainWithoutConf(shared.Service, svcmain.Config{}, svcmain.OutOfBandConfiguration{
 		Logging: func() conf.LogSinksSource {
 			if sentryDSN == "" {

--- a/enterprise/cmd/migrator/BUILD.bazel
+++ b/enterprise/cmd/migrator/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//enterprise/internal/oobmigration/migrations",
         "//internal/env",
         "//internal/oobmigration",
+        "//internal/sanitycheck",
         "//internal/version",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/enterprise/cmd/migrator/main.go
+++ b/enterprise/cmd/migrator/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/oobmigration/migrations"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
@@ -15,6 +16,7 @@ func init() {
 }
 
 func main() {
+	sanitycheck.Pass()
 	liblog := log.Init(log.Resource{
 		Name:    env.MyName,
 		Version: version.Version(),

--- a/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
+++ b/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/precise-code-intel-worker/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/repo-updater/BUILD.bazel
+++ b/enterprise/cmd/repo-updater/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/repo-updater/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/server/shared",
+        "//internal/sanitycheck",
         "//ui/assets/enterprise",
     ],
 )

--- a/enterprise/cmd/server/main.go
+++ b/enterprise/cmd/server/main.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/server/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 
 	_ "github.com/sourcegraph/sourcegraph/ui/assets/enterprise" // Select enterprise assets
 )
 
 func main() {
+	sanitycheck.Pass()
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		log.Println("enterprise edition")

--- a/enterprise/cmd/sourcegraph/BUILD.bazel
+++ b/enterprise/cmd/sourcegraph/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//enterprise/cmd/sourcegraph/enterprisecmd",
         "//enterprise/cmd/symbols/shared",
         "//enterprise/cmd/worker/shared",
+        "//internal/sanitycheck",
         "//internal/service",
         "//internal/service/servegit",
         "//ui/assets",

--- a/enterprise/cmd/sourcegraph/main.go
+++ b/enterprise/cmd/sourcegraph/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/servegit"
 
@@ -40,6 +41,7 @@ var services = []service.Service{
 }
 
 func main() {
+	sanitycheck.Pass()
 	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}

--- a/enterprise/cmd/symbols/BUILD.bazel
+++ b/enterprise/cmd/symbols/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/sourcegraph/enterprisecmd",
         "//enterprise/cmd/symbols/shared",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/symbols/main.go
+++ b/enterprise/cmd/symbols/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/enterprise/cmd/worker/BUILD.bazel
+++ b/enterprise/cmd/worker/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//enterprise/cmd/sourcegraph/enterprisecmd",
         "//enterprise/cmd/worker/shared",
+        "//internal/sanitycheck",
     ],
 )
 

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph/enterprisecmd"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
 )
 
 func main() {
+	sanitycheck.Pass()
 	enterprisecmd.SingleServiceMainEnterprise(shared.Service)
 }

--- a/internal/sanitycheck/BUILD.bazel
+++ b/internal/sanitycheck/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sanitycheck",
+    srcs = ["sanitycheck.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/sanitycheck",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/sanitycheck/sanitycheck.go
+++ b/internal/sanitycheck/sanitycheck.go
@@ -1,0 +1,18 @@
+package sanitycheck
+
+import (
+	"fmt"
+	"os"
+)
+
+// Pass exits with a code zero if the environment variable SANITY_CHECK equals
+// to "true". This enables testing that the current program is in a runnable
+// state against the platform it's being executed on.
+//
+// See https://github.com/GoogleContainerTools/container-structure-test
+func Pass() {
+	if os.Getenv("SANITY_CHECK") == "true" {
+		fmt.Println("Sanity check passed, exiting without error")
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
As we're using https://github.com/GoogleContainerTools/container-structure-test when building images with Bazel, we can write tests that ensures that the binaries we produced are executable on the current platform. 

The code using this feature is not present in this PR, as it makes it much more readable for everyone to ship this independently. 

We may still be bitten by `init()` functions, but we'll set low timeouts on those container structure tests to ensure it stays quick. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->



```
~/work/other  jh/sanity_check $ SANITY_CHECK=true ./bazel-bin/docker-images/syntax-highlighter/syntect_server
Sanity check passed, exiting without error

~/work/other U jh/sanity_check $ ./bazel-bin/docker-images/syntax-highlighter/syntect_server  
## Embedded themes:

- `InspiredGitHub`
- `Monokai`
- `Solarized (dark)`
# ... 
```

```
~/work/other  jh/sanity_check $ SANITY_CHECK=true bazel-bin/cmd/worker/worker_/worker
Sanity check passed, exiting without error

```