### PR TITLE
own: add API for removing an assigned owner.

### DIFF
--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -61,6 +61,7 @@ type OwnResolver interface {
 
 	// Assigned ownership mutations.
 	AssignOwner(context.Context, *AssignOwnerArgs) (*EmptyResponse, error)
+	RemoveAssignedOwner(context.Context, *AssignOwnerArgs) (*EmptyResponse, error)
 
 	// Config.
 	OwnSignalConfigurations(ctx context.Context) ([]SignalConfigurationResolver, error)

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -249,6 +249,10 @@ extend type Mutation {
     assignOwner creates a new assigned owner.
     """
     assignOwner(input: AssignOwnerInput!): EmptyResponse
+    """
+    removeAssignedOwner removes an assigned owner.
+    """
+    removeAssignedOwner(input: AssignOwnerInput!): EmptyResponse
 }
 
 """
@@ -347,7 +351,7 @@ input UpdateSignalConfigurationsInput {
 }
 
 """
-AssignOwnerInput represents the input for assigning an owner.
+AssignOwnerInput represents the input for assigning or deleting an owner.
 """
 input AssignOwnerInput {
     """


### PR DESCRIPTION
Test plan:
GraphQL tests added.

Closes https://github.com/sourcegraph/sourcegraph/issues/52135.