### PR TITLE
batches: doc feature availability badge cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 - 429 errors from external services Sourcegraph talks to are only retried automatically if the Retry-After header doesn't indicate that a retry would be useless. The time grace period can be configured using `SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION` and `SRC_HTTP_CLI_INTERNAL_RETRY_AFTER_MAX_DURATION`. [#51743](https://github.com/sourcegraph/sourcegraph/pull/51743)
 - Security Events NO LONGER write to database by default - instead, they will be written in the [audit log format](https://docs.sourcegraph.com/admin/audit_log) to console. There is a new site config setting `log.securityEventLogs` that can be used to configure security event logs to write to database if the old behaviour is desired. This new default will significantly improve performance for large instances. In addition, the old environment variable `SRC_DISABLE_LOG_PRIVATE_REPO_ACCESS` no longer does anything. [#51686](https://github.com/sourcegraph/sourcegraph/pull/51686)
 - Update minimum supported Redis version to 6.2 [#52248](https://github.com/sourcegraph/sourcegraph/pull/52248)
+- The batch spec properties [`transformChanges`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#transformchanges) and [`workspaces`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#workspaces) are now generally available.
 
 ### Fixed
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -151,7 +151,7 @@ To enable forks, update the site configuration to include:
 
 ## Automatically delete branches on merge/close
 
-<span class="badge badge-note">Sourcegraph 5.0.5+</span>
+<span class="badge badge-note">Sourcegraph 5.1+</span>
 
 Sourcegraph can be configured to automatically delete branches created for Batch Changes changesets when changesets are merged or closed by enabling the `batchChanges.autoDeleteBranch` site configuration option.
 

--- a/doc/batch_changes/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/batch_changes/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -5,8 +5,6 @@
 .markdown-body pre.chroma { font-size: 0.75em; }
 </style>
 
-<span class="badge badge-note">Sourcegraph 3.25+</span>
-
 ## Overview
 
 Large repositories often contain multiple projects, making them so-called monorepos. It can make sense to run the batch spec [`steps`][steps] separately in each project and create one changeset per project.

--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -10,8 +10,6 @@
 <span class="badge badge-beta">beta</span>This feature is in beta and might change in the future.</p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
-
-<p>It's available in Sourcegraph 3.23 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23.0 and later.</p>
 </aside>
 
 ## Overview

--- a/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
+++ b/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
@@ -1,7 +1,5 @@
 # Opting out of batch changes
 
-<span class="badge badge-note">Sourcegraph CLI 3.26.3+</span>
-
 Repository owners that are not interested in batch change changesets can opt out so that their repository will be skipped when a batch spec is executed.
 
 To opt out: create a file called `.batchignore` at the root of the repository you wish to be skipped. `src batch [apply|preview]` will now skip that repository if it's yielded by the `on` part of the batch spec.

--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -55,9 +55,6 @@ Templating is supported in the following fields:
 - [`steps.files`](batch_spec_yaml_reference.md#steps-run) values
 - [`steps.outputs.<name>.value`](batch_spec_yaml_reference.md#steps-outputs)
 - [`steps.if`](batch_spec_yaml_reference.md#steps-if)
-
-Additionally, with Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later:
-
 - [`changesetTemplate.title`](batch_spec_yaml_reference.md#changesettemplate-title)
 - [`changesetTemplate.body`](batch_spec_yaml_reference.md#changesettemplate-body)
 - [`changesetTemplate.branch`](batch_spec_yaml_reference.md#changesettemplate-branch)
@@ -81,29 +78,27 @@ They are evaluated before the execution of each entry in `steps`, except for the
 
 | Template variable | Type | Description |
 | --- | --- | --- |
-| `batch_change.name` | `string` | The `name` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>. |
-| `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>. 
+| `batch_change.name` | `string` | The `name` of the batch change, as set in the batch spec. |
+| `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. |
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
-| `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
+| `repository.branch` | `string` | The target branch of the repository in which the step is being executed. |
 | `repository.name` | `string` | Full name of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `previous_step.modified_files` | `list of strings` | List of files that have been modified by the previous steps. Empty list if no files have been modified. |
 | `previous_step.added_files` | `list of strings` | List of files that have been added by the previous steps. Empty list if no files have been added. |
 | `previous_step.deleted_files` | `list of strings` | List of files that have been deleted by the previous steps. Empty list if no files have been deleted. |
 | `previous_step.stdout` | `string` | The complete output of the previous step on standard output. |
 | `previous_step.stderr` | `string` | The complete output of the previous step on standard error. |
-| `step.modified_files` | `list of strings` | Only in `steps.outputs`: List of files that have been modified by the just-executed step. Empty list if no files have been modified. </br><i><small>Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later</small></i>. |
-| `step.added_files` | `list of strings` | Only in `steps.outputs`: List of files that have been added by the just-executed step. Empty list if no files have been added. </br><i><small>Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later</small></i>. |
-| `step.deleted_files` | `list of strings` | Only in `steps.outputs`: List of files that have been deleted by the just-executed step. Empty list if no files have been deleted. </br><i><small>Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later</small></i>. |
-| `step.stdout` | `string` | Only in `steps.outputs`: The complete output of the just-executed step on standard output.</br><i><small>Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later</small></i>. |
-| `step.stderr` | `string` | Only in `steps.outputs`: The complete output of the just-executed step on standard error. </br><i><small>Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later</small></i>. |
-| `steps.modified_files` | `list of strings` | List of files that have been modified by the `steps`. Empty list if no files have been modified. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.28 or later</small></i>. |
-| `steps.added_files` | `list of strings` | List of files that have been added by the `steps`. Empty list if no files have been added. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.28 or later</small></i>. |
-| `steps.deleted_files` | `list of strings` | List of files that have been deleted by the `steps`. Empty list if no files have been deleted. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.28 or later</small></i>. |
-| `steps.path` | `string` | Path (relative to the root of the directory, no leading `/` or `.`) in which the `steps` have been executed. Empty if no workspaces have been used and the `steps` were executed in the root of the repository. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.28 or later</small></i>. |
+| `step.modified_files` | `list of strings` | Only in `steps.outputs`: List of files that have been modified by the just-executed step. Empty list if no files have been modified. |
+| `step.added_files` | `list of strings` | Only in `steps.outputs`: List of files that have been added by the just-executed step. Empty list if no files have been added. |
+| `step.deleted_files` | `list of strings` | Only in `steps.outputs`: List of files that have been deleted by the just-executed step. Empty list if no files have been deleted. |
+| `step.stdout` | `string` | Only in `steps.outputs`: The complete output of the just-executed step on standard output.|
+| `step.stderr` | `string` | Only in `steps.outputs`: The complete output of the just-executed step on standard error. |
+| `steps.modified_files` | `list of strings` | List of files that have been modified by the `steps`. Empty list if no files have been modified. |
+| `steps.added_files` | `list of strings` | List of files that have been added by the `steps`. Empty list if no files have been added. |
+| `steps.deleted_files` | `list of strings` | List of files that have been deleted by the `steps`. Empty list if no files have been deleted. |
+| `steps.path` | `string` | Path (relative to the root of the directory, no leading `/` or `.`) in which the `steps` have been executed. Empty if no workspaces have been used and the `steps` were executed in the root of the repository. |
 
 ### `changesetTemplate` context
-
-<span class="badge badge-note">Sourcegraph 3.24+<span>
 
 The following template variables are available in the fields under `changesetTemplate`.
 
@@ -111,15 +106,15 @@ They are evaluated after the execution of all entries in `steps`.
 
 | Template variable | Type | Description |
 | --- | --- | --- |
-| `batch_change.name` | `string` | The `name` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>. |
-| `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.26 or later</small></i>.  |
+| `batch_change.name` | `string` | The `name` of the batch change, as set in the batch spec. |
+| `batch_change.description` | `string` | The `description` of the batch change, as set in the batch spec. |
 | `repository.search_result_paths` | `list of strings` | Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found. |
-| `repository.branch` | `string` | The target branch of the repository in which the step is being executed. </br><i><small>Requires Sourcegraph 3.35 or later.</small></i> |
+| `repository.branch` | `string` | The target branch of the repository in which the step is being executed. |
 | `repository.name` | `string` | Full name of the repository in which the step is being executed. Example: `org_foo/repo_bar`. |
 | `steps.modified_files` | `list of strings` | List of files that have been modified by the `steps`. Empty list if no files have been modified. |
 | `steps.added_files` | `list of strings` | List of files that have been added by the `steps`. Empty list if no files have been added. |
 | `steps.deleted_files` | `list of strings` | List of files that have been deleted by the `steps`. Empty list if no files have been deleted. |
-| `steps.path` | `string` | Path (relative to the root of the directory, no leading `/` or `.`) in which the `steps` have been executed. Empty if no workspaces have been used and the `steps` were executed in the root of the repository. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.25 or later</small></i> |
+| `steps.path` | `string` | Path (relative to the root of the directory, no leading `/` or `.`) in which the `steps` have been executed. Empty if no workspaces have been used and the `steps` were executed in the root of the repository. |
 | `outputs.<name>` | depends on `outputs.<name>.format`, default: `string`| Value of an [`output`](batch_spec_yaml_reference.md#steps-outputs) set by `steps`. If the [`outputs.<name>.format`](batch_spec_yaml_reference.md#steps-outputs-format) is `yaml` or `json` and the `value` a data structure (i.e. array, object, ...), then subfields can be accessed too. See "[Examples](#examples)" below. |
 | `batch_change_link` | `string` | <strong><small>Only available in `changesetTemplate.body`</small></strong><br />Link back to the batch change that produced the changeset on Sourcegraph. If omitted, the link will be automatically appended to the end of the body. </br><i><small>Requires [Sourcegraph CLI](../../cli/index.md) 3.40.9 or later</small></i> |
 

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -737,10 +737,6 @@ changesetTemplate:
 
 ## `transformChanges`
 
-<aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> <code>transformChanges</code> is an experimental feature in Sourcegraph 3.23 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.23. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
-</aside>
-
 A description of how to transform the changes (diffs) produced in each repository before turning them into separate changeset specs by inserting them into the [`changesetTemplate`](#changesettemplate).
 
 This allows the creation of multiple changeset specs (and thus changesets) in a single repository.
@@ -799,10 +795,6 @@ The branch that should be used for this additional changeset. This **overwrites 
 Optional: the file diffs matching the given directory will only be grouped in a repository with that name, as configured on your Sourcegraph instance.
 
 ## `workspaces`
-
-<aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> <code>workspaces</code> is an experimental feature in Sourcegraph 3.25 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.25. It's a <b>preview</b> of functionality we're currently exploring to make managing large changes in large repositories easier. If you have any feedback, please let us know!
-</aside>
 
 The optional `workspaces` property allows users to define where projects are located in repositories and cause the [`steps`](#steps) to be executed for each project, instead of once per repository. That allows easier creation of multiple changesets in large repositories.
 

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -162,7 +162,7 @@ steps:
 The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>steps.run</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> <code>steps.run</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ## `steps.container`
@@ -177,10 +177,10 @@ It is executed using `docker` on the machine on which the [Sourcegraph CLI (`src
 
 Environment variables to set in the environment when running this command.
 
-These may be defined either as an [object](#environment-object) or (in Sourcegraph 3.23 and later) as an [array](#environment-array).
+These may be defined either as an [object](#environment-object) or as an [array](#environment-array).
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.env</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> <code>steps.env</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ### Environment object
@@ -198,8 +198,6 @@ steps:
 ```
 
 ### Environment array
-
-<span class="badge badge-note">Sourcegraph 3.23+</span>
 
 In this case, `steps.env` is an array. Each array item is either:
 
@@ -234,14 +232,12 @@ For instance, if `USER` is set to `adam`, this would append `Hello world! from a
 
 ## `steps.files`
 
-<span class="badge badge-note">Sourcegraph 3.22+</span>
-
 Files to create on the host machine and mount into the container when running `steps.run`.
 
 `steps.files` is an object, where the key is the name of the file _inside the container_ and the value is the content of the file.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.files</code> can include <a href="batch_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://sourcegraph.com/github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<span class="badge badge-feature">Templating</span> <code>steps.files</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ### Examples
@@ -274,8 +270,6 @@ steps:
 ```
 
 ## `steps.outputs`
-
-<span class="badge badge-note">Sourcegraph 3.24+</span>
 
 Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available in the global `outputs` namespace as `outputs.<name>` <a href="batch_spec_templating">template variables</a> in the `run`, `env`, and `outputs` properties of subsequent steps, and the [`changesetTemplate`](#changesettemplate). Two steps with the same output variable name will overwrite the previous contents.
 
@@ -349,8 +343,6 @@ The format of the corresponding [`steps.outputs.<name>.value`](#outputs-value). 
 Possible values: `text`, `yaml`, `json`. Default is `text`.
 
 ## `steps.if`
-
-<span class="badge badge-note">Sourcegraph 3.28+</span>with Sourcegraph CLI 3.28 and later.
 
 Condition to check before executing the step. If the value of the `if:` attribute is `true` (boolean) or `"true"` (string) then the step is executed in the given repository (or workspace, in case [workspaces](#workspaces) are used). Otherwise the step is skipped.
 
@@ -555,7 +547,7 @@ changesetTemplate:
 The title of the changeset on the code host.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="batch_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ## `changesetTemplate.body`
@@ -563,7 +555,7 @@ The title of the changeset on the code host.
 The body (description) of the changeset on the code host. If the code supports Markdown you can use it here.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.body</code> can include <a href="batch_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.body</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ## `changesetTemplate.branch`
@@ -584,7 +576,7 @@ changesetTemplate:
 ```
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.branch</code> can include <a href="batch_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.branch</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ## `changesetTemplate.commit`
@@ -596,7 +588,7 @@ The Git commit to create with the changes.
 The Git commit message.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.commit.message</code> can include <a href="batch_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.commit.message</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ##[`changesetTemplate.commit.author`
@@ -604,7 +596,7 @@ The Git commit message.
 The `name` and `email` of the Git commit author.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.commit.author</code> can include <a href="batch_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.commit.author</code> can include <a href="batch_spec_templating">template variables</a>.
 </aside>
 
 ### Examples


### PR DESCRIPTION
A couple mini docs changes in one PR:

- Drops the "Experimental" label from `transformChanges` and `workspaces` (Closes https://github.com/sourcegraph/sourcegraph/issues/52631).
- Updates the version availability badge for the `batchChanges.autoDeleteBranch` site setting from the patch version to 5.1, since we've decided to defer its release until then.
- Drops version availability badges from anywhere in the Batch Changes docs that mentions a version constraint <= 3.28. Sorucegraph v3.28 will have been released 2 years ago from the upcoming v5.1, so I feel like that's a sufficient amount of time to have waited before cleaning up the docs and removing these. If a customer is actually still on a version that old, they've got _much bigger problems_ at this point.

## Test plan

Ran docsite locally and validated pages look okay.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
