### PR TITLE
(chore) remove "repo:has(), repo:has.key() and repo:has.tag()" from autocomplete suggestion list

### DIFF
--- a/client/branded/src/search-ui/results/sidebar/SearchReference.tsx
+++ b/client/branded/src/search-ui/results/sidebar/SearchReference.tsx
@@ -229,30 +229,6 @@ To use this filter, the search query must contain \`type:diff\` or \`type:commit
         showSuggestions: false,
     },
     {
-        ...createQueryExampleFromString('has.tag({any string})'),
-        field: FilterType.repo,
-        description:
-            'DEPRECATED: Use "has.meta({tag}:)" instead. Search inside repositories that are tagged with the provided string.',
-        examples: ['repo:has.tag(ocaml)', '-repo:has.tag(golang)'],
-        showSuggestions: false,
-    },
-    {
-        ...createQueryExampleFromString('has({key:value})'),
-        field: FilterType.repo,
-        description:
-            'DEPRECATED: Use "has.meta({key}:{value})" instead. Search inside repositories associated with a key:value pair that matches the provided key:value pair.',
-        examples: ['repo:has(owner:jordan)', '-repo:has(team:search)'],
-        showSuggestions: false,
-    },
-    {
-        ...createQueryExampleFromString('has.key({any string})'),
-        field: FilterType.repo,
-        description:
-            'DEPRECATED: Use "has.meta({key})" instead. Search inside repositories that are associated with the given key, regardless of its value.',
-        examples: ['repo:has.key(owner)', '-repo:has.key(wip)'],
-        showSuggestions: false,
-    },
-    {
         ...createQueryExampleFromString('has.meta({key:value})'),
         field: FilterType.repo,
         description:
@@ -549,7 +525,7 @@ export interface SearchReferenceProps extends TelemetryProps, Pick<SearchQuerySt
     filter: string
 }
 
-const SearchReference = React.memo((props: SearchReferenceProps): ReactElement => {
+const SearchReference = React.memo(function SearchReference(props: SearchReferenceProps) {
     const [persistedTabIndex, setPersistedTabIndex] = useLocalStorage(SEARCH_REFERENCE_TAB_KEY, 0)
 
     const { setQueryState, telemetryService } = props
@@ -649,5 +625,7 @@ const SearchReference = React.memo((props: SearchReferenceProps): ReactElement =
 export function getSearchReferenceFactory(
     props: Omit<SearchReferenceProps, 'filter'>
 ): (filter: string) => React.ReactNode {
-    return (filter: string) => <SearchReference {...props} filter={filter} />
+    return function SearchReferenceFactory(filter: string) {
+        return <SearchReference {...props} filter={filter} />
+    }
 }

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -408,9 +408,6 @@ describe('getCompletionItems()', () => {
               "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) ",
               "has.meta(\${1:key}:\${2:value}) ",
-              "has.tag(\${1}) ",
-              "has(\${1:key}:\${2:value}) ",
-              "has.key(\${1}) ",
               "^repo/with\\\\ a\\\\ space$ "
             ]
         `)
@@ -434,10 +431,7 @@ describe('getCompletionItems()', () => {
               "has.topic(\${1}) ",
               "has.commit.after(\${1:1 month ago}) ",
               "has.description(\${1}) ",
-              "has.meta(\${1:key}:\${2:value}) ",
-              "has.tag(\${1}) ",
-              "has(\${1:key}:\${2:value}) ",
-              "has.key(\${1}) "
+              "has.meta(\${1:key}:\${2:value}) "
             ]
         `)
     })

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -219,27 +219,6 @@ export const predicateCompletion = (field: string): Completion[] => {
                     'Search only inside repositories having ({key}:{value}) pair, or ({key}) with any value or ({key}:) with no value metadata',
                 asSnippet: true,
             },
-            {
-                label: 'has.tag(...)',
-                insertText: 'has.tag(${1})',
-                asSnippet: true,
-                description:
-                    'DEPRECATED: Use "has.meta({tag}:)" instead. Search only inside repositories tagged with a given tag',
-            },
-            {
-                label: 'has(...)',
-                insertText: 'has(${1:key}:${2:value})',
-                description:
-                    'DEPRECATED: Use "has.meta({key}:{value})" instead. Search only inside repositories having a specified key:value pair',
-                asSnippet: true,
-            },
-            {
-                label: 'has.key(...)',
-                insertText: 'has.key(${1})',
-                description:
-                    'DEPRECATED: Use "has.meta({key})" instead. Search only inside repositories having a specific key with any value',
-                asSnippet: true,
-            },
         ]
     }
     if (field === 'file') {


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/sourcegraph/pull/52150.

This PR  because `repo:has()`, `repo:has.key()` and `repo:has.tag()` are now deprecated, it removes them autocomplete suggestion list as well as search reference sidebar.

## Test plan
- `sg start`
- Start typing `repo:has` and you should not get above filter suggestions

## Screenshot
| Before | After |
| --: | :-- |
| <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/67f0390c-1b21-40f9-9050-b3b8f9ea6b34"> |  <img width="1728" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/eed4e587-f089-43df-aec0-e31a40c4fa49"> |
| <img width="440" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/8ffc0e23-f710-484c-97a0-7594fdb2043b"> | <img width="440" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/b08b6f5e-1623-4c9c-a366-220e2a3daca9"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
