### PR TITLE
frontend/bg: disable deleteOldSecurityEventLogsInPostgres by default

### DIFF
--- a/cmd/frontend/internal/bg/BUILD.bazel
+++ b/cmd/frontend/internal/bg/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//cmd/frontend/globals",
         "//cmd/frontend/internal/auth/userpasswd",
+        "//internal/conf",
         "//internal/conf/deploy",
         "//internal/database",
         "//internal/rbac",

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -201,7 +201,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	goroutine.Go(func() { bg.CheckRedisCacheEvictionPolicy() })
 	goroutine.Go(func() { bg.DeleteOldCacheDataInRedis() })
 	goroutine.Go(func() { bg.DeleteOldEventLogsInPostgres(context.Background(), db) })
-	goroutine.Go(func() { bg.DeleteOldSecurityEventLogsInPostgres(context.Background(), db) })
+	goroutine.Go(func() { bg.DeleteOldSecurityEventLogsInPostgres(context.Background(), logger, db) })
 	goroutine.Go(func() { bg.UpdatePermissions(ctx, logger, db) })
 	goroutine.Go(func() { updatecheck.Start(logger, db) })
 	goroutine.Go(func() { adminanalytics.StartAnalyticsCacheRefresh(context.Background(), db) })

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -200,7 +200,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	goroutine.Go(func() { bg.CheckRedisCacheEvictionPolicy() })
 	goroutine.Go(func() { bg.DeleteOldCacheDataInRedis() })
-	goroutine.Go(func() { bg.DeleteOldEventLogsInPostgres(context.Background(), db) })
+	goroutine.Go(func() { bg.DeleteOldEventLogsInPostgres(context.Background(), logger, db) })
 	goroutine.Go(func() { bg.DeleteOldSecurityEventLogsInPostgres(context.Background(), logger, db) })
 	goroutine.Go(func() { bg.UpdatePermissions(ctx, logger, db) })
 	goroutine.Go(func() { updatecheck.Start(logger, db) })


### PR DESCRIPTION
As of https://github.com/sourcegraph/sourcegraph/pull/51686 we will no longer write audit logs to DB by default. I noticed this background prune job is causing high load on a customer instance, and I think this should be disabled by default now as well.

While here, I also removed the log15 usages from this file.

## Test plan

n/a
