### PR TITLE
Cody: Chat history content display

### DIFF
--- a/client/cody/webviews/UserHistory.module.css
+++ b/client/cody/webviews/UserHistory.module.css
@@ -43,5 +43,6 @@
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 4;
     overflow: hidden;
-    overflow-wrap: break-word
+    overflow-wrap: break-word;
+    word-break: break-all;
 }


### PR DESCRIPTION
This PR fixes the issue with the overflow of chat history text content which came up in #52363.

## Test plan
Tested it manually by resizing the content section it works fine.

https://github.com/sourcegraph/sourcegraph/assets/44617923/5e8ccf34-6fcf-4c0f-b7f8-056cb60a742a

