### PR TITLE
web/app: update auth token callback page design

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -29,6 +29,7 @@ import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
 import { parseSearchURLQuery } from './search'
 import { NotepadContainer } from './search/Notepad'
 import { SearchQueryStateObserver } from './SearchQueryStateObserver'
+import { isAccessTokenCallbackPage } from './user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage'
 
 import styles from './storm/pages/LayoutPage/LayoutPage.module.scss'
 
@@ -56,7 +57,6 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     )
 
     const routeMatch = route?.path
-    const isFullPageRoute = route?.handle?.isFullPage
 
     const isSearchRelatedPage = (routeMatch === PageRoutes.RepoContainer || routeMatch?.startsWith('/search')) ?? false
     const isSearchHomepage = location.pathname === '/search' && !parseSearchURLQuery(location.search)
@@ -68,6 +68,13 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     const isCodySearchPage = routeMatch === EnterprisePageRoutes.CodySearch
     const isRepositoryRelatedPage = routeMatch === PageRoutes.RepoContainer ?? false
     const isCodyStandalonePage = location.pathname === PageRoutes.CodyStandalone
+
+    // Since the access token callback page is rendered in a nested route, we can't use
+    // `route.handle.isFullPage` to determine whether to render the header. Instead, we check
+    // whether the current page is the access token callback page.
+    const isAuthTokenCallbackPage = isAccessTokenCallbackPage()
+
+    const isFullPageRoute = !!route?.handle?.isFullPage || isAuthTokenCallbackPage
 
     // eslint-disable-next-line no-restricted-syntax
     const [wasSetupWizardSkipped] = useLocalStorage('setup.skipped', false)

--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -66,7 +66,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
                         readOnly={true}
                         onClick={this.onClickInput}
                     />
-                    <div className="input-group-append">
+                    <div className="input-group-append flex-shrink-0">
                         <Button
                             onClick={this.onClickButton}
                             disabled={this.state.copied}
