### PR TITLE
cody: escape message from guardrails

### DIFF
--- a/client/cody-shared/src/guardrails/index.ts
+++ b/client/cody-shared/src/guardrails/index.ts
@@ -1,3 +1,5 @@
+import { escapeMarkdown } from '@sourcegraph/common'
+
 import { parseMarkdown } from '../chat/markdown'
 import { isError } from '../utils'
 
@@ -29,8 +31,7 @@ export async function annotateAttribution(guardrails: Guardrails, text: string):
 
             const msg = await guardrails.searchAttribution(token.text).then(summariseAttribution)
 
-            // TODO(keegancsmith) escape msg?
-            return `${token.raw}\n<div title="guardrails">🛡️ ${msg}</div>`
+            return `${token.raw}\n<div title="guardrails">🛡️ ${escapeMarkdown(msg)}</div>`
         })
     )
     return parts.join('')

--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -1,41 +1,46 @@
-import { renderMarkdown, registerHighlightContributions } from '.'
+import { renderMarkdown, registerHighlightContributions, escapeMarkdown } from '.'
 
 registerHighlightContributions()
 
+const complicatedMarkdown = [
+    '# This is a heading',
+    '',
+    '## This is a subheading',
+    '',
+    'Some text',
+    'in the same paragraph',
+    'with a [link](./destination).',
+    '',
+    '```ts',
+    'const someTypeScriptCode = funcCall()',
+    '```',
+    '',
+    '- bullet list item 1',
+    '- bullet list item 2',
+    '',
+    '1. item 1',
+    '  ```ts',
+    '  const codeInsideTheBulletPoint = "string"',
+    '  ```',
+    '1. item 2',
+    '',
+    '> quoted',
+    '> text',
+    '',
+    '| col 1 | col 2 |',
+    '|-------|-------|',
+    '| A     | B     |',
+    '',
+    '![image alt text](./src.jpg)',
+    '',
+    '<b>inline html</b>',
+    '',
+    'Escaped \\* markdown and escaped html code \\&gt\\;',
+].join('\n')
+
 describe('renderMarkdown', () => {
     it('renders code blocks, with syntax highlighting', () => {
-        const markdown = [
-            '# This is a heading',
-            '',
-            '## This is a subheading',
-            '',
-            'Some text',
-            'in the same paragraph',
-            'with a [link](./destination).',
-            '',
-            '```ts',
-            'const someTypeScriptCode = funcCall()',
-            '```',
-            '',
-            '- bullet list item 1',
-            '- bullet list item 2',
-            '',
-            '1. item 1',
-            '  ```ts',
-            '  const codeInsideTheBulletPoint = "string"',
-            '  ```',
-            '1. item 2',
-            '',
-            '> quoted',
-            '> text',
-            '',
-            '| col 1 | col 2 |',
-            '|-------|-------|',
-            '| A     | B     |',
-            '',
-            '![image alt text](./src.jpg)',
-        ].join('\n')
-        expect(renderMarkdown(markdown)).toMatchInlineSnapshot(`
+        expect(renderMarkdown(complicatedMarkdown)).toMatchInlineSnapshot(`
             "<h1 id=\\"this-is-a-heading\\">This is a heading</h1>
             <h2 id=\\"this-is-a-subheading\\">This is a subheading</h2>
             <p>Some text
@@ -69,7 +74,9 @@ describe('renderMarkdown', () => {
             <td>B</td>
             </tr>
             </tbody></table>
-            <p><img alt=\\"image alt text\\" src=\\"./src.jpg\\"></p>"
+            <p><img alt=\\"image alt text\\" src=\\"./src.jpg\\"></p>
+            <p><b>inline html</b></p>
+            <p>Escaped * markdown and escaped html code &amp;gt;</p>"
         `)
     })
     it('renders to plain text with plainText: true', () => {
@@ -99,5 +106,44 @@ describe('renderMarkdown', () => {
     test('forbids data URI links', () => {
         const input = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
         expect(renderMarkdown(input)).toBe('<p><a download="">D</a>\n<a>D2</a></p>')
+    })
+})
+
+describe('escapeMarkdown', () => {
+    it('handles complicated document', () => {
+        expect(escapeMarkdown(complicatedMarkdown)).toBe(`\
+\\# This is a heading
+
+\\#\\# This is a subheading
+
+Some text
+in the same paragraph
+with a \\[link\\]\\(\\.\\/destination\\)\\.
+
+\\\`\\\`\\\`ts
+const someTypeScriptCode \\= funcCall\\(\\)
+\\\`\\\`\\\`
+
+\\- bullet list item 1
+\\- bullet list item 2
+
+1\\. item 1
+  \\\`\\\`\\\`ts
+  const codeInsideTheBulletPoint \\= \\"string\\"
+  \\\`\\\`\\\`
+1\\. item 2
+
+&gt; quoted
+&gt; text
+
+\\| col 1 \\| col 2 \\|
+\\|\\-\\-\\-\\-\\-\\-\\-\\|\\-\\-\\-\\-\\-\\-\\-\\|
+\\| A     \\| B     \\|
+
+\\!\\[image alt text\\]\\(\\.\\/src\\.jpg\\)
+
+&lt;b&gt;inline html&lt;\\/b&gt;
+
+Escaped \\\\\\* markdown and escaped html code \\\\\\&gt\\\\\\;`)
     })
 })

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -99,3 +99,25 @@ export const renderMarkdown = (
 }
 
 export const markdownLexer = (markdown: string): marked.TokensList => marked.lexer(markdown)
+
+/**
+ * Escapes markdown by escaping all ASCII punctuation.
+ *
+ * Note: this does not escape whitespace, so when rendered markdown will
+ * likely collapse adjacent whitespace.
+ */
+export const escapeMarkdown = (text: string): string => {
+    /*
+     * GFM you can escape any ASCII punctuation [1]. So we do that, with two
+     * special notes:
+     * - we escape "\" first to prevent double escaping it
+     * - we replace < and > with HTML escape codes to prevent needing to do
+     *   HTML escaping.
+     * [1]: https://github.github.com/gfm/#backslash-escapes
+     */
+    const punctuation = '\\!"#%&\'()*+,-./:;=?@[]^_`{|}~'
+    for (const char of punctuation) {
+        text = text.replaceAll(char, '\\' + char)
+    }
+    return text.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}


### PR DESCRIPTION
We introduce a markdown escaping function based on the GFM specification. The message generated by cody contains repository names from our open source corpus which may contain special characters in them. This prevents incorrectly rendering them.

Additionally there are likely other parts of cody which need this function when we generated our own markdown.

Test Plan: unit test added. Additionally tested the test case markdown in the github comment render. It correctly escaped the output. See below with and without escaping:

![image](https://github.com/sourcegraph/sourcegraph/assets/187831/3a59d288-3d85-4ade-87b4-cfe4d587f1c3)

![image](https://github.com/sourcegraph/sourcegraph/assets/187831/4b72c213-215f-4e49-867d-07ec25fbc0ff)