### PR TITLE
Code monitors: use new settings code

### DIFF
--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -174,7 +175,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, triggerJob 
 	ctx = actor.WithActor(ctx, actor.FromUser(m.UserID))
 	ctx = featureflag.WithFlags(ctx, r.db.FeatureFlags())
 
-	settings, err := codemonitors.Settings(ctx)
+	settings, err := settings.CurrentUserFinal(ctx, r.db)
 	if err != nil {
 		return errors.Wrap(err, "query settings")
 	}

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -1,16 +1,10 @@
 package codemonitors
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"net/http"
 	"net/url"
 	"sort"
 
-	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/opentracing/opentracing-go"
-	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -20,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	gitprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/commit"
@@ -32,79 +25,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-const gqlSettingsQuery = `query CodeMonitorSettings{
-	viewerSettings {
-		final
-	}
-}`
-
-type gqlSettingsResponse struct {
-	Data struct {
-		ViewerSettings struct {
-			Final string `json:"final"`
-		} `json:"viewerSettings"`
-	} `json:"data"`
-	Errors []gqlerrors.FormattedError
-}
-
-// Settings queries for the computed Settings for the current actor
-func Settings(ctx context.Context) (_ *schema.Settings, err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "CodeMonitorSearch")
-	defer func() {
-		span.LogFields(otlog.Error(err))
-		span.Finish()
-	}()
-
-	reqBody, err := json.Marshal(map[string]any{"query": gqlSettingsQuery})
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal request body")
-	}
-
-	urlStr, err := gqlURL("CodeMonitorSettings")
-	if err != nil {
-		return nil, errors.Wrap(err, "construct frontend URL")
-	}
-
-	req, err := http.NewRequest("POST", urlStr, bytes.NewReader(reqBody))
-	if err != nil {
-		return nil, errors.Wrap(err, "construct request")
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if span != nil {
-		carrier := opentracing.HTTPHeadersCarrier(req.Header)
-		span.Tracer().Inject(
-			span.Context(),
-			opentracing.HTTPHeaders,
-			carrier,
-		)
-	}
-
-	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
-	if err != nil {
-		return nil, errors.Wrap(err, "do request")
-	}
-	defer resp.Body.Close()
-
-	var res gqlSettingsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return nil, errors.Wrap(err, "decode response")
-	}
-
-	if len(res.Errors) > 0 {
-		var combined error
-		for _, err := range res.Errors {
-			combined = errors.Append(combined, err)
-		}
-		return nil, combined
-	}
-
-	var unmarshaledSettings schema.Settings
-	if err := json.Unmarshal([]byte(res.Data.ViewerSettings.Final), &unmarshaledSettings); err != nil {
-		return nil, err
-	}
-	return &unmarshaledSettings, nil
-}
 
 func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
 	searchClient := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs)


### PR DESCRIPTION
Previously, to avoid importing from graphqlbackend, code monitors got settings via the GraphQL API. Now that settings just requires a db connection, no need for all that cruft.

## Test plan

Existing integration tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
