### PR TITLE
vscode: drop redundant types

### DIFF
--- a/client/vscode/BUILD.bazel
+++ b/client/vscode/BUILD.bazel
@@ -219,6 +219,7 @@ ts_project(
         "//:node_modules/@types/react-dom",
         "//:node_modules/@types/uuid",
         "//:node_modules/@types/vscode",
+        "//:node_modules/@types/vscode-webview",  #keep
         "//:node_modules/@vscode/webview-ui-toolkit",
         "//:node_modules/agent-base",  #keep
         "//:node_modules/classnames",

--- a/client/vscode/src/vsCodeApi.ts
+++ b/client/vscode/src/vsCodeApi.ts
@@ -1,10 +1,3 @@
-declare global {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // eslint-disable-next-line no-var
-    var acquireVsCodeApi: <State = any>() => VsCodeApi<State>
-}
-
 /**
  * Built-in VS Code API exposed to webviews to communicate with the "Core" extension.
  * We typically use this as a low-level building block for the APIs used in our webviews


### PR DESCRIPTION
## Context

Remove the redundant Typescript type and tell Bazel to use the npm package with type declarations instead.

## Test plan

CI
