### PR TITLE
Cody: Add docs on generate index

### DIFF
--- a/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
@@ -49,7 +49,7 @@ export const ChatInputContext: React.FunctionComponent<{
                 </h3>
             ) : contextStatus.supportsKeyword ? (
                 <h3 title={warning} className={classNames(styles.badge, styles.indexMissing)}>
-                    <a href="https://docs.sourcegraph.com/cody/explanations/code_graph_context">
+                    <a href="https://docs.sourcegraph.com/cody/explanations/indexing">
                         <span className={styles.indexStatus}>⚠ Not Indexed</span>
                         <span className={styles.indexStatusOnHover}>Generate Index</span>
                     </a>

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -1,6 +1,7 @@
 # Explanations
 
 - [Enabling Cody for Sourcegraph Enterprise](enabling_cody_enterprise.md)
-- [Enabling Cody for Sourcegraph Enterprise](enabling_cody.md)
+- [Enabling Cody with Sourcegraph.com](enabling_cody.md)
+- [Generating Index to enable Codebase-Aware Answers](indexing.md)
 - [Installing the Cody VS Code extension](installing_vs_code.md)
-- [Configuring code graph context](code_graph_context.md)
+- [Configuring Code Graph Context](code_graph_context.md)

--- a/doc/cody/explanations/indexing.md
+++ b/doc/cody/explanations/indexing.md
@@ -1,0 +1,54 @@
+# Generate Index to Enable Codebase-Aware Answers for Cody
+
+This docs provides instructions on how to generate an index that enables codebase-aware answers for Cody. Codebase-aware answers leverage code graph context to enhance Cody's understanding of code from selected codebases. 
+
+By following the steps outlined in this guide, you can configure the necessary prerequisites and enable Cody to provide more accurate and contextually relevant answers to your coding questions based on the codebase you are working in.
+
+## General Index
+
+You can enhance Cody's understanding of existing code by generating index for your codebases to enable [code graph context](https://docs.sourcegraph.com/cody/explanations/code_graph_context).
+
+### Sourcegraph Enterprise
+
+To generate an index for your codebase and enable codebase-aware answers for Cody, your Site Admins must:
+
+- Configure code graph context on your Sourcegraph instance
+- Enable Cody for your Sourcegraph account
+
+> If you are a Site Admin, please refer to our documentation on [Code Graph Context](https://docs.sourcegraph.com/cody/explanations/code_graph_context) for detailed instructions.
+
+### Sourcegraph.com
+
+Code graph context is available only for public repositories on Sourcegraph.com that are already embedded.
+
+Please refer to the [list of repositories with embeddings](https://docs.sourcegraph.com/cody/embedded-repos) for instant access.
+
+If the codebase you want to connect to is not on the list, it will not provide code graph context to Cody. However, you can request assistance in the #cody-embeddings channel on the Sourcegraph team's [Discord](https://discord.gg/8wJF5EdAyA).
+
+Please note that Sourcegraph.com currently does not support private repositories.
+
+## Enable Codebase-Aware Answers
+
+To enable codebase-aware answers for the Cody extension, you need to set the `Cody: Codebase` (`cody.codebase`) configuration option in VS Code. Set this option to the repository name on your Sourcegraph instance. By doing so, Cody will provide more accurate and relevant answers to your coding questions, referring to the context of the codebase you are currently working in.
+
+### Extension Settings
+
+Here are the steps to configure the `codebase` setting for Cody via the [Extension Settings](https://code.visualstudio.com/docs/getstarted/settings#_extension-settings) in VS Code:
+
+1. Open the VS Code workspace settings by clicking: 
+   - Mac: `Code` > `Settings` > `Settings`
+   - Windows & Linux: `File` > `Preferences (Settings)`
+2. Enter `Cody: Codebase` in the search bar
+3. Enter the repository name as listed on your Sourcegraph instance.
+  - For example, the name for the [Sourcegraph repository on Sourcegraph.com](https://sourcegraph.com/github.com/sourcegraph/sourcegraph) is `github.com/sourcegraph/sourcegraph`, so we will enter it to the setting field without the https protocol as `github.com/sourcegraph/sourcegraph`
+
+### Settings.json
+
+Alternatively, if you can configure via [settings.json](https://code.visualstudio.com/docs/getstarted/settings#_settingsjson) using the `cody.codebase` configuration contribution point:
+
+```json
+{
+  "cody.serverEndpoint": "https://sourcegraph.com",
+  "cody.codebase": "github.com/sourcegraph/sourcegraph"
+}
+```

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -1,8 +1,6 @@
 # <picture title="Cody"><img class="theme-dark-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
 
-<span class="badge badge-beta">Beta</span>
-
-Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
+<span class="badge badge-beta">Beta</span> Cody is an AI code assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
 
 Cody uses a combination of Sourcegraph's code graph and Large Language Models (LLMs) to eliminate toil and keep human devs in flow. You can think of Cody as your coding assistant who has read through all the code in open source, all the questions on StackOverflow, and your own entire codebase, and is always there to answer questions you might have or suggest ways of doing something based on prior knowledge.
 
@@ -20,11 +18,11 @@ There are currently two ways to experience Cody:
 
 Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in the Sourcegraph web interface.
 
-<div class="cta-group">
-<a class="btn btn-primary" href="quickstart">★ Cody quickstart</a>
-<a class="btn" href="explanations/use_cases">Cody use cases</a>
-<a class="btn" href="faq">FAQ</a>
-<a class="btn" href="https://discord.com/servers/sourcegraph-969688426372825169">Join our Discord</a>
+<div class="getting-started">
+  <a class="btn btn-primary text-center" href="quickstart">★ Cody quickstart</a>
+  <a class="btn text-center" href="explanations/use_cases">Cody use cases</a>
+  <a class="btn text-center" href="faq">FAQ</a>
+  <a class="btn text-center" href="https://discord.com/servers/sourcegraph-969688426372825169">Join our Discord</a>
 </div>
 
 ## Features


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/52204

## PR Summary

### New Docs page on Generate Index for Cody

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/9dcb8334-35c3-4864-be79-a6d617f46d70)

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/2154af07-6630-4346-8385-27988ec81e4e)

### Update current `Generate Index` link in Cody extension to the new one

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/5a485cbe-ceb1-4980-8475-002f7d241fb6)

### Minor Updates on Cody Docs homepage

#### Before:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/450e3431-e7b7-469e-8390-a03389fd6330)

#### After:

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/25c9308d-169c-4864-a4d3-3bf215e95216)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

To start a local env for the docs site:
1. Check out the latest commit from this branch
2. run `pnpm i && pnpm` from the root of this directory
3. Open http://localhost:5080/cody in your browser to see the minor style update for the Cody homepage
4. Click on `explanations` in the sidebar to see the updated [code/explanations page](http://localhost:5080/cody/explanations)
5. Click on [Generating Index to enable Codebase-Aware Answers](http://localhost:5080/cody/explanations/indexing) in the [code/explanations page](http://localhost:5080/cody/explanations) to see the new docs that will also be linked in the Cody extension in VS Code.
