### PR TITLE
(feat) make "repository-metadata" feature flag enabled by default

### DIFF
--- a/client/web/src/repo/RepoMetadataPage/index.tsx
+++ b/client/web/src/repo/RepoMetadataPage/index.tsx
@@ -33,7 +33,7 @@ interface RepoMetadataPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>
  */
 export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, useBreadcrumb, repo, ...props }) => {
     useBreadcrumb(BREADCRUMB)
-    const [repoMetadataEnabled, status] = useFeatureFlag('repository-metadata')
+    const [repoMetadataEnabled, status] = useFeatureFlag('repository-metadata', true)
 
     useEffect(() => {
         if (repoMetadataEnabled) {

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -210,7 +210,7 @@ const ExtraInfoSection: React.FC<{
     className?: string
     hasWritePermissions?: boolean
 }> = ({ repo, className, hasWritePermissions }) => {
-    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
     const metadataItems = useMemo(() => repo.metadata.map(({ key, value }) => ({ key, value })) || [], [repo.metadata])
     const queryState = useNavbarQueryState(state => state.queryState)

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -85,7 +85,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     const [enableSearchResultsKeyboardNavigation] = useFeatureFlag('search-results-keyboard-navigation', true)
     const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership', false)
     const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
-    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
     const [sidebarCollapsed, setSidebarCollapsed] = useTemporarySetting('search.sidebar.collapsed', false)
 

--- a/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
+++ b/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
@@ -44,7 +44,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<ErrorLike | undefined>()
 
-    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
     const downloadResults = useCallback(() => {
         if (!searchCompleted) {

--- a/cmd/frontend/graphqlbackend/repository_metadata.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata.go
@@ -31,6 +31,8 @@ func (k KeyValuePair) Value() *string {
 	return k.value
 }
 
+var featureDisabledError = errors.New("'repository-metadata' feature flag is not enabled")
+
 type emptyNonNilValueError struct {
 	value string
 }
@@ -59,8 +61,8 @@ func (r *schemaResolver) AddRepoMetadata(ctx context.Context, args struct {
 		return &EmptyResponse{}, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
-		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", true) {
+		return nil, featureDisabledError
 	}
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
@@ -100,8 +102,8 @@ func (r *schemaResolver) UpdateRepoMetadata(ctx context.Context, args struct {
 		return &EmptyResponse{}, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
-		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", true) {
+		return nil, featureDisabledError
 	}
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
@@ -138,8 +140,8 @@ func (r *schemaResolver) DeleteRepoMetadata(ctx context.Context, args struct {
 		return &EmptyResponse{}, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
-		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", true) {
+		return nil, featureDisabledError
 	}
 
 	repoID, err := UnmarshalRepositoryID(args.Repo)
@@ -192,8 +194,8 @@ func (r *repoMetaResolver) Keys(ctx context.Context, args *RepoMetadataKeysArgs)
 		return nil, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
-		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", true) {
+		return nil, featureDisabledError
 	}
 
 	listOptions := &args.RepoKVPListKeysOptions
@@ -268,8 +270,8 @@ func (r *repoMetaKeyResolver) Values(ctx context.Context, args *RepoMetadataValu
 		return nil, err
 	}
 
-	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", false) {
-		return nil, errors.New("'repository-metadata' feature flag is not enabled")
+	if !featureflag.FromContext(ctx).GetBoolOr("repository-metadata", true) {
+		return nil, featureDisabledError
 	}
 
 	connectionStore := &repoMetaValuesConnectionStore{

--- a/cmd/frontend/graphqlbackend/repository_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata_test.go
@@ -25,9 +25,6 @@ import (
 func TestRepositoryMetadata(t *testing.T) {
 	ctx := context.Background()
 
-	flags := map[string]bool{"repository-metadata": true}
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
-
 	logger := logtest.Scoped(t)
 	db := database.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(logger, t)))
 
@@ -229,5 +226,43 @@ func TestRepositoryMetadata(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Equal(t, err, &rbac.ErrNotAuthorized{Permission: string(rbac.RepoMetadataWritePermission)})
+	})
+
+	t.Run("handles feature flag", func(t *testing.T) {
+		flags := map[string]bool{"repository-metadata": false}
+		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+		_, err = schema.AddRepoMetadata(ctx, struct {
+			Repo  graphql.ID
+			Key   string
+			Value *string
+		}{
+			Repo:  gqlID,
+			Key:   "key1",
+			Value: strPtr("val1"),
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
+
+		_, err = schema.UpdateRepoMetadata(ctx, struct {
+			Repo  graphql.ID
+			Key   string
+			Value *string
+		}{
+			Repo:  gqlID,
+			Key:   "key1",
+			Value: strPtr("val2"),
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
+
+		_, err = schema.DeleteRepoMetadata(ctx, struct {
+			Repo graphql.ID
+			Key  string
+		}{
+			Repo: gqlID,
+			Key:  "key1",
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
 	})
 }

--- a/cmd/frontend/graphqlbackend/repository_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata_test.go
@@ -187,6 +187,44 @@ func TestRepositoryMetadata(t *testing.T) {
 		require.Empty(t, kvps)
 	})
 
+	t.Run("handles feature flag", func(t *testing.T) {
+		flags := map[string]bool{"repository-metadata": false}
+		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+		_, err = schema.AddRepoMetadata(ctx, struct {
+			Repo  graphql.ID
+			Key   string
+			Value *string
+		}{
+			Repo:  gqlID,
+			Key:   "key1",
+			Value: strPtr("val1"),
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
+
+		_, err = schema.UpdateRepoMetadata(ctx, struct {
+			Repo  graphql.ID
+			Key   string
+			Value *string
+		}{
+			Repo:  gqlID,
+			Key:   "key1",
+			Value: strPtr("val2"),
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
+
+		_, err = schema.DeleteRepoMetadata(ctx, struct {
+			Repo graphql.ID
+			Key  string
+		}{
+			Repo: gqlID,
+			Key:  "key1",
+		})
+		require.Error(t, err)
+		require.Equal(t, featureDisabledError, err)
+	})
+
 	t.Run("handles rbac", func(t *testing.T) {
 		permissions.GetPermissionForUserFunc.SetDefaultReturn(nil, nil)
 
@@ -228,41 +266,4 @@ func TestRepositoryMetadata(t *testing.T) {
 		require.Equal(t, err, &rbac.ErrNotAuthorized{Permission: string(rbac.RepoMetadataWritePermission)})
 	})
 
-	t.Run("handles feature flag", func(t *testing.T) {
-		flags := map[string]bool{"repository-metadata": false}
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
-		_, err = schema.AddRepoMetadata(ctx, struct {
-			Repo  graphql.ID
-			Key   string
-			Value *string
-		}{
-			Repo:  gqlID,
-			Key:   "key1",
-			Value: strPtr("val1"),
-		})
-		require.Error(t, err)
-		require.Equal(t, featureDisabledError, err)
-
-		_, err = schema.UpdateRepoMetadata(ctx, struct {
-			Repo  graphql.ID
-			Key   string
-			Value *string
-		}{
-			Repo:  gqlID,
-			Key:   "key1",
-			Value: strPtr("val2"),
-		})
-		require.Error(t, err)
-		require.Equal(t, featureDisabledError, err)
-
-		_, err = schema.DeleteRepoMetadata(ctx, struct {
-			Repo graphql.ID
-			Key  string
-		}{
-			Repo: gqlID,
-			Key:  "key1",
-		})
-		require.Error(t, err)
-		require.Equal(t, featureDisabledError, err)
-	})
 }

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -143,7 +143,6 @@ func addKVPs(t *testing.T, client *gqltestutil.Client) {
 		t.Fatal(err)
 	}
 
-	err = client.SetFeatureFlag("repository-metadata", true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usagestats/BUILD.bazel
+++ b/internal/usagestats/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
     name = "usagestats_test",
     srcs = [
         "aggregated_codeintel_test.go",
+        "aggregated_repo_metadata_test.go",
         "aggregated_search_test.go",
         "aggregated_test.go",
         "batches_test.go",

--- a/internal/usagestats/aggregated_repo_metadata.go
+++ b/internal/usagestats/aggregated_repo_metadata.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -50,11 +51,14 @@ func getAggregatedRepoMetadataSummary(ctx context.Context, db database.DB) (*typ
 	if err != nil {
 		return nil, err
 	}
+
 	flag, err := db.FeatureFlags().GetFeatureFlag(ctx, "repository-metadata")
 	if err != nil {
-		return nil, err
+		if err != sql.ErrNoRows {
+			return nil, err
+		}
 	}
-	summary.IsEnabled = flag != nil && flag.Bool.Value
+	summary.IsEnabled = flag == nil || flag.Bool.Value
 
 	return &summary, nil
 }

--- a/internal/usagestats/aggregated_repo_metadata_test.go
+++ b/internal/usagestats/aggregated_repo_metadata_test.go
@@ -1,0 +1,96 @@
+package usagestats
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestAggregatedRepoMetadataSummary(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	ctx := context.Background()
+
+	err := db.Repos().Create(ctx, &types.Repo{
+		Name: "repo",
+	})
+	require.NoError(t, err)
+
+	repo, err := db.Repos().GetByName(ctx, "repo")
+	require.NoError(t, err)
+
+	kvps := db.RepoKVPs()
+
+	t.Run("no data", func(t *testing.T) {
+		summary, err := getAggregatedRepoMetadataSummary(ctx, db)
+
+		require.NoError(t, err)
+		require.Equal(t, &types.RepoMetadataAggregatedSummary{
+			RepoMetadataCount:      int32Ptr(0),
+			ReposWithMetadataCount: int32Ptr(0),
+			IsEnabled:              true,
+		}, summary)
+	})
+
+	t.Run("with data", func(t *testing.T) {
+		err = kvps.Create(ctx, repo.ID, database.KeyValuePair{
+			Key:   "tag1",
+			Value: nil,
+		})
+		require.NoError(t, err)
+
+		value1 := "value1"
+		err = kvps.Create(ctx, repo.ID, database.KeyValuePair{
+			Key:   "key1",
+			Value: &value1,
+		})
+		require.NoError(t, err)
+
+		summary, err := getAggregatedRepoMetadataSummary(ctx, db)
+
+		require.NoError(t, err)
+		require.Equal(t, &types.RepoMetadataAggregatedSummary{
+			RepoMetadataCount:      int32Ptr(2),
+			ReposWithMetadataCount: int32Ptr(1),
+			IsEnabled:              true,
+		}, summary)
+	})
+
+	t.Run("feature flag is set to true", func(t *testing.T) {
+		db.FeatureFlags().CreateBool(ctx, "repository-metadata", true)
+
+		summary, err := getAggregatedRepoMetadataSummary(ctx, db)
+
+		require.NoError(t, err)
+		require.Equal(t, &types.RepoMetadataAggregatedSummary{
+			RepoMetadataCount:      int32Ptr(2),
+			ReposWithMetadataCount: int32Ptr(1),
+			IsEnabled:              true,
+		}, summary)
+	})
+
+	t.Run("feature flag is set to false", func(t *testing.T) {
+		db.FeatureFlags().DeleteFeatureFlag(ctx, "repository-metadata")
+		db.FeatureFlags().CreateBool(ctx, "repository-metadata", false)
+
+		summary, err := getAggregatedRepoMetadataSummary(ctx, db)
+
+		require.NoError(t, err)
+		require.Equal(t, &types.RepoMetadataAggregatedSummary{
+			RepoMetadataCount:      int32Ptr(2),
+			ReposWithMetadataCount: int32Ptr(1),
+			IsEnabled:              false,
+		}, summary)
+	})
+}


### PR DESCRIPTION
Part of https://github.com/sourcegraph/pr-faqs/issues/96.

## Test plan
- `sg start`
- Remove `repository-metadata` feature flag if exist
- Search using `select:repo`, go to repo root page, all the repo metadata features should be enabled by default
- Add `repository-metadata=false` feature flag
- All the repository metadata related features should be disabled now

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
