### PR TITLE
Rc/more k8s fixes

### DIFF
--- a/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_client_go//kubernetes",
         "@io_k8s_utils//pointer",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -65,9 +66,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/watch",
         "@io_k8s_client_go//kubernetes/fake",
-        "@io_k8s_client_go//kubernetes/scheme",
-        "@io_k8s_client_go//rest",
-        "@io_k8s_client_go//rest/fake",
         "@io_k8s_client_go//testing",
         "@io_k8s_utils//pointer",
     ],

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -73,24 +75,49 @@ type KubernetesSecurityContext struct {
 
 // KubernetesCommand interacts with the Kubernetes API.
 type KubernetesCommand struct {
-	Logger    log.Logger
-	Clientset kubernetes.Interface
+	Logger     log.Logger
+	Clientset  kubernetes.Interface
+	Operations *Operations
 }
 
 // CreateJob creates a Kubernetes job with the given name and command.
-func (c *KubernetesCommand) CreateJob(ctx context.Context, namespace string, job *batchv1.Job) (*batchv1.Job, error) {
+func (c *KubernetesCommand) CreateJob(ctx context.Context, namespace string, job *batchv1.Job) (createdJob *batchv1.Job, err error) {
+	ctx, _, endObservation := c.Operations.KubernetesCreateJob.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("name", job.Name),
+	}})
+	defer endObservation(1, observation.Args{})
+
 	return c.Clientset.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
 }
 
 // DeleteJob deletes the Kubernetes job with the given name.
-func (c *KubernetesCommand) DeleteJob(ctx context.Context, namespace string, jobName string) error {
+func (c *KubernetesCommand) DeleteJob(ctx context.Context, namespace string, jobName string) (err error) {
+	ctx, _, endObservation := c.Operations.KubernetesDeleteJob.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("name", jobName),
+	}})
+	defer endObservation(1, observation.Args{})
+
 	return c.Clientset.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 }
 
 var propagationPolicy = metav1.DeletePropagationBackground
 
 // ReadLogs reads the logs of the given pod and writes them to the logger.
-func (c *KubernetesCommand) ReadLogs(ctx context.Context, namespace string, pod *corev1.Pod, containerName string, cmdLogger Logger, key string, command []string) error {
+func (c *KubernetesCommand) ReadLogs(
+	ctx context.Context,
+	namespace string,
+	pod *corev1.Pod,
+	containerName string,
+	cmdLogger Logger,
+	key string,
+	command []string,
+) (err error) {
+	ctx, _, endObservation := c.Operations.KubernetesReadLogs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("podName", pod.Name),
+		attribute.String("containerName", containerName),
+	}})
+	defer endObservation(1, observation.Args{})
+
 	logEntry := cmdLogger.LogEntry(key, command)
 	defer logEntry.Close()
 
@@ -151,7 +178,12 @@ func (c *KubernetesCommand) FindPod(ctx context.Context, namespace string, name 
 }
 
 // WaitForJobToComplete waits for the job with the given name to complete.
