### PR TITLE
cody: share `vscode` mocks between `jest` unit tests

### DIFF
--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -66,6 +66,7 @@ ts_project(
         "src/services/LocalStorageProvider.ts",
         "src/services/SecretStorageProvider.ts",
         "src/test-support.ts",
+        "src/testSetup/vscode.ts",
         "src/wink-nlp-utils.d.ts",
         "webviews/App.story.tsx",
         "webviews/App.tsx",

--- a/client/cody/jest.config.js
+++ b/client/cody/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
   displayName: 'cody',
   rootDir: __dirname,
   testPathIgnorePatterns: ['test/integration', 'test/e2e'],
+  setupFilesAfterEnv: ['<rootDir>/src/testSetup/vscode.ts'],
 }

--- a/client/cody/src/__mocks__/vscode.js
+++ b/client/cody/src/__mocks__/vscode.js
@@ -1,21 +1,2 @@
-module.exports = {
-  window: {
-    showInformationMessage: () => undefined,
-    showErrorMessage: () => undefined,
-    showWarningMessage: () => undefined,
-    showQuickPick: () => undefined,
-    showInputBox: () => undefined,
-    createOutputChannel: () => undefined,
-  },
-  getConfiguration: () => undefined,
-  WorkspaceConfiguration: {
-    get: () => undefined,
-    update: () => undefined,
-  },
-  workspace: {
-    getConfiguration: () => undefined,
-  },
-  ConfigurationTarget: {
-    Global: undefined,
-  },
-}
+// The Typescript mock is defined in `client/cody/src/testSetup/vscode.ts`.
+module.exports = {}

--- a/client/cody/src/completions/cache.ts
+++ b/client/cody/src/completions/cache.ts
@@ -7,6 +7,10 @@ export class CompletionsCache {
         max: 500, // Maximum input prefixes in the cache.
     })
 
