### PR TITLE
Expose new domain property on github_app nodes

### DIFF
--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -36,6 +36,7 @@ type GitHubAppResolver interface {
 	ID() graphql.ID
 	AppID() int32
 	Name() string
+	Domain() string
 	Slug() string
 	BaseURL() string
 	AppURL() string

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -52,7 +52,7 @@ type GitHubApp implements Node {
     """
     name: String!
     """
-    The domain of the GitHub App, ie: repos or batches
+    The domain of the GitHub App (e.g. "repos" or "batches")
     """
     domain: String!
     """

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -52,6 +52,10 @@ type GitHubApp implements Node {
     """
     name: String!
     """
+    The domain of the GitHub App, ie: repo or batches
+    """
+    domain: String!
+    """
     The slug of the GitHub App
     """
     slug: String!

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -52,7 +52,7 @@ type GitHubApp implements Node {
     """
     name: String!
     """
-    The domain of the GitHub App, ie: repo or batches
+    The domain of the GitHub App, ie: repos or batches
     """
     domain: String!
     """

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -187,6 +187,10 @@ func (r *gitHubAppResolver) Name() string {
 	return r.app.Name
 }
 
+func (r *gitHubAppResolver) Domain() string {
+	return r.app.Domain
+}
+
 func (r *gitHubAppResolver) Slug() string {
 	return r.app.Slug
 }

--- a/enterprise/internal/github_apps/store/store.go
+++ b/enterprise/internal/github_apps/store/store.go
@@ -88,10 +88,10 @@ func (s *gitHubAppsStore) Create(ctx context.Context, app *types.GitHubApp) (int
 	}
 
 	query := sqlf.Sprintf(`INSERT INTO
-	    github_apps (app_id, name, slug, base_url, app_url, client_id, client_secret, private_key, encryption_key_id, logo)
-    	VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+	    github_apps (app_id, name, domain, slug, base_url, app_url, client_id, client_secret, private_key, encryption_key_id, logo)
+    	VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
 		RETURNING id`,
-		app.AppID, app.Name, app.Slug, app.BaseURL, app.AppURL, app.ClientID, clientSecret, privateKey, keyID, app.Logo)
+		app.AppID, app.Name, app.Domain, app.Slug, app.BaseURL, app.AppURL, app.ClientID, clientSecret, privateKey, keyID, app.Logo)
 	id, _, err := basestore.ScanFirstInt(s.Query(ctx, query))
 	return id, err
 }
@@ -109,6 +109,7 @@ func scanGitHubApp(s dbutil.Scanner) (*types.GitHubApp, error) {
 		&app.ID,
 		&app.AppID,
 		&app.Name,
+		&app.Domain,
 		&app.Slug,
 		&app.BaseURL,
 		&app.AppURL,
@@ -160,10 +161,10 @@ func (s *gitHubAppsStore) Update(ctx context.Context, id int, app *types.GitHubA
 	}
 
 	query := sqlf.Sprintf(`UPDATE github_apps
-             SET app_id = %s, name = %s, slug = %s, base_url = %s, app_url = %s, client_id = %s, client_secret = %s, webhook_id = %d, private_key = %s, encryption_key_id = %s, logo = %s, updated_at = NOW()
+             SET app_id = %s, name = %s, domain = %s, slug = %s, base_url = %s, app_url = %s, client_id = %s, client_secret = %s, webhook_id = %d, private_key = %s, encryption_key_id = %s, logo = %s, updated_at = NOW()
              WHERE id = %s
-			 RETURNING id, app_id, name, slug, base_url, app_url, client_id, client_secret, webhook_id, private_key, encryption_key_id, logo, created_at, updated_at`,
-		app.AppID, app.Name, app.Slug, app.BaseURL, app.AppURL, app.ClientID, clientSecret, app.WebhookID, privateKey, keyID, app.Logo, id)
+			 RETURNING id, app_id, name, domain, slug, base_url, app_url, client_id, client_secret, webhook_id, private_key, encryption_key_id, logo, created_at, updated_at`,
+		app.AppID, app.Name, app.Domain, app.Slug, app.BaseURL, app.AppURL, app.ClientID, clientSecret, app.WebhookID, privateKey, keyID, app.Logo, id)
 	app, ok, err := scanFirstGitHubApp(s.Query(ctx, query))
 	if err != nil {
 		return nil, err
@@ -183,6 +184,7 @@ func (s *gitHubAppsStore) get(ctx context.Context, where *sqlf.Query) (*types.Gi
 		id,
 		app_id,
 		name,
+		domain,
 		slug,
 		base_url,
 		app_url,
@@ -218,6 +220,7 @@ func (s *gitHubAppsStore) list(ctx context.Context, where *sqlf.Query) ([]*types
 		id,
 		app_id,
 		name,
+		domain,
 		slug,
 		base_url,
 		app_url,

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -27,7 +27,7 @@ func TestCreateGitHubApp(t *testing.T) {
 	app := &types.GitHubApp{
 		AppID:        1,
 		Name:         "Test App",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app",
 		ClientID:     "abc123",
 		ClientSecret: "secret",
@@ -69,7 +69,7 @@ func TestDeleteGitHubApp(t *testing.T) {
 
 	app := &types.GitHubApp{
 		Name:         "Test App",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app",
 		ClientID:     "abc123",
 		ClientSecret: "secret",
@@ -105,7 +105,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 	app := &types.GitHubApp{
 		AppID:        123,
 		Name:         "Test App",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app",
 		BaseURL:      "https://example.com",
 		AppURL:       "https://example.com/apps/testapp",
@@ -123,7 +123,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 	updated := &types.GitHubApp{
 		AppID:        234,
 		Name:         "Updated Name",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "updated-slug",
 		BaseURL:      "https://updated-example.com",
 		AppURL:       "https://updated-example.com/apps/updated-app",
@@ -164,7 +164,7 @@ func TestGetByID(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app-1",
 		BaseURL:      "https://github.com",
 		AppURL:       "https://github.com/apps/testapp",
@@ -177,7 +177,7 @@ func TestGetByID(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        5678,
 		Name:         "Test App 2",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app-2",
 		BaseURL:      "https://enterprise.github.com",
 		AppURL:       "https://enterprise.github.com/apps/testapp",
@@ -227,7 +227,7 @@ func TestGetByAppID(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app-1",
 		BaseURL:      "https://github.com",
 		ClientID:     "abc123",
@@ -239,7 +239,7 @@ func TestGetByAppID(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 2",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app-2",
 		BaseURL:      "https://enterprise.github.com",
 		ClientID:     "abc123",
@@ -289,7 +289,7 @@ func TestGetBySlug(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app",
 		BaseURL:      "https://github.com",
 		AppURL:       "https://github.com/apps/testapp1",
@@ -302,7 +302,7 @@ func TestGetBySlug(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        5678,
 		Name:         "Test App",
-		Domain:       "repo",
+		Domain:       "repos",
 		Slug:         "test-app",
 		BaseURL:      "https://enterprise.github.com",
 		AppURL:       "https://enterprise.github.com/apps/testapp",

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -27,6 +27,7 @@ func TestCreateGitHubApp(t *testing.T) {
 	app := &types.GitHubApp{
 		AppID:        1,
 		Name:         "Test App",
+		Domain:       "repo",
 		Slug:         "test-app",
 		ClientID:     "abc123",
 		ClientSecret: "secret",
@@ -39,10 +40,11 @@ func TestCreateGitHubApp(t *testing.T) {
 	require.NoError(t, err)
 
 	var createdApp types.GitHubApp
-	query := sqlf.Sprintf(`SELECT app_id, name, slug, base_url, app_url, client_id, client_secret, private_key, encryption_key_id, logo FROM github_apps WHERE id=%s`, id)
+	query := sqlf.Sprintf(`SELECT app_id, name, domain, slug, base_url, app_url, client_id, client_secret, private_key, encryption_key_id, logo FROM github_apps WHERE id=%s`, id)
 	err = store.QueryRow(ctx, query).Scan(
 		&createdApp.AppID,
 		&createdApp.Name,
+		&createdApp.Domain,
 		&createdApp.Slug,
 		&createdApp.BaseURL,
 		&createdApp.AppURL,
@@ -67,6 +69,7 @@ func TestDeleteGitHubApp(t *testing.T) {
 
 	app := &types.GitHubApp{
 		Name:         "Test App",
+		Domain:       "repo",
 		Slug:         "test-app",
 		ClientID:     "abc123",
 		ClientSecret: "secret",
@@ -102,6 +105,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 	app := &types.GitHubApp{
 		AppID:        123,
 		Name:         "Test App",
+		Domain:       "repo",
 		Slug:         "test-app",
 		BaseURL:      "https://example.com",
 		AppURL:       "https://example.com/apps/testapp",
@@ -119,6 +123,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 	updated := &types.GitHubApp{
 		AppID:        234,
 		Name:         "Updated Name",
+		Domain:       "repo",
 		Slug:         "updated-slug",
 		BaseURL:      "https://updated-example.com",
 		AppURL:       "https://updated-example.com/apps/updated-app",
@@ -134,6 +139,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 
 	require.Equal(t, updated.AppID, fetched.AppID)
 	require.Equal(t, updated.Name, fetched.Name)
+	require.Equal(t, updated.Domain, fetched.Domain)
 	require.Equal(t, updated.Slug, fetched.Slug)
 	require.Equal(t, updated.BaseURL, fetched.BaseURL)
 	require.Equal(t, updated.ClientID, fetched.ClientID)
@@ -158,6 +164,7 @@ func TestGetByID(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
+		Domain:       "repo",
 		Slug:         "test-app-1",
 		BaseURL:      "https://github.com",
 		AppURL:       "https://github.com/apps/testapp",
@@ -170,6 +177,7 @@ func TestGetByID(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        5678,
 		Name:         "Test App 2",
+		Domain:       "repo",
 		Slug:         "test-app-2",
 		BaseURL:      "https://enterprise.github.com",
 		AppURL:       "https://enterprise.github.com/apps/testapp",
@@ -188,6 +196,7 @@ func TestGetByID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, app1.AppID, fetched.AppID)
 	require.Equal(t, app1.Name, fetched.Name)
+	require.Equal(t, app1.Domain, fetched.Domain)
 	require.Equal(t, app1.Slug, fetched.Slug)
 	require.Equal(t, app1.BaseURL, fetched.BaseURL)
 	require.Equal(t, app1.ClientID, fetched.ClientID)
@@ -218,6 +227,7 @@ func TestGetByAppID(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
+		Domain:       "repo",
 		Slug:         "test-app-1",
 		BaseURL:      "https://github.com",
 		ClientID:     "abc123",
@@ -229,6 +239,7 @@ func TestGetByAppID(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 2",
+		Domain:       "repo",
 		Slug:         "test-app-2",
 		BaseURL:      "https://enterprise.github.com",
 		ClientID:     "abc123",
@@ -246,6 +257,7 @@ func TestGetByAppID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, app1.AppID, fetched.AppID)
 	require.Equal(t, app1.Name, fetched.Name)
+	require.Equal(t, app1.Domain, fetched.Domain)
 	require.Equal(t, app1.Slug, fetched.Slug)
 	require.Equal(t, app1.BaseURL, fetched.BaseURL)
 	require.Equal(t, app1.ClientID, fetched.ClientID)
@@ -277,6 +289,7 @@ func TestGetBySlug(t *testing.T) {
 	app1 := &types.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
+		Domain:       "repo",
 		Slug:         "test-app",
 		BaseURL:      "https://github.com",
 		AppURL:       "https://github.com/apps/testapp1",
@@ -289,6 +302,7 @@ func TestGetBySlug(t *testing.T) {
 	app2 := &types.GitHubApp{
 		AppID:        5678,
 		Name:         "Test App",
+		Domain:       "repo",
 		Slug:         "test-app",
 		BaseURL:      "https://enterprise.github.com",
 		AppURL:       "https://enterprise.github.com/apps/testapp",
@@ -307,6 +321,7 @@ func TestGetBySlug(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, app1.AppID, fetched.AppID)
 	require.Equal(t, app1.Name, fetched.Name)
+	require.Equal(t, app1.Domain, fetched.Domain)
 	require.Equal(t, app1.Slug, fetched.Slug)
 	require.Equal(t, app1.BaseURL, fetched.BaseURL)
 	require.Equal(t, app1.ClientID, fetched.ClientID)

--- a/enterprise/internal/github_apps/types/types.go
+++ b/enterprise/internal/github_apps/types/types.go
@@ -7,6 +7,7 @@ type GitHubApp struct {
 	ID            int
 	AppID         int
 	Name          string
+	Domain        string
 	Slug          string
 	BaseURL       string
 	AppURL        string


### PR DESCRIPTION
Closes #52270
Exposes new `domain` property from #52268

## Test plan
- Make sure there is a GitHub App on your instance
- In the API Console ensure the following query doesn't fail and returns the `domain` property:
```
query {
  gitHubApps {
    nodes {
      name
      domain
    }
  }
}
````