### PR TITLE
Search: fix UseKeywordScoring hack

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -114,9 +114,6 @@ func (s *searchClient) Plan(
 	}
 	tr.LazyPrintf("parsing done")
 
-	features := ToFeatures(featureflag.FromContext(ctx), s.logger)
-	features.KeywordScoring = searchType == query.SearchTypeKeyword
-
 	inputs := &search.Inputs{
 		Plan:                   plan,
 		Query:                  plan.ToQ(),
@@ -124,7 +121,7 @@ func (s *searchClient) Plan(
 		SearchMode:             searchMode,
 		UserSettings:           settings,
 		OnSourcegraphDotCom:    sourcegraphDotComMode,
-		Features:               features,
+		Features:               ToFeatures(featureflag.FromContext(ctx), s.logger),
 		PatternType:            searchType,
 		Protocol:               protocol,
 		SanitizeSearchPatterns: sanitizeSearchPatterns(ctx, s.db, s.logger), // Experimental: check site config to see if search sanitization is enabled

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -93,6 +93,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 
 		builder := &jobBuilder{
 			query:          b,
+			patternType:    inputs.PatternType,
 			resultTypes:    resultTypes,
 			repoOptions:    repoOptions,
 			features:       inputs.Features,
@@ -747,6 +748,7 @@ func toRepoOptions(b query.Basic, userSettings *schema.Settings) search.RepoOpti
 // If in doubt, ask the search team.
 type jobBuilder struct {
 	query          query.Basic
+	patternType    query.SearchType
 	resultTypes    result.Types
 	repoOptions    search.RepoOptions
 	features       *search.Features
@@ -779,6 +781,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
 		Features:       *b.features,
+		KeywordScoring: b.patternType == query.SearchTypeKeyword,
 	}
 
 	switch typ {
@@ -809,6 +812,7 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
 		Features:       *b.features,
+		KeywordScoring: b.patternType == query.SearchTypeKeyword,
 	}
 
 	switch typ {

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1476,13 +1476,17 @@ func RunRepoSubsetTextSearch(
 			return nil, streaming.Stats{}, err
 		}
 
-		zoektJob := &zoektutil.RepoSubsetTextSearchJob{
-			Repos:          indexed,
-			Query:          zoektQuery,
-			Typ:            search.TextRequest,
+		zoektParams := &search.ZoektParameters{
 			FileMatchLimit: patternInfo.FileMatchLimit,
 			Select:         patternInfo.Select,
-			Since:          nil,
+		}
+
+		zoektJob := &zoektutil.RepoSubsetTextSearchJob{
+			Repos:       indexed,
+			Query:       zoektQuery,
+			Typ:         search.TextRequest,
+			ZoektParams: zoektParams,
+			Since:       nil,
 		}
 
 		// Run literal and regexp searches on indexed repositories.

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -174,6 +174,9 @@ type ZoektParameters struct {
 
 	// Features are feature flags that can affect behaviour of searcher.
 	Features Features
+
+	// If true, use keyword-style scoring instead of Zoekt's default scoring formula.
+	KeywordScoring bool
 }
 
 // SearcherParameters the inputs for a search fulfilled by the Searcher service
@@ -348,8 +351,6 @@ type Features struct {
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.
 	Debug bool `json:"debug"`
-
-	KeywordScoring bool `json:"keyword-scoring"`
 
 	// CodeOwnershipSearch when true will enable searching through code ownership
 	// using `file:has.owner({owner})` and `select:file.owners` filters.

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -276,6 +276,7 @@ func DoZoektSearchGlobal(ctx context.Context, logger log.Logger, client zoekt.St
 		Selector:       params.Select,
 		FileMatchLimit: params.FileMatchLimit,
 		Features:       params.Features,
+		KeywordScoring: params.KeywordScoring,
 		GlobalSearch:   true,
 	}).ToSearch(ctx, logger)
 
@@ -325,6 +326,7 @@ func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs,
 		NumRepos:       len(repos.RepoRevs),
 		FileMatchLimit: zoektParams.FileMatchLimit,
 		Features:       zoektParams.Features,
+		KeywordScoring: zoektParams.KeywordScoring,
 	}).ToSearch(ctx, logger)
 
 	// Start event stream.

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -271,11 +271,11 @@ func PartitionRepos(
 	return indexed, unindexed, nil
 }
 
-func DoZoektSearchGlobal(ctx context.Context, logger log.Logger, client zoekt.Streamer, args *search.ZoektParameters, pathRegexps []*regexp.Regexp, c streaming.Sender) error {
+func DoZoektSearchGlobal(ctx context.Context, logger log.Logger, client zoekt.Streamer, params *search.ZoektParameters, pathRegexps []*regexp.Regexp, c streaming.Sender) error {
 	searchOpts := (&Options{
-		Selector:       args.Select,
-		FileMatchLimit: args.FileMatchLimit,
-		Features:       args.Features,
+		Selector:       params.Select,
+		FileMatchLimit: params.FileMatchLimit,
+		Features:       params.Features,
 		GlobalSearch:   true,
 	}).ToSearch(ctx, logger)
 
@@ -296,19 +296,19 @@ func DoZoektSearchGlobal(ctx context.Context, logger log.Logger, client zoekt.St
 		defer cancel()
 	}
 
-	return client.StreamSearch(ctx, args.Query, searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+	return client.StreamSearch(ctx, params.Query, searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		sendMatches(event, pathRegexps, func(file *zoekt.FileMatch) (types.MinimalRepo, []string) {
 			repo := types.MinimalRepo{
 				ID:   api.RepoID(file.RepositoryID),
 				Name: api.RepoName(file.Repository),
 			}
 			return repo, []string{""}
-		}, args.Typ, args.Select, c)
+		}, params.Typ, params.Select, c)
 	}))
 }
 
 // zoektSearch searches repositories using zoekt.
-func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs, q zoektquery.Q, pathRegexps []*regexp.Regexp, typ search.IndexedRequestType, client zoekt.Streamer, fileMatchLimit int32, selector filter.SelectPath, feat search.Features, since func(t time.Time) time.Duration, c streaming.Sender) error {
+func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs, q zoektquery.Q, pathRegexps []*regexp.Regexp, typ search.IndexedRequestType, client zoekt.Streamer, zoektParams *search.ZoektParameters, since func(t time.Time) time.Duration, c streaming.Sender) error {
 	if len(repos.RepoRevs) == 0 {
 		return nil
 	}
@@ -321,10 +321,10 @@ func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs,
 	finalQuery := zoektquery.NewAnd(&zoektquery.BranchesRepos{List: brs}, q)
 
 	searchOpts := (&Options{
-		Selector:       selector,
+		Selector:       zoektParams.Select,
 		NumRepos:       len(repos.RepoRevs),
-		FileMatchLimit: fileMatchLimit,
-		Features:       feat,
+		FileMatchLimit: zoektParams.FileMatchLimit,
+		Features:       zoektParams.Features,
 	}).ToSearch(ctx, logger)
 
 	// Start event stream.
@@ -350,7 +350,7 @@ func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs,
 	foundResults := atomic.Bool{}
 	err := client.StreamSearch(ctx, finalQuery, searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 		foundResults.CompareAndSwap(false, event.FileCount != 0 || event.MatchCount != 0)
-		sendMatches(event, pathRegexps, repos.getRepoInputRev, typ, selector, c)
+		sendMatches(event, pathRegexps, repos.getRepoInputRev, typ, zoektParams.Select, c)
 	}))
 	if err != nil {
 		return err
@@ -667,9 +667,7 @@ type RepoSubsetTextSearchJob struct {
 	Query             zoektquery.Q
 	ZoektQueryRegexps []*regexp.Regexp // used for getting file path match ranges
 	Typ               search.IndexedRequestType
-	FileMatchLimit    int32
-	Select            filter.SelectPath
-	Features          search.Features
+	ZoektParams       *search.ZoektParameters
 	Since             func(time.Time) time.Duration `json:"-"` // since if non-nil will be used instead of time.Since. For tests
 }
 
@@ -690,7 +688,7 @@ func (z *RepoSubsetTextSearchJob) Run(ctx context.Context, clients job.RuntimeCl
 		since = z.Since
 	}
 
-	return nil, zoektSearch(ctx, clients.Logger, z.Repos, z.Query, z.ZoektQueryRegexps, z.Typ, clients.Zoekt, z.FileMatchLimit, z.Select, z.Features, since, stream)
+	return nil, zoektSearch(ctx, clients.Logger, z.Repos, z.Query, z.ZoektQueryRegexps, z.Typ, clients.Zoekt, z.ZoektParams, since, stream)
 }
 
 func (*RepoSubsetTextSearchJob) Name() string {
@@ -701,8 +699,8 @@ func (z *RepoSubsetTextSearchJob) Attributes(v job.Verbosity) (res []attribute.K
 	switch v {
 	case job.VerbosityMax:
 		res = append(res,
-			attribute.Int("fileMatchLimit", int(z.FileMatchLimit)),
-			attribute.Stringer("select", z.Select),
+			attribute.Int("fileMatchLimit", int(z.ZoektParams.FileMatchLimit)),
+			attribute.Stringer("select", z.ZoektParams.Select),
 			trace.Stringers("zoektQueryRegexps", z.ZoektQueryRegexps),
 		)
 		// z.Repos is nil for un-indexed search
@@ -727,7 +725,7 @@ func (j *RepoSubsetTextSearchJob) MapChildren(job.MapFunc) job.Job { return j }
 
 type GlobalTextSearchJob struct {
 	GlobalZoektQuery        *GlobalZoektQuery
-	ZoektArgs               *search.ZoektParameters
+	ZoektParams             *search.ZoektParameters
 	RepoOpts                search.RepoOptions
 	GlobalZoektQueryRegexps []*regexp.Regexp // used for getting file path match ranges
 }
@@ -738,9 +736,9 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 
 	userPrivateRepos := privateReposForActor(ctx, clients.Logger, clients.DB, t.RepoOpts)
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
-	t.ZoektArgs.Query = t.GlobalZoektQuery.Generate()
+	t.ZoektParams.Query = t.GlobalZoektQuery.Generate()
 
-	return nil, DoZoektSearchGlobal(ctx, clients.Logger, clients.Zoekt, t.ZoektArgs, t.GlobalZoektQueryRegexps, stream)
+	return nil, DoZoektSearchGlobal(ctx, clients.Logger, clients.Zoekt, t.ZoektParams, t.GlobalZoektQueryRegexps, stream)
 }
 
 func (*GlobalTextSearchJob) Name() string {
@@ -751,8 +749,8 @@ func (t *GlobalTextSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyVa
 	switch v {
 	case job.VerbosityMax:
 		res = append(res,
-			attribute.Int("fileMatchLimit", int(t.ZoektArgs.FileMatchLimit)),
-			attribute.Stringer("select", t.ZoektArgs.Select),
+			attribute.Int("fileMatchLimit", int(t.ZoektParams.FileMatchLimit)),
+			attribute.Stringer("select", t.ZoektParams.Select),
 			trace.Stringers("repoScope", t.GlobalZoektQuery.RepoScope),
 			attribute.Bool("includePrivate", t.GlobalZoektQuery.IncludePrivate),
 			trace.Stringers("globalZoektQueryRegexps", t.GlobalZoektQueryRegexps),
@@ -761,7 +759,7 @@ func (t *GlobalTextSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyVa
 	case job.VerbosityBasic:
 		res = append(res,
 			attribute.Stringer("query", t.GlobalZoektQuery.Query),
-			attribute.String("type", string(t.ZoektArgs.Typ)),
+			attribute.String("type", string(t.ZoektParams.Typ)),
 		)
 		res = append(res, trace.Scoped("repoOpts", t.RepoOpts.Attributes()...)...)
 	}

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -310,13 +310,17 @@ func TestIndexedSearch(t *testing.T) {
 				t.Errorf("unindexed mismatch (-want +got):\n%s", diff)
 			}
 
-			zoektJob := &RepoSubsetTextSearchJob{
-				Repos:          indexed,
-				Query:          zoektQuery,
-				Typ:            search.TextRequest,
+			zoektParams := &search.ZoektParameters{
 				FileMatchLimit: tt.args.fileMatchLimit,
 				Select:         tt.args.selectPath,
-				Since:          tt.args.since,
+			}
+
+			zoektJob := &RepoSubsetTextSearchJob{
+				Repos:       indexed,
+				Query:       zoektQuery,
+				Typ:         search.TextRequest,
+				ZoektParams: zoektParams,
+				Since:       tt.args.since,
 			}
 
 			_, err = zoektJob.Run(tt.args.ctx, job.RuntimeClients{Zoekt: fakeZoekt}, agg)

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -595,6 +595,22 @@ func TestZoektSearchOptions(t *testing.T) {
 				DocumentRanksWeight: 4500,
 			},
 		},
+		{
+			name:    "test keyword scoring",
+			context: context.Background(),
+			options: &Options{
+				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
+				NumRepos:       3,
+				KeywordScoring: true,
+			},
+			want: &zoekt.SearchOptions{
+				ShardMaxMatchCount: 10000,
+				TotalMaxMatchCount: 100000,
+				MaxWallTime:        20000000000,
+				MaxDocDisplayCount: 500,
+				ChunkMatches:       true,
+				UseKeywordScoring:  true},
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -88,6 +88,9 @@ type Options struct {
 
 	// Features are feature flags that can affect behaviour of searcher.
 	Features search.Features
+
+	// If true, use keyword-style scoring instead of Zoekt's default scoring formula.
+	KeywordScoring bool
 }
 
 func (o *Options) ToSearch(ctx context.Context, logger log.Logger) *zoekt.SearchOptions {
@@ -97,7 +100,7 @@ func (o *Options) ToSearch(ctx context.Context, logger log.Logger) *zoekt.Search
 		SpanContext:       spanContext,
 		MaxWallTime:       defaultTimeout,
 		ChunkMatches:      true,
-		UseKeywordScoring: o.Features.KeywordScoring,
+		UseKeywordScoring: o.KeywordScoring,
 	}
 
 	// These are reasonable default amounts of work to do per shard and


### PR DESCRIPTION
We recently enabled Zoekt's new BM25 scoring for the `keyword` search type. We enabled the option using feature flags, which is hacky because users will never be touching this setting.

This PR refactors all Zoekt-related jobs to use the `search.ZoektParameters` struct. This lets us pass the flag to Zoekt directly when constructing jobs.

Follow-up to #52233

## Test plan

Added a new case to `indexed_search_test`. Manually tested scoring for both global and repo-scoped and keyword searches.