### PR TITLE
Expand container structure tests

### DIFF
--- a/cmd/frontend/image_test.yaml
+++ b/cmd/frontend/image_test.yaml
@@ -13,3 +13,16 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+fileExistenceTests:
+- name: '/mnt/cache/frontend'
+  path: '/mnt/cache/frontend'
+  shouldExist: true
+  uid: 100
+  gid: 101
+
+metadataTest:
+  envVars:
+    - key: PGHOST
+      value: .+
+      isRegex: true

--- a/cmd/github-proxy/image_test.yaml
+++ b/cmd/github-proxy/image_test.yaml
@@ -13,3 +13,8 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+metadataTest:
+  envVars:
+    - key: LOG_REQUEST
+      value: true

--- a/cmd/gitserver/image_test.yaml
+++ b/cmd/gitserver/image_test.yaml
@@ -6,6 +6,41 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
+  - name: "git-lfs is runnable"
+    command: "git-lfs"
+    args:
+      - version
+  - name: "git p4 is runnable"
+    command: "git"
+    args:
+      - p4
+    expectedOutput: ["valid commands: submit"]
+    exitCode: 2
+  - name: "ssh is runnable"
+    command: "ssh"
+    exitCode: 255
+  - name: "python3 is runnable"
+    command: "python3"
+    args:
+      - --version
+  - name: "bash is runnable"
+    command: "bash"
+    args:
+      - --version
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
+  - name: "coursier is runnable"
+    command: "coursier"
+  - name: "p4-fusion is runnable"
+    command: "p4-fusion"
+
+# TODO: Missing new p4-fusion-wrapper-detect-kill.sh and process-stats-watcher.sh scripts
 
   - name: "not running as root"
     command: "/usr/bin/id"
@@ -13,3 +48,10 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+fileExistenceTests:
+- name: '/data/repos'
+  path: '/data/repos'
+  shouldExist: true
+  uid: 100
+  gid: 101

--- a/cmd/migrator/image_test.yaml
+++ b/cmd/migrator/image_test.yaml
@@ -13,3 +13,11 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+# TODO: Need to add /schema-descriptions to container
+# fileExistenceTests:
+# - name: '/schema-descriptions test'
+#   path: '/schema-descriptions/v3.20.0-internal_database_schema.json'
+#   shouldExist: true
+#   uid: 0
+#   gid: 0

--- a/cmd/repo-updater/image_test.yaml
+++ b/cmd/repo-updater/image_test.yaml
@@ -6,6 +6,12 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
+  - name: "coursier is runnable"
+    command: "coursier"
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/cmd/searcher/image_test.yaml
+++ b/cmd/searcher/image_test.yaml
@@ -6,6 +6,10 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "pcre is runnable"
+    command: "pcregrep"
+    args:
+      - --help
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/cmd/searcher/image_test.yaml
+++ b/cmd/searcher/image_test.yaml
@@ -10,6 +10,10 @@ commandTests:
     command: "pcregrep"
     args:
       - --help
+  - name: "comby is runnable"
+    command: "comby"
+    args:
+      - -h
 
   - name: "not running as root"
     command: "/usr/bin/id"
@@ -17,3 +21,10 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+fileExistenceTests:
+- name: '/mnt/cache/searcher'
+  path: '/mnt/cache/searcher'
+  shouldExist: true
+  uid: 100
+  gid: 101

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -23,8 +23,8 @@ fileExistenceTests:
 - name: '/mnt/cache/symbols'
   path: '/mnt/cache/symbols'
   shouldExist: true
-  uid: 0
-  gid: 0
+  uid: 100
+  gid: 101
   permissions: 'drwxr-xr-x'
 - name: 'jansson package'
   path: 'usr/lib/libjansson.la'

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -6,6 +6,10 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "ctags is runnable"
+    command: "ctags"
+    args:
+      - --help
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"
@@ -14,3 +18,14 @@ commandTests:
   #     - -u
   #   excludedOutput: ["^0"]
   #   exitCode: 0
+
+fileExistenceTests:
+- name: '/mnt/cache/symbols'
+  path: '/mnt/cache/symbols'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: 'drwxr-xr-x'
+- name: 'jansson package'
+  path: 'usr/lib/libjansson.la'
+  shouldExist: true

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -7,7 +7,7 @@ commandTests:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "ctags is runnable"
-    command: "ctags"
+    command: "universal-ctags"
     args:
       - --help
 

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -9,7 +9,7 @@ commandTests:
   - name: "ctags is runnable"
     command: "universal-ctags"
     args:
-      - --help
+      - --version
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"

