### PR TITLE
batches: remove site admin restriction on license info in JS context

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -195,7 +195,7 @@ func init() {
 }
 
 func storageLimitReachedAlert(args AlertFuncArgs) []*Alert {
-	licenseInfo := hooks.GetLicenseInfo(args.IsSiteAdmin)
+	licenseInfo := hooks.GetLicenseInfo()
 	if licenseInfo == nil {
 		return nil
 	}

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -31,4 +31,4 @@ type LicenseInfo struct {
 	BatchChanges           *FeatureBatchChanges `json:"batchChanges"`
 }
 
-var GetLicenseInfo = func(isSiteAdmin bool) *LicenseInfo { return nil }
+var GetLicenseInfo = func() *LicenseInfo { return nil }

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -19,8 +19,9 @@ type FeatureBatchChanges struct {
 	MaxNumChangesets int `json:"maxNumChangesets"`
 }
 
-// LicenseInfo contains information about the legitimate usage of the current
-// license on the instance.
+// LicenseInfo contains non-sensitive information about the legitimate usage of the
+// current license on the instance. It is technically accessible to all users, so only
+// include information that is safe to be seen by others.
 type LicenseInfo struct {
 	CurrentPlan string `json:"currentPlan"`
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -277,15 +277,13 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		openTelemetry = clientObservability.OpenTelemetry
 	}
 
-	var licenseInfo *hooks.LicenseInfo
+	licenseInfo := hooks.GetLicenseInfo()
+
 	var user *types.User
 	temporarySettings := "{}"
-	if !a.IsAuthenticated() {
-		licenseInfo = hooks.GetLicenseInfo(false)
-	} else {
+	if a.IsAuthenticated() {
 		// Ignore err as we don't care if user does not exist
 		user, _ = a.User(ctx, db.Users())
-		licenseInfo = hooks.GetLicenseInfo(user != nil && user.SiteAdmin)
 		if user != nil {
 			if settings, err := db.TemporarySettings().GetTemporarySettings(ctx, user.ID); err == nil {
 				temporarySettings = settings.Contents

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -277,6 +277,10 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		openTelemetry = clientObservability.OpenTelemetry
 	}
 
+	// License info contains basic, non-sensitive information about the license type. Some
+	// properties are only set for certain license types. This information can be used to
+	// soft-gate features from the UI, and to provide info to admins from site admin
+	// settings pages in the UI.
 	licenseInfo := hooks.GetLicenseInfo()
 
 	var user *types.User

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -49,11 +49,7 @@ func Init(
 	database.BeforeCreateExternalService = enforcement.NewBeforeCreateExternalServiceHook()
 
 	logger := log.Scoped("licensing", "licensing enforcement")
-	hooks.GetLicenseInfo = func(isSiteAdmin bool) *hooks.LicenseInfo {
-		if !isSiteAdmin {
-			return nil
-		}
-
+	hooks.GetLicenseInfo = func() *hooks.LicenseInfo {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
 			logger.Error("Failed to get license info", log.Error(err))

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -49,6 +49,10 @@ func Init(
 	database.BeforeCreateExternalService = enforcement.NewBeforeCreateExternalServiceHook()
 
 	logger := log.Scoped("licensing", "licensing enforcement")
+
+	// Surface basic, non-sensitive information about the license type. This information
+	// can be used to soft-gate features from the UI, and to provide info to admins from
+	// site admin settings pages in the UI.
 	hooks.GetLicenseInfo = func() *hooks.LicenseInfo {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -56,11 +56,6 @@ func Init(
 			return nil
 		}
 
-		if info.Plan().IsFree() {
-			// We don't enforce anything on the free plan
-			return nil
-		}
-
 		licenseInfo := &hooks.LicenseInfo{
 			CurrentPlan: string(info.Plan()),
 		}
@@ -90,7 +85,7 @@ func Init(
 				licenseInfo.KnownLicenseTags = append(licenseInfo.KnownLicenseTags, feature.FeatureName())
 			}
 			licenseInfo.KnownLicenseTags = append(licenseInfo.KnownLicenseTags, licensing.MiscTags...)
-		} else {
+		} else { // returning BC info only makes sense on non-dotcom
 			bcFeature := &licensing.FeatureBatchChanges{}
 			if err := licensing.Check(bcFeature); err == nil {
 				if bcFeature.Unrestricted {


### PR DESCRIPTION
Silly me committed the cardinal sin of not testing changes as a non-admin user once again. 🙃 When will I learn, eh?

`window.context.licenseInfo` was `null` for non-admins, which unintentionally locked them out of BC since it looks like the instance is running in OSS. 😬 None of the information contained in license info is sensitive, and besides the BC stuff, it's only surfaced in the UI from site admin settings anyway, so I don't think there's any risk in removing this. However, I've tagged @pjlast just in case. If at some point we add something sensitive in here, we could put the site admin guard back but just for the sensitive fields.

## Test plan

- Run the instance as enterprise and sign in as a non-admin
- Verify `window.context.licenseInfo` is not null
- Verify BC nav menu option and pages are visible

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
