### PR TITLE
embeddings: configurable cool down between jobs

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	sglog "github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
@@ -41,20 +39,19 @@ func (r repoEmbeddingSchedulerJob) Routines(_ context.Context, observationCtx *o
 	ctx := context.Background()
 
 	return []goroutine.BackgroundRoutine{
-		newRepoEmbeddingScheduler(ctx, observationCtx.Logger, gitserver.NewClient(), db, repo.NewRepoEmbeddingJobsStore(db)),
+		newRepoEmbeddingScheduler(ctx, gitserver.NewClient(), db, repo.NewRepoEmbeddingJobsStore(db)),
 	}, nil
 }
 
 func newRepoEmbeddingScheduler(
 	ctx context.Context,
-	logger sglog.Logger,
 	gitserverClient gitserver.Client,
 	db database.DB,
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 ) goroutine.BackgroundRoutine {
 	enqueueActive := goroutine.HandlerFunc(
 		func(ctx context.Context) error {
-			opts := repo.GetEmbeddableRepoOpts(logger)
+			opts := repo.GetEmbeddableRepoOpts()
 			embeddableRepos, err := repoEmbeddingJobsStore.GetEmbeddableRepos(ctx, opts)
 			if err != nil {
 				return err

--- a/enterprise/internal/embeddings/background/repo/BUILD.bazel
+++ b/enterprise/internal/embeddings/background/repo/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//internal/api",
         "//internal/conf",
+        "//internal/conf/conftypes",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbutil",
@@ -21,7 +22,6 @@ go_library(
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
-        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/enterprise/internal/embeddings/background/repo/BUILD.bazel
+++ b/enterprise/internal/embeddings/background/repo/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//internal/api",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbutil",
@@ -20,6 +21,7 @@ go_library(
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/enterprise/internal/embeddings/background/repo/mocks_temp.go
+++ b/enterprise/internal/embeddings/background/repo/mocks_temp.go
@@ -89,7 +89,7 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		GetEmbeddableReposFunc: &RepoEmbeddingJobsStoreGetEmbeddableReposFunc{
-			defaultHook: func(context.Context) (r0 []EmbeddableRepo, r1 error) {
+			defaultHook: func(context.Context, EmbeddableRepoOpts) (r0 []EmbeddableRepo, r1 error) {
 				return
 			},
 		},
@@ -152,7 +152,7 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		GetEmbeddableReposFunc: &RepoEmbeddingJobsStoreGetEmbeddableReposFunc{
-			defaultHook: func(context.Context) ([]EmbeddableRepo, error) {
+			defaultHook: func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.GetEmbeddableRepos")
 			},
 		},
@@ -769,24 +769,24 @@ func (c RepoEmbeddingJobsStoreExecFuncCall) Results() []interface{} {
 // the GetEmbeddableRepos method of the parent MockRepoEmbeddingJobsStore
 // instance is invoked.
 type RepoEmbeddingJobsStoreGetEmbeddableReposFunc struct {
-	defaultHook func(context.Context) ([]EmbeddableRepo, error)
-	hooks       []func(context.Context) ([]EmbeddableRepo, error)
+	defaultHook func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error)
+	hooks       []func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error)
 	history     []RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall
 	mutex       sync.Mutex
 }
 
 // GetEmbeddableRepos delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockRepoEmbeddingJobsStore) GetEmbeddableRepos(v0 context.Context) ([]EmbeddableRepo, error) {
-	r0, r1 := m.GetEmbeddableReposFunc.nextHook()(v0)
-	m.GetEmbeddableReposFunc.appendCall(RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall{v0, r0, r1})
+func (m *MockRepoEmbeddingJobsStore) GetEmbeddableRepos(v0 context.Context, v1 EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
+	r0, r1 := m.GetEmbeddableReposFunc.nextHook()(v0, v1)
+	m.GetEmbeddableReposFunc.appendCall(RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the GetEmbeddableRepos
 // method of the parent MockRepoEmbeddingJobsStore instance is invoked and
 // the hook queue is empty.
-func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) SetDefaultHook(hook func(context.Context) ([]EmbeddableRepo, error)) {
+func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) SetDefaultHook(hook func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error)) {
 	f.defaultHook = hook
 }
 
@@ -795,7 +795,7 @@ func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) PushHook(hook func(context.Context) ([]EmbeddableRepo, error)) {
+func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) PushHook(hook func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -804,19 +804,19 @@ func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) PushHook(hook func(contex
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) SetDefaultReturn(r0 []EmbeddableRepo, r1 error) {
-	f.SetDefaultHook(func(context.Context) ([]EmbeddableRepo, error) {
+	f.SetDefaultHook(func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) PushReturn(r0 []EmbeddableRepo, r1 error) {
-	f.PushHook(func(context.Context) ([]EmbeddableRepo, error) {
+	f.PushHook(func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) nextHook() func(context.Context) ([]EmbeddableRepo, error) {
+func (f *RepoEmbeddingJobsStoreGetEmbeddableReposFunc) nextHook() func(context.Context, EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -854,6 +854,9 @@ type RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 EmbeddableRepoOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []EmbeddableRepo
@@ -865,7 +868,7 @@ type RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c RepoEmbeddingJobsStoreGetEmbeddableReposFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/internal/embeddings/background/repo/store.go
+++ b/enterprise/internal/embeddings/background/repo/store.go
@@ -185,17 +185,17 @@ WHERE lsj.finished_at IS NULL OR lsj.finished_at < current_timestamp - (%s * '1 
 `
 
 type EmbeddableRepoOpts struct {
-	// CoolDown is the minimum amount of time that must have passed since the last
+	// MinimumInterval is the minimum amount of time that must have passed since the last
 	// successful embedding job.
-	CoolDown time.Duration
+	MinimumInterval time.Duration
 }
 
 func GetEmbeddableRepoOpts(logger sglog.Logger) EmbeddableRepoOpts {
-	coolDownString := conf.Get().Embeddings.CoolDown
-	d, err := time.ParseDuration(coolDownString)
+	minimumIntervalString := conf.Get().Embeddings.MinimumInterval
+	d, err := time.ParseDuration(minimumIntervalString)
 	if err != nil {
 		d = 24 * time.Hour // default
-		if coolDownString != "" {
+		if minimumIntervalString != "" {
 			logger.Warn(
 				"Could not parse site-config value for embeddings.coolDown. Using default value instead.",
 				sglog.Duration("default", d),
@@ -204,11 +204,11 @@ func GetEmbeddableRepoOpts(logger sglog.Logger) EmbeddableRepoOpts {
 		}
 	}
 
-	return EmbeddableRepoOpts{CoolDown: d}
+	return EmbeddableRepoOpts{MinimumInterval: d}
 }
 
 func (s *repoEmbeddingJobsStore) GetEmbeddableRepos(ctx context.Context, opts EmbeddableRepoOpts) ([]EmbeddableRepo, error) {
-	q := sqlf.Sprintf(getEmbeddableReposFmtStr, opts.CoolDown.Seconds())
+	q := sqlf.Sprintf(getEmbeddableReposFmtStr, opts.MinimumInterval.Seconds())
 	return scanEmbeddableRepos(s.Query(ctx, q))
 }
 

--- a/enterprise/internal/embeddings/background/repo/store.go
+++ b/enterprise/internal/embeddings/background/repo/store.go
@@ -103,7 +103,7 @@ type RepoEmbeddingJobsStore interface {
 	GetLastRepoEmbeddingJobForRevision(ctx context.Context, repoID api.RepoID, revision api.CommitID) (*RepoEmbeddingJob, error)
 	ListRepoEmbeddingJobs(ctx context.Context, args *database.PaginationArgs) ([]*RepoEmbeddingJob, error)
 	CountRepoEmbeddingJobs(ctx context.Context) (int, error)
-	GetEmbeddableRepos(ctx context.Context, opts EmbeddableRepoOpts)
+	GetEmbeddableRepos(ctx context.Context, opts EmbeddableRepoOpts) ([]EmbeddableRepo, error)
 	CancelRepoEmbeddingJob(ctx context.Context, job int) error
 }
 

--- a/enterprise/internal/embeddings/schedule.go
+++ b/enterprise/internal/embeddings/schedule.go
@@ -2,6 +2,7 @@ package embeddings
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -9,6 +10,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+type SchedulerConfig struct {
+	CoolDown time.Duration
+}
 
 func ScheduleRepositoriesForEmbedding(
 	ctx context.Context,

--- a/enterprise/internal/embeddings/schedule.go
+++ b/enterprise/internal/embeddings/schedule.go
@@ -2,7 +2,6 @@ package embeddings
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -10,10 +9,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-type SchedulerConfig struct {
-	CoolDown time.Duration
-}
 
 func ScheduleRepositoriesForEmbedding(
 	ctx context.Context,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -608,8 +608,6 @@ type EmailTemplates struct {
 type Embeddings struct {
 	// AccessToken description: The access token used to authenticate with the external embedding API service.
 	AccessToken string `json:"accessToken"`
-	// CoolDown description: The time to wait between runs. Valid time units are "s", "m", "h". Example values: "30s", "5m", "1h".
-	CoolDown string `json:"coolDown,omitempty"`
 	// Dimensions description: The dimensionality of the embedding vectors.
 	Dimensions int `json:"dimensions"`
 	// Enabled description: Toggles whether embedding service is enabled.
@@ -622,6 +620,8 @@ type Embeddings struct {
 	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`
 	// MaxTextEmbeddingsPerRepo description: The maximum number of embeddings for text files to generate per repo
 	MaxTextEmbeddingsPerRepo int `json:"maxTextEmbeddingsPerRepo,omitempty"`
+	// MinimumInterval description: The time to wait between runs. Valid time units are "s", "m", "h". Example values: "30s", "5m", "1h".
+	MinimumInterval string `json:"minimumInterval,omitempty"`
 	// Model description: The model used for embedding.
 	Model string `json:"model"`
 	// Url description: The url to the external embedding API service.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -608,6 +608,8 @@ type EmailTemplates struct {
 type Embeddings struct {
 	// AccessToken description: The access token used to authenticate with the external embedding API service.
 	AccessToken string `json:"accessToken"`
+	// CoolDown description: The time to wait between runs. Valid time units are "s", "m", "h". Example values: "30s", "5m", "1h".
+	CoolDown string `json:"coolDown,omitempty"`
 	// Dimensions description: The dimensionality of the embedding vectors.
 	Dimensions int `json:"dimensions"`
 	// Enabled description: Toggles whether embedding service is enabled.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2349,6 +2349,11 @@
           "description": "Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
           "type": "boolean",
           "default": false
+        },
+        "coolDown": {
+          "description": "The time to wait between runs. Valid time units are \"s\", \"m\", \"h\". Example values: \"30s\", \"5m\", \"1h\".",
+          "type": "string",
+          "default": "24h"
         }
       },
       "examples": [

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2350,7 +2350,7 @@
           "type": "boolean",
           "default": false
         },
-        "coolDown": {
+        "minimumInterval": {
           "description": "The time to wait between runs. Valid time units are \"s\", \"m\", \"h\". Example values: \"30s\", \"5m\", \"1h\".",
           "type": "string",
           "default": "24h"


### PR DESCRIPTION
This adds a site-config setting `embedding.minimumInterval` which specifies the minimum amount of time that must have passed since the last successful embedding.

This avoids triggering too many embedding jobs for active repos. The setting is only relevant for repos scheduled via the policy framework. Manually scheduled jobs are not affected.

## Test plan
Manual testing
- `sg start embedding`
- `src serve-git <path to your favorite repos>`
- In Sourcegraph, create an embedding policy that covers a least 1 repo
- set embeddings.coolDown: 5m in site-config. Locally I just modify site-config.json in dev-private
- commit to a repo that is covered by the policy -> embedding job is triggered
- commit to the same repo -> embedding job is only triggered after 5m

I also verified that a new repo without prior embedding jobs gets embedded right away if a policy covers it.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
