### PR TITLE
Clarify the cody.codebase setting is optional and is a Git repo URL

### DIFF
--- a/client/cody/README.md
+++ b/client/cody/README.md
@@ -37,8 +37,6 @@ Examples of the kinds of questions Cody can handle:
 
 Cody tells you which code files it read to generate its response. (If Cody gives a wrong answer, please share feedback so we can improve it.)
 
-**Note:** For full codebase awareness, you must set the `cody.codebase` setting to the name of the repository on the connected Sourcegraph instance.
-
 ### ✨ Fixup code
 
 [**📽️ Demo**](https://twitter.com/sqs/status/1647673013343780864)

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -484,8 +484,11 @@
         "cody.codebase": {
           "order": 2,
           "type": "string",
-          "markdownDescription": "The name of the embedded repository that Cody will use to gather context for its responses. This is automatically inferred from your Git metadata, but you can use this option if you need to override the default.",
-          "example": "github.com/sourcegraph/sourcegraph"
+          "markdownDescription": "The Git repository URL for your code. This will be sent to the Sourcegraph API to fetch the code graph context data. When set to empty, the URL will be inferred from your Git metadata.",
+          "examples": [
+            "https://github.com/sourcegraph/sourcegraph.git",
+            "ssh://git@github.com/sourcegraph/sourcegraph"
+          ]
         },
         "cody.useContext": {
           "order": 3,

--- a/client/cody/src/external-services.ts
+++ b/client/cody/src/external-services.ts
@@ -43,7 +43,7 @@ export async function configureExternalServices(
     if (isError(repoId)) {
         const infoMessage =
             `Cody could not find the '${initialConfig.codebase}' repository on your Sourcegraph instance.\n` +
-            'Please check that the repository exists and is entered correctly in the cody.codebase setting.'
+            'Please check that the repository exists. You can override the repository with the "cody.codebase" setting.'
         console.info(infoMessage)
     }
     const embeddingsSearch = repoId && !isError(repoId) ? new SourcegraphEmbeddingsSearchClient(client, repoId) : null


### PR DESCRIPTION
This improves Cody’s `cody.codebase` setting description to make it clear that it's a Git repository URL, and removes the caveat from the readme that says it is required to set before getting embeddings.

Before:
<img width="791" alt="Screenshot 2023-05-31 at 3 34 27 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/103ba9e2-08f6-4c8a-bce0-a3f9061311cf">

After:
<img width="839" alt="Screenshot 2023-05-31 at 3 34 07 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/73a62779-c212-4e3b-affe-713803b741ab">

## Test plan

- Opened settings