-func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace string, name string) error {
+func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace string, name string) (err error) {
+	ctx, _, endObservation := c.Operations.KubernetesWaitForJobToComplete.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("name", name),
+	}})
+	defer endObservation(1, observation.Args{})
+
 	watch, err := c.Clientset.BatchV1().Jobs(namespace).Watch(ctx, metav1.ListOptions{Watch: true, FieldSelector: "metadata.name=" + name})
 	if err != nil {
 		return errors.Wrap(err, "watching job")
@@ -176,14 +208,6 @@ func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace 
 
 // ErrKubernetesJobFailed is returned when a Kubernetes job fails.
 var ErrKubernetesJobFailed = errors.New("job failed")
-
-func (c *KubernetesCommand) getJob(ctx context.Context, namespace string, name string) (*batchv1.Job, error) {
-	return c.Clientset.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
-}
-
-func (c *KubernetesCommand) getPod(ctx context.Context, namespace string, name string) (*corev1.Pod, error) {
-	return c.Clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-}
 
 // NewKubernetesJob creates a Kubernetes job with the given name, image, volume path, and spec.
 func NewKubernetesJob(name string, image string, spec Spec, path string, options KubernetesContainerOptions) *batchv1.Job {

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -165,49 +165,41 @@ func readProcessPipe(w io.WriteCloser, stdout io.Reader) *errgroup.Group {
 	return eg
 }
 
-// FindPod finds the pod for the given job name.
-func (c *KubernetesCommand) FindPod(ctx context.Context, namespace string, name string) (*corev1.Pod, error) {
-	list, err := c.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "job-name=" + name})
-	if err != nil {
-		return nil, errors.Wrap(err, "finding pod")
-	}
-	if len(list.Items) == 0 {
-		return nil, errors.Newf("no pods found for job %s", name)
-	}
-	return &list.Items[0], nil
-}
-
-// WaitForJobToComplete waits for the job with the given name to complete.
-func (c *KubernetesCommand) WaitForJobToComplete(ctx context.Context, namespace string, name string) (err error) {
-	ctx, _, endObservation := c.Operations.KubernetesWaitForJobToComplete.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("name", name),
+// WaitForPodToSucceed waits for the pod with the given job label to succeed.
+func (c *KubernetesCommand) WaitForPodToSucceed(ctx context.Context, namespace string, jobName string) (p *corev1.Pod, err error) {
+	ctx, _, endObservation := c.Operations.KubernetesWaitForPodToSucceed.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("jobName", jobName),
 	}})
 	defer endObservation(1, observation.Args{})
 
-	watch, err := c.Clientset.BatchV1().Jobs(namespace).Watch(ctx, metav1.ListOptions{Watch: true, FieldSelector: "metadata.name=" + name})
+	watch, err := c.Clientset.CoreV1().Pods(namespace).Watch(ctx, metav1.ListOptions{Watch: true, LabelSelector: "job-name=" + jobName})
 	if err != nil {
-		return errors.Wrap(err, "watching job")
+		return nil, errors.Wrap(err, "watching pod")
 	}
 	defer watch.Stop()
 	// No need to add a timer. If the job exceeds the deadline, it will fail.
 	for event := range watch.ResultChan() {
-		job, ok := event.Object.(*batchv1.Job)
+		pod, ok := event.Object.(*corev1.Pod)
 		if !ok {
-			return errors.New("unexpected object type")
+			return nil, errors.New("unexpected object type")
 		}
-		if job.Status.Succeeded > 0 {
-			return nil
-		}
-		if job.Status.Failed > 0 {
-			return ErrKubernetesJobFailed
+		c.Logger.Debug(
+			"watching pod",
+			log.String("name", pod.Name),
+			log.String("phase", string(pod.Status.Phase)),
+		)
+		switch pod.Status.Phase {
+		case corev1.PodFailed:
+			return pod, ErrKubernetesPodFailed
+		case corev1.PodSucceeded:
+			return pod, nil
 		}
 	}
-	// Wont happen
-	return nil
+	return nil, errors.New("unexpected end of watch")
 }
 
