### PR TITLE
Cody: remove non-backwards-compatible fields

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -32,16 +32,12 @@ export const SEARCH_EMBEDDINGS_QUERY = `
 query EmbeddingsSearch($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {
 	embeddingsMultiSearch(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {
 		codeResults {
-            repoName
-            revision
 			fileName
 			startLine
 			endLine
 			content
 		}
 		textResults {
-            repoName
-            revision
 			fileName
 			startLine
 			endLine


### PR DESCRIPTION
This removes fields that do not exist in older versions of Sourcegraph. In the Typescript types, these fields are marked optional, so everything should work as expected. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
