### PR TITLE
batches: Specify domain when creating a Github App

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -95,7 +95,9 @@ export const CreateGitHubAppPage: FC<AddGitHubPageProps> = () => {
     const createState = useCallback(async () => {
         setError(null)
         try {
-            const response = await fetch(`/.auth/githubapp/new-app-state?appName=${name}&webhookURN=${url}`)
+            const response = await fetch(
+                `/.auth/githubapp/new-app-state?appName=${name}&webhookURN=${url}&domain=repos`
+            )
             const state: stateResponse = await response.json()
             const webhookURL = new URL(`/.api/webhooks/${state.webhookUUID}`, baseUrl).href
             submitForm(state.state, webhookURL, name)


### PR DESCRIPTION
Closes [#52346](https://github.com/sourcegraph/sourcegraph/issues/52346)

This PR allows the domain to be specified when creating a GitHub app. Right now it's hard coded to only work with the `repos` domain till we figure out the UX for creating a Batch Changes GitHub App.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Create a GitHub app.
* inspect the `github_apps` table for the newly created GitHub app - the app should have the value of `repos` in the `domain` column.