### PR TITLE
cody: logEvent for guardrails

### DIFF
--- a/client/cody-shared/src/guardrails/index.ts
+++ b/client/cody-shared/src/guardrails/index.ts
@@ -16,26 +16,40 @@ export interface Guardrails {
     searchAttribution(snippet: string): Promise<Attribution | Error>
 }
 
+interface AnnotatedText {
+    text: string
+    codeBlocks: number
+    duration: number
+}
+
 /**
  * Returns markdown text with attribution information added in.
  *
  * @param guardrails client to use to lookup if a snippet of codes attributions
  * @param text markdown text
  */
-export async function annotateAttribution(guardrails: Guardrails, text: string): Promise<string> {
+export async function annotateAttribution(guardrails: Guardrails, text: string): Promise<AnnotatedText> {
+    const start = performance.now()
     const tokens = parseMarkdown(text)
+    let codeBlocks = 0
     const parts = await Promise.all(
         tokens.map(async token => {
             if (token.type !== 'code') {
                 return token.raw
             }
 
+            codeBlocks++
             const msg = await guardrails.searchAttribution(token.text).then(summariseAttribution)
 
             return `${token.raw}\n<div title="guardrails">🛡️ ${escapeMarkdown(msg)}</div>`
         })
     )
-    return parts.join('')
+    const annotated = parts.join('')
+    return {
+        text: annotated,
+        codeBlocks,
+        duration: performance.now() - start,
+    }
 }
 
 export function summariseAttribution(attribution: Attribution | Error): string {


### PR DESCRIPTION
This adds some telemetry which records how long guardrails runs. It only records an event if guardrails had to annotate some text. This is the missing data before I can encourage dogfooding.

Test Plan: added debug point just before logEvent and confirmed the shape of the event made sense. Also confirmed annotations continued to show.

Fixes https://github.com/sourcegraph/sourcegraph/issues/52313