### PR TITLE
bzl: fix logic to build enterprise repo-updater

### DIFF
--- a/cmd/repo-updater/build.sh
+++ b/cmd/repo-updater/build.sh
@@ -12,8 +12,9 @@ cleanup() {
 
 trap cleanup EXIT
 if [[ "${DOCKER_BAZEL:-false}" == "true" ]]; then
-  ./dev/ci/bazel.sh build //cmd/repo-updater
-  out=$(./dev/ci/bazel.sh cquery //cmd/repo-updater --output=files)
+  package=${1:-//cmd/repo-updater}
+  ./dev/ci/bazel.sh build "$package"
+  out=$(./dev/ci/bazel.sh cquery "$package" --output=files)
   cp "$out" "$OUTPUT"
 
   docker build -f cmd/repo-updater/Dockerfile -t "$IMAGE" "$OUTPUT" \

--- a/enterprise/cmd/repo-updater/build.sh
+++ b/enterprise/cmd/repo-updater/build.sh
@@ -3,4 +3,9 @@
 set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 
+if [[ "${DOCKER_BAZEL:-false}" == "true" ]]; then
+  ./cmd/repo-updater/build.sh //enterprise/cmd/repo-updater
+  exit $?
+fi
+
 ./cmd/repo-updater/build.sh github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater


### PR DESCRIPTION
ensures we're building enterprise repo-updater 


## Test plan

CI and tested locally