### PR TITLE
Connections for Gerrit Source for Batch Changes

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -59,8 +59,15 @@ const scopeRequirements: Record<ExternalServiceKind, JSX.Element> = {
             permissions.
         </span>
     ),
+    [ExternalServiceKind.GERRIT]: (
+        // TODO: @varsanojidan change this after spike
+        <span>
+            with <Code>Organization:All accessible organizations</Code>, <Code>Code:Full</Code>,{' '}
+            <Code>Code:Status</Code>, <Code>Pull Request Threads:Read & Write</Code>, and <Code>User Profile:Read</Code>{' '}
+            permissions.
+        </span>
+    ),
     // These are just for type completeness and serve as placeholders for a bright future.
-    [ExternalServiceKind.GERRIT]: <span>Unsupported</span>,
     [ExternalServiceKind.GITOLITE]: <span>Unsupported</span>,
     [ExternalServiceKind.GOMODULES]: <span>Unsupported</span>,
     [ExternalServiceKind.PYTHONPACKAGES]: <span>Unsupported</span>,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -31,7 +31,7 @@ func (c *batchChangesCodeHostResolver) RequiresSSH() bool {
 
 func (c *batchChangesCodeHostResolver) RequiresUsername() bool {
 	switch c.codeHost.ExternalServiceType {
-	case extsvc.TypeBitbucketCloud, extsvc.TypeAzureDevOps:
+	case extsvc.TypeBitbucketCloud, extsvc.TypeAzureDevOps, extsvc.TypeGerrit:
 		return true
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -1256,6 +1256,13 @@ func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, exter
 			PublicKey:  keypair.PublicKey,
 			Passphrase: keypair.Passphrase,
 		}
+	} else if externalServiceType == extsvc.TypeGerrit {
+		a = &extsvcauth.BasicAuthWithSSH{
+			BasicAuth:  extsvcauth.BasicAuth{Username: *username, Password: credential},
+			PrivateKey: keypair.PrivateKey,
+			PublicKey:  keypair.PublicKey,
+			Passphrase: keypair.Passphrase,
+		}
 	} else {
 		a = &extsvcauth.OAuthBearerTokenWithSSH{
 			OAuthBearerToken: extsvcauth.OAuthBearerToken{Token: credential},

--- a/enterprise/internal/authz/gerrit/mocks_test.go
+++ b/enterprise/internal/authz/gerrit/mocks_test.go
@@ -8,11 +8,10 @@ package gerrit
 
 import (
 	"context"
-	"net/url"
-	"sync"
-
 	auth "github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	gerrit "github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
+	"net/url"
+	"sync"
 )
 
 // MockGerritClient is a mock implementation of the Client interface (from

--- a/enterprise/internal/authz/gerrit/mocks_test.go
+++ b/enterprise/internal/authz/gerrit/mocks_test.go
@@ -8,10 +8,11 @@ package gerrit
 
 import (
 	"context"
-	auth "github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
-	gerrit "github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 	"net/url"
 	"sync"
+
+	auth "github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	gerrit "github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 )
 
 // MockGerritClient is a mock implementation of the Client interface (from

--- a/enterprise/internal/batches/sources/BUILD.bazel
+++ b/enterprise/internal/batches/sources/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//enterprise/internal/batches/sources/azuredevops",
         "//enterprise/internal/batches/sources/bitbucketcloud",
+        "//enterprise/internal/batches/sources/gerrit",
         "//enterprise/internal/batches/store",
         "//enterprise/internal/batches/types",
         "//internal/database",

--- a/enterprise/internal/batches/sources/gerrit.go
+++ b/enterprise/internal/batches/sources/gerrit.go
@@ -177,21 +177,16 @@ func (s GerritSource) GetFork(_ context.Context, _ *types.Repo, _, _ *string) (*
 }
 
 func (s GerritSource) setChangesetMetadata(change *gerrit.Change, cs *Changeset) error {
-	apr, err := s.annotatePullRequest(change)
-	if err != nil {
-		return errors.Wrap(err, "annotating pull request")
-	}
-
+	apr := s.annotatePullRequest(change)
 	if err := cs.SetMetadata(apr); err != nil {
 		return errors.Wrap(err, "setting changeset metadata")
 	}
-
 	return nil
 }
 
-func (s GerritSource) annotatePullRequest(change *gerrit.Change) (*gerritbatches.AnnotatedChange, error) {
+func (s GerritSource) annotatePullRequest(change *gerrit.Change) *gerritbatches.AnnotatedChange {
 	return &gerritbatches.AnnotatedChange{
 		Change: change,
 		URL:    s.client.GetURL(),
-	}, nil
+	}
 }

--- a/enterprise/internal/batches/sources/gerrit.go
+++ b/enterprise/internal/batches/sources/gerrit.go
@@ -91,7 +91,7 @@ func (s GerritSource) LoadChangeset(ctx context.Context, cs *Changeset) error {
 		return errors.Wrap(err, "getting pull request")
 	}
 
-	return errors.Wrap(s.setChangesetMetadata(ctx, pr, cs), "setting Gerrit changeset metadata")
+	return errors.Wrap(s.setChangesetMetadata(pr, cs), "setting Gerrit changeset metadata")
 }
 
 // CreateChangeset will create the Changeset on the source. If it already
@@ -122,7 +122,7 @@ func (s GerritSource) CloseChangeset(ctx context.Context, cs *Changeset) error {
 		return errors.Wrap(err, "abandoning pull request")
 	}
 
-	return errors.Wrap(s.setChangesetMetadata(ctx, updated, cs), "setting Gerrit changeset metadata")
+	return errors.Wrap(s.setChangesetMetadata(updated, cs), "setting Gerrit changeset metadata")
 }
 
 // UpdateChangeset can update Changesets.
@@ -139,7 +139,7 @@ func (s GerritSource) ReopenChangeset(ctx context.Context, cs *Changeset) error 
 		return errors.Wrap(err, "updating pull request")
 	}
 
