### PR TITLE
app: enable updater in app bundling and generate manifest

### DIFF
--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -34,6 +34,7 @@ steps:
           - './dev/ci/pnpm-install-with-retry.sh'
           - './enterprise/dev/app/tauri-build.sh'
         env:
+          SRC_APP_UPDATER_BUILD: 1
           AWS_CONFIG_FILE: /buildkite/.aws/config
           AWS_SHARED_CREDENTIALS_FILE: /buildkite/.aws/credentials
         plugins:
@@ -56,6 +57,7 @@ steps:
         agents: { queue: macos }
         env:
           CODESIGNING: 1
+          SRC_APP_UPDATER_BUILD: 1
         command:
           - './dev/ci/pnpm-install-with-retry.sh'
           - './enterprise/dev/app/tauri-build.sh'

--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -68,3 +68,4 @@ steps:
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'
+          - './enterprise/dev/app/create-update_manifest.sh'

--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -64,6 +64,7 @@ steps:
       - label: "wait for bundles to complete"
         wait: ~
       - label: ':github: Create GitHub release'
+        agents: { queue: stateless }
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'

--- a/.buildkite/pipeline.app.yml
+++ b/.buildkite/pipeline.app.yml
@@ -68,4 +68,4 @@ steps:
         key: create-github-release
         command:
           - './enterprise/dev/app/create-github-release.sh'
-          - './enterprise/dev/app/create-update_manifest.sh'
+          - './enterprise/dev/app/create-update-manifest.sh'

--- a/enterprise/dev/app/app_version.sh
+++ b/enterprise/dev/app/app_version.sh
@@ -5,16 +5,25 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
 
 create_version() {
     local sha
+    local build
     # In a GitHub action this can result in an empty sha
     sha=$(git rev-parse --short HEAD)
     if [[ -z ${sha} ]]; then
       sha=${BUILDKITE_COMMIT:-""}
     fi
 
-    local build="insiders"
-    if [[ ${BUILDKITE_BRANCH:-""} == "app-release/stable" ]]; then
-      build=${BUILDKITE_BUILD_NUMBER:-"release"}
-    fi
+    case ${BUILDKITE_BRANCH:-""} in
+      "app-release/stable")
+        build=${BUILDKITE_BUILD_NUMBER:-"release"}
+        ;;
+      "app-release/debug")
+        build="debug"
+        ;;
+      *)
+        build="insiders"
+        ;;
+    esac
+
     echo "$(date '+%Y.%-m.%-d')+${build}.${sha}"
 }
 

--- a/enterprise/dev/app/create-github-release.sh
+++ b/enterprise/dev/app/create-github-release.sh
@@ -18,10 +18,6 @@ else
   exit 1
 fi
 
-echo "--- :aws: fetching GitHub Token"
-token=$(aws secretsmanager get-secret-value --secret-id sourcegraph/mac/github-token | jq '.SecretString |  fromjson | .token')
-export GITHUB_TOKEN=${token}
-
 VERSION=$(./enterprise/dev/app/app_version.sh)
 echo "--- :github: Creating GitHub release for Sourcegraph App (${VERSION})"
 echo "Release will have to following assets:"

--- a/enterprise/dev/app/create-update-manifest.sh
+++ b/enterprise/dev/app/create-update-manifest.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+
 # deterimes the Sourcegraph App filename based on the platform string given
 # args:
 # - 1: platform string

--- a/enterprise/dev/app/create-update-manifest.sh
+++ b/enterprise/dev/app/create-update-manifest.sh
@@ -13,13 +13,19 @@ filename_from() {
   local filename
   arch=$(echo "$1" | cut -d '-' -f1)
   os=$(echo "$1" | cut -d '-' -f3)
+  # this is kind of annoying but tauri uses `x86_64` as a target platform but generates
+  # bundles using `amd64`
+  if [[ ${arch} == "x86_64" ]]; then
+    arch="amd64"
+  fi
 
   case "${os}" in
     "darwin")
       filename="Sourcegraph.${version}.${arch}.app.tar.gz"
       ;;
     "linux")
-      filename="sourcegraph.${version}.${arch}.AppImage"
+      # note the UNDERSCORES
+      filename="sourcegraph_${version}_${arch}.AppImage.tar.gz"
       ;;
     *)
       echo "cannot determine filename for unsupported os: ${os}"

