### PR TITLE
Fix Context File Links

### DIFF
--- a/client/cody-shared/src/chat/useClient.ts
+++ b/client/cody-shared/src/chat/useClient.ts
@@ -67,6 +67,7 @@ interface CodyClientProps {
     scope?: CodyClientScope
     initialTranscript?: Transcript | null
     onEvent?: (event: CodyClientEvent) => void
+    web?: boolean
 }
 
 export const useClient = ({
@@ -78,6 +79,7 @@ export const useClient = ({
         editor: new NoopEditor(),
     },
     onEvent,
+    web = false,
 }: CodyClientProps): CodyClient => {
     const [transcript, setTranscriptState] = useState<Transcript | null>(initialTranscript)
     const [chatMessages, setChatMessagesState] = useState<ChatMessage[]>([])
@@ -169,7 +171,7 @@ export const useClient = ({
             }
 
             const repoId = await codebaseId
-            const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId) : null
+            const embeddingsSearch = repoId ? new SourcegraphEmbeddingsSearchClient(graphqlClient, repoId, web) : null
             const codebaseContext = new CodebaseContext(config, codebase || undefined, embeddingsSearch, null)
 
             const { humanChatInput = '', prefilledOptions } = options ?? {}

--- a/client/cody-shared/src/chat/useClient.ts
+++ b/client/cody-shared/src/chat/useClient.ts
@@ -252,6 +252,7 @@ export const useClient = ({
             chatClient,
             isMessageInProgress,
             onEvent,
+            web,
         ]
     )
 

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -116,6 +116,7 @@ export const useCodyChat = ({
         },
         scope: initialScope,
         onEvent,
+        web: true,
     })
 
     const loadTranscriptFromHistory = useCallback(


### PR DESCRIPTION
Forgot to pass `web = true` to embedding context fetcher client. 


## Test plan

- Open cody on web in the sidebar
- Ask question regarding the codebase opened
- Check if context files in the response have links. 