### PR TITLE
gitserver: Use a generic FIFO queue for cloning repos

### DIFF
--- a/cmd/gitserver/server/common/BUILD.bazel
+++ b/cmd/gitserver/server/common/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "common",
     srcs = [
         "common.go",
+        "queue.go",
         "run.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common",
@@ -20,7 +21,10 @@ go_library(
 
 go_test(
     name = "common_test",
-    srcs = ["run_test.go"],
+    srcs = [
+        "queue_test.go",
+        "run_test.go",
+    ],
     embed = [":common"],
     deps = [
         "//internal/conf",

--- a/cmd/gitserver/server/common/queue.go
+++ b/cmd/gitserver/server/common/queue.go
@@ -14,6 +14,14 @@ type Queue[T any] struct {
 	Cond  *sync.Cond
 }
 
+// NewQueue initializes a new Queue.
+func NewQueue[T any](jobs *list.List) *Queue[T] {
+	q := Queue[T]{jobs: jobs}
+	q.Cond = sync.NewCond(&q.Mutex)
+
+	return &q
+}
+
 // Push will queue the job to the end of the queue.
 func (q *Queue[T]) Push(job *T) {
 	q.mu.Lock()
@@ -41,12 +49,4 @@ func (q *Queue[T]) Empty() bool {
 	defer q.mu.Unlock()
 
 	return q.jobs.Len() == 0
-}
-
-// NewQueue initializes a new Queue.
-func NewQueue[T any](jobs *list.List) *Queue[T] {
-	q := Queue[T]{jobs: jobs}
-	q.Cond = sync.NewCond(&q.Mutex)
-
-	return &q
 }

--- a/cmd/gitserver/server/common/queue.go
+++ b/cmd/gitserver/server/common/queue.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"container/list"
+	"sync"
+)
+
+// Queue is a threadsafe FIFO queue.
+type Queue[T any] struct {
+	mu   sync.Mutex
+	jobs *list.List
+
+	Mutex sync.Mutex
+	Cond  *sync.Cond
+}
+
+// Push will queue the job to the end of the queue.
+func (q *Queue[T]) Push(job *T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.jobs.PushBack(job)
+	q.Cond.Signal()
+}
+
+// Pop will return the next job. If there's no next job available, it returns nil.
+func (q *Queue[T]) Pop() *T {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	next := q.jobs.Front()
+	if next == nil {
+		return nil
+	}
+
+	return q.jobs.Remove(next).(*T)
+}
+
+func (q *Queue[T]) Empty() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	return q.jobs.Len() == 0
+}
+
+// NewQueue initializes a new Queue.
+func NewQueue[T any](jobs *list.List) *Queue[T] {
+	q := Queue[T]{jobs: jobs}
+	q.Cond = sync.NewCond(&q.Mutex)
+
+	return &q
+}

--- a/cmd/gitserver/server/common/queue_test.go
+++ b/cmd/gitserver/server/common/queue_test.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"container/list"
+	"testing"
+)
+
+func TestQueue(t *testing.T) {
+	queue := NewQueue[int](list.New())
+
+	if !queue.Empty() {
+		t.Error("Expected queue to be empty initially")
+	}
+
+	// Push 1, 2 and 3 into the queue.
+	for i := 1; i < 4; i++ {
+		v := i
+		queue.Push(&v)
+	}
+
+	if queue.Empty() {
+		t.Error("Expected queue to not be empty after pushing elements")
+	}
+
+	// Pop and expect 1, 2 and 3 in that order (FIFO queue).
+	for i := 1; i < 4; i++ {
+		value := queue.Pop()
+		if *value != i {
+			t.Errorf("Expected 1, got %d", *value)
+		}
+	}
+
+	if !queue.Empty() {
+		t.Error("Expected queue to be empty after popping all elements")
+	}
+}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -200,44 +200,6 @@ type cloneJob struct {
 	options   *cloneOptions
 }
 
-// cloneQueue is a threadsafe list.List of cloneJobs that functions as a queue in practice.
-type cloneQueue struct {
-	mu   sync.Mutex
-	jobs *list.List
-
-	cmu  sync.Mutex
-	cond *sync.Cond
-}
-
-// push will queue the cloneJob to the end of the queue.
-func (c *cloneQueue) push(cj *cloneJob) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.jobs.PushBack(cj)
-	c.cond.Signal()
-}
-
-// pop will return the next cloneJob. If there's no next job available, it returns nil.
-func (c *cloneQueue) pop() *cloneJob {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	next := c.jobs.Front()
-	if next == nil {
-		return nil
-	}
-
-	return c.jobs.Remove(next).(*cloneJob)
-}
-
-func (c *cloneQueue) empty() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.jobs.Len() == 0
-}
-
 // NewCloneQueue initializes a new cloneQueue.
 func NewCloneQueue(jobs *list.List) *common.Queue[cloneJob] {
 	return common.NewQueue[cloneJob](jobs)


### PR DESCRIPTION
Part of #40330

## Why

In #51860 we are adding a new queue to perform mapping of perforce depots. The queue implementation is a copy-paste of the existing `cloneQueue`. Instead of copy-pasting, we take a short detour to implement the queue with generics so that it may be used in the new feature as well.

No functional change to how repos are cloned is being introduced here.

## Note to reviewers

If you could add a few new repos to your code host config and verify if they get cloned successfully then it would be great validation, although I did check this locally on my dev setup, but it would be nice to know it works on someone else's machine too.

## Test plan

- Added tests
- sg start works locally and new repos added to code host config are cloned successfully
- [main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/222492) should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
