### PR TITLE
App: Fix endpoint for embeddings api when running as a release

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -43,6 +43,7 @@ func Init(logger log.Logger) {
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")
 	setDefaultEnv(logger, "SEARCHER_URL", "http://127.0.0.1:3181")
 	setDefaultEnv(logger, "BLOBSTORE_URL", "http://127.0.0.1:9000")
+	setDefaultEnv(logger, "EMBEDDINGS_URL", "http://127.0.0.1:9991")
 
 	// The syntax-highlighter might not be running, but this is a better default than an internal
 	// hostname.


### PR DESCRIPTION
When running via sg the `EMBEDDINGS_URL` was set however when the app was bundled for release the single program startup did not set the `EMBEDDINGS_URL`.
## Test plan
Build app release
Ask Cody a question - verify embeddings search is run successful and additional context is added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