@@ -78,7 +78,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
                         </Button>
                     </div>
                     {this.props.secret && (
-                        <div className="input-group-append">
+                        <div className="input-group-append flex-shrink-0">
                             <Button
                                 onClick={this.onClickSecretButton}
                                 variant="secondary"

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
           />
         </div>
         <div
-          class="input-group-append"
+          class="input-group-append flex-shrink-0"
         >
           <button
             aria-disabled="false"
@@ -239,7 +239,7 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
           />
         </div>
         <div
-          class="input-group-append"
+          class="input-group-append flex-shrink-0"
         >
           <button
             aria-disabled="false"

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -17,6 +17,7 @@ import { Page } from '../../components/Page'
 import { UserAreaUserFields, UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../../graphql-operations'
 import { NamespaceProps } from '../../namespaces'
 import { RouteV6Descriptor } from '../../util/contributions'
+import { isAccessTokenCallbackPage } from '../settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage'
 import { UserSettingsAreaRoute } from '../settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from '../settings/UserSettingsSidebar'
 
@@ -177,6 +178,11 @@ export const UserArea: FC<UserAreaProps> = ({
         return <NotFoundPage pageType="user" />
     }
 
+    // Since the access token callback page is rendered in a nested route, we can't use the
+    // `fullPage` route prop to determine whether to render the header. Instead, we check
+    // whether the current page is the access token callback page.
+    const isFullscreenPage = isAccessTokenCallbackPage()
+
     const context: UserAreaRouteContext = {
         ...props,
         url: userAreaMainUrl,
@@ -202,7 +208,7 @@ export const UserArea: FC<UserAreaProps> = ({
                             <Route
                                 errorElement={<RouteError />}
                                 element={
-                                    fullPage ? (
+                                    fullPage || isFullscreenPage ? (
                                         render(context)
                                     ) : (
                                         <Page>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
@@ -19,6 +19,17 @@
     min-height: 54px;
 }
 
+.card {
+    padding: 1.75rem 1.5rem;
+    box-shadow: var(--box-shadow);
+    border-color: var(--border-color);
+    --card-border-radius: 6px;
+}
+
+.heading {
+    letter-spacing: -0.015625rem;
+}
+
 .button-row {
     display: flex;
     flex-direction: row;

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
@@ -23,6 +23,7 @@
     padding: 1.75rem 1.5rem;
     box-shadow: var(--box-shadow);
     border-color: var(--border-color);
+
     --card-border-radius: 6px;
 }
 

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.module.scss
@@ -1,0 +1,27 @@
+.wrapper {
+    width: 23rem;
+    margin: auto;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.logo {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    width: 13rem;
+    max-width: 90%;
+    margin-bottom: 1.875rem;
+
+    /* Reserve the image's height to avoid jitter before it loads. */
+    min-height: 54px;
+}
+
+.button-row {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    justify-content: stretch;
+}

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -83,6 +83,11 @@ const REQUESTERS: Record<string, TokenRequester> = {
         callbackType: 'new-tab',
     },
 }
+
+export function isAccessTokenCallbackPage(): boolean {
+    return location.pathname.startsWith('/users/') && location.pathname.endsWith('/settings/tokens/new/callback')
+}
+
 /**
  * This page acts as a callback URL after the authentication process has been completed by a user.
  * This can be shared among different SG integrations as long as the value that is being passed in

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -1,37 +1,31 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { useLocation, useNavigate } from 'react-router-dom'
-import { NEVER } from 'rxjs'
-import { catchError, startWith, tap } from 'rxjs/operators'
+import { NEVER, Observable } from 'rxjs'
+import { catchError, startWith, switchMap, tap } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import {
-    Container,
-    PageHeader,
-    Button,
-    useObservable,
-    Link,
-    LoadingSpinner,
-    Alert,
-    Text,
-    ErrorAlert,
-    Form,
-} from '@sourcegraph/wildcard'
+import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
+import { Button, Link, Text, ErrorAlert, Card, H1, H2, useEventObservable } from '@sourcegraph/wildcard'
 
 import { AccessTokenScopes } from '../../../auth/accessToken'
+import { BrandLogo } from '../../../components/branding/BrandLogo'
 import { CopyableText } from '../../../components/CopyableText'
-import { PageTitle } from '../../../components/PageTitle'
+import { LoaderButton } from '../../../components/LoaderButton'
 import { CreateAccessTokenResult } from '../../../graphql-operations'
 import { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
 import { createAccessToken } from './create'
+
+import styles from './UserSettingsCreateAccessTokenCallbackPage.module.scss'
 
 /**
  * Utility function to open the callback URL in Sourcegraph App. Used where
  * window.open or target="_blank" cannot be used.
  */
 function tauriShellOpen(uri: string): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any
     ;(window as any).__TAURI__?.shell?.open(uri)
 }
 
@@ -49,8 +43,6 @@ interface TokenRequester {
     /** The URL where the token should be added to */
     /** SECURITY: Local context only! Do not send token to non-local servers*/
     redirectURL: string
-    /** A description of where the request is coming from */
-    description: string
     /** The message to show users when the token has been created successfully */
     successMessage?: string
     /** The message to show users in case the token cannot be imported automatically */
@@ -58,8 +50,6 @@ interface TokenRequester {
     /** How the redirect URL should be open: open in same tab vs open in a new-tab */
     /** Default: Open link in same tab */
     callbackType?: 'open' | 'new-tab'
-    /** Show button to redirect URL on click */
-    showRedirectButton?: boolean
     /** If set, the requester is only allowed on dotcom */
     onlyDotCom?: boolean
     /** If true, it will forward the `destination` param to the redirect URL if it starts with / */
@@ -70,35 +60,27 @@ const REQUESTERS: Record<string, TokenRequester> = {
     VSCEAUTH: {
         name: 'VS Code Extension',
         redirectURL: 'vscode://sourcegraph.sourcegraph?code=$TOKEN',
-        description: 'Auth from VS Code Extension for Sourcegraph',
-        successMessage:
-            'Importing your token will automatically connect your Sourcegraph account in the VS Code extension.',
+        successMessage: 'Now opening VS Code...',
         infoMessage:
             'Please make sure you have VS Code running on your machine if you do not see an open dialog in your browser.',
         callbackType: 'new-tab',
-        showRedirectButton: true,
     },
     APP: {
         name: 'Sourcegraph App',
         redirectURL: 'sourcegraph://app/auth/callback?code=$TOKEN',
-        description: 'Authenticate Sourcegraph App',
-        successMessage: 'Click on the link bellow to continue in Sourcegraph App',
-        infoMessage: 'You will be redirected to Sourcegraph App',
+        successMessage: 'Now opening the Sourcegraph App...',
+        infoMessage: 'You will be redirected to Sourcegraph App.',
         callbackType: 'open',
-        showRedirectButton: true,
         onlyDotCom: true,
         forwardDestination: true,
     },
     CODY: {
         name: 'Sourcegraph Cody - VS Code Extension',
         redirectURL: 'vscode://sourcegraph.cody-ai?code=$TOKEN',
-        description: 'Auth from VS Code Extension for Sourcegraph Cody',
-        successMessage:
-            'Importing your token will automatically connect your Sourcegraph account to the Cody extension in VS Code.',
+        successMessage: 'Now opening VS Code...',
         infoMessage:
-            'If you do not see an open dialog in your browser, please make sure you have VS Code running on your machine.',
+            'Please make sure you have VS Code running on your machine if you do not see an open dialog in your browser.',
         callbackType: 'new-tab',
-        showRedirectButton: true,
     },
 }
 /**
@@ -117,9 +99,10 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     isSourcegraphDotCom,
     isSourcegraphApp,
 }) => {
+    const isLightTheme = useIsLightTheme()
     const navigate = useNavigate()
     const location = useLocation()
-    useMemo(() => {
+    useEffect(() => {
         telemetryService.logPageView('NewAccessTokenCallback')
     }, [telemetryService])
     /** Get the requester from the url parameters if any */
@@ -130,6 +113,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     const [note, setNote] = useState<string>('')
     /** The newly created token if any. */
     const [newToken, setNewToken] = useState('')
+
     // Check and Match URL Search Prams
     useEffect((): void => {
         // If a requester is already set, we don't need to run this effect
@@ -171,106 +155,111 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
         setRequester(nextRequester)
         setNote(REQUESTERS[requestFrom].name)
     }, [isSourcegraphDotCom, isSourcegraphApp, location.search, navigate, requestFrom, requester])
+
     /**
      * We use this to handle token creation request from redirections.
      * Don't create token if this page wasn't linked to from a valid
      * requester (e.g. VS Code extension).
      */
-    const creationOrError = useObservable(
-        useMemo(
-            () =>
-                (requester ? createAccessToken(user.id, [AccessTokenScopes.UserAll], note) : NEVER).pipe(
-                    tap(result => {
-                        // SECURITY: If the request was from a valid requestor, redirect to the allowlisted redirect URL.
-                        // SECURITY: Local context ONLY
-                        if (requester) {
-                            onDidCreateAccessToken(result)
-                            setNewToken(result.token)
-                            const uri = replaceToken(requester?.redirectURL, result.token)
+    const [onAuthorize, creationOrError] = useEventObservable(
+        useCallback(
+            (click: Observable<React.MouseEvent>) =>
+                click.pipe(
+                    switchMap(() =>
+                        (requester ? createAccessToken(user.id, [AccessTokenScopes.UserAll], note) : NEVER).pipe(
+                            tap(result => {
+                                // SECURITY: If the request was from a valid requestor, redirect to the allowlisted redirect URL.
+                                // SECURITY: Local context ONLY
+                                if (requester) {
+                                    onDidCreateAccessToken(result)
+                                    setNewToken(result.token)
+                                    const uri = replaceToken(requester?.redirectURL, result.token)
 
-                            // If we're in App, override the callbackType
-                            // because we need to use tauriShellOpen to open the
-                            // callback in a browser.
-                            if (isSourcegraphApp) {
-                                tauriShellOpen(uri)
-                                return
-                            }
+                                    // If we're in App, override the callbackType
+                                    // because we need to use tauriShellOpen to open the
+                                    // callback in a browser.
+                                    if (isSourcegraphApp) {
+                                        tauriShellOpen(uri)
+                                        return
+                                    }
 
-                            switch (requester.callbackType) {
-                                case 'new-tab':
-                                    window.open(uri, '_blank')
-                                default:
-                                    // open the redirect link in the same tab
-                                    window.location.replace(uri)
-                            }
-                        }
-                    }),
-                    startWith('loading'),
-                    catchError(error => [asError(error)])
+                                    switch (requester.callbackType) {
+                                        case 'new-tab':
+                                            window.open(uri, '_blank')
+                                        default:
+                                            // open the redirect link in the same tab
+                                            window.location.replace(uri)
+                                    }
+                                }
+                            }),
+                            startWith('loading'),
+                            catchError(error => [asError(error)])
+                        )
+                    )
                 ),
             [requester, user.id, note, onDidCreateAccessToken, isSourcegraphApp]
         )
     )
-    /**
-     * If there's a uriPattern but no result or error yet, we can assume that creation is
-     * in progress and show a loading spinner + message.
-     */
-    if (creationOrError === 'loading') {
-        return <LoadingSpinner />
-    }
+
     if (!requester) {
         return null
     }
+
     return (
-        <div className="user-settings-create-access-token-page">
-            <PageTitle title="Create access token" />
-            <PageHeader
-                path={[{ text: `Connect my account to ${requester ? requester.name : ''}` }]}
-                headingElement="h2"
-                className="mb-3"
-            />
-            {!isErrorLike(creationOrError) && requester?.infoMessage && (
-                <Alert className="my-2" variant="warning">
-                    <Text className="my-2">{requester?.infoMessage}</Text>
-                </Alert>
-            )}
-            {newToken && requester && (
-                <Form>
-                    <Container className="mb-3">
-                        <Alert className="access-token-created-alert mt-3" variant="success">
-                            <Text weight="bold">{requester.name} access token successfully generated</Text>
-                            <Text>{requester?.successMessage}</Text>
-                            <CopyableText className="test-access-token" text={newToken} size={48} />
-                            <Text className="form-help text-muted" size="small">
-                                This is a one-time access token to connect your account to {requester.name}. You will
-                                not be able to see this token again once the window is closed.
-                            </Text>
-                        </Alert>
-                    </Container>
-                    <div className="mb-3">
-                        {requester.showRedirectButton && (
-                            <Button
-                                className="mr-2"
-                                to={replaceToken(requester.redirectURL, newToken)}
-                                disabled={creationOrError === 'loading'}
-                                variant="primary"
-                                as={Link}
-                            >
-                                Import token to {requester.name}
-                            </Button>
-                        )}
+        <div className={styles.wrapper}>
+            <BrandLogo className={styles.logo} isLightTheme={isLightTheme} variant="logo" />
+
+            <Card className="p-3">
+                <H2 as={H1}>Authorize {requester.name}?</H2>
+
+                <Text weight="bold">This grants access to:</Text>
+                <ul>
+                    <li>Your Sourcegraph.com account</li>
+                    <li>Perform actions on your behalf</li>
+                </ul>
+                <Text>{requester.infoMessage}</Text>
+                <Text>If you are not trying to connect {requester.name}, click cancel.</Text>
+
+                {!newToken && (
+                    <div className={styles.buttonRow}>
+                        <LoaderButton
+                            className="flex-1"
+                            variant="primary"
+                            label="Authorize"
+                            loading={creationOrError === 'loading'}
+                            onClick={onAuthorize}
+                        />
                         <Button
+                            className="flex-1"
+                            variant="secondary"
                             to={location.pathname.replace(/\/new\/callback$/, '')}
                             disabled={creationOrError === 'loading'}
-                            variant="secondary"
                             as={Link}
                         >
-                            Back
+                            Cancel
                         </Button>
                     </div>
-                </Form>
-            )}
-            {isErrorLike(creationOrError) && <ErrorAlert className="my-3" error={creationOrError} />}
+                )}
+
+                {newToken && (
+                    <>
+                        <Text weight="bold">{requester.successMessage}</Text>
+                        <details>
+                            <summary>Authorization details</summary>
+                            <div className="mt-2">
+                                <Text>{requester.name} access token successfully generated.</Text>
+                                <CopyableText className="test-access-token" text={newToken} />
+                                <Text className="form-help text-muted" size="small">
+                                    This is a one-time access token to connect your account to {requester.name}. You
+                                    will not be able to see this token again once the window is closed.
+                                </Text>
+                            </div>
+                        </details>
+                    </>
+                )}
+
+                {isErrorLike(creationOrError) && <ErrorAlert className="my-3 " error={creationOrError} />}
+            </Card>
         </div>
     )
 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -214,8 +214,10 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
         <div className={styles.wrapper}>
             <BrandLogo className={styles.logo} isLightTheme={isLightTheme} variant="logo" />
 
-            <Card className="p-3">
-                <H2 as={H1}>Authorize {requester.name}?</H2>
+            <Card className={styles.card}>
+                <H2 as={H1} className={styles.heading}>
+                    Authorize {requester.name}?
+                </H2>
 
                 <Text weight="bold">This grants access to:</Text>
                 <ul>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -183,8 +183,11 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                                     // If we're in App, override the callbackType
                                     // because we need to use tauriShellOpen to open the
                                     // callback in a browser.
+                                    // Then navigate back to the home page since App doesn't
+                                    // have a back button or tab that can be closed.
                                     if (isSourcegraphApp) {
                                         tauriShellOpen(uri)
+                                        navigate('/')
                                         return
                                     }
 
@@ -202,7 +205,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                         )
                     )
                 ),
-            [requester, user.id, note, onDidCreateAccessToken, isSourcegraphApp]
+            [requester, user.id, note, onDidCreateAccessToken, isSourcegraphApp, navigate]
         )
     )
 


### PR DESCRIPTION
- Page is now full-screen and matches the [new Figma design](https://www.figma.com/file/8UUuaIUPVJDzp8U9ImNvA7/Connect-Cody-and-polish-setup-experience?type=design&node-id=577-3891&t=8vwCpa6u8bjAMcfv-4)
- Token is no longer created on page load, the user has to click the "Authorize" button
- This affects the auth token page for both App and for the VSCode extensions (regular and Cody)
- In the webapp, this page will stay open and the user can see the details of the created access token. In the desktop app (eg. when connecting Cody extension to App), this page will navigate back to the homepage, because App doesn't have tabs that can be closed.

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/206864/91e9734b-a1a5-4de8-a997-fd56400f27a4


