### PR TITLE
app: bucket, logger, manifest fixes

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -21,7 +21,7 @@ import (
 const RouteAppUpdateCheck = "app.update.check"
 
 // ManifestBucket the name of the bucket where the Sourcegraph App update manifest is stored
-const ManifestBucket = "sourcegraph_app"
+const ManifestBucket = "sourcegraph-app"
 
 // ManifestName is the name of the manifest object that is in the ManifestBucket
 const ManifestName = "app.update.prod.manifest.json"
@@ -34,7 +34,7 @@ type AppVersion struct {
 
 type AppUpdateResponse struct {
 	Version   string    `json:"version"`
-	Notes     string    `json:"notes"`
+	Notes     string    `json:"notes,omitempty"`
 	PubDate   time.Time `json:"pub_date"`
 	Signature string    `json:"signature"`
 	URL       string    `json:"url"`
@@ -184,10 +184,15 @@ func (checker *AppUpdateChecker) Handler() http.HandlerFunc {
 
 		checker.logger.Debug("found client platform in App Update Manifest", log.Object("platform", log.String("signature", platformLoc.Signature), log.String("url", platformLoc.URL)))
 
+		var notes = "A new Sourcegraph version is available! For more information see https://github.com/sourcegraph/sourcegraph/releases"
+		if len(manifest.Notes) > 0 {
+			notes = manifest.Notes
+		}
+
 		updateResp := AppUpdateResponse{
 			Version:   manifest.Version,
 			PubDate:   manifest.PubDate,
-			Notes:     manifest.Notes,
+			Notes:     notes,
 			Signature: platformLoc.Signature,
 			URL:       platformLoc.URL,
 		}

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -24,7 +24,7 @@ const RouteAppUpdateCheck = "app.update.check"
 const ManifestBucket = "sourcegraph_app"
 
 // ManifestName is the name of the manifest object that is in the ManifestBucket
-const ManifestName = "update.test.manifest.json"
+const ManifestName = "app.update.prod.manifest.json"
 
 type AppVersion struct {
 	Target  string
@@ -119,7 +119,7 @@ func (r *StaticManifestResolver) Resolve(_ context.Context) (*AppUpdateManifest,
 
 func NewAppUpdateChecker(logger log.Logger, resolver UpdateManifestResolver) *AppUpdateChecker {
 	return &AppUpdateChecker{
-		logger:           logger,
+		logger:           logger.Scoped("app.update.checker", "Handler that handles sourcegraph app requests that check for updates"),
 		manifestResolver: resolver,
 	}
 }


### PR DESCRIPTION
Small fixes:
* Use a different bucket name depending where we are deployed
* created the bucket in the dotcom GCP project
* fix manifest name
* have a default note if there is not one in the manifest

## Test plan
* tested locally with dev bucket
* bucket should resolve on dotcom and not return 500
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
