### PR TITLE
app: set name of app updater route and add it to anon api routes

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -73,6 +73,7 @@ var (
 		router.ResetPasswordInit:  {},
 		router.ResetPasswordCode:  {},
 		router.CheckUsernameTaken: {},
+		router.AppUpdateCheck:     {},
 	}
 	anonymousAccessibleUIRoutes = map[string]struct{}{
 		uirouter.RouteSignIn:             {},

--- a/cmd/frontend/internal/app/router/BUILD.bazel
+++ b/cmd/frontend/internal/app/router/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/internal/app/updatecheck",
         "//cmd/frontend/internal/routevar",
         "//internal/api",
         "@com_github_gorilla_mux//:mux",

--- a/cmd/frontend/internal/app/router/router.go
+++ b/cmd/frontend/internal/app/router/router.go
@@ -7,6 +7,7 @@ package router
 import (
 	"github.com/gorilla/mux"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 )
 
@@ -54,6 +55,8 @@ const (
 	GopherconLiveBlog = "gophercon.live.blog"
 
 	UI = "ui"
+
+	AppUpdateCheck = updatecheck.RouteAppUpdateCheck
 )
 
 // Router returns the frontend app router.

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -141,6 +141,7 @@ func (checker *AppUpdateChecker) Handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		appClientVersion := readClientAppVersion(r.URL)
 		if err := appClientVersion.validate(); err != nil {
+			checker.logger.Error("app client version failed validation", log.Error(err))
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -157,7 +157,7 @@ func NewHandler(
 	m.Get(apirouter.CodeInsightsDataExport).Handler(trace.Route(handlers.CodeInsightsDataExportHandler))
 
 	if envvar.SourcegraphDotComMode() {
-		m.Path("/app/check/update").Handler(trace.Route(updatecheck.AppUpdateHandler(logger)))
+		m.Path("/app/check/update").Name(updatecheck.RouteAppUpdateCheck).Handler(trace.Route(updatecheck.AppUpdateHandler(logger)))
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.Route(http.HandlerFunc(updatecheck.HandlerWithLog(logger))))
 	}
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,7 +67,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://sourcegraph.com/.api/update/app?target={{target}}&current_version={{current_version}}&arch={{arch}}"
+        "https://sourcegraph.com/.api/app/check/update?target={{target}}&current_version={{current_version}}&arch={{arch}}"
       ],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDhGNTY0NDBFMkYwN0NGMzUKUldRMXp3Y3ZEa1JXanllL3ozNVBFaGIyd1NQcEg1T3BucHRrWGJSYmFFZ1hYRWkwT24yM3NrWUcK"


### PR DESCRIPTION
The updater route was missing some "glue". This fixes it by:
- adding it to anon api routes
- naming the route
## Test plan
tested locally

#### No update
```
curl -o /dev/null -s -w "%{http_code}\n" "https://sourcegraph.test:3443/.api/app/check/update?target=aarch64&current_version=2023.8.1&arch=darwin"
204
```

#### Update!
```
curl -s "https://sourcegraph.test:3443/.api/app/check/update?target=aarch64&current_version=2023.2.1&arch=darwin" | jq
{
  "version": "2023.5.8+dev.123.shamd245",
  "notes": "Test version",
  "pub_date": "2023-05-07T12:25:57Z",
  "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVTWVByYmswNFZITlB3UDZaQUE1WnlrZEYxMzBZd1hNYVY5U2U0dGJmZzZNUm1aTDdoMzF3TFNoYlo5VFRiblI5NTQzV2NsS1J0TWZUSmFJQXVmejV1U1p2WXo5ZWhDMGc4PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjgzNTQzMzgyCWZpbGU6U291cmNlZ3JhcGguQXBwXzEuMC4wLWRldl94NjQuZG1nCmdGM1NDODlWNmJFdEpyUGZNd3orYzdYT1pjOXFjMFJQZXBqNG00ZC9zTC9vajBrakVzSkV5OGRIUE4zak1aSlNVZDN5eXc2YVNRNWs3elovZ3Z1bkJnPT0K",
  "url": "https://github.com/sourcegraph/sourcegraph/releases/download/untagged-03042cee5585262192cf/Sourcegraph.App_1.0.0-dev_x64.dmg"
}

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
