### PR TITLE
own: add assigned owners to GraphQL API.

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -8,6 +8,7 @@ import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { Badge, Button, ButtonLink, Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 
 import {
+    AssignedOwnerFields,
     CodeownersFileEntryFields,
     OwnerFields,
     RecentContributorOwnershipSignalFields,
@@ -26,6 +27,7 @@ type OwnershipReason =
     | CodeownersFileEntryFields
     | RecentContributorOwnershipSignalFields
     | RecentViewOwnershipSignalFields
+    | AssignedOwnerFields
 
 export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons }) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(false)

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -78,6 +78,7 @@ export const FETCH_OWNERS = gql`
                                     ...CodeownersFileEntryFields
                                     ...RecentContributorOwnershipSignalFields
                                     ...RecentViewOwnershipSignalFields
+                                    ...AssignedOwnerFields
                                 }
                             }
                         }

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -41,10 +41,18 @@ export const RECENT_VIEW_FIELDS = gql`
     }
 `
 
+export const ASSIGNED_OWNER_FIELDS = gql`
+    fragment AssignedOwnerFields on AssignedOwner {
+        title
+        description
+    }
+`
+
 export const FETCH_OWNERS = gql`
     ${OWNER_FIELDS}
     ${RECENT_CONTRIBUTOR_FIELDS}
     ${RECENT_VIEW_FIELDS}
