### PR TITLE
Cody completions: Initial experimentation with multiline inline completions

### DIFF
--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -136,8 +136,17 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        if (precedingLine.trim() === '' && prefix.trim().at(prefix.trim().length - 1) === '{') {
-            // Start of block: Do multiline completion
+        // TODO(philipp-spiess): Add a better detection for start-of-block and don't require C like
+        // languages.
+        const multilineEnabledLanguage =
+            document.languageId === 'typescript' || document.languageId === 'javascript' || document.languageId === 'go'
+        if (
+            multilineEnabledLanguage &&
+            // Only trigger multiline inline suggestions for empty lines
+            precedingLine.trim() === '' &&
+            // Only trigger multiline inline suggestions for the beginning of blocks
+            prefix.trim().at(prefix.trim().length - 1) === '{'
+        ) {
             waitMs = 500
             completers.push(
                 new EndOfLineCompletionProvider(

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -136,7 +136,23 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
             return []
         }
 
-        if (precedingLine.trim() === '') {
+        if (precedingLine.trim() === '' && prefix.trim().at(prefix.trim().length - 1) === '{') {
+            // Start of block: Do multiline completion
+            waitMs = 500
+            completers.push(
+                new EndOfLineCompletionProvider(
+                    this.completionsClient,
+                    remainingChars,
+                    this.responseTokens,
+                    similarCode,
+                    prefix,
+                    suffix,
+                    '',
+                    3,
+                    true // multiline
+                )
+            )
+        } else if (precedingLine.trim() === '') {
             // Start of line: medium debounce
             waitMs = 500
             completers.push(

--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -191,6 +191,20 @@ export class MultilineCompletionProvider extends CompletionProvider {
 }
 
 export class EndOfLineCompletionProvider extends CompletionProvider {
+    constructor(
+        completionsClient: SourcegraphNodeCompletionsClient,
+        promptChars: number,
+        responseTokens: number,
+        snippets: ReferenceSnippet[],
+        prefix: string,
+        suffix: string,
+        injectPrefix: string,
+        defaultN: number = 1,
+        protected multiline: boolean = false
+    ) {
+        super(completionsClient, promptChars, responseTokens, snippets, prefix, suffix, injectPrefix, defaultN)
+    }
+
     protected createPromptPrefix(): Message[] {
         // TODO(beyang): escape 'Human:' and 'Assistant:'
         const prefixLines = this.prefix.split('\n')
@@ -235,6 +249,7 @@ export class EndOfLineCompletionProvider extends CompletionProvider {
     }
 
     private postProcess(completion: string): string {
+        console.log(completion, this.prefix)
         // Sometimes Claude emits an extra space
         if (
             completion.length > 0 &&
@@ -270,7 +285,7 @@ export class EndOfLineCompletionProvider extends CompletionProvider {
             this.completionsClient,
             {
                 messages: prompt,
-                stopSequences: [anthropic.HUMAN_PROMPT, '\n'],
+                stopSequences: this.multiline ? [anthropic.HUMAN_PROMPT, '\n\n\n'] : [anthropic.HUMAN_PROMPT, '\n'],
                 maxTokensToSample: this.responseTokens,
                 temperature: 1,
                 topK: -1,

--- a/client/cody/test/fixtures/workspace/.vscode/settings.json
+++ b/client/cody/test/fixtures/workspace/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cody.serverEndpoint": "http://localhost:49300"
+}

--- a/client/cody/test/fixtures/workspace/.vscode/settings.json
+++ b/client/cody/test/fixtures/workspace/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cody.serverEndpoint": "http://localhost:49300"
-}


### PR DESCRIPTION
Part of #51344 

This PR adds initial exploration for inline completion of multiple lines. The approach applied here does some very rudimentary language parsing (we might need to look into treesitter for this to enable support for more languages). The rules are as follows:

To trigger multiline completion:
- We must be at an empty line
- The line must be the beginning of a new block (i.e the last character of the prefix is an `{`).

To find the right place to cut off the completion:
- We capture the initial indentation of the first line of the completion
- We include everything up to the point where the indentation goes _below_ our current start 
  - However we do include the last line if it is a sole `}`
  - We skip over lines starting with `} else ` so we can chain all conditions in an if block
  - We skip over empty lines as they do not have an indentation.

@beyang I’m curious what your thoughts on this are?  

## Test plan


https://github.com/sourcegraph/sourcegraph/assets/458591/a224db92-ef77-4e5c-b4db-4e833d59d2aa



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
