### PR TITLE
migrations: Fix failed downgrade status

### DIFF
--- a/internal/database/migration/store/BUILD.bazel
+++ b/internal/database/migration/store/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//internal/database/migration/definition",
         "//internal/database/migration/shared",
         "//internal/observation",
+        "//internal/timeutil",
         "@com_github_google_go_cmp//cmp",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_keegancsmith_sqlf//:sqlf",

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -270,7 +270,11 @@ WITH ranked_migration_logs AS (
 		migration_logs.*,
 		ROW_NUMBER() OVER (PARTITION BY version ORDER BY backfilled, started_at DESC) AS row_number
 	FROM migration_logs
-	WHERE schema = %s
+	WHERE schema = %s AND NOT (
+		NOT up AND
+		NOT SUCCESS AND
+		finished_at IS NOT NULL
+	)
 )
 SELECT
 	schema,

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -270,11 +270,16 @@ WITH ranked_migration_logs AS (
 		migration_logs.*,
 		ROW_NUMBER() OVER (PARTITION BY version ORDER BY backfilled, started_at DESC) AS row_number
 	FROM migration_logs
-	WHERE schema = %s AND NOT (
-		NOT up AND
-		NOT SUCCESS AND
-		finished_at IS NOT NULL
-	)
+	WHERE
+		schema = %s AND
+		-- Filter out failed reverts, which should have no visible effect but are
+		-- a common occurrence in development. We don't allow CIC in downgrades
+		-- therefore all reverts are applied in a txn.
+		NOT (
+			NOT up AND
+			NOT SUCCESS AND
+			finished_at IS NOT NULL
+		)
 )
 SELECT
 	schema,

--- a/internal/database/migration/store/store.go
+++ b/internal/database/migration/store/store.go
@@ -277,7 +277,7 @@ WITH ranked_migration_logs AS (
 		-- therefore all reverts are applied in a txn.
 		NOT (
 			NOT up AND
-			NOT SUCCESS AND
+			NOT success AND
 			finished_at IS NOT NULL
 		)
 )


### PR DESCRIPTION
Filter non-pending, non-successful reverts from the list of current versions. Since downgrades are atomic (we don't allow CIC and all downgrades are applied in transaction) these should be safely ignorable and are *rampant* in development.

Fixes #52311.

## Test plan

Updated unit tests.