### PR TITLE
App: Add a manual check for updates tray option

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -6,6 +6,8 @@ use tauri::{
     SystemTrayMenuItem,
 };
 
+pub const EVENT_CHECK_FOR_UPDATES: &str = "tauri://update";
+
 pub fn create_system_tray() -> SystemTray {
     SystemTray::new().with_menu(create_system_tray_menu())
 }
@@ -18,6 +20,10 @@ fn create_system_tray_menu() -> SystemTrayMenu {
         .add_item(
             CustomMenuItem::new("settings".to_string(), "Settings").accelerator("CmdOrCtrl+,"),
         )
+        .add_item(CustomMenuItem::new(
+            "update".to_string(),
+            "Check for Updates...",
+        ))
         .add_item(CustomMenuItem::new(
             "troubleshoot".to_string(),
             "Troubleshoot",
@@ -56,6 +62,12 @@ pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
             }
             "restart" => app.restart(),
             "quit" => app.exit(0),
+            "update" => match app.emit_all(EVENT_CHECK_FOR_UPDATES, {}) {
+                Ok(_) => {}
+                Err(e) => {
+                    log::error!("failed checking for updates {}", e)
+                }
+            },
             _ => {}
         }
     }


### PR DESCRIPTION
Tauri apps only check for updates at launch, this adds an option to manually check for updates
## Test plan
App launches and menu option available.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
