### PR TITLE
Embeddings: support cancelling embedding jobs

### DIFF
--- a/cmd/frontend/graphqlbackend/embeddings.go
+++ b/cmd/frontend/graphqlbackend/embeddings.go
@@ -17,6 +17,7 @@ type EmbeddingsResolver interface {
 
 	ScheduleRepositoriesForEmbedding(ctx context.Context, args ScheduleRepositoriesForEmbeddingArgs) (*EmptyResponse, error)
 	ScheduleContextDetectionForEmbedding(ctx context.Context) (*EmptyResponse, error)
+	CancelRepoEmbeddingJob(ctx context.Context, args CancelRepoEmbeddingJobArgs) (*EmptyResponse, error)
 }
 
 type ScheduleRepositoriesForEmbeddingArgs struct {
@@ -57,6 +58,11 @@ type EmbeddingsSearchResultResolver interface {
 
 type ListRepoEmbeddingJobsArgs struct {
 	graphqlutil.ConnectionResolverArgs
+}
+
+type CancelRepoEmbeddingJobArgs struct {
+	RepoName string
+	Revision string
 }
 
 type RepoEmbeddingJobResolver interface {

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -90,6 +90,10 @@ extend type Mutation {
     Experimental: Schedules a job to create an embedding index used for context detection. The index is used to determine wheter a query requires additional context.
     """
     scheduleContextDetectionForEmbedding: EmptyResponse!
+    """
+    Experimental: Cancels embedding jobs for the given repositories.
+    """
+    cancelRepoEmbeddingJob(repoName: String!, revision: String!): EmptyResponse!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -184,6 +184,25 @@ func (r *Resolver) ScheduleContextDetectionForEmbedding(ctx context.Context) (*g
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r *Resolver) CancelRepoEmbeddingJob(ctx context.Context, args graphqlbackend.CancelRepoEmbeddingJobArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: check whether user is site-admin
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
+		return nil, err
+	}
+
+	repoStore := r.db.Repos()
+	repo, err := repoStore.GetByName(ctx, api.RepoName(args.RepoName))
+	if err != nil {
+		return nil, err
+	}
+
+	commitID := api.CommitID(args.Revision)
+	if err := r.repoEmbeddingJobsStore.CancelRepoEmbeddingJob(ctx, repo.ID, commitID); err != nil {
+		return nil, err
+	}
+	return &graphqlbackend.EmptyResponse{}, nil
+}
+
 type embeddingsSearchResultsResolver struct {
 	results   *embeddings.EmbeddingCombinedSearchResults
 	gitserver gitserver.Client

--- a/enterprise/internal/embeddings/background/repo/mocks_temp.go
+++ b/enterprise/internal/embeddings/background/repo/mocks_temp.go
@@ -21,6 +21,9 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo)
 // used for unit testing.
 type MockRepoEmbeddingJobsStore struct {
+	// CancelRepoEmbeddingJobFunc is an instance of a mock function object
+	// controlling the behavior of the method CancelRepoEmbeddingJob.
+	CancelRepoEmbeddingJobFunc *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc
 	// CountRepoEmbeddingJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountRepoEmbeddingJobs.
 	CountRepoEmbeddingJobsFunc *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc
@@ -60,6 +63,11 @@ type MockRepoEmbeddingJobsStore struct {
 // results, unless overwritten.
 func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 	return &MockRepoEmbeddingJobsStore{
+		CancelRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc{
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 error) {
+				return
+			},
+		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
 				return
@@ -118,6 +126,11 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 // overwritten.
 func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 	return &MockRepoEmbeddingJobsStore{
+		CancelRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc{
+			defaultHook: func(context.Context, api.RepoID, api.CommitID) error {
+				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CancelRepoEmbeddingJob")
+			},
+		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
 			defaultHook: func(context.Context) (int, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CountRepoEmbeddingJobs")
@@ -176,6 +189,9 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 // implementation, unless overwritten.
 func NewMockRepoEmbeddingJobsStoreFrom(i RepoEmbeddingJobsStore) *MockRepoEmbeddingJobsStore {
 	return &MockRepoEmbeddingJobsStore{
+		CancelRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc{
+			defaultHook: i.CancelRepoEmbeddingJob,
+		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
 			defaultHook: i.CountRepoEmbeddingJobs,
 		},
@@ -207,6 +223,118 @@ func NewMockRepoEmbeddingJobsStoreFrom(i RepoEmbeddingJobsStore) *MockRepoEmbedd
 			defaultHook: i.Transact,
 		},
 	}
+}
+
+// RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc describes the behavior
+// when the CancelRepoEmbeddingJob method of the parent
+// MockRepoEmbeddingJobsStore instance is invoked.
+type RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc struct {
+	defaultHook func(context.Context, api.RepoID, api.CommitID) error
+	hooks       []func(context.Context, api.RepoID, api.CommitID) error
+	history     []RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall
+	mutex       sync.Mutex
+}
+
+// CancelRepoEmbeddingJob delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockRepoEmbeddingJobsStore) CancelRepoEmbeddingJob(v0 context.Context, v1 api.RepoID, v2 api.CommitID) error {
+	r0 := m.CancelRepoEmbeddingJobFunc.nextHook()(v0, v1, v2)
+	m.CancelRepoEmbeddingJobFunc.appendCall(RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall{v0, v1, v2, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// CancelRepoEmbeddingJob method of the parent MockRepoEmbeddingJobsStore
+// instance is invoked and the hook queue is empty.
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CancelRepoEmbeddingJob method of the parent MockRepoEmbeddingJobsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID) error {
+		return r0
+	})
+}
+
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) appendCall(r0 RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall objects describing
+// the invocations of this function.
+func (f *RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFunc) History() []RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall is an object that
+// describes an invocation of method CancelRepoEmbeddingJob on an instance
+// of MockRepoEmbeddingJobsStore.
+type RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 api.CommitID
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc describes the behavior

--- a/enterprise/internal/embeddings/background/repo/types.go
+++ b/enterprise/internal/embeddings/background/repo/types.go
@@ -31,5 +31,5 @@ func (j *RepoEmbeddingJob) RecordID() int {
 }
 
 func (j *RepoEmbeddingJob) IsRepoEmbeddingJobScheduledOrCompleted() bool {
-	return j != nil && (j.State == "completed" || j.State == "processing" || j.State == "queued")
+	return j != nil && (j.State == "completed" || j.State == "processing" || j.State == "queued" || j.Cancel)
 }

--- a/enterprise/internal/embeddings/embed/api.go
+++ b/enterprise/internal/embeddings/embed/api.go
@@ -42,10 +42,8 @@ type embeddingsClient struct {
 	config *schema.Embeddings
 }
 
-// isDisabled checks the current state of the site config to see if embeddings are
-// enabled. This gives an "escape hatch" for cancelling a long-running embeddings job.
 func (c *embeddingsClient) isDisabled() bool {
-	return !conf.EmbeddingsEnabled()
+	return c.config == nil || !c.config.Enabled
 }
 
 func (c *embeddingsClient) GetDimensions() (int, error) {

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -15,10 +15,7 @@ import (
 )
 
 const GET_EMBEDDINGS_MAX_RETRIES = 5
-
-const EMBEDDING_BATCHES = 5
 const EMBEDDING_BATCH_SIZE = 512
-
 const maxFileSize = 1000000 // 1MB
 
 // EmbedRepo embeds file contents from the given file names for a repository.
@@ -185,6 +182,10 @@ func embedFiles(
 		statsSkipped            SkipStats
 	)
 	for _, file := range files {
+		if ctx.Err() != nil {
+			return embeddings.EmbeddingIndex{}, embeddings.EmbedFilesStats{}, ctx.Err()
+		}
+
 		// This is a fail-safe measure to prevent producing an extremely large index for large repositories.
 		if statsEmbeddedChunkCount >= maxEmbeddingVectors {
 			statsSkipped.Add(SkipReasonMaxEmbeddings, int(file.Size))

--- a/enterprise/internal/embeddings/schedule.go
+++ b/enterprise/internal/embeddings/schedule.go
@@ -42,7 +42,7 @@ func ScheduleRepositoriesForEmbedding(
 
 			job, _ := tx.GetLastRepoEmbeddingJobForRevision(ctx, r.ID, latestRevision)
 			// Skip creating a repo embedding job for a repo at revision, if there already exists
-			// an identical job that has been completed or is scheduled to run (processing or queued).
+			// an identical job that has been completed, cancelled or is scheduled to run (processing or queued).
 			if job.IsRepoEmbeddingJobScheduledOrCompleted() {
 				return nil
 			}


### PR DESCRIPTION
This PR adds a GraphQL endpoint for cancelling a specific embedding job. It updates the existing 'cancel' field in the job store. The worker knows to periodically check this, and shuts down the job by cancelling the context.

In follow-up work, we'll surface the GraphQL endpoint through the UI. 

Closes #52066

## Test plan

Added new unit tests for GraphQL resolver and store method. Tested manually using API console.
