### PR TITLE
chore: update to Aspect CLI 5.4.11

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.3.4
+USE_BAZEL_VERSION=aspect/5.4.11


### PR DESCRIPTION
v5.4.11 release should resolve the `bazel build $(bazel query)` piping issue as it includes a fix to direct CLI plugin status to stderr instead of stdout.

## Test plan

CI