### PR TITLE
Make cody requires a verified email consistent with site resolver

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -32,6 +32,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         batchChangesWebhookLogsEnabled: true,
         executorsEnabled: false,
         codyEnabled: true,
+        codyRequiresVerifiedEmail: false,
         codeIntelAutoIndexingEnabled: false,
         codeIntelAutoIndexingAllowGlobalPolicies: false,
         codeInsightsEnabled: true,

--- a/client/web/src/cody/useIsCodyEnabled.tsx
+++ b/client/web/src/cody/useIsCodyEnabled.tsx
@@ -17,7 +17,7 @@ interface IsCodyEnabled {
 }
 
 export const isEmailVerificationNeeded = (): boolean =>
-    window.context?.sourcegraphDotComMode && !window.context?.currentUser?.hasVerifiedEmail
+    window.context?.codyRequiresVerifiedEmail && !window.context?.currentUser?.hasVerifiedEmail
 
 export const useIsCodyEnabled = (): IsCodyEnabled => {
     const [chatEnabled] = useFeatureFlag('cody-web-chat')

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -26,6 +26,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     codeInsightsEnabled: true,
     executorsEnabled: true,
     codyEnabled: true,
+    codyRequiresVerifiedEmail: false,
     extsvcConfigAllowEdits: false,
     extsvcConfigFileExists: false,
     codeIntelAutoIndexingEnabled: true,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -177,6 +177,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether cody is enabled for the user. */
     codyEnabled: boolean
 
+    /** Whether the site requires a verified email for cody. */
+    codyRequiresVerifiedEmail: boolean
+
     /** Whether executors are enabled on the site. */
     executorsEnabled: boolean
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -180,7 +180,8 @@ type JSContext struct {
 	BatchChangesDisableWebhooksWarning bool `json:"batchChangesDisableWebhooksWarning"`
 	BatchChangesWebhookLogsEnabled     bool `json:"batchChangesWebhookLogsEnabled"`
 
-	CodyEnabled bool `json:"codyEnabled"`
+	CodyEnabled               bool `json:"codyEnabled"`
+	CodyRequiresVerifiedEmail bool `json:"codyRequiresVerifiedEmail"`
 
 	ExecutorsEnabled                         bool `json:"executorsEnabled"`
 	CodeIntelAutoIndexingEnabled             bool `json:"codeIntelAutoIndexingEnabled"`
@@ -360,7 +361,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		BatchChangesDisableWebhooksWarning: conf.Get().BatchChangesDisableWebhooksWarning,
 		BatchChangesWebhookLogsEnabled:     webhooks.LoggingEnabled(conf.Get()),
 
-		CodyEnabled: cody.IsCodyEnabled(ctx),
+		CodyEnabled:               cody.IsCodyEnabled(ctx),
+		CodyRequiresVerifiedEmail: siteResolver.RequiresVerifiedEmailForCody(ctx),
 
 		ExecutorsEnabled:                         conf.ExecutorsEnabled(),
 		CodeIntelAutoIndexingEnabled:             conf.CodeIntelAutoIndexingEnabled(),

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -219,10 +219,14 @@ func TestNewCommon_repo_error(t *testing.T) {
 			repoStatistics := database.NewMockRepoStatisticsStore()
 			repoStatistics.GetRepoStatisticsFunc.SetDefaultReturn(database.RepoStatistics{Total: 1}, nil)
 
+			users := database.NewMockUserStore()
+			users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, nil)
+
 			db := database.NewMockDB()
 			db.GlobalStateFunc.SetDefaultReturn(gss)
 			db.ExternalServicesFunc.SetDefaultReturn(extSvcs)
 			db.RepoStatisticsFunc.SetDefaultReturn(repoStatistics)
+			db.UsersFunc.SetDefaultReturn(users)
 
 			_, err = newCommon(httptest.NewRecorder(), req, db, "test", index, serveError)
 			if err != nil {


### PR DESCRIPTION
Currently the `useIsCodyEnabled` hook and the server side checks for if the site requires the user to have a verified email are inconsistent.

This adds to the JSContext a property that indicates if the site requires verified emails and then uses that instead of directly checking against sourcegraph.com.  This consistently helps App because it usually passes cody requests though to dotcom.
## Test plan
`sg start enterprise`  verify  window.context.codyRequiresVerifiedEmail = false
`sg start dotcom` not an admin - verify window.context.codyRequiresVerifiedEmail = true
`sg start dotcom` not signed in - verify window.context.codyRequiresVerifiedEmail = true
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
