### PR TITLE
Proper semantics for AND-ed ownerhsip filters

### DIFF
--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -440,7 +440,12 @@ func assignedOwnerSetup(path string, user *types.User) func(*edb.MockEnterpriseD
 			},
 		}
 		usersStore := database.NewMockUserStore()
-		usersStore.GetByUsernameFunc.SetDefaultReturn(user, nil)
+		usersStore.GetByUsernameFunc.SetDefaultHook(func(_ context.Context, name string) (*types.User, error) {
+			if name == user.Username {
+				return user, nil
+			}
+			return nil, database.NewUserNotFoundErr()
+		})
 		usersStore.GetByVerifiedEmailFunc.SetDefaultReturn(nil, nil)
 		db.UsersFunc.SetDefaultReturn(usersStore)
 		assignedOwnersStore := database.NewMockAssignedOwnersStore()

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -304,29 +304,65 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				// No CODEOWNERS
 				repoContent: map[string]string{},
 			},
-			setup: func(db *edb.MockEnterpriseDB) {
-				user := &types.User{
+			setup: assignedOwnerSetup(
+				"src/main",
+				&types.User{
 					ID:       42,
 					Username: "test",
-				}
-				assignedOwners := []*database.AssignedOwnerSummary{
-					{
-						OwnerUserID: user.ID,
-						FilePath:    "src/main",
-					},
-				}
-				usersStore := database.NewMockUserStore()
-				usersStore.GetByUsernameFunc.SetDefaultReturn(user, nil)
-				usersStore.GetByVerifiedEmailFunc.SetDefaultReturn(nil, nil)
-				db.UsersFunc.SetDefaultReturn(usersStore)
-				assignedOwnersStore := database.NewMockAssignedOwnersStore()
-				assignedOwnersStore.ListAssignedOwnersForRepoFunc.SetDefaultReturn(assignedOwners, nil)
-				db.AssignedOwnersFunc.SetDefaultReturn(assignedOwnersStore)
-			},
+				},
+			),
 			want: autogold.Expect([]result.Match{
 				&result.FileMatch{
 					File: result.File{
 						Path: "src/main/README.md",
+					},
+				},
+			}),
+		},
+		{
+			name: "selects results with AND-ed owners specified",
+			args: args{
+				includeOwners: []string{"assigned", "codeowner"},
+				excludeOwners: []string{},
+				matches: []result.Match{
+					&result.FileMatch{
+						File: result.File{
+							// assigned owns src/main,
+							// but @codeowner does not own the file
+							Path: "src/main/onlyAssigned.md",
+						},
+					},
+					&result.FileMatch{
+						File: result.File{
+							// @codeowner owns all go files,
+							// and assigned owns src/main
+							Path: "src/main/bothMatch.go",
+						},
+					},
+					&result.FileMatch{
+						File: result.File{
+							// @codeowner owns all go files
+							// but assigned only owns src/main
+							// and this is in src/test.
+							Path: "src/test/onlyCodeowner.go",
+						},
+					},
+				},
+				repoContent: map[string]string{
+					"CODEOWNERS": "*.go @codeowner",
+				},
+			},
+			setup: assignedOwnerSetup(
+				"src/main",
+				&types.User{
+					ID:       42,
+					Username: "assigned",
+				},
+			),
+			want: autogold.Expect([]result.Match{
+				&result.FileMatch{
+					File: result.File{
+						Path: "src/main/bothMatch.go",
 					},
 				},
 			}),
@@ -366,22 +402,49 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				tt.setup(db)
 			}
 
+			// TODO(#52450): Invoke filterHasOwnersJob.Run rather than duplicate code here.
 			rules := NewRulesCache(gitserverClient, db)
 
-			include, err := own.ByTextReference(ctx, db, tt.args.includeOwners...)
-			require.NoError(t, err)
-			exclude, err := own.ByTextReference(ctx, db, tt.args.excludeOwners...)
-			require.NoError(t, err)
+			var includeBags []own.Bag
+			for _, o := range tt.args.includeOwners {
+				b, err := own.ByTextReference(ctx, db, o)
+				require.NoError(t, err)
+				includeBags = append(includeBags, b)
+			}
+			var excludeBags []own.Bag
+			for _, o := range tt.args.excludeOwners {
+				b, err := own.ByTextReference(ctx, db, o)
+				require.NoError(t, err)
+				excludeBags = append(excludeBags, b)
+			}
 			matches, _ := applyCodeOwnershipFiltering(
 				ctx,
 				&rules,
-				include,
+				includeBags,
 				tt.args.includeOwners,
-				exclude,
+				excludeBags,
 				tt.args.excludeOwners,
 				tt.args.matches)
 			//require.NoError(t, err)
 			tt.want.Equal(t, matches)
 		})
+	}
+}
+
+func assignedOwnerSetup(path string, user *types.User) func(*edb.MockEnterpriseDB) {
+	return func(db *edb.MockEnterpriseDB) {
+		assignedOwners := []*database.AssignedOwnerSummary{
+			{
+				OwnerUserID: user.ID,
+				FilePath:    path,
+			},
+		}
+		usersStore := database.NewMockUserStore()
+		usersStore.GetByUsernameFunc.SetDefaultReturn(user, nil)
+		usersStore.GetByVerifiedEmailFunc.SetDefaultReturn(nil, nil)
+		db.UsersFunc.SetDefaultReturn(usersStore)
+		assignedOwnersStore := database.NewMockAssignedOwnersStore()
+		assignedOwnersStore.ListAssignedOwnersForRepoFunc.SetDefaultReturn(assignedOwners, nil)
+		db.AssignedOwnersFunc.SetDefaultReturn(assignedOwnersStore)
 	}
 }

--- a/enterprise/internal/own/search/rules_cache.go
+++ b/enterprise/internal/own/search/rules_cache.go
@@ -130,7 +130,7 @@ func (d fileOwnershipData) NonEmpty() bool {
 	return false
 }
 
-func (d fileOwnershipData) Contains(bag own.Bag) bool {
+func (d fileOwnershipData) IsWithin(bag own.Bag) bool {
 	for _, o := range d.rule.GetOwner() {
 		if bag.Contains(own.Reference{
 			Handle: o.Handle,

--- a/enterprise/internal/own/search/rules_cache.go
+++ b/enterprise/internal/own/search/rules_cache.go
@@ -2,6 +2,8 @@ package search
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/own"
@@ -145,4 +147,20 @@ func (d fileOwnershipData) IsWithin(bag own.Bag) bool {
 		}
 	}
 	return false
+}
+
+func (d fileOwnershipData) String() string {
+	var references []string
+	for _, o := range d.rule.GetOwner() {
+		if h := o.GetHandle(); h != "" {
+			references = append(references, h)
+		}
+		if e := o.GetEmail(); e != "" {
+			references = append(references, e)
+		}
+	}
+	for _, o := range d.assignedOwners {
+		references = append(references, fmt.Sprintf("#%d", o.OwnerUserID))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(references, ", "))
 }


### PR DESCRIPTION
Closes #52450

- Multiple values passed into `includeOwners` and `excludeOwners` should be treated as _all_ of the mentioned owners are supposed to be included or excluded (not any as before)
- Add also a small name change so that `ownership.IsWithin(bag)` rahter than `ownership.Contains(bag)`.

Loom: https://www.loom.com/share/6df6368bca3c47368666ead6c1b6a6ab

## Test plan

Unit test and manual check.
