### PR TITLE
fix doc url for executors binary

### DIFF
--- a/doc/admin/executors/deploy_executors_kubernetes.md
+++ b/doc/admin/executors/deploy_executors_kubernetes.md
@@ -25,7 +25,7 @@ Ensure you have the following tools installed:
 
 1. Clone the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository to your local machine.
 2. Run `cd deploy-sourcegraph/configure/executors`.
-3. Configure the [Executor environment variables](https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables) in the `executor/executor.deployment.yaml` file.
+3. Configure the [Executor environment variables](https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables) in the `executor/executor.deployment.yaml` file.
 4. Run  `kubectl apply -f . --recursive` to deploy all components.
 5. Confirm executors are working are working by checking the _Executors_ page under **Site admin > Executors > Instances** .
 
@@ -182,7 +182,7 @@ Ensure you have the following tools installed.
 1. Clone the [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) repository to your local machine.
 2. Run `cd deploy-sourcegraph/configure/executors`.
 3. Configure
-   the [Executor environment variables](https://docs.sourcegraph.com/admin/deploy_executors_binary#step-2-setup-environment-variables)
+   the [Executor environment variables](https://docs.sourcegraph.com/admin/executors/deploy_executors_binary#step-2-setup-environment-variables)
    in the `executor/executor.deployment.yaml` file.
 4. Run  `kubectl apply -f . --recursive` to deploy all components.
 5. Confirm executors are working by checking the _Executors_ page under _Site Admin_ > _Executors_ > _Instances_ .


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
A customer reported some links in the docs were pointing to a non-existent URL, this PR fixes that.