### PR TITLE
ranking: Do not prematurely vacuum exports

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/uploads.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/uploads.go
@@ -206,7 +206,7 @@ locked_exported_uploads AS (
 			FROM codeintel_ranking_progress crp
 			WHERE
 				crp.graph_key = %s AND
-				crp.mapper_completed_at IS NULL
+				crp.reducer_completed_at IS NULL
 		)
 	ORDER BY cre.id
 	FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
#52502 added the necessity that definition records stay around until after the reducer phase (not just the mappers). This PR ensures that we don't start removing records until after the reducer has completed.

## Test plan

CI.