### PR TITLE
(fix) enable 'repository-metadata' feature flag by default

### DIFF
--- a/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
+++ b/client/web/src/search/results/components/aggregation/components/aggregation-mode-controls/AggregationModeControls.tsx
@@ -24,7 +24,7 @@ export const AggregationModeControls: FC<AggregationModeControlsProps> = props =
     const { mode, loading, availability = [], size, className, onModeChange, onModeHover, ...attributes } = props
 
     const debouncedOnModeHover = useDebouncedCallback(onModeHover, 1000)
-    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', false)
+    const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
     const availabilityGroups = availability.reduce((store, availability) => {
         store[availability.mode] = availability


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/52301.

Apparently I missed one place where `repository-metadata` feature flag is set false by default. This PR fixes it to make it on by default.

## Test plan
- `sg start`
- Remove `repository-metadata` feature flag if exist
- Search and check that "repo metadata" aggregation is available 

## Screenshot
|BEFORE | AFTER |
| --: | :--|
| <img width="1475" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/5c20c52f-3f1b-4d80-9983-1fafaef13a3e"> |  <img width="1475" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/75fd746a-03f1-49aa-8d8c-15496bab5bc1"> |

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
