### PR TITLE
(style) update search results page

### DIFF
--- a/client/branded/src/search-ui/components/CodeHostIcon.tsx
+++ b/client/branded/src/search-ui/components/CodeHostIcon.tsx
@@ -4,15 +4,15 @@ import { mdiBitbucket, mdiGithub, mdiGitlab } from '@mdi/js'
 
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
-const iconMap: { [key: string]: string } = {
-    'github.com': mdiGithub,
-    'gitlab.com': mdiGitlab,
-    'bitbucket.org': mdiBitbucket,
+const iconMap: { [key: string]: { svgPath: string; color?: string } } = {
+    'github.com': { svgPath: mdiGithub, color: 'var(--black)' },
+    'gitlab.com': { svgPath: mdiGitlab, color: '#E24329' },
+    'bitbucket.org': { svgPath: mdiBitbucket, color: '#2584FF' },
 }
-export function codeHostIcon(repoName: string): { hostName: string; svgPath?: string } {
+export function codeHostIcon(repoName: string): { hostName: string; svgPath?: string; color?: string } {
     const hostName = repoName.split('/')[0]
 
-    return { hostName, svgPath: iconMap[hostName] }
+    return { hostName, svgPath: iconMap[hostName]?.svgPath, color: iconMap[hostName]?.color }
 }
 
 export function isValidCodeHost(repoName: string): boolean {
@@ -26,12 +26,12 @@ export function isValidCodeHost(repoName: string): boolean {
 export const CodeHostIcon: React.FunctionComponent<
     React.PropsWithChildren<{ repoName: string; className?: string }>
 > = ({ repoName, className }) => {
-    const { hostName, svgPath } = codeHostIcon(repoName)
+    const { hostName, svgPath, color } = codeHostIcon(repoName)
 
     if (svgPath) {
         return (
             <Tooltip content={hostName}>
-                <Icon aria-label={hostName} className={className} svgPath={svgPath} />
+                <Icon aria-label={hostName} className={className} svgPath={svgPath} color={color} />
             </Tooltip>
         )
     }

--- a/client/branded/src/search-ui/components/CommitSearchResult.tsx
+++ b/client/branded/src/search-ui/components/CommitSearchResult.tsx
@@ -36,13 +36,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
 }) => {
     const title = (
         <div className={styles.title}>
-            <span
-                className={classNames(
-                    'test-search-result-label flex-grow-1',
-                    styles.titleInner,
-                    styles.mutedRepoFileLink
-                )}
-            >
+            <span className={classNames('test-search-result-label flex-grow-1', styles.titleInner)}>
                 <Link to={getRepositoryUrl(result.repository)}>{displayRepoName(result.repository)}</Link>
                 <span aria-hidden={true}> ›</span> <Link to={getCommitMatchUrl(result)}>{result.authorName}</Link>
                 <span aria-hidden={true}>{': '}</span>

--- a/client/branded/src/search-ui/components/CommitSearchResult.tsx
+++ b/client/branded/src/search-ui/components/CommitSearchResult.tsx
@@ -72,6 +72,7 @@ export const CommitSearchResult: React.FunctionComponent<Props> = ({
             repoStars={result.repoStars}
             className={containerClassName}
             as={as}
+            repoLastFetched={result.repoLastFetched}
         >
             <CommitSearchResultMatch
                 key={result.url}

--- a/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
+++ b/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
@@ -59,11 +59,6 @@
     position: relative;
 }
 
-.last-synced-icon {
-    /* Override top spacing for smaller padding on commit/diff results */
-    top: 0.25rem;
-}
-
 .match-hover:hover {
     background-color: var(--color-bg-1);
 }

--- a/client/branded/src/search-ui/components/CommitSearchResultMatch.tsx
+++ b/client/branded/src/search-ui/components/CommitSearchResultMatch.tsx
@@ -12,8 +12,6 @@ import { highlightCode } from '@sourcegraph/shared/src/search'
 import { CommitMatch } from '@sourcegraph/shared/src/search/stream'
 import { LoadingSpinner, Link, Code, Markdown } from '@sourcegraph/wildcard'
 
-import { LastSyncedIcon } from './LastSyncedIcon'
-
 import styles from './CommitSearchResultMatch.module.scss'
 import searchResultStyles from './SearchResult.module.scss'
 
@@ -77,9 +75,6 @@ export const CommitSearchResultMatch: React.FunctionComponent<CommitSearchResult
 
     return (
         <div className={styles.commitSearchResultMatch}>
-            {item.repoLastFetched && (
-                <LastSyncedIcon className={styles.lastSyncedIcon} lastSyncedTime={item.repoLastFetched} />
-            )}
             <Link
                 key={item.url}
                 to={item.url}

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -211,7 +211,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                             ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                             : undefined
                     }
-                    className={classNames(styles.titleInner, styles.mutedRepoFileLink)}
+                    className={styles.titleInner}
                 />
                 <CopyPathAction
                     className={styles.copyButton}

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -257,6 +257,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
             resultClassName={resultContainerStyles.highlightResult}
             rankingDebug={result.debug}
             ref={rootRef}
+            repoLastFetched={result.repoLastFetched}
         >
             <div data-testid="file-search-result" data-expanded={expanded}>
                 <FileMatchChildren

--- a/client/branded/src/search-ui/components/FileMatchChildren.tsx
+++ b/client/branded/src/search-ui/components/FileMatchChildren.tsx
@@ -16,7 +16,6 @@ import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-crea
 
 import { CodeExcerpt } from './CodeExcerpt'
 import { navigateToCodeExcerpt, navigateToFileOnMiddleMouseButtonClick } from './codeLinkNavigation'
-import { LastSyncedIcon } from './LastSyncedIcon'
 
 import styles from './FileMatchChildren.module.scss'
 
@@ -123,8 +122,6 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
             data-testid="file-match-children"
             data-selectable-search-results-group="true"
         >
-            {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
-
             {/* Line matches */}
             {grouped.length > 0 && (
                 <div>

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -6,7 +6,6 @@ import { getFileMatchUrl, getRepositoryUrl, getRevision, PathMatch } from '@sour
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CopyPathAction } from './CopyPathAction'
-import { LastSyncedIcon } from './LastSyncedIcon'
 import { RepoFileLink } from './RepoFileLink'
 import { ResultContainer } from './ResultContainer'
 
@@ -61,9 +60,9 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
             repoStars={result.repoStars}
             rankingDebug={result.debug}
             className={classNames(styles.copyButtonContainer, containerClassName)}
+            repoLastFetched={result.repoLastFetched}
         >
             <div className={classNames(styles.searchResultMatch, 'p-2')}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                 <small>{result.pathMatches ? 'Path match' : 'File contains matching content'}</small>
             </div>
         </ResultContainer>

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -44,7 +44,7 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
                         ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                         : undefined
                 }
-                className={classNames(styles.titleInner, styles.mutedRepoFileLink)}
+                className={styles.titleInner}
                 isKeyboardSelectable={true}
             />
             <CopyPathAction filePath={result.path} className={styles.copyButton} telemetryService={telemetryService} />

--- a/client/branded/src/search-ui/components/LastSyncedIcon.module.scss
+++ b/client/branded/src/search-ui/components/LastSyncedIcon.module.scss
@@ -1,8 +1,0 @@
-.last-synced-icon {
-    position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
-    height: 1rem;
-    isolation: isolate;
-    z-index: 1;
-}

--- a/client/branded/src/search-ui/components/LastSyncedIcon.tsx
+++ b/client/branded/src/search-ui/components/LastSyncedIcon.tsx
@@ -6,8 +6,6 @@ import format from 'date-fns/format'
 
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 
-import styles from './LastSyncedIcon.module.scss'
-
 interface Props {
     lastSyncedTime: string
     className?: string
@@ -40,7 +38,7 @@ export const LastSyncedIcon: React.FunctionComponent<React.PropsWithChildren<Pro
         <Tooltip content={status}>
             <Icon
                 tabIndex={0}
-                className={classNames(props.className, styles.lastSyncedIcon, 'text-muted')}
+                className={classNames(props.className, 'text-muted')}
                 aria-label={status}
                 svgPath={icon}
                 style={{ fill: color }}

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -43,7 +43,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     const title = (
         <div className={styles.title}>
-            <span className={classNames('test-search-result-label', styles.titleInner, styles.mutedRepoFileLink)}>
+            <span className={classNames('test-search-result-label', styles.titleInner)}>
                 <Link to={getRepoMatchUrl(result)} ref={repoNameElement} data-selectable-search-result="true">
                     {displayRepoName(getRepoMatchLabel(result))}
                 </Link>

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -6,7 +6,7 @@ import { highlightNode } from '@sourcegraph/common'
 import { codeHostSubstrLength, displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { BuildSearchQueryURLParameters, QueryState } from '@sourcegraph/shared/src/search'
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
-import { Link } from '@sourcegraph/wildcard'
+import { Link, Text } from '@sourcegraph/wildcard'
 
 import { RepoMetadata } from './RepoMetadata'
 import { ResultContainer } from './ResultContainer'
@@ -90,26 +90,24 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             as={as}
         >
             {(description || showRepoMetadata) && (
-                <div data-testid="search-repo-result">
-                    <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-                        {description && (
-                            <small>
-                                <em ref={repoDescriptionElement}>
-                                    {description.length > REPO_DESCRIPTION_CHAR_LIMIT
-                                        ? description.slice(0, REPO_DESCRIPTION_CHAR_LIMIT) + ' ...'
-                                        : description}
-                                </em>
-                            </small>
-                        )}
-                        {showRepoMetadata && (
-                            <RepoMetadata
-                                className="mt-2"
-                                queryState={queryState}
-                                buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
-                                items={Object.entries(metadata).map(([key, value]) => ({ key, value }))}
-                            />
-                        )}
-                    </div>
+                <div
+                    data-testid="search-repo-result"
+                    className={classNames(styles.searchResultMatch, styles.gap1, 'p-2 flex-column')}
+                >
+                    {description && (
+                        <Text as="em" ref={repoDescriptionElement}>
+                            {description.length > REPO_DESCRIPTION_CHAR_LIMIT
+                                ? description.slice(0, REPO_DESCRIPTION_CHAR_LIMIT) + ' ...'
+                                : description}
+                        </Text>
+                    )}
+                    {showRepoMetadata && (
+                        <RepoMetadata
+                            queryState={queryState}
+                            buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
+                            items={Object.entries(metadata).map(([key, value]) => ({ key, value }))}
+                        />
+                    )}
                 </div>
             )}
         </ResultContainer>

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -9,7 +9,6 @@ import { BuildSearchQueryURLParameters, QueryState } from '@sourcegraph/shared/s
 import { getRepoMatchLabel, getRepoMatchUrl, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { Icon, Link } from '@sourcegraph/wildcard'
 
-import { LastSyncedIcon } from './LastSyncedIcon'
 import { RepoMetadata } from './RepoMetadata'
 import { ResultContainer } from './ResultContainer'
 
@@ -90,10 +89,10 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             repoStars={result.repoStars}
             className={containerClassName}
             as={as}
+            repoLastFetched={result.repoLastFetched}
         >
             <div data-testid="search-repo-result">
                 <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-                    {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                     <div className="d-flex align-items-center flex-row">
                         <div className={styles.matchType}>
                             <small>Repository match</small>

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -8,6 +8,7 @@ import { ForwardReferenceExoticComponent } from '@sourcegraph/wildcard'
 import { formatRepositoryStarCount } from '../util/stars'
 
 import { CodeHostIcon } from './CodeHostIcon'
+import { LastSyncedIcon } from './LastSyncedIcon'
 import { SearchResultStar } from './SearchResultStar'
 
 import styles from './ResultContainer.module.scss'
@@ -18,6 +19,7 @@ export interface ResultContainerProps {
     titleClassName?: string
     resultClassName?: string
     repoStars?: number
+    repoLastFetched?: string
     resultType?: SearchMatch['type']
     repoName?: string
     className?: string
@@ -55,6 +57,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
         rankingDebug,
         as: Component = 'div',
         onResultClicked,
+        repoLastFetched,
     } = props
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(repoStars)
@@ -87,6 +90,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                             <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
                         </span>
                     )}
+                    {repoLastFetched && <LastSyncedIcon lastSyncedTime={repoLastFetched} className="ml-2" />}
                 </div>
                 {rankingDebug && <div>{rankingDebug}</div>}
                 <div className={classNames(styles.result, resultClassName)}>{children}</div>

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -77,7 +77,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                     {/* Add a result type to be read out to screen readers only, so that screen reader users can
                     easily scan the search results list (for example, by navigating by landmarks). */}
                     <span className="sr-only">{resultType ? accessibleResultType[resultType] : 'search'} result,</span>
-                    {repoName && <CodeHostIcon repoName={repoName} className="text-muted flex-shrink-0 mr-1" />}
+                    {repoName && <CodeHostIcon repoName={repoName} className="flex-shrink-0 mr-1" />}
                     <div
                         className={classNames(styles.headerTitle, titleClassName)}
                         data-testid="result-container-header"

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 
+import { mdiArchive, mdiLock, mdiSourceFork } from '@mdi/js'
 import classNames from 'classnames'
 
 import { SearchMatch } from '@sourcegraph/shared/src/search/stream'
-import { ForwardReferenceExoticComponent } from '@sourcegraph/wildcard'
+import { ForwardReferenceExoticComponent, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import { formatRepositoryStarCount } from '../util/stars'
 
@@ -25,6 +26,9 @@ export interface ResultContainerProps {
     className?: string
     rankingDebug?: string
     onResultClicked?: () => void
+    isFork?: boolean
+    isArchived?: boolean
+    isPrivate?: boolean
 }
 
 const accessibleResultType: Record<SearchMatch['type'], string> = {
@@ -58,6 +62,9 @@ export const ResultContainer: ForwardReferenceExoticComponent<
         as: Component = 'div',
         onResultClicked,
         repoLastFetched,
+        isFork,
+        isArchived,
+        isPrivate,
     } = props
 
     const formattedRepositoryStarCount = formatRepositoryStarCount(repoStars)
@@ -90,10 +97,37 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                             <span aria-hidden={true}>{formattedRepositoryStarCount}</span>
                         </span>
                     )}
+                    {isFork && (
+                        <Tooltip content="Forked repository">
+                            <Icon
+                                aria-label="Forked repository"
+                                className="flex-shrink-0 text-muted ml-2"
+                                svgPath={mdiSourceFork}
+                            />
+                        </Tooltip>
+                    )}
+                    {isArchived && (
+                        <Tooltip content="Archived repository">
+                            <Icon
+                                aria-label="Archived repository"
+                                className="flex-shrink-0 text-muted ml-2"
+                                svgPath={mdiArchive}
+                            />
+                        </Tooltip>
+                    )}
+                    {isPrivate && (
+                        <Tooltip content="Private repository">
+                            <Icon
+                                aria-label="Private repository"
+                                className="flex-shrink-0 text-muted ml-2"
+                                svgPath={mdiLock}
+                            />
+                        </Tooltip>
+                    )}
                     {repoLastFetched && <LastSyncedIcon lastSyncedTime={repoLastFetched} className="ml-2" />}
                 </div>
                 {rankingDebug && <div>{rankingDebug}</div>}
-                <div className={classNames(styles.result, resultClassName)}>{children}</div>
+                {children && <div className={classNames(styles.result, resultClassName)}>{children}</div>}
             </article>
         </Component>
     )

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -88,18 +88,6 @@
     padding: 0.25rem;
 }
 
-.muted-repo-file-link {
-    color: var(--text-muted);
-
-    a {
-        color: var(--text-muted);
-
-        &:hover {
-            color: var(--text-muted);
-        }
-    }
-}
-
 .header-description {
     line-height: (14/11);
 }

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -9,10 +9,6 @@
     padding: 0.25rem 0;
     position: relative;
 
-    &-clickable {
-        cursor: pointer;
-    }
-
     &:hover {
         text-decoration: none;
     }
@@ -46,10 +42,6 @@
     }
 }
 
-.icon {
-    margin-right: 0.25rem;
-}
-
 .match-type {
     white-space: nowrap;
 }
@@ -64,10 +56,6 @@
     border-right: 1px solid var(--border-color-2);
     height: 1rem;
     margin: 0 0.5rem;
-}
-
-.spacer {
-    flex: 1;
 }
 
 .title {
@@ -111,20 +99,6 @@
 
     &-text {
         margin-left: 0.125rem;
-    }
-}
-
-.collapsible-results {
-    // The LastSyncedIcon is absolutely-positions inside the search results.
-    // This causes it to show over the sticky header when scrolling unless
-    // we isolate the search result contents.
-    isolation: isolate;
-
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color);
-
-    &:hover {
-        border-color: var(--border-color-2);
     }
 }
 

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -114,3 +114,7 @@
         visibility: visible;
     }
 }
+
+.gap-1 {
+    gap: 0.5rem;
+}

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -63,7 +63,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                         ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                         : undefined
                 }
