### PR TITLE
Pings: speed up growth query

### DIFF
--- a/internal/usagestats/growth.go
+++ b/internal/usagestats/growth.go
@@ -81,14 +81,6 @@ COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month',
                    AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS retained_users
   FROM recent_usage_by_user
     `
-	const accessRequestsQuery = `
-	SELECT
-		COUNT(*) FILTER (WHERE status = 'PENDING') AS pending_access_requests,
-		COUNT(*) FILTER (WHERE status = 'APPROVED') AS approved_access_requests,
-		COUNT(*) FILTER (WHERE status = 'REJECTED') AS rejected_access_requests
-	FROM access_requests
-	WHERE created_at >= DATE_TRUNC('month', $1::timestamp)
-	`
 	var (
 		createdUsers     int
 		deletedUsers     int
@@ -123,7 +115,12 @@ type accessRequestsGrowthStatistics struct {
 
 func getAccessRequestsGrowthStatistics(ctx context.Context, db database.DB) (*accessRequestsGrowthStatistics, error) {
 	const accessRequestsQuery = `
-	SELECT COUNT(*) FILTER (WHERE status LIKE 'PENDING') AS pending_access_requests, COUNT(*) FILTER (WHERE status LIKE 'APPROVED') AS approved_access_requests, COUNT(*) FILTER (WHERE status LIKE 'REJECTED') AS rejected_access_requests FROM access_requests WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', $1::timestamp)
+	SELECT
+		COUNT(*) FILTER (WHERE status LIKE 'PENDING') AS pending_access_requests,
+		COUNT(*) FILTER (WHERE status LIKE 'APPROVED') AS approved_access_requests,
+		COUNT(*) FILTER (WHERE status LIKE 'REJECTED') AS rejected_access_requests
+	FROM access_requests
+	WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', $1::timestamp)
 	`
 	var (
 		pendingAccessRequests  int

--- a/internal/usagestats/growth.go
+++ b/internal/usagestats/growth.go
@@ -42,40 +42,45 @@ type usersGrowthStatistics struct {
 
 func getUsersGrowthStatistics(ctx context.Context, db database.DB) (*usersGrowthStatistics, error) {
 	const usersQuery = `
-WITH all_usage_by_user_and_month AS (
-    SELECT user_id,
-           DATE_TRUNC('month', timestamp) AS month_active
-      FROM event_logs
-     GROUP BY user_id,
-              month_active),
+WITH active_last_month AS (
+	SELECT
+		DISTINCT user_id
+	FROM event_logs
+	WHERE timestamp > (DATE_TRUNC('month', $1::timestamp) - INTERVAL '1 month')
+		AND timestamp < DATE_TRUNC('month', $1::timestamp)
+),
+active_this_month AS (
+	SELECT
+		DISTINCT user_id
+	FROM event_logs
+	WHERE timestamp > DATE_TRUNC('month', $1::timestamp)
+		AND timestamp < (DATE_TRUNC('month', $1::timestamp) + INTERVAL '1 month')
+),
 recent_usage_by_user AS (
     SELECT users.id,
-           BOOL_OR(CASE WHEN DATE_TRUNC('month', month_active) = DATE_TRUNC('month', $1::timestamp) THEN TRUE ELSE FALSE END) AS current_month,
-           BOOL_OR(CASE WHEN DATE_TRUNC('month', month_active) = DATE_TRUNC('month', $1::timestamp) - INTERVAL '1 month' THEN TRUE ELSE FALSE END) AS previous_month,
+		   EXISTS(SELECT * FROM active_this_month WHERE user_id = users.id) as current_month,
+		   EXISTS(SELECT * FROM active_last_month WHERE user_id = users.id) as previous_month,
            DATE_TRUNC('month', DATE(users.created_at)) AS created_month,
            DATE_TRUNC('month', DATE(users.deleted_at)) AS deleted_month
       FROM users
-      LEFT JOIN all_usage_by_user_and_month ON all_usage_by_user_and_month.user_id = users.id
-     GROUP BY id,
-              created_month,
-              deleted_month)
+)
 SELECT COUNT(*) FILTER ( WHERE recent_usage_by_user.created_month = DATE_TRUNC('month', $1::timestamp)) AS created_users,
