### PR TITLE
Bag supports adding and resolving references out of bound

### DIFF
--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -95,6 +95,10 @@ func ByTextReference(ctx context.Context, db edb.EnterpriseDB, text ...string) (
 		references:    map[refKey]*refContext{},
 	}
 	for _, t := range text {
+		// Empty text does not resolve at all.
+		if t == "" {
+			continue
+		}
 		if _, err := mail.ParseAddress(t); err == nil {
 			b.add(refKey{email: t})
 		} else {
@@ -386,9 +390,7 @@ func (refs userReferences) textReferences() []string {
 	for _, h := range refs.codeHostHandles {
 		rs = append(rs, fmt.Sprintf("@%s", h))
 	}
-	for _, e := range refs.verifiedEmails {
-		rs = append(rs, e)
-	}
+	rs = append(rs, refs.verifiedEmails...)
 	return rs
 }
 

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -203,6 +203,8 @@ func findUserIDByEmail(ctx context.Context, db edb.EnterpriseDB, email string) (
 	return verifiedEmails[0].UserID, nil
 }
 
+// augment fetches all the references for this user that are missing.
+// These can then be linked back into the bag using `linkBack`.
 func (r *userReferences) augment(ctx context.Context, db edb.EnterpriseDB) error {
 	if r.id == 0 {
 		return errors.New("userReferences needs id set for augmenting")
@@ -300,6 +302,8 @@ func (k refKey) String() string {
 	return "<empty refKey>"
 }
 
+// fetch pulls userReferences for given key from the database.
+// It queries by email, userID or username based on what information is available.
 func (k refKey) fetch(ctx context.Context, db edb.EnterpriseDB) (*userReferences, error) {
 	if k.userID != 0 {
 		return &userReferences{id: k.userID}, nil

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -156,7 +156,7 @@ func (b *bag) resolve(ctx context.Context, db edb.EnterpriseDB) error {
 // {email:alice2@example.com} -> 42
 // {handle:aliceCodes} -> 42
 //
-// TODO: For now the first handle or email assigned points to a user.
+// TODO(#52441): For now the first handle or email assigned points to a user.
 // This needs to be refined so that the same handle text can be considered
 // in different contexts properly.
 func (b *bag) linkBack(userRefs *userReferences) {
@@ -190,7 +190,7 @@ func findUserByUsername(ctx context.Context, db edb.EnterpriseDB, handle string)
 	return user, nil
 }
 
-// TODO: GetVerifiedEmails accepts var-args, can batch
+// TODO(#52246): GetVerifiedEmails accepts var-args, can batch
 func findUserIDByEmail(ctx context.Context, db edb.EnterpriseDB, email string) (int32, error) {
 	// Checking that provided email is verified.
 	verifiedEmails, err := db.UserEmails().GetVerifiedEmails(ctx, email)

--- a/enterprise/internal/own/ownref_test.go
+++ b/enterprise/internal/own/ownref_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -123,7 +124,7 @@ func TestSearchFilteringExample(t *testing.T) {
 			require.NoError(t, err)
 			for name, r := range ownerReferences {
 				t.Run(name, func(t *testing.T) {
-					assert.True(t, bag.Contains(r), fmt.Sprintf("bag.Contains(%s), want true, got false", r))
+					assert.True(t, bag.Contains(r), fmt.Sprintf("%s.Contains(%s), want true, got false", bag, r))
 				})
 			}
 		})


### PR DESCRIPTION
Part of #52133

This is a refactoring of the Bag implementation.

Before: resolution of references is like a functional constructor. We take a number of references, and try to resolve all of them. The result is a Bag that can be queried for these and associated references.

This works well for search filtering `f:has.owner(...)` since everything hinges on the query text in the predicate.

For graphQL API owners unification (bunch of owners of different data kinds), and `select:file.owners` search, the model is different. Many different owner references appear, and they need to be reconciled with each other (in an online fashion for search).

So the implementation changes to the following set of bag methods:

- `add` puts one more potentially unresolved reference, like `{handle: "foo"}`, `{email:"bar@example.com"}` or `{userID: 42}`
- `resolve` takes in all the references that were `add`-ed and not attempted to be resolved before
  - it tries to find users associated with these references
  - if these users are found, and are not in the bag, they are `augment`-ed, that is
    - all the other references for given user are fetched from the database
    - and linked back (`linkBack`) into the bag
- `contains` can look up resolved and unresolved entities based on the references above. 

## Test plan

Existing unit tests - this is a refactoring
