### PR TITLE
app: Set Github release step agent with correct syntax

### DIFF
--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -62,6 +62,7 @@ steps:
       - label: "wait for bundles to complete"
         wait: ~
       - label: ':github: Create GitHub release'
+        agent: { queue: stateless }
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'

--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -62,7 +62,7 @@ steps:
       - label: "wait for bundles to complete"
         wait: ~
       - label: ':github: Create GitHub release'
-        agent: { queue: stateless }
+        agents: { queue: stateless }
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'

--- a/enterprise/dev/app/create-github-release.sh
+++ b/enterprise/dev/app/create-github-release.sh
@@ -18,14 +18,12 @@ else
   exit 1
 fi
 
-echo "--- :aws: fetching GitHub Token"
-token=$(aws secretsmanager get-secret-value --secret-id sourcegraph/mac/github-token | jq '.SecretString |  fromjson | .token')
-export GITHUB_TOKEN=${token}
-
 VERSION=$(./enterprise/dev/app/app_version.sh)
 echo "--- :github: Creating GitHub release for Sourcegraph App (${VERSION})"
 echo "Release will have to following assets:"
 ls -al ./dist
+
+# On CI it is assumed this command runs in a stateless agent, where the GITHUB_TOKEN is injected
 gh release create "app-v${VERSION}" \
   --prerelease \
   --draft \


### PR DESCRIPTION
`agent` key needed a smol `s` at the end 😭 
## Test plan
Successful release on the `app-release/debug` branch: https://buildkite.com/sourcegraph/sourcegraph-app-release/builds/1282#018847c9-1ddc-4309-ae11-2855b74e2f33
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
