### PR TITLE
App - Fix shutdown of postgres when terminating

### DIFF
--- a/cmd/github-proxy/shared/shared.go
+++ b/cmd/github-proxy/shared/shared.go
@@ -103,7 +103,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		}
 		cancel()
 
-		os.Exit(0)
 	}()
 
 	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -88,7 +88,13 @@ func Main(services []sgservice.Service, config Config, args []string) {
 	}
 	app.Action = func(_ *cli.Context) error {
 		logger := log.Scoped("sourcegraph", "Sourcegraph")
-		singleprogram.Init(logger)
+		cleanup := singleprogram.Init(logger)
+		defer func() {
+			err := cleanup()
+			if err != nil {
+				logger.Error("cleaning up", log.Error(err))
+			}
+		}()
 		run(liblog, logger, services, config, nil)
 		return nil
 	}
@@ -226,6 +232,7 @@ func run(
 	// Start the debug server. The ready boolean state it publishes will become true when *all*
 	// services report ready.
 	var allReadyWG sync.WaitGroup
+	var allDoneWG sync.WaitGroup
 	go debugserver.NewServerRoutine(allReady, allDebugserverEndpoints...).Start()
 
 	// Start the services.
@@ -233,6 +240,7 @@ func run(
 		service := services[i]
 		serviceConfig := serviceConfigs[i]
 		allReadyWG.Add(1)
+		allDoneWG.Add(1)
 		go func() {
 			// TODO(sqs): TODO(single-binary): Consider using the goroutine package and/or the errgroup package to report
 			// errors and listen to signals to initiate cleanup in a consistent way across all
@@ -244,6 +252,7 @@ func run(
 			defer ready()
 
 			err := service.Start(ctx, obctx, ready, serviceConfig)
+			allDoneWG.Done()
 			if err != nil {
 				// Special case in App: continue without executor if it fails to start.
 				if deploy.IsApp() && service.Name() == "executor" {
@@ -261,5 +270,7 @@ func run(
 		close(allReady)
 	}()
 
-	select {}
+	// wait for all services to stop
+	allDoneWG.Wait()
+
 }

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -251,6 +251,8 @@ func run(
 			ready := syncx.OnceFunc(allReadyWG.Done)
 			defer ready()
 
+			// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
+			// This should be made explicit or refactored to accept to done channel or function in addition to ready.
 			err := service.Start(ctx, obctx, ready, serviceConfig)
 			allDoneWG.Done()
 			if err != nil {

--- a/internal/singleprogram/BUILD.bazel
+++ b/internal/singleprogram/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//internal/conf/confdefaults",
         "//internal/conf/deploy",
         "//internal/env",
-        "//internal/goroutine",
         "//internal/version",
         "//lib/errors",
         "@com_github_fatih_color//:color",


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/issues/52420

Previously when App shut down it was leaving behind postgres processes thats caused issues due to the socket from the previous instance remaining.  This is manifest to the user as a app with a blank screen that wouldn't launch.

There were several issues

1. The github proxy was calling `os.Exit` on the first shutdown signal received.  This is an issue for app because all services are running in the same parent process it would terminate the app before any other services or postgres could properly close.
2. Once the `os.Exit` issue was resolved the single binary would never terminate because it was paused on an empty select.  This replaces the empty select with a 2nd wait group that waits for the termination of each service that was started. The app will exit now but leaves a race condition on shutdown of the services and postgres.
3. To resolve the race condition I removed postgres from being monitored as a background process and instead return a cleanup function from `Init` so that balance can be restored.  Init is responsible for starting postgres before any service and now it can inform the caller how to clean up anything it needs to.

## Test plan
run `sg start app`  navigate around in app 
send SIGINT to the `sourcegraph` process ensure it terminates and there are no remaining postgres processes tied to the app

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
