### PR TITLE
Cody JetBrains: allow new-style access tokens

### DIFF
--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
@@ -244,11 +244,13 @@ public class SettingsComponent implements Disposable {
     }
 
     public boolean areChatPredictionsEnabled() {
-        return areChatPredictionsEnabledCheckBox.isSelected();
+        return areChatPredictionsEnabledCheckBox != null && areChatPredictionsEnabledCheckBox.isSelected();
     }
 
     public void setAreChatPredictionsEnabled(boolean value) {
-        areChatPredictionsEnabledCheckBox.setSelected(value);
+        if (areChatPredictionsEnabledCheckBox != null) {
+            areChatPredictionsEnabledCheckBox.setSelected(value);
+        }
     }
 
     private void setDotcomSettingsEnabled(boolean enable) {

--- a/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
+++ b/client/cody-jetbrains/src/main/java/com/sourcegraph/cody/config/SettingsComponent.java
@@ -83,9 +83,9 @@ public class SettingsComponent implements Disposable {
         dotcomAccessTokenTextField = new JBTextField();
         dotcomAccessTokenTextField.getEmptyText().setText("Paste your access token here");
         addValidation(dotcomAccessTokenTextField, () ->
-            (dotcomAccessTokenTextField.getText().length() > 0 && dotcomAccessTokenTextField.getText().length() != 40)
-                ? new ValidationInfo("Invalid access token", dotcomAccessTokenTextField)
-                : null);
+            isValidAccessToken(dotcomAccessTokenTextField.getText())
+                ? null
+                : new ValidationInfo("Invalid access token", dotcomAccessTokenTextField));
         dotcomAccessTokenLinkComment = new JBLabel("<html><body>Have no token yet? Create one <a href=\"https://sourcegraph.com/user/settings/tokens/new\">here</a>.</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
         //
 
@@ -106,9 +106,9 @@ public class SettingsComponent implements Disposable {
         enterpriseAccessTokenTextField = new JBTextField();
         enterpriseAccessTokenTextField.getEmptyText().setText("Paste your access token here");
         addValidation(enterpriseAccessTokenTextField, () ->
-            (enterpriseAccessTokenTextField.getText().length() > 0 && enterpriseAccessTokenTextField.getText().length() != 40)
-                ? new ValidationInfo("Invalid access token", enterpriseAccessTokenTextField)
-                : null);
+            isValidAccessToken(enterpriseAccessTokenTextField.getText())
+                ? null
+                : new ValidationInfo("Invalid access token", enterpriseAccessTokenTextField));
 
         // Create comments
         userDocsLinkComment = new JBLabel("<html><body>You will need an access token to sign in. See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> for a video guide</body></html>", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
@@ -316,6 +316,12 @@ public class SettingsComponent implements Disposable {
         enterpriseAccessTokenLinkComment.setText(isUrlValid(baseUrl)
             ? "<html><body>or go to <a href=\"" + settingsUrl + "\">" + settingsUrl + "</a> | \"Access tokens\" to create one.</body></html>"
             : "");
+    }
+
+    private boolean isValidAccessToken(@NotNull String accessToken) {
+        return accessToken.isEmpty() ||
+            accessToken.length() == 40 ||
+            (accessToken.startsWith("sgp_") && accessToken.length() == 44);
     }
 
     private boolean isUrlValid(@NotNull String url) {

--- a/client/jetbrains-shared/.gitignore
+++ b/client/jetbrains-shared/.gitignore
@@ -1,0 +1,40 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+*.jar
+!gradle-wrapper.jar
+
+# User local IDEA configuration files
+.idea/
+
+# IntelliJ project
+*.iml
+
+# Build output & caches for IntelliJ plugin development
+build/
+idea-sandbox/
+.gradle/
+
+## File-based project format:
+*.iws
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# JavaScript resources
+src/main/resources/dist/*
+
+# VSCode langserver artifacts
+/bin/


### PR DESCRIPTION
Previously, the settings UI didn't accept access tokens using the new
`sgp_` prefix.

## Test plan

- Open Cody settings
- Paste in a new-style access token that starts with `sgp_`, for example sgp_f20349d34e331cc511fa1949791ab680f552b627 (this is not an actual token)
- Confirm that you can save the settings

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
