### PR TITLE
Fix handling of embeddings api backward compatibility for vs code

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -66,7 +66,7 @@ export async function createClient({
         )
     }
 
-    const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId) : null
+    const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId, true) : null
 
     const codebaseContext = new CodebaseContext(config, config.codebase, embeddingsSearch, null)
 

--- a/client/cody-shared/src/embeddings/client.ts
+++ b/client/cody-shared/src/embeddings/client.ts
@@ -3,7 +3,7 @@ import { SourcegraphGraphQLAPIClient, EmbeddingsSearchResults } from '../sourceg
 import { EmbeddingsSearch } from '.'
 
 export class SourcegraphEmbeddingsSearchClient implements EmbeddingsSearch {
-    constructor(private client: SourcegraphGraphQLAPIClient, private repoId: string, private web: boolean = true) {}
+    constructor(private client: SourcegraphGraphQLAPIClient, private repoId: string, private web: boolean = false) {}
 
     public async search(
         query: string,

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -46,8 +46,7 @@ export async function configureExternalServices(
             'Please check that the repository exists and is entered correctly in the cody.codebase setting.'
         console.info(infoMessage)
     }
-    const embeddingsSearch =
-        repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId, false) : null
+    const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null
 
     const codebaseContext = new CodebaseContext(
         initialConfig,


### PR DESCRIPTION
Flip logic to check for web and enable it only inside the web client which is not shared.  

<img width="545" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/22571395/6cbdb041-1375-46c5-a7d2-34043db2dfab">


## Test plan

- install latest version of vs code and test it against this API. It should work with cody replies containing links to context files.