### PR TITLE
ci: error handle story book build fail

### DIFF
--- a/dev/ci/post-chromatic.sh
+++ b/dev/ci/post-chromatic.sh
@@ -14,6 +14,11 @@ chromatic_publish_output=$(</dev/stdin)
 
 echo "$chromatic_publish_output"
 
+if echo "$chromatic_publish_output" | grep -q "Failed to extract stories from your Storybook"; then
+  echo "Storybook failed to build"
+  exit 1
+fi
+
 # Chromatic preview url from Chromatic publish output (`-m 1` for getting first match)
 chromatic_storybook_url=$(echo "$chromatic_publish_output" | grep -oh -m 1 "https:\/\/[[:alnum:]]*\-[[:alnum:]]*\.chromatic\.com")
 

--- a/dev/ci/post-chromatic.sh
+++ b/dev/ci/post-chromatic.sh
@@ -10,14 +10,17 @@ set -eu -o pipefail
 # - BUILDKITE_PULL_REQUEST
 # - RENDER_PREVIEW_GITHUB_TOKEN
 
+exit_status=$?
 chromatic_publish_output=$(</dev/stdin)
 
-echo "$chromatic_publish_output"
-
-if echo "$chromatic_publish_output" | grep -q "Failed to extract stories from your Storybook"; then
-  echo "Storybook failed to build"
+if [ $exit_status -eq 0 ]; then
+  echo "$chromatic_publish_output"
+else
+  echo "$chromatic_publish_output"
   exit 1
 fi
+
+echo "$chromatic_publish_output"
 
 # Chromatic preview url from Chromatic publish output (`-m 1` for getting first match)
 chromatic_storybook_url=$(echo "$chromatic_publish_output" | grep -oh -m 1 "https:\/\/[[:alnum:]]*\-[[:alnum:]]*\.chromatic\.com")


### PR DESCRIPTION
Automatically fail Buildkite build step `:chromatic: Upload Storybook to Chromatic`  if Chromatic storybook build fails. 

Previously, if the Chromatic deployment failed to build for some reason, the build would still succeed. Making the report unreliable

This change adds a check to see if the `pnpm chromatic` exit status is non zero, and If so, the script will immediately exit with a failure, causing the Buildkite build to be marked as failed.

context: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1684969967117259 

## Test plan
ci 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
