### PR TITLE
codeintel.policies: do not make embeddingsEnabled required

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.policies.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.policies.graphql
@@ -80,6 +80,9 @@ extend type Mutation {
     """
     Creates a new configuration policy with the given attributes.
     """
+    # 🚧 CLOUD: This mutation is used by Cloud automation - please do not
+    # introduce any breaking changes, and let new parameters be optional with
+    # reasonable defaults instead.
     createCodeIntelligenceConfigurationPolicy(
         """
         If supplied, the repository to which this configuration policy applies. If not supplied,
@@ -102,7 +105,11 @@ extend type Mutation {
         indexingEnabled: Boolean!
         indexCommitMaxAgeHours: Int
         indexIntermediateCommits: Boolean!
-        embeddingsEnabled: Boolean!
+
+        """
+        embeddingsEnabled, if not provided, currently defaults to false.
+        """
+        embeddingsEnabled: Boolean
     ): CodeIntelligenceConfigurationPolicy!
 
     """

--- a/cmd/frontend/graphqlbackend/codeintel.policies.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.policies.graphql
@@ -108,6 +108,9 @@ extend type Mutation {
     """
     Updates the attributes configuration policy with the given identifier.
     """
+    # 🚧 This mutation is used by Cloud automation - please do not introduce
+    # any breaking changes, and let new parameters be optional with reasonable
+    # defaults instead.
     updateCodeIntelligenceConfigurationPolicy(
         id: ID!
         repositoryPatterns: [String!]

--- a/cmd/frontend/graphqlbackend/codeintel.policies.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.policies.graphql
@@ -108,9 +108,9 @@ extend type Mutation {
     """
     Updates the attributes configuration policy with the given identifier.
     """
-    # 🚧 This mutation is used by Cloud automation - please do not introduce
-    # any breaking changes, and let new parameters be optional with reasonable
-    # defaults instead.
+    # 🚧 CLOUD: This mutation is used by Cloud automation - please do not
+    # introduce any breaking changes, and let new parameters be optional with
+    # reasonable defaults instead.
     updateCodeIntelligenceConfigurationPolicy(
         id: ID!
         repositoryPatterns: [String!]

--- a/cmd/frontend/graphqlbackend/codeintel.policies.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.policies.graphql
@@ -120,7 +120,11 @@ extend type Mutation {
         indexingEnabled: Boolean!
         indexCommitMaxAgeHours: Int
         indexIntermediateCommits: Boolean!
-        embeddingsEnabled: Boolean!
+
+        """
+        embeddingsEnabled, if not provided, currently defaults to false.
+        """
+        embeddingsEnabled: Boolean
     ): EmptyResponse
 
     """

--- a/enterprise/internal/codeintel/policies/transport/graphql/root_resolver_policy_mutations.go
+++ b/enterprise/internal/codeintel/policies/transport/graphql/root_resolver_policy_mutations.go
@@ -50,7 +50,7 @@ func (r *rootResolver) CreateCodeIntelligenceConfigurationPolicy(ctx context.Con
 		IndexingEnabled:           args.IndexingEnabled,
 		IndexCommitMaxAge:         toDuration(args.IndexCommitMaxAgeHours),
 		IndexIntermediateCommits:  args.IndexIntermediateCommits,
-		EmbeddingEnabled:          args.EmbeddingsEnabled,
+		EmbeddingEnabled:          args.EmbeddingsEnabled != nil && *args.EmbeddingsEnabled,
 	}
 	configurationPolicy, err := r.policySvc.CreateConfigurationPolicy(ctx, opts)
 	if err != nil {
@@ -92,7 +92,7 @@ func (r *rootResolver) UpdateCodeIntelligenceConfigurationPolicy(ctx context.Con
 		IndexingEnabled:           args.IndexingEnabled,
 		IndexCommitMaxAge:         toDuration(args.IndexCommitMaxAgeHours),
 		IndexIntermediateCommits:  args.IndexIntermediateCommits,
-		EmbeddingEnabled:          args.EmbeddingsEnabled,
+		EmbeddingEnabled:          args.EmbeddingsEnabled != nil && *args.EmbeddingsEnabled,
 	}
 	if err := r.policySvc.UpdateConfigurationPolicy(ctx, opts); err != nil {
 		return nil, err
@@ -157,7 +157,7 @@ func validateConfigurationPolicy(policy resolverstubs.CodeIntelConfigurationPoli
 		return errors.Errorf("illegal index commit max age '%d'", *policy.IndexCommitMaxAgeHours)
 	}
 
-	if policy.EmbeddingsEnabled {
+	if policy.EmbeddingsEnabled != nil && *policy.EmbeddingsEnabled {
 		if policy.RetentionEnabled || policy.IndexingEnabled {
 			return errors.Errorf("configuration policies can apply to SCIP indexes or embeddings, but not both")
 		}

--- a/internal/codeintel/resolvers/policies.go
+++ b/internal/codeintel/resolvers/policies.go
@@ -50,7 +50,8 @@ type CodeIntelConfigurationPolicy struct {
 	IndexingEnabled           bool
 	IndexCommitMaxAgeHours    *int32
 	IndexIntermediateCommits  bool
-	EmbeddingsEnabled         bool
+	// EmbeddingsEnabled, if nil, should currently default to false.
+	EmbeddingsEnabled *bool
 }
 
 type UpdateCodeIntelligenceConfigurationPolicyArgs struct {


### PR DESCRIPTION
This breaking change in `updateCodeIntelligenceConfigurationPolicy` introduced in https://github.com/sourcegraph/sourcegraph/pull/52326 affects Cloud's automated configuration of instances. This particular breaking change doesn't seem necessary, since we should have a reasonable default if `embeddingsEnabled` is not provided.

This PR makes the default `false`, but happy to change that if the intended default is `true`.

Aside: this currently doesn't affect any customer instances, but we spotted this when reconciling S2 and if this makes it into a release it could be problematic to update our tooling at the same time. I've added a comment here to note that we depend on it.

## Test plan

CI