### PR TITLE
observation: use attribute instead of event for completion

### DIFF
--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -381,7 +381,7 @@ func (op *Operation) finishTrace(err *error, tr *trace.Trace, attrs []attribute.
 		tr.SetError(*err)
 	}
 
-	tr.AddEvent("done", attrs...)
+	tr.SetAttributes(attrs...)
 	tr.Finish()
 }
 


### PR DESCRIPTION
When a span ends that's already an indicator that the span is done, so I don't think we need a separate `done` event here. This also means that it's easier to search for spans with the attributes to `finishTrace`.

## Test plan

n/a
