### PR TITLE
Revert "app-release: force stateless queue for github release step (#52228)"

### DIFF
--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -62,7 +62,6 @@ steps:
       - label: "wait for bundles to complete"
         wait: ~
       - label: ':github: Create GitHub release'
-        agent: { queue: stateless }
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'

--- a/enterprise/dev/app/create-github-release.sh
+++ b/enterprise/dev/app/create-github-release.sh
@@ -18,12 +18,14 @@ else
   exit 1
 fi
 
+echo "--- :aws: fetching GitHub Token"
+token=$(aws secretsmanager get-secret-value --secret-id sourcegraph/mac/github-token | jq '.SecretString |  fromjson | .token')
+export GITHUB_TOKEN=${token}
+
 VERSION=$(./enterprise/dev/app/app_version.sh)
 echo "--- :github: Creating GitHub release for Sourcegraph App (${VERSION})"
 echo "Release will have to following assets:"
 ls -al ./dist
-
-# On CI it is assumed this command runs in a stateless agent, where the GITHUB_TOKEN is injected
 gh release create "app-v${VERSION}" \
   --prerelease \
   --draft \


### PR DESCRIPTION
This reverts commit a52296cc49247f6a16a9009f199ef1400d96aaaf - which broke the app release pipeline:

```
$ trap 'kill -- $' INT TERM QUIT; buildkite-agent pipeline upload .buildkite/pipeline.app.yml
--
  | 2023-05-22 18:52:04 INFO   Reading pipeline config from ".buildkite/pipeline.app.yml"
  | 2023-05-22 18:52:04 INFO   Updating BUILDKITE_COMMIT to "0d43a156081ffe2fca34c912a4a575c77440c66f"
  | 2023-05-22 18:52:05 WARN   POST https://agent.buildkite.com/v3/jobs/018844cc-f041-44a4-9ceb-6863943f1473/pipelines: 422 `agent` is not a valid property on the `command` step, perhaps you meant `agents`? (Attempt 1/60 Retrying in 5s)
  | 2023-05-22 18:52:05 ERROR  Unrecoverable error, skipping retries
  | 2023-05-22 18:52:05 FATAL  Failed to upload and process pipeline: POST https://agent.buildkite.com/v3/jobs/018844cc-f041-44a4-9ceb-6863943f1473/pipelines: 422 `agent` is not a valid property on the `command` step, perhaps you meant `agents`?
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1
  |  

<br class="Apple-interchange-newline">
```

## Test plan

It worked before, so reverting.
