### PR TITLE
App: Fix no code hosts (repositories) link in the status UI

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -373,7 +373,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                     {fuzzyFinderNavbar && FuzzyFinderNavItem(props.setFuzzyFinderIsVisible)}
                     {props.authenticatedUser?.siteAdmin && (
                         <NavAction>
-                            <StatusMessagesNavItem />
+                            <StatusMessagesNavItem isSourcegraphApp={isSourcegraphApp} />
                         </NavAction>
                     )}
                     {!props.authenticatedUser ? (

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -273,9 +273,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                                 key="no-repositories"
                                 title="No repositories"
                                 message="Connect a code host to connect repositories to Sourcegraph."
-                                linkTo={
-                                    props.isSourcegraphApp ? '/users/admin/app-settings/local-repositories' : '/setup'
-                                }
+                                linkTo={props.isSourcegraphApp ? '/user/app-settings/local-repositories' : '/setup'}
                                 linkText="Setup code hosts"
                                 linkOnClick={toggleIsOpen}
                                 entryType="info"

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -172,6 +172,7 @@ const STATUS_MESSAGES_POLL_INTERVAL = 10000
 
 interface Props {
     disablePolling?: boolean
+    isSourcegraphApp?: boolean
 }
 /**
  * Displays a status icon in the navbar reflecting the completion of backend
@@ -272,7 +273,9 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                                 key="no-repositories"
                                 title="No repositories"
                                 message="Connect a code host to connect repositories to Sourcegraph."
-                                linkTo="/setup"
+                                linkTo={
+                                    props.isSourcegraphApp ? '/users/admin/app-settings/local-repositories' : '/setup'
+                                }
                                 linkText="Setup code hosts"
                                 linkOnClick={toggleIsOpen}
                                 entryType="info"

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -344,7 +344,7 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                 })}
             </>
         )
-    }, [data])
+    }, [data, props.isSourcegraphApp])
 
     return (
         <Popover isOpen={isOpen} onOpenChange={event => setIsOpen(event.isOpen)}>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/52558

## Test plan
- Open the app without any repositories and check the link in the repo status UI 
- It should lead to the repository setting page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
