### PR TITLE
[Backport 5.0] (feat) add ability to allow anonymous usage mode based on "auth.publi…

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -99,6 +99,18 @@ func matchedRouteName(req *http.Request, router *mux.Router) string {
 	return m.Route.GetName()
 }
 
+// checks the `auth.public` site configuration
+// and `AllowAnonymousRequestContextKey` context key value
+func isAllowAnonymousUsageEnabled(req *http.Request) bool {
+	if !conf.Get().AuthPublic {
+		return false
+	}
+
+	allowAnonymousRequest, ok := req.Context().Value(AllowAnonymousRequestContextKey).(bool)
+
+	return ok && allowAnonymousRequest
+}
+
 // AllowAnonymousRequest reports whether handling of the HTTP request (which is from an anonymous
 // user) should proceed. The eventual handler for the request may still perform other authn/authz
 // checks.
@@ -107,6 +119,10 @@ func matchedRouteName(req *http.Request, router *mux.Router) string {
 // users to perform undesired actions.
 func AllowAnonymousRequest(req *http.Request) bool {
 	if conf.AuthPublic() {
+		return true
+	}
+
+	if isAllowAnonymousUsageEnabled(req) {
 		return true
 	}
 
@@ -175,3 +191,7 @@ func anonymousStatusCode(req *http.Request, defaultCode int) int {
 
 	return defaultCode
 }
+
+type key int
+
+const AllowAnonymousRequestContextKey key = iota

--- a/cmd/frontend/auth/non_public_test.go
+++ b/cmd/frontend/auth/non_public_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -50,6 +52,66 @@ func TestAllowAnonymousRequest(t *testing.T) {
 			if got != test.want {
 				t.Errorf("got %v, want %v", got, test.want)
 			}
+		})
+	}
+}
+
+func TestAllowAnonymousRequestWithAdditionalConfig(t *testing.T) {
+	ui.InitRouter(database.NewMockDB(), jobutil.NewUnimplementedEnterpriseJobs())
+	// Ensure auth.public is false (be robust against some other tests having side effects that
+	// change it, or changed defaults).
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthPublic: false, AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})
+	defer conf.Mock(nil)
+
+	req := func(method, urlStr string) *http.Request {
+		r, err := http.NewRequest(method, urlStr, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return r
+	}
+
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		req                      *http.Request
+		confAuthPublic           bool
+		allowAnonymousContextKey *bool
+		want                     bool
+	}{
+		{req: req("GET", "/"), confAuthPublic: false, allowAnonymousContextKey: nil, want: false},
+		{req: req("GET", "/"), confAuthPublic: true, allowAnonymousContextKey: nil, want: false},
+		{req: req("GET", "/"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(false), want: false},
+		{req: req("GET", "/"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(false), want: false},
+		{req: req("GET", "/"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(true), want: false},
+		{req: req("GET", "/"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(true), want: true},
+		{req: req("POST", "/"), confAuthPublic: false, allowAnonymousContextKey: nil, want: false},
+		{req: req("POST", "/"), confAuthPublic: true, allowAnonymousContextKey: nil, want: false},
+		{req: req("POST", "/"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(false), want: false},
+		{req: req("POST", "/"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(false), want: false},
+		{req: req("POST", "/"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(true), want: false},
+		{req: req("POST", "/"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(true), want: true},
+
+		{req: req("POST", "/-/sign-in"), confAuthPublic: false, allowAnonymousContextKey: nil, want: true},
+		{req: req("POST", "/-/sign-in"), confAuthPublic: true, allowAnonymousContextKey: nil, want: true},
+		{req: req("POST", "/-/sign-in"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(true), want: true},
+		{req: req("POST", "/-/sign-in"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(true), want: true},
+		{req: req("GET", "/sign-in"), confAuthPublic: false, allowAnonymousContextKey: nil, want: true},
+		{req: req("GET", "/sign-in"), confAuthPublic: true, allowAnonymousContextKey: nil, want: true},
+		{req: req("GET", "/sign-in"), confAuthPublic: false, allowAnonymousContextKey: boolPtr(true), want: true},
+		{req: req("GET", "/sign-in"), confAuthPublic: true, allowAnonymousContextKey: boolPtr(true), want: true},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s %s + auth.public=%v, allowAnonymousContext=%v", test.req.Method, test.req.URL, test.confAuthPublic, test.allowAnonymousContextKey), func(t *testing.T) {
+			r := test.req
+			if test.allowAnonymousContextKey != nil {
+				r = r.WithContext(context.WithValue(r.Context(), auth.AllowAnonymousRequestContextKey, *test.allowAnonymousContextKey))
+			}
+			conf.Get().AuthPublic = test.confAuthPublic
+			defer func() { conf.Get().AuthPublic = false }()
+
+			got := auth.AllowAnonymousRequest(r)
+			require.Equal(t, test.want, got)
 		})
 	}
 }

--- a/enterprise/cmd/frontend/internal/auth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//cmd/frontend/graphqlbackend",
         "//enterprise/cmd/frontend/internal/auth/azureoauth",
         "//enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth",
+        "//enterprise/cmd/frontend/internal/auth/confauth",
         "//enterprise/cmd/frontend/internal/auth/gerrit",
         "//enterprise/cmd/frontend/internal/auth/githuboauth",
         "//enterprise/cmd/frontend/internal/auth/gitlaboauth",

--- a/enterprise/cmd/frontend/internal/auth/confauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/confauth/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "confauth",
+    srcs = ["middleware.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/confauth",
+    visibility = ["//enterprise/cmd/frontend:__subpackages__"],
+    deps = [
+        "//cmd/frontend/auth",
+        "//enterprise/internal/licensing",
+    ],
+)
+
+go_test(
+    name = "confauth_test",
+    srcs = ["middleware_test.go"],
+    embed = [":confauth"],
+    deps = [
+        "//cmd/frontend/auth",
+        "//cmd/frontend/external/session",
+        "//enterprise/internal/license",
+        "//enterprise/internal/licensing",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/enterprise/cmd/frontend/internal/auth/confauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/confauth/middleware.go
@@ -1,0 +1,26 @@
+package confauth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+)
+
+func setAllowAnonymousUsageContextKey(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		if info, err := licensing.GetConfiguredProductLicenseInfo(); err == nil && info != nil {
+			ctx = context.WithValue(r.Context(), auth.AllowAnonymousRequestContextKey, info.HasTag(licensing.AllowAnonymousUsageTag))
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func Middleware() *auth.Middleware {
+	return &auth.Middleware{
+		API: setAllowAnonymousUsageContextKey,
+		App: setAllowAnonymousUsageContextKey,
+	}
+}

--- a/enterprise/cmd/frontend/internal/auth/confauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/confauth/middleware_test.go
@@ -1,0 +1,80 @@
+package confauth
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+)
+
+func TestMiddleware(t *testing.T) {
+	cleanup := session.ResetMockSessionStore(t)
+	defer cleanup()
+
+	value := false
+	ok := false
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		value, ok = r.Context().Value(auth.AllowAnonymousRequestContextKey).(bool)
+	})
+	handler := http.NewServeMux()
+	handler.Handle("/.api/", Middleware().API(h))
+	handler.Handle("/", Middleware().API(h))
+
+	doRequest := func(method, urlStr, body string) *http.Response {
+		req := httptest.NewRequest(method, urlStr, bytes.NewBufferString(body))
+		respRecorder := httptest.NewRecorder()
+		handler.ServeHTTP(respRecorder, req)
+		return respRecorder.Result()
+	}
+
+	expiresAt := time.Now().Add(time.Hour)
+
+	tests := []struct {
+		name      string
+		license   *license.Info
+		wantOk    bool
+		wantValue bool
+	}{
+		{
+			name:      "no license",
+			license:   nil,
+			wantOk:    false,
+			wantValue: false,
+		},
+		{
+			name:      "with license, no special tag",
+			license:   &license.Info{UserCount: 10, ExpiresAt: expiresAt},
+			wantOk:    true,
+			wantValue: false,
+		},
+		{
+			name:      "with license, with special tag",
+			license:   &license.Info{Tags: []string{licensing.AllowAnonymousUsageTag}, UserCount: 10, ExpiresAt: expiresAt},
+			wantOk:    true,
+			wantValue: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			licensing.MockGetConfiguredProductLicenseInfo = func() (*license.Info, string, error) {
+				return test.license, "test-signature", nil
+			}
+			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
+
+			resp := doRequest("GET", "/", "")
+			if want := http.StatusOK; resp.StatusCode != want {
+				t.Errorf("got response code %v, want %v", resp.StatusCode, want)
+			}
+			require.Equal(t, test.wantOk, ok)
+			require.Equal(t, test.wantValue, value)
+		})
+	}
+}

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/azureoauth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/confauth"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/gerrit"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/githuboauth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/gitlaboauth"
@@ -50,6 +52,7 @@ func Init(logger log.Logger, db database.DB) {
 		gitlaboauth.Middleware(db),
 		bitbucketcloudoauth.Middleware(db),
 		azureoauth.Middleware(db),
+		confauth.Middleware(),
 	)
 	// Register app-level sign-out handler
 	app.RegisterSSOSignOutHandler(ssoSignOutHandler)

--- a/enterprise/internal/licensing/tags.go
+++ b/enterprise/internal/licensing/tags.go
@@ -10,6 +10,9 @@ const (
 	// TrueUpUserCountTag is the license tag that indicates that the licensed user count can be
 	// exceeded and will be charged later.
 	TrueUpUserCountTag = "true-up"
+	// AllowAnonymousUsageTag denotes licenses that allow anonymous usage, a.k.a public access to the instance
+	// Warning: This should be used with care and only at special, probably trial/poc stages with customers
+	AllowAnonymousUsageTag = "allow-anonymous-usage"
 )
 
 // ProductNameWithBrand returns the product name with brand (e.g., "Sourcegraph Enterprise") based
@@ -72,5 +75,6 @@ var MiscTags = []string{
 	"trial",
 	"dev",
 	TrueUpUserCountTag,
+	AllowAnonymousUsageTag,
 	"starter",
 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52439. Original PR https://github.com/sourcegraph/sourcegraph/pull/52440.

## Test plan
- `sg start dotcom` and generate license with `allow-anonymous-usage` tag
- Restart in enterprise mode `sg start enterprise` and set newly created license
- Set `auth.public=true` in site config
- Check that instance allows searching and browsing public repositories

## Demo

https://github.com/sourcegraph/sourcegraph/assets/6717049/344f9b1e-f54a-4148-9bc8-f0f3d3bb4cd7



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
