### PR TITLE
Wildcard: [BarChart] Fix bar chart bar id generation

### DIFF
--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -218,9 +218,11 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): ActiveBarTuple<Da
 }
 
 function getBarId(categoryId: string, datumName: string): string {
-    if (categoryId === datumName) {
-        return categoryId
+    let id = `${categoryId}${datumName}`
+
+    if (categoryId !== datumName) {
+        id = categoryId
     }
 
-    return `${categoryId}${datumName}`
+    return encodeURIComponent(id)
 }

--- a/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/components/GroupedBars.tsx
@@ -218,11 +218,5 @@ function getActiveBar<Datum>(input: GetActiveBarInput<Datum>): ActiveBarTuple<Da
 }
 
 function getBarId(categoryId: string, datumName: string): string {
-    let id = `${categoryId}${datumName}`
-
-    if (categoryId !== datumName) {
-        id = categoryId
-    }
-
-    return encodeURIComponent(id)
+    return encodeURIComponent(`${categoryId}${datumName}`)
 }


### PR DESCRIPTION
Originally reported by @coury-clark 

## Problem 

![CleanShot 2023-05-19 at 08 08 03](https://github.com/sourcegraph/sourcegraph/assets/18492575/73536a5a-5ab6-4f7b-b92c-16bd1c6bb3d7)

Some queries that produce aggregation with some particular labels (with some unsupported symbols) break the Bar aggregation chart tooltip. [Link from the video above](https://sourcegraph.sourcegraph.com/search?q=context%3Asourcegraph+sqlf.Join%5C%28conds%2C+%28.*%29%5C%29&patternType=regexp&sm=1&groupBy=group) to check this problem.

## Solution

The problem was that we used bar labels as id to find the dom element to bind the tooltip, we used labels because we don't have any IDs over bars/groups in aggregation data. With labels like `" And ""` we can't use it as id for data attribute selectors `.queryElement("[data-id="""And""]"` this simply breaks queryElement and fails in runtime. Solution is simple - use encode URI to avoid having any non-supported letter sequence in `queryElement ` selectors

## Test plan
- Check that this fix works for corner case queries that produce non-supported labels (an example of this query you can find [here](https://sourcegraph.sourcegraph.com/search?q=context%3Asourcegraph+sqlf.Join%5C%28conds%2C+%28.*%29%5C%29&patternType=regexp&sm=1&groupBy=group)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
