### PR TITLE
Cody: move section higher in admin sidebar

### DIFF
--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -190,11 +190,11 @@ export const enterpriseSiteAdminSidebarGroups: SiteAdminSideBarGroups = [
     configurationGroup,
     repositoriesGroup,
     codeIntelGroup,
+    codyGroup,
     usersGroup,
     executorsGroup,
     maintenanceGroup,
     batchChangesGroup,
     businessGroup,
-    codyGroup,
     apiConsoleGroup,
 ].filter(Boolean) as SiteAdminSideBarGroups


### PR DESCRIPTION
Previously, the section was near the end and easy to miss when the other sections were expanded. This moves it much higher (below "Code graph").

Closes https://github.com/sourcegraph/sourcegraph/issues/52455

## Test plan

Manually tested site admin page.