### PR TITLE
batches: add entry point to GH App commit signing from repo GH Apps page

### DIFF
--- a/client/web/src/components/gitHubApps/GitHubAppsPage.module.scss
+++ b/client/web/src/components/gitHubApps/GitHubAppsPage.module.scss
@@ -1,0 +1,5 @@
+.page-header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+}

--- a/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
@@ -20,8 +20,13 @@ import { PageTitle } from '../PageTitle'
 import { GITHUB_APPS_QUERY } from './backend'
 import { GitHubAppCard } from './GitHubAppCard'
 
-export const GitHubAppsPage: React.FC = () => {
 import styles from './GitHubAppsPage.module.scss'
+
+interface Props {
+    batchChangesEnabled: boolean
+}
+
+export const GitHubAppsPage: React.FC<Props> = ({ batchChangesEnabled }) => {
     const { data, loading, error, refetch } = useQuery<GitHubAppsResult, GitHubAppsVariables>(GITHUB_APPS_QUERY, {})
     const gitHubApps = useMemo(() => data?.gitHubApps?.nodes ?? [], [data])
 
@@ -50,6 +55,14 @@ import styles from './GitHubAppsPage.module.scss'
                         <Link to="/help/admin/external_service/github#using-a-github-app">
                             See how GitHub App configuration works.
                         </Link>
+                        {batchChangesEnabled && (
+                            <>
+                                {' '}
+                                To create a GitHub App to sign Batch Changes commits, visit{' '}
+                                <Link to="/site-admin/batch-changes">Batch Changes settings</Link>.
+                            </>
+                        )}
+                    </>
                 }
                 actions={
                     <ButtonLink

--- a/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 
 import { mdiPlus } from '@mdi/js'
+import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { ButtonLink, ErrorAlert, Icon, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
@@ -20,6 +21,7 @@ import { GITHUB_APPS_QUERY } from './backend'
 import { GitHubAppCard } from './GitHubAppCard'
 
 export const GitHubAppsPage: React.FC = () => {
+import styles from './GitHubAppsPage.module.scss'
     const { data, loading, error, refetch } = useQuery<GitHubAppsResult, GitHubAppsVariables>(GITHUB_APPS_QUERY, {})
     const gitHubApps = useMemo(() => data?.gitHubApps?.nodes ?? [], [data])
 
@@ -38,23 +40,28 @@ export const GitHubAppsPage: React.FC = () => {
     return (
         <>
             <PageTitle title="GitHub Apps" />
-            <PageHeader path={[{ text: 'GitHub Apps' }]} className="mb-1" />
-            <div className="d-flex align-items-center">
-                <span>
-                    Create and connect a GitHub App to better manage GitHub code host connections.
-                    <Link to="/help/admin/external_service/github#using-a-github-app" className="ml-1">
-                        See how GitHub App configuration works.
-                    </Link>
-                </span>
-                <ButtonLink
-                    to="/site-admin/github-apps/new"
-                    className="ml-auto text-nowrap"
-                    variant="primary"
-                    as={Link}
-                >
-                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Create GitHub App
-                </ButtonLink>
-            </div>
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'GitHub Apps' }]}
+                className={classNames(styles.pageHeader, 'mb-3')}
+                description={
+                    <>
+                        Create and connect a GitHub App to better manage GitHub code host connections.{' '}
+                        <Link to="/help/admin/external_service/github#using-a-github-app">
+                            See how GitHub App configuration works.
+                        </Link>
+                }
+                actions={
+                    <ButtonLink
+                        to="/site-admin/github-apps/new"
+                        className="ml-auto text-nowrap"
+                        variant="primary"
+                        as={Link}
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiPlus} /> Create GitHub App
+                    </ButtonLink>
+                }
+            />
             {error && <ErrorAlert className="mt-4 mb-0 text-left" error={error} />}
             <ConnectionContainer>
                 {error && <ErrorAlert error={error} />}

--- a/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
+++ b/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
@@ -22,6 +22,7 @@ const GitHubAppsPage = lazyComponent(() => import('../components/gitHubApps/GitH
 interface Props extends TelemetryProps, PlatformContextProps {
     authenticatedUser: AuthenticatedUser
     isSourcegraphApp: boolean
+    batchChangesEnabled: boolean
 }
 
 export const SiteAdminGitHubAppsArea: FC<Props> = props => {
@@ -44,7 +45,7 @@ export const SiteAdminGitHubAppsArea: FC<Props> = props => {
 
     return (
         <Routes>
-            <Route index={true} element={<GitHubAppsPage />} />
+            <Route index={true} element={<GitHubAppsPage batchChangesEnabled={props.batchChangesEnabled} />} />
 
             <Route path="new" element={<CreateGitHubAppPage {...props} />} />
             <Route


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52342.

Based on the discussion and resolution over Slack, we don't want the Batch Changes GitHub App to live on the main GH Apps page since their purposes and connection flow differ in most regards. However, it might still be natural for admins to expect to find a Batch Changes GH App on this page, or to wind up here by mistake when trying to set up a GH App for commit signing.

As such, this PR adds a note and link to the Batch Changes settings page in the page header description, to serve as a secondary entry point into the future GH App commit signing flow.

<img width="1171" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/650d00bf-5614-43c2-b298-513fcc317b6a">

When the Batch Changes feature is disabled on an instance, this additional text will not be present.

Obviously, there's nothing on the Batch Changes settings page for this yet; this PR is just for adding the link.

## Test plan

Manual testing:
- With `batchChangesEnabled: false`, verified the description appeared as-is.
- With `batchChangesEnabled: true`, verified the updated description appeared and the link routed me to the BC site admin settings page.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
