### PR TITLE
cody: deduplicate summariseAttribution implementations

### DIFF
--- a/client/cody-shared/src/guardrails/client.ts
+++ b/client/cody-shared/src/guardrails/client.ts
@@ -1,19 +1,21 @@
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
 import { isError } from '../utils'
 
-import { Guardrails, RepositoryAttribution } from '.'
+import { Guardrails, Attribution } from '.'
 
 export class SourcegraphGuardrailsClient implements Guardrails {
     constructor(private client: SourcegraphGraphQLAPIClient) {}
 
-    public async searchAttribution(snippet: string): Promise<RepositoryAttribution[] | Error> {
+    public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // TODO(keegancsmith) adjust implementation to respect line count thresholds and to handle resultLimitHit.
         const query = `type:file select:repo content:${goEscapeString(snippet)}`
         const results = await this.client.searchTypeRepo(query)
         if (isError(results)) {
             return results
         }
-        return results.repositories
+        return {
+            repositories: results.repositories,
+        }
     }
 }
 

--- a/client/cody/src/services/GuardrailsProvider.ts
+++ b/client/cody/src/services/GuardrailsProvider.ts
@@ -1,6 +1,5 @@
 import { Editor } from '@sourcegraph/cody-shared/src/editor'
-import { Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+import { Guardrails, summariseAttribution } from '@sourcegraph/cody-shared/src/guardrails'
 
 export class GuardrailsProvider {
     // TODO(keegancsmith) this provider should create the client since the guardrails client requires a dotcom graphql connection.
@@ -12,23 +11,7 @@ export class GuardrailsProvider {
             return
         }
 
-        const msg = await this.client.searchAttribution(snippet).then(result => {
-            if (isError(result)) {
-                return `guardrails attribution search failed: ${result.message}`
-            }
-
-            const count = result.length
-            if (count === 0) {
-                return 'no matching repositories found'
-            }
-
-            const summary = result.slice(0, count < 5 ? count : 5).map(repo => repo.name)
-            if (count > 5) {
-                summary.push('...')
-            }
-
-            return `found ${count} matching repositories ${summary.join(', ')}`
-        })
+        const msg = await this.client.searchAttribution(snippet).then(summariseAttribution)
 
         await this.editor.showWarningMessage(msg)
     }


### PR DESCRIPTION
We don't expect to keep sharing this implementation in the future, but for now it makes sense to atleast deduplicate. This was motivated by me changing the shape of the API and being annoyed by the duplication. I didn't finish changing the shape, but in a future PR will be adding more fields to the newly introduced Attribution interface.

Test Plan: CI