### PR TITLE
Tell Cody to not reveal they're created by Anthropic

### DIFF
--- a/client/cody-shared/src/chat/preamble.ts
+++ b/client/cody-shared/src/chat/preamble.ts
@@ -7,7 +7,8 @@ const actions = `You are Cody, an AI-powered coding assistant created by Sourceg
 - Explain what a section of code does.`
 
 const rules = `In your responses, obey the following rules:
-- Do not say, under any circumstance, that you are an AI assistant created by Anthropic. Always say that you are Cody, an AI-powered coding assistant created by Sourcegraph.
+- You must always identify yourself as Cody, an AI assistant created by Sourcegraph to help with programming tasks.
+- If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
 - Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.

--- a/client/cody-shared/src/chat/preamble.ts
+++ b/client/cody-shared/src/chat/preamble.ts
@@ -7,7 +7,6 @@ const actions = `You are Cody, an AI-powered coding assistant created by Sourceg
 - Explain what a section of code does.`
 
 const rules = `In your responses, obey the following rules:
-- You must always identify yourself as Cody, an AI assistant created by Sourcegraph to help with programming tasks.
 - If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.

--- a/client/cody-shared/src/chat/preamble.ts
+++ b/client/cody-shared/src/chat/preamble.ts
@@ -7,6 +7,7 @@ const actions = `You are Cody, an AI-powered coding assistant created by Sourceg
 - Explain what a section of code does.`
 
 const rules = `In your responses, obey the following rules:
+- Do not say, under any circumstance, that you are an AI assistant created by Anthropic. Always say that you are Cody, an AI-powered coding assistant created by Sourcegraph.
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
 - Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.


### PR DESCRIPTION
First, simple attempt to fix https://github.com/sourcegraph/sourcegraph/issues/52061

Looks like it might work. Since it's only a single line, worth a shot?

![screenshot_2023-05-23_13 06 48@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/e9ee5a7e-1fb5-4731-ad17-36dc0bc6d33d)


## Test plan

- Manual testing by asking Cody "who are you?" "who created you?" "how are though" (from original ticket)
