### PR TITLE
move some `init`s calling `conf.Watch` to explicit `Init`s

### DIFF
--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//internal/adminanalytics",
         "//internal/api",
         "//internal/auth",
+        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/conf/deploy",

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -22,7 +22,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
@@ -139,6 +141,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// Run enterprise setup hook
 	enterpriseServices := enterpriseSetupHook(db, conf.DefaultClient())
+
+	highlight.Init()
+	userpasswd.Init()
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to create sub-repo client")

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -22,13 +22,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	oce "github.com/sourcegraph/sourcegraph/cmd/frontend/oneclickexport"
 	"github.com/sourcegraph/sourcegraph/internal/adminanalytics"
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
@@ -112,6 +112,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		}
 	}
 
+	userpasswd.Init()
+	highlight.Init()
+
 	// After our DB, redis is our next most important datastore
 	if err := redispoolRegisterDB(db); err != nil {
 		return errors.Wrap(err, "failed to register postgres backed redis")
@@ -141,9 +144,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	// Run enterprise setup hook
 	enterpriseServices := enterpriseSetupHook(db, conf.DefaultClient())
-
-	highlight.Init()
-	userpasswd.Init()
 
 	if err != nil {
 		return errors.Wrap(err, "Failed to create sub-repo client")

--- a/cmd/frontend/internal/highlight/language.go
+++ b/cmd/frontend/internal/highlight/language.go
@@ -94,6 +94,7 @@ var highlightConfig = syntaxHighlightConfig{
 	Extensions: map[string]string{},
 	Patterns:   []languagePattern{},
 }
+
 var baseHighlightConfig = syntaxHighlightConfig{
 	Extensions: map[string]string{
 		"jsx":  "jsx", // default `getLanguage()` helper doesn't handle JSX
@@ -136,7 +137,7 @@ var baseEngineConfig = syntaxEngineConfig{
 	},
 }
 
-func init() {
+func Init() {
 	// Validation only: Do NOT set any values in the configuration in this function.
 	conf.ContributeValidator(func(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 		highlights := c.SiteConfig().SyntaxHighlighting

--- a/enterprise/cmd/worker/shared/BUILD.bazel
+++ b/enterprise/cmd/worker/shared/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//enterprise/internal/authz/subrepoperms",
         "//enterprise/internal/database",
         "//enterprise/internal/oobmigration/migrations",
+        "//internal/auth/userpasswd",
         "//internal/authz",
         "//internal/conf",
         "//internal/database",

--- a/internal/auth/userpasswd/config_watch.go
+++ b/internal/auth/userpasswd/config_watch.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Watch for configuration changes related to the builtin auth provider.
-func init() {
+func Init() {
 	go func() {
 		conf.Watch(func() {
 			newPC, _ := GetProviderConfig()


### PR DESCRIPTION
As part of my work, I need to be able to do some longer-running processing before the config server etc can be initialized. This gets interrupted by conf deadlock detection caused by `conf.Watch` being started in `init` functions.
By moving them to explicitly called `Init` functions, we can control when this begins, so that it can happen _after_ the longer-running processing has completed and before it is needed.

## Test plan

This is where I need _your_ help. What way can this be tested, besides "startup and assuming it looks right?"
