### PR TITLE
Add reviews to Gerrit Batch Changes

### DIFF
--- a/enterprise/internal/authz/gerrit/mocks_test.go
+++ b/enterprise/internal/authz/gerrit/mocks_test.go
@@ -32,6 +32,9 @@ type MockGerritClient struct {
 	// GetChangeFunc is an instance of a mock function object controlling
 	// the behavior of the method GetChange.
 	GetChangeFunc *GerritClientGetChangeFunc
+	// GetChangeReviewsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetChangeReviews.
+	GetChangeReviewsFunc *GerritClientGetChangeReviewsFunc
 	// GetGroupFunc is an instance of a mock function object controlling the
 	// behavior of the method GetGroup.
 	GetGroupFunc *GerritClientGetGroupFunc
@@ -76,6 +79,11 @@ func NewMockGerritClient() *MockGerritClient {
 		},
 		GetChangeFunc: &GerritClientGetChangeFunc{
 			defaultHook: func(context.Context, string) (r0 *gerrit.Change, r1 error) {
+				return
+			},
+		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: func(context.Context, string) (r0 *[]gerrit.Reviewer, r1 error) {
 				return
 			},
 		},
@@ -141,6 +149,11 @@ func NewStrictMockGerritClient() *MockGerritClient {
 				panic("unexpected invocation of MockGerritClient.GetChange")
 			},
 		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: func(context.Context, string) (*[]gerrit.Reviewer, error) {
+				panic("unexpected invocation of MockGerritClient.GetChangeReviews")
+			},
+		},
 		GetGroupFunc: &GerritClientGetGroupFunc{
 			defaultHook: func(context.Context, string) (gerrit.Group, error) {
 				panic("unexpected invocation of MockGerritClient.GetGroup")
@@ -195,6 +208,9 @@ func NewMockGerritClientFrom(i gerrit.Client) *MockGerritClient {
 		},
 		GetChangeFunc: &GerritClientGetChangeFunc{
 			defaultHook: i.GetChange,
+		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: i.GetChangeReviews,
 		},
 		GetGroupFunc: &GerritClientGetGroupFunc{
 			defaultHook: i.GetGroup,
@@ -641,6 +657,115 @@ func (c GerritClientGetChangeFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GerritClientGetChangeFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GerritClientGetChangeReviewsFunc describes the behavior when the
+// GetChangeReviews method of the parent MockGerritClient instance is
+// invoked.
+type GerritClientGetChangeReviewsFunc struct {
+	defaultHook func(context.Context, string) (*[]gerrit.Reviewer, error)
+	hooks       []func(context.Context, string) (*[]gerrit.Reviewer, error)
+	history     []GerritClientGetChangeReviewsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetChangeReviews delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGerritClient) GetChangeReviews(v0 context.Context, v1 string) (*[]gerrit.Reviewer, error) {
+	r0, r1 := m.GetChangeReviewsFunc.nextHook()(v0, v1)
+	m.GetChangeReviewsFunc.appendCall(GerritClientGetChangeReviewsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetChangeReviews
+// method of the parent MockGerritClient instance is invoked and the hook
+// queue is empty.
+func (f *GerritClientGetChangeReviewsFunc) SetDefaultHook(hook func(context.Context, string) (*[]gerrit.Reviewer, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetChangeReviews method of the parent MockGerritClient instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GerritClientGetChangeReviewsFunc) PushHook(hook func(context.Context, string) (*[]gerrit.Reviewer, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GerritClientGetChangeReviewsFunc) SetDefaultReturn(r0 *[]gerrit.Reviewer, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) (*[]gerrit.Reviewer, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GerritClientGetChangeReviewsFunc) PushReturn(r0 *[]gerrit.Reviewer, r1 error) {
+	f.PushHook(func(context.Context, string) (*[]gerrit.Reviewer, error) {
+		return r0, r1
+	})
+}
+
+func (f *GerritClientGetChangeReviewsFunc) nextHook() func(context.Context, string) (*[]gerrit.Reviewer, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GerritClientGetChangeReviewsFunc) appendCall(r0 GerritClientGetChangeReviewsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GerritClientGetChangeReviewsFuncCall
+// objects describing the invocations of this function.
+func (f *GerritClientGetChangeReviewsFunc) History() []GerritClientGetChangeReviewsFuncCall {
+	f.mutex.Lock()
+	history := make([]GerritClientGetChangeReviewsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GerritClientGetChangeReviewsFuncCall is an object that describes an
+// invocation of method GetChangeReviews on an instance of MockGerritClient.
+type GerritClientGetChangeReviewsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *[]gerrit.Reviewer
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GerritClientGetChangeReviewsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GerritClientGetChangeReviewsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/batches/sources/gerrit/types.go
+++ b/enterprise/internal/batches/sources/gerrit/types.go
@@ -12,5 +12,6 @@ import (
 // changesets.
 type AnnotatedChange struct {
 	*gerrit.Change
+	Reviewers   *[]gerrit.Reviewer
 	CodeHostURL *url.URL
 }

--- a/enterprise/internal/batches/sources/gerrit_test.go
+++ b/enterprise/internal/batches/sources/gerrit_test.go
@@ -130,6 +130,7 @@ func TestGerritSource_LoadChangeset(t *testing.T) {
 			assert.Equal(t, changeID, testGerritChangeID)
 			return change, nil
 		})
+		client.GetChangeReviewsFunc.SetDefaultReturn(&[]gerrit.Reviewer{}, nil)
 
 		err := s.LoadChangeset(ctx, cs)
 		assert.Nil(t, err)
@@ -154,7 +155,7 @@ func TestGerritSource_CreateChangeset(t *testing.T) {
 		assert.False(t, b)
 	})
 
-	t.Run("pull request not found", func(t *testing.T) {
+	t.Run("change not found", func(t *testing.T) {
 		cs, _ := mockGerritChangeset()
 		s, client := mockGerritSource()
 		client.GetChangeFunc.SetDefaultHook(func(ctx context.Context, changeID string) (*gerrit.Change, error) {
@@ -180,6 +181,7 @@ func TestGerritSource_CreateChangeset(t *testing.T) {
 			assert.Equal(t, changeID, testGerritChangeID)
 			return change, nil
 		})
+		client.GetChangeReviewsFunc.SetDefaultReturn(&[]gerrit.Reviewer{}, nil)
 
 		b, err := s.CreateChangeset(ctx, cs)
 		assert.Nil(t, err)
@@ -215,6 +217,7 @@ func TestGerritSource_CloseChangeset(t *testing.T) {
 			assert.Equal(t, changeID, testGerritChangeID)
 			return pr, nil
 		})
+		client.GetChangeReviewsFunc.SetDefaultReturn(&[]gerrit.Reviewer{}, nil)
 
 		err := s.CloseChangeset(ctx, cs)
 		assert.Nil(t, err)
@@ -274,7 +277,7 @@ func TestGerritSource_MergeChangeset(t *testing.T) {
 		assert.Equal(t, want.Error(), target.ErrorMsg)
 	})
 
-	t.Run("pull request not found", func(t *testing.T) {
+	t.Run("change not found", func(t *testing.T) {
 		cs, _ := mockGerritChangeset()
 		s, client := mockGerritSource()
 
@@ -299,6 +302,7 @@ func TestGerritSource_MergeChangeset(t *testing.T) {
 			assert.Equal(t, testGerritChangeID, changeID)
 			return pr, nil
 		})
+		client.GetChangeReviewsFunc.SetDefaultReturn(&[]gerrit.Reviewer{}, nil)
 
 		err := s.MergeChangeset(ctx, cs, true)
 		assert.Nil(t, err)
@@ -316,6 +320,7 @@ func TestGerritSource_MergeChangeset(t *testing.T) {
 			assert.Equal(t, testGerritChangeID, changeID)
 			return pr, nil
 		})
+		client.GetChangeReviewsFunc.SetDefaultReturn(&[]gerrit.Reviewer{}, nil)
 
 		err := s.MergeChangeset(ctx, cs, false)
 		assert.Nil(t, err)

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -8122,6 +8122,9 @@ type MockGerritClient struct {
 	// GetChangeFunc is an instance of a mock function object controlling
 	// the behavior of the method GetChange.
 	GetChangeFunc *GerritClientGetChangeFunc
+	// GetChangeReviewsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetChangeReviews.
+	GetChangeReviewsFunc *GerritClientGetChangeReviewsFunc
 	// GetGroupFunc is an instance of a mock function object controlling the
 	// behavior of the method GetGroup.
 	GetGroupFunc *GerritClientGetGroupFunc
@@ -8166,6 +8169,11 @@ func NewMockGerritClient() *MockGerritClient {
 		},
 		GetChangeFunc: &GerritClientGetChangeFunc{
 			defaultHook: func(context.Context, string) (r0 *gerrit.Change, r1 error) {
+				return
+			},
+		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: func(context.Context, string) (r0 *[]gerrit.Reviewer, r1 error) {
 				return
 			},
 		},
@@ -8231,6 +8239,11 @@ func NewStrictMockGerritClient() *MockGerritClient {
 				panic("unexpected invocation of MockGerritClient.GetChange")
 			},
 		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: func(context.Context, string) (*[]gerrit.Reviewer, error) {
+				panic("unexpected invocation of MockGerritClient.GetChangeReviews")
+			},
+		},
 		GetGroupFunc: &GerritClientGetGroupFunc{
 			defaultHook: func(context.Context, string) (gerrit.Group, error) {
 				panic("unexpected invocation of MockGerritClient.GetGroup")
@@ -8285,6 +8298,9 @@ func NewMockGerritClientFrom(i gerrit.Client) *MockGerritClient {
 		},
 		GetChangeFunc: &GerritClientGetChangeFunc{
 			defaultHook: i.GetChange,
+		},
+		GetChangeReviewsFunc: &GerritClientGetChangeReviewsFunc{
+			defaultHook: i.GetChangeReviews,
 		},
 		GetGroupFunc: &GerritClientGetGroupFunc{
 			defaultHook: i.GetGroup,
@@ -8731,6 +8747,115 @@ func (c GerritClientGetChangeFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GerritClientGetChangeFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// GerritClientGetChangeReviewsFunc describes the behavior when the
+// GetChangeReviews method of the parent MockGerritClient instance is
+// invoked.
+type GerritClientGetChangeReviewsFunc struct {
+	defaultHook func(context.Context, string) (*[]gerrit.Reviewer, error)
+	hooks       []func(context.Context, string) (*[]gerrit.Reviewer, error)
+	history     []GerritClientGetChangeReviewsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetChangeReviews delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGerritClient) GetChangeReviews(v0 context.Context, v1 string) (*[]gerrit.Reviewer, error) {
+	r0, r1 := m.GetChangeReviewsFunc.nextHook()(v0, v1)
+	m.GetChangeReviewsFunc.appendCall(GerritClientGetChangeReviewsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetChangeReviews
+// method of the parent MockGerritClient instance is invoked and the hook
+// queue is empty.
+func (f *GerritClientGetChangeReviewsFunc) SetDefaultHook(hook func(context.Context, string) (*[]gerrit.Reviewer, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetChangeReviews method of the parent MockGerritClient instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GerritClientGetChangeReviewsFunc) PushHook(hook func(context.Context, string) (*[]gerrit.Reviewer, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GerritClientGetChangeReviewsFunc) SetDefaultReturn(r0 *[]gerrit.Reviewer, r1 error) {
+	f.SetDefaultHook(func(context.Context, string) (*[]gerrit.Reviewer, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GerritClientGetChangeReviewsFunc) PushReturn(r0 *[]gerrit.Reviewer, r1 error) {
+	f.PushHook(func(context.Context, string) (*[]gerrit.Reviewer, error) {
+		return r0, r1
+	})
+}
+
+func (f *GerritClientGetChangeReviewsFunc) nextHook() func(context.Context, string) (*[]gerrit.Reviewer, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GerritClientGetChangeReviewsFunc) appendCall(r0 GerritClientGetChangeReviewsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GerritClientGetChangeReviewsFuncCall
+// objects describing the invocations of this function.
+func (f *GerritClientGetChangeReviewsFunc) History() []GerritClientGetChangeReviewsFuncCall {
+	f.mutex.Lock()
+	history := make([]GerritClientGetChangeReviewsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GerritClientGetChangeReviewsFuncCall is an object that describes an
+// invocation of method GetChangeReviews on an instance of MockGerritClient.
+type GerritClientGetChangeReviewsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *[]gerrit.Reviewer
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GerritClientGetChangeReviewsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GerritClientGetChangeReviewsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/batches/types/BUILD.bazel
+++ b/enterprise/internal/batches/types/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//internal/extsvc/azuredevops",
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/bitbucketserver",
+        "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
         "//internal/extsvc/gitlab/webhooks",

--- a/enterprise/internal/batches/types/changeset_event.go
+++ b/enterprise/internal/batches/types/changeset_event.go
@@ -108,13 +108,19 @@ const (
 	ChangesetEventKindAzureDevOpsPullRequestUpdated                 ChangesetEventKind = "azuredevops:pullrequest:updated"
 	ChangesetEventKindAzureDevOpsPullRequestApproved                ChangesetEventKind = "azuredevops:pullrequest:approved"
 	ChangesetEventKindAzureDevOpsPullRequestApprovedWithSuggestions ChangesetEventKind = "azuredevops:pullrequest:approved_with_suggestions"
-	ChangesetEventKindAzureDevOpsPullRequesReviewed                 ChangesetEventKind = "azuredevops:pullrequest:reviewed"
+	ChangesetEventKindAzureDevOpsPullRequestReviewed                ChangesetEventKind = "azuredevops:pullrequest:reviewed"
 	ChangesetEventKindAzureDevOpsPullRequestWaitingForAuthor        ChangesetEventKind = "azuredevops:pullrequest:waiting_for_author"
 	ChangesetEventKindAzureDevOpsPullRequestRejected                ChangesetEventKind = "azuredevops:pullrequest:rejected"
 	ChangesetEventKindAzureDevOpsPullRequestBuildSucceeded          ChangesetEventKind = "azuredevops:pullrequest:build_succeeded"
 	ChangesetEventKindAzureDevOpsPullRequestBuildFailed             ChangesetEventKind = "azuredevops:pullrequest:build_failed"
 	ChangesetEventKindAzureDevOpsPullRequestBuildError              ChangesetEventKind = "azuredevops:pullrequest:build_error"
 	ChangesetEventKindAzureDevOpsPullRequestBuildPending            ChangesetEventKind = "azuredevops:pullrequest:build_pending"
+
+	ChangesetEventKindGerritChangeApproved                ChangesetEventKind = "gerrit:change:approved"
+	ChangesetEventKindGerritChangeApprovedWithSuggestions ChangesetEventKind = "gerrit:change:approved_with_suggestions"
+	ChangesetEventKindGerritChangeReviewed                ChangesetEventKind = "gerrit:change:reviewed"
+	ChangesetEventKindGerritChangeNeedsChanges            ChangesetEventKind = "gerrit:change:needs_changes"
+	ChangesetEventKindGerritChangeRejected                ChangesetEventKind = "gerrit:change:rejected"
 
 	ChangesetEventKindInvalid ChangesetEventKind = "invalid"
 )

--- a/enterprise/internal/batches/types/changeset_event_test.go
+++ b/enterprise/internal/batches/types/changeset_event_test.go
@@ -368,7 +368,7 @@ func TestChangesetEvent(t *testing.T) {
 				Metadata:    reviewers[1],
 			}, {
 				ChangesetID: 24,
-				Kind:        ChangesetEventKindAzureDevOpsPullRequesReviewed,
+				Kind:        ChangesetEventKindAzureDevOpsPullRequestReviewed,
 				Key:         reviewers[2].ID,
 				Metadata:    reviewers[2],
 			}, {

--- a/internal/extsvc/gerrit/changes.go
+++ b/internal/extsvc/gerrit/changes.go
@@ -137,3 +137,30 @@ func (c *client) WriteReviewComment(ctx context.Context, changeID string, commen
 
 	return nil
 }
+
+// GetChangeReviews gets the list of reviewrs/reviews for the change.
+func (c *client) GetChangeReviews(ctx context.Context, changeID string) (*[]Reviewer, error) {
+	pathStr, err := url.JoinPath("a/changes", url.PathEscape(changeID), "revisions/current/reviewers")
+	if err != nil {
+		return nil, err
+	}
+	reqURL := url.URL{Path: pathStr}
+
+	req, err := http.NewRequest("GET", reqURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "text/plain; charset=UTF-8")
+
+	var reviewers []Reviewer
+	resp, err := c.do(ctx, req, &reviewers)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, errors.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return &reviewers, nil
+}

--- a/internal/extsvc/gerrit/changes_test.go
+++ b/internal/extsvc/gerrit/changes_test.go
@@ -46,7 +46,6 @@ func TestClient_AbandonChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	testutil.AssertGolden(t, "testdata/golden/AbandonChange.json", *update, resp)
-
 }
 
 func TestClient_SubmitChange(t *testing.T) {
@@ -73,4 +72,18 @@ func TestClient_RestoreChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	testutil.AssertGolden(t, "testdata/golden/RestoreChange.json", *update, resp)
+}
+
+func TestClient_GetChangeReviews(t *testing.T) {
+	cli, save := NewTestClient(t, "GetChangeReviews", *update)
+	defer save()
+
+	ctx := context.Background()
+
+	resp, err := cli.GetChangeReviews(ctx, "Ic433e1f2e4edfebe4cf75b23ded032bb790d872a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.AssertGolden(t, "testdata/golden/GetChangeReviews.json", *update, resp)
+
 }

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -43,6 +43,7 @@ type Client interface {
 	SubmitChange(ctx context.Context, changeID string) (*Change, error)
 	RestoreChange(ctx context.Context, changeID string) (*Change, error)
 	WriteReviewComment(ctx context.Context, changeID string, comment ChangeReviewComment) error
+	GetChangeReviews(ctx context.Context, changeID string) (*[]Reviewer, error)
 }
 
 // NewClient returns an authenticated Gerrit API client with

--- a/internal/extsvc/gerrit/testdata/golden/GetChangeReviews.json
+++ b/internal/extsvc/gerrit/testdata/golden/GetChangeReviews.json
@@ -1,0 +1,19 @@
+[
+  {
+   "approvals": {
+    "Code-Review": "-2"
+   },
+   "_account_id": 1000018,
+   "name": "Idan Varsano",
+   "email": "idan.varsano@sourcegraph.com",
+   "username": "ivarsano"
+  },
+  {
+   "approvals": {
+    "Code-Review": "+1"
+   },
+   "_account_id": 1000034,
+   "name": "Kelli Rockwell",
+   "email": "kelli@sourcegraph.com"
+  }
+ ]

--- a/internal/extsvc/gerrit/testdata/vcr/GetChangeReviews.yaml
+++ b/internal/extsvc/gerrit/testdata/vcr/GetChangeReviews.yaml
@@ -1,0 +1,61 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - text/plain; charset=UTF-8
+    url: https://gerrit.sgdev.org/a/changes/Ic433e1f2e4edfebe4cf75b23ded032bb790d872a/revisions/current/reviewers
+    method: GET
+  response:
+    body: |
+      )]}'
+      [
+        {
+          "approvals": {
+            "Code-Review": "-2"
+          },
+          "_account_id": 1000018,
+          "name": "Idan Varsano",
+          "email": "idan.varsano@sourcegraph.com",
+          "username": "ivarsano"
+        },
+        {
+          "approvals": {
+            "Code-Review": "+1"
+          },
+          "_account_id": 1000034,
+          "name": "Kelli Rockwell",
+          "email": "kelli@sourcegraph.com"
+        }
+      ]
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7ccfcc00f8fea234-YYZ
+      Content-Disposition:
+      - attachment
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Thu, 25 May 2023 18:21:13 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/gerrit/types.go
+++ b/internal/extsvc/gerrit/types.go
@@ -99,6 +99,26 @@ type ChangeReviewComment struct {
 	Comments      map[string]string `json:"comments,omitempty"`
 }
 
+// Approvals
+// Score represents the status of a review on Gerrit. Here are possible values for Vote:
+//
+//	+2 : approved, can be merged
+//	+1 : approved, but needs additional reviews
+//	 0 : no score
+//	-1 : needs changes
+//	-2 : rejected
+type Approvals struct {
+	CodeReview string `json:"Code-Review"`
+}
+
+type Reviewer struct {
+	Approvals Approvals `json:"approvals"`
+	AccountID int       `json:"_account_id"`
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	Username  string    `json:"username,omitempty"`
+}
+
 type NotifyDetails struct {
 	EmailOnly bool `json:"email_only,omitempty"`
 }

--- a/mockgen.test.yaml
+++ b/mockgen.test.yaml
@@ -4,6 +4,25 @@
       interfaces:
         - Client
       prefix: Gerrit
+- filename: enterprise/internal/batches/sources/mocks_test.go
+  sources:
+    - path: github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources
+      interfaces:
+        - ChangesetSource
+        - ForkableChangesetSource
+        - SourcerStore
+    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud
+      interfaces:
+        - Client
+      prefix: BitbucketCloud
+    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops
+      interfaces:
+        - Client
+      prefix: AzureDevOps
+    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit
+      interfaces:
+        - Client
+      prefix: Gerrit
 - filename: cmd/frontend/internal/httpapi/mocks_test.go
   path: github.com/sourcegraph/sourcegraph/internal/httpcli
   interfaces:
@@ -111,25 +130,6 @@
   path: github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executorqueue
   interfaces:
     - GitserverClient
-- filename: enterprise/internal/batches/sources/mocks_test.go
-  sources:
-    - path: github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources
-      interfaces:
-        - ChangesetSource
-        - ForkableChangesetSource
-        - SourcerStore
-    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud
-      interfaces:
-        - Client
-      prefix: BitbucketCloud
-    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/azuredevops
-      interfaces:
-        - Client
-      prefix: AzureDevOps
-    - path: github.com/sourcegraph/sourcegraph/internal/extsvc/gerrit
-      interfaces:
-        - Client
-      prefix: Gerrit
 - filename: enterprise/internal/batches/syncer/mocks_test.go
   path: github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer
   interfaces:


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/50867.

Gerrit Changes don't come with reviews built in, so I had to jam them into the AnnotatedChange object.

## Test plan
updated some of the unit tests.