### PR TITLE
licensing: add 'internal' as a valid tag, update LLM-proxy internal mode

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/productsubscription/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//enterprise/cmd/llm-proxy/internal/actor",
         "//enterprise/cmd/llm-proxy/internal/dotcom",
+        "//enterprise/internal/licensing",
         "//enterprise/internal/llm-proxy",
         "//internal/trace",
         "//lib/errors",

--- a/enterprise/cmd/llm-proxy/shared/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/shared/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//enterprise/cmd/llm-proxy/internal/auth",
         "//enterprise/cmd/llm-proxy/internal/dotcom",
         "//enterprise/cmd/llm-proxy/internal/events",
+        "//enterprise/internal/licensing",
         "@com_github_derision_test_go_mockgen//testutil/require",
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",

--- a/enterprise/cmd/llm-proxy/shared/config.go
+++ b/enterprise/cmd/llm-proxy/shared/config.go
@@ -21,9 +21,9 @@ type Config struct {
 	DiagnosticsSecret string
 
 	Dotcom struct {
-		URL             string
-		AccessToken     string
-		DevLicensesOnly bool
+		URL          string
+		AccessToken  string
+		InternalMode bool
 	}
 
 	Anthropic struct {
@@ -63,7 +63,8 @@ func (c *Config) Load() {
 
 	c.Dotcom.AccessToken = c.Get("LLM_PROXY_DOTCOM_ACCESS_TOKEN", "", "The Sourcegraph.com access token to be used.")
 	c.Dotcom.URL = c.Get("LLM_PROXY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
-	c.Dotcom.DevLicensesOnly = c.GetBool("LLM_PROXY_DOTCOM_DEV_LICENSES_ONLY", "false", "Only allow tokens associated with active dev licenses to be used.")
+	c.Dotcom.InternalMode = c.GetBool("LLM_PROXY_DOTCOM_INTERNAL_MODE", "false", "Only allow tokens associated with active internal and dev licenses to be used.") ||
+		c.GetBool("LLM_PROXY_DOTCOM_DEV_LICENSES_ONLY", "false", "DEPRECATED, use LLM_PROXY_DOTCOM_INTERNAL_MODE")
 
 	c.Anthropic.AccessToken = c.Get("LLM_PROXY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 	c.Anthropic.AllowedModels = splitMaybe(c.Get("LLM_PROXY_ANTHROPIC_ALLOWED_MODELS", "claude-v1,claude-v1.0,claude-v1.2,claude-v1.3,claude-instant-v1,claude-instant-v1.0", "The Anthropic access token to be used."))

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -61,7 +61,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			obctx.Logger,
 			rcache.New("product-subscriptions"),
 			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
-			config.Dotcom.DevLicensesOnly),
+			config.Dotcom.InternalMode),
 	}
 
 	// Set up our handler chain, which is run from the bottom up. Application handlers

--- a/enterprise/internal/licensing/tags.go
+++ b/enterprise/internal/licensing/tags.go
@@ -7,9 +7,15 @@ import (
 )
 
 const (
+	// TrialTag denotes trial licenses.
+	TrialTag = "trial"
 	// TrueUpUserCountTag is the license tag that indicates that the licensed user count can be
 	// exceeded and will be charged later.
 	TrueUpUserCountTag = "true-up"
+	// InternalTag denotes Sourcegraph-internal tags
+	InternalTag = "internal"
+	// DevTag denotes licenses used in development environments
+	DevTag = "dev"
 )
 
 // ProductNameWithBrand returns the product name with brand (e.g., "Sourcegraph Enterprise") based
@@ -55,11 +61,14 @@ func ProductNameWithBrand(hasLicense bool, licenseTags []string) string {
 	}
 
 	var misc []string
-	if hasTag("trial") {
+	if hasTag(TrialTag) {
 		misc = append(misc, "trial")
 	}
-	if hasTag("dev") {
+	if hasTag(DevTag) {
 		misc = append(misc, "dev use only")
+	}
+	if hasTag(InternalTag) {
+		misc = append(misc, "internal use only")
 	}
 	if len(misc) > 0 {
 		name += " (" + strings.Join(misc, ", ") + ")"
@@ -69,9 +78,10 @@ func ProductNameWithBrand(hasLicense bool, licenseTags []string) string {
 }
 
 var MiscTags = []string{
-	"trial",
-	"dev",
+	TrialTag,
 	TrueUpUserCountTag,
+	InternalTag,
+	DevTag,
 	"starter",
 	"mau",
 }

--- a/enterprise/internal/licensing/tags_test.go
+++ b/enterprise/internal/licensing/tags_test.go
@@ -24,35 +24,41 @@ func TestProductNameWithBrand(t *testing.T) {
 		{hasLicense: true, licenseTags: []string{"starter", "dev"}, want: "Sourcegraph Enterprise Starter (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"starter", "trial", "dev"}, want: "Sourcegraph Enterprise Starter (trial, dev use only)"},
 		{hasLicense: true, licenseTags: []string{"trial", "dev"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"internal"}, want: "Sourcegraph Enterprise (internal use only)"},
 
 		{hasLicense: true, licenseTags: []string{"team"}, want: "Sourcegraph Team"},
 		{hasLicense: true, licenseTags: []string{"starter", "team"}, want: "Sourcegraph Team"}, // Team should overrule the old Starter plan
 		{hasLicense: true, licenseTags: []string{"team", "trial"}, want: "Sourcegraph Team (trial)"},
 		{hasLicense: true, licenseTags: []string{"team", "dev"}, want: "Sourcegraph Team (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"team", "dev", "trial"}, want: "Sourcegraph Team (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"team", "internal"}, want: "Sourcegraph Team (internal use only)"},
 
 		{hasLicense: true, licenseTags: []string{"plan:team-0"}, want: "Sourcegraph Team"},
 		{hasLicense: true, licenseTags: []string{"plan:team-0", "starter"}, want: "Sourcegraph Team"}, // Team should overrule the old Starter plan
 		{hasLicense: true, licenseTags: []string{"plan:team-0", "trial"}, want: "Sourcegraph Team (trial)"},
 		{hasLicense: true, licenseTags: []string{"plan:team-0", "dev"}, want: "Sourcegraph Team (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"plan:team-0", "dev", "trial"}, want: "Sourcegraph Team (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:team-0", "internal"}, want: "Sourcegraph Team (internal use only)"},
 
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-0"}, want: "Sourcegraph Enterprise"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "starter"}, want: "Sourcegraph Enterprise"}, // Enterprise should overrule the old Starter plan
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "trial"}, want: "Sourcegraph Enterprise (trial)"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "dev"}, want: "Sourcegraph Enterprise (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "dev", "trial"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-0", "internal"}, want: "Sourcegraph Enterprise (internal use only)"},
 
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-1"}, want: "Sourcegraph Enterprise"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-1", "starter"}, want: "Sourcegraph Enterprise"}, // Enterprise should overrule the old Starter plan
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-1", "trial"}, want: "Sourcegraph Enterprise (trial)"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-1", "dev"}, want: "Sourcegraph Enterprise (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"plan:enterprise-1", "dev", "trial"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:enterprise-1", "internal"}, want: "Sourcegraph Enterprise (internal use only)"},
 
 		{hasLicense: true, licenseTags: []string{"plan:business-0"}, want: "Sourcegraph Business"},
 		{hasLicense: true, licenseTags: []string{"plan:business-0", "trial"}, want: "Sourcegraph Business (trial)"},
 		{hasLicense: true, licenseTags: []string{"plan:business-0", "dev"}, want: "Sourcegraph Business (dev use only)"},
 		{hasLicense: true, licenseTags: []string{"plan:business-0", "dev", "trial"}, want: "Sourcegraph Business (trial, dev use only)"},
+		{hasLicense: true, licenseTags: []string{"plan:business-0", "internal"}, want: "Sourcegraph Business (internal use only)"},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("hasLicense=%v licenseTags=%v", test.hasLicense, test.licenseTags), func(t *testing.T) {


### PR DESCRIPTION
Currently, k8s.sgdev.org can't talk to the dev LLM-proxy instance because its license doesn't have a `dev` tag - instead it has the `internal` tag. It kind of makes sense to have an `internal` tag though because we have a number of long-lived internal instances that aren't quite just for `dev` usage so maybe it's useful to have this distinguished as a separate use case.

## Test plan

CI