-// ErrKubernetesJobFailed is returned when a Kubernetes job fails.
-var ErrKubernetesJobFailed = errors.New("job failed")
+// ErrKubernetesPodFailed is returned when a Kubernetes pod fails.
+var ErrKubernetesPodFailed = errors.New("pod failed")
 
 // NewKubernetesJob creates a Kubernetes job with the given name, image, volume path, and spec.
 func NewKubernetesJob(name string, image string, spec Spec, path string, options KubernetesContainerOptions) *batchv1.Job {

--- a/enterprise/cmd/executor/internal/worker/command/observability.go
+++ b/enterprise/cmd/executor/internal/worker/command/observability.go
@@ -18,10 +18,18 @@ type Operations struct {
 	SetupGitSparseCheckoutSet    *observation.Operation
 	SetupGitCheckout             *observation.Operation
 	SetupGitSetRemoteUrl         *observation.Operation
-	SetupFirecrackerStart        *observation.Operation
 	SetupStartupScript           *observation.Operation
-	TeardownFirecrackerRemove    *observation.Operation
-	Exec                         *observation.Operation
+
+	SetupFirecrackerStart     *observation.Operation
+	TeardownFirecrackerRemove *observation.Operation
+
+	Exec *observation.Operation
+
+	KubernetesCreateJob            *observation.Operation
+	KubernetesDeleteJob            *observation.Operation
+	KubernetesReadLogs             *observation.Operation
+	KubernetesFindPod              *observation.Operation
+	KubernetesWaitForJobToComplete *observation.Operation
 
 	RunLockWaitTotal prometheus.Counter
 	RunLockHeldTotal prometheus.Counter
@@ -68,10 +76,18 @@ func NewOperations(observationCtx *observation.Context) *Operations {
 		SetupGitSparseCheckoutSet:    op("setup.git.sparse-checkout-set"),
 		SetupGitCheckout:             op("setup.git.checkout"),
 		SetupGitSetRemoteUrl:         op("setup.git.set-remote"),
-		SetupFirecrackerStart:        op("setup.firecracker.start"),
 		SetupStartupScript:           op("setup.startup-script"),
-		TeardownFirecrackerRemove:    op("teardown.firecracker.remove"),
-		Exec:                         op("exec"),
+
+		SetupFirecrackerStart:     op("setup.firecracker.start"),
+		TeardownFirecrackerRemove: op("teardown.firecracker.remove"),
+
+		Exec: op("exec"),
+
+		KubernetesCreateJob:            op("kubernetes.job.create"),
+		KubernetesDeleteJob:            op("kubernetes.job.delete"),
+		KubernetesReadLogs:             op("kubernetes.pod.logs"),
+		KubernetesFindPod:              op("kubernetes.pod.find"),
+		KubernetesWaitForJobToComplete: op("kubernetes.job.wait"),
 
 		RunLockWaitTotal: runLockWaitTotal,
 		RunLockHeldTotal: runLockHeldTotal,

--- a/enterprise/cmd/executor/internal/worker/command/observability.go
+++ b/enterprise/cmd/executor/internal/worker/command/observability.go
@@ -25,11 +25,11 @@ type Operations struct {
 
 	Exec *observation.Operation
 
-	KubernetesCreateJob            *observation.Operation
-	KubernetesDeleteJob            *observation.Operation
-	KubernetesReadLogs             *observation.Operation
-	KubernetesFindPod              *observation.Operation
-	KubernetesWaitForJobToComplete *observation.Operation
+	KubernetesCreateJob           *observation.Operation
+	KubernetesDeleteJob           *observation.Operation
+	KubernetesReadLogs            *observation.Operation
+	KubernetesFindPod             *observation.Operation
+	KubernetesWaitForPodToSucceed *observation.Operation
 
 	RunLockWaitTotal prometheus.Counter
 	RunLockHeldTotal prometheus.Counter
@@ -83,11 +83,11 @@ func NewOperations(observationCtx *observation.Context) *Operations {
 
 		Exec: op("exec"),
 
-		KubernetesCreateJob:            op("kubernetes.job.create"),
-		KubernetesDeleteJob:            op("kubernetes.job.delete"),
-		KubernetesReadLogs:             op("kubernetes.pod.logs"),
-		KubernetesFindPod:              op("kubernetes.pod.find"),
-		KubernetesWaitForJobToComplete: op("kubernetes.job.wait"),
+		KubernetesCreateJob:           op("kubernetes.job.create"),
+		KubernetesDeleteJob:           op("kubernetes.job.delete"),
+		KubernetesReadLogs:            op("kubernetes.pod.logs"),
+		KubernetesFindPod:             op("kubernetes.pod.find"),
+		KubernetesWaitForPodToSucceed: op("kubernetes.pod.wait"),
 
 		RunLockWaitTotal: runLockWaitTotal,
 		RunLockHeldTotal: runLockHeldTotal,

--- a/enterprise/cmd/executor/internal/worker/runner/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/runner/kubernetes.go
@@ -115,7 +115,7 @@ func (r *kubernetesRunner) Run(ctx context.Context, spec Spec) error {
 	}
 	pod, err := r.cmd.FindPod(ctx, r.options.Namespace, job.Name)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "job %s succeeded but failed to find pod", job.Name)
 	}
 
 	return r.cmd.ReadLogs(ctx, r.options.Namespace, pod, command.KubernetesJobContainerName, r.commandLogger, spec.CommandSpec.Key, spec.CommandSpec.Command)

--- a/enterprise/cmd/executor/internal/worker/runner/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/runner/kubernetes.go
@@ -88,7 +88,7 @@ func (r *kubernetesRunner) Run(ctx context.Context, spec Spec) error {
 		if errors.Is(err, command.ErrKubernetesJobFailed) {
 			pod, findPodErr := r.cmd.FindPod(ctx, r.options.Namespace, job.Name)
 			if findPodErr != nil {
-				return err
+				return errors.Append(err, findPodErr)
 			}
 
 			var errMessage string

--- a/enterprise/cmd/executor/internal/worker/runner/kubernetes_test.go
+++ b/enterprise/cmd/executor/internal/worker/runner/kubernetes_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/command"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/runner"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -169,7 +170,7 @@ func TestKubernetesRunner_Run(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
-			cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset}
+			cmd := &command.KubernetesCommand{Logger: logtest.Scoped(t), Clientset: clientset, Operations: command.NewOperations(&observation.TestContext)}
 			logger := runner.NewMockLogger()
 			logEntry := runner.NewMockLogEntry()
 			logger.LogEntryFunc.PushReturn(logEntry)

--- a/enterprise/cmd/executor/internal/worker/runtime/runtime.go
+++ b/enterprise/cmd/executor/internal/worker/runtime/runtime.go
@@ -101,8 +101,9 @@ func New(
 			return nil, err
 		}
 		kubeCmd := &command.KubernetesCommand{
-			Logger:    logger,
-			Clientset: clientset,
+			Logger:     logger,
+			Clientset:  clientset,
+			Operations: ops,
 		}
 		logger.Info("using runtime 'kubernetes'")
 		return &kubernetesRuntime{

--- a/enterprise/cmd/executor/kubernetes/README.md
+++ b/enterprise/cmd/executor/kubernetes/README.md
@@ -27,13 +27,26 @@ If you run `codeintel`, you may need to tinker with the `EXECUTOR_KUBERNETES_RES
 and `EXECUTOR_MAXIMUM_NUM_JOBS` to ensure that each Job has enough memory to run and that the node does not run out of
 memory.
 
-## Build Image
+## Build Images
 
-Run the following command to build the image.
+To run Executors in Kubernetes you will need to build the `executor-kubernetes` image. If you are running Server Side
+Batch Changes, you will also need to build the `batcheshelper` image.
+
+### Executor
+
+Run the following command to build the executor image.
 
 ```bash
 # Build the image in enterprise/cmd/executor-kubernetes
 IMAGE=executor-kubernetes ../../executor-kubernetes/build.sh
+```
+
+### Batches Helper
+
+If you are running Server Side Batch Changes, you will need to build the batches helper image.
+
+```bash
+IMAGE=sourcegraph/batcheshelper:insiders ../../batcheshelper/build.sh
 ```
 
 ## Secrets


### PR DESCRIPTION
Some more tweaks to K8s support.

## Changes

- Fixed issue with flags not being used by `batcheshelper` when arguments are present
    - Apparently `flags` silently die when there are arguments present
- Added observability to `KubernetesCommand` to help met some metrics
- Added some `Debug` logs
- Changed the wait functionality from waiting on the K8s Job to the K8s Pod
    - This eliminates another API call we make
    - Since we always have 1 pod for every job, this is safe
    - Simplifies the code a little (removes the ugly error check)
- Updated docs to clarify that `batcheshelper` also needs to be built if running ssbc

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
