### PR TITLE
embeddings: toggle incremental embeddings in site-config

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -64,7 +64,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	// job for this repo. If we can find one, we'll attempt a delta index, otherwise
 	// we fall back to a full index.
 	var lastSuccessfulJobRevision api.CommitID
-	if featureflag.FromContext(ctx).GetBoolOr("sh-delta-embeddings", false) {
+	if conf.Get().Embeddings.Incremental {
 		lastSuccessfulJob, err := h.repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, record.RepoID)
 		if err != nil {
 			logger.Info("no previous successful embeddings job found. Falling back to full index")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -614,6 +614,8 @@ type Embeddings struct {
 	Enabled bool `json:"enabled"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
+	// Incremental description: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
+	Incremental bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
 	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`
 	// MaxTextEmbeddingsPerRepo description: The maximum number of embeddings for text files to generate per repo

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -614,7 +614,7 @@ type Embeddings struct {
 	Enabled bool `json:"enabled"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
-	// Incremental description: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
+	// Incremental description: Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
 	Incremental bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
 	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2337,6 +2337,11 @@
           "description": "The maximum number of embeddings for text files to generate per repo",
           "type": "integer",
           "minimum": 0
+        },
+        "incremental":{
+          "description": "Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
+          "type": "boolean",
+          "default": false
         }
       },
       "examples": [

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2339,7 +2339,7 @@
           "minimum": 0
         },
         "incremental":{
-          "description": "Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
+          "description": "Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
           "type": "boolean",
           "default": false
         }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2338,7 +2338,7 @@
           "type": "integer",
           "minimum": 0
         },
-        "incremental":{
+        "incremental": {
           "description": "Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
           "type": "boolean",
           "default": false


### PR DESCRIPTION
This replaces the feature-flag "sh-delta-embeddings" with the site-config setting "embeddings.incremental".

## Test plan
- I started a local instance and checked in the logs that an incremental embeddings jobs was triggered if embeddings.incremental was set to `true` and vice-versa.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
