### PR TITLE
App: Make Settings menu item go to App Settings

### DIFF
--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -205,6 +205,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     </div>
                                 </div>
                             )}
+
                             {organizations.length > 0 && (
                                 <>
                                     <MenuDivider className={styles.dropdownDivider} />
@@ -231,6 +232,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 {isSourcegraphApp ? 'Documentation' : 'Help'}{' '}
                                 <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                             </MenuLink>
+
                             {isSourcegraphApp ? (
                                 <MenuLink as={AnchorLink} to="/user/settings/product-research">
                                     Feedback
@@ -238,7 +240,9 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             ) : (
                                 <MenuItem onSelect={showFeedbackModal}>Feedback</MenuItem>
                             )}
+
                             <MenuItem onSelect={showKeyboardShortcutsHelp}>Keyboard shortcuts</MenuItem>
+
                             {authenticatedUser.session?.canSignOut && !isSourcegraphApp && (
                                 <MenuLink as={AnchorLink} to="/-/sign-out">
                                     Sign out

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -139,7 +139,10 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     <MenuDivider className={styles.dropdownDivider} />
                                 </>
                             ) : null}
-                            <MenuLink as={Link} to={authenticatedUser.settingsURL!}>
+                            <MenuLink
+                                as={Link}
+                                to={isSourcegraphApp ? '/user/app-settings' : authenticatedUser.settingsURL!}
+                            >
                                 Settings
                             </MenuLink>
                             <MenuLink as={Link} to={`/users/${props.authenticatedUser.username}/searches`}>
@@ -202,7 +205,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                     </div>
                                 </div>
                             )}
-
                             {organizations.length > 0 && (
                                 <>
                                     <MenuDivider className={styles.dropdownDivider} />
@@ -229,7 +231,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 {isSourcegraphApp ? 'Documentation' : 'Help'}{' '}
                                 <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                             </MenuLink>
-
                             {isSourcegraphApp ? (
                                 <MenuLink as={AnchorLink} to="/user/settings/product-research">
                                     Feedback
@@ -237,9 +238,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             ) : (
                                 <MenuItem onSelect={showFeedbackModal}>Feedback</MenuItem>
                             )}
-
                             <MenuItem onSelect={showKeyboardShortcutsHelp}>Keyboard shortcuts</MenuItem>
-
                             {authenticatedUser.session?.canSignOut && !isSourcegraphApp && (
                                 <MenuLink as={AnchorLink} to="/-/sign-out">
                                     Sign out


### PR DESCRIPTION
In App, make the Settings menu item go to "Local repositories" (the view internally called App Settings) instead of "Settings"

Close #52512

## Test plan

- run App
- Settings link goes to "Local repositories"
