### PR TITLE
Cody: fast file finder

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -33,6 +33,7 @@ ts_project(
     srcs = [
         "package.json",
         "src/chat/ChatViewProvider.ts",
+        "src/chat/fastFileFinder.ts",
         "src/chat/protocol.ts",
         "src/chat/recipes.ts",
         "src/chat/utils.ts",
@@ -118,6 +119,7 @@ ts_project(
     name = "cody_tests",
     testonly = True,
     srcs = [
+        "src/chat/fastFileFinder.test.ts",
         "src/chat/utils.test.ts",
         "src/completions/cache.test.ts",
         "src/completions/context.test.ts",

--- a/client/cody/scripts/download-rg.sh
+++ b/client/cody/scripts/download-rg.sh
@@ -2,6 +2,11 @@
 
 VERSION="v13.0.0-8"
 
+# get first command line arg if it exists
+if [ -n "$1" ]; then
+  FILTER="$1"
+fi
+
 run() {
   RIPGREP_DIR="$(dirname "$(readlink -f "$0")")/../resources/bin"
   mkdir -p "${RIPGREP_DIR}"
@@ -9,6 +14,10 @@ run() {
   trap 'popd' EXIT
 
   for url in $(curl https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/$VERSION 2>/dev/null | jq -r '.assets[] | .browser_download_url'); do
+    # filter out files that don't match the filter
+    if [ -n "$FILTER" ] && [[ "$url" != *"$FILTER"* ]]; then
+      continue
+    fi
 
     b=$(basename "$url")
     ext=${b##*.}

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -29,6 +29,7 @@ import { LocalStorage } from '../services/LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, SecretStorage } from '../services/SecretStorageProvider'
 import { TestSupport } from '../test-support'
 
+import { fastFilesExist } from './fastFileFinder'
 import {
     AuthStatus,
     ConfigurationSubsetForWebview,
@@ -39,7 +40,7 @@ import {
     isLoggedIn,
 } from './protocol'
 import { getRecipe } from './recipes'
-import { filesExist, getCodebaseContext } from './utils'
+import { getCodebaseContext } from './utils'
 
 export async function getAuthStatus(
     config: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'accessToken' | 'customHeaders'>
@@ -302,7 +303,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 const lastInteraction = this.transcript.getLastInteraction()
                 if (lastInteraction) {
                     const displayText = reformatBotMessage(text, responsePrefix)
-                    let { text: highlightedDisplayText } = await highlightTokens(displayText || '', filesExist)
+                    const fileExistFunc = (filePaths: string[]): Promise<{ [filePath: string]: boolean }> => {
+                        const rootPath = this.editor.getWorkspaceRootPath()
+                        if (!rootPath) {
+                            return Promise.resolve({})
+                        }
+                        return fastFilesExist(this.rgPath, rootPath, filePaths)
+                    }
+                    let { text: highlightedDisplayText } = await highlightTokens(displayText || '', fileExistFunc)
                     // TODO(keegancsmith) guardrails may be slow, we need to make this async update the interaction.
                     highlightedDisplayText = await this.guardrailsAnnotateAttributions(highlightedDisplayText)
                     this.transcript.addAssistantResponse(text || '', highlightedDisplayText)

--- a/client/cody/src/chat/fastFileFinder.test.ts
+++ b/client/cody/src/chat/fastFileFinder.test.ts
@@ -1,0 +1,29 @@
+import { filePathContains } from './fastFileFinder'
+
+describe('filePathContains', () => {
+    it('should handle exact matches', () => {
+        expect(filePathContains('/a/b/c', '/a/b/c')).toBe(true)
+    })
+    it('should handle child directories', () => {
+        expect(filePathContains('/a/b/c', 'c')).toBe(true)
+        expect(filePathContains('/a/b/c', 'b/c')).toBe(true)
+    })
+    it('should handle mid-level directories', () => {
+        expect(filePathContains('/a/b/c', 'b')).toBe(true)
+        expect(filePathContains('/a/b/c', 'a/b')).toBe(true)
+        expect(filePathContains('lib/batches/env/var.go', 'batches/env')).toBe(true)
+        expect(filePathContains('lib/batches/env/var.go', 'lib')).toBe(true)
+        expect(filePathContains('lib/batches/env/var.go', 'lib/batches')).toBe(true)
+    })
+    it('should handle relative paths', () => {
+        expect(filePathContains('/a/b/c', './c')).toBe(true)
+    })
+    it('should trim separators', () => {
+        expect(filePathContains('/a/b/c/', 'c/')).toBe(true)
+        expect(filePathContains('/a/b/c', '/c')).toBe(true)
+    })
+    it('should not match if the contained path is not actually contained', () => {
+        expect(filePathContains('/a/b/c', 'd')).toBe(false)
+        expect(filePathContains('/a/b/c', 'a/d')).toBe(false)
+    })
+})

--- a/client/cody/src/chat/fastFileFinder.ts
+++ b/client/cody/src/chat/fastFileFinder.ts
@@ -1,0 +1,91 @@
+import { execFile } from 'child_process'
+import * as path from 'path'
+
+export async function fastFilesExist(
+    rgPath: string,
+    rootPath: string,
+    filePaths: string[]
+): Promise<{ [filePath: string]: boolean }> {
+    const searchPath =
+        '{' +
+        filePaths
+            .flatMap(filePath => {
+                let pathChunk = filePath
+                while (
+                    pathChunk.endsWith('*') ||
+                    pathChunk.endsWith(path.sep) ||
+                    pathChunk.startsWith('*') ||
+                    pathChunk.startsWith(path.sep)
+                ) {
+                    const trimToks = ['**', '*', path.sep]
+                    for (const trimTok of trimToks) {
+                        if (pathChunk.startsWith(trimTok)) {
+                            pathChunk = pathChunk.slice(trimTok.length)
+                        }
+                        if (pathChunk.endsWith(trimTok)) {
+                            pathChunk = pathChunk.slice(0, -trimTok.length)
+                        }
+                    }
+                }
+                return [`**${path.sep}${pathChunk}${path.sep}**`, `**${path.sep}${pathChunk}`]
+            })
+            .join(',') +
+        '}'
+    const out = await new Promise<string>((resolve, reject) => {
+        execFile(
+            rgPath,
+            ['--files', '-g', searchPath, '--crlf', '--fixed-strings', '--no-config', '--no-ignore-global'],
+            {
+                cwd: rootPath,
+                maxBuffer: 1024 * 1024 * 1024,
+            },
+            (error, stdout, stderr) => {
+                if (error?.code === 2) {
+                    reject(new Error(`${error.message}: ${stderr}`))
+                } else {
+                    resolve(stdout)
+                }
+            }
+        )
+    })
+    const unvalidatedPaths = new Set<string>(filePaths)
+    for (const line of out.split('\n')) {
+        const realFile = line.trim()
+        for (const filePath of [...unvalidatedPaths]) {
+            if (filePathContains(realFile, filePath)) {
+                unvalidatedPaths.delete(filePath)
+            }
+        }
+        if (unvalidatedPaths.size === 0) {
+            break
+        }
+    }
+
+    const ret: { [filePath: string]: boolean } = {}
+    for (const filePath of filePaths) {
+        ret[filePath] = !unvalidatedPaths.has(filePath)
+    }
+
+    return ret
+}
+
+export function filePathContains(container: string, contained: string): boolean {
+    let trimmedContained = contained
+    if (trimmedContained.endsWith(path.sep)) {
+        trimmedContained = trimmedContained.slice(0, -path.sep.length)
+    }
+    if (trimmedContained.startsWith(path.sep)) {
+        trimmedContained = trimmedContained.slice(path.sep.length)
+    }
+    if (trimmedContained.startsWith('.' + path.sep)) {
+        trimmedContained = trimmedContained.slice(1 + path.sep.length)
+    }
+    return (
+        container === contained || // exact match
+        container === path.sep + trimmedContained ||
+        container === trimmedContained ||
+        container.startsWith(trimmedContained + path.sep) || // relative parent directory
+        container.includes(path.sep + trimmedContained + path.sep) || // mid-level directory
+        container.endsWith(path.sep + trimmedContained) // child
+    )
+}

--- a/client/cody/test/e2e/inline-assist.test.ts
+++ b/client/cody/test/e2e/inline-assist.test.ts
@@ -10,8 +10,8 @@ test('start a fixup job from inline assist with valid auth', async ({ page, side
     // Open the Explorer view from the sidebar
     await sidebarExplorer(page).click()
 
-    // Select the second files from the tree view, which is the index.html file
-    await page.locator('.monaco-highlighted-label').nth(2).click()
+    // Select the 4th file from the tree view, which is the index.html file
+    await page.locator('.monaco-highlighted-label').nth(3).click()
 
     // Click on line number 6 to open the comment thread
     await page.locator('.comment-diff-added').nth(5).hover()

--- a/client/cody/test/e2e/task-controller.test.ts
+++ b/client/cody/test/e2e/task-controller.test.ts
@@ -10,8 +10,8 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     // Open the Explorer view from the sidebar
     await sidebarExplorer(page).click()
 
-    // Select the second files from the tree view, which is the index.html file
-    await page.locator('.monaco-highlighted-label').nth(2).click()
+    // Select the 4th file from the tree view, which is the index.html file
+    await page.locator('.monaco-highlighted-label').nth(3).click()
 
     // Bring the cody sidebar to the foreground
     await page.click('[aria-label="Sourcegraph Cody"]')

--- a/client/cody/test/fixtures/workspace/lib/batches/env/var.go
+++ b/client/cody/test/fixtures/workspace/lib/batches/env/var.go
@@ -1,0 +1,1 @@
+package env

--- a/client/cody/test/fixtures/workspace/lib/codeintel/tools/lsif-visualize/visualize.go
+++ b/client/cody/test/fixtures/workspace/lib/codeintel/tools/lsif-visualize/visualize.go
@@ -1,0 +1,1 @@
+package visualize

--- a/client/cody/test/integration/BUILD.bazel
+++ b/client/cody/test/integration/BUILD.bazel
@@ -26,6 +26,7 @@ ts_project(
         "chat.test.ts",
         "helpers.ts",
         "index.ts",
+        "local-search.test.ts",
         "main.ts",
         "recipes.test.ts",
         "task-controller.test.ts",

--- a/client/cody/test/integration/local-search.test.ts
+++ b/client/cody/test/integration/local-search.test.ts
@@ -9,8 +9,16 @@ import { getRgPath } from '../../src/rg'
 import { afterIntegrationTest, beforeIntegrationTest } from './helpers'
 
 suite('Local search', function () {
-    this.beforeEach(() => beforeIntegrationTest())
-    this.afterEach(() => afterIntegrationTest())
+    let mockRgPath: string | undefined
+    this.beforeEach(() => {
+        mockRgPath = process.env.MOCK_RG_PATH
+        process.env.MOCK_RG_PATH = ''
+        void beforeIntegrationTest()
+    })
+    this.afterEach(() => {
+        void afterIntegrationTest()
+        process.env.MOCK_RG_PATH = mockRgPath
+    })
 
     test('fast file finder', async () => {
         const workspaceFolders = vscode.workspace.workspaceFolders

--- a/client/cody/test/integration/local-search.test.ts
+++ b/client/cody/test/integration/local-search.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert'
+import path from 'path'
+
+import * as vscode from 'vscode'
+
+import { fastFilesExist } from '../../src/chat/fastFileFinder'
+import { getRgPath } from '../../src/rg'
+
+import { afterIntegrationTest, beforeIntegrationTest } from './helpers'
+
+suite('Local search', function () {
+    this.beforeEach(() => beforeIntegrationTest())
+    this.afterEach(() => afterIntegrationTest())
+
+    test('fast file finder', async () => {
+        const workspaceFolders = vscode.workspace.workspaceFolders
+        assert.ok(workspaceFolders)
+        assert.ok(workspaceFolders.length >= 1)
+
+        const rgPath = await getRgPath(path.join(__dirname, '..', '..', '..'))
+        const filesExistMap = await fastFilesExist(rgPath, workspaceFolders[0].uri.fsPath, [
+            'lib',
+            'batches',
+            'env',
+            'var.go',
+            'lib/batches',
+            'batches/env',
+            'lib/batches/env/var.go',
+            'lib/batches/var.go',
+            './lib/codeintel/tools/lsif-visualize/visualize.go',
+        ])
+        assert.deepStrictEqual(filesExistMap, {
+            lib: true,
+            batches: true,
+            env: true,
+            'var.go': true,
+            'lib/batches': true,
+            'batches/env': true,
+            'lib/batches/env/var.go': true,
+            'lib/batches/var.go': false,
+            './lib/codeintel/tools/lsif-visualize/visualize.go': true,
+        })
+    })
+})

--- a/client/cody/test/integration/main.ts
+++ b/client/cody/test/integration/main.ts
@@ -8,10 +8,6 @@ async function main(): Promise<void> {
     // Set this environment variable so the extension exposes hooks to the test runner.
     process.env.CODY_TESTING = 'true'
 
-    // No rg is installed on CI, so use `true` (which ignores arguments and always returns empty
-    // with exit status 0).
-    process.env.MOCK_RG_PATH = 'true'
-
     // When run, this script's filename is `client/cody/out/integration-test/main.js`, so
     // __dirname is derived from that path, not this file's source path.
     const codyRoot = path.resolve(__dirname, '..', '..', '..')

--- a/client/cody/test/integration/main.ts
+++ b/client/cody/test/integration/main.ts
@@ -8,6 +8,10 @@ async function main(): Promise<void> {
     // Set this environment variable so the extension exposes hooks to the test runner.
     process.env.CODY_TESTING = 'true'
 
+    // No rg is installed on CI, so use `true` (which ignores arguments and always returns empty
+    // with exit status 0).
+    process.env.MOCK_RG_PATH = 'true'
+
     // When run, this script's filename is `client/cody/out/integration-test/main.js`, so
     // __dirname is derived from that path, not this file's source path.
     const codyRoot = path.resolve(__dirname, '..', '..', '..')

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -260,7 +260,6 @@ func addVsceTests(pipeline *bk.Pipeline) {
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("pnpm generate"),
-		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter @sourcegraph/vscode run build:test"),
 		// TODO: fix integrations tests and re-enable: https://github.com/sourcegraph/sourcegraph/issues/40891
 		// bk.Cmd("pnpm --filter @sourcegraph/vscode run test-integration --verbose"),
@@ -273,6 +272,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		":vscode::robot_face: Unit, integration, and E2E tests for the Cody VS Code extension",
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
+		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -273,6 +273,7 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		":vscode::robot_face: Unit, integration, and E2E tests for the Cody VS Code extension",
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
+		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -260,6 +260,7 @@ func addVsceTests(pipeline *bk.Pipeline) {
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("pnpm generate"),
+		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter @sourcegraph/vscode run build:test"),
 		// TODO: fix integrations tests and re-enable: https://github.com/sourcegraph/sourcegraph/issues/40891
 		// bk.Cmd("pnpm --filter @sourcegraph/vscode run test-integration --verbose"),

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -273,7 +273,6 @@ func addCodyExtensionTests(pipeline *bk.Pipeline) {
 		":vscode::robot_face: Unit, integration, and E2E tests for the Cody VS Code extension",
 		withPnpmCache(),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
-		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),
 		bk.Cmd("pnpm --filter cody-shared run test"),
 		bk.Cmd("pnpm --filter cody-ai run test:integration"),


### PR DESCRIPTION
This increases the speed of the local file finder used for file path verification by an order of magnitude. It does this by replacing the invocation of `windows.workspace.findFiles` with a direct invocation of `rg`.

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td width="50%">
<img width="419" alt="ffe0" src="https://github.com/sourcegraph/sourcegraph/assets/1646931/4e67cb77-5f53-4e2a-b6fb-0384c2721f5b">
<p>
(This shows a cold run, and then a hot one. `console.time` prints each timestamp twice for some reason.)
</p>
</td>
<td width="50%" valign="top">
<img width="438" alt="ffe" src="https://github.com/sourcegraph/sourcegraph/assets/1646931/755e2eea-ae34-403c-9637-8484698e165a">
</td>
</tr>
<tr>
<td>

https://github.com/sourcegraph/sourcegraph/assets/1646931/ca1488a4-00df-4d18-a51e-5fe9c9829f5b


</td>
<td>

https://github.com/sourcegraph/sourcegraph/assets/1646931/9d81ad6a-4c36-4cfb-b282-4105e84ac3ed


</td>
</tr>
</table>

## Test plan

* Speed tested locally on sourcegraph/sourcegraph
* [Integration test](https://github.com/sourcegraph/sourcegraph/pull/52541/files#diff-378c6718aaa232f7963a1e0d81225da8413a75a9a0ff5adc7c92d05483040381)
* [Unit test](https://github.com/sourcegraph/sourcegraph/pull/52541/files#diff-7eefacf1114ef6cebb922b3f2fd3b099fda85553ec2ceea37853914f66b697b4)