### PR TITLE
Cody: Fix flake in E2E setup

### DIFF
--- a/client/cody/test/e2e/auth.test.ts
+++ b/client/cody/test/e2e/auth.test.ts
@@ -8,6 +8,7 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
     await sidebar.getByRole('textbox', { name: 'Sourcegraph Instance URL' }).fill(SERVER_URL)
 
     await sidebar.getByRole('textbox', { name: 'Access Token (docs)' }).fill('test token')
+    console.log(await sidebar.textContent('body'))
     await sidebar.getByRole('button', { name: 'Sign In' }).click()
 
     await expect(sidebar.getByText('Invalid credentials')).toBeVisible()

--- a/client/cody/test/e2e/auth.test.ts
+++ b/client/cody/test/e2e/auth.test.ts
@@ -8,7 +8,6 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
     await sidebar.getByRole('textbox', { name: 'Sourcegraph Instance URL' }).fill(SERVER_URL)
 
     await sidebar.getByRole('textbox', { name: 'Access Token (docs)' }).fill('test token')
-    console.log(await sidebar.textContent('body'))
     await sidebar.getByRole('button', { name: 'Sign In' }).click()
 
     await expect(sidebar.getByText('Invalid credentials')).toBeVisible()

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -78,8 +78,9 @@ export const test = base
             await app.close()
 
             // Delete the recorded video if the test passes
+            console.log({ testInfo })
             if (testInfo.status === 'passed') {
-                rmdirSync(videoDirectory, { recursive: true })
+                // rmdirSync(videoDirectory, { recursive: true })
             }
 
             rmdirSync(userDataDirectory, { recursive: true })

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -95,6 +95,13 @@ export const test = base
 
 export async function getCodySidebar(page: Page): Promise<Frame> {
     async function findCodySidebarFrame(): Promise<null | Frame> {
+        console.log('### debug frames')
+        for (const frame of page.frames()) {
+            const title = await frame.title()
+            console.log('+ ' + title)
+        }
+        console.log('### /debug frames')
+
         for (const frame of page.frames()) {
             try {
                 const title = await frame.title()

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -56,6 +56,8 @@ export const test = base
 
             // Bring the cody sidebar to the foreground
             await page.click('[aria-label="Sourcegraph Cody"]')
+            // Ensure that we remove the hover from the activity icon
+            await page.getByRole('heading', { name: 'Sourcegraph Cody: Chat' }).hover()
             // Wait for Cody to become activated
             // TODO(philipp-spiess): Figure out which playwright matcher we can use that works for
             // the signed-in and signed-out cases
@@ -78,7 +80,6 @@ export const test = base
             await app.close()
 
             // Delete the recorded video if the test passes
-            console.log({ status: testInfo.status })
             if (testInfo.status === 'passed') {
                 rmdirSync(videoDirectory, { recursive: true })
             }

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -78,9 +78,9 @@ export const test = base
             await app.close()
 
             // Delete the recorded video if the test passes
-            console.log({ testInfo })
+            console.log({ status: testInfo.status })
             if (testInfo.status === 'passed') {
-                // rmdirSync(videoDirectory, { recursive: true })
+                rmdirSync(videoDirectory, { recursive: true })
             }
 
             rmdirSync(userDataDirectory, { recursive: true })
@@ -96,17 +96,6 @@ export const test = base
 
 export async function getCodySidebar(page: Page): Promise<Frame> {
     async function findCodySidebarFrame(): Promise<null | Frame> {
-        console.log('### debug frames')
-        for (const frame of page.frames()) {
-            try {
-                const title = await frame.title()
-                console.log('+ ' + title)
-            } catch (error: any) {
-                void error
-            }
-        }
-        console.log('### /debug frames')
-
         for (const frame of page.frames()) {
             try {
                 const title = await frame.title()

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -98,8 +98,12 @@ export async function getCodySidebar(page: Page): Promise<Frame> {
     async function findCodySidebarFrame(): Promise<null | Frame> {
         console.log('### debug frames')
         for (const frame of page.frames()) {
-            const title = await frame.title()
-            console.log('+ ' + title)
+            try {
+                const title = await frame.title()
+                console.log('+ ' + title)
+            } catch (error: any) {
+                void error
+            }
         }
         console.log('### /debug frames')
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -275,7 +275,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
-		bk.Cmd("until ! pnpm --filter cody-ai run test:e2e; do :; done"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
 		bk.ArtifactPaths("./playwright/**/*"),
 	)
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -275,17 +275,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
-		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("until ! pnpm --filter cody-ai run test:e2e; do :; done"),
 		bk.ArtifactPaths("./playwright/*"),
 	)
 }

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -276,7 +276,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
 		bk.Cmd("until ! pnpm --filter cody-ai run test:e2e; do :; done"),
-		bk.ArtifactPaths("./playwright/*"),
+		bk.ArtifactPaths("./playwright/**/*"),
 	)
 }
 

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -276,6 +276,16 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),
 		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
+		bk.Cmd("pnpm --filter cody-ai run test:e2e"),
 		bk.ArtifactPaths("./playwright/*"),
 	)
 }


### PR DESCRIPTION
This PR fixes an issue with the new Cody E2E setup occasionally failing. After some back and forth, it turns out that the tooltip on the activity icon for Cody was overlaying the log in button 😐 

<img width="525" alt="Screenshot 2023-05-23 at 10 29 57" src="https://github.com/sourcegraph/sourcegraph/assets/458591/fb80b10c-72bb-4d7b-a9ad-78b706e006d2">

As a side effect, this PR also fixes the video collection via artifacts. So now if a test is flaky, we can directly watch the recording. 💪 

## Test plan

- Test passes even with lots of retries (it ran flawlessly in a loop for >20 minutes)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
