### PR TITLE
bazel: add flag to disable nogo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "nogo")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
@@ -276,20 +277,33 @@ js_library(
 # For nogo to be able to run a linter, it needs to have `var Analyzer analysis.Analyzer` defined in the main package.
 # some of the linters do not have that, so we need to define that ourselves. The linters where we have defined can
 # be found at dev/linters. Finally, the nogo configuration can be found at the root of the repository in `nogo_config.json`
+bool_flag(
+    name = "disable_nogo",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "nogo_disabled",
+    flag_values = {":disable_nogo": "true"},
+)
+
 nogo(
     name = "sg_nogo",
     config = ":nogo_config.json",
     vet = True,
     visibility = ["//visibility:public"],  # must have public visibility
-    deps = [
-        "//dev/linters/bodyclose",
-        "//dev/linters/depguard",
-        "//dev/linters/exportloopref",
-        "//dev/linters/forbidigo",
-        "//dev/linters/gocritic",
-        "//dev/linters/ineffassign",
-        "//dev/linters/unparam",
-    ] + STATIC_CHECK_ANALYZERS,
+    deps = select({
+        "//:nogo_disabled": [],
+        "//conditions:default": [
+            "//dev/linters/bodyclose",
+            "//dev/linters/depguard",
+            "//dev/linters/exportloopref",
+            "//dev/linters/forbidigo",
+            "//dev/linters/gocritic",
+            "//dev/linters/ineffassign",
+            "//dev/linters/unparam",
+        ] + STATIC_CHECK_ANALYZERS,
+    }),
 )
 
 exports_files([


### PR DESCRIPTION
`nogo` is active by default for all builds. So when ibazel runs and you make changes to your running code because you're iterating, `nogo` might fail the build due to a linting error. With this we add a bazel flag so that we can disable the `nogo` linters by giving the following flag `--//:disable_nogo`.

In a follow up PR, I'll update ibazel in sg to use this flag.

## Test plan
`bazel build --//:disable_nogo //dev/...`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
