### PR TITLE
cody-gateway: rename CODY_GATEWAY_SENTRY_DSN env var

### DIFF
--- a/enterprise/cmd/cody-gateway/main.go
+++ b/enterprise/cmd/cody-gateway/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/service/svcmain"
 )
 
-var sentryDSN = env.Get("LLM_PROXY_SENTRY_DSN", "", "Sentry DSN")
+var sentryDSN = env.Get("CODY_GATEWAY_SENTRY_DSN", "", "Sentry DSN")
 
 func main() {
 	sanitycheck.Pass()


### PR DESCRIPTION
Missed this as part of renames

## Test plan

n/a