### PR TITLE
Increase minimum supported redis version from 5.0 -> 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix.
 - The commit message defined in a batch spec will now be quoted when git is invoked, i.e. `git commit -m "commit message"`, to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash. This may mean that previous escaping strategies will behave differently.
 - 429 errors from external services Sourcegraph talks to are only retried automatically if the Retry-After header doesn't indicate that a retry would be useless. The time grace period can be configured using `SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION` and `SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION`. [#51743](https://github.com/sourcegraph/sourcegraph/pull/51743)
+- Update minimum supported Redis version to 7.0 [#52248](https://github.com/sourcegraph/sourcegraph/pull/52248)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Access tokens now begin with the prefix `sgp_` to make them identifiable as secrets. You can also prepend `sgp_` to previously generated access tokens, although they will continue to work as-is without that prefix.
 - The commit message defined in a batch spec will now be quoted when git is invoked, i.e. `git commit -m "commit message"`, to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash. This may mean that previous escaping strategies will behave differently.
 - 429 errors from external services Sourcegraph talks to are only retried automatically if the Retry-After header doesn't indicate that a retry would be useless. The time grace period can be configured using `SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION` and `SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION`. [#51743](https://github.com/sourcegraph/sourcegraph/pull/51743)
-- Update minimum supported Redis version to 7.0 [#52248](https://github.com/sourcegraph/sourcegraph/pull/52248)
+- Update minimum supported Redis version to 6.2 [#52248](https://github.com/sourcegraph/sourcegraph/pull/52248)
 
 ### Fixed
 

--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -1,6 +1,6 @@
 # Using your own Redis server
 
-**Version requirements**: We support any version *starting from 7.0*. Redis Cluster and Redis Sentinel are not supported.
+**Version requirements**: We support any version *starting from 6.2*. Redis Cluster and Redis Sentinel are not supported.
 
 Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can follow the deployment specific guidance below:
 

--- a/doc/admin/external_services/redis.md
+++ b/doc/admin/external_services/redis.md
@@ -1,6 +1,6 @@
 # Using your own Redis server
 
-**Version requirements**: We support any version *starting from 5.0*. Redis Cluster and Redis Sentinel are not supported.
+**Version requirements**: We support any version *starting from 7.0*. Redis Cluster and Redis Sentinel are not supported.
 
 Generally, there is no reason to do this as Sourcegraph only stores ephemeral cache and session data in Redis. However, if you want to use an external Redis server with Sourcegraph, you can follow the deployment specific guidance below:
 

--- a/wolfi-images/redis.yaml
+++ b/wolfi-images/redis.yaml
@@ -7,7 +7,7 @@ contents:
     - mailcap
 
     # redis packages
-    - redis
+    - redis-6.2
 
 accounts:
   groups:

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -21,7 +21,7 @@ contents:
     - postgresql-12-contrib
     - prometheus-postgres-exporter=0.12.0-r1 # IMPORTANT: Pinned version for managed updates
     - python3 # TODO: Missing python2; required?
-    - redis # TODO: 7.0.10; test upgrade from 5.0
+    - redis-6.2
     - sqlite-libs
     - su-exec
 


### PR DESCRIPTION
~We currently don't use any 7.0 features, but the move to Wolfi will include a switch to Redis 7.0 so all future development will be tested against that version.~

Initially we had planned to updated Redis to 7.0, but GCS Memorystore for Redis [only supports up to 6.2](https://cloud.google.com/memorystore/docs/redis/supported-versions). As a result, we're only upgrading to Redis 6.2.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Docs update - will manually check docs deploy correctly
- Manual testing of updated redis images