### PR TITLE
batches: add docs for new org admin setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
-- Organization members can now administer batch changes created by other members in their organization's namespace if the setting `orgs.allMembersBatchChangesAdmin` is enabled for that organization.
+- Organization members can now administer batch changes created by other members in their organization's namespace if the setting `orgs.allMembersBatchChangesAdmin` is enabled for that organization. [#50724](https://github.com/sourcegraph/sourcegraph/pull/50724)
 
 ## 5.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ All notable changes to Sourcegraph are documented in this file.
 - Unused site-config field `api.rateLimit` has been removed. [#51087](https://github.com/sourcegraph/sourcegraph/pull/51087)
 - Legacy (table-based) blob viewer. [#50915](https://github.com/sourcegraph/sourcegraph/pull/50915)
 
+## 5.0.5
+
+### Added
+
+- Organization members can now administer batch changes created by other members in their organization's namespace if the setting `orgs.allMembersBatchChangesAdmin` is enabled for that organization.
+
 ## 5.0.4
 
 ### Fixed

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -10,7 +10,7 @@ Batch Changes is [RBAC-enabled](../../admin/access_control/index.md) <span class
 
 ### Enable organization members to administer
 
-<span class="badge badge-note">Sourcegraph 5.1+</span>
+<span class="badge badge-note">Sourcegraph 5.0.5+</span>
 
 By default, only a batch change's author or a site admin can administer (apply, close, rename, etc.) a batch change. However, admins can use [organizations](../../admin/organizations) to facilitate closer collaboration and shared administrative control over batch changes by enabling the `orgs.allMembersBatchChangesAdmin` setting for an organization. When enabled, members of the organization will be able to administer all batch changes created in that organization's namespace. Batch changes created in other namespaces (user or organization) will still be restricted to the author and site admins.
 

--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -8,6 +8,12 @@ Batch Changes is generally configured through the same [site configuration](site
 
 Batch Changes is [RBAC-enabled](../../admin/access_control/index.md) <span class="badge badge-beta">Beta</span>. By default, all users have full read and write access for Batch Changes, but this can be restricted by changing the default role permissions, or by creating new custom roles.
 
+### Enable organization members to administer
+
+<span class="badge badge-note">Sourcegraph 5.1+</span>
+
+By default, only a batch change's author or a site admin can administer (apply, close, rename, etc.) a batch change. However, admins can use [organizations](../../admin/organizations) to facilitate closer collaboration and shared administrative control over batch changes by enabling the `orgs.allMembersBatchChangesAdmin` setting for an organization. When enabled, members of the organization will be able to administer all batch changes created in that organization's namespace. Batch changes created in other namespaces (user or organization) will still be restricted to the author and site admins.
+
 ## Rollout windows
 
 By default, Sourcegraph attempts to reconcile (create, update, or close) changesets as quickly as the rate limits on the code host allow. This can result in CI systems being overwhelmed if hundreds or thousands of changesets are being handled as part of a single batch change.

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -4,7 +4,8 @@
 
 1. Using Batch Changes requires a [code host connection](../../admin/external_services/index.md) to a supported code host (currently GitHub, Bitbucket Server / Bitbucket Data Center, GitLab, and Bitbucket Cloud).
 
-1. (Optional) [Configure which users have access to Batch Changes](../../admin/access_control/batch_changes.md) <span class="badge badge-beta">Beta</span>. By default, all users can create and view batch changes.
+1. (Optional) [Configure which users have access to Batch Changes](../../admin/access_control/batch_changes.md) <span class="badge badge-beta">Beta</span>. By default, all users can create and view batch changes, but only the batch change's author or a site admin can administer a given batch change.
+    * Additionally, you can also [customize org settings](../../admin/config/batch_changes.md#enable-organization-members-to-administer) to allow members of an organization to share administration privileges over batch changes created in that organization.
 
 1. (Optional) [Configure repository permissions](../../admin/permissions/index.md), which Batch Changes will respect.
 


### PR DESCRIPTION
Adds CHANGELOG entry and basic site admin docs regarding the new org setting, `orgs.allMembersBatchChangesAdmin`, from https://github.com/sourcegraph/sourcegraph/pull/50724. I think we just forgot about these. 🙈

## Test plan

N/A just docs changes.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
