### PR TITLE
Repo exclusion query fix

### DIFF
--- a/enterprise/internal/own/background/scheduler.go
+++ b/enterprise/internal/own/background/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	logger "github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/own/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -153,7 +154,13 @@ WITH signal_config AS (SELECT * FROM own_signal_configurations WHERE name = %s L
                           WHERE job_type = signal_config.id
                               AND (state IN ('failed', 'completed') AND finished_at > %s) OR (state IN ('processing', 'errored', 'queued'))
                           UNION
-                            SELECT repo.id FROM repo, signal_config WHERE repo.name LIKE (SELECT UNNEST(signal_config.excluded_repo_patterns))
+                            SELECT repo.id
+							FROM repo, signal_config
+							WHERE EXISTS (
+								SELECT 1
+								FROM UNNEST(signal_config.excluded_repo_patterns) AS ps
+								WHERE repo.name LIKE ps
+							)
                           )
 INSERT
 INTO own_background_jobs (repo_id, job_type) (SELECT gr.repo_id, signal_config.id

--- a/enterprise/internal/own/background/scheduler_test.go
+++ b/enterprise/internal/own/background/scheduler_test.go
@@ -84,8 +84,9 @@ func TestOwnRepoIndexSchedulerJob_JobsAreExcluded(t *testing.T) {
 	require.NoError(t, err)
 
 	err = db.OwnSignalConfigurations().UpdateConfiguration(ctx, database.UpdateSignalConfigurationArgs{
-		Name:    config.Name,
-		Enabled: true,
+		Name:                 config.Name,
+		Enabled:              true,
+		ExcludedRepoPatterns: []string{"excluded-repo-1", "excluded-repo-2"},
 	})
 	require.NoError(t, err)
 
@@ -96,6 +97,8 @@ func TestOwnRepoIndexSchedulerJob_JobsAreExcluded(t *testing.T) {
 	states := []string{"queued", "processing", "errored", "failed", "completed"}
 
 	insertRepo(t, db, 500, "great-repo-1", true)
+	insertRepo(t, db, 501, "excluded-repo-1", true)
+	insertRepo(t, db, 502, "excluded-repo-2", true)
 
 	for _, state := range states {
 		doTest := func(t *testing.T, expected int) {


### PR DESCRIPTION
Part of #51815

Symptom in dev:

```
[         worker] ERROR recent-contributors goroutine/periodic.go:87 An error occurred in a background task {"handler": "recent-contributors", "error": "ownRepoIndexSchedulerJob.Handle recent-contributors: ERROR: more than one row returned by a subquery used as an expression (SQLSTATE 21000)"}
```

Seems like `LIKE (... subquery ...)` works only if the subquery returns a single row. This tries to use `EXISTS` query instead.

## Test plan

Extend existing test case to surface issue.
