### PR TITLE
llm-proxy: only consume rate limit on successful upstream request

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/actor.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/actor.go
@@ -85,8 +85,8 @@ type updateOnFailureLimiter struct {
 	*Actor
 }
 
-func (u updateOnFailureLimiter) TryAcquire(ctx context.Context) error {
-	err := (limiter.StaticLimiter{
+func (u updateOnFailureLimiter) TryAcquire(ctx context.Context) (func() error, error) {
+	commit, err := (limiter.StaticLimiter{
 		Identifier: u.ID,
 		Redis:      u.Redis,
 		Limit:      u.RateLimit.Limit,
@@ -99,5 +99,5 @@ func (u updateOnFailureLimiter) TryAcquire(ctx context.Context) error {
 		u.Actor.Update(ctx) // TODO: run this in goroutine+background context maybe?
 	}
 
-	return err
+	return commit, err
 }

--- a/enterprise/cmd/llm-proxy/internal/limiter/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/limiter/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     embed = [":limiter"],
     deps = [
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/cmd/llm-proxy/internal/response/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/response/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "response",
@@ -6,4 +6,11 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy/internal/response",
     visibility = ["//enterprise/cmd/llm-proxy:__subpackages__"],
     deps = ["@com_github_sourcegraph_log//:log"],
+)
+
+go_test(
+    name = "response_test",
+    srcs = ["response_test.go"],
+    embed = [":response"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/enterprise/cmd/llm-proxy/internal/response/response.go
+++ b/enterprise/cmd/llm-proxy/internal/response/response.go
@@ -16,3 +16,30 @@ func JSONError(logger log.Logger, w http.ResponseWriter, code int, err error) {
 		logger.Error("failed to write response", log.Error(err))
 	}
 }
+
+type StatusHeaderRecorder struct {
+	StatusCode int
+	http.ResponseWriter
+}
+
+func NewStatusHeaderRecorder(w http.ResponseWriter) *StatusHeaderRecorder {
+	return &StatusHeaderRecorder{ResponseWriter: w}
+}
+
+// Write writes the data to the connection as part of an HTTP reply.
+//
+// If WriteHeader has not yet been called, Write calls
+// WriteHeader(http.StatusOK) before writing the data.
+func (r *StatusHeaderRecorder) Write(b []byte) (int, error) {
+	if r.StatusCode == 0 {
+		r.StatusCode = http.StatusOK // implicit behaviour of http.ResponseWriter
+	}
+	return r.ResponseWriter.Write(b)
+}
+
+// WriteHeader sends an HTTP response header with the provided status code and
+// records the status code for later inspection.
+func (r *StatusHeaderRecorder) WriteHeader(statusCode int) {
+	r.StatusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}

--- a/enterprise/cmd/llm-proxy/internal/response/response_test.go
+++ b/enterprise/cmd/llm-proxy/internal/response/response_test.go
@@ -1,0 +1,33 @@
+package response
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusHeaderRecorder(t *testing.T) {
+	t.Run("WriteHeader", func(t *testing.T) {
+		underlying := httptest.NewRecorder()
+		recorder := NewStatusHeaderRecorder(underlying)
+
+		var w http.ResponseWriter = recorder
+		w.WriteHeader(http.StatusTeapot)
+
+		assert.Equal(t, http.StatusTeapot, recorder.StatusCode)
+		assert.Equal(t, http.StatusTeapot, underlying.Code)
+	})
+
+	t.Run("implicit WriteHeader", func(t *testing.T) {
+		underlying := httptest.NewRecorder()
+		recorder := NewStatusHeaderRecorder(underlying)
+
+		var w http.ResponseWriter = recorder
+		w.Write([]byte("foo")) // should implicitly write header
+
+		assert.Equal(t, http.StatusOK, recorder.StatusCode)
+		assert.Equal(t, http.StatusOK, underlying.Code)
+	})
+}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/51879. A "commit" callback is now returned from `TryAcquire` so that unless the end response to the client is a healthy response, we do not consume the rate limit. We still check if rate limit has been exceeded in the hot-path of `TryAcquire`

## Test plan

Unit tests
