### PR TITLE
Cody: always fetch context on first chat interaction

### DIFF
--- a/client/cody-shared/src/chat/client.ts
+++ b/client/cody-shared/src/chat/client.ts
@@ -105,6 +105,7 @@ export async function createClient({
             intentDetector,
             codebaseContext,
             responseMultiplexer: new BotResponseMultiplexer(),
+            firstInteraction: transcript.isEmpty,
         })
         if (!interaction) {
             return

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -27,6 +27,7 @@ export class ChatQuestion implements Recipe {
                 this.getContextMessages(
                     truncatedText,
                     context.editor,
+                    context.firstInteraction,
                     context.intentDetector,
                     context.codebaseContext,
                     context.editor.getActiveTextEditorSelection() || null
@@ -38,6 +39,7 @@ export class ChatQuestion implements Recipe {
     private async getContextMessages(
         text: string,
         editor: Editor,
+        firstInteraction: boolean,
         intentDetector: IntentDetector,
         codebaseContext: CodebaseContext,
         selection: ActiveTextEditorSelection | null
@@ -49,7 +51,8 @@ export class ChatQuestion implements Recipe {
             contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
 
-        const isCodebaseContextRequired = await intentDetector.isCodebaseContextRequired(text)
+        const isCodebaseContextRequired = firstInteraction || (await intentDetector.isCodebaseContextRequired(text))
+
         this.debug('ChatQuestion:getContextMessages', 'isCodebaseContextRequired', isCodebaseContextRequired)
         if (isCodebaseContextRequired) {
             const codebaseContextMessages = await codebaseContext.getContextMessages(text, {

--- a/client/cody-shared/src/chat/recipes/recipe.ts
+++ b/client/cody-shared/src/chat/recipes/recipe.ts
@@ -10,6 +10,7 @@ export interface RecipeContext {
     intentDetector: IntentDetector
     codebaseContext: CodebaseContext
     responseMultiplexer: BotResponseMultiplexer
+    firstInteraction: boolean
 }
 
 export type RecipeID =

--- a/client/cody-shared/src/chat/transcript/transcript.test.ts
+++ b/client/cody-shared/src/chat/transcript/transcript.test.ts
@@ -98,6 +98,43 @@ describe('Transcript', () => {
         assert.deepStrictEqual(prompt, expectedPrompt)
     })
 
+    it('generates a prompt with context for a chat question for first interaction', async () => {
+        const embeddings = new MockEmbeddingsClient({
+            search: async () =>
+                Promise.resolve({
+                    codeResults: [{ fileName: 'src/main.go', startLine: 0, endLine: 1, content: 'package main' }],
+                    textResults: [{ fileName: 'docs/README.md', startLine: 0, endLine: 1, content: '# Main' }],
+                }),
+        })
+
+        const interaction = await new ChatQuestion(() => {}).getInteraction(
+            'how do access tokens work in sourcegraph',
+            newRecipeContext({
+                codebaseContext: new CodebaseContext(
+                    { useContext: 'embeddings', serverEndpoint: 'https://example.com' },
+                    'dummy-codebase',
+                    embeddings,
+                    defaultKeywordContextFetcher
+                ),
+                firstInteraction: true,
+            })
+        )
+
+        const transcript = new Transcript()
+        transcript.addInteraction(interaction)
+
+        const prompt = await transcript.toPrompt()
+        const expectedPrompt = [
+            { speaker: 'human', text: 'Use the following text from file `docs/README.md`:\n# Main' },
+            { speaker: 'assistant', text: 'Ok.' },
+            { speaker: 'human', text: 'Use following code snippet from file `src/main.go`:\n```go\npackage main\n```' },
+            { speaker: 'assistant', text: 'Ok.' },
+            { speaker: 'human', text: 'how do access tokens work in sourcegraph' },
+            { speaker: 'assistant', text: undefined },
+        ]
+        assert.deepStrictEqual(prompt, expectedPrompt)
+    })
+
     it('generates a prompt for multiple chat questions, includes context for last question only', async () => {
         const embeddings = new MockEmbeddingsClient({
             search: async () =>

--- a/client/cody-shared/src/test/mocks.ts
+++ b/client/cody-shared/src/test/mocks.ts
@@ -108,5 +108,6 @@ export function newRecipeContext(args?: Partial<RecipeContext>): RecipeContext {
                 defaultKeywordContextFetcher
             ),
         responseMultiplexer: args.responseMultiplexer || new BotResponseMultiplexer(),
+        firstInteraction: args.firstInteraction ?? false,
     }
 }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -435,6 +435,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             intentDetector: this.intentDetector,
             codebaseContext: this.codebaseContext,
             responseMultiplexer: this.multiplexer,
+            firstInteraction: this.transcript.isEmpty,
         })
         if (!interaction) {
             return
@@ -478,6 +479,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             intentDetector: this.intentDetector,
             codebaseContext: this.codebaseContext,
             responseMultiplexer: multiplexer,
+            firstInteraction: this.transcript.isEmpty,
         })
         if (!interaction) {
             return


### PR DESCRIPTION
We've had a few bug reports where Cody doesn't fetch context for a chat question and produces a bad response. This is because we have logic to detect when context is needed vs. when it's a follow-up question, and it's hard to get this right with 100% accuracy.

This PR updates the chat recipe to always fetch context on the first interaction. **This prevents a really bad user experience where on their first chat question, Cody refuses to respond and says it needs more information about the codebase.** Even if context isn't needed for the question, it's not harmful since LLMs tend to be good at ignoring irrelevant content.

## Test plan

Added new unit test. Manually tested that this fixes this reported issue... now Cody fetches context:

<img width="400" alt="Screenshot 2023-05-24 at 12 43 13 PM" src="https://github.com/sourcegraph/sourcegraph/assets/7461306/62dcc8f4-71a2-4619-885a-8739fea4de2e">

<img width="400" alt="Screenshot 2023-05-24 at 12 45 02 PM" src="https://github.com/sourcegraph/sourcegraph/assets/7461306/528a296e-9259-43f5-9884-80dc55e133ef">
