### PR TITLE
Cody: Update task controller e2e test to wait for inbox

### DIFF
--- a/client/cody/test/e2e/task-controller.test.ts
+++ b/client/cody/test/e2e/task-controller.test.ts
@@ -33,6 +33,10 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
 
     // Open the command palette by clicking on the Cody Icon
     await page.getByRole('button', { name: /Cody: Fixup.*/ }).click()
+
+    // Wait for the input box to appear
+    await expect(page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.')).toBeVisible()
+    await page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.').click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')
     // Press enter to submit the fixup

--- a/client/cody/test/e2e/task-controller.test.ts
+++ b/client/cody/test/e2e/task-controller.test.ts
@@ -35,7 +35,6 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     await page.getByRole('button', { name: /Cody: Fixup.*/ }).click()
 
     // Wait for the input box to appear
-    await expect(page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.')).toBeVisible()
     await page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.').click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')


### PR DESCRIPTION
RE https://sourcegraph.slack.com/archives/C02FLQDD3TQ/p1685533593090969

Add new steps to wait for the input box to show up before clicking on it to make sure the right element has the right focus.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```sh
❯ pnpm test:e2e task-controller

> cody-ai@0.1.5 test:e2e /Users/bwork/dev/sourcegraph-chat/client/cody
> npx playwright install && pnpm run --silent build:dev && playwright test "task-controller"

[0]
[0]   dist/extension.js      5.0mb ⚠️
[0]   dist/extension.js.map  7.6mb
[0]
[0] ⚡ Done in 175ms
[0] pnpm esbuild --sourcemap exited with code 0
[1] vite build --mode development exited with code 0

Running 1 test using 1 worker

  ✓  1 task-controller.test.ts:6:5 › task tree view for non-stop cody (4.7s)
Found existing install in /Users/bwork/dev/sourcegraph-chat/client/cody/.vscode-test/vscode-darwin-arm64-1.78.2. Skipping download
Mock server listening on port 49300
(node:49591) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)

  1 passed (5.2s)
```