### PR TITLE
Address comments for #52064

### DIFF
--- a/enterprise/internal/own/service.go
+++ b/enterprise/internal/own/service.go
@@ -48,10 +48,13 @@ type AssignedOwners map[string][]database.AssignedOwnerSummary
 // that is so that owners of a parent directory "a/b" are the owners
 // of all files in that tree, like "a/b/c/d/foo.go".
 func (ao AssignedOwners) Match(path string) []database.AssignedOwnerSummary {
-	summaries := ao[""] // Repository owner is associated with root directory - "".
+	var summaries []database.AssignedOwnerSummary
 	for lastSlash := len(path); lastSlash != -1; lastSlash = strings.LastIndex(path, "/") {
 		path = path[:lastSlash]
 		summaries = append(summaries, ao[path]...)
+	}
+	if path != "" {
+		summaries = append(summaries, ao[""]...)
 	}
 	return summaries
 }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/51916

In https://github.com/sourcegraph/sourcegraph/pull/52064 I pressed merge too quickly without addressing some comments. Here we go:

- Add test for the `AssignedOwners.Match` method (and find a bug!)

## Test plan

Adding extra tests mentioned in https://github.com/sourcegraph/sourcegraph/pull/52064 review.
