### PR TITLE
Tracing: remove remaining uses of `StartSpanFromContext` in gitserver client

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -43,7 +43,6 @@ go_library(
         "//lib/errors",
         "@com_github_go_git_go_git_v5//plumbing/format/config",
         "@com_github_golang_groupcache//lru",
-        "@com_github_opentracing_opentracing_go//ext",
         "@com_github_opentracing_opentracing_go//log",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -461,6 +461,18 @@ type ArchiveOptions struct {
 	Pathspecs []gitdomain.Pathspec // if nonempty, only include these pathspecs.
 }
 
+func (a *ArchiveOptions) Attrs() []attribute.KeyValue {
+	specs := make([]string, len(a.Pathspecs))
+	for i, pathspec := range a.Pathspecs {
+		specs[i] = string(pathspec)
+	}
+	return []attribute.KeyValue{
+		attribute.String("treeish", a.Treeish),
+		attribute.String("format", string(a.Format)),
+		attribute.StringSlice("pathspecs", specs),
+	}
+}
+
 func (o *ArchiveOptions) FromProto(x *proto.ArchiveRequest) {
 	protoPathSpecs := x.GetPathspecs()
 	pathSpecs := make([]gitdomain.Pathspec, 0, len(protoPathSpecs))

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1509,7 +1509,7 @@ func (br *blobReader) convertError(err error) error {
 
 // Stat returns a FileInfo describing the named file at commit.
 func (c *clientImplementor) Stat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (_ fs.FileInfo, err error) {
-	ctx, _, endObservation := c.operations.readFile.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+	ctx, _, endObservation := c.operations.stat.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("commit", string(commit)),
 		attribute.String("path", path),
 	}})
@@ -1626,7 +1626,7 @@ func (c *clientImplementor) GetCommit(ctx context.Context, checker authz.SubRepo
 // Commits returns all commits matching the options.
 func (c *clientImplementor) Commits(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, opt CommitsOptions) (_ []*gitdomain.Commit, err error) {
 	opt = addNameOnly(opt, checker)
-	ctx, _, endObservation := c.operations.getCommit.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+	ctx, _, endObservation := c.operations.commits.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("repo", string(repo)),
 		attribute.String("opts", fmt.Sprintf("%#v", opt)),
 	}})

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -22,6 +22,7 @@ type operations struct {
 	blameFile        *observation.Operation
 	contributorCount *observation.Operation
 	mergeBase        *observation.Operation
+	revList          *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
 	do               *observation.Operation
@@ -63,6 +64,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),
+		revList:          op("RevList"),
 		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),
 		batchLogSingle:   subOp("batchLogSingle"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -16,6 +16,7 @@ type operations struct {
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
 	readFile         *observation.Operation
+	stat             *observation.Operation
 	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
 	listTags         *observation.Operation
@@ -67,6 +68,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),
+		stat:             op("Stat"),
 		readFile:         op("ReadFile"),
 		newFileReader:    op("NewFileReader"),
 		revList:          op("RevList"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	listRefs         *observation.Operation
 	listBranches     *observation.Operation
 	archiveReader    *observation.Operation
 	getCommits       *observation.Operation
@@ -78,6 +79,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		firstEverCommit:  op("FirstEverCommit"),
 		commits:          op("Commits"),
 		listTags:         op("ListTags"),
+		listRefs:         op("ListRefs"),
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	getCommits       *observation.Operation
 	readFile         *observation.Operation
 	stat             *observation.Operation
 	getCommit        *observation.Operation
@@ -69,6 +70,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
 		getCommit:        op("GetCommit"),
+		getCommits:       op("GetCommits"),
 		hasCommitAfter:   op("HasCommitAfter"),
 		firstEverCommit:  op("FirstEverCommit"),
 		commits:          op("Commits"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -16,6 +16,7 @@ type operations struct {
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
 	lstat            *observation.Operation
+	streamBlameFile  *observation.Operation
 	contributorCount *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
@@ -52,6 +53,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		exec:             op("Exec"),
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
+		streamBlameFile:  op("StreamBlameFile"),
 		readDir:          op("ReadDir"),
 		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -14,6 +14,7 @@ type operations struct {
 	search           *observation.Operation
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
+	readDir          *observation.Operation
 	contributorCount *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
@@ -50,6 +51,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		exec:             op("Exec"),
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
+		readDir:          op("ReadDir"),
 		batchLog:         op("BatchLog"),
 		batchLogSingle:   subOp("batchLogSingle"),
 		do:               subOp("do"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -18,6 +18,7 @@ type operations struct {
 	readFile         *observation.Operation
 	stat             *observation.Operation
 	getCommit        *observation.Operation
+	hasCommitAfter   *observation.Operation
 	commits          *observation.Operation
 	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
@@ -67,6 +68,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
 		getCommit:        op("GetCommit"),
+		hasCommitAfter:   op("HasCommitAfter"),
 		commits:          op("Commits"),
 		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,8 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	readFile         *observation.Operation
+	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
 	listTags         *observation.Operation
 	lstat            *observation.Operation
@@ -23,6 +25,7 @@ type operations struct {
 	contributorCount *observation.Operation
 	mergeBase        *observation.Operation
 	revList          *observation.Operation
+	getBehindAhead   *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
 	do               *observation.Operation
@@ -64,7 +67,10 @@ func newOperations(observationCtx *observation.Context) *operations {
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),
+		readFile:         op("ReadFile"),
+		newFileReader:    op("NewFileReader"),
 		revList:          op("RevList"),
+		getBehindAhead:   op("GetBehindAhead"),
 		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),
 		batchLogSingle:   subOp("batchLogSingle"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -11,33 +11,33 @@ import (
 )
 
 type operations struct {
-	search           *observation.Operation
-	exec             *observation.Operation
-	p4Exec           *observation.Operation
-	readDir          *observation.Operation
-	listRefs         *observation.Operation
-	listBranches     *observation.Operation
 	archiveReader    *observation.Operation
-	getCommits       *observation.Operation
-	readFile         *observation.Operation
-	stat             *observation.Operation
-	getCommit        *observation.Operation
-	hasCommitAfter   *observation.Operation
-	firstEverCommit  *observation.Operation
-	commits          *observation.Operation
-	newFileReader    *observation.Operation
-	resolveRevision  *observation.Operation
-	listTags         *observation.Operation
-	lstat            *observation.Operation
-	streamBlameFile  *observation.Operation
-	blameFile        *observation.Operation
-	contributorCount *observation.Operation
-	mergeBase        *observation.Operation
-	revList          *observation.Operation
-	getBehindAhead   *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
+	blameFile        *observation.Operation
+	commits          *observation.Operation
+	contributorCount *observation.Operation
 	do               *observation.Operation
+	exec             *observation.Operation
+	firstEverCommit  *observation.Operation
+	getBehindAhead   *observation.Operation
+	getCommit        *observation.Operation
+	getCommits       *observation.Operation
+	hasCommitAfter   *observation.Operation
+	listBranches     *observation.Operation
+	listRefs         *observation.Operation
+	listTags         *observation.Operation
+	lstat            *observation.Operation
+	mergeBase        *observation.Operation
+	newFileReader    *observation.Operation
+	p4Exec           *observation.Operation
+	readDir          *observation.Operation
+	readFile         *observation.Operation
+	resolveRevision  *observation.Operation
+	revList          *observation.Operation
+	search           *observation.Operation
+	stat             *observation.Operation
+	streamBlameFile  *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -66,33 +66,33 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		search:           op("Search"),
-		exec:             op("Exec"),
-		p4Exec:           op("P4Exec"),
-		contributorCount: op("ContributorCount"),
-		mergeBase:        op("MergeBase"),
-		resolveRevision:  op("ResolveRevision"),
-		getCommit:        op("GetCommit"),
-		listBranches:     op("ListBranches"),
-		getCommits:       op("GetCommits"),
-		hasCommitAfter:   op("HasCommitAfter"),
-		firstEverCommit:  op("FirstEverCommit"),
-		commits:          op("Commits"),
-		listTags:         op("ListTags"),
-		listRefs:         op("ListRefs"),
-		streamBlameFile:  op("StreamBlameFile"),
-		blameFile:        op("BlameFile"),
-		readDir:          op("ReadDir"),
 		archiveReader:    op("ArchiveReader"),
-		stat:             op("Stat"),
-		readFile:         op("ReadFile"),
-		newFileReader:    op("NewFileReader"),
-		revList:          op("RevList"),
-		getBehindAhead:   op("GetBehindAhead"),
-		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),
 		batchLogSingle:   subOp("batchLogSingle"),
+		blameFile:        op("BlameFile"),
+		commits:          op("Commits"),
+		contributorCount: op("ContributorCount"),
 		do:               subOp("do"),
+		exec:             op("Exec"),
+		firstEverCommit:  op("FirstEverCommit"),
+		getBehindAhead:   op("GetBehindAhead"),
+		getCommit:        op("GetCommit"),
+		getCommits:       op("GetCommits"),
+		hasCommitAfter:   op("HasCommitAfter"),
+		listBranches:     op("ListBranches"),
+		listRefs:         op("ListRefs"),
+		listTags:         op("ListTags"),
+		lstat:            op("lStat"),
+		mergeBase:        op("MergeBase"),
+		newFileReader:    op("NewFileReader"),
+		p4Exec:           op("P4Exec"),
+		readDir:          op("ReadDir"),
+		readFile:         op("ReadFile"),
+		resolveRevision:  op("ResolveRevision"),
+		revList:          op("RevList"),
+		search:           op("Search"),
+		stat:             op("Stat"),
+		streamBlameFile:  op("StreamBlameFile"),
 	}
 }
 

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -18,6 +18,7 @@ type operations struct {
 	readFile         *observation.Operation
 	stat             *observation.Operation
 	getCommit        *observation.Operation
+	commits          *observation.Operation
 	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
 	listTags         *observation.Operation
@@ -66,6 +67,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
 		getCommit:        op("GetCommit"),
+		commits:          op("Commits"),
 		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -19,6 +19,7 @@ type operations struct {
 	stat             *observation.Operation
 	getCommit        *observation.Operation
 	hasCommitAfter   *observation.Operation
+	firstEverCommit  *observation.Operation
 	commits          *observation.Operation
 	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
@@ -69,6 +70,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		resolveRevision:  op("ResolveRevision"),
 		getCommit:        op("GetCommit"),
 		hasCommitAfter:   op("HasCommitAfter"),
+		firstEverCommit:  op("FirstEverCommit"),
 		commits:          op("Commits"),
 		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -11,12 +11,13 @@ import (
 )
 
 type operations struct {
-	search         *observation.Operation
-	exec           *observation.Operation
-	p4Exec         *observation.Operation
-	batchLog       *observation.Operation
-	batchLogSingle *observation.Operation
-	do             *observation.Operation
+	search           *observation.Operation
+	exec             *observation.Operation
+	p4Exec           *observation.Operation
+	contributorCount *observation.Operation
+	batchLog         *observation.Operation
+	batchLogSingle   *observation.Operation
+	do               *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -45,12 +46,13 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		search:         op("Search"),
-		exec:           op("Exec"),
-		p4Exec:         op("P4Exec"),
-		batchLog:       op("BatchLog"),
-		batchLogSingle: subOp("batchLogSingle"),
-		do:             subOp("do"),
+		search:           op("Search"),
+		exec:             op("Exec"),
+		p4Exec:           op("P4Exec"),
+		contributorCount: op("ContributorCount"),
+		batchLog:         op("BatchLog"),
+		batchLogSingle:   subOp("batchLogSingle"),
+		do:               subOp("do"),
 	}
 }
 

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	archiveReader    *observation.Operation
 	getCommits       *observation.Operation
 	readFile         *observation.Operation
 	stat             *observation.Operation
@@ -78,6 +79,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),
+		archiveReader:    op("ArchiveReader"),
 		stat:             op("Stat"),
 		readFile:         op("ReadFile"),
 		newFileReader:    op("NewFileReader"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -17,6 +17,7 @@ type operations struct {
 	readDir          *observation.Operation
 	readFile         *observation.Operation
 	stat             *observation.Operation
+	getCommit        *observation.Operation
 	newFileReader    *observation.Operation
 	resolveRevision  *observation.Operation
 	listTags         *observation.Operation
@@ -64,6 +65,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		contributorCount: op("ContributorCount"),
 		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
+		getCommit:        op("GetCommit"),
 		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	lstat            *observation.Operation
 	contributorCount *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
@@ -52,6 +53,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
 		readDir:          op("ReadDir"),
+		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),
 		batchLogSingle:   subOp("batchLogSingle"),
 		do:               subOp("do"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -17,6 +17,7 @@ type operations struct {
 	readDir          *observation.Operation
 	lstat            *observation.Operation
 	streamBlameFile  *observation.Operation
+	blameFile        *observation.Operation
 	contributorCount *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
@@ -54,6 +55,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
 		streamBlameFile:  op("StreamBlameFile"),
+		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),
 		lstat:            op("lStat"),
 		batchLog:         op("BatchLog"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	resolveRevision  *observation.Operation
 	lstat            *observation.Operation
 	streamBlameFile  *observation.Operation
 	blameFile        *observation.Operation
@@ -54,6 +55,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		exec:             op("Exec"),
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
+		resolveRevision:  op("ResolveRevision"),
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -15,6 +15,7 @@ type operations struct {
 	exec             *observation.Operation
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
+	listBranches     *observation.Operation
 	archiveReader    *observation.Operation
 	getCommits       *observation.Operation
 	readFile         *observation.Operation
@@ -71,6 +72,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
 		getCommit:        op("GetCommit"),
+		listBranches:     op("ListBranches"),
 		getCommits:       op("GetCommits"),
 		hasCommitAfter:   op("HasCommitAfter"),
 		firstEverCommit:  op("FirstEverCommit"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -21,6 +21,7 @@ type operations struct {
 	streamBlameFile  *observation.Operation
 	blameFile        *observation.Operation
 	contributorCount *observation.Operation
+	mergeBase        *observation.Operation
 	batchLog         *observation.Operation
 	batchLogSingle   *observation.Operation
 	do               *observation.Operation
@@ -56,6 +57,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		exec:             op("Exec"),
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
+		mergeBase:        op("MergeBase"),
 		resolveRevision:  op("ResolveRevision"),
 		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -16,6 +16,7 @@ type operations struct {
 	p4Exec           *observation.Operation
 	readDir          *observation.Operation
 	resolveRevision  *observation.Operation
+	listTags         *observation.Operation
 	lstat            *observation.Operation
 	streamBlameFile  *observation.Operation
 	blameFile        *observation.Operation
@@ -56,6 +57,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		p4Exec:           op("P4Exec"),
 		contributorCount: op("ContributorCount"),
 		resolveRevision:  op("ResolveRevision"),
+		listTags:         op("ListTags"),
 		streamBlameFile:  op("StreamBlameFile"),
 		blameFile:        op("BlameFile"),
 		readDir:          op("ReadDir"),

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -82,7 +82,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		listBranches:     op("ListBranches"),
 		listRefs:         op("ListRefs"),
 		listTags:         op("ListTags"),
-		lstat:            op("lStat"),
+		lstat:            subOp("lStat"),
 		mergeBase:        op("MergeBase"),
 		newFileReader:    op("NewFileReader"),
 		p4Exec:           op("P4Exec"),


### PR DESCRIPTION
This builds on https://github.com/sourcegraph/sourcegraph/pull/52212 to remove the remaining uses of the deprecated `ot.StartSpanFromContext`.

Since this uses the observation package, this also gives per-method metrics for free.

<img width="1215" alt="Screenshot 2023-05-19 at 14 16 01" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/014e7a6f-1153-46e4-be56-2052271e852b">

## Test plan

Manual testing. Low risk because it's just tracing. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
