### PR TITLE
bext: ignore non-code diff content hovers on Bitbucket

### DIFF
--- a/client/browser/src/shared/code-hosts/bitbucket/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/bitbucket/domFunctions.ts
@@ -132,6 +132,10 @@ const newGetDiffLineElementFromLineNumber = (codeView: HTMLElement, line: number
 
 export const newDiffDOMFunctions: DOMFunctions = {
     getCodeElementFromTarget: target => {
+        if (target.closest('.additional-line-content')) {
+            // ignore additional (non-code) content inside a diff line: comments, etc.
+            return null
+        }
         const container = target.closest<HTMLElement>('.diff-line')
         return container
     },


### PR DESCRIPTION
Ignore hovers over Bitbucket's additional (non-code) diff line content (comments, etc.).

## Test plan
Tested manually. Demo attached.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