-       COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month', $1::timestamp)) AS deleted_users,
+COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month', $1::timestamp)) AS deleted_users,
        COUNT(*) FILTER (
                  WHERE current_month = TRUE
                    AND previous_month = FALSE
-                   AND created_month < DATE_TRUNC('month', $1::timestamp)
-                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS resurrected_users,
+				   AND created_month < DATE_TRUNC('month', $1::timestamp)
+				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS resurrected_users,
        COUNT(*) FILTER (
                  WHERE current_month = FALSE
                    AND previous_month = TRUE
-                   AND created_month < DATE_TRUNC('month', $1::timestamp)
-                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS churned_users,
+				   AND created_month < DATE_TRUNC('month', $1::timestamp)
+				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS churned_users,
        COUNT(*) FILTER (
                  WHERE current_month = TRUE
                    AND previous_month = TRUE
-                   AND created_month < DATE_TRUNC('month', $1::timestamp)
-                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS retained_users
+				   AND created_month < DATE_TRUNC('month', $1::timestamp)
+				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS retained_users
   FROM recent_usage_by_user
     `
 	const accessRequestsQuery = `
@@ -120,12 +125,7 @@ type accessRequestsGrowthStatistics struct {
 
 func getAccessRequestsGrowthStatistics(ctx context.Context, db database.DB) (*accessRequestsGrowthStatistics, error) {
 	const accessRequestsQuery = `
-	SELECT
-		COUNT(*) FILTER (WHERE status LIKE 'PENDING') AS pending_access_requests,
-		COUNT(*) FILTER (WHERE status LIKE 'APPROVED') AS approved_access_requests,
-		COUNT(*) FILTER (WHERE status LIKE 'REJECTED') AS rejected_access_requests
-	FROM access_requests
-	WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', $1::timestamp)
+	SELECT COUNT(*) FILTER (WHERE status LIKE 'PENDING') AS pending_access_requests, COUNT(*) FILTER (WHERE status LIKE 'APPROVED') AS approved_access_requests, COUNT(*) FILTER (WHERE status LIKE 'REJECTED') AS rejected_access_requests FROM access_requests WHERE DATE_TRUNC('month', created_at) = DATE_TRUNC('month', $1::timestamp)
 	`
 	var (
 		pendingAccessRequests  int

--- a/internal/usagestats/growth.go
+++ b/internal/usagestats/growth.go
@@ -43,23 +43,21 @@ type usersGrowthStatistics struct {
 func getUsersGrowthStatistics(ctx context.Context, db database.DB) (*usersGrowthStatistics, error) {
 	const usersQuery = `
 WITH active_last_month AS (
-	SELECT
-		DISTINCT user_id
-	FROM event_logs
-	WHERE timestamp > (DATE_TRUNC('month', $1::timestamp) - INTERVAL '1 month')
-		AND timestamp < DATE_TRUNC('month', $1::timestamp)
+    SELECT DISTINCT user_id
+    FROM event_logs
+    WHERE timestamp > (DATE_TRUNC('month', $1::timestamp) - INTERVAL '1 month')
+        AND timestamp < DATE_TRUNC('month', $1::timestamp)
 ),
 active_this_month AS (
-	SELECT
-		DISTINCT user_id
-	FROM event_logs
-	WHERE timestamp > DATE_TRUNC('month', $1::timestamp)
-		AND timestamp < (DATE_TRUNC('month', $1::timestamp) + INTERVAL '1 month')
+    SELECT DISTINCT user_id
+    FROM event_logs
+    WHERE timestamp > DATE_TRUNC('month', $1::timestamp)
+        AND timestamp < (DATE_TRUNC('month', $1::timestamp) + INTERVAL '1 month')
 ),
 recent_usage_by_user AS (
     SELECT users.id,
-		   EXISTS(SELECT * FROM active_this_month WHERE user_id = users.id) as current_month,
-		   EXISTS(SELECT * FROM active_last_month WHERE user_id = users.id) as previous_month,
+           EXISTS(SELECT * FROM active_this_month WHERE user_id = users.id) as current_month,
+           EXISTS(SELECT * FROM active_last_month WHERE user_id = users.id) as previous_month,
            DATE_TRUNC('month', DATE(users.created_at)) AS created_month,
            DATE_TRUNC('month', DATE(users.deleted_at)) AS deleted_month
       FROM users
@@ -69,18 +67,18 @@ COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month',
        COUNT(*) FILTER (
                  WHERE current_month = TRUE
                    AND previous_month = FALSE
-				   AND created_month < DATE_TRUNC('month', $1::timestamp)
-				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS resurrected_users,
+                   AND created_month < DATE_TRUNC('month', $1::timestamp)
+                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS resurrected_users,
        COUNT(*) FILTER (
                  WHERE current_month = FALSE
                    AND previous_month = TRUE
-				   AND created_month < DATE_TRUNC('month', $1::timestamp)
-				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS churned_users,
+                   AND created_month < DATE_TRUNC('month', $1::timestamp)
+                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS churned_users,
        COUNT(*) FILTER (
                  WHERE current_month = TRUE
                    AND previous_month = TRUE
-				   AND created_month < DATE_TRUNC('month', $1::timestamp)
-				   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS retained_users
+                   AND created_month < DATE_TRUNC('month', $1::timestamp)
+                   AND (deleted_month < DATE_TRUNC('month', $1::timestamp) OR deleted_month IS NULL)) AS retained_users
   FROM recent_usage_by_user
     `
 	const accessRequestsQuery = `

--- a/internal/usagestats/growth.go
+++ b/internal/usagestats/growth.go
@@ -63,7 +63,7 @@ recent_usage_by_user AS (
       FROM users
 )
 SELECT COUNT(*) FILTER ( WHERE recent_usage_by_user.created_month = DATE_TRUNC('month', $1::timestamp)) AS created_users,
-COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month', $1::timestamp)) AS deleted_users,
+       COUNT(*) FILTER ( WHERE recent_usage_by_user.deleted_month = DATE_TRUNC('month', $1::timestamp)) AS deleted_users,
        COUNT(*) FILTER (
                  WHERE current_month = TRUE
                    AND previous_month = FALSE


### PR DESCRIPTION
This speeds up a query on the event logs table that was taking 30 seconds on sourcegraph.com so now it only takes 1 second. 

## Test plan

Existing tests, ran manually on sourcegraph.com to ensure I got the same numbers.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
