### PR TITLE
App -  redact dotcom token

### DIFF
--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -221,6 +221,7 @@ var siteConfigSecrets = []struct {
 	{readPath: `dotcom.srcCliVersionCache.github.webhookSecret`, editPaths: []string{"dotcom", "srcCliVersionCache", "github", "webhookSecret"}},
 	{readPath: `embeddings.accessToken`, editPaths: []string{"embeddings", "accessToken"}},
 	{readPath: `completions.accessToken`, editPaths: []string{"completions", "accessToken"}},
+	{readPath: `app.dotcomAuthToken`, editPaths: []string{"app", "dotcomAuthToken"}},
 }
 
 // UnredactSecrets unredacts unchanged secrets back to their original value for


### PR DESCRIPTION
In App there isn't a reason for the users sg.com token to be visible so redact it.
## Test plan
Opened setting made sure value was REDACTED
Ran release build ensured that connect to sg.com worked.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
