### PR TITLE
Cody completions: Add unit tests

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -116,6 +116,7 @@ ts_project(
     srcs = [
         "src/chat/utils.test.ts",
         "src/completions/cache.test.ts",
+        "src/completions/completion.test.ts",
         "src/completions/context.test.ts",
         "src/completions/provider.test.ts",
         "src/configuration.test.ts",

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -1,0 +1,548 @@
+import type * as vscode from 'vscode'
+
+import {
+    CompletionParameters,
+    CompletionResponse,
+} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+
+import { CodyCompletionItemProvider, __test_only_resetCache } from '.'
+
+jest.mock('vscode', () => {
+    class Position {
+        public line: number
+        public character: number
+
+        constructor(line: number, character: number) {
+            this.line = line
+            this.character = character
+        }
+    }
+    class Range {
+        public start: Position
+        public end: Position
+
+        constructor(start: Position, end: Position) {
+            if (typeof start === 'number') {
+                throw new TypeError('this version of the constructor is not implemented')
+            }
+            this.start = start
+            this.end = end
+        }
+    }
+    class InlineCompletionItem {
+        public content: string
+        constructor(content: string) {
+            this.content = content
+        }
+    }
+    return {
+        Position,
+        Range,
+        InlineCompletionItem,
+        InlineCompletionTriggerKind: {
+            Invoke: 0,
+            Automatic: 1,
+        },
+        workspace: {
+            getConfiguration() {
+                return {
+                    get(key: string) {
+                        switch (key) {
+                            case 'cody.debug.filter':
+                                return '.*'
+                            default:
+                                return ''
+                        }
+                    },
+                }
+            },
+            onDidChangeTextDocument() {
+                return null
+            },
+        },
+        window: {
+            createOutputChannel() {
+                return null
+            },
+            showErrorMessage(message: string) {
+                throw new Error(message)
+            },
+            activeTextEditor: { document: { uri: { scheme: 'not-cody' } } },
+        },
+    }
+})
+
+function createCompletionResponse(completion: string): CompletionResponse {
+    return {
+        completion: truncateMultilineString(completion),
+        stopReason: 'unknown',
+    }
+}
+
+/**
+ * A test helper to trigger a completion request. The code example must include
+ * a pipe character to denote the current cursor position.
+ *
+ * @example
+ *   complete(`
+ * async function foo() {
+ *   |
+ * }`)
+ */
+async function complete(
+    code: string,
+    responses?: CompletionResponse[],
+    languageId: string = 'typescript',
+    context: vscode.InlineCompletionContext = { triggerKind: 1, selectedCompletionInfo: undefined }
+): Promise<{
+    requests: CompletionParameters[]
+    completions: vscode.InlineCompletionItem[]
+}> {
+    code = truncateMultilineString(code)
+
+    const requests: CompletionParameters[] = []
+    let requestCounter = 0
+    const completionsClient = {
+        complete(params: CompletionParameters): Promise<CompletionResponse> {
+            requests.push(params)
+            const response = responses ? responses[requestCounter++] : undefined
+            return Promise.resolve(
+                response || {
+                    completion: '',
+                    stopReason: 'unknown',
+                }
+            )
+        },
+    }
+    const completionProvider = new CodyCompletionItemProvider(
+        error => {
+            throw new Error(error)
+        },
+        completionsClient as any,
+        null as any,
+        null as any,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true // disable timeouts
+    )
+
+    if (!code.includes('|')) {
+        throw new Error('The test code must include a | to denote the cursor position')
+    }
+
+    const prefix = code.slice(0, code.indexOf('|'))
+    const suffix = code.slice(code.indexOf('|') + 1)
+
+    const codeWithoutCursor = prefix + suffix
+
+    const token: any = {
+        onCancellationRequested() {
+            return null
+        },
+    }
+    const document: any = {
+        languageId,
+        offsetAt(): number {
+            return 0
+        },
+        positionAt(): any {
+            const split = codeWithoutCursor.split('\n')
+            return { line: split.length, character: split[split.length - 1].length }
+        },
+        getText(range?: vscode.Range): string {
+            if (!range) {
+                return codeWithoutCursor
+            }
+            if (range.start.line === 0 && range.start.character === 0) {
+                return prefix
+            }
+            return suffix
+        },
+    }
+
+    const splitPrefix = prefix.split('\n')
+    const position: any = { line: splitPrefix.length, character: splitPrefix[splitPrefix.length - 1].length }
+
+    const completions = await completionProvider.provideInlineCompletionItems(document, position, context, token)
+
+    return {
+        requests,
+        completions,
+    }
+}
+
+/**
+ * A helper function used so that the below code example can be intended in code but will have their
+ * prefix stripped. This is similar to what Jest snapshots use but without the prettier hack so that
+ * the starting ` is always in the same line as the function name :shrug:
+ */
+function truncateMultilineString(string: string): string {
+    const lines = string.split('\n')
+
+    if (lines.length <= 1) {
+        return string
+    }
+
+    if (lines[0] !== '') {
+        return string
+    }
+
+    const regex = lines[1].match(/^ */)
+
+    const indentation = regex ? regex[0] : ''
+    return lines
+        .map(line => (line.startsWith(indentation) ? line.replace(indentation, '') : line))
+        .slice(1)
+        .join('\n')
+}
+
+describe('Cody completions', () => {
+    beforeEach(() => __test_only_resetCache())
+
+    it('uses a simple prompt for small files', async () => {
+        const { requests } = await complete('foo |')
+
+        expect(requests).toHaveLength(3)
+        expect(requests[0]!.messages).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "speaker": "human",
+                "text": "Write some code",
+              },
+              Object {
+                "speaker": "assistant",
+                "text": "Here is some code:
+            \`\`\`
+            foo ",
+              },
+            ]
+        `)
+        expect(requests[0]!.stopSequences).toContain('\n')
+    })
+
+    it('uses a more complex prompt for larger files', async () => {
+        const { requests } = await complete(`
+            class Range {
+                public startLine: number
+                public startCharacter: number
+                public endLine: number
+                public endCharacter: number
+                public start: Position
+                public end: Position
+
+                constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+                    this.startLine = |
+                    this.startCharacter = startCharacter
+                    this.endLine = endLine
+                    this.endCharacter = endCharacter
+                    this.start = new Position(startLine, startCharacter)
+                    this.end = new Position(endLine, endCharacter)
+                }
+            }
+        `)
+
+        expect(requests).toHaveLength(3)
+        const messages = requests[0]!.messages
+        expect(messages[messages.length - 1]).toMatchInlineSnapshot(`
+            Object {
+              "speaker": "assistant",
+              "text": "Here is the completion of the file:
+            \`\`\`
+                public start: Position
+                public end: Position
+
+                constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
+                    this.startLine = ",
+            }
+        `)
+        expect(requests[0]!.stopSequences).toContain('\n')
+    })
+
+    it('does not make a request when in the middle of a word', async () => {
+        const { requests } = await complete('foo|')
+        expect(requests).toHaveLength(0)
+    })
+
+    it('completes a single-line at the end of a sentence', async () => {
+        const { completions } = await complete('foo = |', [
+            createCompletionResponse('"bar"'),
+            createCompletionResponse('"baz"'),
+        ])
+
+        expect(completions).toMatchInlineSnapshot(`
+            Array [
+              InlineCompletionItem {
+                "content": "\\"bar\\"",
+              },
+              InlineCompletionItem {
+                "content": "\\"baz\\"",
+              },
+            ]
+        `)
+    })
+
+    it('completes a single-line at the middle of a sentence', async () => {
+        const { completions } = await complete('function bubbleSort(|)', [
+            createCompletionResponse('array) {'),
+            createCompletionResponse('items) {'),
+        ])
+
+        expect(completions).toMatchInlineSnapshot(`
+            Array [
+              InlineCompletionItem {
+                "content": "array) {",
+              },
+              InlineCompletionItem {
+                "content": "items) {",
+              },
+            ]
+        `)
+    })
+
+    it('does not make a request when context has a selectedCompletionInfo', async () => {
+        const { requests } = await complete('foo = |', undefined, undefined, {
+            selectedCompletionInfo: {
+                range: {} as any,
+                text: 'something',
+            },
+            triggerKind: 0,
+        })
+
+        expect(requests).toHaveLength(0)
+    })
+
+    it('filters out completions that start with whitespace', async () => {
+        const { completions } = await complete('function bubbleSort(|)', [
+            createCompletionResponse('\t\t\tarray) {'),
+            createCompletionResponse('items) {'),
+        ])
+
+        expect(completions).toMatchInlineSnapshot(`
+            Array [
+              InlineCompletionItem {
+                "content": "items) {",
+              },
+            ]
+        `)
+    })
+
+    describe('odd indentation', () => {
+        it('filters our odd indentation in single-line completions', async () => {
+            const { completions } = await complete('const foo = |', [createCompletionResponse(' 1')])
+
+            expect(completions).toMatchInlineSnapshot(`
+                Array [
+                  InlineCompletionItem {
+                    "content": "1",
+                  },
+                  InlineCompletionItem {
+                    "content": "",
+                  },
+                ]
+            `)
+        })
+
+        it.todo('removes odd indentation in multi-line completions')
+        it.todo('handles \t in multi-line completions')
+    })
+
+    describe('multi-line completions', () => {
+        it('triggers a multi-line completion at the start of a block', async () => {
+            const { requests } = await complete('function bubbleSort() {\n  |')
+
+            expect(requests).toHaveLength(3)
+            expect(requests[0]!.stopSequences).not.toContain('\n')
+        })
+
+        it('uses an indentation based approach to cut-off completions', async () => {
+            const { completions } = await complete(
+                `
+                class Foo {
+                    constructor() {
+                        |
+                    }
+                }`,
+                [
+                    createCompletionResponse(`
+                    console.log('foo')
+                        }
+
+                        add() {
+                            console.log('bar')
+                        }`),
+                    createCompletionResponse(`
+                    if (foo) {
+                                console.log('foo1');
+                            }
+                        }
+
+                        add() {
+                            console.log('bar')
+                        }`),
+                ]
+            )
+
+            expect(completions).toMatchInlineSnapshot(`
+                Array [
+                  InlineCompletionItem {
+                    "content": "if (foo) {
+                            console.log('foo1');
+                        }",
+                  },
+                  InlineCompletionItem {
+                    "content": "console.log('foo')",
+                  },
+                  InlineCompletionItem {
+                    "content": "",
+                  },
+                ]
+            `)
+        })
+
+        it('skips over empty lines', async () => {
+            const { completions } = await complete(
+                `
+                class Foo {
+                    constructor() {
+                        |
+                    }
+                }`,
+                [
+                    createCompletionResponse(`
+                    console.log('foo')
+
+                            console.log('bar')
+
+                            console.log('baz')`),
+                ]
+            )
+
+            expect(completions[0]).toMatchInlineSnapshot(`
+                InlineCompletionItem {
+                  "content": "console.log('foo')
+
+                        console.log('bar')
+
+                        console.log('baz')",
+                }
+            `)
+        })
+
+        it('skips over else blocks', async () => {
+            const { completions } = await complete(
+                `
+                if (check) {
+                    |
+                }`,
+                [
+                    createCompletionResponse(`
+                    console.log('one')
+                    } else {
+                        console.log('two')
+                    }`),
+                ]
+            )
+
+            expect(completions[0]).toMatchInlineSnapshot(`
+                InlineCompletionItem {
+                  "content": "console.log('one')
+                } else {
+                    console.log('two')",
+                }
+            `)
+        })
+
+        it('includes closing parentheses in the completion', async () => {
+            const { completions } = await complete(
+                `
+                if (check) {
+                    |
+                `,
+                [
+                    createCompletionResponse(`
+                    console.log('one')
+                    }`),
+                ]
+            )
+
+            expect(completions[0]).toMatchInlineSnapshot(`
+                InlineCompletionItem {
+                  "content": "console.log('one')
+                }",
+                }
+            `)
+        })
+
+        it('stops when the next non-empty line of the suffix matches', async () => {
+            const { completions } = await complete(
+                `
+                function myFunction() {
+                    |
+                    console.log('three')
+                }
+                `,
+                [
+                    createCompletionResponse(`
+                    console.log('one')
+                        console.log('two')
+                        console.log('three')
+                        console.log('four')
+                    }`),
+                ]
+            )
+
+            expect(completions[0]).toMatchInlineSnapshot(`
+                InlineCompletionItem {
+                  "content": "console.log('one')
+                    console.log('two')",
+                }
+            `)
+        })
+
+        it('ranks results by number of lines', async () => {
+            const { completions } = await complete(
+                `
+                function test() {
+                    |`,
+                [
+                    createCompletionResponse(`
+                    console.log('foo')
+                    console.log('foo')
+                    `),
+                    createCompletionResponse(`
+                    console.log('foo')
+                        console.log('foo')
+                        console.log('foo')
+                        console.log('foo')
+                        console.log('foo')`),
+                    createCompletionResponse(`
+                    console.log('foo')
+                    `),
+                ]
+            )
+
+            expect(completions).toMatchInlineSnapshot(`
+                Array [
+                  InlineCompletionItem {
+                    "content": "console.log('foo')
+                    console.log('foo')
+                    console.log('foo')
+                    console.log('foo')
+                    console.log('foo')",
+                  },
+                  InlineCompletionItem {
+                    "content": "console.log('foo')",
+                  },
+                  InlineCompletionItem {
+                    "content": "console.log('foo')",
+                  },
+                ]
+            `)
+        })
+
+        it.todo('handles tab/newline interop in completion truncation')
+    })
+})

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -268,17 +268,17 @@ describe('Cody completions', () => {
 
     it('completes a single-line at the end of a sentence', async () => {
         const { completions } = await complete('foo = |', [
-            createCompletionResponse('"bar"'),
-            createCompletionResponse('"baz"'),
+            createCompletionResponse("'bar'"),
+            createCompletionResponse("'baz'"),
         ])
 
         expect(completions).toMatchInlineSnapshot(`
             Array [
               InlineCompletionItem {
-                "content": "\\"bar\\"",
+                "content": "'bar'",
               },
               InlineCompletionItem {
-                "content": "\\"baz\\"",
+                "content": "'baz'",
               },
             ]
         `)


### PR DESCRIPTION
This was deadly necessary: An easy way for us to write tests for the different heuristics we're playing around with.

There's quite a bit of initial mocking involved I’m afraid but the individual test cases are kept very clean. 

My idea here is that the mocks might need to evolve but the number of abstraction should not. It's always the same pattern:

- We have some code as an input. We use `|` to denote the current position. (we later might have different languages as well when we start to extend multi-line completion support or use treesitter)
- We _can_ provide a list of mocked backend responses. These can be used to capture all the oddities we face, e.g. the "odd indentation" bug. They are optional because for some tests we do not care about the result (in which case we return an empty backend response
- We can then assert on the VS Code inline suggestion returned or the requests being bade. The requests are important to have full control over the tests (e.g. do we request a single-line or a multi-line completion?)
- For now, this does not include any context yet but this might be added with mocks.

Some tests are skipped right now because the fix for that is in #52497 and not merged yet. 

## Test plan

tests green 🚤 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
