### PR TITLE
cody: don't search for file paths if no file paths to validate

### DIFF
--- a/client/cody/src/chat/utils.ts
+++ b/client/cody/src/chat/utils.ts
@@ -31,7 +31,13 @@ function filePathContains(container: string, contained: string): boolean {
 }
 
 export async function filesExist(filePaths: string[]): Promise<{ [filePath: string]: boolean }> {
+    if (filePaths.length === 0) {
+        return {}
+    }
+    const { debug } = await import('../log')
+
     const searchPath = `{${filePaths.join(',')}}`
+    debug('ChatViewProvider:filesExist', `searchPath: ${searchPath}`)
     const realFiles = await vscode.workspace.findFiles(searchPath, null, filePaths.length * 5)
     const ret: { [filePath: string]: boolean } = {}
     for (const filePath of filePaths) {


### PR DESCRIPTION
This fixes a performance regression where all messages appear to hang while file paths are validated, even ones that don't include any file paths to validate.

## Test plan

Tested locally