### PR TITLE
batches: `supportsCommitSigning ` field to `BatchChangesCodeHosts`

### DIFF
--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -84,7 +84,7 @@ const CODE_HOST_FIELDS_FRAGMENT = gql`
         externalServiceURL
         requiresSSH
         requiresUsername
-        hasCommitSigning
+        supportsCommitSigning
         credential {
             ...BatchChangesCredentialFields
         }

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -84,7 +84,6 @@ const CODE_HOST_FIELDS_FRAGMENT = gql`
         externalServiceURL
         requiresSSH
         requiresUsername
-        supportsCommitSigning
         credential {
             ...BatchChangesCredentialFields
         }

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -84,6 +84,7 @@ const CODE_HOST_FIELDS_FRAGMENT = gql`
         externalServiceURL
         requiresSSH
         requiresUsername
+        hasCommitSigning
         credential {
             ...BatchChangesCredentialFields
         }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -554,6 +554,7 @@ type BatchChangesCodeHostResolver interface {
 	ExternalServiceURL() string
 	RequiresSSH() bool
 	RequiresUsername() bool
+	HasCommitSigning() bool
 	HasWebhooks() bool
 	Credential() BatchChangesCredentialResolver
 }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -554,7 +554,7 @@ type BatchChangesCodeHostResolver interface {
 	ExternalServiceURL() string
 	RequiresSSH() bool
 	RequiresUsername() bool
-	HasCommitSigning() bool
+	SupportsCommitSigning() bool
 	HasWebhooks() bool
 	Credential() BatchChangesCredentialResolver
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3458,6 +3458,11 @@ type BatchChangesCodeHost {
     requiresUsername: Boolean!
 
     """
+    If true, this code host can setup commit signing.
+    """
+    hasCommitSigning: Boolean!
+
+    """
     If true, the code host has webhooks configured.
     """
     hasWebhooks: Boolean!

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3460,7 +3460,7 @@ type BatchChangesCodeHost {
     """
     If true, this code host can setup commit signing.
     """
-    hasCommitSigning: Boolean!
+    supportsCommitSigning: Boolean!
 
     """
     If true, the code host has webhooks configured.

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -38,6 +38,14 @@ func (c *batchChangesCodeHostResolver) RequiresUsername() bool {
 	return false
 }
 
+func (c *batchChangesCodeHostResolver) HasCommitSigning() bool {
+	if c.codeHost.ExternalServiceType == extsvc.TypeGitHub {
+		return true
+	}
+
+	return false
+}
+
 func (c *batchChangesCodeHostResolver) HasWebhooks() bool {
 	return c.codeHost.HasWebhooks
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -38,7 +38,7 @@ func (c *batchChangesCodeHostResolver) RequiresUsername() bool {
 	return false
 }
 
-func (c *batchChangesCodeHostResolver) HasCommitSigning() bool {
+func (c *batchChangesCodeHostResolver) SupportsCommitSigning() bool {
 	return c.codeHost.ExternalServiceType == extsvc.TypeGitHub
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -39,11 +39,7 @@ func (c *batchChangesCodeHostResolver) RequiresUsername() bool {
 }
 
 func (c *batchChangesCodeHostResolver) HasCommitSigning() bool {
-	if c.codeHost.ExternalServiceType == extsvc.TypeGitHub {
-		return true
-	}
-
-	return false
+	return c.codeHost.ExternalServiceType == extsvc.TypeGitHub
 }
 
 func (c *batchChangesCodeHostResolver) HasWebhooks() bool {

--- a/enterprise/internal/batches/types/code_host.go
+++ b/enterprise/internal/batches/types/code_host.go
@@ -7,6 +7,7 @@ type CodeHost struct {
 	ExternalServiceType string
 	ExternalServiceID   string
 	RequiresSSH         bool
+	HasCommitSigning    bool
 	HasWebhooks         bool
 }
 

--- a/enterprise/internal/batches/types/code_host.go
+++ b/enterprise/internal/batches/types/code_host.go
@@ -4,11 +4,11 @@ import "github.com/sourcegraph/sourcegraph/internal/extsvc"
 
 // CodeHost represents one configured external code host available on this Sourcegraph instance.
 type CodeHost struct {
-	ExternalServiceType string
-	ExternalServiceID   string
-	RequiresSSH         bool
-	HasCommitSigning    bool
-	HasWebhooks         bool
+	ExternalServiceType   string
+	ExternalServiceID     string
+	RequiresSSH           bool
+	SupportsCommitSigning bool
+	HasWebhooks           bool
 }
 
 // IsSupported returns true, when this code host is supported by


### PR DESCRIPTION
Closes #[52465](https://github.com/sourcegraph/sourcegraph/issues/52465), setup for #[52220](https://github.com/sourcegraph/sourcegraph/issues/52220)

Adds new `supportsCommitSigning ` field to the `BatchChangesCodeHosts` resolver. Only GitHub external services have commit signing for now. Later on we will support more code hosts. Even though different mechanisms will support the commit signing (ie SSH keys), that will be handled downstream.

## Test plan
![image](https://github.com/sourcegraph/sourcegraph/assets/59381432/dd77362f-769e-4f5d-a8aa-ae755344e9fc)
- Nav to `/site-admin/batch-changes`
- Ensure `/graphql?GlobalBatchChangesCodeHosts` returns the correct value for `supportsCommitSigning `