### PR TITLE
App: remove postgres socket at startup

### DIFF
--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -84,7 +84,12 @@ func startEmbeddedPostgreSQL(logger log.Logger, pgRootDir string) (*postgresqlEn
 	if err != nil {
 		return nil, errors.Wrap(err, "user.Current")
 	}
+
 	unixSocketDir := filepath.Join(current.HomeDir, ".sourcegraph-psql")
+	err = os.RemoveAll(unixSocketDir)
+	if err != nil {
+		logger.Warn("unable to remove previous connection", log.Error(err))
+	}
 	err = os.MkdirAll(unixSocketDir, os.ModePerm)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating unix socket dir")

--- a/internal/singleprogram/postgresql.go
+++ b/internal/singleprogram/postgresql.go
@@ -84,7 +84,6 @@ func startEmbeddedPostgreSQL(logger log.Logger, pgRootDir string) (*postgresqlEn
 	if err != nil {
 		return nil, errors.Wrap(err, "user.Current")
 	}
-
 	unixSocketDir := filepath.Join(current.HomeDir, ".sourcegraph-psql")
 	err = os.RemoveAll(unixSocketDir)
 	if err != nil {


### PR DESCRIPTION
This removes the socket from the previous run of app if it exists prior to opening a new connection.

This is a partial fix to postgres issues when opening the app, the more though fix is to ensure all the connections are properly closed when exiting app.
## Test plan
Run a previous release version that leaves a socket behind
Run this version ensured app opens.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