-	return errors.Wrap(s.setChangesetMetadata(ctx, updated, cs), "setting Gerrit changeset metadata")
+	return errors.Wrap(s.setChangesetMetadata(updated, cs), "setting Gerrit changeset metadata")
 }
 
 // CreateComment posts a comment on the Changeset.
@@ -155,7 +155,7 @@ func (s GerritSource) CreateComment(ctx context.Context, cs *Changeset, comment 
 // merge. If the changeset cannot be merged, because it is in an unmergeable
 // state, ChangesetNotMergeableError must be returned.
 // Gerrit changes are always single commit, so squash does not matter.
-func (s GerritSource) MergeChangeset(ctx context.Context, cs *Changeset, squash bool) error {
+func (s GerritSource) MergeChangeset(ctx context.Context, cs *Changeset, _ bool) error {
 	updated, err := s.client.SubmitChange(ctx, cs.ExternalID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
@@ -164,7 +164,7 @@ func (s GerritSource) MergeChangeset(ctx context.Context, cs *Changeset, squash 
 		return ChangesetNotMergeableError{ErrorMsg: err.Error()}
 	}
 
-	return errors.Wrap(s.setChangesetMetadata(ctx, updated, cs), "setting Gerrit changeset metadata")
+	return errors.Wrap(s.setChangesetMetadata(updated, cs), "setting Gerrit changeset metadata")
 }
 
 // GetFork returns a repo pointing to a fork of the target repo, ensuring that the fork
@@ -176,8 +176,8 @@ func (s GerritSource) GetFork(_ context.Context, _ *types.Repo, _, _ *string) (*
 	return nil, nil
 }
 
-func (s GerritSource) setChangesetMetadata(ctx context.Context, change *gerrit.Change, cs *Changeset) error {
-	apr, err := s.annotatePullRequest(ctx, change)
+func (s GerritSource) setChangesetMetadata(change *gerrit.Change, cs *Changeset) error {
+	apr, err := s.annotatePullRequest(change)
 	if err != nil {
 		return errors.Wrap(err, "annotating pull request")
 	}
@@ -189,7 +189,7 @@ func (s GerritSource) setChangesetMetadata(ctx context.Context, change *gerrit.C
 	return nil
 }
 
-func (s GerritSource) annotatePullRequest(ctx context.Context, change *gerrit.Change) (*gerritbatches.AnnotatedChange, error) {
+func (s GerritSource) annotatePullRequest(change *gerrit.Change) (*gerritbatches.AnnotatedChange, error) {
 	return &gerritbatches.AnnotatedChange{
 		Change: change,
 		URL:    s.client.GetURL(),

--- a/enterprise/internal/batches/sources/gerrit/BUILD.bazel
+++ b/enterprise/internal/batches/sources/gerrit/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gerrit",
+    srcs = ["types.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/gerrit",
+    visibility = ["//enterprise:__subpackages__"],
+    deps = ["//internal/extsvc/gerrit"],
+)

--- a/enterprise/internal/batches/sources/gerrit/types.go
+++ b/enterprise/internal/batches/sources/gerrit/types.go
@@ -1,0 +1,16 @@
+package gerrit
+
+import (
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
+)
+
+// AnnotatedChange adds metadata we need that lives outside the main
+// Change type returned by the Gerrit API.
+// This type is used as the primary metadata type for Gerrit
+// changesets.
+type AnnotatedChange struct {
+	*gerrit.Change
+	URL *url.URL
+}

--- a/enterprise/internal/batches/sources/gerrit/types.go
+++ b/enterprise/internal/batches/sources/gerrit/types.go
@@ -12,5 +12,5 @@ import (
 // changesets.
 type AnnotatedChange struct {
 	*gerrit.Change
-	URL *url.URL
+	CodeHostURL *url.URL
 }

--- a/enterprise/internal/batches/sources/gerrit_test.go
+++ b/enterprise/internal/batches/sources/gerrit_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -124,6 +125,7 @@ func TestGerritSource_LoadChangeset(t *testing.T) {
 		s, client := mockGerritSource()
 
 		change := mockGerritChange(&testProject)
+		client.GetURLFunc.SetDefaultReturn(&url.URL{})
 		client.GetChangeFunc.SetDefaultHook(func(ctx context.Context, changeID string) (*gerrit.Change, error) {
 			assert.Equal(t, changeID, testGerritChangeID)
 			return change, nil
@@ -157,6 +159,7 @@ func TestGerritSource_CloseChangeset(t *testing.T) {
 		s, client := mockGerritSource()
 
 		pr := mockGerritChange(&testProject)
+		client.GetURLFunc.SetDefaultReturn(&url.URL{})
 		client.AbandonChangeFunc.SetDefaultHook(func(ctx context.Context, changeID string) (*gerrit.Change, error) {
 			assert.Equal(t, changeID, testGerritChangeID)
 			return pr, nil
@@ -240,6 +243,7 @@ func TestGerritSource_MergeChangeset(t *testing.T) {
 		s, client := mockGerritSource()
 
 		pr := mockGerritChange(&testProject)
+		client.GetURLFunc.SetDefaultReturn(&url.URL{})
 		client.SubmitChangeFunc.SetDefaultHook(func(ctx context.Context, changeID string) (*gerrit.Change, error) {
 			assert.Equal(t, testGerritChangeID, changeID)
 			return pr, nil
@@ -256,6 +260,7 @@ func TestGerritSource_MergeChangeset(t *testing.T) {
 		s, client := mockGerritSource()
 
 		pr := mockGerritChange(&testProject)
+		client.GetURLFunc.SetDefaultReturn(&url.URL{})
 		client.SubmitChangeFunc.SetDefaultHook(func(ctx context.Context, changeID string) (*gerrit.Change, error) {
 			assert.Equal(t, testGerritChangeID, changeID)
 			return pr, nil

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -8,9 +8,6 @@ package sources
 
 import (
 	"context"
-	"net/url"
-	"sync"
-
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	types1 "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	database "github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,6 +17,8 @@ import (
 	gerrit "github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 	protocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	types "github.com/sourcegraph/sourcegraph/internal/types"
+	"net/url"
+	"sync"
 )
 
 // MockChangesetSource is a mock implementation of the ChangesetSource

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -8,6 +8,9 @@ package sources
 
 import (
 	"context"
+	"net/url"
+	"sync"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	types1 "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	database "github.com/sourcegraph/sourcegraph/internal/database"
@@ -17,8 +20,6 @@ import (
 	gerrit "github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 	protocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	types "github.com/sourcegraph/sourcegraph/internal/types"
-	"net/url"
-	"sync"
 )
 
 // MockChangesetSource is a mock implementation of the ChangesetSource

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -291,7 +291,8 @@ func loadExternalService(ctx context.Context, s database.ExternalServiceStore, o
 			*schema.BitbucketServerConnection,
 			*schema.GitLabConnection,
 			*schema.BitbucketCloudConnection,
-			*schema.AzureDevOpsConnection:
+			*schema.AzureDevOpsConnection,
+			*schema.GerritConnection:
 			return e, nil
 		}
 	}
@@ -313,6 +314,8 @@ func buildChangesetSource(ctx context.Context, cf *httpcli.Factory, externalServ
 		return NewBitbucketCloudSource(ctx, externalService, cf)
 	case extsvc.KindAzureDevOps:
 		return NewAzureDevOpsSource(ctx, externalService, cf)
+	case extsvc.KindGerrit:
+		return NewGerritSource(ctx, externalService, cf)
 	default:
 		return nil, errors.Errorf("unsupported external service type %q", extsvc.KindToType(externalService.Kind))
 	}

--- a/enterprise/internal/batches/state/BUILD.bazel
+++ b/enterprise/internal/batches/state/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/extsvc/azuredevops",
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/bitbucketserver",
+        "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/gitserver",

--- a/enterprise/internal/batches/state/BUILD.bazel
+++ b/enterprise/internal/batches/state/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//enterprise/internal/batches/sources/azuredevops",
         "//enterprise/internal/batches/sources/bitbucketcloud",
+        "//enterprise/internal/batches/sources/gerrit",
         "//enterprise/internal/batches/types",
         "//internal/actor",
         "//internal/api",

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
+	gerritbatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/gerrit"
 	adobatches "github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 
@@ -119,7 +120,7 @@ func computeCheckState(c *btypes.Changeset, events ChangesetEvents) btypes.Chang
 		return computeBitbucketCloudBuildState(c.UpdatedAt, m, events)
 	case *azuredevops.AnnotatedPullRequest:
 		return computeAzureDevOpsBuildState(m)
-	case *gerrit.Change:
+	case gerritbatches.AnnotatedChange:
 		// Gerrit doesn't have builds built-in, I think its better to be explicit by still
 		// including this case for clarity.
 		return btypes.ChangesetCheckStateUnknown
@@ -569,7 +570,7 @@ func computeSingleChangesetExternalState(c *btypes.Changeset) (s btypes.Changese
 		default:
 			return "", errors.Errorf("unknown Azure DevOps pull request state: %s", m.Status)
 		}
-	case *gerrit.Change:
+	case *gerritbatches.AnnotatedChange:
 		switch m.Status {
 		case gerrit.ChangeStatusAbandoned:
 			s = btypes.ChangesetExternalStateClosed
@@ -670,7 +671,7 @@ func computeSingleChangesetReviewState(c *btypes.Changeset) (s btypes.ChangesetR
 				states[btypes.ChangesetReviewStatePending] = true
 			}
 		}
-	case *gerrit.Change:
+	case gerritbatches.AnnotatedChange:
 		// TODO: @varsanojidan tackling reviews in a separate PR
 		states[btypes.ChangesetReviewStatePending] = true
 	default:

--- a/enterprise/internal/batches/store/BUILD.bazel
+++ b/enterprise/internal/batches/store/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//internal/extsvc/azuredevops",
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/bitbucketserver",
+        "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/featureflag",

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -12,6 +12,7 @@ import (
 
 	adobatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/keegancsmith/sqlf"
@@ -1468,6 +1469,8 @@ func ScanChangeset(t *btypes.Changeset, s dbutil.Scanner) error {
 		// Ensure the inner PR is initialized, it should never be nil.
 		m.PullRequest = &azuredevops.PullRequest{}
 		t.Metadata = m
+	case extsvc.TypeGerrit:
+		t.Metadata = new(gerrit.Change)
 	default:
 		return errors.New("unknown external service type")
 	}

--- a/enterprise/internal/batches/types/BUILD.bazel
+++ b/enterprise/internal/batches/types/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//internal/extsvc/azuredevops",
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/bitbucketserver",
+        "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/timeutil",

--- a/enterprise/internal/batches/types/BUILD.bazel
+++ b/enterprise/internal/batches/types/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//enterprise/internal/batches/sources/azuredevops",
         "//enterprise/internal/batches/sources/bitbucketcloud",
+        "//enterprise/internal/batches/sources/gerrit",
         "//internal/api",
         "//internal/api/internalapi",
         "//internal/conf",
@@ -38,7 +39,6 @@ go_library(
         "//internal/extsvc/azuredevops",
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/bitbucketserver",
-        "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/extsvc/gitlab/webhooks",
@@ -72,6 +72,7 @@ go_test(
     deps = [
         "//enterprise/internal/batches/sources/azuredevops",
         "//enterprise/internal/batches/sources/bitbucketcloud",
+        "//enterprise/internal/batches/sources/gerrit",
         "//internal/database",
         "//internal/executor",
         "//internal/extsvc",

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -654,7 +654,7 @@ func (c *Changeset) URL() (s string, err error) {
 
 		return returnURL.String(), nil
 	case *gerritbatches.AnnotatedChange:
-		return m.URL.JoinPath("c", url.PathEscape(m.Project), "+", url.PathEscape(strconv.Itoa(m.ChangeNumber))).String(), nil
+		return m.CodeHostURL.JoinPath("c", url.PathEscape(m.Project), "+", url.PathEscape(strconv.Itoa(m.ChangeNumber))).String(), nil
 	default:
 		return "", errors.New("unknown changeset type")
 	}

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -457,8 +457,7 @@ func (c *Changeset) SetMetadata(meta any) error {
 		c.ExternalID = pr.ID
 		c.ExternalServiceType = extsvc.TypeGerrit
 		c.ExternalBranch = gitdomain.EnsureRefPrefix(pr.Branch)
-		// TODO: @varsanojidan fix the time unmarshaling
-		// c.ExternalUpdatedAt = pr.Updated
+		c.ExternalUpdatedAt = pr.Updated
 	default:
 		return errors.New("unknown changeset type")
 	}
@@ -569,8 +568,7 @@ func (c *Changeset) ExternalCreatedAt() time.Time {
 	case *adobatches.AnnotatedPullRequest:
 		return m.CreationDate
 	case *gerrit.Change:
-		// TODO: @varsanojidan replace this once the time conversion is complete
-		return time.Time{}
+		return m.Created
 	default:
 		return time.Time{}
 	}

--- a/enterprise/internal/batches/types/changeset_event.go
+++ b/enterprise/internal/batches/types/changeset_event.go
@@ -104,7 +104,6 @@ const (
 	ChangesetEventKindBitbucketCloudRepoCommitStatusCreated          ChangesetEventKind = "bitbucketcloud:repo:commit_status_created"          // RepoCommitStatusCreatedEvent
 	ChangesetEventKindBitbucketCloudRepoCommitStatusUpdated          ChangesetEventKind = "bitbucketcloud:repo:commit_status_updated"          // RepoCommitStatusUpdatedEvent
 
-	ChangesetEventKindAzureDevOpsPullRequestCreated                 ChangesetEventKind = "azuredevops:pullrequest:created"
 	ChangesetEventKindAzureDevOpsPullRequestMerged                  ChangesetEventKind = "azuredevops:pullrequest:merged"
 	ChangesetEventKindAzureDevOpsPullRequestUpdated                 ChangesetEventKind = "azuredevops:pullrequest:updated"
 	ChangesetEventKindAzureDevOpsPullRequestApproved                ChangesetEventKind = "azuredevops:pullrequest:approved"

--- a/enterprise/internal/batches/types/changeset_test.go
+++ b/enterprise/internal/batches/types/changeset_test.go
@@ -222,11 +222,11 @@ func TestChangeset_SetMetadata(t *testing.T) {
 				ExternalUpdatedAt:     time.Unix(10, 0),
 			},
 		},
-		"Gerrit without fork": {
+		"Gerrit": {
 			meta: &gerrit.Change{
 				ID:      "I5de272baea22ef34dfbd00d6e96c45b25019697f",
 				Branch:  "branch",
-				Created: "2023-05-24 19:04:01.000000000",
+				Updated: time.Unix(10, 0),
 			},
 			want: &Changeset{
 				ExternalID:            "I5de272baea22ef34dfbd00d6e96c45b25019697f",
@@ -234,6 +234,7 @@ func TestChangeset_SetMetadata(t *testing.T) {
 				ExternalBranch:        "refs/heads/branch",
 				ExternalForkNamespace: "",
 				ExternalForkName:      "",
+				ExternalUpdatedAt:     time.Unix(10, 0),
 			},
 		},
 	} {
@@ -305,6 +306,9 @@ func TestChangeset_ExternalCreatedAt(t *testing.T) {
 		},
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			CreatedDate: 10 * 1000,
+		},
+		"Gerrit": &gerrit.Change{
+			Created: want,
 		},
 		"GitHub": &github.PullRequest{
 			CreatedAt: want,

--- a/enterprise/internal/batches/types/changeset_test.go
+++ b/enterprise/internal/batches/types/changeset_test.go
@@ -444,7 +444,7 @@ func TestChangeset_URL(t *testing.T) {
 					ChangeNumber: 1,
 					Project:      "foo",
 				},
-				URL: &url.URL{Scheme: "https", Host: "gerrit.sgdev.org"},
+				CodeHostURL: &url.URL{Scheme: "https", Host: "gerrit.sgdev.org"},
 			},
 			want: "https://gerrit.sgdev.org/c/foo/+/1",
 		},

--- a/enterprise/internal/batches/types/changeset_test.go
+++ b/enterprise/internal/batches/types/changeset_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/sourcegraph/go-diff/diff"
 	adobatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/azuredevops"
 	bbcs "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/bitbucketcloud"
+	gerritbatches "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources/gerrit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -223,10 +225,12 @@ func TestChangeset_SetMetadata(t *testing.T) {
 			},
 		},
 		"Gerrit": {
-			meta: &gerrit.Change{
-				ID:      "I5de272baea22ef34dfbd00d6e96c45b25019697f",
-				Branch:  "branch",
-				Updated: time.Unix(10, 0),
+			meta: &gerritbatches.AnnotatedChange{
+				Change: &gerrit.Change{
+					ID:      "I5de272baea22ef34dfbd00d6e96c45b25019697f",
+					Branch:  "branch",
+					Updated: time.Unix(10, 0),
+				},
 			},
 			want: &Changeset{
 				ExternalID:            "I5de272baea22ef34dfbd00d6e96c45b25019697f",
@@ -265,8 +269,10 @@ func TestChangeset_Title(t *testing.T) {
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			Title: want,
 		},
-		"Gerrit": &gerrit.Change{
-			Subject: want,
+		"Gerrit": &gerritbatches.AnnotatedChange{
+			Change: &gerrit.Change{
+				Subject: want,
+			},
 		},
 		"GitHub": &github.PullRequest{
 			Title: want,
@@ -307,8 +313,10 @@ func TestChangeset_ExternalCreatedAt(t *testing.T) {
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			CreatedDate: 10 * 1000,
 		},
-		"Gerrit": &gerrit.Change{
-			Created: want,
+		"Gerrit": &gerritbatches.AnnotatedChange{
+			Change: &gerrit.Change{
+				Created: want,
+			},
 		},
 		"GitHub": &github.PullRequest{
 			CreatedAt: want,
@@ -352,8 +360,10 @@ func TestChangeset_Body(t *testing.T) {
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			Description: want,
 		},
-		"Gerrit": &gerrit.Change{
-			Subject: want,
+		"Gerrit": &gerritbatches.AnnotatedChange{
+			Change: &gerrit.Change{
+				Subject: want,
+			},
 		},
 		"GitHub": &github.PullRequest{
 			Body: want,
@@ -429,9 +439,14 @@ func TestChangeset_URL(t *testing.T) {
 			want: want,
 		},
 		"Gerrit": {
-			// Currently just an empty string until fixed
-			pr:   &gerrit.Change{},
-			want: "",
+			pr: &gerritbatches.AnnotatedChange{
+				Change: &gerrit.Change{
+					ChangeNumber: 1,
+					Project:      "foo",
+				},
+				URL: &url.URL{Scheme: "https", Host: "gerrit.sgdev.org"},
+			},
+			want: "https://gerrit.sgdev.org/c/foo/+/1",
 		},
 		"GitHub": {
 			pr: &github.PullRequest{
@@ -490,7 +505,7 @@ func TestChangeset_HeadRefOid(t *testing.T) {
 			want: "",
 		},
 		"Gerrit": {
-			meta: &gerrit.Change{},
+			meta: &gerritbatches.AnnotatedChange{},
 			want: "",
 		},
 		"GitHub": {
@@ -555,7 +570,7 @@ func TestChangeset_HeadRef(t *testing.T) {
 		},
 		"Gerrit": {
 			// Gerrit does not return the head ref
-			meta: &gerrit.Change{},
+			meta: &gerritbatches.AnnotatedChange{},
 			want: "",
 		},
 		"GitHub": {
@@ -615,7 +630,7 @@ func TestChangeset_BaseRefOid(t *testing.T) {
 			want: "",
 		},
 		"Gerrit": {
-			meta: &gerrit.Change{},
+			meta: &gerritbatches.AnnotatedChange{},
 			want: "",
 		},
 		"GitHub": {
@@ -677,8 +692,10 @@ func TestChangeset_BaseRef(t *testing.T) {
 			want: "foo",
 		},
 		"Gerrit": {
-			meta: &gerrit.Change{
-				Branch: "foo",
+			meta: &gerritbatches.AnnotatedChange{
+				Change: &gerrit.Change{
+					Branch: "foo",
+				},
 			},
 			want: "refs/heads/foo",
 		},
@@ -731,8 +748,10 @@ func TestChangeset_Labels(t *testing.T) {
 			want: []ChangesetLabel{},
 		},
 		"Gerrit": {
-			meta: &gerrit.Change{
-				Hashtags: []string{"black", "green"},
+			meta: &gerritbatches.AnnotatedChange{
+				Change: &gerrit.Change{
+					Hashtags: []string{"black", "green"},
+				},
 			},
 			want: []ChangesetLabel{
 				{Name: "black", Color: "000000"},

--- a/enterprise/internal/batches/types/util.go
+++ b/enterprise/internal/batches/types/util.go
@@ -26,6 +26,7 @@ var SupportedExternalServices = map[string]CodehostCapabilities{
 	extsvc.TypeGitLab:          {CodehostCapabilityLabels: true, CodehostCapabilityDraftChangesets: true},
 	extsvc.TypeBitbucketCloud:  {},
 	extsvc.TypeAzureDevOps:     {CodehostCapabilityDraftChangesets: true},
+	extsvc.TypeGerrit:          {CodehostCapabilityDraftChangesets: true},
 }
 
 // IsRepoSupported returns whether the given ExternalRepoSpec is supported by

--- a/internal/extsvc/gerrit/changes.go
+++ b/internal/extsvc/gerrit/changes.go
@@ -30,7 +30,6 @@ func (c *client) GetChange(ctx context.Context, changeID string) (*Change, error
 	if resp.StatusCode >= http.StatusBadRequest {
 		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-
 	return &change, nil
 }
 

--- a/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
@@ -1,4 +1,6 @@
 {
+  "created": "2023-05-16 20:50:25.000000000",
+  "updated": "2023-05-16 20:50:46.283000000",
   "id": "src-cli~master~I4ae8b9886059252657eef100c74602251b544e82",
   "project": "src-cli",
   "branch": "master",
@@ -6,8 +8,6 @@
   "topic": "",
   "subject": "Revert \"Revert \"newest change\"\"",
   "status": "ABANDONED",
-  "created": "2023-05-16 20:50:25.000000000",
-  "updated": "2023-05-16 20:50:46.283000000",
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],

--- a/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
@@ -11,6 +11,7 @@
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],
+  "_number": 348,
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/AbandonChange.json
@@ -8,6 +8,9 @@
   "status": "ABANDONED",
   "created": "2023-05-16 20:50:25.000000000",
   "updated": "2023-05-16 20:50:46.283000000",
+  "reviewed": false,
+  "work_in_progress": false,
+  "hashtags": [],
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/GetChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/GetChange.json
@@ -15,6 +15,7 @@
    "extremebad",
    "gerritsux"
   ],
+  "_number": 328,
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/GetChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/GetChange.json
@@ -1,4 +1,6 @@
 {
+  "created": "2023-05-11 19:08:09.000000000",
+  "updated": "2023-05-16 20:34:52.000000000",
   "id": "src-cli~master~I52bede3e6dd80b9048924d0416e5d1a7bf49cf5b",
   "project": "src-cli",
   "branch": "master",
@@ -6,8 +8,6 @@
   "topic": "",
   "subject": "newest change",
   "status": "MERGED",
-  "created": "2023-05-11 19:08:09.000000000",
-  "updated": "2023-05-16 20:34:52.000000000",
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [

--- a/internal/extsvc/gerrit/testdata/golden/GetChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/GetChange.json
@@ -8,6 +8,13 @@
   "status": "MERGED",
   "created": "2023-05-11 19:08:09.000000000",
   "updated": "2023-05-16 20:34:52.000000000",
+  "reviewed": false,
+  "work_in_progress": false,
+  "hashtags": [
+   "bad",
+   "extremebad",
+   "gerritsux"
+  ],
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
@@ -8,6 +8,9 @@
   "status": "NEW",
   "created": "2023-05-23 23:43:42.000000000",
   "updated": "2023-05-23 23:45:36.710000000",
+  "reviewed": false,
+  "work_in_progress": false,
+  "hashtags": [],
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
@@ -1,4 +1,6 @@
 {
+  "created": "2023-05-23 23:43:42.000000000",
+  "updated": "2023-05-23 23:45:36.710000000",
   "id": "src-cli~master~Ida085bb4e62b9adb5991496ab31987e45cfd5d62",
   "project": "src-cli",
   "branch": "master",
@@ -6,8 +8,6 @@
   "topic": "",
   "subject": "Revert \"Revert \"Revert \"newest change\"\"\"",
   "status": "NEW",
-  "created": "2023-05-23 23:43:42.000000000",
-  "updated": "2023-05-23 23:45:36.710000000",
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],

--- a/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/RestoreChange.json
@@ -11,6 +11,7 @@
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],
+  "_number": 349,
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
@@ -8,6 +8,9 @@
   "status": "NEW",
   "created": "2023-05-16 20:50:25.000000000",
   "updated": "2023-05-23 23:42:03.000000000",
+  "reviewed": false,
+  "work_in_progress": false,
+  "hashtags": [],
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
@@ -1,4 +1,6 @@
 {
+  "created": "2023-05-16 20:50:25.000000000",
+  "updated": "2023-05-23 23:42:03.000000000",
   "id": "src-cli~master~I4ae8b9886059252657eef100c74602251b544e82",
   "project": "src-cli",
   "branch": "master",
@@ -6,8 +8,6 @@
   "topic": "",
   "subject": "Revert \"Revert \"newest change\"\"",
   "status": "NEW",
-  "created": "2023-05-16 20:50:25.000000000",
-  "updated": "2023-05-23 23:42:03.000000000",
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],

--- a/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
+++ b/internal/extsvc/gerrit/testdata/golden/SubmitChange.json
@@ -11,6 +11,7 @@
   "reviewed": false,
   "work_in_progress": false,
   "hashtags": [],
+  "_number": 348,
   "owner": {
    "name": "",
    "email": "",

--- a/internal/extsvc/gerrit/types.go
+++ b/internal/extsvc/gerrit/types.go
@@ -39,6 +39,7 @@ type Change struct {
 	Reviewed       bool         `json:"reviewed"`
 	WorkInProgress bool         `json:"work_in_progress"`
 	Hashtags       []string     `json:"hashtags"`
+	ChangeNumber   int          `json:"_number"`
 	Owner          struct {
 		Name     string `json:"name"`
 		Email    string `json:"email"`

--- a/internal/extsvc/gerrit/types.go
+++ b/internal/extsvc/gerrit/types.go
@@ -6,6 +6,14 @@ import (
 	"net/url"
 )
 
+var (
+	ChangeStatusNew       ChangeStatus = "NEW"
+	ChangeStatusAbandoned ChangeStatus = "ABANDONED"
+	ChangeStatusMerged    ChangeStatus = "MERGED"
+)
+
+type ChangeStatus string
+
 // ListProjectsArgs defines options to be set on ListProjects method calls.
 type ListProjectsArgs struct {
 	Cursor *Pagination
@@ -17,22 +25,26 @@ type ListProjectsArgs struct {
 type ListProjectsResponse map[string]*Project
 
 type Change struct {
-	ID       string `json:"id"`
-	Project  string `json:"project"`
-	Branch   string `json:"branch"`
-	ChangeID string `json:"change_id"`
-	Topic    string `json:"topic"`
-	Subject  string `json:"subject"`
-	Status   string `json:"status"`
-	Created  string `json:"created"`
-	Updated  string `json:"updated"`
-	Owner    struct {
+	ID             string       `json:"id"`
+	Project        string       `json:"project"`
+	Branch         string       `json:"branch"`
+	ChangeID       string       `json:"change_id"`
+	Topic          string       `json:"topic"`
+	Subject        string       `json:"subject"`
+	Status         ChangeStatus `json:"status"`
+	Created        string       `json:"created"`
+	Updated        string       `json:"updated"`
+	Reviewed       bool         `json:"reviewed"`
+	WorkInProgress bool         `json:"work_in_progress"`
+	Hashtags       []string     `json:"hashtags"`
+	Owner          struct {
 		Name     string `json:"name"`
 		Email    string `json:"email"`
 		Username string `json:"username"`
 	} `json:"owner"`
-	// Add more fields as needed
 }
+
+const GerritTimeFormat = "2023-05-23 23:43:42.000000000"
 
 type ChangeReviewComment struct {
 	Message       string            `json:"message"`


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/50867.

You will probably notice that some things about the translation of Gerrit Change data to Changeset aren't filled in, and that's because the Gerrit Change API does not give you much info to go off of. 

This is an example of what a Gerrit API response looks like
```json
{
"id": "src-cli~master~I5de272baea22ef34dfbd00d6e96c45b25019697f",
"project": "src-cli",
"branch": "master",
"hashtags": [
"testhash"
],
"change_id": "I5de272baea22ef34dfbd00d6e96c45b25019697f",
"subject": "testing off of a diff branch",
"status": "NEW",
"created": "2023-05-24 19:04:01.000000000",
"updated": "2023-05-24 19:50:00.000000000",
"submit_type": "MERGE_IF_NECESSARY",
"mergeable": true,
"insertions": 1,
"deletions": 0,
"total_comment_count": 0,
"unresolved_comment_count": 0,
"has_review_started": true,
"_number": 329,
"owner": {
"_account_id": 1000018
},
"requirements": []
}
```

I plan to do the event/reviewer stuff in follow-up PRs

## Test plan
Added additional unit tests