### PR TITLE
Rerun reindex command when updating database to Wolfi

### DIFF
--- a/docker-images/postgres-12-alpine/rootfs/env.sh
+++ b/docker-images/postgres-12-alpine/rootfs/env.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-export REINDEX_COMPLETED_FILE="${PGDATA}/3.31-reindex.completed"
+export REINDEX_COMPLETED_FILE="${PGDATA}/5.1-reindex.completed"

--- a/docker-images/postgres-12-alpine/rootfs/reindex.sh
+++ b/docker-images/postgres-12-alpine/rootfs/reindex.sh
@@ -117,7 +117,7 @@ if [ ! -s "${REINDEX_COMPLETED_FILE}" ]; then
   reindex --all
 
   # mark reindexing process as done
-  echo "Re-indexing for 3.31 release completed successfully at $(date)" >"${REINDEX_COMPLETED_FILE}"
+  echo "Re-indexing for 5.1 release completed successfully at $(date)" >"${REINDEX_COMPLETED_FILE}"
 
   echo
   echo 'PostgreSQL reindexing process complete - ready for start up.'


### PR DESCRIPTION
Migrating unmanaged Postgres databases from Alpine to Wolfi requires an re-index.

To do this, I've simply reused the existing 3.31 migration code as this covers all cases:
- databases >=3.31 will be on Alpine, so they need to be re-indexed.
- [unlikely] databases <3.31 will not have yet migrated to Alpine, but don't need to reindex twice during the upgrade.

## Why is this necessary?

Indexes are dependent on the system's locale for sorting, and if the locale changes then postgres' index might need to be rebuilt. We are migrating our postgres databases from Alpine to Wolfi; this changes the libc implementation from musl to glibc, and these use different locales.

I've tested this practically - migrating codeinsights-db on scaletesting from Alpine to Wolfi and running [bt_index_parent_check](https://docs.sourcegraph.com/admin/how-to/rebuild-corrupt-postgres-indexes) gives the error `ERROR: down-link lower bound invariant violated for index "repo_names_name_unique_idx"`. This indicates a corrupted index, and rebuilding the index fixes the issue.

I'm happy to be corrected on the necessity of this, but logically it seems likely that it's required and in the worst case reindexing unnecessarily is safe (just slow).

## Current unknowns

- How long will reindexing take for large customers?
- What kind of communication to CEs and customers is required for this change. Reindexing will not require user interaction (unless an index is somehow already corrupted), but will potentially take time

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Run upgrade manually on scaletesting and check for corruption
- ..?