### PR TITLE
sandbox: Ensure we call f.Close()

### DIFF
--- a/internal/luasandbox/modules.go
+++ b/internal/luasandbox/modules.go
@@ -30,12 +30,7 @@ func LuaModulesFromFS(fs embed.FS, dir, prefix string) (map[string]string, error
 
 	modules := make(map[string]string, len(files))
 	for _, file := range files {
-		f, err := fs.Open(file)
-		if err != nil {
-			return nil, err
-		}
-
-		contents, err := io.ReadAll(f)
+		contents, err := readFile(fs, file)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +40,7 @@ func LuaModulesFromFS(fs embed.FS, dir, prefix string) (map[string]string, error
 			name = prefix + "." + name
 		}
 
-		modules[name] = string(contents)
+		modules[name] = contents
 	}
 
 	return modules, nil
@@ -76,4 +71,15 @@ func getAllFilepaths(fs embed.FS, path string) (out []string, err error) {
 		}
 	}
 	return
+}
+
+func readFile(fs embed.FS, filepath string) (string, error) {
+	f, err := fs.Open(filepath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	contents, err := io.ReadAll(f)
+	return string(contents), err
 }


### PR DESCRIPTION
close dem filos

Shouldn't actually affect anything since we should only hit this code path on `embed.FS` which no-ops a close, but it is _strictly more correct_.

## Test plan

Ran it