### PR TITLE
ranking: Allow deletion of exports with same base graph key

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/uploads.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/uploads.go
@@ -206,7 +206,8 @@ locked_exported_uploads AS (
 			FROM codeintel_ranking_progress crp
 			WHERE
 				crp.graph_key = %s AND
-				crp.reducer_completed_at IS NULL
+				crp.reducer_completed_at IS NULL AND
+				crp.mappers_started_at <= cre.deleted_at
 		)
 	ORDER BY cre.id
 	FOR UPDATE SKIP LOCKED


### PR DESCRIPTION
Allow deletion of export records when the current ranking calculation is not currently active. The old query was holding on to any base graph key that has a current calculation.

We're hoarding records on dotcom.

## Test plan

Existing unit tests.