### PR TITLE
add support for code selection copy in chat ui

### DIFF
--- a/client/cody-ui/src/chat/CodeBlocks.tsx
+++ b/client/cody-ui/src/chat/CodeBlocks.tsx
@@ -33,8 +33,15 @@ function createCopyButtonWithContainer(
     copyButton.textContent = 'Copy'
     copyButton.className = className
     copyButton.addEventListener('click', () => {
-        navigator.clipboard.writeText(text).catch(error => console.error(error))
-        copyButton.textContent = 'Copied!'
+        const selection = window.getSelection()
+        if (selection !== null && selection.toString().length > 0) {
+            navigator.clipboard.writeText(selection.toString()).catch(error => console.error(error))
+            copyButton.textContent = 'Selection Copied!'
+        } else {
+            navigator.clipboard.writeText(text).catch(error => console.error(error))
+            copyButton.textContent = 'Snippet Copied!'
+        }
+
         setTimeout(() => (copyButton.textContent = 'Copy'), 3000)
         if (copyButtonOnSubmit) {
             copyButtonOnSubmit('copyButton')


### PR DESCRIPTION
This PR introduces a new behavior for the "Copy" button that is displayed in the Cody chat UI in association to any code block. It allows a user to mouse-select any part of a code suggestion made by Cody, and copy that selection to the clipboard. 

## Issue

For users who work with Jupyter notebooks in VSCode , one of the limitations of the chat UI is that it if you select a subpart of any code suggestion made by Cody, then use Ctrl-C/cmd-C to copy it to the clipboard, and then use Ctrl-V/Cmd-V to paste it in an Jupyter notebook cell, the pasting is not producing any output.  This unexpected behavior does not happen with regular source code files(.py for instance).

This prevents users from being as productive as they would be with regular files, when it comes to curating those suggestions as the conversation with the assistant unfolds. Solving for this issue would allow the user to be more selective, and work around the fact that Cody tends to drop useful code parts from one suggestion to another. 

## Test plan

For our definition of success, in the plan below, "active editor tab" can be either a Jupyter notebook or a regular source code file.

- when Cody displays a code block in the chat UI, a user can click on "Copy" button. The entire content of the code snippet is then copied to the clipboard for the user to later paste anywhere they wish (most likely one of the active editor tabs). 
- when Cody displays a code block in the chat UI, a user can mouse-select any subpart of the code block, then click on the "Copy" button. The content of the code selection is then copied to the clipboard for the user to later paste anywhere they wish (most likely one of the active editor tabs). 
- when Cody displays a code block in the chat UI, a user can mouse-select any part of an active editor tab, then click on the "Copy" button. The content of the entire code snippet coming from the Cody chat UI is then copied to the clipboard, and the active selection done by the user outside the context of the chat UI simply ignored.




