### PR TITLE
Backend: fix exporting env vars

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -16,8 +16,8 @@ import (
 )
 
 type envflag struct {
-	description string
-	value       string
+	Description string `json:"description"`
+	Value       string `json:"value"`
 }
 
 var (
@@ -126,7 +126,7 @@ func Get(name, defaultValue, description string) string {
 		env = map[string]envflag{}
 	}
 
-	e := envflag{description: description, value: value}
+	e := envflag{Description: description, Value: value}
 	if existing, ok := env[name]; ok && existing != e {
 		panic(fmt.Sprintf("env var %q already registered with a different description or value", name))
 	}
@@ -201,7 +201,7 @@ func HelpString() string {
 
 	for _, name := range sorted {
 		e := env[name]
-		helpStr += fmt.Sprintf("  %-40s %s (value: %q)\n", name, e.description, e.value)
+		helpStr += fmt.Sprintf("  %-40s %s (value: %q)\n", name, e.Description, e.Value)
 	}
 
 	return helpStr

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"expvar"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -64,5 +65,17 @@ func TestGet(t *testing.T) {
 		}()
 		Get("A", "y", "bar")
 		t.Error("want panic")
+	})
+
+	t.Run("export", func(t *testing.T) {
+		reset(nil)
+
+		_ = Get("MY_ENV", "my default value", "my description")
+		Lock()
+		got := expvar.Get("env").String()
+		want := `{"MY_ENV":{"description":"my description","value":"my default value"}}`
+		if want != got {
+			t.Fatalf("got %q, want %q", got, want)
+		}
 	})
 }


### PR DESCRIPTION
TIL that the `internal/env` package theoretically exports environment variables via the `expvar` package. This would frequently be useful when debugging with customers (no need to dig up their deployment artifacts), but it's currently broken because the registered var does not correctly marshal to JSON.

This PR fixes that, and also acts as a general PSA that:
1) we should be using the `env` package for environment variables (not `os.Getenv`), and 
2) (after this PR) the env vars defined with the `env` package are accessible from the [debug pages](https://sourcegraph.com/-/debug/)

## Test plan

Added a mini test and checked that the env vars are visible locally.

<img width="1486" alt="Screenshot 2023-05-30 at 10 00 05" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/c5637e1d-2f4a-4736-bf75-73157efda557">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
