### PR TITLE
app: web: force-enable Cody feature flags for app (temporary)

### DIFF
--- a/client/web/src/cody/useIsCodyEnabled.tsx
+++ b/client/web/src/cody/useIsCodyEnabled.tsx
@@ -24,10 +24,16 @@ export const useIsCodyEnabled = (): IsCodyEnabled => {
     const [searchEnabled] = useFeatureFlag('cody-web-search')
     const [sidebarEnabled] = useFeatureFlag('cody-web-sidebar')
     const [editorRecipesEnabled] = useFeatureFlag('cody-web-editor-recipes')
-    const [allEnabled] = useFeatureFlag('cody-web-all')
+    let [allEnabled] = useFeatureFlag('cody-web-all')
 
     if (!window.context?.codyEnabled) {
         return notEnabled
+    }
+    if (window.context.sourcegraphAppMode) {
+        // TODO(app-team): This is temporary to force code always-on; we will make this enabled/disabled
+        // based on the GraphQL API that can detect if you can enable it based on your account (connected
+        // to Sourcegraph.com, email verified, etc.) in the future.
+        allEnabled = true
     }
 
     return {


### PR DESCRIPTION
Until we can intelligently enable this based on whether the user has signed into Sourcegraph.com, etc. it's better to just force-enable this feature flag by default - so that at least Cody works out of the box etc.

## Test plan

Ran `./enterprise/dev/app/build.sh` and confirmed it's on-by-default / cody chat works.