### PR TITLE
cody: guardrails aggregate attribution from dotcom and private

### DIFF
--- a/client/cody-shared/src/guardrails/client.ts
+++ b/client/cody-shared/src/guardrails/client.ts
@@ -1,14 +1,55 @@
 import { SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+import { isError } from '../utils'
 
 import { Guardrails, Attribution } from '.'
 
 export class SourcegraphGuardrailsClient implements Guardrails {
-    constructor(private client: SourcegraphGraphQLAPIClient) {}
+    private clients: SourcegraphGraphQLAPIClient[]
+
+    constructor(client: SourcegraphGraphQLAPIClient) {
+        this.clients = [client]
+        // We want to use dotcom since that has a much larger corpus.
+        if (!client.isDotCom()) {
+            // Note: this is an anonymous request. We intend on adding a
+            // guardrails specific API to sourcegraph which will do
+            // authenticated federation to dotcom.
+            this.clients.push(
+                new SourcegraphGraphQLAPIClient({
+                    serverEndpoint: 'https://sourcegraph.com',
+                    accessToken: null,
+                    customHeaders: {},
+                })
+            )
+        }
+    }
 
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
         // TODO(keegancsmith) adjust implementation to respect line count thresholds
         const query = `type:file select:repo content:${goEscapeString(snippet)}`
-        return this.client.searchTypeRepo(query)
+        const results = await Promise.all(this.clients.map(client => client.searchTypeRepo(query)))
+
+        // aggregate unique repos by name
+        const seen = new Set<string>()
+        const aggregate: Attribution = {
+            limitHit: false,
+            repositories: [],
+        }
+
+        for (const result of results) {
+            if (isError(result)) {
+                return result
+            }
+            aggregate.limitHit = aggregate.limitHit || result.limitHit
+            for (const repo of result.repositories) {
+                if (seen.has(repo.name)) {
+                    continue
+                }
+                seen.add(repo.name)
+                aggregate.repositories.push(repo)
+            }
+        }
+
+        return aggregate
     }
 }
 


### PR DESCRIPTION
Previously we only searched the configured instance. We now additionally
search sourcegraph.com which contains the public corpus of code we
actually want to be matching against.

This introduced a more noticeable lag which I need to investigate. These
queries should be fast on dotcom.

This isn't the final design for how this works. We will explore doing
federation on the instance to avoid anonymous requests. Additionally we
don't want to use the private instance for filtering. However, this was
quick to implement to unblock testing the corpus.

Test Plan: configured cody against s2 and did an attribution search
against the zoekt repo. It only found sourcegraph/zoekt results. Then
used this PR and it also found google/zoekt results.