### PR TITLE
Cody completions: Fix responses that start with an empty line

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Sourcegraph Cody will be documented in this file.
 
 - Cody completions: Fixed interop between spaces and tabs. [pull/52497](https://github.com/sourcegraph/sourcegraph/pull/52497)
 - Fixes an issue where new conversations did not bring the chat into the foreground. [pull/52363](https://github.com/sourcegraph/sourcegraph/pull/52363)
+- Cody completions: Fixed an issue where the Cody response starts with a newline and was previously ignored [issues/52586](https://github.com/sourcegraph/sourcegraph/issues/52586)
 
 ### Changed
 

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -556,5 +556,15 @@ describe('Cody completions', () => {
                 \t}"
             `)
         })
+
+        it('normalizes Cody responses starting with an empty line and following the exact same indentation as the start line', async () => {
+            const { completions } = await complete(
+                `function test() {
+                    ${CURSOR_MARKER}`,
+                [createCompletionResponse("\n    console.log('foo')")]
+            )
+
+            expect(completions[0].insertText).toBe("console.log('foo')")
+        })
     })
 })

--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -304,6 +304,13 @@ export class InlineCompletionProvider extends CompletionProvider {
             const prefixIndentationWithFirstCompletionLine = this.prefix.slice(prefixLastNewline + 1) + completion[0]
             const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
 
+            // Normalize responses that start with a newline followed by the exact indentation of
+            // the first line.
+            if (lines.length > 1 && lines[0] === '' && indentation(lines[1]) === startIndent) {
+                lines.shift()
+                lines[0] = lines[0].trimStart()
+            }
+
             // If odd indentation is detected (i.e Claude adds a space to every line),
             // we fix it for the whole multiline block first.
             //


### PR DESCRIPTION
Closes #52586

This fixes an issue that @abeatrix helped me debug based on the logs she sent me. Cody would respond with this response which starts with a `\n` and whitespace of the exact indentation as the start indentation:

![](https://github.com/sourcegraph/sourcegraph/assets/458591/1c880b00-514c-4254-a283-36d825eccf89)

We can normalize these and not throw them away, 

## Test plan

- Added a unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
