### PR TITLE
mvu: fix handle missing 'auto_upgrade' column in versions table

### DIFF
--- a/internal/version/upgradestore/store.go
+++ b/internal/version/upgradestore/store.go
@@ -147,12 +147,11 @@ func isMissingRelation(err error) bool {
 func (s *store) GetAutoUpgrade(ctx context.Context) (version string, enabled bool, err error) {
 	if err = s.db.QueryRow(ctx, sqlf.Sprintf(getAutoUpgradeQuery)).Scan(&version, &enabled); err != nil {
 		var pgerr *pgconn.PgError
-		if errors.As(err, &pgerr) {
-			if pgerr.Code == pgerrcode.UndefinedColumn {
-				if err = s.db.QueryRow(ctx, sqlf.Sprintf(getAutoUpgradeFallbackQuery)).Scan(&version); err != nil {
-					return "", false, errors.Wrap(err, "failed to get frontend version from fallback")
-				}
+		if errors.As(err, &pgerr) && pgerr.Code == pgerrcode.UndefinedColumn {
+			if err = s.db.QueryRow(ctx, sqlf.Sprintf(getAutoUpgradeFallbackQuery)).Scan(&version); err != nil {
+				return "", false, errors.Wrap(err, "failed to get frontend version from fallback")
 			}
+			return version, enabled, nil
 		}
 		return "", false, errors.Wrap(err, "failed to get frontend version and auto_upgrade state")
 	}


### PR DESCRIPTION
We weren't returning the values when performing the fallback query, instead returning an error regardless

## Test plan

Tested in a full run of migrator
