### PR TITLE
Move Gitlab API debug logging to the logger

### DIFF
--- a/internal/extsvc/gitlab/BUILD.bazel
+++ b/internal/extsvc/gitlab/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//internal/rcache",
         "//internal/trace/ot",
         "//lib/errors",
-        "@com_github_inconshreveable_log15//:log15",
         "@com_github_masterminds_semver//:semver",
         "@com_github_peterhellberg_link//:link",
         "@com_github_prometheus_client_golang//prometheus",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -183,7 +183,8 @@
               "type": "boolean",
               "default": false
             }
-          }
+          },
+          "deprecationMessage": "Deprecated in favor of internal debug logging."
         },
         "structuralSearch": {
           "description": "Enables structural search.",


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C07KZF47K/p1685114844073579)
Moving it to just be a regular debug log so that we don't need to us an init function.


## Test plan
manual.