### PR TITLE
Merge extsvc Kind and Type enums

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -282,7 +282,7 @@ func VariantValueOf(input string) (Variant, error) {
 // DO NOT ADD MORE VARIABLES TO THE TYPE AND KIND VARIABLES
 // instead, follow the instructions above for adding and using Variant variables
 
-// Deprecated: use Variant with its `AsKind()` function instead
+// TODO: Deprecated: use Variant with its `AsKind()` function instead
 var (
 	// The constants below represent the different kinds of external service we support and should be used
 	// in preference to the Type values below.
@@ -308,7 +308,7 @@ var (
 	KindOther           = VariantOther.AsKind()
 )
 
-// Deprecated: use Variant with its `AsType()` function instead
+// TODO: Deprecated: use Variant with its `AsType()` function instead
 var (
 	// The constants below represent the values used for the external_service_type column of the repo table.
 

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -526,9 +526,6 @@ func WebhookURL(kind string, externalServiceID int64, cfg any, externalURL strin
 	q.Set(IDParam, strconv.FormatInt(externalServiceID, 10))
 
 	if variant == VariantBitbucketCloud {
-		if cfg == nil {
-			return "", errors.Newf("external service with id=%d claims to be a Bitbucket Cloud service, but the configuration is of type %T", externalServiceID, cfg)
-		}
 		// Unlike other external service kinds, Bitbucket Cloud doesn't support
 		// a shared secret defined as part of the webhook. As a result, we need
 		// to include it as an explicit part of the URL that we construct.

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -118,20 +118,26 @@ func (s *Accounts) TracingFields() []attribute.KeyValue {
 	}
 }
 
-// ServiceVariant enumerates different types/kinds of external services
-// It replaces both the Type... and Kind... enums
+// ServiceVariant enumerates different types/kinds of external services.
+// It replaces both the Type... and Kind... variables.
 // Types and Kinds are exposed through AsKind and AsType functions
 // so that usages relying on the particular string of Type vs Kind
 // will continue to behave correctly.
-// The Type... and Kind... enums are left in place to avoid edge-case issues and to support
+// The Type... and Kind... variables are left in place to avoid edge-case issues and to support
 // commits that come in while the switch to Variant is ongoing.
-// The Type... and Kind... enums are turned into vars and use
+// The Type... and Kind... variables are turned from consts into vars and use
 // the corresponding Variant's AsType()/AsKind() functions.
-// Consolidating Type... and Kind... into a single enum should decrease the stink
+// Consolidating Type... and Kind... into a single enum should decrease the smell
 // and increase the usability and maintainability of this code.
 // Note that Go Packages and Modules seem to have been a victim of the confusion engendered by having both Type and Kind:
 // There was `KindGoPackages` and `TypeGoModules`, both with the value of (case insensitivly) "gomodules".
 // I think that they both refer to the same thing and can be merged into one variant.
+// Olaf confirms that the name `...GoPackages` should be used to align naming conventions with the other `...Packages` variables.
+
+// To add another external service variant
+// 1. Add the name to the enum
+// 2. Add an entry to the `variantValues` map, containing the appropriate values for `AsType`, `AsKind`, and the other values, if applicable
+// 3. Use that Variant elsewhere in code, using the `AsType` and `AsKind` functions as necessary.
 
 type ServiceVariant int64
 
@@ -268,7 +274,9 @@ func ServiceVariantValueOf(input string) (ServiceVariant, error) {
 }
 
 // TODO: DEPRECATE/REMOVE ONCE CONVERSION TO Variants IS COMPLETE (2023-05-18)
-// the Kind... and Type... enums have been superceded by the ServiceVariant enum
+// the Kind... and Type... variables have been superceded by the ServiceVariant enum
+// DO NOT ADD MORE VARIABLES TO THE TYPE AND KIND VARIABLES
+// instead, follow the instructions above for adding and using Variant variables
 
 var (
 	// The constants below represent the different kinds of external service we support and should be used
@@ -362,7 +370,7 @@ var (
 // END TODO: DEPRECATE/REMOVE
 
 // TODO: handle in a less smelly way with Variants
-// KindToType returns a Type constants given a Kind
+// KindToType returns a Type constant given a Kind
 // It will panic when given an unknown kind
 func KindToType(kind string) string {
 	sv, err := ServiceVariantValueOf(kind)
@@ -373,7 +381,7 @@ func KindToType(kind string) string {
 }
 
 // TODO: handle in a less smelly way with Variants
-// TypeToKind returns a Kind constants given a Type
+// TypeToKind returns a Kind constant given a Type
 // It will panic when given an unknown type.
 func TypeToKind(t string) string {
 	sv, err := ServiceVariantValueOf(t)

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -122,7 +122,7 @@ func (s *Accounts) TracingFields() []attribute.KeyValue {
 // Currently it backs the Type... and Kind... variables, avoiding duplication.
 // Eventually it will replace the Type... and Kind... variables,
 // providing a single place to declare and resolve values for Type and Kind
-
+//
 // Types and Kinds are exposed through AsKind and AsType functions
 // so that usages relying on the particular string of Type vs Kind
 // will continue to behave correctly.

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -22,59 +22,59 @@ func TestVariantConfigPrototypePointers(t *testing.T) {
 		}
 	}
 	// check all of the current prototypes, thanks to Cody generating this code for me!
-	if _, ok := VariantAWSCodeCommit.ConfigPrototype().(schema.AWSCodeCommitConnection); ok {
-		t.Error("wrong type for AWS CodeCommit configuration prototype")
+	if y, ok := VariantAWSCodeCommit.ConfigPrototype().(*schema.AWSCodeCommitConnection); !ok {
+		t.Errorf("wrong type for AWS CodeCommit configuration prototype: %T", y)
 	}
-	if _, ok := VariantAzureDevOps.ConfigPrototype().(schema.AzureDevOpsConnection); ok {
-		t.Error("wrong type for Azure DevOps configuration prototype")
+	if y, ok := VariantAzureDevOps.ConfigPrototype().(*schema.AzureDevOpsConnection); !ok {
+		t.Errorf("wrong type for Azure DevOps configuration prototype: %T", y)
 	}
-	if _, ok := VariantBitbucketCloud.ConfigPrototype().(schema.BitbucketCloudConnection); ok {
-		t.Error("wrong type for Bitbucket Cloud configuration prototype")
+	if y, ok := VariantBitbucketCloud.ConfigPrototype().(*schema.BitbucketCloudConnection); !ok {
+		t.Errorf("wrong type for Bitbucket Cloud configuration prototype: %T", y)
 	}
-	if _, ok := VariantBitbucketServer.ConfigPrototype().(schema.BitbucketServerConnection); ok {
-		t.Error("wrong type for Bitbucket Server configuration prototype")
+	if y, ok := VariantBitbucketServer.ConfigPrototype().(*schema.BitbucketServerConnection); !ok {
+		t.Errorf("wrong type for Bitbucket Server configuration prototype: %T", y)
 	}
-	if _, ok := VariantGerrit.ConfigPrototype().(schema.GerritConnection); ok {
-		t.Error("wrong type for Gerrit configuration prototype")
+	if y, ok := VariantGerrit.ConfigPrototype().(*schema.GerritConnection); !ok {
+		t.Errorf("wrong type for Gerrit configuration prototype: %T", y)
 	}
-	if _, ok := VariantGitHub.ConfigPrototype().(schema.GitHubConnection); ok {
-		t.Error("wrong type for GitHub configuration prototype")
+	if y, ok := VariantGitHub.ConfigPrototype().(*schema.GitHubConnection); !ok {
+		t.Errorf("wrong type for GitHub configuration prototype: %T", y)
 	}
-	if _, ok := VariantGitLab.ConfigPrototype().(schema.GitLabConnection); ok {
-		t.Error("wrong type for GitLab configuration prototype")
+	if y, ok := VariantGitLab.ConfigPrototype().(*schema.GitLabConnection); !ok {
+		t.Errorf("wrong type for GitLab configuration prototype: %T", y)
 	}
-	if _, ok := VariantGitolite.ConfigPrototype().(schema.GitoliteConnection); ok {
-		t.Error("wrong type for Gitolite configuration prototype")
+	if y, ok := VariantGitolite.ConfigPrototype().(*schema.GitoliteConnection); !ok {
+		t.Errorf("wrong type for Gitolite configuration prototype: %T", y)
 	}
-	if _, ok := VariantGoPackages.ConfigPrototype().(schema.GoModulesConnection); ok {
-		t.Error("wrong type for Go Packages configuration prototype")
+	if y, ok := VariantGoPackages.ConfigPrototype().(*schema.GoModulesConnection); !ok {
+		t.Errorf("wrong type for Go Packages configuration prototype: %T", y)
 	}
-	if _, ok := VariantJVMPackages.ConfigPrototype().(schema.JVMPackagesConnection); ok {
-		t.Error("wrong type for JVM Packages configuration prototype")
+	if y, ok := VariantJVMPackages.ConfigPrototype().(*schema.JVMPackagesConnection); !ok {
+		t.Errorf("wrong type for JVM Packages configuration prototype: %T", y)
 	}
-	if _, ok := VariantNpmPackages.ConfigPrototype().(schema.NpmPackagesConnection); ok {
-		t.Error("wrong type for NPM Packages configuration prototype")
+	if y, ok := VariantNpmPackages.ConfigPrototype().(*schema.NpmPackagesConnection); !ok {
+		t.Errorf("wrong type for NPM Packages configuration prototype: %T", y)
 	}
-	if _, ok := VariantOther.ConfigPrototype().(schema.OtherExternalServiceConnection); ok {
-		t.Error("wrong type for Other configuration prototype")
+	if y, ok := VariantOther.ConfigPrototype().(*schema.OtherExternalServiceConnection); !ok {
+		t.Errorf("wrong type for Other configuration prototype: %T", y)
 	}
-	if _, ok := VariantPagure.ConfigPrototype().(schema.PagureConnection); ok {
-		t.Error("wrong type for Pagure configuration prototype")
+	if y, ok := VariantPagure.ConfigPrototype().(*schema.PagureConnection); !ok {
+		t.Errorf("wrong type for Pagure configuration prototype: %T", y)
 	}
-	if _, ok := VariantPerforce.ConfigPrototype().(schema.PerforceConnection); ok {
-		t.Error("wrong type for Perforce configuration prototype")
+	if y, ok := VariantPerforce.ConfigPrototype().(*schema.PerforceConnection); !ok {
+		t.Errorf("wrong type for Perforce configuration prototype: %T", y)
 	}
-	if _, ok := VariantPhabricator.ConfigPrototype().(schema.PhabricatorConnection); ok {
-		t.Error("wrong type for Phabricator configuration prototype")
+	if y, ok := VariantPhabricator.ConfigPrototype().(*schema.PhabricatorConnection); !ok {
+		t.Errorf("wrong type for Phabricator configuration prototype: %T", y)
 	}
-	if _, ok := VariantPythonPackages.ConfigPrototype().(schema.PythonPackagesConnection); ok {
-		t.Error("wrong type for Python Packages configuration prototype")
+	if y, ok := VariantPythonPackages.ConfigPrototype().(*schema.PythonPackagesConnection); !ok {
+		t.Errorf("wrong type for Python Packages configuration prototype: %T", y)
 	}
-	if _, ok := VariantRubyPackages.ConfigPrototype().(schema.RubyPackagesConnection); ok {
-		t.Error("wrong type for Ruby Packages configuration prototype")
+	if y, ok := VariantRubyPackages.ConfigPrototype().(*schema.RubyPackagesConnection); !ok {
+		t.Errorf("wrong type for Ruby Packages configuration prototype: %T", y)
 	}
-	if _, ok := VariantRustPackages.ConfigPrototype().(schema.RustPackagesConnection); ok {
-		t.Error("wrong type for Rust Packages configuration prototype")
+	if y, ok := VariantRustPackages.ConfigPrototype().(*schema.RustPackagesConnection); !ok {
+		t.Errorf("wrong type for Rust Packages configuration prototype: %T", y)
 	}
 }
 

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+func TestVariantConfigPrototypePointers(t *testing.T) {
+	// every call to `Variant::ConfigPrototype` should return a new instance of the prototype type
+	// or nil if there is no prototype defined for that variant
+	for variant, _ := range variantValuesMap {
+		x := variant.ConfigPrototype()
+		y := variant.ConfigPrototype()
+		if x != nil && x == y {
+			t.Errorf("%s pointers are the same: %p == %p", variant.AsKind(), x, y)
+		}
+	}
+	// spot-check a few of the prototypes
+	if _, ok := VariantGerrit.ConfigPrototype().(schema.GerritConnection); ok {
+		t.Error("wrong type for Gerrit configuration prototype")
+	}
+	if _, ok := VariantPhabricator.ConfigPrototype().(schema.PhabricatorConnection); ok {
+		t.Error("wrong type for Gerrit configuration prototype")
+	}
+	if _, ok := VariantAzureDevOps.ConfigPrototype().(schema.AzureDevOpsConnection); ok {
+		t.Error("wrong type for Gerrit configuration prototype")
+	}
+}
+
 func TestExtractToken(t *testing.T) {
 	for _, tc := range []struct {
 		config string

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -14,7 +14,7 @@ import (
 func TestVariantConfigPrototypePointers(t *testing.T) {
 	// every call to `Variant::ConfigPrototype` should return a new instance of the prototype type
 	// or nil if there is no prototype defined for that variant
-	for variant, _ := range variantValuesMap {
+	for variant := range variantValuesMap {
 		x := variant.ConfigPrototype()
 		y := variant.ConfigPrototype()
 		if x != nil && x == y {

--- a/internal/extsvc/types_test.go
+++ b/internal/extsvc/types_test.go
@@ -21,15 +21,60 @@ func TestVariantConfigPrototypePointers(t *testing.T) {
 			t.Errorf("%s pointers are the same: %p == %p", variant.AsKind(), x, y)
 		}
 	}
-	// spot-check a few of the prototypes
+	// check all of the current prototypes, thanks to Cody generating this code for me!
+	if _, ok := VariantAWSCodeCommit.ConfigPrototype().(schema.AWSCodeCommitConnection); ok {
+		t.Error("wrong type for AWS CodeCommit configuration prototype")
+	}
+	if _, ok := VariantAzureDevOps.ConfigPrototype().(schema.AzureDevOpsConnection); ok {
+		t.Error("wrong type for Azure DevOps configuration prototype")
+	}
+	if _, ok := VariantBitbucketCloud.ConfigPrototype().(schema.BitbucketCloudConnection); ok {
+		t.Error("wrong type for Bitbucket Cloud configuration prototype")
+	}
+	if _, ok := VariantBitbucketServer.ConfigPrototype().(schema.BitbucketServerConnection); ok {
+		t.Error("wrong type for Bitbucket Server configuration prototype")
+	}
 	if _, ok := VariantGerrit.ConfigPrototype().(schema.GerritConnection); ok {
 		t.Error("wrong type for Gerrit configuration prototype")
 	}
-	if _, ok := VariantPhabricator.ConfigPrototype().(schema.PhabricatorConnection); ok {
-		t.Error("wrong type for Gerrit configuration prototype")
+	if _, ok := VariantGitHub.ConfigPrototype().(schema.GitHubConnection); ok {
+		t.Error("wrong type for GitHub configuration prototype")
 	}
-	if _, ok := VariantAzureDevOps.ConfigPrototype().(schema.AzureDevOpsConnection); ok {
-		t.Error("wrong type for Gerrit configuration prototype")
+	if _, ok := VariantGitLab.ConfigPrototype().(schema.GitLabConnection); ok {
+		t.Error("wrong type for GitLab configuration prototype")
+	}
+	if _, ok := VariantGitolite.ConfigPrototype().(schema.GitoliteConnection); ok {
+		t.Error("wrong type for Gitolite configuration prototype")
+	}
+	if _, ok := VariantGoPackages.ConfigPrototype().(schema.GoModulesConnection); ok {
+		t.Error("wrong type for Go Packages configuration prototype")
+	}
+	if _, ok := VariantJVMPackages.ConfigPrototype().(schema.JVMPackagesConnection); ok {
+		t.Error("wrong type for JVM Packages configuration prototype")
+	}
+	if _, ok := VariantNpmPackages.ConfigPrototype().(schema.NpmPackagesConnection); ok {
+		t.Error("wrong type for NPM Packages configuration prototype")
+	}
+	if _, ok := VariantOther.ConfigPrototype().(schema.OtherExternalServiceConnection); ok {
+		t.Error("wrong type for Other configuration prototype")
+	}
+	if _, ok := VariantPagure.ConfigPrototype().(schema.PagureConnection); ok {
+		t.Error("wrong type for Pagure configuration prototype")
+	}
+	if _, ok := VariantPerforce.ConfigPrototype().(schema.PerforceConnection); ok {
+		t.Error("wrong type for Perforce configuration prototype")
+	}
+	if _, ok := VariantPhabricator.ConfigPrototype().(schema.PhabricatorConnection); ok {
+		t.Error("wrong type for Phabricator configuration prototype")
+	}
+	if _, ok := VariantPythonPackages.ConfigPrototype().(schema.PythonPackagesConnection); ok {
+		t.Error("wrong type for Python Packages configuration prototype")
+	}
+	if _, ok := VariantRubyPackages.ConfigPrototype().(schema.RubyPackagesConnection); ok {
+		t.Error("wrong type for Ruby Packages configuration prototype")
+	}
+	if _, ok := VariantRustPackages.ConfigPrototype().(schema.RustPackagesConnection); ok {
+		t.Error("wrong type for Rust Packages configuration prototype")
 	}
 }
 


### PR DESCRIPTION
External Services come in many flavors, from GitHub repositories to Rust packages. To support this wide variety of services, schemas and structs are created to define the capabilities and properties of each service. Different strings are used to define what kind of service each one is. There is a string in GraphQL and the configuration files that is labeled as the "Kind" of service is it, and there is a string in the database that is labeled as the "Type" of service it is. There is a lot of converting between those two, and one has to make sure to use the correct label in the correct situation.

OK, I'm going to shut up now and let Cody describe the situation.

Cody, why are there separate "Type" and "Kind" variables defined? What is the difference?

> The `Type` and `Kind` variables in the extsvc package represent the same external service concepts, but are used in different contexts:
> 
> - `Kind` variables are used in the Sourcegraph API and configuration. For example, the kind field in external service configuration specifies the kind of external service.
> 
> - `Type` variables are used in the Sourcegraph database schema. For example, the `external_service_type` column in the `repo` table stores the type of an external repository.
> 
> So in short:
> 
> - `Kind` is used in the API and config.
> - `Type` is used in the database schema.
> They represent the same concepts, just used in different contexts.
> 
> The reason for having separate `Type` and `Kind` variables is mostly historical. Going forward, the `extsvc` package is moving to using `ServiceVariant` enums instead, which unify the Type and Kind concepts.

Yep, going forward we'll be able to clean this mess up by consolidating on a `ServiceVariant` type that describes the type/kind of service.

This PR adds the `ServiceVariant` type, with supporting enum and a map to hold the values associated with the variant.

The rest of the code continues to use the `Type` and `Kind` variables, but those variables are now backed by `ServiceVariant`. Conversion will happen later, probably in stages, because there are hundreds of usages across dozens of files.

## Test plan

All existing tests should pass
