### PR TITLE
Cody: Button to return to current chat session from history

### DIFF
--- a/client/cody/webviews/UserHistory.tsx
+++ b/client/cody/webviews/UserHistory.tsx
@@ -57,6 +57,17 @@ export const UserHistory: React.FunctionComponent<React.PropsWithChildren<Histor
                     </div>
                 </div>
                 <div className={styles.itemsContainer}>
+                    <VSCodeButton
+                        key="current"
+                        className={styles.itemButton}
+                        onClick={() => setView('chat')}
+                        type="button"
+                    >
+                        <div className={styles.itemButtonInnerContainer}>
+                            <div className={styles.itemDate}>{new Date(Date.now()).toLocaleString()} - current</div>
+                            <div className={styles.itemLastMessage}>Conversation in progress...</div>
+                        </div>
+                    </VSCodeButton>
                     {userHistory &&
                         [...Object.entries(userHistory)]
                             .sort(


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/52544#issuecomment-1569344847

Added a new button on top that would go back to the current chat view:
<img width="530" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/2a1e9891-0561-4064-8885-e21a638df592">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


Passing the history e2e test