### PR TITLE
Setup: Clean up old setup links and new setup page 

### DIFF
--- a/client/web/src/enterprise/app/settings/AppSettingsArea.tsx
+++ b/client/web/src/enterprise/app/settings/AppSettingsArea.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 import { Routes, Route, Outlet, Navigate, useLocation } from 'react-router-dom'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, H2, Link, PageHeader } from '@sourcegraph/wildcard'
+import { Button, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import { RemoteRepositoriesStep } from '../../../setup-wizard/components'
 
@@ -13,7 +13,6 @@ import styles from './AppSettingsArea.module.scss'
 
 enum AppSettingURL {
     LocalRepositories = 'local-repositories',
-    ConnectToSourcegraphDotCom = 'connect-to-dot-com',
     RemoteRepositories = 'remote-repositories',
 }
 
@@ -25,11 +24,6 @@ export const AppSettingsArea: FC<TelemetryProps> = ({ telemetryService }) => (
                 path={`${AppSettingURL.RemoteRepositories}/*`}
                 element={<RemoteRepositoriesTab telemetryService={telemetryService} />}
             />
-            <Route
-                path={AppSettingURL.ConnectToSourcegraphDotCom}
-                element={<H2>Hello Connect to sourcegraph.com</H2>}
-            />
-
             <Route path="*" element={<Navigate to={AppSettingURL.LocalRepositories} replace={true} />} />
         </Route>
     </Routes>
@@ -43,7 +37,6 @@ interface AppSetting {
 const APP_SETTINGS: AppSetting[] = [
     { url: AppSettingURL.LocalRepositories, name: 'Local repositories' },
     { url: AppSettingURL.RemoteRepositories, name: 'Remote repositories' },
-    { url: AppSettingURL.ConnectToSourcegraphDotCom, name: 'Connect sourcegraph.com' },
 ]
 
 const AppSettingsLayout: FC = () => {

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -146,11 +146,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 Saved searches
                             </MenuLink>
                             {isSourcegraphApp && (
-                                <MenuLink as={Link} to="/setup">
-                                    Setup wizard
-                                </MenuLink>
-                            )}
-                            {isSourcegraphApp && (
                                 <MenuLink as={Link} to="/site-admin/repositories">
                                     Repositories
                                 </MenuLink>

--- a/client/web/src/user/area/navitems.ts
+++ b/client/web/src/user/area/navitems.ts
@@ -10,7 +10,7 @@ import { UserAreaHeaderNavItem } from './UserAreaHeader'
 export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
     {
         to: '/app-settings',
-        label: 'Cody settings',
+        label: 'Repositories',
         icon: CodyIcon,
         condition: ({ isSourcegraphApp }) => isSourcegraphApp,
     },


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/52124

## Test plan
- Make sure that you can't see the setup wizard item in the user menu
- Check that the new setup page doesn't have any blank tabs (it should have only local and remote repositories tabs)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