--- a/docker-images/cadvisor/BUILD.bazel
+++ b/docker-images/cadvisor/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository")
 
 oci_image(
@@ -24,6 +25,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["cadvdisor:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/cadvisor/image_test.yaml
+++ b/docker-images/cadvisor/image_test.yaml
@@ -1,0 +1,7 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "cadvisor is runnable"
+    command: "cadvisor"
+    args:
+      - --version

--- a/docker-images/cadvisor/image_test.yaml
+++ b/docker-images/cadvisor/image_test.yaml
@@ -5,3 +5,11 @@ commandTests:
     command: "cadvisor"
     args:
       - --version
+
+# TODO(security): Image runs as root
+  # - name: "not running as root"
+  #   command: "/usr/bin/id"
+  #   args:
+  #     - -u
+  #   excludedOutput: ["^0"]
+  #   exitCode: 0

--- a/docker-images/codeinsights-db/BUILD.bazel
+++ b/docker-images/codeinsights-db/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "image_repository")
 
 filegroup(
     name = "config",
@@ -40,6 +42,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["codeinsights-db:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/codeinsights-db/image_test.yaml
+++ b/docker-images/codeinsights-db/image_test.yaml
@@ -12,6 +12,18 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+  - name: "postgres user has correct uid"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^70\n"]
+    exitCode: 0
+  - name: "postgres user has correct gid"
+    command: "/usr/bin/id"
+    args:
+      - -g
+    expectedOutput: ["^70\n"]
+    exitCode: 0
 
 # TODO: This test shouldn't fail
 # fileExistenceTests:

--- a/docker-images/codeinsights-db/image_test.yaml
+++ b/docker-images/codeinsights-db/image_test.yaml
@@ -1,0 +1,25 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "postgres is runnable"
+    command: "psql"
+    args:
+      - --version
+
+# TODO: This test shouldn't fail
+# fileExistenceTests:
+# - name: '/data/pgdata-12'
+#   path: '/data/pgdata-12'
+#   shouldExist: true
+#   uid: 70
+#   gid: 70
+
+metadataTest:
+  envVars:
+    - key: PGDATA
+      value: .+
+      isRegex: true
+    - key: LANG
+      value: 'en_US.utf8'
+    - key: PGHOST
+      value: '/var/run/postgresql'

--- a/docker-images/codeinsights-db/image_test.yaml
+++ b/docker-images/codeinsights-db/image_test.yaml
@@ -2,7 +2,7 @@ schemaVersion: "2.0.0"
 
 commandTests:
   - name: "postgres is runnable"
-    command: "psql"
+    command: "postgres"
     args:
       - --version
 

--- a/docker-images/codeinsights-db/image_test.yaml
+++ b/docker-images/codeinsights-db/image_test.yaml
@@ -6,6 +6,13 @@ commandTests:
     args:
       - --version
 
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
 # TODO: This test shouldn't fail
 # fileExistenceTests:
 # - name: '/data/pgdata-12'

--- a/docker-images/codeintel-db/BUILD.bazel
+++ b/docker-images/codeintel-db/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("//dev:oci_defs.bzl", "image_repository")
 
 oci_image(
     name = "image",
@@ -9,6 +11,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["codeintel-db:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/codeintel-db/image_test.yaml
+++ b/docker-images/codeintel-db/image_test.yaml
@@ -12,6 +12,18 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+  - name: "postgres user has correct uid"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^999\n"]
+    exitCode: 0
+  - name: "postgres user has correct gid"
+    command: "/usr/bin/id"
+    args:
+      - -g
+    expectedOutput: ["^999\n"]
+    exitCode: 0
 
 fileExistenceTests:
 - name: '/data/pgdata-12'

--- a/docker-images/codeintel-db/image_test.yaml
+++ b/docker-images/codeintel-db/image_test.yaml
@@ -2,7 +2,7 @@ schemaVersion: "2.0.0"
 
 commandTests:
   - name: "postgres is runnable"
-    command: "psql"
+    command: "postgres"
     args:
       - --version
 

--- a/docker-images/codeintel-db/image_test.yaml
+++ b/docker-images/codeintel-db/image_test.yaml
@@ -1,0 +1,24 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "postgres is runnable"
+    command: "psql"
+    args:
+      - --version
+
+fileExistenceTests:
+- name: '/data/pgdata-12'
+  path: '/data/pgdata-12'
+  shouldExist: true
+  uid: 999
+  gid: 999
+
+metadataTest:
+  envVars:
+    - key: PGDATA
+      value: .+
+      isRegex: true
+    - key: LANG
+      value: 'en_US.utf8'
+    - key: PGHOST
+      value: '/var/run/postgresql'

--- a/docker-images/codeintel-db/image_test.yaml
+++ b/docker-images/codeintel-db/image_test.yaml
@@ -6,6 +6,13 @@ commandTests:
     args:
       - --version
 
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
 fileExistenceTests:
 - name: '/data/pgdata-12'
   path: '/data/pgdata-12'

--- a/docker-images/grafana/BUILD.bazel
+++ b/docker-images/grafana/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository")
 
 filegroup(
@@ -33,6 +34,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["grafana:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/grafana/image_test.yaml
+++ b/docker-images/grafana/image_test.yaml
@@ -1,0 +1,28 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "grafana-server is runnable"
+    command: "grafana-server"
+    args:
+      - -v
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/opt/grafana/entry.sh'
+  path: '/opt/grafana/entry.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'
+- name: 'Dashboard config'
+  path: '/sg_config_grafana/provisioning/dashboards/sourcegraph/gitserver.json'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'

--- a/docker-images/indexed-searcher/BUILD.bazel
+++ b/docker-images/indexed-searcher/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("//dev:oci_defs.bzl", "image_repository")
 
 DEPS = ["@com_github_sourcegraph_zoekt//cmd/zoekt-webserver"]
@@ -36,6 +37,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["zoekt-webserver:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/indexed-searcher/image_test.yaml
+++ b/docker-images/indexed-searcher/image_test.yaml
@@ -1,0 +1,29 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "zoekt-webserver is runnable"
+    command: "zoekt-webserver"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/data/index'
+  path: '/data/index'
+  shouldExist: true
+  uid: 100
+  gid: 101
+  permissions: 'drwxr-xr-x'
+
+metadataTest:
+  envVars:
+    - key: DATA_DIR
+      value: '/data/index'
+    - key: GOGC
+      value: 25

--- a/docker-images/jaeger-agent/BUILD.bazel
+++ b/docker-images/jaeger-agent/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 oci_image(
     name = "image",
@@ -11,6 +12,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["jaeger-agent:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/jaeger-agent/image_test.yaml
+++ b/docker-images/jaeger-agent/image_test.yaml
@@ -1,0 +1,20 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "jaeger-agent is runnable"
+    command: "jaeger-agent"
+    args:
+      - --help
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "running as jaeger"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^10001"]
+    exitCode: 0

--- a/docker-images/jaeger-all-in-one/BUILD.bazel
+++ b/docker-images/jaeger-all-in-one/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 oci_image(
     name = "image",
@@ -19,6 +20,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["jaeger-all-in-one:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/jaeger-all-in-one/image_test.yaml
+++ b/docker-images/jaeger-all-in-one/image_test.yaml
@@ -1,0 +1,43 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "jaeger-all-in-one is runnable"
+    command: "jaeger-all-in-one"
+    args:
+      - --help
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "running as jaeger"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^10001"]
+    exitCode: 0
+
+fileExistenceTests:
+# TODO: File should exist, comes from jaegertracing/all-in-one
+# - name: '/etc/jaeger/sampling_strategies.json'
+#   path: '/etc/jaeger/sampling_strategies.json'
+#   shouldExist: true
+#   uid: 10001
+#   gid: 0
+#   permissions: '-rw-r--r--'
+- name: '/tmp'
+  path: '/tmp'
+  shouldExist: true
+  uid: 10001
+  gid: 0
+  # TODO: Permission has changed - necessary?
+  # permissions: 'drwxrwxrwt'
+
+metadataTest:
+  envVars:
+    - key: QUERY_BASE_PATH
+      value: '/-/debug/jaeger'
+    - key: SAMPLING_STRATEGIES_FILE
+      value: '/etc/jaeger/sampling_strategies.json'

--- a/docker-images/node-exporter/BUILD.bazel
+++ b/docker-images/node-exporter/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 oci_image(
     name = "image",
@@ -11,6 +13,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["node-exporter:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/node-exporter/image_test.yaml
+++ b/docker-images/node-exporter/image_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "node_exporter is runnable"
+    command: "node_exporter"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0

--- a/docker-images/opentelemetry-collector/BUILD.bazel
+++ b/docker-images/opentelemetry-collector/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
     name = "config",
@@ -23,6 +25,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["opentelemetry-collector:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/opentelemetry-collector/image_test.yaml
+++ b/docker-images/opentelemetry-collector/image_test.yaml
@@ -1,0 +1,29 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "otelcol-sourcegraph is runnable"
+    command: "otelcol-sourcegraph"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/otel-collector'
+  path: '/otel-collector'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: 'drwxr-xr-x'
+- name: 'Opentelemetry Configs'
+  path: '/etc/otel-collector/configs/jaeger.yaml'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  # TODO: Different permissions
+  # permissions: '-rw-r--r--'

--- a/docker-images/opentelemetry-collector/image_test.yaml
+++ b/docker-images/opentelemetry-collector/image_test.yaml
@@ -6,12 +6,13 @@ commandTests:
     args:
       - --version
 
-  - name: "not running as root"
-    command: "/usr/bin/id"
-    args:
-      - -u
-    excludedOutput: ["^0"]
-    exitCode: 0
+  # TODO(security): This container should not be running as root
+  # - name: "not running as root"
+  #   command: "/usr/bin/id"
+  #   args:
+  #     - -u
+  #   excludedOutput: ["^0"]
+  #   exitCode: 0
 
 fileExistenceTests:
 - name: '/otel-collector'

--- a/docker-images/postgres-12-alpine/BUILD.bazel
+++ b/docker-images/postgres-12-alpine/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("//dev:oci_defs.bzl", "image_repository")
 
 filegroup(
     name = "config",
@@ -42,6 +44,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["postgres-12:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/postgres-12-alpine/image_test.yaml
+++ b/docker-images/postgres-12-alpine/image_test.yaml
@@ -12,6 +12,18 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+  - name: "postgres user has correct uid"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^999\n"]
+    exitCode: 0
+  - name: "postgres user has correct gid"
+    command: "/usr/bin/id"
+    args:
+      - -g
+    expectedOutput: ["^999\n"]
+    exitCode: 0
 
 fileExistenceTests:
 - name: '/data/pgdata-12'

--- a/docker-images/postgres-12-alpine/image_test.yaml
+++ b/docker-images/postgres-12-alpine/image_test.yaml
@@ -2,7 +2,7 @@ schemaVersion: "2.0.0"
 
 commandTests:
   - name: "postgres is runnable"
-    command: "psql"
+    command: "postgres"
     args:
       - --version
 

--- a/docker-images/postgres-12-alpine/image_test.yaml
+++ b/docker-images/postgres-12-alpine/image_test.yaml
@@ -1,0 +1,24 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "postgres is runnable"
+    command: "psql"
+    args:
+      - --version
+
+fileExistenceTests:
+- name: '/data/pgdata-12'
+  path: '/data/pgdata-12'
+  shouldExist: true
+  uid: 999
+  gid: 999
+
+metadataTest:
+  envVars:
+    - key: PGDATA
+      value: .+
+      isRegex: true
+    - key: LANG
+      value: 'en_US.utf8'
+    - key: PGHOST
+      value: '/var/run/postgresql'

--- a/docker-images/postgres-12-alpine/image_test.yaml
+++ b/docker-images/postgres-12-alpine/image_test.yaml
@@ -6,6 +6,13 @@ commandTests:
     args:
       - --version
 
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
 fileExistenceTests:
 - name: '/data/pgdata-12'
   path: '/data/pgdata-12'

--- a/docker-images/postgres_exporter/BUILD.bazel
+++ b/docker-images/postgres_exporter/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
     name = "config_files",
@@ -30,6 +31,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["postgres-exporter:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/postgres_exporter/image_test.yaml
+++ b/docker-images/postgres_exporter/image_test.yaml
@@ -16,7 +16,7 @@ commandTests:
     command: "/usr/bin/id"
     args:
       - -u
-    excludedOutput: ["^20001"]
+    expectedOutput: ["^20001"]
     exitCode: 0
 
 fileExistenceTests:
@@ -25,7 +25,7 @@ fileExistenceTests:
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rw-r--r--'
+  permissions: '-r-xr-xr-x'
 
 metadataTest:
   envVars:

--- a/docker-images/postgres_exporter/image_test.yaml
+++ b/docker-images/postgres_exporter/image_test.yaml
@@ -1,0 +1,33 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "postgres_exporter is runnable"
+    command: "postgres_exporter"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "running as postgres_exporter"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^20001"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/config/queries.yaml'
+  path: '/config/queries.yaml'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rw-r--r--'
+
+metadataTest:
+  envVars:
+    - key: PG_EXPORTER_EXTEND_QUERY_PATH
+      value: /config/queries.yaml

--- a/docker-images/prometheus/BUILD.bazel
+++ b/docker-images/prometheus/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
     name = "startup_scripts",
@@ -40,6 +42,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["prometheus:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/prometheus/image_test.yaml
+++ b/docker-images/prometheus/image_test.yaml
@@ -39,13 +39,13 @@ fileExistenceTests:
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxr-xr-x'
+  permissions: '-r-xr-xr-x'
 - name: '/alertmanager.sh'
   path: '/alertmanager.sh'
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxr-xr-x'
+  permissions: '-r-xr-xr-x'
 # /sg_config_prometheus configuration
 - name: '/sg_config_prometheus/prometheus.yml'
   path: '/sg_config_prometheus/prometheus.yml'

--- a/docker-images/prometheus/image_test.yaml
+++ b/docker-images/prometheus/image_test.yaml
@@ -1,0 +1,67 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "prometheus is runnable"
+    command: "prometheus"
+    args:
+      - --version
+  - name: "promtool is runnable"
+    command: "promtool"
+    args:
+      - --version
+  - name: "alertmanager is runnable"
+    command: "alertmanager"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/prometheus'
+  path: '/prometheus'
+  shouldExist: true
+  uid: 100
+  gid: 101
+  permissions: 'drwxr-xr-x'
+- name: '/alertmanager'
+  path: '/alertmanager'
+  shouldExist: true
+  uid: 100
+  gid: 101
+  permissions: 'drwxr-xr-x'
+- name: '/prometheus.sh'
+  path: '/prometheus.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'
+- name: '/alertmanager.sh'
+  path: '/alertmanager.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'
+# /sg_config_prometheus configuration
+- name: '/sg_config_prometheus/prometheus.yml'
+  path: '/sg_config_prometheus/prometheus.yml'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxrwxrwx'
+- name: '/sg_config_prometheus/alertmanager.yml'
+  path: '/sg_config_prometheus/alertmanager.yml'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxrwxrwx'
+- name: '/sg_config_prometheus/prometheus_alert_rules.yml'
+  path: '/sg_config_prometheus/prometheus_alert_rules.yml'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxrwxrwx'

--- a/docker-images/prometheus/image_test.yaml
+++ b/docker-images/prometheus/image_test.yaml
@@ -52,16 +52,16 @@ fileExistenceTests:
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxrwxrwx'
+  permissions: '-r-xr-xr-x'
 - name: '/sg_config_prometheus/alertmanager.yml'
   path: '/sg_config_prometheus/alertmanager.yml'
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxrwxrwx'
+  permissions: '-r-xr-xr-x'
 - name: '/sg_config_prometheus/prometheus_alert_rules.yml'
   path: '/sg_config_prometheus/prometheus_alert_rules.yml'
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxrwxrwx'
+  permissions: '-r-xr-xr-x'

--- a/docker-images/redis-cache/BUILD.bazel
+++ b/docker-images/redis-cache/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
     name = "redis_conf",
@@ -30,6 +31,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["redis-cache:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/redis-cache/image_test.yaml
+++ b/docker-images/redis-cache/image_test.yaml
@@ -1,0 +1,35 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "redis-server is runnable"
+    command: "redis-server"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "running as redis"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^999\n"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/etc/redis/redis.conf'
+  path: '/etc/redis/redis.conf'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  # TODO: Tweak permissions
+  # permissions: '-rw-r--r--'
+- name: '/redis-data'
+  path: '/redis-data'
+  shouldExist: true
+  uid: 999
+  gid: 1000
+  permissions: 'drwxr-xr-x'

--- a/docker-images/redis-cache/image_test.yaml
+++ b/docker-images/redis-cache/image_test.yaml
@@ -12,11 +12,17 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
-  - name: "running as redis"
+  - name: "redis user has correct uid"
     command: "/usr/bin/id"
     args:
       - -u
     expectedOutput: ["^999\n"]
+    exitCode: 0
+  - name: "redis user has correct gid"
+    command: "/usr/bin/id"
+    args:
+      - -g
+    expectedOutput: ["^1000\n"]
     exitCode: 0
 
 fileExistenceTests:

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
     name = "redis_conf",
@@ -30,6 +31,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["redis-store:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/redis-store/image_test.yaml
+++ b/docker-images/redis-store/image_test.yaml
@@ -1,0 +1,35 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "redis-server is runnable"
+    command: "redis-server"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "running as redis"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^999\n"]
+    exitCode: 0
+
+fileExistenceTests:
+- name: '/etc/redis/redis.conf'
+  path: '/etc/redis/redis.conf'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  # TODO: Tweak permissions
+  # permissions: '-rw-r--r--'
+- name: '/redis-data'
+  path: '/redis-data'
+  shouldExist: true
+  uid: 999
+  gid: 1000
+  permissions: 'drwxr-xr-x'

--- a/docker-images/redis-store/image_test.yaml
+++ b/docker-images/redis-store/image_test.yaml
@@ -12,11 +12,17 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
-  - name: "running as redis"
+  - name: "redis user has correct uid"
     command: "/usr/bin/id"
     args:
       - -u
     expectedOutput: ["^999\n"]
+    exitCode: 0
+  - name: "redis user has correct gid"
+    command: "/usr/bin/id"
+    args:
+      - -g
+    expectedOutput: ["^1000\n"]
     exitCode: 0
 
 fileExistenceTests:

--- a/docker-images/redis_exporter/BUILD.bazel
+++ b/docker-images/redis_exporter/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 oci_image(
     name = "image",
@@ -12,6 +13,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["redis-exporter:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/redis_exporter/image_test.yaml
+++ b/docker-images/redis_exporter/image_test.yaml
@@ -1,0 +1,14 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "redis_exporter is runnable"
+    command: "redis_exporter"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0

--- a/docker-images/search-indexer/BUILD.bazel
+++ b/docker-images/search-indexer/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 DEPS = [
     "@com_github_sourcegraph_zoekt//cmd/zoekt-archive-index",
@@ -33,6 +34,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["zoekt-indexserver:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/search-indexer/image_test.yaml
+++ b/docker-images/search-indexer/image_test.yaml
@@ -4,7 +4,7 @@ commandTests:
   - name: "zoekt-sourcegraph-indexserver is runnable"
     command: "zoekt-sourcegraph-indexserver"
     args:
-      - --version
+      - --help
   - name: "zoekt-archive-index is runnable"
     command: "zoekt-archive-index"
     args:

--- a/docker-images/search-indexer/image_test.yaml
+++ b/docker-images/search-indexer/image_test.yaml
@@ -1,0 +1,57 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "zoekt-sourcegraph-indexserver is runnable"
+    command: "zoekt-sourcegraph-indexserver"
+    args:
+      - --version
+  - name: "zoekt-archive-index is runnable"
+    command: "zoekt-archive-index"
+    args:
+      - --help
+  - name: "zoekt-git-index is runnable"
+    command: "zoekt-git-index"
+    args:
+      - --version
+
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
+  - name: "ctags is runnable"
+    command: "universal-ctags"
+    args:
+      - --version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+fileExistenceTests:
+# zoekt-merge-index doesn't have any arguments we can use for testing
+- name: '/usr/local/bin/zoekt-merge-index'
+  path: '/usr/local/bin/zoekt-merge-index'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-r-xr-xr-x'
+- name: '/data/index'
+  path: '/data/index'
+  shouldExist: true
+  uid: 100
+  gid: 101
+  permissions: 'drwxr-xr-x'
+- name: 'jansson package'
+  path: 'usr/lib/libjansson.la'
+  shouldExist: true
+
+metadataTest:
+  envVars:
+    # TODO: Should this be http or https?
+    # - key: SRC_FRONTEND_INTERNAL
+    #   value: 'http://sourcegraph-frontend-internal'
+    - key: DATA_DIR
+      value: '/data/index'

--- a/docker-images/sg/BUILD.bazel
+++ b/docker-images/sg/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//dev:oci_defs.bzl", "image_repository")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 pkg_tar(
     name = "sg_tarball",
@@ -23,6 +24,15 @@ oci_tarball(
     name = "image_tarball",
     image = ":image",
     repo_tags = ["sg:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
 )
 
 oci_push(

--- a/docker-images/sg/image_test.yaml
+++ b/docker-images/sg/image_test.yaml
@@ -1,0 +1,15 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  # TODO: sg does not exist in final image
+  # - name: "sg is runnable"
+  #   command: "sg"
+  #   args:
+  #     - version
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0

--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -73,6 +73,8 @@ oci_image(
         # See https://github.com/sourcegraph/sourcegraph/issues/2615 for details on
         # what we observed when this was enabled with the default 5s.
         "ROCKET_KEEP_ALIVE": "0",
+        "WORKERS": "4",
+        "QUIET": "true",
     },
     tars = [":tar_syntect_server"],
 )

--- a/docker-images/syntax-highlighter/image_test.yaml
+++ b/docker-images/syntax-highlighter/image_test.yaml
@@ -6,7 +6,6 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
-
   - name: "http-server-stabilizer binary is runnable"
     command: "/usr/local/bin/http-server-stabilizer"
     args: ["-h"]
@@ -18,3 +17,26 @@ commandTests:
   #     - -u
   #   excludedOutput: ["^0"]
   #   exitCode: 0
+
+fileExistenceTests:
+- name: '/data/index'
+  path: '/data/index'
+  shouldExist: true
+  uid: 100
+  gid: 101
+  permissions: 'drwxr-xr-x'
+
+metadataTest:
+  envVars:
+    - key: ROCKET_ENV
+      value: 'production'
+    - key: ROCKET_LIMITS
+      value: '{json=10485760}'
+    - key: ROCKET_SECRET_KEY
+      value: 'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='
+    - key: ROCKET_KEEP_ALIVE
+      value: '0'
+    - key: WORKERS
+      value: '4'
+    - key: QUIET
+      value: 'true'

--- a/docker-images/syntax-highlighter/image_test.yaml
+++ b/docker-images/syntax-highlighter/image_test.yaml
@@ -18,14 +18,6 @@ commandTests:
   #   excludedOutput: ["^0"]
   #   exitCode: 0
 
-fileExistenceTests:
-- name: '/data/index'
-  path: '/data/index'
-  shouldExist: true
-  uid: 100
-  gid: 101
-  permissions: 'drwxr-xr-x'
-
 metadataTest:
   envVars:
     - key: ROCKET_ENV

--- a/enterprise/cmd/batcheshelper/image_test.yaml
+++ b/enterprise/cmd/batcheshelper/image_test.yaml
@@ -6,6 +6,10 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"

--- a/enterprise/cmd/embeddings/image_test.yaml
+++ b/enterprise/cmd/embeddings/image_test.yaml
@@ -6,6 +6,11 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  # TODO: Test currently fails
+  # - name: "bash is runnable"
+  #   command: "bash"
+  #   args:
+  #     - --version
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/enterprise/cmd/executor/image_test.yaml
+++ b/enterprise/cmd/executor/image_test.yaml
@@ -24,3 +24,9 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+# TODO: Test currently fails
+# metadataTest:
+#   envVars:
+#     - key: EXECUTOR_USE_FIRECRACKER
+#       value: false

--- a/enterprise/cmd/executor/image_test.yaml
+++ b/enterprise/cmd/executor/image_test.yaml
@@ -6,6 +6,17 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "docker is runnable"
+    command: "docker"
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
+  # TODO: Test currently fails
+  # - name: "src is runnable"
+  #   command: "src"
+  #   args:
+  #     - version
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/enterprise/cmd/frontend/image_test.yaml
+++ b/enterprise/cmd/frontend/image_test.yaml
@@ -13,3 +13,16 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+fileExistenceTests:
+- name: '/mnt/cache/frontend'
+  path: '/mnt/cache/frontend'
+  shouldExist: true
+  uid: 100
+  gid: 101
+
+metadataTest:
+  envVars:
+    - key: PGHOST
+      value: .+
+      isRegex: true

--- a/enterprise/cmd/gitserver/image_test.yaml
+++ b/enterprise/cmd/gitserver/image_test.yaml
@@ -6,6 +6,39 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
+  - name: "git-lfs is runnable"
+    command: "git-lfs"
+    args:
+      - version
+  - name: "git p4 is runnable"
+    command: "git"
+    args:
+      - p4
+    expectedOutput: ["valid commands: submit"]
+    exitCode: 2
+  - name: "ssh is runnable"
+    command: "ssh"
+    exitCode: 255
+  - name: "python3 is runnable"
+    command: "python3"
+    args:
+      - --version
+  - name: "bash is runnable"
+    command: "bash"
+    args:
+      - --version
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
+  - name: "coursier is runnable"
+    command: "coursier"
+
+# TODO: Missing new p4-fusion-wrapper-detect-kill.sh and process-stats-watcher.sh scripts
 
   - name: "not running as root"
     command: "/usr/bin/id"
@@ -13,3 +46,10 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+fileExistenceTests:
+- name: '/data/repos'
+  path: '/data/repos'
+  shouldExist: true
+  uid: 100
+  gid: 101

--- a/enterprise/cmd/gitserver/image_test.yaml
+++ b/enterprise/cmd/gitserver/image_test.yaml
@@ -37,6 +37,8 @@ commandTests:
       - -h
   - name: "coursier is runnable"
     command: "coursier"
+  - name: "p4-fusion is runnable"
+    command: "p4-fusion"
 
 # TODO: Missing new p4-fusion-wrapper-detect-kill.sh and process-stats-watcher.sh scripts
 

--- a/enterprise/cmd/migrator/image_test.yaml
+++ b/enterprise/cmd/migrator/image_test.yaml
@@ -13,3 +13,11 @@ commandTests:
       - -u
     excludedOutput: ["^0"]
     exitCode: 0
+
+# TODO: Need to add /schema-descriptions to container
+# fileExistenceTests:
+# - name: '/schema-descriptions test'
+#   path: '/schema-descriptions/v3.20.0-internal_database_schema.json'
+#   shouldExist: true
+#   uid: 0
+#   gid: 0

--- a/enterprise/cmd/repo-updater/image_test.yaml
+++ b/enterprise/cmd/repo-updater/image_test.yaml
@@ -6,6 +6,12 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
+  - name: "coursier is runnable"
+    command: "coursier"
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -118,6 +118,11 @@ oci_image(
     name = "image",
     base = "@wolfi_server_base",
     entrypoint = ["/server"],
+    env = {
+        "GO111MODULES": "on",
+        "LANG": "en_US.utf8",
+        "PGHOST": "/var/run/postgresql",
+    },
     tars = [
         ":tar_server",
         ":static_config_tar",

--- a/enterprise/cmd/server/image_test.yaml
+++ b/enterprise/cmd/server/image_test.yaml
@@ -6,64 +6,65 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
-  # Sourcegraph binaries
-  - name: "embeddings binary is runnable"
-    command: "/embeddings"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
 
+  # Sourcegraph binaries
+  # TODO: Add embeddings binary to image
+  # - name: "embeddings binary is runnable"
+  #   command: "/embeddings"
+  #   envVars:
+  #     - key: "SANITY_CHECK"
+  #       value: "true"
   - name: "frontend binary is runnable"
-    command: "/frontend"
+    command: "frontend"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "github-proxy binary is runnable"
-    command: "/github-proxy"
+    command: "github-proxy"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "gitserver binary is runnable"
-    command: "/gitserver"
+    command: "gitserver"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
-
   - name: "migrator binary is runnable"
-    command: "/migrator"
+    command: "migrator"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "precise-code-intel-worker binary is runnable"
-    command: "/precise-code-intel-worker"
+    command: "precise-code-intel-worker"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "repo-updater binary is runnable"
-    command: "/repo-updater"
+    command: "repo-updater"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "searcher binary is runnable"
-    command: "/searcher"
+    command: "searcher"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "symbols binary is runnable"
-    command: "/symbols"
+    command: "symbols"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
-  - name: "syntect_server binary is runnable"
-    command: "/syntect_server"
+  - name: "syntax_highlighter binary is runnable"
+    command: "syntax_highlighter"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "worker binary is runnable"
-    command: "/worker"
+    command: "worker"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+
   # Git
   - name: "git is runnable"
     command: "git"

--- a/enterprise/cmd/server/image_test.yaml
+++ b/enterprise/cmd/server/image_test.yaml
@@ -101,7 +101,7 @@ commandTests:
 
   # Postgresql
   - name: "postgres is runnable"
-    command: "psql"
+    command: "postgres"
     args:
       - --version
   # Bash
@@ -183,12 +183,14 @@ commandTests:
       - --version
   # Grafana
   - name: "grafana-server is runnable"
-    command: "grafana-server"
+    command: "/usr/share/grafana/bin/grafana-server"
     args:
       - -v
   # Correct users and groups
   - name: "correct users exist"
-    command: "cat /etc/passwd"
+    command: "cat"
+    args:
+      - '/etc/passwd'
     expectedOutput: [
       "sourcegraph:x:100:101",
       "postgres:x:70:70",
@@ -221,18 +223,19 @@ fileExistenceTests:
   gid: 0
   permissions: '-r-xr-xr-x'
 # Grafana
-- name: '/opt/grafana/entry.sh'
-  path: '/opt/grafana/entry.sh'
-  shouldExist: true
-  uid: 0
-  gid: 0
-  permissions: '-rwxr-xr-x'
+# TODO: Check if required
+# - name: '/opt/grafana/entry.sh'
+#   path: '/opt/grafana/entry.sh'
+#   shouldExist: true
+#   uid: 0
+#   gid: 0
+#   permissions: '-rwxr-xr-x'
 - name: 'Dashboard config'
   path: '/sg_config_grafana/provisioning/dashboards/sourcegraph/gitserver.json'
   shouldExist: true
   uid: 0
   gid: 0
-  permissions: '-rwxr-xr-x'
+  permissions: '-r-xr-xr-x'
 
 metadataTest:
   envVars:

--- a/enterprise/cmd/server/image_test.yaml
+++ b/enterprise/cmd/server/image_test.yaml
@@ -1,11 +1,200 @@
 schemaVersion: "2.0.0"
 
 commandTests:
-  - name: "binary is runnable"
+  - name: "server binary is runnable"
     command: "/server"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  # Sourcegraph binaries
+  - name: "embeddings binary is runnable"
+    command: "/embeddings"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+
+  - name: "frontend binary is runnable"
+    command: "/frontend"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "github-proxy binary is runnable"
+    command: "/github-proxy"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "gitserver binary is runnable"
+    command: "/gitserver"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+
+  - name: "migrator binary is runnable"
+    command: "/migrator"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "precise-code-intel-worker binary is runnable"
+    command: "/precise-code-intel-worker"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "repo-updater binary is runnable"
+    command: "/repo-updater"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "searcher binary is runnable"
+    command: "/searcher"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "symbols binary is runnable"
+    command: "/symbols"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "syntect_server binary is runnable"
+    command: "/syntect_server"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  - name: "worker binary is runnable"
+    command: "/worker"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+  # Git
+  - name: "git is runnable"
+    command: "git"
+    args:
+      - version
+  - name: "git-lfs is runnable"
+    command: "git-lfs"
+    args:
+      - version
+  - name: "git p4 is runnable"
+    command: "git"
+    args:
+      - p4
+    expectedOutput: ["valid commands: submit"]
+    exitCode: 2
+
+  # Zoekt binaries
+  - name: "zoekt-webserver is runnable"
+    command: "zoekt-webserver"
+    args:
+      - --version
+  - name: "zoekt-archive-index is runnable"
+    command: "zoekt-archive-index"
+    args:
+      - --help
+  - name: "zoekt-git-index is runnable"
+    command: "zoekt-git-index"
+    args:
+      - --version
+  - name: "zoekt-sourcegraph-indexserver is runnable"
+    command: "zoekt-sourcegraph-indexserver"
+    args:
+      - --help
+
+  # Postgresql
+  - name: "postgres is runnable"
+    command: "psql"
+    args:
+      - --version
+  # Bash
+  - name: "bash is runnable"
+    command: "bash"
+    args:
+      - --version
+  # P4 tools
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
+  - name: "p4-fusion is runnable"
+    command: "p4-fusion"
+  # Coursier
+  - name: "coursier is runnable"
+    command: "coursier"
+  # Redis
+  - name: "redis-server is runnable"
+    command: "redis-server"
+    args:
+      - --version
+  # Python3
+  - name: "python3 is runnable"
+    command: "python3"
+    args:
+      - --version
+  # SSH
+  - name: "ssh is runnable"
+    command: "ssh"
+    exitCode: 255
+  # PCRE
+  - name: "pcre is runnable"
+    command: "pcregrep"
+    args:
+      - --help
+  # Comby
+  - name: "comby is runnable"
+    command: "comby"
+    args:
+      - -h
+  # s3proxy
+  - name: "s3proxy is runnable"
+    command: "/opt/s3proxy/s3proxy"
+    args:
+      - --version
+  # Ctags
+  - name: "ctags is runnable"
+    command: "universal-ctags"
+    args:
+      - --version
+  # su-exec
+  - name: "su-exec is runnable"
+    command: "su-exec"
+    args:
+      - --help
+  # nginx
+  - name: "nginx is runnable"
+    command: "nginx"
+    args:
+      - -version
+  # postgres_exporter
+  - name: "postgres_exporter is runnable"
+    command: "postgres_exporter"
+    args:
+      - --version
+  # Prometheus + Alertmanager
+  - name: "prometheus is runnable"
+    command: "prometheus"
+    args:
+      - --version
+  - name: "promtool is runnable"
+    command: "promtool"
+    args:
+      - --version
+  - name: "alertmanager is runnable"
+    command: "alertmanager"
+    args:
+      - --version
+  # Grafana
+  - name: "grafana-server is runnable"
+    command: "grafana-server"
+    args:
+      - -v
+  # Correct users and groups
+  - name: "correct users exist"
+    command: "cat /etc/passwd"
+    expectedOutput: [
+      "sourcegraph:x:100:101",
+      "postgres:x:70:70",
+      "nginx:x:101:102",
+      "redis:x:102:103",
+      "grafana:x:103:104",
+    ]
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"
@@ -14,3 +203,39 @@ commandTests:
   #     - -u
   #   excludedOutput: ["^0"]
   #   exitCode: 0
+
+
+fileExistenceTests:
+# Prometheus
+- name: '/prometheus.sh'
+  path: '/prometheus.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-r-xr-xr-x'
+- name: '/alertmanager.sh'
+  path: '/alertmanager.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-r-xr-xr-x'
+# Grafana
+- name: '/opt/grafana/entry.sh'
+  path: '/opt/grafana/entry.sh'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'
+- name: 'Dashboard config'
+  path: '/sg_config_grafana/provisioning/dashboards/sourcegraph/gitserver.json'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: '-rwxr-xr-x'
+
+metadataTest:
+  envVars:
+    - key: GO111MODULES
+      value: 'on'
+    - key: LANG
+      value: 'en_US.utf8'

--- a/enterprise/cmd/symbols/image_test.yaml
+++ b/enterprise/cmd/symbols/image_test.yaml
@@ -23,8 +23,8 @@ fileExistenceTests:
 - name: '/mnt/cache/symbols'
   path: '/mnt/cache/symbols'
   shouldExist: true
-  uid: 0
-  gid: 0
+  uid: 100
+  gid: 101
   permissions: 'drwxr-xr-x'
 - name: 'jansson package'
   path: 'usr/lib/libjansson.la'

--- a/enterprise/cmd/symbols/image_test.yaml
+++ b/enterprise/cmd/symbols/image_test.yaml
@@ -6,6 +6,10 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "ctags is runnable"
+    command: "ctags"
+    args:
+      - --help
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"
@@ -14,3 +18,14 @@ commandTests:
   #     - -u
   #   excludedOutput: ["^0"]
   #   exitCode: 0
+
+fileExistenceTests:
+- name: '/mnt/cache/symbols'
+  path: '/mnt/cache/symbols'
+  shouldExist: true
+  uid: 0
+  gid: 0
+  permissions: 'drwxr-xr-x'
+- name: 'jansson package'
+  path: 'usr/lib/libjansson.la'
+  shouldExist: true

--- a/enterprise/cmd/symbols/image_test.yaml
+++ b/enterprise/cmd/symbols/image_test.yaml
@@ -7,7 +7,7 @@ commandTests:
       - key: "SANITY_CHECK"
         value: "true"
   - name: "ctags is runnable"
-    command: "ctags"
+    command: "universal-ctags"
     args:
       - --help
 

--- a/enterprise/cmd/symbols/image_test.yaml
+++ b/enterprise/cmd/symbols/image_test.yaml
@@ -9,7 +9,7 @@ commandTests:
   - name: "ctags is runnable"
     command: "universal-ctags"
     args:
-      - --help
+      - --version
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"


### PR DESCRIPTION
Expand the container structure tests to include additional binaries and paths.

I've built this by using the original Dockerfile as a reference, so it will help us detected any discrepancies caused by either the Wolfi or Bazel migrations.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
- Bazel container structure unit tests
