### PR TITLE
Clean up repo metadata admin empty states

### DIFF
--- a/client/branded/src/search-ui/components/RepoMetadata.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.tsx
@@ -75,13 +75,13 @@ const Meta: React.FC<MetaProps> = ({
 
     if (onDelete) {
         return (
-            <Tooltip content="Delete metadata">
+            <Tooltip content="Remove from this repository">
                 <Badge
                     variant="secondary"
                     small={small}
                     as={Button}
                     onClick={() => onDelete(meta)}
-                    aria-label="Delete metadata"
+                    aria-label="Remove from this repository"
                     className={styles.badgeButton}
                 >
                     <Icon svgPath={mdiDelete} aria-hidden={true} className="mr-1" />

--- a/client/web/src/repo/RepoMetadataPage/AddMetadataForm.tsx
+++ b/client/web/src/repo/RepoMetadataPage/AddMetadataForm.tsx
@@ -103,7 +103,7 @@ export const AddMetadataForm: FC<{ onDidAdd: () => void; repoID: string }> = ({ 
     return (
         <>
             {!addLoading && !addError && addCalled && (
-                <Alert className="flex-grow-1 m-0 mb-3" variant="success">
+                <Alert className="flex-grow-1 mt-3 mb-3" variant="success">
                     Metadata added
                 </Alert>
             )}

--- a/client/web/src/repo/RepoMetadataPage/index.tsx
+++ b/client/web/src/repo/RepoMetadataPage/index.tsx
@@ -59,7 +59,11 @@ export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, 
 
     const onDelete = useCallback(
         (meta: RepoMetadataItem): void => {
-            if (!window.confirm(`Delete metadata "${meta.key}${meta.value ? `:${meta.value}` : ''}"?`)) {
+            if (
+                !window.confirm(
+                    `Remove metadata "${meta.key}${meta.value ? `:${meta.value}` : ''}" from this repository?`
+                )
+            ) {
                 return
             }
             deleteRepoMetadata({
@@ -125,7 +129,7 @@ export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, 
                             <RepoMetadata items={filteredMetadata} onDelete={onDelete} />
                         ) : (
                             searchQuery.length > 0 && (
-                                <Text className="text-muted">No metadata containing "{searchQuery}"</Text>
+                                <Text className="text-muted m-0">No metadata containing "{searchQuery}"</Text>
                             )
                         )}
                     </>

--- a/client/web/src/repo/RepoMetadataPage/index.tsx
+++ b/client/web/src/repo/RepoMetadataPage/index.tsx
@@ -104,25 +104,33 @@ export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, 
             <PageTitle title="Repo metadata settings" />
             <PageHeader path={[{ text: 'Metadata' }]} headingElement="h2" className="mb-3" />
             <Text>
-                Repository metadata allows you to search, filter and navigate between repositories. Administrators can
-                add repository metadata via the web, cli or API. Learn more about{' '}
-                <Link to="/help/admin/repo/metadata">Repository Metadata</Link>.
+                Add repository metadata to help search, filter and navigate between repositories. Repository metadata
+                can also be added via the CLI and API. See the{' '}
+                <Link to="/help/admin/repo/metadata">Repository Metadata Documentation</Link> to learn more.
             </Text>
             <Container className="repo-settings-metadata-page mb-2">
                 {fetchError && <ErrorAlert error={fetchError} />}
                 {deleteError && <ErrorAlert error={deleteError} />}
                 {fetchLoading && deleteLoading && <LoadingSpinner />}
-                <Input
-                    placeholder="Filter metadata by key or value…"
-                    value={searchQuery}
-                    onChange={handleSearchChange}
-                    type="search"
-                    className="mb-3"
-                />
-                {filteredMetadata.length ? (
-                    <RepoMetadata items={filteredMetadata} onDelete={onDelete} />
+                {items.length ? (
+                    <>
+                        <Input
+                            placeholder="Filter metadata by key or value…"
+                            value={searchQuery}
+                            onChange={handleSearchChange}
+                            type="search"
+                            className="mb-3"
+                        />
+                        {filteredMetadata.length ? (
+                            <RepoMetadata items={filteredMetadata} onDelete={onDelete} />
+                        ) : (
+                            searchQuery.length > 0 && (
+                                <Text className="text-muted">No metadata containing "{searchQuery}"</Text>
+                            )
+                        )}
+                    </>
                 ) : (
-                    <Text className="text-muted">No metadata containing "{searchQuery}"</Text>
+                    <Text className="text-muted m-0">No metadata</Text>
                 )}
             </Container>
             <AddMetadataForm onDidAdd={refetch} repoID={repo.id} />


### PR DESCRIPTION
Cleans up the empty state for the metadata admin page, and a few other small design and UI copy fixups.

| Before | After |
| - | - |
| <img width="1488" alt="Screenshot 2023-05-24 at 3 38 40 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/b3afc561-f72b-4303-bf1d-5f31ccabe866"> | <img width="1488" alt="Screenshot 2023-05-24 at 3 40 56 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/4200df33-2390-4b5a-a6a0-ececaf653f80"> |

## Test plan

* Loaded up the repository admin view
* View the page with no metadata
* View the page with metadata
* Test the search
