### PR TITLE
[fix] use same where condition in user analytics as in pings for mau

### DIFF
--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -127,7 +127,11 @@ enum OwnershipReasonType {
 """
 A union of all the different ownership reasons.
 """
-union OwnershipReason = CodeownersFileEntry | RecentContributorOwnershipSignal | RecentViewOwnershipSignal | AssignedOwner
+union OwnershipReason =
+      CodeownersFileEntry
+    | RecentContributorOwnershipSignal
+    | RecentViewOwnershipSignal
+    | AssignedOwner
 
 """
 A signal derived from recent code contributors.

--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/database",
-        "//internal/eventlogger",
         "//internal/featureflag",
         "//internal/redispool",
         "//lib/errors",

--- a/internal/adminanalytics/codeinsights.go
+++ b/internal/adminanalytics/codeinsights.go
@@ -18,9 +18,6 @@ type CodeInsights struct {
 
 func (c *CodeInsights) InsightHovers() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
-		c.Ctx,
-		c.DB,
-		c.Cache,
 		c.DateRange,
 		c.Grouping,
 		[]string{"InsightHover"},
@@ -44,9 +41,6 @@ func (c *CodeInsights) InsightHovers() (*AnalyticsFetcher, error) {
 
 func (c *CodeInsights) InsightDataPointClicks() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
-		c.Ctx,
-		c.DB,
-		c.Cache,
 		c.DateRange,
 		c.Grouping,
 		[]string{"InsightDataPointClick"},

--- a/internal/adminanalytics/codeintel.go
+++ b/internal/adminanalytics/codeintel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
@@ -16,7 +17,7 @@ type CodeIntel struct {
 }
 
 func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"findReferences"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"findReferences"})
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +34,7 @@ func (s *CodeIntel) ReferenceClicks() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) DefinitionClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition"})
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func (s *CodeIntel) DefinitionClicks() (*AnalyticsFetcher, error) {
 
 func (s *CodeIntel) InAppEvents() (*AnalyticsFetcher, error) {
 	sourceCond := sqlf.Sprintf("source = 'WEB'")
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +70,7 @@ func (s *CodeIntel) InAppEvents() (*AnalyticsFetcher, error) {
 
 func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
 	sourceCond := sqlf.Sprintf("source = 'CODEHOSTINTEGRATION'")
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"goToDefinition.preloaded", "goToDefinition", "findReferences"}, sourceCond)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (s *CodeIntel) CodeHostEvents() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) SearchBasedEvents() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
 		"codeintel.searchDefinitions",
 		"codeintel.searchDefinitions.xrepo",
 		"codeintel.searchReferences",
@@ -108,7 +109,7 @@ func (s *CodeIntel) SearchBasedEvents() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) PreciseEvents() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
 		"codeintel.lsifDefinitions",
 		"codeintel.lsifDefinitions.xrepo",
 		"codeintel.lsifReferences",
@@ -130,7 +131,7 @@ func (s *CodeIntel) PreciseEvents() (*AnalyticsFetcher, error) {
 }
 
 func (s *CodeIntel) CrossRepoEvents() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
 		"codeintel.searchDefinitions.xrepo",
 		"codeintel.searchReferences.xrepo",
 		"codeintel.lsifDefinitions.xrepo",

--- a/internal/adminanalytics/extensions.go
+++ b/internal/adminanalytics/extensions.go
@@ -18,9 +18,6 @@ type Extensions struct {
 
 func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
-		e.Ctx,
-		e.DB,
-		e.Cache,
 		e.DateRange,
 		e.Grouping,
 		[]string{"IDESearchSubmitted", "VSCESearchSubmitted"},
@@ -42,9 +39,6 @@ func (e *Extensions) Jetbrains() (*AnalyticsFetcher, error) {
 
 func (e *Extensions) Vscode() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
-		e.Ctx,
-		e.DB,
-		e.Cache,
 		e.DateRange,
 		e.Grouping,
 		[]string{"IDESearchSubmitted", "VSCESearchSubmitted"},
@@ -67,9 +61,6 @@ func (e *Extensions) Vscode() (*AnalyticsFetcher, error) {
 
 func (e *Extensions) Browser() (*AnalyticsFetcher, error) {
 	nodesQuery, summaryQuery, err := makeEventLogsQueries(
-		e.Ctx,
-		e.DB,
-		e.Cache,
 		e.DateRange,
 		e.Grouping,
 		[]string{"goToDefinition.preloaded", "goToDefinition", "findReferences"},

--- a/internal/adminanalytics/notebooks.go
+++ b/internal/adminanalytics/notebooks.go
@@ -15,7 +15,7 @@ type Notebooks struct {
 }
 
 func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"SearchNotebookCreated"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchNotebookCreated"})
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (s *Notebooks) Creations() (*AnalyticsFetcher, error) {
 }
 
 func (s *Notebooks) Views() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"SearchNotebookPageViewed"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchNotebookPageViewed"})
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (s *Notebooks) Views() (*AnalyticsFetcher, error) {
 }
 
 func (s *Notebooks) BlockRuns() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
 		"SearchNotebookRunAllBlocks",
 		"SearchNotebookRunBlock",
 	})

--- a/internal/adminanalytics/search.go
+++ b/internal/adminanalytics/search.go
@@ -15,7 +15,7 @@ type Search struct {
 }
 
 func (s *Search) Searches() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"SearchResultsQueried"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchResultsQueried"})
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ func (s *Search) Searches() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) ResultClicks() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"SearchResultClicked"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"SearchResultClicked"})
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (s *Search) ResultClicks() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) FileViews() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"ViewBlob"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"ViewBlob"})
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (s *Search) FileViews() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) FileOpens() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{
 		"GoToCodeHostClicked",
 		"vscode.open.file",
 		"openInAtom.open.file",
@@ -88,7 +88,7 @@ func (s *Search) FileOpens() (*AnalyticsFetcher, error) {
 }
 
 func (s *Search) CodeCopied() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{"CodeCopied"})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{"CodeCopied"})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -139,6 +139,7 @@ const (
 		TO_CHAR(timestamp, 'YYYY-MM') AS date,
 		COUNT(DISTINCT CASE WHEN user_id = 0 THEN anonymous_user_id ELSE CAST(user_id AS TEXT) END) AS count
 	FROM event_logs
+	LEFT OUTER JOIN users ON users.id = event_logs.user_id
 	WHERE
 		timestamp BETWEEN %s AND %s
     AND (%s)

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -40,7 +40,7 @@ const (
 	WITH user_days_used AS (
         SELECT
             CASE WHEN user_id = 0 THEN anonymous_user_id ELSE CAST(user_id AS TEXT) END AS user_id,
-            COUNT(DISTINCT DATE(timestamp)) AS days_used
+            COUNT(DISTINCT DATE(TIMEZONE('UTC', timestamp))) AS days_used
         FROM event_logs
 		LEFT OUTER JOIN users ON users.id = event_logs.user_id
         WHERE

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -136,7 +136,7 @@ func (n *UsersFrequencyNode) Percentage() float64 { return n.Data.Percentage }
 const (
 	mauQuery = `
 	SELECT
-		TO_CHAR(timestamp, 'YYYY-MM') AS date,
+		TO_CHAR(TIMEZONE('UTC', timestamp), 'YYYY-MM') AS date,
 		COUNT(DISTINCT CASE WHEN user_id = 0 THEN anonymous_user_id ELSE CAST(user_id AS TEXT) END) AS count
 	FROM event_logs
 	LEFT OUTER JOIN users ON users.id = event_logs.user_id

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -44,7 +44,7 @@ const (
         FROM event_logs
         WHERE
             DATE(timestamp) %s
-            AND %s
+            AND (%s)
         GROUP BY 1
     ),
     days_used_frequency AS (
@@ -87,7 +87,7 @@ func (f *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 		return nil, err
 	}
 
-	query := sqlf.Sprintf(frequencyQuery, dateRangeCond, sqlf.Join(getDefaultConds(), " AND "))
+	query := sqlf.Sprintf(frequencyQuery, dateRangeCond, sqlf.Join(getDefaultConds(), ") AND ("))
 
 	rows, err := f.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 
@@ -139,7 +139,7 @@ const (
 	FROM event_logs
 	WHERE
 		timestamp BETWEEN %s AND %s
-    AND %s
+    AND (%s)
 	GROUP BY 1
 	ORDER BY 1 ASC
 	`
@@ -158,7 +158,7 @@ func (f *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRo
 	prevMonth := now.AddDate(0, -2, 0) // going back 2 months
 	from := time.Date(prevMonth.Year(), prevMonth.Month(), 1, 0, 0, 0, 0, now.Location()).Format(time.RFC3339)
 
-	query := sqlf.Sprintf(mauQuery, from, to, sqlf.Join(getDefaultConds(), " AND "))
+	query := sqlf.Sprintf(mauQuery, from, to, sqlf.Join(getDefaultConds(), ") AND ("))
 
 	rows, err := f.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	if err != nil {

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -87,12 +87,7 @@ func (f *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 		return nil, err
 	}
 
-	defaultConds, err := getDefaultConds(f.Ctx, f.DB, f.Cache)
-	if err != nil {
-		return nil, err
-	}
-
-	query := sqlf.Sprintf(frequencyQuery, dateRangeCond, sqlf.Join(defaultConds, " AND "))
+	query := sqlf.Sprintf(frequencyQuery, dateRangeCond, sqlf.Join(getDefaultConds(), " AND "))
 
 	rows, err := f.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 
@@ -163,12 +158,7 @@ func (f *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRo
 	prevMonth := now.AddDate(0, -2, 0) // going back 2 months
 	from := time.Date(prevMonth.Year(), prevMonth.Month(), 1, 0, 0, 0, 0, now.Location()).Format(time.RFC3339)
 
-	defaultConds, err := getDefaultConds(f.Ctx, f.DB, f.Cache)
-	if err != nil {
-		return nil, err
-	}
-
-	query := sqlf.Sprintf(mauQuery, from, to, sqlf.Join(defaultConds, " AND "))
+	query := sqlf.Sprintf(mauQuery, from, to, sqlf.Join(getDefaultConds(), " AND "))
 
 	rows, err := f.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 	if err != nil {

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -42,6 +42,7 @@ const (
             CASE WHEN user_id = 0 THEN anonymous_user_id ELSE CAST(user_id AS TEXT) END AS user_id,
             COUNT(DISTINCT DATE(timestamp)) AS days_used
         FROM event_logs
+		LEFT OUTER JOIN users ON users.id = event_logs.user_id
         WHERE
             DATE(timestamp) %s
             AND (%s)
@@ -88,6 +89,7 @@ func (f *Users) Frequencies(ctx context.Context) ([]*UsersFrequencyNode, error) 
 	}
 
 	query := sqlf.Sprintf(frequencyQuery, dateRangeCond, sqlf.Join(getDefaultConds(), ") AND ("))
+	fmt.Printf("Query %v", query)
 
 	rows, err := f.DB.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
 

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -19,7 +19,7 @@ type Users struct {
 }
 
 func (s *Users) Activity() (*AnalyticsFetcher, error) {
-	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.Ctx, s.DB, s.Cache, s.DateRange, s.Grouping, []string{})
+	nodesQuery, summaryQuery, err := makeEventLogsQueries(s.DateRange, s.Grouping, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -2,14 +2,12 @@ package adminanalytics
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -37,7 +35,7 @@ func makeDateParameters(dateRange string, grouping string, dateColumnName string
 		return nil, nil, errors.New("Invalid groupBy")
 	}
 
-	return sqlf.Sprintf(fmt.Sprintf(`DATE_TRUNC('%s', %s::date)`, groupBy, dateColumnName)), sqlf.Sprintf(`BETWEEN %s AND %s`, from.Format(time.RFC3339), now.Format(time.RFC3339)), nil
+	return sqlf.Sprintf(fmt.Sprintf(`DATE_TRUNC('%s', TIMEZONE('UTC', %s::date))`, groupBy, dateColumnName)), sqlf.Sprintf(`BETWEEN %s AND %s`, from.Format(time.RFC3339), now.Format(time.RFC3339)), nil
 }
 
 func getFromDate(dateRange string, now time.Time) (time.Time, error) {
@@ -52,61 +50,6 @@ func getFromDate(dateRange string, now time.Time) (time.Time, error) {
 	return now, errors.New("Invalid date range")
 }
 
-// find sourcegraph employee user ids to exclude (usually CEs)
-var sgEmpUserIdsQuery = `
-SELECT
-  DISTINCT users.id AS user_id
-FROM
-  users INNER JOIN user_emails ON user_emails.user_id = users.id
-WHERE
-  (
-    users.username ILIKE 'managed-%%'
-		OR users.username ILIKE 'sourcegraph-management-%%'
-		OR users.username = 'sourcegraph-admin'
-  )
-	AND user_emails.email ILIKE '%%@sourcegraph.com'
-`
-
-const employeeUserIdsCacheExpirySeconds = 300
-const employeeUserIdsCacheKey = "sourcegraph_employee_user_ids"
-
-func getSgEmpUserIDs(ctx context.Context, db database.DB, cache bool) ([]*int32, error) {
-	if cache {
-		if ids, err := getArrayFromCache[int32](employeeUserIdsCacheKey); err == nil {
-			return ids, nil
-		}
-	}
-
-	query := sqlf.Sprintf(sgEmpUserIdsQuery)
-	rows, err := db.QueryContext(ctx, query.Query(sqlf.PostgresBindVar), query.Args()...)
-	if err != nil {
-		return []*int32{}, err
-	}
-	defer rows.Close()
-
-	ids := make([]*int32, 0)
-	for rows.Next() {
-		var id int32
-
-		if err := rows.Scan(&id); err != nil {
-			return ids, err
-		}
-
-		ids = append(ids, &id)
-	}
-
-	cacheData, err := json.Marshal(ids)
-	if err != nil {
-		return ids, err
-	}
-
-	if err := setDataToCache(employeeUserIdsCacheKey, string(cacheData), employeeUserIdsCacheExpirySeconds); err != nil {
-		return ids, err
-	}
-
-	return ids, nil
-}
-
 const eventLogsNodesQuery = `
 SELECT
 	%s AS date,
@@ -115,6 +58,7 @@ SELECT
 	COUNT(DISTINCT user_id) FILTER (WHERE user_id != 0) AS registered_users
 FROM
 	event_logs
+LEFT OUTER JOIN users ON users.id = event_logs.user_id
 %s
 GROUP BY date
 `
@@ -126,36 +70,17 @@ SELECT
 	COUNT(DISTINCT user_id) FILTER (WHERE user_id != 0) AS registered_users
 FROM
 	event_logs
+LEFT OUTER JOIN users ON users.id = event_logs.user_id
 %s
 `
 
-func getDefaultConds(ctx context.Context, db database.DB, cache bool) ([]*sqlf.Query, error) {
-	nonActiveUserEvents := []*sqlf.Query{}
-	for _, name := range eventlogger.NonActiveUserEvents {
-		nonActiveUserEvents = append(nonActiveUserEvents, sqlf.Sprintf("%s", name))
-	}
-
-	conds := []*sqlf.Query{
-		sqlf.Sprintf("anonymous_user_id <> 'backend'"),
-		sqlf.Sprintf("name NOT IN (%s)", sqlf.Join(nonActiveUserEvents, ", ")),
-		sqlf.Sprintf(fmt.Sprintf(`NOT public_argument @> '{"%s": true}'`, database.EventLogsSourcegraphOperatorKey)), // Exclude Sourcegraph Operator user accounts
-	}
-
-	sgEmpUserIds, err := getSgEmpUserIDs(ctx, db, cache)
-	if err != nil {
-		return []*sqlf.Query{}, err
-	}
-
-	if len(sgEmpUserIds) > 0 {
-		excludeUserIDs := []*sqlf.Query{}
-		for _, userId := range sgEmpUserIds {
-			excludeUserIDs = append(excludeUserIDs, sqlf.Sprintf("%d", userId))
-		}
-
-		conds = append(conds, sqlf.Sprintf("user_id NOT IN (%s)", sqlf.Join(excludeUserIDs, ", ")))
-	}
-
-	return conds, nil
+func getDefaultConds() []*sqlf.Query {
+	return database.BuildCommonUsageConds(&database.CommonUsageOptions{
+		ExcludeSystemUsers:          true,
+		ExcludeNonActiveUsers:       true,
+		ExcludeSourcegraphAdmins:    true,
+		ExcludeSourcegraphOperators: true,
+	}, []*sqlf.Query{})
 }
 
 func makeEventLogsQueries(ctx context.Context, db database.DB, cache bool, dateRange string, grouping string, events []string, conditions ...*sqlf.Query) (*sqlf.Query, *sqlf.Query, error) {
@@ -164,12 +89,7 @@ func makeEventLogsQueries(ctx context.Context, db database.DB, cache bool, dateR
 		return nil, nil, err
 	}
 
-	defaultConds, err := getDefaultConds(ctx, db, cache)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	conds := append(defaultConds, sqlf.Sprintf("timestamp %s", dateBetweenCond))
+	conds := append(getDefaultConds(), sqlf.Sprintf("timestamp %s", dateBetweenCond))
 
 	if len(conditions) > 0 {
 		conds = append(conds, conditions...)

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -1,7 +1,6 @@
 package adminanalytics
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -83,7 +82,7 @@ func getDefaultConds() []*sqlf.Query {
 	}, []*sqlf.Query{})
 }
 
-func makeEventLogsQueries(ctx context.Context, db database.DB, cache bool, dateRange string, grouping string, events []string, conditions ...*sqlf.Query) (*sqlf.Query, *sqlf.Query, error) {
+func makeEventLogsQueries(dateRange string, grouping string, events []string, conditions ...*sqlf.Query) (*sqlf.Query, *sqlf.Query, error) {
 	dateTruncExp, dateBetweenCond, err := makeDateParameters(dateRange, grouping, "timestamp")
 	if err != nil {
 		return nil, nil, err

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -102,8 +102,8 @@ func makeEventLogsQueries(dateRange string, grouping string, events []string, co
 		conds = append(conds, sqlf.Sprintf("name IN (%s)", sqlf.Join(eventNames, ",")))
 	}
 
-	nodesQuery := sqlf.Sprintf(eventLogsNodesQuery, dateTruncExp, sqlf.Sprintf("WHERE %s", sqlf.Join(conds, " AND ")))
-	summaryQuery := sqlf.Sprintf(eventLogsSummaryQuery, sqlf.Sprintf("WHERE %s", sqlf.Join(conds, " AND ")))
+	nodesQuery := sqlf.Sprintf(eventLogsNodesQuery, dateTruncExp, sqlf.Sprintf("WHERE (%s)", sqlf.Join(conds, ") AND (")))
+	summaryQuery := sqlf.Sprintf(eventLogsSummaryQuery, sqlf.Sprintf("WHERE (%s)", sqlf.Join(conds, ") AND (")))
 
 	return nodesQuery, summaryQuery, nil
 }

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -550,7 +550,7 @@ func jsonSettingFragment(setting string, value any) string {
 func buildCountUniqueUserConds(opt *CountUniqueUsersOptions) []*sqlf.Query {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opt != nil {
-		conds = buildCommonUsageConds(&opt.CommonUsageOptions, conds)
+		conds = BuildCommonUsageConds(&opt.CommonUsageOptions, conds)
 
 		if opt.EventFilters != nil {
 			if opt.EventFilters.ByEventNamePrefix != "" {
@@ -574,7 +574,7 @@ func buildCountUniqueUserConds(opt *CountUniqueUsersOptions) []*sqlf.Query {
 	return conds
 }
 
-func buildCommonUsageConds(opt *CommonUsageOptions, conds []*sqlf.Query) []*sqlf.Query {
+func BuildCommonUsageConds(opt *CommonUsageOptions, conds []*sqlf.Query) []*sqlf.Query {
 	if opt != nil {
 		if opt.ExcludeSystemUsers {
 			conds = append(conds, sqlf.Sprintf("event_logs.user_id > 0 OR event_logs.anonymous_user_id <> 'backend'"))
@@ -906,7 +906,7 @@ func (l *eventLogStore) SiteUsageCurrentPeriods(ctx context.Context) (types.Site
 func (l *eventLogStore) siteUsageCurrentPeriods(ctx context.Context, now time.Time, opt *SiteUsageOptions) (summary types.SiteUsageSummary, err error) {
 	conds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 	if opt != nil {
-		conds = buildCommonUsageConds(&opt.CommonUsageOptions, conds)
+		conds = BuildCommonUsageConds(&opt.CommonUsageOptions, conds)
 	}
 
 	query := sqlf.Sprintf(siteUsageCurrentPeriodsQuery, now, now, now, now, now, now, sqlf.Join(conds, ") AND ("))


### PR DESCRIPTION
Previously we used a different condition to calculate the MAU and other stats in user analytics page. Now we use the same condition as we use for pings. We also calculate everything using UTC now, so both should give the same value.

## Test plan

Tested locally and also with data from Tinder. The new query for MAU seems to be returning the correct data for us, I manually cross-referenced the old query vs the new. Apart from the timezone difference, the new query is more precise as in it filters the sourcegraph-operator users and non-user events in the same way as we do for the pings.
