### PR TITLE
App: Manually kill the sourcegraph process before exit

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,9 +13,9 @@ rust-version = "1.59"
 
 [profile.release]
 panic = "abort" # Strip expensive panic clean-up logic
-codegen-units = 1 # Compile crates one after another so the compiler can optimize better
+#codegen-units = 1 # Compile crates one after another so the compiler can optimize better
 lto = true # Enables link to optimizations
-opt-level = "s" # Optimize for binary size
+#opt-level = "s" # Optimize for binary size
 strip = true # Remove debug symbols
 
 [build-dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,9 +13,9 @@ rust-version = "1.59"
 
 [profile.release]
 panic = "abort" # Strip expensive panic clean-up logic
-#codegen-units = 1 # Compile crates one after another so the compiler can optimize better
+codegen-units = 1 # Compile crates one after another so the compiler can optimize better
 lto = true # Enables link to optimizations
-#opt-level = "s" # Optimize for binary size
+opt-level = "s" # Optimize for binary size
 strip = true # Remove debug symbols
 
 [build-dependencies]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,5 +1,8 @@
 use crate::cody::init_cody_window;
 use crate::common::show_window;
+use crate::BackendProcessId;
+
+use std::process::Command as StdCommand;
 use tauri::api::shell;
 use tauri::{
     AppHandle, CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu,
@@ -12,10 +15,7 @@ pub fn create_system_tray() -> SystemTray {
 
 fn create_system_tray_menu() -> SystemTrayMenu {
     SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new(
-            "open".to_string(),
-            "Open Sourcegraph",
-        ))
+        .add_item(CustomMenuItem::new("open".to_string(), "Open Sourcegraph"))
         .add_item(CustomMenuItem::new("cody".to_string(), "Show Cody"))
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(
@@ -63,9 +63,39 @@ pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
             "about" => {
                 shell::open(&app.shell_scope(), "https://about.sourcegraph.com", None).unwrap()
             }
-            "restart" => app.restart(),
-            "quit" => app.exit(0),
+            "restart" => {
+                let backend_pid = &app.state::<BackendProcessId>().0;
+                stop_process(app.clone(), *backend_pid);
+                app.restart()
+            }
+            "quit" => {
+                let backend_pid = &app.state::<BackendProcessId>().0;
+                stop_process(app.clone(), *backend_pid);
+                app.exit(0)
+            }
             _ => {}
         }
     }
+}
+
+fn stop_process(app: AppHandle, process_id: u32) {
+    // hide the windows to make it look like it's closing faster
+    for (_name, window) in app.windows() {
+        let _r = window.hide();
+    }
+    log::info!("stopping process pid: {}", process_id);
+    StdCommand::new("kill")
+        .args(["-s", "TERM", &process_id.to_string()])
+        .spawn()
+        .expect("failed to shutdown process")
+        .wait()
+        .expect("failed to wait for shutdown");
+
+    // Sleep some to let the background process close properly before it gets killed by app closing
+    // The above wait only waits for the kill command to finish, not the process itself
+    // The alternative to sleeping is to continuously check if the process is still running
+    // this requires a crate that makes the apple not accept the app to the app store
+    // my testing showed the backend process was always closed in under 200 ms
+    let half_second = std::time::Duration::from_millis(500);
+    std::thread::sleep(half_second);
 }


### PR DESCRIPTION
Tauri is supposed to kill all sidecars before exiting and it does however when it does so it leaves behind a number of postgres processes.  I believe this is because the sourcegraph backend services os.Exit on the 2nd signal.

This sends SIGTERM to sourcegraph backend and then sleeps for a half a second to give the processes change to close.  While this still isn't ideal I think it's an improvement because it closes cleanly far more often.

There is an alternative solution where we can use the [sysinfo](https://crates.io/crates/sysinfo) crate to loop and check to see if the process is still running.  

Additional case that isn't covered is when the app (on mac) is right click quitted.  This bypasses all events that documentation says will be called. 

## Test plan
build a release version
Start app - Quit - check for postgres process from app.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
