### PR TITLE
Cody completions: Fix next line matching multi-line truncation

### DIFF
--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -265,7 +265,11 @@ export class EndOfLineCompletionProvider extends CompletionProvider {
         // Extract a few common parts for the processing
         const currentLinePrefix = this.prefix.slice(this.prefix.lastIndexOf('\n') + 1)
         const firstNlInSuffix = this.suffix.indexOf('\n') + 1
-        const nextLine = this.suffix.slice(firstNlInSuffix, this.suffix.indexOf('\n', firstNlInSuffix))
+        const nextNonEmptyLine =
+            this.suffix
+                .slice(firstNlInSuffix)
+                .split('\n')
+                .find(line => line.trim().length > 0) ?? ''
 
         // Sometimes Claude emits an extra space
         let hasOddIndentation = false
@@ -335,18 +339,18 @@ export class EndOfLineCompletionProvider extends CompletionProvider {
             completion = lines.slice(0, cutOffIndex).join('\n')
         }
 
-        // If a completed line matches the next line of the suffix 1:1, we remove
+        // If a completed line matches the next non-empty line of the suffix 1:1, we remove
         const lines = completion.split('\n')
         const matchedLineIndex = lines.findIndex((line, index) => {
             if (index === 0) {
                 line = currentLinePrefix + line
             }
-            if (line.trim() !== '' && nextLine.trim() !== '') {
+            if (line.trim() !== '' && nextNonEmptyLine.trim() !== '') {
                 // We need a trimEnd here because the machine likes to add trailing whitespace.
                 //
                 // TODO: Fix this earlier in the post process run but this needs to be careful not
                 // to alter the meaning
-                return line.trimEnd() === nextLine
+                return line.trimEnd() === nextNonEmptyLine
             }
             return false
         })


### PR DESCRIPTION
We have a heuristic to truncate multi-line completions (and also filter out single-line completions) starting on the line that matches the next line.

Turns out this behaved a bit oddly since it was only looking at the _very next_ line. If this was an empty line, it would not work.

This PR fixes this by looking at the next non-empty line instead.

## Test plan

<img width="889" alt="Screenshot 2023-05-25 at 12 55 47" src="https://github.com/sourcegraph/sourcegraph/assets/458591/f9ee89f7-9704-4aad-bc0e-d83abcb16e66">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
