### PR TITLE
[github apps] add docs for github apps

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -128,8 +128,10 @@ export const AddGitHubAppPage: FC<AddGitHubPageProps> = () => {
                 description={
                     <>
                         Create and connect a GitHub App to better manage GitHub code host connections.
-                        {/* TODO: add docs link here once we have them */}
-                        <Link to="" className="ml-1">
+                        <Link
+                            to="https://docs.sourcegraph.com/admin/external_service/github#using-a-github-app"
+                            className="ml-1"
+                        >
                             See how GitHub App configuration works.
                         </Link>
                     </>

--- a/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
@@ -37,8 +37,10 @@ export const GitHubAppsPage: React.FC = () => {
             <div className="d-flex align-items-center">
                 <span>
                     Create and connect a GitHub App to better manage GitHub code host connections.
-                    {/* TODO: add docs link here once we have them */}
-                    <Link to="" className="ml-1">
+                    <Link
+                        to="https://docs.sourcegraph.com/admin/external_service/github#using-a-github-app"
+                        className="ml-1"
+                    >
                         See how GitHub App configuration works.
                     </Link>
                 </span>

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -2,7 +2,52 @@
 
 Site admins can sync Git repositories hosted on [GitHub.com](https://github.com) and [GitHub Enterprise](https://enterprise.github.com) with Sourcegraph so that users can search and navigate the repositories.
 
-To connect GitHub to Sourcegraph:
+There are 2 ways to connect with GitHub:
+1. [Using a GitHub App (recommended)](#using-a-github-app)
+2. [Using an access token](#using-an-access-token)
+
+## Supported versions
+
+- GitHub.com
+- GitHub Enterprise v2.10 and newer
+
+## Using a GitHub App
+
+<span class="badge badge-note">Sourcegraph 5.1+</span>
+
+To create a GitHub app and connect it to Sourcegraph:  
+
+1. Go to **Site admin > Github Apps** in the Sourcegraph app.  
+    ![Github Apps page screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/empty-github-apps-list.png)
+2. Click **Create GitHub App**.  
+3. Enter a name for your app, the URL of your GitHub instance, and optionally an organization that will own the app. If no organization is specified, the app will be owned by the user account that creates it in GitHub.  
+    ![Create Github App form screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/create-app-form.png)
+4. Click **Create GitHub App**. You will be redirected to GitHub to confirm the app creation.  
+    ![Create Github App screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/create-app-page.png)
+5. After creating the app, you will be redirected to the app installation screen on GitHub. Review the app permissions and select which repositories the app can access. The default is **All repositories**. You can change this later.  
+    ![Install Github App screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/installation-page.png)
+6. Click **Install**. You will be redirected back to Sourcegraph, where the GitHub app setup screen will display.  
+7. Sourcegraph needs to map Sourcegraph users to GitHub users. Click **Reveal secret** to get the JSON configuration for the auth provider and copy/paste it into the `"auth.providers"` section of your site configuration.  
+    ![Auth provider JSON screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/auth-provider-json.png)
+8. After setting up the auth provider, go back to the GitHub App setup screen in Sourcegraph. Click **Add connection** under your new installation to create a code host connection to GitHub with this app installation. By default, it will sync all repositories the app can access within the organization it was installed on. Repository permission enforcement will also be turned on by default.
+    ![Add connection button screenshot](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/github-apps/add-connection-button.png)
+
+You can now [select repositories to sync](#selecting-repositories-to-sync) or see more configuration options in the [configuration section](#configuration).
+
+### Mutliple installations
+
+In some cases, having multiple installations is beneficial, especially if you want to sync repositories from multiple organizations.  
+
+By default, Sourcegraph creates a private GitHub app, which allows only one installation on the owner account. To allow multiple installations, the app needs to be made public. For security considerations, see [GitHub's documentation on private vs public apps](https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/making-a-github-app-public-or-private). To make the app public, [follow GitHub's documentation](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app#changing-the-visibility-of-a-github-app).  
+
+After making the app public, go back to Sourcegraph **Site admin > GitHub Apps > [YOUR APP]** and click **Add installation**. You will be redirected to GitHub to pick which other organization to install the app on and finish the installation process.
+
+To sync repositories from this installation, click **Add connection** in Sourcegraph.  
+
+> NOTE: Each organization that the app needs to access requires its own installation.
+## Using an access token
+
+To connect GitHub to Sourcegraph with an access token:
 
 1. Go to **Site admin > Manage code hosts**
 2. Select **GitHub**.
@@ -22,30 +67,11 @@ In this example, the kubernetes public repository on GitHub is added by selectin
 }
 ```
 
-## Supported versions
+## GitHub API access
 
-- GitHub.com
-- GitHub Enterprise v2.10 and newer
+GitHub requires a `token` in order to access their API. There are different types of tokens that can be supplied. When using GitHub apps, this is handled automatically by Sourcegraph.
 
-## Selecting repositories for code search
-
-There are four fields for configuring which repositories are mirrored/synchronized:
-
-- [`repos`](github.md#repos)<br>A list of repositories in `owner/name` format. The order determines the order in which we sync repository metadata and is safe to change.
-- [`orgs`](github.md#orgs)<br>A list of organizations (every repository belonging to the organization will be cloned).
-- [`repositoryQuery`](github.md#repositoryQuery)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`, none of which are subject to result limitations), and/or a [GitHub advanced search query](https://github.com/search/advanced). Note: There is an existing limitation that requires the latter, GitHub advanced search queries, to return [less than 1000 results](#repositoryquery-returns-first-1000-results-only). See [this issue](https://github.com/sourcegraph/sourcegraph/issues/2562) for ongoing work to address this limitation.
-- [`exclude`](github.md#exclude)<br>A list of repositories to exclude which takes precedence over the `repos`, `orgs`, and `repositoryQuery` fields.
-
-### Private repositories
-
-A [token that has the prerequisite scopes](#github-api-token-and-access) is required in order to clone private repositories for search, as well as at least read access to the relevant private repositories.
-
-See [GitHub API token and access](#github-api-token-and-access) for more details.
-
-## GitHub API token and access
-
-The GitHub service requires a `token` in order to access their API. There are two different types of tokens you can supply:
-
+- **[GitHub app installation access token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app)**:<br>An installation access token is created automatically when you install a GitHub app. Do not set this token in the code host connection configuration. This token gives Sourcegraph the same level of access to repositories as the GitHub app installation.
 - **[Personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)**:<br>This gives Sourcegraph the same level of access to repositories as the account that created the token. If you don't want to mix your personal repositories with your organizations repositories, you could add an entry to the `exclude` array, or you can use a machine user token or a fine-grained access token.
 - **[Fine-grained access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token)**:<br>Allows scoping access tokens to specific repositories with specific permissions. Consult the [table below](#fine-grained-access-token-permissions) for the required permissions.
 - **[Machine user token](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users)**:<br>Generates a token for a machine user that is affiliated with an organization instead of a user account.
@@ -91,6 +117,21 @@ When creating your fine-grained access token, select the following permissions d
 
 > WARNING: Fine-grained tokens don't support the `repositoryQuery` code host connection option or batch changes. Both of these features rely on GitHub's GraphQL API, which is [unsupported by fine-grained access tokens](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql).
 
+### Private repositories
+
+A [token that has the prerequisite scopes](#github-api-token-and-access) is required in order to clone private repositories for search, as well as at least read access to the relevant private repositories.
+
+See [GitHub API token and access](#github-api-token-and-access) for more details.
+
+## Selecting repositories to sync
+
+There are four fields for configuring which repositories are mirrored/synchronized:
+
+- [`repos`](github.md#repos)<br>A list of repositories in `owner/name` format. The order determines the order in which we sync repository metadata and is safe to change.
+- [`orgs`](github.md#orgs)<br>A list of organizations (every repository belonging to the organization will be cloned).
+- [`repositoryQuery`](github.md#repositoryQuery)<br>A list of strings with three pre-defined options (`public`, `affiliated`, `none`, none of which are subject to result limitations), and/or a [GitHub advanced search query](https://github.com/search/advanced). Note: There is an existing limitation that requires the latter, GitHub advanced search queries, to return [less than 1000 results](#repositoryquery-returns-first-1000-results-only). See [this issue](https://github.com/sourcegraph/sourcegraph/issues/2562) for ongoing work to address this limitation.
+- [`exclude`](github.md#exclude)<br>A list of repositories to exclude which takes precedence over the `repos`, `orgs`, and `repositoryQuery` fields.
+
 ## Rate limits
 
 Always include a token in a configuration for a GitHub.com URL to avoid being denied service by GitHub's [unauthenticated rate limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting). If you don't want to automatically synchronize repositories from the account associated with your personal access token, you can create a token without a [`repo` scope](https://developer.github.com/apps/building-oauth-apps/scopes-for-oauth-apps/#available-scopes) for the purposes of bypassing rate limit restrictions only.
@@ -121,19 +162,16 @@ Then, add or edit the GitHub connection as described above and include the `auth
 
 ```json
 {
-  // The GitHub URL used to set up the GitHub authentication provider must match this URL.
-  "url": "https://github.com",
-  "token": "$PERSONAL_ACCESS_TOKEN",
   // ...
   "authorization": {}
 }
 ```
 
-This needs to be done for every github connection if there is more than one configured.
+This needs to be done for every github code host connection if there is more than one configured.
 
 A [token that has the prerequisite scopes](#github-api-token-and-access) and both read and write access to all relevant repositories is required in order to list collaborators for each repository to perform a complete sync.
 
-> NOTE: Both read and write access to the associated repos for permissions syncing are strongly suggested due to GitHub's token scope requirements. Without write permissions, sync will rely only on [user-centric sync](#background-permissions-syncing) and continue working as expected, though Sourcegraph may have out-of-date permissions more frequently.
+> IMPORTANT: We strongly recommend configuring both read and write access to associated repositories for permission syncing due to GitHub's token scope requirements. Without write access, there will be a conflict between [user-centric sync](../permissions/syncing.md#troubleshooting) and repo-centric sync. In that case, [disable repo-centric permission sync](../permissions/syncing#disable-repo-centric-permission-sync) (supported in <span class="badge badge-note">Sourcegraph 5.0.4+</span>).
 
 <span class="virtual-br"></span>
 

--- a/doc/admin/permissions/syncing.md
+++ b/doc/admin/permissions/syncing.md
@@ -253,7 +253,7 @@ If there are a lot less users, than repositories, it is better to rely on user-c
 {
   // ...
   "permissions.syncOldestUsers": 20,
-  "permissions.syncOldestRepos": 1
+  "permissions.syncOldestRepos": 0 // minimum 1 on versions 5.0.3 and older
 }
 ```
 
@@ -276,7 +276,7 @@ permission sync in these situations:
 ```json
 {
   // ...
-  "permissions.syncOldestUsers": 1,
+  "permissions.syncOldestUsers": 0, // minimum 1 on versions 5.0.3 and older
   "permissions.syncOldestRepos": 20
 }
 ```
@@ -288,3 +288,21 @@ a minute. `2500/(4 * 60) = 10.4`, so the scheduler needs to schedule 11 reposito
 
 The rate limit for the code host needs to be changed to support the load. In that case the recommendation 
 is to set it to 2x of the amount of [requests expected from permission syncing](#request-count).
+
+## Troubleshooting 
+
+In some cases, user-centric and repo-centric permission sync can conflict. This typically happens when the code host connection token is misconfigured or expired, but the user token works correctly. A conflict like this can periodically revoke users' access to repositories until the next user permission sync.
+
+### Disable repo-centric permission sync
+
+> IMPORTANT: This feature is only supported in Sourcegraph 5.0.4 and later. 
+
+> IMPORTANT: Disabling repo-centric permission sync can break your permission setup depending on your code host and user authentication method. Contact Sourcegraph support before disabling repo-centric permission sync.
+
+To completely disable repo-centric permission sync scheduling, use this site configuration:
+
+```json
+{
+ // ...
+ "permissions.syncOldestRepos": 0 
+}

--- a/doc/integration/github.md
+++ b/doc/integration/github.md
@@ -4,14 +4,14 @@ You can use Sourcegraph with [GitHub.com](https://github.com) and [GitHub Enterp
 
 Feature | Supported?
 ------- | ----------
-[Repository syncing](../admin/external_service/github.md#selecting-repositories-for-code-search) | ✅
+[Repository syncing](../admin/external_service/github.md#selecting-repositories-to-sync) | ✅
 [Repository permissions](../admin/external_service/github.md#repository-permissions) | ✅
 [User authentication](../admin/external_service/github.md#user-authentication) | ✅
 [Browser extension](#browser-extension) | ✅
 
 ## Repository syncing
 
-Site admins can [add GitHub repositories to Sourcegraph](../admin/external_service/github.md#selecting-repositories-for-code-search).
+Site admins can [add GitHub repositories to Sourcegraph](../admin/external_service/github.md#selecting-repositories-to-sync).
 
 ## Repository permissions
 


### PR DESCRIPTION
## Description

This PR adds documentation for setting up github apps with sourcegraph.

### Current docs
https://docs.sourcegraph.com/admin/external_service/github

### New docs
https://docs.sourcegraph.com/@milan-docs-ghapps/admin/external_service/github

## Test plan

Only docs changes + fixed links to docs from UI. Checked if the docs render properly locally.
