### PR TITLE
Use SRC_LOG_LEVEL for audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ All notable changes to Sourcegraph are documented in this file.
 - The commit message defined in a batch spec will now be quoted when git is invoked, i.e. `git commit -m "commit message"`, to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash. This may mean that previous escaping strategies will behave differently.
 - 429 errors from external services Sourcegraph talks to are only retried automatically if the Retry-After header doesn't indicate that a retry would be useless. The time grace period can be configured using `SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION` and `SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION`. [#51743](https://github.com/sourcegraph/sourcegraph/pull/51743)
 - Security Events NO LONGER write to database by default - instead, they will be written in the [audit log format](https://docs.sourcegraph.com/admin/audit_log) to console. There is a new site config setting `log.securityEventLogs` that can be used to configure security event logs to write to database if the old behaviour is desired. This new default will significantly improve performance for large instances. In addition, the old environment variable `SRC_DISABLE_LOG_PRIVATE_REPO_ACCESS` no longer does anything. [#51686](https://github.com/sourcegraph/sourcegraph/pull/51686)
+- Audit Logs & Security Events are written with the same severity level as `SRC_LOG_LEVEL`. This prevents a misconfiguration
+  issue when `log.AuditLogs.SeverityLevel` was set below the overall instance log level. `log.AuditLogs.SeverityLevel` has
+  been marked as deprecated and will be removed in a future release [#52566](https://github.com/sourcegraph/sourcegraph/pull/52566)
 - Update minimum supported Redis version to 6.2 [#52248](https://github.com/sourcegraph/sourcegraph/pull/52248)
 
 ### Fixed

--- a/doc/admin/audit_log.md
+++ b/doc/admin/audit_log.md
@@ -91,7 +91,7 @@ Audit logs are structured logs. As long as one can ingest logs, we assume one ca
 
 There are two easy approaches to filtering the audit logs:
 
-- JSON-based: look for the presence of the `Attributes.audit` node.
+- JSON-based: look for the presence of the `Attributes.audit` node. Do not depend on the log level, as it can change based on `SRC_LOG_LEVEL`.
 - Message-based: we recommend going the JSON route, but if there's no easy way of parsing JSON using your SIEM or data processing stack, you can filter based on the following string: `auditId`.
 
 ### Cloud

--- a/doc/admin/audit_log.md
+++ b/doc/admin/audit_log.md
@@ -71,7 +71,7 @@ The audit log is currently configured using the site config. Here's the correspo
       "internalTraffic": false,
       "graphQL": false,
       "gitserverAccess": false,
-      "severityLevel": "INFO"
+      "severityLevel": "INFO" // DEPRECATED, defaults to SRC_LOG_LEVEL
     }
     "securityEventLog": {
      "location": "auditlog" // option to set "database" or "all" as well, default to outputing as an audit log 
@@ -82,7 +82,6 @@ We believe the individual settings are self-explanatory, but here are a couple o
 
 - `securityEventLog` configures the destination of security events, logging to the database may result in performance issues
 - `internalTraffic` is disabled by default and will result in security events from internal traffic not being logged
-- We recommend using `INFO` level severity, but beware, if your instance sets the base logging level above, the audit log will be lost.
 
 ## Using
 

--- a/doc/admin/audit_log.md
+++ b/doc/admin/audit_log.md
@@ -126,9 +126,9 @@ audit.Log(ctx, logger, audit.Record{
 The `audit.actor` node carries ID of the user who performed the action (`actorUID`), but it’s not mapped into a full Sourcegraph user right now. You can, however, obtain the user details by following these steps:
 
 1. Grab the user ID from the audit log
-2. Base64 [encode](https://www.base64encode.org) the ID with a "User:" prefix. For example, for Actor with ID 71 use `User:71`, which encodes to `VXNlcjo3MQ==`
-4. Navigate to Site Admin -> API Console and run the query below
-5. Find the corresponding user by searching the query results for the encoded ID from above
+1. Base64 [encode](https://www.base64encode.org) the ID with a "User:" prefix. For example, for Actor with ID 71 use `User:71`, which encodes to `VXNlcjo3MQ==`
+1. Navigate to Site Admin -> API Console and run the query below
+1. Find the corresponding user by searching the query results for the encoded ID from above
 
 GraphQL query:
 ```
@@ -140,4 +140,17 @@ GraphQL query:
     }
   }
 }
+```
+
+**Excessive audit logging**
+
+If you are seeing a large number of logs in the format `frontend.SecurityEvents` or similar, these are securityEventLogs.
+
+To disable them, in the site config set `log.securityEventLog.location` to `none`.
+
+```
+ "log": {
+    "securityEventLog": {
+      "location": "none"
+    }
 ```

--- a/doc/admin/audit_log.md
+++ b/doc/admin/audit_log.md
@@ -142,7 +142,7 @@ GraphQL query:
 }
 ```
 
-**Excessive audit logging**
+### Excessive audit logging
 
 If you are seeing a large number of logs in the format `frontend.SecurityEvents` or similar, these are securityEventLogs.
 

--- a/internal/audit/BUILD.bazel
+++ b/internal/audit/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//internal/actor",
         "//internal/conf",
+        "//internal/env",
         "//internal/requestclient",
         "//schema",
         "@com_github_sourcegraph_log//:log",

--- a/internal/audit/BUILD.bazel
+++ b/internal/audit/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//internal/actor",
         "//internal/conf",
+        "//internal/env",
         "//internal/requestclient",
         "//schema",
         "@com_github_google_uuid//:uuid",

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -3,10 +3,10 @@ package audit
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sourcegraph/log"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
 
 // Log creates an INFO log statement that will be a part of the audit log.
 // The audit log records comply with the following design: an actor takes an action on an entity within a context.
@@ -107,18 +106,18 @@ func IsEnabled(cfg schema.SiteConfiguration, setting AuditLogSetting) bool {
 
 // getLoggerFuncWithSeverity returns a specific logger function (logger.Info, logger.Warn, etc.) based on the overall audit log configuration
 func getLoggerFuncWithSeverity(logger log.Logger) func(string, ...log.Field) {
-	lvl := log.Level(env.LogLevel).Parse()
+	lvl := log.Level(strings.ToLower(env.LogLevel))
 	switch lvl {
-	case zapcore.DebugLevel:
+	case log.LevelDebug:
 		return logger.Debug
-	case zapcore.InfoLevel:
+	case log.LevelInfo:
 		return logger.Info
-	case zapcore.WarnLevel:
+	case log.LevelWarn:
 		return logger.Warn
-	case zapcore.ErrorLevel:
+	case log.LevelError:
 		return logger.Error
 	default:
-		return logger.Info
+		return logger.Warn // match default log level
 	}
 }
 

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -197,18 +198,19 @@ func TestIsEnabled(t *testing.T) {
 	}
 }
 
-func TestSwitchingSeverityLevel(t *testing.T) {
+// Remove when deprecated audit log schema.Log.AuditLog.SeverityLevel is removed.
+func TestSwitchingSeverityLevelDoesNothing(t *testing.T) {
 	useAuditLogLevel("INFO")
 	defer conf.Mock(nil)
 
 	logs := auditLogMessage(t)
 	assert.Equal(t, 1, len(logs))
-	assert.Equal(t, log.LevelInfo, logs[0].Level)
+	assert.Equal(t, log.Level(env.LogLevel), logs[0].Level)
 
 	useAuditLogLevel("WARN")
 	logs = auditLogMessage(t)
 	assert.Equal(t, 1, len(logs))
-	assert.Equal(t, log.LevelWarn, logs[0].Level)
+	assert.Equal(t, log.Level(env.LogLevel), logs[0].Level)
 }
 
 func useAuditLogLevel(level string) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -78,7 +78,7 @@ type AuditLog struct {
 	GraphQL bool `json:"graphQL"`
 	// InternalTraffic description: Capture security events performed by the internal traffic (adds significant noise).
 	InternalTraffic bool `json:"internalTraffic"`
-	// SeverityLevel description: Severity logging level for the audit log.
+	// SeverityLevel description: DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL
 	SeverityLevel string `json:"severityLevel,omitempty"`
 }
 

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1429,7 +1429,8 @@
               "default": false
             },
             "severityLevel": {
-              "description": "Severity logging level for the audit log.",
+              "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
+              "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
               "enum": ["DEBUG", "INFO", "WARN", "ERROR"],
               "default": "INFO"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1432,8 +1432,7 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": ["DEBUG", "INFO", "WARN", "ERROR"],
-              "default": "INFO"
+              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
             }
           },
           "required": ["internalTraffic", "graphQL", "gitserverAccess"],
@@ -1441,8 +1440,7 @@
             {
               "internalTraffic": false,
               "graphQL": false,
-              "gitserverAccess": false,
-              "severityLevel": "INFO"
+              "gitserverAccess": false
             }
           ]
         },


### PR DESCRIPTION
SRC_LOG_LEVEL is not immediately viewable to the site admin. We should set our audit logs to the same level to avoid the footgun of setting the log level below the instance level, which would result in unexpected behavior of NO audit logs being captured. 

This results in audit logging occurring by default on startup for security event logs which may be unexpected and requires the user to explicitly set no audit logs to be gathered. 



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Go tests and manual testing
