### PR TITLE
inference: Surface lua `print(message)` to UI

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/backend.ts
+++ b/client/web/src/enterprise/codeintel/configuration/backend.ts
@@ -49,7 +49,10 @@ export const AutoIndexJobFieldsFragment = gql`
 export const INFER_JOBS_SCRIPT = gql`
     query InferAutoIndexJobsForRepo($repository: ID!, $rev: String, $script: String) {
         inferAutoIndexJobsForRepo(repository: $repository, rev: $rev, script: $script) {
-            ...AutoIndexJobDescriptionFields
+            jobs {
+                ...AutoIndexJobDescriptionFields
+            }
+            inferenceOutput
         }
     }
 

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
@@ -85,8 +85,10 @@ export const InferenceScriptPreview: React.FunctionComponent<InferenceScriptPrev
                 <ErrorAlert error={error} />
             ) : data ? (
                 <>
-                    {data.inferAutoIndexJobsForRepo.inferenceOutput && (
+                    {data.inferAutoIndexJobsForRepo.inferenceOutput ? (
                         <p>{data.inferAutoIndexJobsForRepo.inferenceOutput}</p>
+                    ) : (
+                        <>nothing?</>
                     )}
 
                     <InferenceForm

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
@@ -11,6 +11,7 @@ import {
     useForm,
     Form,
     Label,
+    Text,
 } from '@sourcegraph/wildcard'
 
 import { LogOutput } from '../../../../../components/LogOutput'
@@ -87,7 +88,10 @@ export const InferenceScriptPreview: React.FunctionComponent<InferenceScriptPrev
             ) : data ? (
                 <>
                     {data.inferAutoIndexJobsForRepo.inferenceOutput && (
-                        <LogOutput text={data.inferAutoIndexJobsForRepo.inferenceOutput} />
+                        <>
+                            <Text weight="bold">Script output:</Text>
+                            <LogOutput text={data.inferAutoIndexJobsForRepo.inferenceOutput} />
+                        </>
                     )}
 
                     <InferenceForm

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
@@ -13,6 +13,7 @@ import {
     Label,
 } from '@sourcegraph/wildcard'
 
+import { LogOutput } from '../../../../../components/LogOutput'
 import {
     GetRepoIdResult,
     GetRepoIdVariables,
@@ -85,10 +86,8 @@ export const InferenceScriptPreview: React.FunctionComponent<InferenceScriptPrev
                 <ErrorAlert error={error} />
             ) : data ? (
                 <>
-                    {data.inferAutoIndexJobsForRepo.inferenceOutput ? (
-                        <p>{data.inferAutoIndexJobsForRepo.inferenceOutput}</p>
-                    ) : (
-                        <>nothing?</>
+                    {data.inferAutoIndexJobsForRepo.inferenceOutput && (
+                        <LogOutput text={data.inferAutoIndexJobsForRepo.inferenceOutput} />
                     )}
 
                     <InferenceForm

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptPreview.tsx
@@ -84,10 +84,16 @@ export const InferenceScriptPreview: React.FunctionComponent<InferenceScriptPrev
             ) : error ? (
                 <ErrorAlert error={error} />
             ) : data ? (
-                <InferenceForm
-                    initialFormData={autoIndexJobsToFormData({ jobs: data.inferAutoIndexJobsForRepo })}
-                    readOnly={true}
-                />
+                <>
+                    {data.inferAutoIndexJobsForRepo.inferenceOutput && (
+                        <p>{data.inferAutoIndexJobsForRepo.inferenceOutput}</p>
+                    )}
+
+                    <InferenceForm
+                        initialFormData={autoIndexJobsToFormData({ jobs: data.inferAutoIndexJobsForRepo.jobs })}
+                        readOnly={true}
+                    />
+                </>
             ) : (
                 <></>
             )}

--- a/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
@@ -81,7 +81,7 @@ extend type Query {
     """
     Return (but do not enqueue) descriptions of auto indexing jobs at the current revision.
     """
-    inferAutoIndexJobsForRepo(repository: ID!, rev: String, script: String): [AutoIndexJobDescription!]!
+    inferAutoIndexJobsForRepo(repository: ID!, rev: String, script: String): InferAutoIndexJobsResult!
 }
 
 extend type Mutation {
@@ -190,6 +190,21 @@ extend type Repository {
     Provides a summary of the most recent upload and index status.
     """
     codeIntelSummary: CodeIntelRepositorySummary!
+}
+
+"""
+The result of running the auto-index inference script over a particular repo.
+"""
+type InferAutoIndexJobsResult {
+    """
+    The list of inferred jobs.
+    """
+    jobs: [AutoIndexJobDescription!]!
+
+    """
+    The output from the inference script.
+    """
+    inferenceOutput: String!
 }
 
 """

--- a/enterprise/internal/codeintel/autoindexing/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//internal/metrics",
         "//internal/observation",
         "//internal/repoupdater",
-        "//lib/codeintel/autoindex/config",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",

--- a/enterprise/internal/codeintel/autoindexing/internal/background/summary/job_summary_builder.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/summary/job_summary_builder.go
@@ -50,7 +50,7 @@ func NewSummaryBuilder(
 
 				if autoIndexingEnabled() {
 					commit := "HEAD"
-					indexJobs, err := jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit, "", false)
+					indexJobs, _, err := jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit, "", false)
 					if err != nil {
 						if errors.As(err, &inference.LimitError{}) {
 							continue

--- a/enterprise/internal/codeintel/autoindexing/internal/background/summary/job_summary_builder.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/background/summary/job_summary_builder.go
@@ -50,7 +50,7 @@ func NewSummaryBuilder(
 
 				if autoIndexingEnabled() {
 					commit := "HEAD"
-					indexJobs, _, err := jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit, "", false)
+					result, err := jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryWithCount.RepositoryID, commit, "", false)
 					if err != nil {
 						if errors.As(err, &inference.LimitError{}) {
 							continue
@@ -78,7 +78,7 @@ func NewSummaryBuilder(
 						blocklist[key] = struct{}{}
 					}
 
-					inferredAvailableIndexers = uploadsshared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
+					inferredAvailableIndexers = uploadsshared.PopulateInferredAvailableIndexers(result.IndexJobs, blocklist, inferredAvailableIndexers)
 					// inferredAvailableIndexers = uploadsshared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
 				}
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//enterprise/internal/codeintel/autoindexing/internal/inference/libs",
         "//enterprise/internal/codeintel/autoindexing/internal/inference/lua",
         "//enterprise/internal/codeintel/autoindexing/internal/inference/luatypes",
+        "//enterprise/internal/codeintel/autoindexing/shared",
         "//enterprise/internal/paths",
         "//internal/api",
         "//internal/authz",

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference/lua"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/internal/inference/luatypes"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -83,7 +84,7 @@ func newService(
 // is assumed to be a table of recognizer instances. Keys conflicting with the default recognizers
 // will overwrite them (to disable or change default behavior). Each recognizer's generate function
 // is invoked and the resulting index jobs are combined into a flattened list.
-func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ []config.IndexJob, logs string, err error) {
+func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ *shared.InferenceResult, err error) {
 	ctx, _, endObservation := s.operations.inferIndexJobs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("repo", string(repo)),
 		attribute.String("commit", commit),
@@ -111,19 +112,22 @@ func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit,
 
 	jobOrHints, logs, err := s.inferIndexJobOrHints(ctx, repo, commit, overrideScript, functionTable)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	jobs := make([]config.IndexJob, 0, len(jobOrHints))
 	for _, jobOrHint := range jobOrHints {
 		if jobOrHint.indexJob == nil {
-			return nil, "", errors.New("unexpected nil index job")
+			return nil, errors.New("unexpected nil index job")
 		}
 
 		jobs = append(jobs, *jobOrHint.indexJob)
 	}
 
-	return jobs, logs, nil
+	return &shared.InferenceResult{
+		IndexJobs:       jobs,
+		InferenceOutput: logs,
+	}, nil
 }
 
 // InferIndexJobHints invokes the given script in a fresh Lua sandbox. The return value of this script

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service.go
@@ -243,7 +243,9 @@ func (s *Service) setupRecognizers(ctx context.Context, invocationContext invoca
 	ctx, _, endObservation := s.operations.setupRecognizers.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 
-	opts := luasandbox.RunOptions{}
+	opts := luasandbox.RunOptions{
+		PrintSink: invocationContext.printSink,
+	}
 	rawRecognizers, err := invocationContext.sandbox.RunScriptNamed(ctx, opts, lua.Scripts, "recognizers.lua")
 	if err != nil {
 		return nil, err
@@ -540,7 +542,9 @@ func (s *Service) invokeLinearizedRecognizer(
 		return nil, nil
 	}
 
-	opts := luasandbox.RunOptions{}
+	opts := luasandbox.RunOptions{
+		PrintSink: invocationContext.printSink,
+	}
 	args := []any{registrationAPI, callPaths, callContentsByPath}
 	value, err := invocationContext.sandbox.Call(ctx, opts, invocationContext.callback(recognizer), args...)
 	if err != nil {

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
@@ -143,7 +143,7 @@ func testGenerator(t *testing.T, testCase generatorTestCase) {
 	t.Run(testCase.description, func(t *testing.T) {
 		service := testService(t, testCase.repositoryContents)
 
-		jobs, err := service.InferIndexJobs(
+		jobs, _, err := service.InferIndexJobs(
 			context.Background(),
 			"github.com/test/test",
 			"HEAD",

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/service_generator_test.go
@@ -143,7 +143,7 @@ func testGenerator(t *testing.T, testCase generatorTestCase) {
 	t.Run(testCase.description, func(t *testing.T) {
 		service := testService(t, testCase.repositoryContents)
 
-		jobs, _, err := service.InferIndexJobs(
+		result, err := service.InferIndexJobs(
 			context.Background(),
 			"github.com/test/test",
 			"HEAD",
@@ -152,7 +152,7 @@ func testGenerator(t *testing.T, testCase generatorTestCase) {
 		if err != nil {
 			t.Fatalf("unexpected error inferring jobs: %s", err)
 		}
-		if diff := cmp.Diff(sortIndexJobs(testCase.expected), sortIndexJobs(jobs)); diff != "" {
+		if diff := cmp.Diff(sortIndexJobs(testCase.expected), sortIndexJobs(result.IndexJobs)); diff != "" {
 			t.Errorf("unexpected index jobs (-want +got):\n%s", diff)
 		}
 	})

--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/autoindexing/internal/store",
+        "//enterprise/internal/codeintel/autoindexing/shared",
         "//enterprise/internal/codeintel/uploads/shared",
         "//internal/api",
         "//internal/authz",

--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/iface.go
@@ -8,6 +8,6 @@ import (
 )
 
 type InferenceService interface {
-	InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) ([]config.IndexJob, error)
+	InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ []config.IndexJob, logs string, _ error)
 	InferIndexJobHints(ctx context.Context, repo api.RepoName, commit, overrideScript string) ([]config.IndexJobHint, error)
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/iface.go
@@ -3,11 +3,12 @@ package jobselector
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
 
 type InferenceService interface {
-	InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ []config.IndexJob, logs string, _ error)
+	InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (*shared.InferenceResult, error)
 	InferIndexJobHints(ctx context.Context, repo api.RepoName, commit, overrideScript string) ([]config.IndexJobHint, error)
 }

--- a/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/jobselector/job_selector.go
@@ -71,7 +71,6 @@ func (s *JobSelector) InferIndexJobsFromRepositoryStructure(ctx context.Context,
 		return nil, "", nil
 	}
 
-	// FOOBAR1
 	indexes, logs, err := s.inferenceSvc.InferIndexJobs(ctx, repo.Name, commit, script)
 	if err != nil {
 		return nil, "", err
@@ -79,7 +78,7 @@ func (s *JobSelector) InferIndexJobsFromRepositoryStructure(ctx context.Context,
 
 	if !bypassLimit && len(indexes) > MaximumIndexJobsPerInferredConfiguration {
 		s.logger.Info("Too many inferred roots. Scheduling no index jobs for repository.", log.Int("repository_id", repositoryID))
-		return nil, "", nil
+		indexes = nil
 	}
 
 	return indexes, logs, nil

--- a/enterprise/internal/codeintel/autoindexing/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/mocks_test.go
@@ -2620,7 +2620,7 @@ func NewMockInferenceService() *MockInferenceService {
 			},
 		},
 		InferIndexJobsFunc: &InferenceServiceInferIndexJobsFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (r0 []config.IndexJob, r1 error) {
+			defaultHook: func(context.Context, api.RepoName, string, string) (r0 []config.IndexJob, r1 string, r2 error) {
 				return
 			},
 		},
@@ -2637,7 +2637,7 @@ func NewStrictMockInferenceService() *MockInferenceService {
 			},
 		},
 		InferIndexJobsFunc: &InferenceServiceInferIndexJobsFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error) {
+			defaultHook: func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
 				panic("unexpected invocation of MockInferenceService.InferIndexJobs")
 			},
 		},
@@ -2779,24 +2779,24 @@ func (c InferenceServiceInferIndexJobHintsFuncCall) Results() []interface{} {
 // InferIndexJobs method of the parent MockInferenceService instance is
 // invoked.
 type InferenceServiceInferIndexJobsFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error)
-	hooks       []func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error)
+	defaultHook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)
+	hooks       []func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)
 	history     []InferenceServiceInferIndexJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // InferIndexJobs delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockInferenceService) InferIndexJobs(v0 context.Context, v1 api.RepoName, v2 string, v3 string) ([]config.IndexJob, error) {
-	r0, r1 := m.InferIndexJobsFunc.nextHook()(v0, v1, v2, v3)
-	m.InferIndexJobsFunc.appendCall(InferenceServiceInferIndexJobsFuncCall{v0, v1, v2, v3, r0, r1})
-	return r0, r1
+func (m *MockInferenceService) InferIndexJobs(v0 context.Context, v1 api.RepoName, v2 string, v3 string) ([]config.IndexJob, string, error) {
+	r0, r1, r2 := m.InferIndexJobsFunc.nextHook()(v0, v1, v2, v3)
+	m.InferIndexJobsFunc.appendCall(InferenceServiceInferIndexJobsFuncCall{v0, v1, v2, v3, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the InferIndexJobs
 // method of the parent MockInferenceService instance is invoked and the
 // hook queue is empty.
-func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error)) {
+func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)) {
 	f.defaultHook = hook
 }
 
@@ -2804,7 +2804,7 @@ func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Co
 // InferIndexJobs method of the parent MockInferenceService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error)) {
+func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2812,20 +2812,20 @@ func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *InferenceServiceInferIndexJobsFunc) SetDefaultReturn(r0 []config.IndexJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error) {
-		return r0, r1
+func (f *InferenceServiceInferIndexJobsFunc) SetDefaultReturn(r0 []config.IndexJob, r1 string, r2 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *InferenceServiceInferIndexJobsFunc) PushReturn(r0 []config.IndexJob, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error) {
-		return r0, r1
+func (f *InferenceServiceInferIndexJobsFunc) PushReturn(r0 []config.IndexJob, r1 string, r2 error) {
+	f.PushHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *InferenceServiceInferIndexJobsFunc) nextHook() func(context.Context, api.RepoName, string, string) ([]config.IndexJob, error) {
+func (f *InferenceServiceInferIndexJobsFunc) nextHook() func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2876,7 +2876,10 @@ type InferenceServiceInferIndexJobsFuncCall struct {
 	Result0 []config.IndexJob
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 string
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2888,7 +2891,7 @@ func (c InferenceServiceInferIndexJobsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c InferenceServiceInferIndexJobsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // MockRepoUpdaterClient is a mock implementation of the RepoUpdaterClient

--- a/enterprise/internal/codeintel/autoindexing/mocks_test.go
+++ b/enterprise/internal/codeintel/autoindexing/mocks_test.go
@@ -2620,7 +2620,7 @@ func NewMockInferenceService() *MockInferenceService {
 			},
 		},
 		InferIndexJobsFunc: &InferenceServiceInferIndexJobsFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) (r0 []config.IndexJob, r1 string, r2 error) {
+			defaultHook: func(context.Context, api.RepoName, string, string) (r0 *shared.InferenceResult, r1 error) {
 				return
 			},
 		},
@@ -2637,7 +2637,7 @@ func NewStrictMockInferenceService() *MockInferenceService {
 			},
 		},
 		InferIndexJobsFunc: &InferenceServiceInferIndexJobsFunc{
-			defaultHook: func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
+			defaultHook: func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error) {
 				panic("unexpected invocation of MockInferenceService.InferIndexJobs")
 			},
 		},
@@ -2779,24 +2779,24 @@ func (c InferenceServiceInferIndexJobHintsFuncCall) Results() []interface{} {
 // InferIndexJobs method of the parent MockInferenceService instance is
 // invoked.
 type InferenceServiceInferIndexJobsFunc struct {
-	defaultHook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)
-	hooks       []func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)
+	defaultHook func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error)
+	hooks       []func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error)
 	history     []InferenceServiceInferIndexJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // InferIndexJobs delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockInferenceService) InferIndexJobs(v0 context.Context, v1 api.RepoName, v2 string, v3 string) ([]config.IndexJob, string, error) {
-	r0, r1, r2 := m.InferIndexJobsFunc.nextHook()(v0, v1, v2, v3)
-	m.InferIndexJobsFunc.appendCall(InferenceServiceInferIndexJobsFuncCall{v0, v1, v2, v3, r0, r1, r2})
-	return r0, r1, r2
+func (m *MockInferenceService) InferIndexJobs(v0 context.Context, v1 api.RepoName, v2 string, v3 string) (*shared.InferenceResult, error) {
+	r0, r1 := m.InferIndexJobsFunc.nextHook()(v0, v1, v2, v3)
+	m.InferIndexJobsFunc.appendCall(InferenceServiceInferIndexJobsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the InferIndexJobs
 // method of the parent MockInferenceService instance is invoked and the
 // hook queue is empty.
-func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)) {
+func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error)) {
 	f.defaultHook = hook
 }
 
@@ -2804,7 +2804,7 @@ func (f *InferenceServiceInferIndexJobsFunc) SetDefaultHook(hook func(context.Co
 // InferIndexJobs method of the parent MockInferenceService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error)) {
+func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2812,20 +2812,20 @@ func (f *InferenceServiceInferIndexJobsFunc) PushHook(hook func(context.Context,
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *InferenceServiceInferIndexJobsFunc) SetDefaultReturn(r0 []config.IndexJob, r1 string, r2 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
-		return r0, r1, r2
+func (f *InferenceServiceInferIndexJobsFunc) SetDefaultReturn(r0 *shared.InferenceResult, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *InferenceServiceInferIndexJobsFunc) PushReturn(r0 []config.IndexJob, r1 string, r2 error) {
-	f.PushHook(func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
-		return r0, r1, r2
+func (f *InferenceServiceInferIndexJobsFunc) PushReturn(r0 *shared.InferenceResult, r1 error) {
+	f.PushHook(func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error) {
+		return r0, r1
 	})
 }
 
-func (f *InferenceServiceInferIndexJobsFunc) nextHook() func(context.Context, api.RepoName, string, string) ([]config.IndexJob, string, error) {
+func (f *InferenceServiceInferIndexJobsFunc) nextHook() func(context.Context, api.RepoName, string, string) (*shared.InferenceResult, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2873,13 +2873,10 @@ type InferenceServiceInferIndexJobsFuncCall struct {
 	Arg3 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []config.IndexJob
+	Result0 *shared.InferenceResult
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 string
-	// Result2 is the value of the 3rd result returned from this method
-	// invocation.
-	Result2 error
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -2891,7 +2888,7 @@ func (c InferenceServiceInferIndexJobsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c InferenceServiceInferIndexJobsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // MockRepoUpdaterClient is a mock implementation of the RepoUpdaterClient

--- a/enterprise/internal/codeintel/autoindexing/service.go
+++ b/enterprise/internal/codeintel/autoindexing/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -80,7 +79,7 @@ func (s *Service) GetIndexConfigurationByRepositoryID(ctx context.Context, repos
 
 // InferIndexConfiguration looks at the repository contents at the latest commit on the default branch of the given
 // repository and determines an index configuration that is likely to succeed.
-func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ *config.IndexConfiguration, _ string, err error) {
+func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ *shared.InferenceResult, err error) {
 	ctx, trace, endObservation := s.operations.inferIndexConfiguration.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 	}})
@@ -88,35 +87,28 @@ func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int,
 
 	repo, err := s.repoStore.Get(ctx, api.RepoID(repositoryID))
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	if commit == "" {
 		var ok bool
 		commit, ok, err = s.gitserverClient.Head(ctx, authz.DefaultSubRepoPermsChecker, repo.Name)
 		if err != nil || !ok {
-			return nil, "", errors.Wrapf(err, "gitserver.Head: error resolving HEAD for %d", repositoryID)
+			return nil, errors.Wrapf(err, "gitserver.Head: error resolving HEAD for %d", repositoryID)
 		}
 	} else {
 		exists, err := s.gitserverClient.CommitExists(ctx, authz.DefaultSubRepoPermsChecker, repo.Name, api.CommitID(commit))
 		if err != nil {
-			return nil, "", errors.Wrapf(err, "gitserver.CommitExists: error checking %s for %d", commit, repositoryID)
+			return nil, errors.Wrapf(err, "gitserver.CommitExists: error checking %s for %d", commit, repositoryID)
 		}
 
 		if !exists {
-			return nil, "", errors.Newf("revision %s not found for %d", commit, repositoryID)
+			return nil, errors.Newf("revision %s not found for %d", commit, repositoryID)
 		}
 	}
 	trace.AddEvent("found", attribute.String("commit", commit))
 
-	indexJobs, logs, err := s.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return &config.IndexConfiguration{
-		IndexJobs: indexJobs,
-	}, logs, nil
+	return s.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
 }
 
 func (s *Service) UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, data []byte) error {
@@ -143,7 +135,7 @@ func (s *Service) QueueIndexesForPackage(ctx context.Context, pkg dependencies.M
 	return s.indexEnqueuer.QueueIndexesForPackage(ctx, pkg, assumeSynced)
 }
 
-func (s *Service) InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error) {
+func (s *Service) InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (*shared.InferenceResult, error) {
 	return s.jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
 }
 

--- a/enterprise/internal/codeintel/autoindexing/service.go
+++ b/enterprise/internal/codeintel/autoindexing/service.go
@@ -109,8 +109,7 @@ func (s *Service) InferIndexConfiguration(ctx context.Context, repositoryID int,
 	}
 	trace.AddEvent("found", attribute.String("commit", commit))
 
-	logs := "" // TODO
-	indexJobs, err := s.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
+	indexJobs, logs, err := s.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
 	if err != nil {
 		return nil, "", err
 	}
@@ -144,7 +143,7 @@ func (s *Service) QueueIndexesForPackage(ctx context.Context, pkg dependencies.M
 	return s.indexEnqueuer.QueueIndexesForPackage(ctx, pkg, assumeSynced)
 }
 
-func (s *Service) InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) ([]config.IndexJob, error) {
+func (s *Service) InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error) {
 	return s.jobSelector.InferIndexJobsFromRepositoryStructure(ctx, repositoryID, commit, localOverrideScript, bypassLimit)
 }
 

--- a/enterprise/internal/codeintel/autoindexing/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/service_test.go
@@ -341,14 +341,14 @@ func TestQueueIndexesInferred(t *testing.T) {
 	gitserverClient.ReadFileFunc.SetDefaultReturn(nil, os.ErrNotExist)
 
 	inferenceService := NewMockInferenceService()
-	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, string, error) {
+	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) (*shared.InferenceResult, error) {
 		switch string(rn) {
 		case "r42":
-			return []config.IndexJob{{Root: ""}}, "", nil
+			return &shared.InferenceResult{IndexJobs: []config.IndexJob{{Root: ""}}}, nil
 		case "r44":
-			return []config.IndexJob{{Root: "a"}, {Root: "b"}}, "", nil
+			return &shared.InferenceResult{IndexJobs: []config.IndexJob{{Root: "a"}, {Root: "b"}}}, nil
 		default:
-			return nil, "", nil
+			return &shared.InferenceResult{IndexJobs: nil}, nil
 		}
 	})
 
@@ -423,20 +423,22 @@ func TestQueueIndexesForPackage(t *testing.T) {
 	})
 
 	inferenceService := NewMockInferenceService()
-	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, string, error) {
-		return []config.IndexJob{
-			{
-				Root: "",
-				Steps: []config.DockerStep{
-					{
-						Image:    "sourcegraph/lsif-go:latest",
-						Commands: []string{"go mod download"},
+	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) (*shared.InferenceResult, error) {
+		return &shared.InferenceResult{
+			IndexJobs: []config.IndexJob{
+				{
+					Root: "",
+					Steps: []config.DockerStep{
+						{
+							Image:    "sourcegraph/lsif-go:latest",
+							Commands: []string{"go mod download"},
+						},
 					},
+					Indexer:     "sourcegraph/lsif-go:latest",
+					IndexerArgs: []string{"lsif-go", "--no-animation"},
 				},
-				Indexer:     "sourcegraph/lsif-go:latest",
-				IndexerArgs: []string{"lsif-go", "--no-animation"},
 			},
-		}, "", nil
+		}, nil
 	})
 
 	service := newService(

--- a/enterprise/internal/codeintel/autoindexing/service_test.go
+++ b/enterprise/internal/codeintel/autoindexing/service_test.go
@@ -341,14 +341,14 @@ func TestQueueIndexesInferred(t *testing.T) {
 	gitserverClient.ReadFileFunc.SetDefaultReturn(nil, os.ErrNotExist)
 
 	inferenceService := NewMockInferenceService()
-	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, error) {
+	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, string, error) {
 		switch string(rn) {
 		case "r42":
-			return []config.IndexJob{{Root: ""}}, nil
+			return []config.IndexJob{{Root: ""}}, "", nil
 		case "r44":
-			return []config.IndexJob{{Root: "a"}, {Root: "b"}}, nil
+			return []config.IndexJob{{Root: "a"}, {Root: "b"}}, "", nil
 		default:
-			return nil, nil
+			return nil, "", nil
 		}
 	})
 
@@ -423,7 +423,7 @@ func TestQueueIndexesForPackage(t *testing.T) {
 	})
 
 	inferenceService := NewMockInferenceService()
-	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, error) {
+	inferenceService.InferIndexJobsFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, s1, s2 string) ([]config.IndexJob, string, error) {
 		return []config.IndexJob{
 			{
 				Root: "",
@@ -436,7 +436,7 @@ func TestQueueIndexesForPackage(t *testing.T) {
 				Indexer:     "sourcegraph/lsif-go:latest",
 				IndexerArgs: []string{"lsif-go", "--no-animation"},
 			},
-		}, nil
+		}, "", nil
 	})
 
 	service := newService(

--- a/enterprise/internal/codeintel/autoindexing/shared/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/shared/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["types.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared",
     visibility = ["//enterprise:__subpackages__"],
+    deps = ["//lib/codeintel/autoindex/config"],
 )

--- a/enterprise/internal/codeintel/autoindexing/shared/types.go
+++ b/enterprise/internal/codeintel/autoindexing/shared/types.go
@@ -1,8 +1,15 @@
 package shared
 
+import "github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+
 // IndexConfiguration stores the index configuration for a repository.
 type IndexConfiguration struct {
 	ID           int
 	RepositoryID int
 	Data         []byte
+}
+
+type InferenceResult struct {
+	IndexJobs       []config.IndexJob
+	InferenceOutput string
 }

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
@@ -20,5 +20,5 @@ type AutoIndexingService interface {
 	// Inference
 	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool, bypassLimit bool) ([]uploadsshared.Index, error)
 	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ *config.IndexConfiguration, logs string, _ error)
-	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) ([]config.IndexJob, error)
+	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error)
 }

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
 	uploadsshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
 
 type AutoIndexingService interface {
@@ -19,6 +18,6 @@ type AutoIndexingService interface {
 
 	// Inference
 	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool, bypassLimit bool) ([]uploadsshared.Index, error)
-	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ *config.IndexConfiguration, logs string, _ error)
-	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error)
+	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (*shared.InferenceResult, error)
+	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (*shared.InferenceResult, error)
 }

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/iface.go
@@ -19,6 +19,6 @@ type AutoIndexingService interface {
 
 	// Inference
 	QueueIndexes(ctx context.Context, repositoryID int, rev, configuration string, force bool, bypassLimit bool) ([]uploadsshared.Index, error)
-	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (*config.IndexConfiguration, []config.IndexJobHint, error)
+	InferIndexConfiguration(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ *config.IndexConfiguration, logs string, _ error)
 	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) ([]config.IndexJob, error)
 }

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
@@ -104,7 +104,7 @@ func (r *indexConfigurationResolver) InferredConfiguration(ctx context.Context) 
 	defer r.errTracer.Collect(&err, attribute.String("indexConfigResolver.field", "inferredConfiguration"))
 
 	var limitErr error
-	configuration, _, err := r.autoindexSvc.InferIndexConfiguration(ctx, r.repositoryID, "", "", true)
+	result, err := r.autoindexSvc.InferIndexConfiguration(ctx, r.repositoryID, "", "", true)
 	if err != nil {
 		if errors.As(err, &inference.LimitError{}) {
 			limitErr = err
@@ -112,11 +112,8 @@ func (r *indexConfigurationResolver) InferredConfiguration(ctx context.Context) 
 			return nil, err
 		}
 	}
-	if configuration == nil {
-		return nil, nil
-	}
 
-	marshaled, err := config.MarshalJSON(*configuration)
+	marshaled, err := config.MarshalJSON(config.IndexConfiguration{IndexJobs: result.IndexJobs})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
@@ -18,7 +18,7 @@ import (
 )
 
 // 🚨 SECURITY: Only site admins may infer auto-index jobs
-func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *resolverstubs.InferAutoIndexJobsForRepoArgs) (_ []resolverstubs.AutoIndexJobDescriptionResolver, err error) {
+func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *resolverstubs.InferAutoIndexJobsForRepoArgs) (_ resolverstubs.InferAutoIndexJobsResultResolver, err error) {
 	ctx, _, endObservation := r.operations.inferAutoIndexJobsForRepo.WithErrors(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("repository", string(args.Repository)),
 		attribute.String("rev", resolverstubs.Deref(args.Rev, "")),
@@ -58,7 +58,15 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 		return nil, nil
 	}
 
-	return newDescriptionResolvers(r.siteAdminChecker, config)
+	jobResolvers, err := newDescriptionResolvers(r.siteAdminChecker, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &inferAutoIndexJobsResultResolver{
+		jobs:            jobResolvers,
+		inferenceOutput: "OOGA BOOGA!", // TODO
+	}, nil
 }
 
 // 🚨 SECURITY: Only site admins may queue auto-index jobs
@@ -119,6 +127,22 @@ func (r *rootResolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *reso
 	}
 
 	return resolvers, nil
+}
+
+//
+//
+
+type inferAutoIndexJobsResultResolver struct {
+	jobs            []resolverstubs.AutoIndexJobDescriptionResolver
+	inferenceOutput string
+}
+
+func (r *inferAutoIndexJobsResultResolver) Jobs() []resolverstubs.AutoIndexJobDescriptionResolver {
+	return r.jobs
+}
+
+func (r *inferAutoIndexJobsResultResolver) InferenceOutput() string {
+	return r.inferenceOutput
 }
 
 //

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
@@ -48,26 +48,19 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 		localOverrideScript = *args.Script
 	}
 
-	config, logs, err := r.autoindexSvc.InferIndexConfiguration(ctx, repositoryID, rev, localOverrideScript, false)
+	result, err := r.autoindexSvc.InferIndexConfiguration(ctx, repositoryID, rev, localOverrideScript, false)
 	if err != nil {
 		return nil, err
 	}
 
-	if config == nil {
-		return &inferAutoIndexJobsResultResolver{
-			jobs:            nil,
-			inferenceOutput: logs,
-		}, nil
-	}
-
-	jobResolvers, err := newDescriptionResolvers(r.siteAdminChecker, config)
+	jobResolvers, err := newDescriptionResolvers(r.siteAdminChecker, &config.IndexConfiguration{IndexJobs: result.IndexJobs})
 	if err != nil {
 		return nil, err
 	}
 
 	return &inferAutoIndexJobsResultResolver{
 		jobs:            jobResolvers,
-		inferenceOutput: logs,
+		inferenceOutput: result.InferenceOutput,
 	}, nil
 }
 

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
@@ -48,8 +48,7 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 		localOverrideScript = *args.Script
 	}
 
-	// TODO - expose hints
-	config, _, err := r.autoindexSvc.InferIndexConfiguration(ctx, repositoryID, rev, localOverrideScript, false)
+	config, logs, err := r.autoindexSvc.InferIndexConfiguration(ctx, repositoryID, rev, localOverrideScript, false)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +64,7 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 
 	return &inferAutoIndexJobsResultResolver{
 		jobs:            jobResolvers,
-		inferenceOutput: "OOGA BOOGA!", // TODO
+		inferenceOutput: logs,
 	}, nil
 }
 

--- a/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
+++ b/enterprise/internal/codeintel/autoindexing/transport/graphql/root_resolver_inference.go
@@ -54,7 +54,10 @@ func (r *rootResolver) InferAutoIndexJobsForRepo(ctx context.Context, args *reso
 	}
 
 	if config == nil {
-		return nil, nil
+		return &inferAutoIndexJobsResultResolver{
+			jobs:            nil,
+			inferenceOutput: logs,
+		}, nil
 	}
 
 	jobResolvers, err := newDescriptionResolvers(r.siteAdminChecker, config)

--- a/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/codeintel/autoindexing",
+        "//enterprise/internal/codeintel/autoindexing/shared",
         "//enterprise/internal/codeintel/policies/shared",
         "//enterprise/internal/codeintel/policies/transport/graphql",
         "//enterprise/internal/codeintel/shared/resolvers",
@@ -39,7 +40,6 @@ go_library(
         "//internal/gqlutil",
         "//internal/metrics",
         "//internal/observation",
-        "//lib/codeintel/autoindex/config",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_graph_gophers_graphql_go//:graphql-go",

--- a/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"time"
 
+	autoindexingshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindexing/shared"
 	policiesshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	uploadshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
 	uploadsshared "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/uploads/shared"
-	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
 
 type UploadsService interface {
@@ -38,7 +38,7 @@ type UploadsService interface {
 
 type AutoIndexingService interface {
 	RepositoryIDsWithConfiguration(ctx context.Context, offset, limit int) (_ []uploadshared.RepositoryWithAvailableIndexers, totalCount int, err error)
-	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error)
+	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (*autoindexingshared.InferenceResult, error)
 	GetLastIndexScanForRepository(ctx context.Context, repositoryID int) (*time.Time, error)
 }
 

--- a/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
@@ -38,7 +38,7 @@ type UploadsService interface {
 
 type AutoIndexingService interface {
 	RepositoryIDsWithConfiguration(ctx context.Context, offset, limit int) (_ []uploadshared.RepositoryWithAvailableIndexers, totalCount int, err error)
-	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) ([]config.IndexJob, error)
+	InferIndexJobsFromRepositoryStructure(ctx context.Context, repositoryID int, commit string, localOverrideScript string, bypassLimit bool) (_ []config.IndexJob, logs string, _ error)
 	GetLastIndexScanForRepository(ctx context.Context, repositoryID int) (*time.Time, error)
 }
 

--- a/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
@@ -82,7 +82,7 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, repoID graphql.ID)
 	if autoIndexingEnabled() {
 		commit := "HEAD"
 
-		indexJobs, _, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, id, commit, "", false)
+		result, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, id, commit, "", false)
 		if err != nil {
 			if !autoindexing.IsLimitError(err) {
 				return nil, err
@@ -99,7 +99,7 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, repoID graphql.ID)
 		// 	limitErr = errors.Append(limitErr, err)
 		// }
 
-		inferredAvailableIndexers = uploadsShared.PopulateInferredAvailableIndexers(indexJobs, blocklist, inferredAvailableIndexers)
+		inferredAvailableIndexers = uploadsShared.PopulateInferredAvailableIndexers(result.IndexJobs, blocklist, inferredAvailableIndexers)
 		// inferredAvailableIndexers = uploadsShared.PopulateInferredAvailableIndexers(indexJobHints, blocklist, inferredAvailableIndexers)
 	}
 

--- a/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
@@ -82,7 +82,7 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, repoID graphql.ID)
 	if autoIndexingEnabled() {
 		commit := "HEAD"
 
-		indexJobs, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, id, commit, "", false)
+		indexJobs, _, err := r.autoindexSvc.InferIndexJobsFromRepositoryStructure(ctx, id, commit, "", false)
 		if err != nil {
 			if !autoindexing.IsLimitError(err) {
 				return nil, err

--- a/internal/codeintel/resolvers/autoindexing.go
+++ b/internal/codeintel/resolvers/autoindexing.go
@@ -16,7 +16,7 @@ type AutoindexingServiceResolver interface {
 	UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error)
 
 	// Inference
-	InferAutoIndexJobsForRepo(ctx context.Context, args *InferAutoIndexJobsForRepoArgs) ([]AutoIndexJobDescriptionResolver, error)
+	InferAutoIndexJobsForRepo(ctx context.Context, args *InferAutoIndexJobsForRepoArgs) (InferAutoIndexJobsResultResolver, error)
 	QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAutoIndexJobsForRepoArgs) ([]PreciseIndexResolver, error)
 }
 
@@ -51,6 +51,11 @@ type InferredConfigurationResolver interface {
 	Configuration() string
 	ParsedConfiguration(ctx context.Context) (*[]AutoIndexJobDescriptionResolver, error)
 	LimitError() *string
+}
+
+type InferAutoIndexJobsResultResolver interface {
+	Jobs() []AutoIndexJobDescriptionResolver
+	InferenceOutput() string
 }
 
 type (

--- a/internal/codeintel/resolvers/root_resolver.go
+++ b/internal/codeintel/resolvers/root_resolver.go
@@ -149,7 +149,7 @@ func (r *Resolver) QueueAutoIndexJobsForRepo(ctx context.Context, args *QueueAut
 	return r.autoIndexingRootResolver.QueueAutoIndexJobsForRepo(ctx, args)
 }
 
-func (r *Resolver) InferAutoIndexJobsForRepo(ctx context.Context, args *InferAutoIndexJobsForRepoArgs) (_ []AutoIndexJobDescriptionResolver, err error) {
+func (r *Resolver) InferAutoIndexJobsForRepo(ctx context.Context, args *InferAutoIndexJobsForRepoArgs) (_ InferAutoIndexJobsResultResolver, err error) {
 	return r.autoIndexingRootResolver.InferAutoIndexJobsForRepo(ctx, args)
 }
 

--- a/internal/luasandbox/globals.go
+++ b/internal/luasandbox/globals.go
@@ -15,7 +15,7 @@ var globalsToUnset = []string{
 	// "newproxy",
 	// "next",
 	// "pcall",
-	// "print",
+	"print",
 	// "rawequal",
 	// "rawget",
 	// "rawset",

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -85,7 +85,7 @@ func (s *Sandbox) RunScriptNamed(ctx context.Context, opts RunOptions, fs FS, na
 }
 
 // makeScopedLoadfile creates a Lua function that will read the file relative to the given
-// filesystem indiciated by the invocation parameter and return the resulting function.
+// filesystem indicated by the invocation parameter and return the resulting function.
 func makeScopedLoadfile(state *lua.LState, fs FS) *lua.LFunction {
 	return state.NewFunction(util.WrapLuaFunction(func(state *lua.LState) error {
 		filename := state.CheckString(1)

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -3,6 +3,7 @@ package luasandbox
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -207,7 +208,8 @@ func makeScopedPrint(state *lua.LState, w io.Writer) *lua.LFunction {
 			return nil
 		}
 
-		_, err := io.Copy(w, strings.NewReader(message))
+		formattedMessage := fmt.Sprintf("[%s] %s\n", time.Now().UTC().Format(time.RFC3339), message)
+		_, err := io.Copy(w, strings.NewReader(formattedMessage))
 		return err
 	}))
 }


### PR DESCRIPTION
Feed the lua sandbox `print` output back to the UI in the inference page.

![image](https://github.com/sourcegraph/sourcegraph/assets/103087/a453f2c7-82ac-4cd3-84c8-dfb72df2f4cc)

## Test plan

Tested locally.