### PR TITLE
gitserver: Move GitDir into common package

### DIFF
--- a/cmd/gitserver/server/common/common.go
+++ b/cmd/gitserver/server/common/common.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// GitDir is an absolute path to a GIT_DIR.
+// They will all follow the form:
+//
+//	${s.ReposDir}/${name}/.git
+type GitDir string
+
+// Path is a helper which returns filepath.Join(dir, elem...)
+func (dir GitDir) Path(elem ...string) string {
+	return filepath.Join(append([]string{string(dir)}, elem...)...)
+}
+
+// Set updates cmd so that it will run in dir.
+//
+// Note: GitDir is always a valid GIT_DIR, so we additionally set the
+// environment variable GIT_DIR. This is to avoid git doing discovery in case
+// of a bad repo, leading to hard to diagnose error messages.
+func (dir GitDir) Set(cmd *exec.Cmd) {
+	cmd.Dir = string(dir)
+	if cmd.Env == nil {
+		// Do not strip out existing env when setting.
+		cmd.Env = os.Environ()
+	}
+	cmd.Env = append(cmd.Env, "GIT_DIR="+string(dir))
+}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -185,7 +186,7 @@ func TestExecRequest(t *testing.T) {
 	h := s.Handler()
 
 	origRepoCloned := repoCloned
-	repoCloned = func(dir GitDir) bool {
+	repoCloned = func(dir common.GitDir) bool {
 		return dir == s.dir("github.com/gorilla/mux") || dir == s.dir("my-mux")
 	}
 	t.Cleanup(func() { repoCloned = origRepoCloned })
@@ -338,7 +339,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 	tmp := b.TempDir()
 
 	dir := filepath.Join(tmp, ".git")
-	gitDir := GitDir(dir)
+	gitDir := common.GitDir(dir)
 	if err := os.Mkdir(dir, 0o700); err != nil {
 		b.Fatal(err)
 	}
@@ -412,7 +413,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) 
 	tmp := b.TempDir()
 
 	dir := filepath.Join(tmp, ".git")
-	gitDir := GitDir(dir)
+	gitDir := common.GitDir(dir)
 	if err := os.Mkdir(dir, 0o700); err != nil {
 		b.Fatal(err)
 	}
@@ -1140,7 +1141,7 @@ func TestHandleRepoUpdateFromShard(t *testing.T) {
 
 func TestRemoveBadRefs(t *testing.T) {
 	dir := t.TempDir()
-	gitDir := GitDir(filepath.Join(dir, ".git"))
+	gitDir := common.GitDir(filepath.Join(dir, ".git"))
 
 	cmd := func(name string, arg ...string) string {
 		t.Helper()
@@ -1232,7 +1233,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		_ = makeSingleCommitRepo(cmd)
 		s := makeTestServer(ctx, t, reposDir, remote, nil)
 
-		testRepoCorrupter = func(_ context.Context, tmpDir GitDir) {
+		testRepoCorrupter = func(_ context.Context, tmpDir common.GitDir) {
 			if err := os.Remove(tmpDir.Path("HEAD")); err != nil {
 				t.Fatal(err)
 			}
@@ -1272,7 +1273,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		_ = makeSingleCommitRepo(cmd)
 		s := makeTestServer(ctx, t, reposDir, remote, nil)
 
-		testRepoCorrupter = func(_ context.Context, tmpDir GitDir) {
+		testRepoCorrupter = func(_ context.Context, tmpDir common.GitDir) {
 			cmd("sh", "-c", fmt.Sprintf(": > %s/HEAD", tmpDir))
 		}
 		t.Cleanup(func() { testRepoCorrupter = nil })
@@ -1464,7 +1465,7 @@ type BatchLogTest struct {
 
 func TestHandleBatchLog(t *testing.T) {
 	originalRepoCloned := repoCloned
-	repoCloned = func(dir GitDir) bool {
+	repoCloned = func(dir common.GitDir) bool {
 		return dir == "github.com/foo/bar/.git" || dir == "github.com/foo/baz/.git" || dir == "github.com/foo/bonk/.git"
 	}
 	t.Cleanup(func() { repoCloned = originalRepoCloned })

--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
@@ -90,7 +91,7 @@ func (s *vcsPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	}
 
 	// The Fetch method is responsible for cleaning up temporary directories.
-	if _, err := s.Fetch(ctx, remoteURL, GitDir(bareGitDirectory), ""); err != nil {
+	if _, err := s.Fetch(ctx, remoteURL, common.GitDir(bareGitDirectory), ""); err != nil {
 		return nil, errors.Wrapf(err, "failed to fetch repo for %s", remoteURL)
 	}
 
@@ -98,7 +99,7 @@ func (s *vcsPackagesSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL
 	return exec.CommandContext(ctx, "git", "--version"), nil
 }
 
-func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error) {
+func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
 	var pkg reposource.Package
 	pkg, err := s.source.ParsePackageFromRepoName(api.RepoName(remoteURL.Path))
 	if err != nil {
@@ -122,7 +123,7 @@ func (s *vcsPackagesSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir G
 // existingVersions. If download and upserting the new version into database
 // succeeds, it calls s.fetchVersions with the newly-added version and the old
 // ones, to possibly update the "latest" tag.
-func (s *vcsPackagesSyncer) fetchRevspec(ctx context.Context, name reposource.PackageName, dir GitDir, existingVersions []string, revspec string) error {
+func (s *vcsPackagesSyncer) fetchRevspec(ctx context.Context, name reposource.PackageName, dir common.GitDir, existingVersions []string, revspec string) error {
 	// Optionally try to resolve the version of the user-provided revspec (formatted as `"v${VERSION}^0"`).
 	// This logic lives inside `vcsPackagesSyncer` meaning this repo must be a package repo where all
 	// the git tags are created by our npm/crates/pypi/maven integrations (no human commits/branches/tags).
@@ -184,7 +185,7 @@ func (s *vcsPackagesSyncer) fetchRevspec(ctx context.Context, name reposource.Pa
 // fetchVersions checks whether the given versions are all valid version
 // specifiers, then checks whether they've already been downloaded and, if not,
 // downloads them.
-func (s *vcsPackagesSyncer) fetchVersions(ctx context.Context, name reposource.PackageName, dir GitDir, versions []string) error {
+func (s *vcsPackagesSyncer) fetchVersions(ctx context.Context, name reposource.PackageName, dir common.GitDir, versions []string) error {
 	var errs errors.MultiError
 	cloneable := make([]reposource.VersionedPackage, 0, len(versions))
 	for _, version := range versions {

--- a/cmd/gitserver/server/vcs_packages_syncer_test.go
+++ b/cmd/gitserver/server/vcs_packages_syncer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -45,7 +46,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 
 	remoteURL := &vcs.URL{URL: url.URL{Path: "fake/foo"}}
 
-	dir := GitDir(t.TempDir())
+	dir := common.GitDir(t.TempDir())
 	_, err := s.CloneCommand(ctx, remoteURL, string(dir))
 	require.NoError(t, err)
 
@@ -384,7 +385,7 @@ func (s *vcsPackagesSyncer) assertDownloadCounts(t *testing.T, depsSource *fakeD
 	require.Equal(t, want, depsSource.downloadCount)
 }
 
-func (s *vcsPackagesSyncer) assertRefs(t *testing.T, dir GitDir, want map[string]string) {
+func (s *vcsPackagesSyncer) assertRefs(t *testing.T, dir common.GitDir, want map[string]string) {
 	t.Helper()
 
 	cmd := exec.Command("git", "show-ref", "--head", "--dereference")

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
@@ -24,7 +25,7 @@ type VCSSyncer interface {
 	// to lazily fetch package versions. More details at
 	// https://github.com/sourcegraph/sourcegraph/issues/37921#issuecomment-1184301885
 	// Beware that the revspec parameter can be any random user-provided string.
-	Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error)
+	Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error)
 	// RemoteShowCommand returns the command to be executed for showing remote.
 	RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error)
 }

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -81,7 +82,7 @@ func (s *GitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 }
 
 // Fetch tries to fetch updates of a Git repository.
-func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, revspec string) ([]byte, error) {
+func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
 	if output, err := runWith(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -150,7 +151,7 @@ func (s *PerforceDepotSyncer) buildP4FusionCmd(ctx context.Context, depot, usern
 }
 
 // Fetch tries to fetch updates of a Perforce depot as a Git repository.
-func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir GitDir, _ string) ([]byte, error) {
+func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, _ string) ([]byte, error) {
 	username, password, host, depot, err := decomposePerforceRemoteURL(remoteURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "decompose")


### PR DESCRIPTION
## Why

I'm introducing a new subpackage `perforce` under `cmd/gitserver/server` in #51860 and I need to import `GitDir` into the package while also import the new types back into the `server` package which will cause a cyclic import.

The diagram below should help replace a thousand words.

![image](https://github.com/sourcegraph/sourcegraph/assets/2682729/1469e8d0-f6d8-48f0-ab6c-baaf9c8db3d1)
 


## Test plan

- `sg start` worked
- Builds should pass
- main-dry-run should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
