### PR TITLE
web: add a tooltip to BrainDot in `forNerds` case.

### DIFF
--- a/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
@@ -100,13 +100,14 @@ export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName, com
     return forNerds ? (
         <Menu>
             <>
-                <MenuButton
-                    className={classNames('text-decoration-none', styles.braindot, dotStyle)}
-                    aria-label="Code graph"
-                >
-                    <Icon aria-hidden={true} svgPath={mdiBrain} />
-                </MenuButton>
-
+                <Tooltip content="View code intelligence summary">
+                    <MenuButton
+                        className={classNames('text-decoration-none', styles.braindot, dotStyle)}
+                        aria-label="Code graph"
+                    >
+                        <Icon aria-hidden={true} svgPath={mdiBrain} />
+                    </MenuButton>
+                </Tooltip>
                 <MenuList position={Position.bottomEnd} className={styles.dropdownMenu}>
                     <MenuHeader>
                         Click to view code intelligence summary


### PR DESCRIPTION
Test plan:
Local sg run and visual check.

Randomly noticed it. Now there is a tooltip:
<img width="302" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/2a85748b-3271-43a6-8b14-97a77073a555">
