### PR TITLE
Layout fixes for the repository info sidebar (description + metadata)

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.module.scss
+++ b/client/web/src/repo/tree/TreePageContent.module.scss
@@ -62,6 +62,25 @@
     }
 }
 
+.extra-info {
+    align-self: start;
+    grid-area: contributors;
+    gap: 1rem;
+    margin-top: 1rem;
+    padding: 1rem;
+
+    @media (--lg-breakpoint-up) {
+        padding: 0 0 0 1.5rem;
+        border-top: none;
+        border-bottom: none;
+        border-right: none;
+    }
+
+    p {
+        margin: 0;
+    }
+}
+
 .extra-info-section-item {
     &-header-icon {
         opacity: 0;

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -313,23 +313,25 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
     return (
         <>
-            <section className={classNames('container mb-3 px-0', styles.section)}>
-                {readmeEntry && (
-                    <ReadmePreviewCard
-                        entry={readmeEntry}
-                        repoName={repo.name}
-                        revision={revision}
-                        className={styles.files}
-                    />
-                )}
-                {isRoot && (
-                    <ExtraInfoSection
-                        repo={repo}
-                        className={styles.extraInfo}
-                        hasWritePermissions={hasRepoMetaWritePermissions}
-                    />
-                )}
-            </section>
+            {(readmeEntry || isRoot) && (
+                <section className={classNames('container mb-3 px-0', styles.section)}>
+                    {readmeEntry && (
+                        <ReadmePreviewCard
+                            entry={readmeEntry}
+                            repoName={repo.name}
+                            revision={revision}
+                            className={styles.files}
+                        />
+                    )}
+                    {isRoot && (
+                        <ExtraInfoSection
+                            repo={repo}
+                            className={styles.extraInfo}
+                            hasWritePermissions={hasRepoMetaWritePermissions}
+                        />
+                    )}
+                </section>
+            )}
             <section className={classNames('test-tree-entries container mb-3 px-0', styles.section)}>
                 <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} filePath={filePath} />
 

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -218,7 +218,7 @@ const ExtraInfoSection: React.FC<{
     return (
         <Card className={className}>
             <ExtraInfoSectionItem>
-                <ExtraInfoSectionItemHeader title="Description" tooltip="Synced from the code host." />
+                <ExtraInfoSectionItemHeader title="Description" tooltip="Synchronized from the code host" />
                 {repo.description && <Text>{repo.description}</Text>}
             </ExtraInfoSectionItem>
             {enableRepositoryMetadata && (

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -280,6 +280,8 @@ interface TreePageContentProps extends ExtensionsControllerProps, TelemetryProps
 export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<TreePageContentProps>> = props => {
     const { filePath, tree, repo, revision, isPackage } = props
 
+    const isRoot = filePath === ''
+
     const readmeEntry = useMemo(() => {
         for (const entry of tree.entries) {
             const name = entry.name.toLocaleLowerCase()
@@ -320,11 +322,13 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                         className={styles.files}
                     />
                 )}
-                <ExtraInfoSection
-                    repo={repo}
-                    className={styles.extraInfo}
-                    hasWritePermissions={hasRepoMetaWritePermissions}
-                />
+                {isRoot && (
+                    <ExtraInfoSection
+                        repo={repo}
+                        className={styles.extraInfo}
+                        hasWritePermissions={hasRepoMetaWritePermissions}
+                    />
+                )}
             </section>
             <section className={classNames('test-tree-entries container mb-3 px-0', styles.section)}>
                 <FilesCard diffStats={diffStats} entries={tree.entries} className={styles.files} filePath={filePath} />

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -322,7 +322,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
                 )}
                 <ExtraInfoSection
                     repo={repo}
-                    className={classNames(styles.contributors, 'p-3')}
+                    className={styles.extraInfo}
                     hasWritePermissions={hasRepoMetaWritePermissions}
                 />
             </section>


### PR DESCRIPTION
Cleans up the new `ExtraInfo` box on the repository page that contains the repository description and metadata.

* Shows only on the root page (which makes it consistent with the repo button bar)
* Makes padding and margin consistent with page
* Uses only a left border on full width screens
* Removes extra bottom padding within the container if no metadata is present

| Before | After |
| - | - |
| <img width="1422" alt="Screenshot 2023-05-24 at 2 17 32 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/c6050744-1e4c-488d-9a7c-6f88a859d268"> | <img width="1422" alt="Screenshot 2023-05-24 at 2 17 09 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/81550042-ea7a-49a4-8234-96a9d5800a60"> |
| <img width="1422" alt="Screenshot 2023-05-24 at 2 17 52 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/fa85c5a1-f591-428a-95b0-8cc1a5ad7302"> | <img width="1422" alt="Screenshot 2023-05-24 at 2 18 22 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/7a06f46d-100e-4b56-889d-64ab1aee8cb5"> |

## Test plan

Verified via:
* Viewing repo root and sub-paths
* Changing screen widths