### PR TITLE
app-release: force stateless queue for github release step

### DIFF
--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -62,6 +62,7 @@ steps:
       - label: "wait for bundles to complete"
         wait: ~
       - label: ':github: Create GitHub release'
+        agent: { queue: stateless }
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'

--- a/enterprise/dev/app/create-github-release.sh
+++ b/enterprise/dev/app/create-github-release.sh
@@ -18,14 +18,12 @@ else
   exit 1
 fi
 
-echo "--- :aws: fetching GitHub Token"
-token=$(aws secretsmanager get-secret-value --secret-id sourcegraph/mac/github-token | jq '.SecretString |  fromjson | .token')
-export GITHUB_TOKEN=${token}
-
 VERSION=$(./enterprise/dev/app/app_version.sh)
 echo "--- :github: Creating GitHub release for Sourcegraph App (${VERSION})"
 echo "Release will have to following assets:"
 ls -al ./dist
+
+# On CI it is assumed this command runs in a stateless agent, where the GITHUB_TOKEN is injected
 gh release create "app-v${VERSION}" \
   --prerelease \
   --draft \


### PR DESCRIPTION
When running in a  stateless agent we don't have to fetch the github token from AWS secrets manager
## Test plan
green ci
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