+    ${ASSIGNED_OWNER_FIELDS}
 
     fragment CodeownersFileEntryFields on CodeownersFileEntry {
         title

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -69,6 +69,7 @@ type OwnershipReasonResolver interface {
 	ToCodeownersFileEntry() (CodeownersFileEntryResolver, bool)
 	ToRecentContributorOwnershipSignal() (RecentContributorOwnershipSignalResolver, bool)
 	ToRecentViewOwnershipSignal() (RecentViewOwnershipSignalResolver, bool)
+	ToAssignedOwner() (AssignedOwnerResolver, bool)
 }
 
 type SimpleOwnReasonResolver interface {
@@ -89,6 +90,11 @@ type RecentContributorOwnershipSignalResolver interface {
 }
 
 type RecentViewOwnershipSignalResolver interface {
+	Title() (string, error)
+	Description() (string, error)
+}
+
+type AssignedOwnerResolver interface {
 	Title() (string, error)
 	Description() (string, error)
 }

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -127,7 +127,7 @@ enum OwnershipReasonType {
 """
 A union of all the different ownership reasons.
 """
-union OwnershipReason = CodeownersFileEntry | RecentContributorOwnershipSignal | RecentViewOwnershipSignal
+union OwnershipReason = CodeownersFileEntry | RecentContributorOwnershipSignal | RecentViewOwnershipSignal | AssignedOwner
 
 """
 A signal derived from recent code contributors.
@@ -161,6 +161,21 @@ type RecentViewOwnershipSignal {
 
 """
 The entity is an owner because they were mentioned on a codeowners file.
+"""
+type AssignedOwner {
+    """
+    Descriptive title to display in the UI for the determination.
+    """
+    title: String!
+
+    """
+    More detailed description to display in the UI for the determination.
+    """
+    description: String!
+}
+
+"""
+The entity is an owner because they were manually assigned as an owner.
 """
 type CodeownersFileEntry {
     """

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -92,6 +92,11 @@ func (o *ownershipReasonResolver) ToRecentContributorOwnershipSignal() (res grap
 }
 
 func (o *ownershipReasonResolver) ToRecentViewOwnershipSignal() (res graphqlbackend.RecentViewOwnershipSignalResolver, ok bool) {
+	res, ok = o.resolver.(*assignedOwner)
+	return
+}
+
+func (o *ownershipReasonResolver) ToAssignedOwner() (res graphqlbackend.AssignedOwnerResolver, ok bool) {
 	res, ok = o.resolver.(*recentViewOwnershipSignal)
 	return
 }
@@ -130,6 +135,13 @@ func (r *ownResolver) GitBlobOwnership(
 		return nil, err
 	}
 	ownerships = append(ownerships, viewerResolvers...)
+
+	// Retrieve assigned owners.
+	assignedOwners, err := r.computeAssignedOwners(ctx, r.logger, r.db, blob, repoID)
+	if err != nil {
+		return nil, err
+	}
+	ownerships = append(ownerships, assignedOwners...)
 
 	return r.ownershipConnection(args, ownerships)
 }
@@ -593,6 +605,71 @@ func computeRecentViewSignals(ctx context.Context, logger log.Logger, db edb.Ent
 			reasons: []*ownershipReasonResolver{
 				{
 					&recentViewOwnershipSignal{},
+				},
+			},
+		}
+		results = append(results, &res)
+	}
+	return results, nil
+}
+
+type assignedOwner struct {
+	total int32
+}
+
+func (a *assignedOwner) Title() (string, error) {
+	return "assigned owner", nil
+}
+
+func (a *assignedOwner) Description() (string, error) {
+	return "Owner is manually assigned.", nil
+}
+
+func (r *ownResolver) computeAssignedOwners(ctx context.Context, logger log.Logger, db edb.EnterpriseDB, blob *graphqlbackend.GitTreeEntryResolver, repoID api.RepoID) (results []*ownershipResolver, err error) {
+	assignedOwnership, err := r.ownService().AssignedOwnership(ctx, repoID, api.CommitID(blob.Commit().OID()))
+	if err != nil {
+		return nil, errors.Wrap(err, "computing assigned ownership")
+	}
+	assignedOwnerSummaries := assignedOwnership.Match(blob.Path())
+
+	fetchedUsers := make(map[int32]*types.User)
+	userEmails := make(map[int32]string)
+
+	for _, summary := range assignedOwnerSummaries {
+		var user *types.User
+		var email string
+		userID := summary.OwnerUserID
+		if fetchedUser, found := fetchedUsers[userID]; found {
+			user = fetchedUser
+			email = userEmails[userID]
+		} else {
+			userFromDB, err := db.Users().GetByID(ctx, userID)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting user")
+			}
+			primaryEmail, _, err := db.UserEmails().GetPrimaryEmail(ctx, userID)
+			if err != nil {
+				if errcode.IsNotFound(err) {
+					logger.Warn("Cannot find a primary email", log.Int32("userID", userID))
+				} else {
+					return nil, errors.Wrap(err, "getting user primary email")
+				}
+			}
+			user = userFromDB
+			email = primaryEmail
+			fetchedUsers[userID] = userFromDB
+			userEmails[userID] = primaryEmail
+		}
+		res := ownershipResolver{
+			db: db,
+			resolvedOwner: &codeowners.Person{
+				User:         user,
+				PrimaryEmail: &email,
+				Handle:       user.Username,
+			},
+			reasons: []*ownershipReasonResolver{
+				{
+					&assignedOwner{},
 				},
 			},
 		}

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -55,6 +55,8 @@ var (
 	_ graphqlbackend.SimpleOwnReasonResolver                  = &recentContributorOwnershipSignal{}
 	_ graphqlbackend.RecentViewOwnershipSignalResolver        = &recentViewOwnershipSignal{}
 	_ graphqlbackend.SimpleOwnReasonResolver                  = &recentViewOwnershipSignal{}
+	_ graphqlbackend.AssignedOwnerResolver                    = &assignedOwner{}
+	_ graphqlbackend.SimpleOwnReasonResolver                  = &assignedOwner{}
 	_ graphqlbackend.SimpleOwnReasonResolver                  = &codeownersFileEntryResolver{}
 )
 
@@ -92,18 +94,19 @@ func (o *ownershipReasonResolver) ToRecentContributorOwnershipSignal() (res grap
 }
 
 func (o *ownershipReasonResolver) ToRecentViewOwnershipSignal() (res graphqlbackend.RecentViewOwnershipSignalResolver, ok bool) {
-	res, ok = o.resolver.(*assignedOwner)
-	return
-}
-
-func (o *ownershipReasonResolver) ToAssignedOwner() (res graphqlbackend.AssignedOwnerResolver, ok bool) {
 	res, ok = o.resolver.(*recentViewOwnershipSignal)
 	return
 }
 
+func (o *ownershipReasonResolver) ToAssignedOwner() (res graphqlbackend.AssignedOwnerResolver, ok bool) {
+	res, ok = o.resolver.(*assignedOwner)
+	return
+}
+
 func (o *ownershipReasonResolver) makesAnOwner() bool {
-	_, ok := o.resolver.(*codeownersFileEntryResolver)
-	return ok
+	_, makesAnOwner := o.resolver.(*codeownersFileEntryResolver)
+	_, makesAnAssignedOwner := o.resolver.(*assignedOwner)
+	return makesAnOwner || makesAnAssignedOwner
 }
 
 func (r *ownResolver) GitBlobOwnership(

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -38,6 +38,11 @@ import (
 	codeownerspb "github.com/sourcegraph/sourcegraph/enterprise/internal/own/codeowners/v1"
 )
 
+const (
+	santaEmail = "santa@northpole.com"
+	santaName  = "santa claus"
+)
+
 // userCtx returns a context where give user ID identifies logged in user.
 func userCtx(userID int32) context.Context {
 	ctx := context.Background()
@@ -47,7 +52,8 @@ func userCtx(userID int32) context.Context {
 
 // fakeOwnService returns given owners file and resolves owners to UnknownOwner.
 type fakeOwnService struct {
-	Ruleset *codeowners.Ruleset
+	Ruleset        *codeowners.Ruleset
+	AssignedOwners own.AssignedOwners
 }
 
 func (s fakeOwnService) RulesetForRepo(context.Context, api.RepoName, api.RepoID, api.CommitID) (*codeowners.Ruleset, error) {
@@ -69,7 +75,7 @@ func (s fakeOwnService) ResolveOwnersWithType(_ context.Context, owners []*codeo
 }
 
 func (s fakeOwnService) AssignedOwnership(context.Context, api.RepoID, api.CommitID) (own.AssignedOwners, error) {
-	return own.AssignedOwners{}, nil
+	return s.AssignedOwners, nil
 }
 
 // fakeGitServer is a limited gitserver.Client that returns a file for every Stat call.
@@ -619,8 +625,6 @@ func TestOwnership_WithSignals(t *testing.T) {
 	db := fakeOwnDb()
 
 	recentContribStore := database.NewMockRecentContributionSignalStore()
-	santaEmail := "santa@northpole.com"
-	santaName := "santa claus"
 	recentContribStore.FindRecentAuthorsFunc.SetDefaultReturn([]database.RecentContributorSummary{{
 		AuthorName:        santaName,
 		AuthorEmail:       santaEmail,
@@ -787,8 +791,6 @@ func TestTreeOwnershipSignals(t *testing.T) {
 	db := fakeOwnDb()
 
 	recentContribStore := database.NewMockRecentContributionSignalStore()
-	santaEmail := "santa@northpole.com"
-	santaName := "santa claus"
 	recentContribStore.FindRecentAuthorsFunc.SetDefaultReturn([]database.RecentContributorSummary{{
 		AuthorName:        santaName,
 		AuthorEmail:       santaEmail,
@@ -1226,5 +1228,173 @@ func Test_SignalConfigurations(t *testing.T) {
 		}`
 
 		graphqlbackend.RunTest(t, mutationTest)
+	})
+}
+
+func TestOwnership_WithAssignedOwners(t *testing.T) {
+	logger := logtest.Scoped(t)
+	fakeDB := fakedb.New()
+	db := fakeOwnDb()
+
+	userEmails := database.NewMockUserEmailsStore()
+	userEmails.GetPrimaryEmailFunc.SetDefaultHook(func(_ context.Context, id int32) (email string, verified bool, err error) {
+		verified = true
+		switch id {
+		case 1:
+			email = "assigned@owner1.com"
+		case 2:
+			email = "assigned@owner2.com"
+		default:
+			email = santaEmail
+		}
+		return
+	})
+	db.UserEmailsFunc.SetDefaultReturn(userEmails)
+
+	fakeDB.Wire(db)
+	repoID := api.RepoID(1)
+	assignedOwnerID1 := fakeDB.AddUser(types.User{Username: "assigned owner 1", DisplayName: "I am an assigned owner #1"})
+	assignedOwnerID2 := fakeDB.AddUser(types.User{Username: "assigned owner 2", DisplayName: "I am an assigned owner #2"})
+	own := fakeOwnService{
+		Ruleset: codeowners.NewRuleset(
+			codeowners.IngestedRulesetSource{ID: int32(repoID)},
+			&codeownerspb.File{
+				Rule: []*codeownerspb.Rule{
+					{
+						Pattern: "*.js",
+						Owner: []*codeownerspb.Owner{
+							{Handle: "js-owner"},
+						},
+						LineNumber: 1,
+					},
+				},
+			},
+		),
+		AssignedOwners: own.AssignedOwners{
+			"foo/bar.js": []database.AssignedOwnerSummary{{OwnerUserID: assignedOwnerID1, FilePath: "foo/bar.js", RepoID: repoID}},
+			"foo":        []database.AssignedOwnerSummary{{OwnerUserID: assignedOwnerID2, FilePath: "foo", RepoID: repoID}},
+		},
+	}
+	ctx := userCtx(fakeDB.AddUser(types.User{Username: santaName, DisplayName: santaName, SiteAdmin: true}))
+	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
+	repos := database.NewMockRepoStore()
+	db.ReposFunc.SetDefaultReturn(repos)
+	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
+	backend.Mocks.Repos.ResolveRev = func(_ context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
+		return "deadbeef", nil
+	}
+	git := fakeGitserver{}
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Schema:  schema,
+		Context: ctx,
+		Query: `
+			fragment CodeownersFileEntryFields on CodeownersFileEntry {
+				title
+				description
+				codeownersFile {
+					__typename
+					url
+				}
+				ruleLineMatch
+			}
+
+			query FetchOwnership($repo: ID!, $revision: String!, $currentPath: String!) {
+				node(id: $repo) {
+					... on Repository {
+						commit(rev: $revision) {
+							blob(path: $currentPath) {
+								ownership {
+									totalOwners
+									totalCount
+									nodes {
+										owner {
+											...on Person {
+												displayName
+												email
+											}
+										}
+										reasons {
+											...CodeownersFileEntryFields
+											...on RecentContributorOwnershipSignal {
+											  title
+											  description
+											}
+											... on RecentViewOwnershipSignal {
+											  title
+											  description
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}`,
+		ExpectedResult: `{
+			"node": {
+				"commit": {
+					"blob": {
+						"ownership": {
+							"totalOwners": 1,
+							"totalCount": 3,
+							"nodes": [
+								{
+									"owner": {
+										"displayName": "js-owner",
+										"email": ""
+									},
+									"reasons": [
+										{
+											"title": "codeowners",
+											"description": "Owner is associated with a rule in a CODEOWNERS file.",
+											"codeownersFile": {
+												"__typename": "VirtualFile",
+												"url": "/github.com/sourcegraph/own/-/own"
+											},
+											"ruleLineMatch": 1
+										}
+									]
+								},
+								{
+									"owner": {
+										"displayName": "I am an assigned owner #1",
+										"email": "assigned@owner1.com"
+									},
+									"reasons": [
+										{
+											"title": "assigned owner",
+											"description": "Owner is manually assigned."
+										}
+									]
+								},
+								{
+									"owner": {
+										"displayName": "I am an assigned owner #2",
+										"email": "assigned@owner2.com"
+									},
+									"reasons": [
+										{
+											"title": "assigned owner",
+											"description": "Owner is manually assigned."
+										}
+									]
+								}
+							]
+						}
+					}
+				}
+			}
+		}`,
+		Variables: map[string]any{
+			"repo":        string(relay.MarshalID("Repository", repoID)),
+			"revision":    "revision",
+			"currentPath": "foo/bar.js",
+		},
 	})
 }


### PR DESCRIPTION
I tried to keep the diff as small as possible.
I'll surface other assigned owner data and wire up API with UI in a next PR.

Test plan:
GraphQL tests added.

First part of https://github.com/sourcegraph/sourcegraph/issues/52134