### PR TITLE
Embeddings: enable SIMD search by default

### DIFF
--- a/enterprise/internal/embeddings/dot.go
+++ b/enterprise/internal/embeddings/dot.go
@@ -3,7 +3,7 @@ package embeddings
 import "github.com/sourcegraph/sourcegraph/internal/env"
 
 var (
-	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", false, "Enable SIMD dot product for embeddings search")
+	simdEnabled = env.MustGetBool("ENABLE_EMBEDDINGS_SEARCH_SIMD", true, "Enable SIMD dot product for embeddings search")
 
 	// dotArch is a dot product function that is architecture-optimized. Its
 	// inputs must be of equal length and that length must be a multiple of 64.


### PR DESCRIPTION
This has been running on all cloud instances and on sourcegraph.com for a month. I think the risk is pretty low here, so let's enable this by default.

## Test plan

No additional testing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
