### PR TITLE
wolfi: add missing packages to server base image

### DIFF
--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -15,11 +15,14 @@ contents:
     - libstdc++ # TODO: Is this still required?
     - nginx
     - openjdk-11
+    - openjdk-11-default-jvm
     - openssh-client
     - pcre
     - postgresql-12
     - postgresql-12-contrib
     - prometheus-postgres-exporter=0.12.0-r1 # IMPORTANT: Pinned version for managed updates
+    - prometheus
+    - prometheus-alertmanager
     - python3 # TODO: Missing python2; required?
     - redis-6.2
     - sqlite-libs
@@ -35,6 +38,7 @@ contents:
     - p4cli@sourcegraph
     - p4-fusion@sourcegraph
     - s3proxy@sourcegraph
+    - grafana@chainguard
 
 accounts:
   groups:

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -34,6 +34,7 @@ contents:
     - coursier@sourcegraph
     - p4cli@sourcegraph
     - p4-fusion@sourcegraph
+    - s3proxy@sourcegraph
 
 accounts:
   groups:

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -3,9 +3,11 @@ contents:
   keyring:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     - https://storage.googleapis.com/package-repository/packages/melange.rsa.pub
+    - https://storage.googleapis.com/package-repository/chainguard/chainguard-enterprise.rsa.pub
   repositories:
     - https://packages.wolfi.dev/os
     - '@sourcegraph https://storage.googleapis.com/package-repository/packages/main'
+    - '@chainguard https://storage.googleapis.com/package-repository/chainguard'
   packages:
     ## Base set of packages
     - wolfi-baselayout


### PR DESCRIPTION
As long as we're using s3proxy instead of the new experimental blobstore implementation, we need to have it in our base images. Also ported a few other changes from https://github.com/sourcegraph/sourcegraph/pull/52074/files

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 