--- a/enterprise/dev/app/create-update-manifest.sh
+++ b/enterprise/dev/app/create-update-manifest.sh
@@ -84,9 +84,11 @@ platform_json_for() {
 
   key=$(short_platform ${platform})
 
-  if [[ -n "${signature:""}" ]]; then
+  if [[ -n "${signature:-""}" ]]; then
     echo ${RELEASE_JSON} | jq -r --arg key "${key}" --arg filename "${filename}" --arg sig "${signature}" \
       '.assets[] | select(.name == $filename) | { ($key): { "signature": $sig, "url": .url }}'
+  else
+    echo ""
   fi
 }
 

--- a/enterprise/dev/app/create-update-manifest.sh
+++ b/enterprise/dev/app/create-update-manifest.sh
@@ -11,8 +11,8 @@ filename_from() {
   local arch
   local os
   local filename
-  arch=$(echo $1 | cut -d '-' -f1)
-  os=$(echo $1 | cut -d '-' -f3)
+  arch=$(echo "$1" | cut -d '-' -f1)
+  os=$(echo "$1" | cut -d '-' -f3)
 
   case "${os}" in
     "darwin")
@@ -26,7 +26,7 @@ filename_from() {
       exit 1
   esac
 
-  echo ${filename}
+  echo "${filename}"
 }
 #
 # short_platform breaks a long form platform strings like <arch>-<vendor>-<os> up into just <arch>-<os>
