### PR TITLE
App: fix app start up in sg start app

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
 }
 
 #[cfg(dev)]
-fn start_embedded_services(app_handle: tauri::AppHandle) {
+fn start_embedded_services(app_handle: &tauri::AppHandle) {
     let args = get_sourcegraph_args(app_handle);
     println!("embedded Sourcegraph services disabled for local development");
     println!("Sourcegraph would start with args: {:?}", args);


### PR DESCRIPTION
Missed a type change when running in dev mode
## Test plan
`sg start app` runs
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
