### PR TITLE
llm-proxy: use Operation for sync jobs, improve tracing

### DIFF
--- a/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/llm-proxy/internal/actor/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//enterprise/cmd/llm-proxy/internal/limiter",
         "//internal/goroutine",
+        "//internal/observation",
         "//internal/trace",
         "//lib/errors",
         "@com_github_go_redsync_redsync_v4//:redsync",
@@ -32,6 +33,7 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//internal/observation",
         "//internal/redispool",
         "//lib/errors",
         "@com_github_go_redsync_redsync_v4//:redsync",

--- a/enterprise/cmd/llm-proxy/internal/actor/source_test.go
+++ b/enterprise/cmd/llm-proxy/internal/actor/source_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/conc"
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -60,7 +61,7 @@ func TestSourcesWorkers(t *testing.T) {
 	s1 := &mockSourceSyncer{}
 	stop1 := make(chan struct{})
 	g.Go(func() {
-		w := (Sources{s1}).Worker(logger, sourceWorkerMutex1, time.Millisecond)
+		w := (Sources{s1}).Worker(observation.NewContext(logger), sourceWorkerMutex1, time.Millisecond)
 		go func() {
 			<-stop1
 			w.Stop()
@@ -75,7 +76,7 @@ func TestSourcesWorkers(t *testing.T) {
 		sourceWorkerMutex := rs.NewMutex(lockName,
 			// Competing worker should only try once to avoid getting stuck
 			redsync.WithTries(1))
-		w := (Sources{s2}).Worker(logger, sourceWorkerMutex, time.Millisecond)
+		w := (Sources{s2}).Worker(observation.NewContext(logger), sourceWorkerMutex, time.Millisecond)
 		go func() {
 			<-stop2
 			w.Stop()

--- a/enterprise/cmd/llm-proxy/shared/main.go
+++ b/enterprise/cmd/llm-proxy/shared/main.go
@@ -131,7 +131,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	// Block until done
 	goroutine.MonitorBackgroundRoutines(ctx,
 		server,
-		sources.Worker(obctx.Logger, sourceWorkerMutex, config.SourcesSyncInterval),
+		sources.Worker(obctx, sourceWorkerMutex, config.SourcesSyncInterval),
 	)
 
 	return nil


### PR DESCRIPTION
Back with more tracing touch-ups! This hooks up our background worker with Operation (figuring out a nice way to name the scope without duplication is quite the exercise 😅 ) which gives us a parent span on all syncs. This is handy for getting overall error message states of background jobs if we get multiple SourceSyncer implementations, and shows the gap between the start of the job and when work actually starts - this illustrates time spent acquiring the distributed lock.


## Test plan

<img width="1697" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/6cc6015b-eaf3-491a-bbb1-28c294880778">