+    public clear(): void {
+        this.cache.clear()
+    }
+
     // TODO: The caching strategy only takes the file content prefix into
     // account. We need to add additional information like file path or suffix
     // to make sure the cache does not return undesired results for other files

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -5,40 +5,13 @@ import {
     CompletionResponse,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
+import { mockVSCodeExports } from '../testSetup/vscode'
+
 import { CodyCompletionItemProvider, inlineCompletionsCache } from '.'
 
 jest.mock('vscode', () => {
-    class Position {
-        public line: number
-        public character: number
-
-        constructor(line: number, character: number) {
-            this.line = line
-            this.character = character
-        }
-    }
-    class Range {
-        public start: Position
-        public end: Position
-
-        constructor(start: Position, end: Position) {
-            if (typeof start === 'number') {
-                throw new TypeError('this version of the constructor is not implemented')
-            }
-            this.start = start
-            this.end = end
-        }
-    }
-    class InlineCompletionItem {
-        public content: string
-        constructor(content: string) {
-            this.content = content
-        }
-    }
     return {
-        Position,
-        Range,
-        InlineCompletionItem,
+        ...mockVSCodeExports(),
         InlineCompletionTriggerKind: {
             Invoke: 0,
             Automatic: 1,
@@ -59,15 +32,6 @@ jest.mock('vscode', () => {
             onDidChangeTextDocument() {
                 return null
             },
-        },
-        window: {
-            createOutputChannel() {
-                return null
-            },
-            showErrorMessage(message: string) {
-                throw new Error(message)
-            },
-            activeTextEditor: { document: { uri: { scheme: 'not-cody' } } },
         },
     }
 })

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -10,29 +10,29 @@ import { mockVSCodeExports } from '../testSetup/vscode'
 import { CodyCompletionItemProvider, inlineCompletionsCache } from '.'
 
 jest.mock('vscode', () => ({
-        ...mockVSCodeExports(),
-        InlineCompletionTriggerKind: {
-            Invoke: 0,
-            Automatic: 1,
+    ...mockVSCodeExports(),
+    InlineCompletionTriggerKind: {
+        Invoke: 0,
+        Automatic: 1,
+    },
+    workspace: {
+        getConfiguration() {
+            return {
+                get(key: string) {
+                    switch (key) {
+                        case 'cody.debug.filter':
+                            return '.*'
+                        default:
+                            return ''
+                    }
+                },
+            }
         },
-        workspace: {
-            getConfiguration() {
-                return {
-                    get(key: string) {
-                        switch (key) {
-                            case 'cody.debug.filter':
-                                return '.*'
-                            default:
-                                return ''
-                        }
-                    },
-                }
-            },
-            onDidChangeTextDocument() {
-                return null
-            },
+        onDidChangeTextDocument() {
+            return null
         },
-    }))
+    },
+}))
 
 function createCompletionResponse(completion: string): CompletionResponse {
     return {

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -9,8 +9,7 @@ import { mockVSCodeExports } from '../testSetup/vscode'
 
 import { CodyCompletionItemProvider, inlineCompletionsCache } from '.'
 
-jest.mock('vscode', () => {
-    return {
+jest.mock('vscode', () => ({
         ...mockVSCodeExports(),
         InlineCompletionTriggerKind: {
             Invoke: 0,
@@ -33,8 +32,7 @@ jest.mock('vscode', () => {
                 return null
             },
         },
-    }
-})
+    }))
 
 function createCompletionResponse(completion: string): CompletionResponse {
     return {

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -5,7 +5,7 @@ import {
     CompletionResponse,
 } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 
-import { CodyCompletionItemProvider, __test_only_resetCache } from '.'
+import { CodyCompletionItemProvider, inlineCompletionsCache } from '.'
 
 jest.mock('vscode', () => {
     class Position {
@@ -200,7 +200,7 @@ function truncateMultilineString(string: string): string {
 }
 
 describe('Cody completions', () => {
-    beforeEach(() => __test_only_resetCache())
+    beforeEach(() => inlineCompletionsCache.clear())
 
     it('uses a simple prompt for small files', async () => {
         const { requests } = await complete('foo |')

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -20,10 +20,7 @@ function lastNLines(text: string, n: number): string {
     return lines.slice(Math.max(0, lines.length - n)).join('\n')
 }
 
-let inlineCompletionsCache = new CompletionsCache()
-export const __test_only_resetCache = (): void => {
-    inlineCompletionsCache = new CompletionsCache()
-}
+export const inlineCompletionsCache = new CompletionsCache()
 
 export class CodyCompletionItemProvider implements vscode.InlineCompletionItemProvider {
     private promptTokens: number

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -44,8 +44,7 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         private charsPerToken = 4,
         private responseTokens = 200,
         private prefixPercentage = 0.6,
-        private suffixPercentage = 0.1,
-        private disableTimeouts = false
+        private suffixPercentage = 0.1
     ) {
         this.promptTokens = this.contextWindowTokens - this.responseTokens
         this.maxPrefixTokens = Math.floor(this.promptTokens * this.prefixPercentage)
@@ -237,10 +236,6 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     1 // tries
                 )
             )
-        }
-
-        if (!this.disableTimeouts) {
-            await new Promise<void>(resolve => setTimeout(resolve, timeout))
         }
 
         // We don't need to make a request at all if the signal is already aborted after the

--- a/client/cody/src/completions/index.ts
+++ b/client/cody/src/completions/index.ts
@@ -41,7 +41,8 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
         private charsPerToken = 4,
         private responseTokens = 200,
         private prefixPercentage = 0.6,
-        private suffixPercentage = 0.1
+        private suffixPercentage = 0.1,
+        private disableTimeouts = false
     ) {
         this.promptTokens = this.contextWindowTokens - this.responseTokens
         this.maxPrefixTokens = Math.floor(this.promptTokens * this.prefixPercentage)
@@ -233,6 +234,10 @@ export class CodyCompletionItemProvider implements vscode.InlineCompletionItemPr
                     1 // tries
                 )
             )
+        }
+
+        if (!this.disableTimeouts) {
+            await new Promise<void>(resolve => setTimeout(resolve, timeout))
         }
 
         // We don't need to make a request at all if the signal is already aborted after the

--- a/client/cody/src/services/InlineAssist.test.ts
+++ b/client/cody/src/services/InlineAssist.test.ts
@@ -2,40 +2,6 @@ import * as vscode from 'vscode'
 
 import { updateRangeOnDocChange } from './InlineAssist'
 
-jest.mock('vscode', () => {
-    class Position {
-        public line: number
-        public character: number
-
-        constructor(line: number, character: number) {
-            this.line = line
-            this.character = character
-        }
-    }
-    class Range {
-        public startLine: number
-        public startCharacter: number
-        public endLine: number
-        public endCharacter: number
-        public start: Position
-        public end: Position
-
-        constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
-            this.startLine = startLine
-            this.startCharacter = startCharacter
-            this.endLine = endLine
-            this.endCharacter = endCharacter
-            this.start = new Position(startLine, startCharacter)
-            this.end = new Position(endLine, endCharacter)
-        }
-    }
-
-    return {
-        Position,
-        Range,
-    }
-})
-
 describe('UpdateRangeOnDocChange returns a new selection range by calculating lines of code changed in current docs', () => {
     it('Returns current Range if change occurs after the current selected range', () => {
         const cur = new vscode.Range(1, 0, 3, 0)

--- a/client/cody/src/testSetup/vscode.ts
+++ b/client/cody/src/testSetup/vscode.ts
@@ -1,0 +1,94 @@
+/**
+ * This module defines shared VSCode mocks for use in every Jest test.
+ * Tests requiring no custom mocks will automatically apply the mocks defined in this file.
+ * This is made possible via the `setupFilesAfterEnv` property in the Jest configuration.
+ */
+
+class Position {
+    public line: number
+    public character: number
+
+    constructor(line: number, character: number) {
+        this.line = line
+        this.character = character
+    }
+}
+
+class Range {
+    public startLine?: number
+    public startCharacter?: number
+    public endLine?: number
+    public endCharacter?: number
+    public start: Position
+    public end: Position
+
+    constructor(
+        startLine: number | Position,
+        startCharacter: number | Position,
+        endLine: number,
+        endCharacter: number
+    ) {
+        if (typeof startLine !== 'number' && typeof startCharacter !== 'number') {
+            this.start = startLine
+            this.end = startCharacter
+        } else if (typeof startLine === 'number' && typeof startCharacter === 'number') {
+            this.startLine = startLine
+            this.startCharacter = startCharacter
+            this.endLine = endLine
+            this.endCharacter = endCharacter
+            this.start = new Position(startLine, startCharacter)
+            this.end = new Position(endLine, endCharacter)
+        } else {
+            throw new TypeError('this version of the constructor is not implemented')
+        }
+    }
+}
+
+class InlineCompletionItem {
+    public content: string
+    constructor(content: string) {
+        this.content = content
+    }
+}
+
+/**
+ * Mock name is required to keep Jest happy and avoid the error:
+ * "The module factory of jest.mock() is not allowed to reference any out-of-scope variables"
+ *
+ * This function can be used to customize the default VSCode mocks in any test file.
+ */
+export function mockVSCodeExports() {
+    return {
+        Range,
+        Position,
+        InlineCompletionItem,
+        window: {
+            showInformationMessage: () => undefined,
+            showWarningMessage: () => undefined,
+            showQuickPick: () => undefined,
+            showInputBox: () => undefined,
+            createOutputChannel() {
+                return null
+            },
+            showErrorMessage(message: string) {
+                throw new Error(message)
+            },
+            activeTextEditor: { document: { uri: { scheme: 'not-cody' } } },
+        },
+        workspace: {
+            getConfiguration() {
+                return undefined
+            },
+        },
+        ConfigurationTarget: {
+            Global: undefined,
+        },
+    }
+}
+
+/**
+ * Apply the default VSCode mocks to the global scope.
+ */
+jest.mock('vscode', () => {
+    return mockVSCodeExports()
+})

--- a/client/cody/src/testSetup/vscode.ts
+++ b/client/cody/src/testSetup/vscode.ts
@@ -51,44 +51,44 @@ class InlineCompletionItem {
     }
 }
 
+const vsCodeMocks = {
+    Range,
+    Position,
+    InlineCompletionItem,
+    window: {
+        showInformationMessage: () => undefined,
+        showWarningMessage: () => undefined,
+        showQuickPick: () => undefined,
+        showInputBox: () => undefined,
+        createOutputChannel() {
+            return null
+        },
+        showErrorMessage(message: string) {
+            throw new Error(message)
+        },
+        activeTextEditor: { document: { uri: { scheme: 'not-cody' } } },
+    },
+    workspace: {
+        getConfiguration() {
+            return undefined
+        },
+    },
+    ConfigurationTarget: {
+        Global: undefined,
+    },
+} as const
+
 /**
  * Mock name is required to keep Jest happy and avoid the error:
  * "The module factory of jest.mock() is not allowed to reference any out-of-scope variables"
  *
  * This function can be used to customize the default VSCode mocks in any test file.
  */
-export function mockVSCodeExports() {
-    return {
-        Range,
-        Position,
-        InlineCompletionItem,
-        window: {
-            showInformationMessage: () => undefined,
-            showWarningMessage: () => undefined,
-            showQuickPick: () => undefined,
-            showInputBox: () => undefined,
-            createOutputChannel() {
-                return null
-            },
-            showErrorMessage(message: string) {
-                throw new Error(message)
-            },
-            activeTextEditor: { document: { uri: { scheme: 'not-cody' } } },
-        },
-        workspace: {
-            getConfiguration() {
-                return undefined
-            },
-        },
-        ConfigurationTarget: {
-            Global: undefined,
-        },
-    }
+export function mockVSCodeExports(): typeof vsCodeMocks {
+    return vsCodeMocks
 }
 
 /**
  * Apply the default VSCode mocks to the global scope.
  */
-jest.mock('vscode', () => {
-    return mockVSCodeExports()
-})
+jest.mock('vscode', () => mockVSCodeExports())


### PR DESCRIPTION
## Context

- Follow-up on https://github.com/sourcegraph/sourcegraph/pull/52513
- `vscode` `jest` mocks are moved into a shared module.
- Completion unit tests now use a `<cursor>` string to mark the cursor position.

## Test plan

CI
