### PR TITLE
Insights: fix number of data points message

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/CaptureGoupCreationForm.tsx
@@ -178,7 +178,7 @@ export const CaptureGroupCreationForm: FC<CaptureGroupCreationFormProps> = props
                     errorInputState={stepValue.meta.touched && stepValue.meta.validState === 'INVALID'}
                     stepType={step.input.value}
                     onStepTypeChange={step.input.onChange}
-                    numberOfPoints={7}
+                    numberOfPoints={12}
                 />
             </FormGroup>
 

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/components/SearchInsightCreationForm.tsx
@@ -108,7 +108,7 @@ export const SearchInsightCreationForm: FC<CreationSearchInsightFormProps> = pro
                     errorInputState={stepValue.meta.touched && stepValue.meta.validState === 'INVALID'}
                     stepType={step.input.value}
                     onStepTypeChange={step.input.onChange}
-                    numberOfPoints={7}
+                    numberOfPoints={12}
                 />
             </FormGroup>
 


### PR DESCRIPTION
Insights creation screen was incorrectly say 7 data points would be present.
## Test plan
open creation screen view correct 12 points
<img width="673" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/5caeebd8-00b5-4a6b-b021-cdc29a2cafe9">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
