### PR TITLE
Cody: Enable rg for Windows

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Added
 
+- Added support for local keyword search on Windows. [pull/52251](https://github.com/sourcegraph/sourcegraph/pull/52251)
+
 ### Fixed
 
 - Setting `cody.useContext` to `none` will now limit Cody to using only the currently open file. [pull/52126](https://github.com/sourcegraph/sourcegraph/pull/52126)

--- a/client/cody/scripts/check-rg.sh
+++ b/client/cody/scripts/check-rg.sh
@@ -2,34 +2,38 @@
 
 run() {
 
-	pushd "$(dirname "$(readlink -f "$0")")/../resources/bin" &> /dev/null || return
-	trap 'popd > /dev/null' EXIT
+  pushd "$(dirname "$(readlink -f "$0")")/../resources/bin" &>/dev/null || return
+  trap 'popd > /dev/null' EXIT
 
-	# Get this list by copying output of `ls resources/bin/ripgrep*`
-	binaries=$(cat <<EOF
-ripgrep-v13.0.0-4-aarch64-apple-darwin
-ripgrep-v13.0.0-4-aarch64-unknown-linux-gnu
-ripgrep-v13.0.0-4-aarch64-unknown-linux-musl
-ripgrep-v13.0.0-4-arm-unknown-linux-gnueabihf
-ripgrep-v13.0.0-4-i686-unknown-linux-musl
-ripgrep-v13.0.0-4-powerpc64le-unknown-linux-gnu
-ripgrep-v13.0.0-4-s390x-unknown-linux-gnu
-ripgrep-v13.0.0-4-x86_64-apple-darwin
-ripgrep-v13.0.0-4-x86_64-unknown-linux-musl
+  # Get this list by copying output of `ls resources/bin/ripgrep*`
+  binaries=$(
+    cat <<EOF
+ripgrep-v13.0.0-8-aarch64-apple-darwin
+ripgrep-v13.0.0-8-aarch64-pc-windows-msvc
+ripgrep-v13.0.0-8-aarch64-unknown-linux-gnu
+ripgrep-v13.0.0-8-aarch64-unknown-linux-musl
+ripgrep-v13.0.0-8-arm-unknown-linux-gnueabihf
+ripgrep-v13.0.0-8-i686-pc-windows-msvc
+ripgrep-v13.0.0-8-i686-unknown-linux-musl
+ripgrep-v13.0.0-8-powerpc64le-unknown-linux-gnu
+ripgrep-v13.0.0-8-s390x-unknown-linux-gnu
+ripgrep-v13.0.0-8-x86_64-apple-darwin
+ripgrep-v13.0.0-8-x86_64-pc-windows-msvc
+ripgrep-v13.0.0-8-x86_64-unknown-linux-musl
 EOF
-			)
+  )
 
-	for binary in $binaries; do
-		if ls "$binary"; then
-			continue
-		fi
-		return 1
-	done
+  for binary in $binaries; do
+    if ls "$binary"; then
+      continue
+    fi
+    return 1
+  done
 }
 
 if run; then
-	exit 0
+  exit 0
 else
-	echo "Need to download ripgrep binaries. Try running 'scripts/download-rg.sh'? Afterward, update the list of binaries in 'scripts/check-rg.sh'"
-	exit 1
+  echo "Need to download ripgrep binaries. Try running 'scripts/download-rg.sh'? Afterward, update the list of binaries in 'scripts/check-rg.sh'"
+  exit 1
 fi

--- a/client/cody/scripts/download-rg.sh
+++ b/client/cody/scripts/download-rg.sh
@@ -1,31 +1,38 @@
 #!/bin/bash
 
-VERSION="v13.0.0-4"
+VERSION="v13.0.0-8"
 
 run() {
-        RIPGREP_DIR="$(dirname "$(readlink -f "$0")")/../resources/bin"
-        mkdir -p "${RIPGREP_DIR}"
-	pushd "${RIPGREP_DIR}" || return
-	trap 'popd' EXIT
+  RIPGREP_DIR="$(dirname "$(readlink -f "$0")")/../resources/bin"
+  mkdir -p "${RIPGREP_DIR}"
+  pushd "${RIPGREP_DIR}" || return
+  trap 'popd' EXIT
 
-	for url in $(curl https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/$VERSION 2>/dev/null | jq -r '.assets[] | .browser_download_url'); do
+  for url in $(curl https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/$VERSION 2>/dev/null | jq -r '.assets[] | .browser_download_url'); do
 
-		b=$(basename "$url")
-		ext=${b##*.}
+    b=$(basename "$url")
+    ext=${b##*.}
 
-		if [ "$ext" = "gz" ]; then
-			stripped=${b%.tar.gz}
+    if [ "$ext" = "gz" ]; then
+      stripped=${b%.tar.gz}
 
-			echo "$url -> $stripped"
-			wget -qO- "$url" | tar xvz -C ./ && mv ./rg "./$stripped"
+      echo "$url -> $stripped"
+      wget -qO- "$url" | tar xvz -C ./ && mv ./rg "./$stripped"
 
-		elif [ "$ext" = "zip" ]; then
-			stripped=${b%.zip}
-		else
-			echo "ERROR: unrecognized extension $ext"
-		fi
+    elif [ "$ext" = "zip" ]; then
+      stripped=${b%.zip}
 
-	done
+      echo "$url -> $stripped"
+      wget -q "$url"
+      unzip -q "$b"
+      mv "rg.exe" "./$stripped"
+      rm "$b"
+
+    else
+      echo "ERROR: unrecognized extension $ext"
+    fi
+
+  done
 }
 
 run

--- a/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
+++ b/client/cody/src/keyword-context/local-keyword-context-fetcher.ts
@@ -184,6 +184,7 @@ export class LocalKeywordContextFetcher implements KeywordContextFetcher {
         const proc = spawn(this.rgPath, ['-i', ...fileExtRipgrepParams, '--json', regexQuery, './'], {
             cwd: rootPath,
             stdio: ['ignore', 'pipe', process.stderr],
+            windowsHide: true,
         })
         const fileTermCounts: {
             [filename: string]: {


### PR DESCRIPTION
Closes #51685

This PR does three things:

- Adds the windows binaries for ripgrep to our builds
- Updates the ripgrep version to the latest build
- Ensures that the spawned window is hidden in Windows (using the [windowsHide]([nodejs.org/dist/latest/docs/api/child_process.html#child_process_child_process_spawn_command_args_options](https://nodejs.org/dist/latest/docs/api/child_process.html#child_process_child_process_spawn_command_args_options)) option)

With all of this, I’m happy to report that Windows now works with local context search 😎 

## Test plan

- Boot up your Windows machine of choice (or gaming rig, whatever you call it)
- Create a build of the extension on mac (`pnpm run vsce:package`)
- Find a way to move the `.vsix` file to Windows (iCloud etc.)
- Open a `C:\` folder in VS Code on Windows (to ensure you're not running in WSL mode) 
- Remove Cody from VS Code on Windows 
- Install from VSIX... and select the archive
- Ask it a question in an unindexed repo

<img width="510" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/458591/55a39a66-690c-462a-911e-1066d040a067">
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
