### PR TITLE
Cody completions: Add docs page

### DIFF
--- a/doc/cody/completions.md
+++ b/doc/cody/completions.md
@@ -1,0 +1,26 @@
+# Cody completions
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change or be removed in the future. We've released it as an experimental feature to provide a preview of functionality we're working on.
+</p>
+</aside>
+
+![Example of Cody completions. You see a code snippet starting with async function getWeather(city: string) { and Cody response with a multi-line suggestion using a public weather API to return the current weather ](https://storage.googleapis.com/sourcegraph-assets/cody_completions.png)
+
+## What are Cody completions
+
+ Cody Completions provide suggestions for how to continue your code at the current cursor position.
+
+
+## Enabling Cody completions
+
+While in experimental state, Cody completions need to be enabled manually. To do that:
+
+1. Make sure your Cody AI by Sourcegraph extension is on the latest version
+   - <kbd>shift</kbd>+<kbd>cmd</kbd>+<kbd>x</kbd> to see all extensions, select Cody, confirm the version
+1. Next, go to the Cody Extension Settings and enable completions
+   - Click to check the box for: `Cody > Experimental Suggestions`
+1. Finally, restart VS Code and test it out!
+
+> NOTE: Self-hosted customers need to update to a minimum of version 5.0.4 to use completions.

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -75,6 +75,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Quickstart](cody/quickstart.md)
   - [Explanations](cody/explanations/index.md)
   - [FAQ](cody/faq.md)
+  - [Completions (experimental)](cody/completions.md)
 - [App (beta)](app/index.md)
 - [Own (experimental)](own/index.md)
 - <br/>


### PR DESCRIPTION
Shipping a simple docs page about completions with some guide on how to enable them.

If this needs to include some marketing specific language, please let me know 😅 

## Test plan

Docs page, view rendered here: 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
