### PR TITLE
app-release: remove set x in tauri script

### DIFF
--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exu
+set -eu
 
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
 


### PR DESCRIPTION

## Test plan
Should not see command output when running tuairi-build.sh
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