@@ -34,8 +34,8 @@ filename_from() {
 short_platform() {
   local arch
   local os
-  arch=$(echo $1 | cut -d '-' -f1)
-  os=$(echo $1 | cut -d '-' -f3)
+  arch=$(echo "$1" | cut -d '-' -f1)
+  os=$(echo "$1" | cut -d '-' -f3)
 
   echo "${arch}-${os}"
 }
@@ -82,10 +82,10 @@ platform_json_for() {
     signature=""
   fi
 
-  key=$(short_platform ${platform})
+  key=$(short_platform "${platform}")
 
   if [[ -n "${signature:-""}" ]]; then
-    echo ${RELEASE_JSON} | jq -r --arg key "${key}" --arg filename "${filename}" --arg sig "${signature}" \
+    echo "${RELEASE_JSON}" | jq -r --arg key "${key}" --arg filename "${filename}" --arg sig "${signature}" \
       '.assets[] | select(.name == $filename) | { ($key): { "signature": $sig, "url": .url }}'
   else
     echo ""
@@ -109,12 +109,11 @@ platform_json_for() {
 generate_manifest() {
   local manifest
   local version
-  local json_data
   local pub_date
 
   version="$1"
 
-  pub_date="$(echo ${RELEASE_JSON} | jq -r ".createdAt")"
+  pub_date="$(echo "${RELEASE_JSON}" | jq -r ".createdAt")"
 
   # This is the base manifest, which we will append platform json too
   manifest=$(cat <<EOF
@@ -132,11 +131,11 @@ EOF
     json="$(platform_json_for ${platform})"
 
     if [[ -n ${json} ]]; then
-      manifest=$(echo ${manifest} | jq --argjson platform_json "${json}" '.platforms += $platform_json')
+      manifest=$(echo "${manifest}" | jq --argjson platform_json "${json}" '.platforms += $platform_json')
     fi
   done
 
-  echo ${manifest}
+  echo "${manifest}"
 }
 
 version=$(./enterprise/dev/app/app_version.sh)
@@ -151,11 +150,11 @@ if [[ -z "${RELEASE_JSON}" ]]; then
 fi
 
 echo "--- generating app update manifest for version: ${version}"
-manifest=$(generate_manifest ${version} )
+manifest=$(generate_manifest "${version}" )
 
 if [[ ${CI:-""} == "true" ]]; then
   mkdir -p manifest
-  echo ${manifest} | jq >> manifest/app.update.manifest
+  echo "${manifest}" | jq >> manifest/app.update.manifest
   buildkite-agent artifact upload manifest/app.update.manifest
 else
   echo "--- app update manifest ---"

--- a/enterprise/dev/app/create-update-manifest.sh
+++ b/enterprise/dev/app/create-update-manifest.sh
@@ -156,7 +156,7 @@ manifest=$(generate_manifest ${version} )
 if [[ ${CI:-""} == "true" ]]; then
   mkdir -p manifest
   echo ${manifest} | jq >> manifest/app.update.manifest
-  buildkite-agent artefact upload manifest/app.update.manifest
+  buildkite-agent artifact upload manifest/app.update.manifest
 else
   echo "--- app update manifest ---"
   echo "${manifest}" | jq

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -75,8 +75,8 @@ create_app_archive() {
     popd
   elif [[ -e ${app_tar_gz} ]]; then
     echo "--- :file_cabinet: Moving existing archive/signatures to ${target}"
-    mv -vf "${app_tar_gz}" "$(dirname ${app_tar_gz})/${target}"
-    mv -vf "${app_tar_gz}.sig" "$(dirname ${app_tar_gz})/${target}.sig" || echo "--- signature not found - skipping"
+    mv -vf "${app_tar_gz}" "$(dirname "${app_tar_gz}")/${target}"
+    mv -vf "${app_tar_gz}.sig" "$(dirname "${app_tar_gz}")/${target}.sig" || echo "--- signature not found - skipping"
   fi
 }
 

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -35,7 +35,7 @@ upload_dist() {
   local target_dir
   path="$(bundle_path)"
   echo "searching for artefacts in '${path}' and moving them to dist/"
-  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" \));
+  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" -o -name "*.sig" \));
   target_dir="./${DIST_DIR}"
 
   mkdir -p "${target_dir}"
@@ -43,18 +43,9 @@ upload_dist() {
     mv -vf "${from}" "${target_dir}/"
   done
 
-  src=$(find "${path}" -type f -name "*.sig")
-  target_dir="${target_dir}/sigs"
-  mkdir -p ${target_dir}
-  for from in ${src}; do
-    mv -vf "${from}" "${target_dir}/"
-  done
-
   echo --- Uploading artifacts from dist
   ls -al "./${DIST_DIR}"
   buildkite-agent artifact upload "${DIST_DIR}/*"
-
-
 }
 
 create_app_archive() {
@@ -83,8 +74,9 @@ create_app_archive() {
     tar -czvf "${target}" "Sourcegraph.app"
     popd
   elif [[ -e ${app_tar_gz} ]]; then
-    echo "--- :file_cabinet: Moving existing archive to ${target}"
+    echo "--- :file_cabinet: Moving existing archive/signatures to ${target}"
     mv -vf "${app_tar_gz}" "$(dirname ${app_tar_gz})/${target}"
+    mv -vf "${app_tar_gz}.sig" "$(dirname ${app_tar_gz})/${target}.sig" || echo "--- signature not found - skipping"
   fi
 }
 

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -34,7 +34,7 @@ upload_dist() {
   local path
   path="$(bundle_path)"
   echo "searching for artefacts in '${path}' and moving them to dist/"
-  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" \));
+  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" -name "*.sig" \));
 
   mkdir -p dist
   for from in ${src}; do

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -43,7 +43,7 @@ upload_dist() {
     mv -vf "${from}" "${target_dir}/"
   done
 
-  src=$(find "${path}" -type f "*.sig")
+  src=$(find "${path}" -type f -name "*.sig")
   target_dir="${target_dir}/sigs"
   mkdir -p ${target_dir}
   for from in ${src}; do
@@ -82,7 +82,7 @@ create_app_archive() {
     echo "--- :file_cabinet: Creating archive ${target}"
     tar -czvf "${target}" "Sourcegraph.app"
     popd
-  else
+  elif [[ -e ${app_tar_gz} ]]; then
     echo "--- :file_cabinet: Moving existing archive to ${target}"
     mv -vf "${app_tar_gz}" "$(dirname ${app_tar_gz})/${target}"
   fi

--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -32,18 +32,28 @@ bundle_path() {
 
 upload_dist() {
   local path
+  local target_dir
   path="$(bundle_path)"
   echo "searching for artefacts in '${path}' and moving them to dist/"
-  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" -name "*.sig" \));
+  src=$(find "${path}" -type f \( -name "Sourcegraph*.dmg" -o -name "Sourcegraph*.tar.gz" -o -name "sourcegraph*.deb" -o -name "sourcegraph*.AppImage" -o -name "sourcegraph*.tar.gz" \));
+  target_dir="./${DIST_DIR}"
 
-  mkdir -p dist
+  mkdir -p "${target_dir}"
   for from in ${src}; do
-    mv -vf "${from}" "./${DIST_DIR}/"
+    mv -vf "${from}" "${target_dir}/"
+  done
+
+  src=$(find "${path}" -type f "*.sig")
+  target_dir="${target_dir}/sigs"
+  mkdir -p ${target_dir}
+  for from in ${src}; do
+    mv -vf "${from}" "${target_dir}/"
   done
 
   echo --- Uploading artifacts from dist
-  ls -al ./dist
-  buildkite-agent artifact upload "./${DIST_DIR}/*"
+  ls -al "./${DIST_DIR}"
+  buildkite-agent artifact upload "${DIST_DIR}/*"
+
 
 }
 
@@ -51,25 +61,30 @@ create_app_archive() {
   local version
   local path
   local app_path
+  local arch
+  local target
+
   version=$1
   path="$(bundle_path)"
   app_path=$(find "${path}" -type d -name "Sourcegraph.app")
+  app_tar_gz=$(find "${path}" -type f -name "Sourcegraph.app.tar.gz")
 
+  arch="$(uname -m)"
+  if [[ "${arch}" == "arm64" ]]; then
+    arch="aarch64"
+  fi
+
+  target="Sourcegraph.${version}.${arch}.app.tar.gz"
   # # we have to handle Sourcegraph.App differently since it is a dir
-  if [[ -d  ${app_path} ]]; then
-    local arch
-    local target
-    arch="$(uname -m)"
-    if [[ "${arch}" == "arm64" ]]; then
-      arch="aarch64"
-    fi
-
-    target="Sourcegraph.${version}.${arch}.app.tar.gz"
+  if [[ -d  ${app_path} && -z ${app_tar_gz} ]]; then
     pushd .
     cd "${path}/macos/"
     echo "--- :file_cabinet: Creating archive ${target}"
     tar -czvf "${target}" "Sourcegraph.app"
     popd
+  else
+    echo "--- :file_cabinet: Moving existing archive to ${target}"
+    mv -vf "${app_tar_gz}" "$(dirname ${app_tar_gz})/${target}"
   fi
 }
 
@@ -143,11 +158,21 @@ secret_value() {
 
 build() {
   echo --- :magnify_glass: detecting platform
+  local version
+  local do_updater_bundle
   local platform
-  platform="$(./enterprise/dev/app/detect_platform.sh)"
+  local bundles
+
+  platform="$1"
+  version="$2"
+  do_updater_bundle="$3"
+
+  # we only allow the updater build once we're in CI or see "SRC_APP_UPDATER_BUILD=1"
+  bundles="deb,appimage,app,dmg"
+
   echo "platform is: ${platform}"
 
-  if [[ ${CI} == "true" ]]; then
+  if [[ ${CI:-""} == "true" ]]; then
     local secrets
     echo "--- :aws::gcp::tauri: Retrieving tauri signing secrets"
     secrets=$(secret_value "sourcegraph/tauri-key")
@@ -156,9 +181,13 @@ build() {
     export TAURI_KEY_PASSWORD="${TAURI_KEY_PASSWORD:-"$(echo "${secrets}" | jq -r '.TAURI_KEY_PASSWORD' || echo '')"}"
   fi
 
-  echo "--- :tauri: Building Application (${VERSION}) for platform: ${platform}"
+  if [[ ${do_updater_bundle} == 1 ]]; then
+    bundles="$bundles,updater"
+  fi
+
+  echo "--- :tauri: Building Application (${version}) with bundles '${bundles}' for platform: ${platform}"
   NODE_ENV=production pnpm run build-app-shell
-  pnpm tauri build --bundles deb,appimage,app,dmg,updater --target "${platform}"
+  pnpm tauri build --bundles ${bundles} --target "${platform}"
 }
 
 if [[ ${CI:-""} == "true" ]]; then
@@ -188,7 +217,8 @@ fi
 
 CI="${CI:-"false"}"
 PLATFORM="$(./enterprise/dev/app/detect_platform.sh)"
-build "${PLATFORM}"
+SRC_APP_UPDATER_BUILD="${SRC_APP_UPDATER_BUILD:-"0"}"
+build "${PLATFORM}" "${VERSION}" "${SRC_APP_UPDATER_BUILD:-"0"}"
 
 create_app_archive "${VERSION}"
 

--- a/enterprise/dev/app/update_manifest.sh
+++ b/enterprise/dev/app/update_manifest.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# deterimes the Sourcegraph App filename based on the platform string given
+# args:
+# - 1: platform string
+filename_from() {
+  local arch
+  local os
+  local filename
+  arch=$(echo $1 | cut -d '-' -f1)
+  os=$(echo $1 | cut -d '-' -f3)
+
+  case "${os}" in
+    "darwin")
+      filename="Sourcegraph.${version}.${arch}.app.tar.gz"
+      ;;
+    "linux")
+      filename="sourcegraph.${version}.${arch}.AppImage"
+      ;;
+    *)
+      echo "cannot determine filename for unsupported os: ${os}"
+      exit 1
+  esac
+
+  echo ${filename}
+}
+#
+# short_platform breaks a long form platform strings like <arch>-<vendor>-<os> up into just <arch>-<os>
+# ex. x86_64-unknown-linux-gnu becomes x86_64-linux
+short_platform() {
+  local arch
+  local os
+  arch=$(echo $1 | cut -d '-' -f1)
+  os=$(echo $1 | cut -d '-' -f3)
+
+  echo "${arch}-${os}"
+}
+
+
+# local_file given a dir and filename, local_file finds the file locally with that name
+# args:
+# 1: directory to search in
+# 2: filename to search for
+local_file() {
+  local dir
+  local filename
+  dir=$1
+  filename=$2
+
+  find "${dir}" -type f -name "${filename}"
+}
+
+# platform_json_for creates the following json:
+# { "<short-platform-key>": {
+#   "signature": "<contents of signature file>",
+#   "url": "<github release url>"
+# }
+#
+# We determine the release artefact name for the particular platform. The artefact name is then used to
+# locate the .sig file locally. If we have a signature for a artefact, get the contents of it as well as
+# the github release url for the artefact. Once we have all the values, we return json using the values.
+# args:
+# 2: platform - platform to generate json for
+platform_json_for() {
+  local filename
+  local key
+  local signature_file
+  local signature
+  local platform
+
+  platform="$1"
+  filename=$(filename_from "${platform}")
+
+  signature_file=$(local_file "dist" "${filename}.sig")
+  if [[ -e "${signature_file}" ]]; then
+    signature=$(cat "${signature_file}")
+  else
+    signature=""
+  fi
+
+  key=$(short_platform ${platform})
+
+  if [[ -n "${signature:""}" ]]; then
+    echo ${RELEASE_JSON} | jq -r --arg key "${key}" --arg filename "${filename}" --arg sig "${signature}" \
+      '.assets[] | select(.name == $filename) | { ($key): { "signature": $sig, "url": .url }}'
+  fi
+}
+
+# generate_manifest generates an update manifest with the following structure:
+# {
+#   "version": "1.2.3",
+#   "pub_date": "<github release created At value>"
+#   "platforms": {
+#     "<short-platform name>": {
+#       "signature": "<contents of release signature>"
+#       "url": "<github release url>"
+#     }
+#   }
+# }
+#
+# args:
+# 1: version - the version for that should be used in the update manifest
+generate_manifest() {
+  local manifest
+  local version
+  local json_data
+  local pub_date
+
+  version="$1"
+
+  pub_date="$(echo ${RELEASE_JSON} | jq -r ".createdAt")"
+
+  # This is the base manifest, which we will append platform json too
+  manifest=$(cat <<EOF
+{
+  "version": "${version}",
+  "pub_date": "${pub_date}",
+  "platforms": {}
+}
+EOF
+)
+
+  # we loop through our supported platforms. If we do have platform json for the particular platform, we append to our base manifest
+  local json
+  for platform in "aarch64-apple-darwin" "x86_64-unknown-linux-gnu"; do
+    json="$(platform_json_for ${platform})"
+
+    if [[ -n ${json} ]]; then
+      manifest=$(echo ${manifest} | jq --argjson platform_json "${json}" '.platforms += $platform_json')
+    fi
+  done
+
+  echo ${manifest}
+}
+
+version=$(./enterprise/dev/app/app_version.sh)
+release_tag="app-v${version}"
+
+echo "--- :github: fetching release information for tag: ${release_tag}"
+RELEASE_JSON=$(gh release view "${release_tag}" --json name,createdAt,assets || echo '')
+
+if [[ -z "${RELEASE_JSON}" ]]; then
+  echo "No release information for ${release_tag} - skipping generating update manifest. Verify that there is a release for this tag"
+  exit 0
+fi
+
+echo "--- generating app update manifest for version: ${version}"
+manifest=$(generate_manifest ${version} )
+
+if [[ ${CI:-""} == "true" ]]; then
+  mkdir -p manifest
+  echo ${manifest} | jq >> manifest/app.update.manifest
+  buildkite-agent artefact upload manifest/app.update.manifest
+else
+  echo "--- app update manifest ---"
+  echo "${manifest}" | jq
+  echo "--- end ---"
+fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -103,6 +103,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "flate2",
+ "http",
+ "log",
+ "native-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1661,24 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1836,6 +1876,50 @@ checksum = "2078c0039e6a54a0c42c28faa984e115fb4c2d5bf2208f77d1961002df8576f8"
 dependencies = [
  "pathdiff",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2368,6 +2452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+dependencies = [
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2477,29 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "security-framework"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2462,6 +2578,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa 1.0.6",
+ "ryu",
  "serde",
 ]
 
@@ -2796,6 +2924,8 @@ version = "1.3.0"
 source = "git+https://github.com/tauri-apps/tauri?branch=dev#6a6b1388ea5787aea4c0e0b0701a4772087bbc0f"
 dependencies = [
  "anyhow",
+ "attohttpc",
+ "base64 0.21.0",
  "cocoa",
  "dirs-next",
  "embed_plist",
@@ -2808,6 +2938,7 @@ dependencies = [
  "heck 0.4.1",
  "http",
  "ignore",
+ "minisign-verify",
  "objc",
  "once_cell",
  "open",
@@ -2831,12 +2962,14 @@ dependencies = [
  "tauri-utils 1.3.0 (git+https://github.com/tauri-apps/tauri?branch=dev)",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "url",
  "uuid",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
+ "zip",
 ]
 
 [[package]]
@@ -3363,6 +3496,12 @@ dependencies = [
  "ctor",
  "version_check",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4007,4 +4146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ tauri-utils = { git = "https://github.com/tauri-apps/tauri", branch = "dev" }
 [dependencies.tauri]
 git = "https://github.com/tauri-apps/tauri"
 branch = "dev"
-features = [ "dialog-open","devtools", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "window-start-dragging"]
+features = [ "updater", "dialog-open","devtools", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "window-start-dragging"]
 
 [patch.crates-io]
 tauri = { git = "https://github.com/tauri-apps/tauri", branch = "dev" }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -65,7 +65,12 @@
       "csp": "default-src 'self' http://localhost:3080; style-src 'self' http://localhost:3080 'unsafe-eval' 'unsafe-inline'; navigate-to 'self' http://localhost:3080 'unsafe-allow-redirects';"
     },
     "updater": {
-      "active": false
+      "active": true,
+      "endpoints" : [
+        "https://sourcegraph.com/.api/update/app?target=blah&current_version=2&arc=will"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGNTY0NDBFMkYwN0NGMzUKUldRMXp3Y3ZEa1JXanllL3ozNVBFaGIyd1NQcEg1T3BucHRrWGJSYmFFZ1hYRWkwT24yM3NrWUcK"
     },
     "windows": [
       {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
     },
     "updater": {
       "active": true,
-      "endpoints" : [
+      "endpoints": [
         "https://sourcegraph.com/.api/update/app?target={{target}}&current_version={{current_version}}&arch={{arch}}"
       ],
       "dialog": true,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,7 +67,7 @@
     "updater": {
       "active": true,
       "endpoints" : [
-        "https://sourcegraph.com/.api/update/app?target=blah&current_version=2&arc=will"
+        "https://sourcegraph.com/.api/update/app?target={{target}}&current_version={{current_version}}&arch={{arch}}"
       ],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGNTY0NDBFMkYwN0NGMzUKUldRMXp3Y3ZEa1JXanllL3ozNVBFaGIyd1NQcEg1T3BucHRrWGJSYmFFZ1hYRWkwT24yM3NrWUcK"


### PR DESCRIPTION
This enables the updater in during the tauri bundling. In particular a signature gets generated which we need in our update manifest. 
This manifest is used in conjunction with the app updater endpoint on dotcom. The manifest is consultated to tell clients whether they can update or not

## Test plan
[Green](https://buildkite.com/sourcegraph/sourcegraph-app-release/builds/1288#01884980-d278-433a-8e37-fb8b979be18a) ci on `app-release/debug` branch
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