-                className={classNames(searchResultStyles.titleInner, searchResultStyles.mutedRepoFileLink)}
+                className={searchResultStyles.titleInner}
             />
             <CopyPathAction
                 filePath={result.path}

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -16,7 +16,6 @@ import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-crea
 import { CodeExcerpt } from './CodeExcerpt'
 import { navigateToCodeExcerpt, navigateToFileOnMiddleMouseButtonClick } from './codeLinkNavigation'
 import { CopyPathAction } from './CopyPathAction'
-import { LastSyncedIcon } from './LastSyncedIcon'
 import { RepoFileLink } from './RepoFileLink'
 import { ResultContainer } from './ResultContainer'
 
@@ -138,9 +137,9 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
             repoStars={result.repoStars}
             className={classNames(searchResultStyles.copyButtonContainer, containerClassName)}
             resultClassName={styles.symbolsOverride}
+            repoLastFetched={result.repoLastFetched}
         >
             <div className={styles.symbols}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                 {result.symbols.map(symbol => (
                     <div
                         key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}

--- a/client/vscode/src/webview/search-panel/alias/FileMatchChildren.tsx
+++ b/client/vscode/src/webview/search-panel/alias/FileMatchChildren.tsx
@@ -5,7 +5,7 @@ import * as H from 'history'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
-import { LastSyncedIcon, FileMatchChildrenStyles as styles, CodeExcerpt } from '@sourcegraph/branded'
+import { FileMatchChildrenStyles as styles, CodeExcerpt } from '@sourcegraph/branded'
 import { HoverMerged } from '@sourcegraph/client-api'
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { appendLineRangeQueryParameter, toPositionOrRangeQueryParameter } from '@sourcegraph/common'
@@ -226,7 +226,6 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
 
     return (
         <div className={styles.fileMatchChildren} data-testid="file-match-children">
-            {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
             {/* Path */}
             {result.type === 'path' && (
                 <div className={styles.item} data-testid="file-match-children-item">

--- a/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoSearchResult.tsx
@@ -4,7 +4,7 @@ import { mdiSourceFork, mdiArchive, mdiLock } from '@mdi/js'
 import classNames from 'classnames'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 
-import { SearchResultStyles as styles, LastSyncedIcon, LegacyResultContainer } from '@sourcegraph/branded'
+import { SearchResultStyles as styles, LegacyResultContainer } from '@sourcegraph/branded'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { getRepoMatchLabel, RepositoryMatch } from '@sourcegraph/shared/src/search/stream'
 import { Button, Icon } from '@sourcegraph/wildcard'
@@ -47,7 +47,6 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const renderBody = (): JSX.Element => (
         <div data-testid="search-repo-result">
             <div className={classNames(styles.searchResultMatch, 'p-2 flex-column')}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                 <div className="d-flex align-items-center flex-row">
                     <div className={styles.matchType}>
                         <small>Repository match</small>

--- a/client/vscode/src/webview/search-panel/alias/SymbolSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/SymbolSearchResult.tsx
@@ -66,7 +66,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                         ? `${repoDisplayName}${revisionDisplayName ? `@${revisionDisplayName}` : ''}`
                         : undefined
                 }
-                className={classNames(searchResultStyles.titleInner, searchResultStyles.mutedRepoFileLink)}
+                className={classNames(searchResultStyles.titleInner)}
             />
             <CopyPathAction
                 filePath={result.path}

--- a/client/vscode/src/webview/search-panel/alias/SymbolSearchResult.tsx
+++ b/client/vscode/src/webview/search-panel/alias/SymbolSearchResult.tsx
@@ -5,7 +5,6 @@ import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import {
-    LastSyncedIcon,
     SymbolSearchResultStyles as styles,
     SearchResultStyles as searchResultStyles,
     CodeExcerpt,
@@ -134,9 +133,9 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
             repoStars={result.repoStars}
             className={classNames(searchResultStyles.copyButtonContainer, containerClassName)}
             resultClassName={styles.symbolsOverride}
+            repoLastFetched={result.repoLastFetched}
         >
             <div className={styles.symbols}>
-                {result.repoLastFetched && <LastSyncedIcon lastSyncedTime={result.repoLastFetched} />}
                 {result.symbols.map(symbol => (
                     <div
                         key={`symbol:${symbol.name}${String(symbol.containerName)}${symbol.url}`}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52551.

## Test plan
- `sg start`
- Search different result types and check the UI in light/dark mode

## Screenshots
| Before | After |
| --: | :-- |
| <img width="1464" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/17fb5190-36cd-4600-a5da-3fe00315a5ca"> |  <img width="1464" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/70d22798-8a12-468f-ac39-88afdf301903"> |
| <img width="1464" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/e683fa5f-0c8b-42ae-8e58-cf95e5e40d1a"> | <img width="1464" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/96306f59-00ce-4f65-897c-37d44a9bdb9e"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
