### PR TITLE
bazel: add config setting for zig linux 86 and incompatible cc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,7 +20,10 @@ build --test_env=ENABLE_BAZEL_PACKAGES_LOAD_HACK=true
 
 # Needed by https://github.com/uber/bazel-zig-cc which we use to cross-compile
 # CGo code for cmd/symbols to be used in containers.
-build --incompatible_enable_cc_toolchain_resolution
+build:incompat-zig-linux-amd64 --incompatible_enable_cc_toolchain_resolution
+build:incompat-zig-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
+build:incompat-zig-linux-amd64 --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+
 
 # Except in CI run E2E tests in headless mode
 try-import %workspace%/user.bazelrc

--- a/cmd/server/build-bazel.sh
+++ b/cmd/server/build-bazel.sh
@@ -57,33 +57,37 @@ MUSL_TARGETS=(
 
 if [[ "${ENTERPRISE:-"false"}" == "false" ]]; then
   MUSL_TARGETS+=(//cmd/symbols)
-  exit $?
 else
   MUSL_TARGETS+=(//enterprise/cmd/symbols)
 fi
 
+bazelrc=(
+  --bazelrc=.bazelrc
+)
+if [[ ${CI:-""} == "true" ]]; then
+  bazelrc+=(
+    --bazelrc=.aspect/bazelrc/ci.bazelrc
+    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc
+  )
+fi
+
 echo "--- bazel build musl"
 bazel \
-  --bazelrc=.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  "${bazelrc[@]}"
   build \
   "${MUSL_TARGETS[@]}" \
   --stamp \
   --workspace_status_command=./dev/bazel_stamp_vars.sh \
-  --platforms @zig_sdk//platform:linux_amd64 \
-  --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+  --config incompat-zig-linux-amd64
 
 for MUSL_TARGET in "${MUSL_TARGETS[@]}"; do
-  out=$(bazel --bazelrc=.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  out=$(bazel
+    "${bazelrc[@]}"
     cquery \
     "$MUSL_TARGET" \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \
-    --platforms @zig_sdk//platform:linux_amd64 \
-    --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl \
+    --config incompat-zig-linux-amd64
     --output=files)
   cp "$out" "$BINDIR"
   echo "copying $MUSL_TARGET"
@@ -91,7 +95,6 @@ done
 
 if [[ "${ENTERPRISE:-"false"}" == "false" ]]; then
   TARGETS=("${OSS_TARGETS[@]}")
-  exit $?
 else
   TARGETS=("${ENTERPRISE_TARGETS[@]}")
 fi

--- a/cmd/server/build-bazel.sh
+++ b/cmd/server/build-bazel.sh
@@ -87,7 +87,7 @@ for MUSL_TARGET in "${MUSL_TARGETS[@]}"; do
     "$MUSL_TARGET" \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \
-    --config incompat-zig-linux-amd64
+    --config incompat-zig-linux-amd64 \
     --output=files)
   cp "$out" "$BINDIR"
   echo "copying $MUSL_TARGET"

--- a/cmd/symbols/build-bazel.sh
+++ b/cmd/symbols/build-bazel.sh
@@ -12,25 +12,31 @@ cleanup() {
 trap cleanup EXIT
 
 echo "--- bazel build"
-bazel build \
-  --bazelrc=.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+
+bazelrc=(
+  --bazelrc=.bazelrc
+)
+if [[ ${CI:-""} == "true" ]]; then
+  bazelrc+=(
+    --bazelrc=.aspect/bazelrc/ci.bazelrc
+    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc
+  )
+fi
+
+
+bazel ${bazelrc[@]} \
+  build \
   //cmd/symbols \
   --stamp \
   --workspace_status_command=./dev/bazel_stamp_vars.sh \
-  --platforms @zig_sdk//platform:linux_amd64 \
-  --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+  --config incompat-zig-linux-amd64
 
 out=$(
-  bazel build \
-    --bazelrc=.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \ cquery //cmd/symbols \
+  bazel ${bazelrc[@]} \
+    cquery //cmd/symbols \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \
-    --platforms @zig_sdk//platform:linux_amd64 \
-    --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl \
+    --config incompat-zig-linux-amd64 \
     --output=files
 )
 cp "$out" "$OUTPUT"

--- a/cmd/symbols/build-bazel.sh
+++ b/cmd/symbols/build-bazel.sh
@@ -24,7 +24,7 @@ if [[ ${CI:-""} == "true" ]]; then
 fi
 
 
-bazel ${bazelrc[@]} \
+bazel "${bazelrc[@]}" \
   build \
   //cmd/symbols \
   --stamp \
@@ -32,7 +32,7 @@ bazel ${bazelrc[@]} \
   --config incompat-zig-linux-amd64
 
 out=$(
-  bazel ${bazelrc[@]} \
+  bazel "${bazelrc[@]}" \
     cquery //cmd/symbols \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \

--- a/enterprise/cmd/symbols/build-bazel.sh
+++ b/enterprise/cmd/symbols/build-bazel.sh
@@ -3,7 +3,7 @@
 # This script builds the symbols docker image.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
-set -eux
+set -eu
 
 OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)
 cleanup() {
@@ -11,28 +11,33 @@ cleanup() {
 }
 trap cleanup EXIT
 
+bazelrc=(
+  --bazelrc=.bazelrc
+)
+if [[ ${CI:-""} == "true" ]]; then
+  bazelrc+=(
+    --bazelrc=.aspect/bazelrc/ci.bazelrc
+    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc
+  )
+fi
+
 echo "--- bazel build"
 bazel \
-  --bazelrc=.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  "${bazelrc[@]}" \
   build \
   //enterprise/cmd/symbols \
   --stamp \
   --workspace_status_command=./dev/bazel_stamp_vars.sh \
-  --platforms @zig_sdk//platform:linux_amd64 \
-  --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+  --config incompat-zig-linux-amd64
 
 out=$(
-  bazel --bazelrc=.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  bazel \
+    "${bazelrc[@]}" \
     cquery \
     //enterprise/cmd/symbols \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \
-    --platforms @zig_sdk//platform:linux_amd64 \
-    --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl \
+    --config incompat-zig-linux-amd64
     --output=files
 )
 cp "$out" "$OUTPUT"

--- a/enterprise/cmd/symbols/build-bazel.sh
+++ b/enterprise/cmd/symbols/build-bazel.sh
@@ -37,7 +37,7 @@ out=$(
     //enterprise/cmd/symbols \
     --stamp \
     --workspace_status_command=./dev/bazel_stamp_vars.sh \
-    --config incompat-zig-linux-amd64
+    --config incompat-zig-linux-amd64 \
     --output=files
 )
 cp "$out" "$OUTPUT"

--- a/enterprise/dev/app/build-backend.sh
+++ b/enterprise/dev/app/build-backend.sh
@@ -65,6 +65,7 @@ bazel_build() {
   # for more info see the BUILD.bazel file in enterprise/cmd/sourcegraph
   if [[ ${CROSS_COMPILE_X86_64_MACOS:-0} == 1 ]]; then
     bazel_target="//enterprise/cmd/sourcegraph:sourcegraph_x86_64_darwin"
+    # we don't use the incompat-zig-linux-amd64 bazel config here, since we need bazel to pick up the host cc
     bazel_opts="${bazel_opts} --platforms @zig_sdk//platform:darwin_amd64 --extra_toolchains @zig_sdk//toolchain:darwin_amd64"
   fi
 


### PR DESCRIPTION
For some bazel targets we want bazel to detect the host cc and use it. This puts the `--incompatible_enable_cc_toolchain_resolution` flag behind a config setting one has to opt into to use with `--config incompat-zig-linux-amd64`.

I also extracted some of the bazelrc to selectively add the CI bazelrc, so that it is easier to run these scripts locally.


## Test plan
* green ci
* executed the symbols and server scripts locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
