### PR TITLE
Cody: Fix Inline Assist decorations

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
-- Inline Assist broken decorations on Fixup tasks []()
+- Inline Assist broken decorations for Inline-Fixup tasks [pull/52322](https://github.com/sourcegraph/sourcegraph/pull/52322)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 ### Fixed
 
+- Inline Assist broken decorations on Fixup tasks []()
+
 ### Changed
 
 ## [0.1.4]

--- a/client/cody/src/services/InlineController.ts
+++ b/client/cody/src/services/InlineController.ts
@@ -129,7 +129,6 @@ export class InlineController {
         const codyReply = new Comment(text, 'Cody', this.codyIcon, false, this.thread, undefined)
         this.thread.comments = [...this.thread.comments, codyReply]
         this.thread.canReply = true
-        this.currentTaskId = ''
         void vscode.commands.executeCommand('setContext', 'cody.replied', true)
     }
     /**


### PR DESCRIPTION
Close: https://github.com/sourcegraph/sourcegraph/issues/52320

We are resetting the task ID when Cody replies before the replacement task is run, which led to the fixup replacement task unable to locate the Code Lens which handles the decorations using the task ID.

Solution: The task ID should only need to be reset after the fixup task has been completed, as it is only set when a fix up task is run.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally:
<img width="1482" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/78f18a64-83d1-4143-92d7-5c924dddaa18">

<img width="1438" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/140b311b-dc76-4413-afb2-7887a4007e96">

The fix also pass the WIP e2e test in https://github.com/sourcegraph/sourcegraph/pull/52337
