### PR TITLE
Tracing: remove deprecated OT spans

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//lib/errors",
         "@com_github_go_git_go_git_v5//plumbing/format/config",
         "@com_github_golang_groupcache//lru",
-        "@com_github_opentracing_contrib_go_stdlib//nethttp",
         "@com_github_opentracing_opentracing_go//ext",
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_prometheus_client_golang//prometheus",

--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -170,6 +171,7 @@ type RemoteGitCommand struct {
 	noTimeout      bool
 	exitStatus     int
 	execer         execer
+	execOp         *observation.Operation
 }
 
 type execer interface {

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -12,6 +12,7 @@ import (
 
 type operations struct {
 	search         *observation.Operation
+	p4Exec         *observation.Operation
 	batchLog       *observation.Operation
 	batchLogSingle *observation.Operation
 }
@@ -43,6 +44,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		search:         op("Search"),
+		p4Exec:         op("P4Exec"),
 		batchLog:       op("BatchLog"),
 		batchLogSingle: subOp("batchLogSingle"),
 	}

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -11,6 +11,7 @@ import (
 )
 
 type operations struct {
+	search         *observation.Operation
 	batchLog       *observation.Operation
 	batchLogSingle *observation.Operation
 }
@@ -41,6 +42,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
+		search:         op("Search"),
 		batchLog:       op("BatchLog"),
 		batchLogSingle: subOp("batchLogSingle"),
 	}

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -16,6 +16,7 @@ type operations struct {
 	p4Exec         *observation.Operation
 	batchLog       *observation.Operation
 	batchLogSingle *observation.Operation
+	do             *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -49,6 +50,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		p4Exec:         op("P4Exec"),
 		batchLog:       op("BatchLog"),
 		batchLogSingle: subOp("batchLogSingle"),
+		do:             subOp("do"),
 	}
 }
 

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -12,6 +12,7 @@ import (
 
 type operations struct {
 	search         *observation.Operation
+	exec           *observation.Operation
 	p4Exec         *observation.Operation
 	batchLog       *observation.Operation
 	batchLogSingle *observation.Operation
@@ -44,6 +45,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		search:         op("Search"),
+		exec:           op("Exec"),
 		p4Exec:         op("P4Exec"),
 		batchLog:       op("BatchLog"),
 		batchLogSingle: subOp("batchLogSingle"),


### PR DESCRIPTION
This converts some calls in the gitserver client to use the observation package rather than `ot.StartSpanFromContext`. Additionally, it fixes a few bugs along the way.

## Test plan

Tested manually that the traces look correct in Jaeger. Low risk since this is just tracing code, and some of it was already broken

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
