### PR TITLE
App: Add local/remote repositories app banner

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -33,6 +33,7 @@ export const Overview: Story = () => (
                 autoFocusForm={false}
                 externalServicesFromFile={false}
                 allowEditExternalServicesWithFile={false}
+                isSourcegraphApp={false}
             />
         )}
     </WebStory>
@@ -49,6 +50,7 @@ export const AddConnectionBykind: Story = () => (
                 autoFocusForm={false}
                 externalServicesFromFile={false}
                 allowEditExternalServicesWithFile={false}
+                isSourcegraphApp={false}
             />
         )}
     </WebStory>

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -7,6 +7,7 @@ import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useLocalStorage, Button, Link, Alert, H2, H3, Icon, Text, Container } from '@sourcegraph/wildcard'
 
+import { LimitedAccessBanner } from '../LimitedAccessBanner'
 import { PageTitle } from '../PageTitle'
 
 import { AddExternalServicePage } from './AddExternalServicePage'
@@ -29,6 +30,7 @@ export interface AddExternalServicesPageProps extends TelemetryProps {
 
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
+    isSourcegraphApp: boolean
 
     /** For testing only. */
     autoFocusForm?: boolean
@@ -44,6 +46,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
+    isSourcegraphApp,
 }) => {
     const { search } = useLocation()
     const [hasDismissedPrivacyWarning, setHasDismissedPrivacyWarning] = useLocalStorage(
@@ -99,6 +102,17 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         <>
             <PageTitle title="Add code host connection" />
             <H2>Add code host connection</H2>
+
+            {isSourcegraphApp && (
+                <LimitedAccessBanner
+                    storageKey="app.manage-repositories-with-new-settings"
+                    badgeText="Repositories"
+                    className="mb-3"
+                >
+                    Manage your local repositories in your settings. Go to{' '}
+                    <Link to="/user/app-settings">Settings → Repositories → Local/Remote repositories</Link>
+                </LimitedAccessBanner>
+            )}
             <Container>
                 <Text>Add code host connection to one of the supported code hosts.</Text>
                 {hasDismissedPrivacyWarning && (

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -7,16 +7,20 @@ import { logger } from '@sourcegraph/common'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, H4, Link, PageHeader } from '@sourcegraph/wildcard'
 
+import { LimitedAccessBanner } from '../components/LimitedAccessBanner'
 import { PageTitle } from '../components/PageTitle'
 import { refreshSiteFlags } from '../site/backend'
 
 import { SiteAdminRepositoriesContainer } from './SiteAdminRepositoriesContainer'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps {
+    isSourcegraphApp: boolean
+}
 
 /** A page displaying the repositories on this site */
 export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    isSourcegraphApp,
 }) => {
     const location = useLocation()
 
@@ -63,6 +67,18 @@ export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithC
                 }
                 className="mb-3"
             />
+
+            {isSourcegraphApp && (
+                <LimitedAccessBanner
+                    storageKey="app.manage-repositories-with-new-settings"
+                    badgeText="Repositories"
+                    className="mb-3"
+                >
+                    Manage your local repositories in your settings. Go to{' '}
+                    <Link to="/user/app-settings">Settings → Repositories → Local/Remote repositories</Link>
+                </LimitedAccessBanner>
+            )}
+
             {licenseInfo && (licenseInfo.codeScaleCloseToLimit || licenseInfo.codeScaleExceededLimit) && (
                 <Alert variant={licenseInfo.codeScaleExceededLimit ? 'danger' : 'warning'}>
                     <H4>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52567

## Tech note
I inlined the banner on purpose in order to avoid having yet another small banner component 

## Test plan
- Check code host connection and repositories page, make sure that banner is there and provides correct text and link to the repositories settings

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
