### PR TITLE
Cody completions: Apply odd-indentation fix to tab indented files

### DIFF
--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -273,7 +273,7 @@ export class EndOfLineCompletionProvider extends CompletionProvider {
             completion.length > 0 &&
             completion.startsWith(' ') &&
             this.prefix.length > 0 &&
-            this.prefix.endsWith(' ')
+            (this.prefix.endsWith(' ') || this.prefix.endsWith('\t'))
         ) {
             completion = completion.slice(1)
             hasOddIndentation = true


### PR DESCRIPTION
I know now why so many people have said that completions have preceding whitespace that I couldn't repro often. Turns out the issue is our `Go` code and the tab based indentation we use.

We are all aware of a problem where Claude adds a space character in their completion (I named this odd indentation recently). However the logic to detect this required indentation _as spaces_ in the prefix. This adds a check for tabs.

## Test plan

Response has an odd trailing space. The logic now works and removes it, showing the suggestion in the IDE

<img width="1644" alt="Screenshot 2023-05-25 at 12 35 08" src="https://github.com/sourcegraph/sourcegraph/assets/458591/15d6a20a-930f-473b-b114-0cacbc2c0285">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
