### PR TITLE
app: clarify postgres error

### DIFF
--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -75,7 +75,7 @@ func startEmbeddedPostgreSQL(logger log.Logger, pgRootDir string) (*postgresqlEn
 	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
 		ldso := "/lib64/ld-linux-x86-64.so.2"
 		if _, err := os.Stat(ldso); err != nil {
-			return nil, errors.Errorf("could not use embedded-postgres since %q is missing", ldso)
+			return nil, errors.Errorf("could not use embedded-postgres since %q is missing - see https://github.com/sourcegraph/sourcegraph/issues/52360 for more details", ldso)
 		}
 	}
 


### PR DESCRIPTION
Fairly costmetic change. Requested via discord to clarify the error message and point to a tracking issue 

[source](https://discord.com/channels/969688426372825169/1079867414541516901/1091833725190414578)
## Test plan
none - error message wording change
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
