### PR TITLE
ranking: Optimize mapper select (but a little bit deeper)

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/mapper.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/mapper.go
@@ -36,6 +36,7 @@ func (s *store) InsertPathCountInputs(
 		batchSize,
 		derivativeGraphKey,
 		derivativeGraphKey,
+		graphKey,
 		derivativeGraphKey,
 	))
 	if err != nil {
@@ -173,8 +174,15 @@ referenced_definitions AS (
 			) AS rank
 		FROM codeintel_ranking_definitions rd
 		JOIN referenced_symbols rs ON rs.symbol_name = rd.symbol_name
-		JOIN exported_uploads eu ON eu.id = rd.exported_upload_id
-		JOIN lsif_uploads u ON u.id = eu.upload_id
+		JOIN codeintel_ranking_exports cre ON cre.id = rd.exported_upload_id
+		JOIN lsif_uploads u ON u.id = cre.upload_id
+		JOIN progress p ON TRUE
+		WHERE
+			rd.graph_key = %s AND
+			-- Ensure that the record is within the bounds where it would be visible
+			-- to the current "snapshot" defined by the ranking computation state row.
+			cre.id <= p.max_export_id AND
+			(cre.deleted_at IS NULL OR cre.deleted_at > p.started_at)
 	) s
 
 	-- For multiple uploads in the same repository/root/indexer, only consider
@@ -302,7 +310,6 @@ unprocessed_path_counts AS (
 				prp.graph_key = %s AND
 				prp.codeintel_initial_path_ranks_id = ipr.id
 		)
-	ORDER BY ipr.id
 	LIMIT %s
 	FOR UPDATE SKIP LOCKED
 ),


### PR DESCRIPTION
Fix a regression caused by materializing a CTE from #52362. Remove an `ORDER BY` in the rewritten path mapper that causes the entire data set to be sorted pre-limit.

## Test plan

Existing unit tests.