### PR TITLE
Make endpoint configurable for OpenAI completions client

### DIFF
--- a/enterprise/internal/completions/client/anthropic/anthropic.go
+++ b/enterprise/internal/completions/client/anthropic/anthropic.go
@@ -14,7 +14,7 @@ import (
 
 const ProviderName = "anthropic"
 
-func NewClient(cli httpcli.Doer, accessToken, apiURL string) types.CompletionsClient {
+func NewClient(cli httpcli.Doer, apiURL, accessToken string) types.CompletionsClient {
 	if apiURL == "" {
 		apiURL = defaultAPIURL
 	}

--- a/enterprise/internal/completions/client/client.go
+++ b/enterprise/internal/completions/client/client.go
@@ -16,9 +16,9 @@ import (
 func Get(endpoint, provider, accessToken string) (types.CompletionsClient, error) {
 	switch provider {
 	case anthropic.ProviderName:
-		return anthropic.NewClient(httpcli.ExternalDoer, accessToken, endpoint), nil
+		return anthropic.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
 	case openai.ProviderName:
-		return openai.NewClient(httpcli.ExternalDoer, accessToken), nil
+		return openai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
 	case dotcom.ProviderName:
 		return dotcom.NewClient(httpcli.ExternalDoer, accessToken), nil
 	case llmproxy.ProviderName:

--- a/enterprise/internal/completions/client/llmproxy/llmproxy.go
+++ b/enterprise/internal/completions/client/llmproxy/llmproxy.go
@@ -63,7 +63,7 @@ func (c *llmProxyClient) clientForParams(feature types.CompletionsFeature, reque
 
 	if strings.HasPrefix(model, openAIModelPrefix) {
 		requestParams.Model = strings.TrimPrefix(model, openAIModelPrefix)
-		return openai.NewClient(llmProxyDoer(c.upstream, feature, c.llmProxyURL, c.accessToken, "/v1/completions/openai"), ""), nil
+		return openai.NewClient(llmProxyDoer(c.upstream, feature, c.llmProxyURL, c.accessToken, "/v1/completions/openai"), "", ""), nil
 	}
 	if strings.HasPrefix(model, anthropicModelPrefix) {
 		requestParams.Model = strings.TrimPrefix(model, anthropicModelPrefix)

--- a/enterprise/internal/completions/client/openai/openai.go
+++ b/enterprise/internal/completions/client/openai/openai.go
@@ -15,18 +15,23 @@ import (
 
 const ProviderName = "openai"
 
-func NewClient(cli httpcli.Doer, accessToken string) types.CompletionsClient {
+func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
+	if endpoint == "" {
+		endpoint = defaultAPIURL
+	}
 	return &openAIChatCompletionStreamClient{
 		cli:         cli,
 		accessToken: accessToken,
+		endpoint:    endpoint,
 	}
 }
 
-const apiURL = "https://api.openai.com/v1/chat/completions"
+const defaultAPIURL = "https://api.openai.com/v1/chat/completions"
 
 type openAIChatCompletionStreamClient struct {
 	cli         httpcli.Doer
 	accessToken string
+	endpoint    string
 }
 
 func (c *openAIChatCompletionStreamClient) Complete(
@@ -147,7 +152,7 @@ func (c *openAIChatCompletionStreamClient) makeRequest(ctx context.Context, requ
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.endpoint, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -550,7 +550,7 @@ type Completions struct {
 	CompletionModel string `json:"completionModel,omitempty"`
 	// Enabled description: Toggles whether completions are enabled.
 	Enabled bool `json:"enabled"`
-	// Endpoint description: The endpoint under which to reach the provider. Currently only used for provider types "llmproxy" and "anthropic". The default values are "https://completions.sourcegraph.com" and "https://api.anthropic.com/v1/complete" for LLM proxy and Anthropic, respectively.
+	// Endpoint description: The endpoint under which to reach the provider. Currently only used for provider types "llmproxy", "openai" and "anthropic". The default values are "https://completions.sourcegraph.com", "https://api.openai.com/v1/chat/completions", and "https://api.anthropic.com/v1/complete" for LLM proxy, OpenAI, and Anthropic, respectively.
 	Endpoint string `json:"endpoint,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2396,7 +2396,7 @@
         },
         "endpoint": {
           "type": "string",
-          "description": "The endpoint under which to reach the provider. Currently only used for provider types \"llmproxy\" and \"anthropic\". The default values are \"https://completions.sourcegraph.com\" and \"https://api.anthropic.com/v1/complete\" for LLM proxy and Anthropic, respectively."
+          "description": "The endpoint under which to reach the provider. Currently only used for provider types \"llmproxy\", \"openai\" and \"anthropic\". The default values are \"https://completions.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/complete\" for LLM proxy, OpenAI, and Anthropic, respectively."
         },
         "perUserDailyLimit": {
           "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",


### PR DESCRIPTION
This makes it possible to switch to an alternative OpenAI compatible endpoint, in line with what we allow for anthropic as well.

## Test plan

Manual test.