### PR TITLE
batches: misc fixes

### DIFF
--- a/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.tsx
+++ b/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.tsx
@@ -15,7 +15,7 @@ export const RolloutWindowsConfiguration: React.FunctionComponent = () => {
     const { loading, error, rolloutWindowConfig } = useBatchChangesRolloutWindowConfig()
     return (
         <Container className="mb-3">
-            <H3>Rollout Windows</H3>
+            <H3>Rollout windows</H3>
             {loading && <LoadingSpinner />}
             {error && <ErrorAlert error={error} />}
             {!loading &&

--- a/doc/admin/config/webhooks/outgoing.md
+++ b/doc/admin/config/webhooks/outgoing.md
@@ -22,7 +22,7 @@ Currently, webhooks are only implemented for events related to [Batch Changes](.
    ![Adding an outgoing webhook](https://storage.googleapis.com/sourcegraph-assets/docs/images/administration/config/webhooks/adding-outgoing-webhook.png)
 1. Fill out the form:
    1. **URL**: URL endpoint of the external service that Sourcegraph should send webhook events to.
-   1. **Secret**: An arbitrary shared secret between Sourcegraph and the code host. A default value is provided, but you are free to change it.
+   1. **Secret**: An arbitrary secret to share between Sourcegraph and the external service. A default value is provided, but you are free to change it.
    1. **Event types**: The types of [events](#supported-event-types) that will trigger a webhook event. Currently, only events related to Batch Changes are supported.
 1. Click **Create**
 


### PR DESCRIPTION
Two unrelated but tiny language issues I came across yesterday.
- Capitalization of "Rollout Windows" (we normally only capitalize the first word of headings, e.g. "Code host tokens" on the same page
- Typo and slight lack of clarity in description of outbound webhook **Secret** property

## Test plan

Just text changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
