### PR TITLE
app: fix local builds; improve postgres error situation

### DIFF
--- a/enterprise/dev/app/app_version.sh
+++ b/enterprise/dev/app/app_version.sh
@@ -21,7 +21,9 @@ create_version() {
 if [[ ${CI:-""} == "true" ]]; then
   version=${VERSION:-$(create_version)}
 else
-  version=${VERSION:-"0.0.0+dev"}
+  # This CANNOT be 0.0.0+dev, or else the binary will not start:
+  # https://github.com/sourcegraph/sourcegraph/issues/50958
+  version=${VERSION:-"1.0.0+dev"}
 fi
 
 echo "${version}"

--- a/enterprise/dev/app/build.sh
+++ b/enterprise/dev/app/build.sh
@@ -4,5 +4,5 @@ set -eu
 GCLOUD_APP_CREDENTIALS_FILE=${GCLOUD_APP_CREDENTIALS_FILE-$HOME/.config/gcloud/application_default_credentials.json}
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
 
-./enterprise/dev/app/bazel-build.sh
+./enterprise/dev/app/build-backend.sh
 ./enterprise/dev/app/tauri-build.sh

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -186,6 +186,7 @@ if [[ ${CODESIGNING:-"0"} == 1 && $(uname -s) == "Darwin" ]]; then
   done
 fi
 
+CI="${CI:-"false"}"
 PLATFORM="$(./enterprise/dev/app/detect_platform.sh)"
 build "${PLATFORM}"
 

--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -109,7 +109,7 @@ func startEmbeddedPostgreSQL(logger log.Logger, pgRootDir string) (*postgresqlEn
 			Username(vars.PGUSER).
 			Database(vars.PGDATABASE).
 			UseUnixSocket(unixSocketDir).
-			StartTimeout(30 * time.Second).
+			StartTimeout(120 * time.Second).
 			Logger(debugLogLinesWriter(logger, "postgres output line")),
 	)
 	if err := db.Start(); err != nil {


### PR DESCRIPTION
After the (awesome!) build changes by @burmudar I noticed that local builds were a bit rocky. After this PR the following produces a local build which works again:

```sh
./enterprise/dev/app/build.sh
```

## Test plan

Ran the above command and confirmed the produced .app starts.
