### PR TITLE
executors: Heartbeat Request payload

### DIFF
--- a/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
@@ -301,6 +301,7 @@ func TestClient_MarkFailed(t *testing.T) {
 	}
 }
 
+// TODO: add test with string jobIDs when multi-queue is implemented.
 func TestHeartbeat(t *testing.T) {
 	spec := routeSpec{
 		expectedMethod:   "POST",
@@ -309,7 +310,7 @@ func TestHeartbeat(t *testing.T) {
 		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
-			"jobIds": ["1","2","3"],
+			"jobIds": [1,2,3],
 
 			"os": "test-os",
 			"architecture": "test-architecture",
@@ -341,6 +342,7 @@ func TestHeartbeat(t *testing.T) {
 	})
 }
 
+// TODO: add test with string jobIDs when multi-queue is implemented.
 func TestHeartbeatBadResponse(t *testing.T) {
 	spec := routeSpec{
 		expectedMethod:   "POST",
@@ -349,7 +351,7 @@ func TestHeartbeatBadResponse(t *testing.T) {
 		expectedToken:    "hunter2",
 		expectedPayload: `{
 			"executorName": "deadbeef",
-			"jobIds": ["1","2","3"],
+			"jobIds": [1,2,3],
 
 			"os": "test-os",
 			"architecture": "test-architecture",

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/handler_test.go
@@ -831,6 +831,20 @@ func TestHandler_HandleHeartbeat(t *testing.T) {
 		assertionFunc        func(t *testing.T, metricsStore *metricsstore.MockDistributedStore, executorStore *database.MockExecutorStore, mockStore *dbworkerstoremocks.MockStore[testRecord])
 	}{
 		{
+			name: "V2 Heartbeat number IDs",
+			body: `{"version":"V2", "executorName": "test-executor", "jobIds": [42, 7], "os": "test-os", "architecture": "test-arch", "dockerVersion": "1.0", "executorVersion": "2.0", "gitVersion": "3.0", "igniteVersion": "4.0", "srcCliVersion": "5.0", "prometheusMetrics": ""}`,
+			mockFunc: func(metricsStore *metricsstore.MockDistributedStore, executorStore *database.MockExecutorStore, mockStore *dbworkerstoremocks.MockStore[testRecord]) {
+				executorStore.UpsertHeartbeatFunc.PushReturn(nil)
+				mockStore.HeartbeatFunc.PushReturn([]string{"42", "7"}, nil, nil)
+			},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: `{"knownIds":["42","7"],"cancelIds":null}`,
+			assertionFunc: func(t *testing.T, metricsStore *metricsstore.MockDistributedStore, executorStore *database.MockExecutorStore, mockStore *dbworkerstoremocks.MockStore[testRecord]) {
+				require.Len(t, executorStore.UpsertHeartbeatFunc.History(), 1)
+				require.Len(t, mockStore.HeartbeatFunc.History(), 1)
+			},
+		},
+		{
 			name: "V2 Heartbeat",
 			body: `{"version":"V2", "executorName": "test-executor", "jobIds": ["42", "7"], "os": "test-os", "architecture": "test-arch", "dockerVersion": "1.0", "executorVersion": "2.0", "gitVersion": "3.0", "igniteVersion": "4.0", "srcCliVersion": "5.0", "prometheusMetrics": ""}`,
 			mockFunc: func(metricsStore *metricsstore.MockDistributedStore, executorStore *database.MockExecutorStore, mockStore *dbworkerstoremocks.MockStore[testRecord]) {

--- a/enterprise/internal/executor/types/BUILD.bazel
+++ b/enterprise/internal/executor/types/BUILD.bazel
@@ -15,10 +15,14 @@ go_library(
 go_test(
     name = "types_test",
     timeout = "short",
-    srcs = ["job_test.go"],
+    srcs = [
+        "http_test.go",
+        "job_test.go",
+    ],
     embed = [":types"],
     deps = [
         "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/internal/executor/types/BUILD.bazel
+++ b/enterprise/internal/executor/types/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/executor/types",
     visibility = ["//enterprise:__subpackages__"],
-    deps = ["//internal/executor"],
+    deps = [
+        "//internal/executor",
+        "//lib/errors",
+    ],
 )
 
 go_test(

--- a/enterprise/internal/executor/types/http.go
+++ b/enterprise/internal/executor/types/http.go
@@ -1,6 +1,10 @@
 package types
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
 	"github.com/sourcegraph/sourcegraph/internal/executor"
 )
 
@@ -38,6 +42,7 @@ type MarkErroredRequest struct {
 	ErrorMessage string `json:"errorMessage"`
 }
 
+// HeartbeatRequest is the payload sent by executors to the executor service to indicate that they are still alive.
 type HeartbeatRequest struct {
 	ExecutorName string   `json:"executorName"`
 	JobIDs       []string `json:"jobIds"`
@@ -54,11 +59,75 @@ type HeartbeatRequest struct {
 	PrometheusMetrics string `json:"prometheusMetrics"`
 }
 
-type ExecutorAPIVersion string
+// HeartbeatRequestV1 is the payload sent by executors to the executor service to indicate that they are still alive.
+// Job IDs are ints instead of strings to support backwards compatibility.
+// TODO: Remove this in Sourcegraph 5.2
+type HeartbeatRequestV1 struct {
+	ExecutorName string `json:"executorName"`
+	JobIDs       []int  `json:"jobIds"`
 
-const (
-	ExecutorAPIVersion2 ExecutorAPIVersion = "V2"
-)
+	// Telemetry data.
+	OS              string `json:"os"`
+	Architecture    string `json:"architecture"`
+	DockerVersion   string `json:"dockerVersion"`
+	ExecutorVersion string `json:"executorVersion"`
+	GitVersion      string `json:"gitVersion"`
+	IgniteVersion   string `json:"igniteVersion"`
+	SrcCliVersion   string `json:"srcCliVersion"`
+
+	PrometheusMetrics string `json:"prometheusMetrics"`
+}
+
+type heartbeatRequestUnmarshaller struct {
+	ExecutorName string `json:"executorName"`
+	JobIDs       []any  `json:"jobIds"`
+
+	// Telemetry data.
+	OS              string `json:"os"`
+	Architecture    string `json:"architecture"`
+	DockerVersion   string `json:"dockerVersion"`
+	ExecutorVersion string `json:"executorVersion"`
+	GitVersion      string `json:"gitVersion"`
+	IgniteVersion   string `json:"igniteVersion"`
+	SrcCliVersion   string `json:"srcCliVersion"`
+
+	PrometheusMetrics string `json:"prometheusMetrics"`
+}
+
+// UnmarshalJSON is a custom unmarshaler for HeartbeatRequest that allows for backwards compatibility when job IDs are
+// ints instead of strings.
+// TODO: Remove this in Sourcegraph 5.2
+func (h *HeartbeatRequest) UnmarshalJSON(b []byte) error {
+	var req heartbeatRequestUnmarshaller
+	if err := json.Unmarshal(b, &req); err != nil {
+		return err
+	}
+	h.ExecutorName = req.ExecutorName
+	h.OS = req.OS
+	h.Architecture = req.Architecture
+	h.DockerVersion = req.DockerVersion
+	h.ExecutorVersion = req.ExecutorVersion
+	h.GitVersion = req.GitVersion
+	h.IgniteVersion = req.IgniteVersion
+	h.SrcCliVersion = req.SrcCliVersion
+	h.PrometheusMetrics = req.PrometheusMetrics
+
+	for _, id := range req.JobIDs {
+		switch id.(type) {
+		case int:
+			h.JobIDs = append(h.JobIDs, strconv.Itoa(id.(int)))
+		case float32:
+			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(float64(id.(float32)), 'f', -1, 32))
+		case float64:
+			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(id.(float64), 'f', -1, 64))
+		case string:
+			h.JobIDs = append(h.JobIDs, id.(string))
+		default:
+			return fmt.Errorf("unknown type for job ID: %T", id)
+		}
+	}
+	return nil
+}
 
 type HeartbeatResponse struct {
 	KnownIDs  []string `json:"knownIds"`

--- a/enterprise/internal/executor/types/http.go
+++ b/enterprise/internal/executor/types/http.go
@@ -2,10 +2,10 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/executor"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type DequeueRequest struct {
@@ -113,17 +113,17 @@ func (h *HeartbeatRequest) UnmarshalJSON(b []byte) error {
 	h.PrometheusMetrics = req.PrometheusMetrics
 
 	for _, id := range req.JobIDs {
-		switch id.(type) {
+		switch jobId := id.(type) {
 		case int:
-			h.JobIDs = append(h.JobIDs, strconv.Itoa(id.(int)))
+			h.JobIDs = append(h.JobIDs, strconv.Itoa(jobId))
 		case float32:
-			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(float64(id.(float32)), 'f', -1, 32))
+			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(float64(jobId), 'f', -1, 32))
 		case float64:
-			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(id.(float64), 'f', -1, 64))
+			h.JobIDs = append(h.JobIDs, strconv.FormatFloat(jobId, 'f', -1, 64))
 		case string:
-			h.JobIDs = append(h.JobIDs, id.(string))
+			h.JobIDs = append(h.JobIDs, jobId)
 		default:
-			return fmt.Errorf("unknown type for job ID: %T", id)
+			return errors.Newf("unknown type for job ID: %T", id)
 		}
 	}
 	return nil

--- a/enterprise/internal/executor/types/http_test.go
+++ b/enterprise/internal/executor/types/http_test.go
@@ -1,0 +1,88 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/executor/types"
+)
+
+func TestHeartbeatRequest_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name            string
+		payload         string
+		expectedRequest types.HeartbeatRequest
+		expectedError   error
+	}{
+		{
+			name: "String IDs",
+			payload: `{
+  "executorName":"test-executor",
+  "jobIds": ["42", "72"],
+  "os": "test-os",
+  "architecture":"test-arch",
+  "dockerVersion":"test-docker",
+  "executorVersion":"test-executor",
+  "gitVersion":"test-git",
+  "igniteVersion":"test-ignite",
+  "srcCliVersion":"test-src-cli",
+  "prometheusMetrics":"test-metrics"
+}`,
+			expectedRequest: types.HeartbeatRequest{
+				ExecutorName:      "test-executor",
+				JobIDs:            []string{"42", "72"},
+				OS:                "test-os",
+				Architecture:      "test-arch",
+				DockerVersion:     "test-docker",
+				ExecutorVersion:   "test-executor",
+				GitVersion:        "test-git",
+				IgniteVersion:     "test-ignite",
+				SrcCliVersion:     "test-src-cli",
+				PrometheusMetrics: "test-metrics",
+			},
+		},
+		{
+			name: "Number IDs",
+			payload: `{
+  "executorName":"test-executor",
+  "jobIds": [42, 72],
+  "os": "test-os",
+  "architecture":"test-arch",
+  "dockerVersion":"test-docker",
+  "executorVersion":"test-executor",
+  "gitVersion":"test-git",
+  "igniteVersion":"test-ignite",
+  "srcCliVersion":"test-src-cli",
+  "prometheusMetrics":"test-metrics"
+}`,
+			expectedRequest: types.HeartbeatRequest{
+				ExecutorName:      "test-executor",
+				JobIDs:            []string{"42", "72"},
+				OS:                "test-os",
+				Architecture:      "test-arch",
+				DockerVersion:     "test-docker",
+				ExecutorVersion:   "test-executor",
+				GitVersion:        "test-git",
+				IgniteVersion:     "test-ignite",
+				SrcCliVersion:     "test-src-cli",
+				PrometheusMetrics: "test-metrics",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actual types.HeartbeatRequest
+			err := json.Unmarshal([]byte(test.payload), &actual)
+			if test.expectedError != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedRequest, actual)
+			}
+		})
+	}
+}

--- a/enterprise/internal/executor/types/http_test.go
+++ b/enterprise/internal/executor/types/http_test.go
@@ -71,6 +71,33 @@ func TestHeartbeatRequest_UnmarshalJSON(t *testing.T) {
 				PrometheusMetrics: "test-metrics",
 			},
 		},
+		{
+			name: "Mix of IDs",
+			payload: `{
+  "executorName":"test-executor",
+  "jobIds": [42, 72, "12"],
+  "os": "test-os",
+  "architecture":"test-arch",
+  "dockerVersion":"test-docker",
+  "executorVersion":"test-executor",
+  "gitVersion":"test-git",
+  "igniteVersion":"test-ignite",
+  "srcCliVersion":"test-src-cli",
+  "prometheusMetrics":"test-metrics"
+}`,
+			expectedRequest: types.HeartbeatRequest{
+				ExecutorName:      "test-executor",
+				JobIDs:            []string{"42", "72", "12"},
+				OS:                "test-os",
+				Architecture:      "test-arch",
+				DockerVersion:     "test-docker",
+				ExecutorVersion:   "test-executor",
+				GitVersion:        "test-git",
+				IgniteVersion:     "test-ignite",
+				SrcCliVersion:     "test-src-cli",
+				PrometheusMetrics: "test-metrics",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Fix backwards compatibility error when executors is behind Sourcegraph and sends jobIDs as numbers instead of strings.

## Test plan

Added and updated Go tests.