### PR TITLE
[fix] fixes for mau calculations in product analytics

### DIFF
--- a/internal/adminanalytics/BUILD.bazel
+++ b/internal/adminanalytics/BUILD.bazel
@@ -32,7 +32,10 @@ go_library(
 go_test(
     name = "adminanalytics_test",
     timeout = "short",
-    srcs = ["users_test.go"],
+    srcs = [
+        "users_test.go",
+        "utils_test.go",
+    ],
     embed = [":adminanalytics"],
     flaky = True,
     tags = [
@@ -45,5 +48,6 @@ go_test(
         "//internal/types",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/adminanalytics/users.go
+++ b/internal/adminanalytics/users.go
@@ -3,7 +3,6 @@ package adminanalytics
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/keegancsmith/sqlf"
 
@@ -156,10 +155,7 @@ func (f *Users) MonthlyActiveUsers(ctx context.Context) ([]*MonthlyActiveUsersRo
 		}
 	}
 
-	now := time.Now()
-	to := now.Format(time.RFC3339)
-	prevMonth := now.AddDate(0, -2, 0) // going back 2 months
-	from := time.Date(prevMonth.Year(), prevMonth.Month(), 1, 0, 0, 0, 0, now.Location()).Format(time.RFC3339)
+	from, to := getTimestamps(2) // go back 2 months
 
 	query := sqlf.Sprintf(mauQuery, from, to, sqlf.Join(getDefaultConds(), ") AND ("))
 

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -74,12 +74,14 @@ LEFT OUTER JOIN users ON users.id = event_logs.user_id
 `
 
 func getDefaultConds() []*sqlf.Query {
-	return database.BuildCommonUsageConds(&database.CommonUsageOptions{
+	commonConds := database.BuildCommonUsageConds(&database.CommonUsageOptions{
 		ExcludeSystemUsers:          true,
 		ExcludeNonActiveUsers:       true,
 		ExcludeSourcegraphAdmins:    true,
 		ExcludeSourcegraphOperators: true,
 	}, []*sqlf.Query{})
+
+	return append(commonConds, sqlf.Sprintf("anonymous_user_id != 'backend'"))
 }
 
 func makeEventLogsQueries(dateRange string, grouping string, events []string, conditions ...*sqlf.Query) (*sqlf.Query, *sqlf.Query, error) {

--- a/internal/adminanalytics/utils.go
+++ b/internal/adminanalytics/utils.go
@@ -16,6 +16,7 @@ var (
 	LastWeek        = "LAST_WEEK"
 	Daily           = "DAILY"
 	Weekly          = "WEEKLY"
+	timeNow         = time.Now
 )
 
 func makeDateParameters(dateRange string, grouping string, dateColumnName string) (*sqlf.Query, *sqlf.Query, error) {
@@ -108,4 +109,14 @@ func makeEventLogsQueries(dateRange string, grouping string, events []string, co
 	summaryQuery := sqlf.Sprintf(eventLogsSummaryQuery, sqlf.Sprintf("WHERE (%s)", sqlf.Join(conds, ") AND (")))
 
 	return nodesQuery, summaryQuery, nil
+}
+
+// getTimestamps returns the start and end timestamps for the given number of months.
+func getTimestamps(months int) (string, string) {
+	now := timeNow().UTC()
+	to := now.Format(time.RFC3339)
+	prevMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -months, 0)
+	from := prevMonth.Format(time.RFC3339)
+
+	return from, to
 }

--- a/internal/adminanalytics/utils_test.go
+++ b/internal/adminanalytics/utils_test.go
@@ -1,0 +1,77 @@
+package adminanalytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTimestamps(t *testing.T) {
+	now := time.Date(2023, 5, 30, 10, 12, 0, 0, time.UTC)
+
+	mockTimeNow := func(t time.Time) {
+		timeNow = func() time.Time {
+			return t
+		}
+	}
+
+	testCases := []struct {
+		name         string
+		months       int
+		now          time.Time
+		expectedFrom string
+		expectedTo   string
+	}{
+		{
+			name:         "3 months",
+			months:       3,
+			now:          now,
+			expectedFrom: "2023-02-01T00:00:00Z",
+			expectedTo:   "2023-05-30T10:12:00Z",
+		},
+		{
+			name:         "1 month",
+			months:       1,
+			now:          now,
+			expectedFrom: "2023-04-01T00:00:00Z",
+			expectedTo:   "2023-05-30T10:12:00Z",
+		},
+		{
+			name:         "0 months",
+			months:       0,
+			now:          now,
+			expectedFrom: "2023-05-01T00:00:00Z",
+			expectedTo:   "2023-05-30T10:12:00Z",
+		},
+		{
+			name:         "February non-leap year",
+			months:       2,
+			now:          time.Date(2023, 4, 30, 10, 59, 0, 0, time.UTC),
+			expectedFrom: "2023-02-01T00:00:00Z",
+			expectedTo:   "2023-04-30T10:59:00Z",
+		},
+		{
+			name:         "February leap year",
+			months:       2,
+			now:          time.Date(2024, 4, 29, 10, 59, 0, 0, time.UTC), // 2024 is a leap year
+			expectedFrom: "2024-02-01T00:00:00Z",
+			expectedTo:   "2024-04-29T10:59:00Z",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockTimeNow(tc.now)
+
+			t.Cleanup(func() {
+				timeNow = time.Now
+			})
+
+			from, to := getTimestamps(tc.months)
+
+			require.Equal(t, tc.expectedFrom, from)
+			require.Equal(t, tc.expectedTo, to)
+		})
+	}
+}


### PR DESCRIPTION
Fixes MAU calculation in usage analytics in the product. 

Previously we were filtering out the backend events, but as part of #52306 this was removed, because I believed it shold not be there, as it was not part of the BuildCommonUsageConds in the event_logs. However event_logs also add this condition directly in the query string, which I did not notice.

Also, our timestamp calculation suffered from an edge case, where the from time was not calculated right, e.g. on dates like `2023-04-30T23:59:00Z`.

## Test plan

Tested locally and with customer data + added unit tests.
