### PR TITLE
refactor owner list to accept tree or blob results

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -15,7 +15,6 @@ import { MarketingBlock } from '../../../components/MarketingBlock'
 import {
     FetchOwnershipResult,
     FetchOwnershipVariables,
-    FetchTreeOwnershipResult,
     OwnerFields,
     OwnershipConnectionFields,
     SearchPatternType,
@@ -141,7 +140,7 @@ interface OwnerListProps {
 }
 
 const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
-    if (data && data.nodes && data.nodes.length > 0) {
+    if (data?.nodes && data.nodes.length > 0) {
         const nodes = data.nodes
         const totalCount = data.totalOwners
         return (

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -61,7 +61,10 @@ export const FileOwnershipPanel: React.FunctionComponent<
         )
     }
 
-    return <OwnerList data={data?.node?.commit?.blob?.ownership} />
+    if (data?.node?.__typename === 'Repository') {
+        return <OwnerList data={data?.node?.commit?.blob?.ownership} />
+    }
+    return <OwnerList/>
 }
 
 interface OwnExplanationProps {

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -139,7 +139,7 @@ const resolveOwnerSearchPredicate = (owners?: OwnerFields[]): string => {
 }
 
 interface OwnerListProps {
-    data?: OwnershipConnectionFields
+    data?: OwnershipConnectionFields | undefined
 }
 
 const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -139,7 +139,7 @@ const resolveOwnerSearchPredicate = (owners?: OwnerFields[]): string => {
 }
 
 interface OwnerListProps {
-    data?: OwnershipConnectionFields | undefined
+    data?: OwnershipConnectionFields
 }
 
 const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -14,8 +14,8 @@ import { Alert, Button, ErrorAlert, H3, H4, Icon, Link, LoadingSpinner, Text } f
 import { MarketingBlock } from '../../../components/MarketingBlock'
 import {
     FetchOwnershipResult,
-    FetchOwnershipVariables,
-    OwnerFields,
+    FetchOwnershipVariables, FetchTreeOwnershipResult,
+    OwnerFields, OwnershipConnectionFields,
     SearchPatternType,
 } from '../../../graphql-operations'
 
@@ -60,101 +60,8 @@ export const FileOwnershipPanel: React.FunctionComponent<
         )
     }
 
-    // TODO(#52452): There is filtering logic in the following rendering
-    // of owners and inference signals. Preferably we'd use filtering
-    // on the GraphQL call and fetch owners and signals separately.
-    // Then re-use a component to render both parts.
-    if (
-        data?.node &&
-        data.node.__typename === 'Repository' &&
-        data.node.commit?.blob &&
-        data.node.commit.blob.ownership.nodes.length > 0
-    ) {
-        const nodes = data.node.commit.blob.ownership.nodes
-        return (
-            <div className={styles.contents}>
-                <OwnExplanation owners={nodes.map(ownership => ownership.owner)} />
-                <table className={styles.table}>
-                    <thead>
-                        <tr className="sr-only">
-                            <th>Contact</th>
-                            <th>Owner</th>
-                            <th>Reason</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <th colSpan={3}>
-                                {data.node.commit.blob.ownership.totalOwners === 0 ? (
-                                    <Alert variant="info">No ownership data for this file.</Alert>
-                                ) : (
-                                    <H4 className="mb-3">Owners</H4>
-                                )}
-                            </th>
-                        </tr>
-                        {nodes
-                            .filter(ownership =>
-                                ownership.reasons.some(
-                                    reason =>
-                                        reason.__typename === 'CodeownersFileEntry' ||
-                                        reason.__typename === 'AssignedOwner'
-                                )
-                            )
-                            .map((ownership, index) => (
-                                // This list is not expected to change, so it's safe to use the index as a key.
-                                // eslint-disable-next-line react/no-array-index-key
-                                <React.Fragment key={index}>
-                                    {index > 0 && <tr className={styles.bordered} />}
-                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
-                                </React.Fragment>
-                            ))}
-                        {
-                            /* Visually separate two sets with a horizontal rule (like subsequent owners are)
-                             * if there is data in both owners and signals.
-                             */
-                            data.node.commit.blob.ownership.totalOwners > 0 &&
-                                data.node.commit.blob.ownership.nodes.length >
-                                    data.node.commit.blob.ownership.totalOwners && <tr className={styles.bordered} />
-                        }
-                        {data.node.commit.blob.ownership.nodes.length > data.node.commit.blob.ownership.totalOwners && (
-                            <tr>
-                                <th colSpan={3}>
-                                    <H4 className="mt-3 mb-2">Inference signals</H4>
-                                    <Text className={styles.ownInferenceExplanation}>
-                                        These users have viewed or contributed to the file but are not registered owners
-                                        of the file.
-                                    </Text>
-                                </th>
-                            </tr>
-                        )}
-                        {nodes
-                            .filter(
-                                ownership =>
-                                    !ownership.reasons.some(
-                                        reason =>
-                                            reason.__typename === 'CodeownersFileEntry' ||
-                                            reason.__typename === 'AssignedOwner'
-                                    )
-                            )
-                            .map((ownership, index) => (
-                                // This list is not expected to change, so it's safe to use the index as a key.
-                                // eslint-disable-next-line react/no-array-index-key
-                                <React.Fragment key={index}>
-                                    {index > 0 && <tr className={styles.bordered} />}
-                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
-                                </React.Fragment>
-                            ))}
-                    </tbody>
-                </table>
-            </div>
-        )
-    }
-
     return (
-        <div className={styles.contents}>
-            <OwnExplanation />
-            <Alert variant="info">No ownership data for this file.</Alert>
-        </div>
+        <OwnerList data={data?.node?.commit?.blob?.ownership} />
     )
 }
 
@@ -227,4 +134,107 @@ const resolveOwnerSearchPredicate = (owners?: OwnerFields[]): string => {
         }
     }
     return 'johndoe'
+}
+
+interface OwnerListProps {
+    data?: OwnershipConnectionFields
+}
+
+const OwnerList: React.FunctionComponent<OwnerListProps> = ({data}) => {
+    console.log(data)
+    if (!data) {
+
+    }
+    if (
+        data &&
+        data.nodes &&
+        data.nodes.length > 0
+    ) {
+        const nodes = data.nodes
+        const totalCount = data.totalOwners
+        return (
+            <div className={styles.contents}>
+                <OwnExplanation owners={nodes.map(ownership => ownership.owner)} />
+                <table className={styles.table}>
+                    <thead>
+                    <tr className="sr-only">
+                        <th>Contact</th>
+                        <th>Owner</th>
+                        <th>Reason</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <th colSpan={3}>
+                            {totalCount === 0 ? (
+                                <Alert variant="info">No ownership data for this file.</Alert>
+                            ) : (
+                                <H4 className="mb-3">Owners</H4>
+                            )}
+                        </th>
+                    </tr>
+                    {nodes
+                        .filter(ownership =>
+                            ownership.reasons.some(
+                                reason =>
+                                    reason.__typename === 'CodeownersFileEntry' ||
+                                    reason.__typename === 'AssignedOwner'
+                            )
+                        )
+                        .map((ownership, index) => (
+                            // This list is not expected to change, so it's safe to use the index as a key.
+                            // eslint-disable-next-line react/no-array-index-key
+                            <React.Fragment key={index}>
+                                {index > 0 && <tr className={styles.bordered} />}
+                                <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                            </React.Fragment>
+                        ))}
+                    {
+                        /* Visually separate two sets with a horizontal rule (like subsequent owners are)
+                         * if there is data in both owners and signals.
+                         */
+                        totalCount > 0 &&
+                        nodes.length >
+                        totalCount && <tr className={styles.bordered} />
+                    }
+                    {nodes.length > totalCount && (
+                        <tr>
+                            <th colSpan={3}>
+                                <H4 className="mt-3 mb-2">Inference signals</H4>
+                                <Text className={styles.ownInferenceExplanation}>
+                                    These users have viewed or contributed to the file but are not registered owners
+                                    of the file.
+                                </Text>
+                            </th>
+                        </tr>
+                    )}
+                    {nodes
+                        .filter(
+                            ownership =>
+                                !ownership.reasons.some(
+                                    reason =>
+                                        reason.__typename === 'CodeownersFileEntry' ||
+                                        reason.__typename === 'AssignedOwner'
+                                )
+                        )
+                        .map((ownership, index) => (
+                            // This list is not expected to change, so it's safe to use the index as a key.
+                            // eslint-disable-next-line react/no-array-index-key
+                            <React.Fragment key={index}>
+                                {index > 0 && <tr className={styles.bordered} />}
+                                <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                            </React.Fragment>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        )
+    }
+
+    return (
+        <div className={styles.contents}>
+            <OwnExplanation />
+            <Alert variant="info">No ownership data for this file.</Alert>
+        </div>
+    )
 }

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -64,7 +64,7 @@ export const FileOwnershipPanel: React.FunctionComponent<
     if (data?.node?.__typename === 'Repository') {
         return <OwnerList data={data?.node?.commit?.blob?.ownership} />
     }
-    return <OwnerList/>
+    return <OwnerList />
 }
 
 interface OwnExplanationProps {

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -14,8 +14,10 @@ import { Alert, Button, ErrorAlert, H3, H4, Icon, Link, LoadingSpinner, Text } f
 import { MarketingBlock } from '../../../components/MarketingBlock'
 import {
     FetchOwnershipResult,
-    FetchOwnershipVariables, FetchTreeOwnershipResult,
-    OwnerFields, OwnershipConnectionFields,
+    FetchOwnershipVariables,
+    FetchTreeOwnershipResult,
+    OwnerFields,
+    OwnershipConnectionFields,
     SearchPatternType,
 } from '../../../graphql-operations'
 
@@ -60,9 +62,7 @@ export const FileOwnershipPanel: React.FunctionComponent<
         )
     }
 
-    return (
-        <OwnerList data={data?.node?.commit?.blob?.ownership} />
-    )
+    return <OwnerList data={data?.node?.commit?.blob?.ownership} />
 }
 
 interface OwnExplanationProps {
@@ -140,16 +140,8 @@ interface OwnerListProps {
     data?: OwnershipConnectionFields
 }
 
-const OwnerList: React.FunctionComponent<OwnerListProps> = ({data}) => {
-    console.log(data)
-    if (!data) {
-
-    }
-    if (
-        data &&
-        data.nodes &&
-        data.nodes.length > 0
-    ) {
+const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
+    if (data && data.nodes && data.nodes.length > 0) {
         const nodes = data.nodes
         const totalCount = data.totalOwners
         return (
@@ -157,74 +149,72 @@ const OwnerList: React.FunctionComponent<OwnerListProps> = ({data}) => {
                 <OwnExplanation owners={nodes.map(ownership => ownership.owner)} />
                 <table className={styles.table}>
                     <thead>
-                    <tr className="sr-only">
-                        <th>Contact</th>
-                        <th>Owner</th>
-                        <th>Reason</th>
-                    </tr>
+                        <tr className="sr-only">
+                            <th>Contact</th>
+                            <th>Owner</th>
+                            <th>Reason</th>
+                        </tr>
                     </thead>
                     <tbody>
-                    <tr>
-                        <th colSpan={3}>
-                            {totalCount === 0 ? (
-                                <Alert variant="info">No ownership data for this file.</Alert>
-                            ) : (
-                                <H4 className="mb-3">Owners</H4>
-                            )}
-                        </th>
-                    </tr>
-                    {nodes
-                        .filter(ownership =>
-                            ownership.reasons.some(
-                                reason =>
-                                    reason.__typename === 'CodeownersFileEntry' ||
-                                    reason.__typename === 'AssignedOwner'
-                            )
-                        )
-                        .map((ownership, index) => (
-                            // This list is not expected to change, so it's safe to use the index as a key.
-                            // eslint-disable-next-line react/no-array-index-key
-                            <React.Fragment key={index}>
-                                {index > 0 && <tr className={styles.bordered} />}
-                                <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
-                            </React.Fragment>
-                        ))}
-                    {
-                        /* Visually separate two sets with a horizontal rule (like subsequent owners are)
-                         * if there is data in both owners and signals.
-                         */
-                        totalCount > 0 &&
-                        nodes.length >
-                        totalCount && <tr className={styles.bordered} />
-                    }
-                    {nodes.length > totalCount && (
                         <tr>
                             <th colSpan={3}>
-                                <H4 className="mt-3 mb-2">Inference signals</H4>
-                                <Text className={styles.ownInferenceExplanation}>
-                                    These users have viewed or contributed to the file but are not registered owners
-                                    of the file.
-                                </Text>
+                                {totalCount === 0 ? (
+                                    <Alert variant="info">No ownership data for this file.</Alert>
+                                ) : (
+                                    <H4 className="mb-3">Owners</H4>
+                                )}
                             </th>
                         </tr>
-                    )}
-                    {nodes
-                        .filter(
-                            ownership =>
-                                !ownership.reasons.some(
+                        {nodes
+                            .filter(ownership =>
+                                ownership.reasons.some(
                                     reason =>
                                         reason.__typename === 'CodeownersFileEntry' ||
                                         reason.__typename === 'AssignedOwner'
                                 )
-                        )
-                        .map((ownership, index) => (
-                            // This list is not expected to change, so it's safe to use the index as a key.
-                            // eslint-disable-next-line react/no-array-index-key
-                            <React.Fragment key={index}>
-                                {index > 0 && <tr className={styles.bordered} />}
-                                <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
-                            </React.Fragment>
-                        ))}
+                            )
+                            .map((ownership, index) => (
+                                // This list is not expected to change, so it's safe to use the index as a key.
+                                // eslint-disable-next-line react/no-array-index-key
+                                <React.Fragment key={index}>
+                                    {index > 0 && <tr className={styles.bordered} />}
+                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                                </React.Fragment>
+                            ))}
+                        {
+                            /* Visually separate two sets with a horizontal rule (like subsequent owners are)
+                             * if there is data in both owners and signals.
+                             */
+                            totalCount > 0 && nodes.length > totalCount && <tr className={styles.bordered} />
+                        }
+                        {nodes.length > totalCount && (
+                            <tr>
+                                <th colSpan={3}>
+                                    <H4 className="mt-3 mb-2">Inference signals</H4>
+                                    <Text className={styles.ownInferenceExplanation}>
+                                        These users have viewed or contributed to the file but are not registered owners
+                                        of the file.
+                                    </Text>
+                                </th>
+                            </tr>
+                        )}
+                        {nodes
+                            .filter(
+                                ownership =>
+                                    !ownership.reasons.some(
+                                        reason =>
+                                            reason.__typename === 'CodeownersFileEntry' ||
+                                            reason.__typename === 'AssignedOwner'
+                                    )
+                            )
+                            .map((ownership, index) => (
+                                // This list is not expected to change, so it's safe to use the index as a key.
+                                // eslint-disable-next-line react/no-array-index-key
+                                <React.Fragment key={index}>
+                                    {index > 0 && <tr className={styles.bordered} />}
+                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                                </React.Fragment>
+                            ))}
                     </tbody>
                 </table>
             </div>

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -143,7 +143,7 @@ interface OwnerListProps {
 }
 
 const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
-    if (data?.nodes && data.nodes.length > 0) {
+    if (data?.nodes && data.nodes.length) {
         const nodes = data.nodes
         const totalCount = data.totalOwners
         return (

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -103,7 +103,7 @@ export const FETCH_TREE_OWNERS = gql`
         }
         ruleLineMatch
     }
-    
+
     fragment OwnershipConnectionFields on OwnershipConnection {
         totalOwners
         nodes {

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -89,6 +89,51 @@ export const FETCH_OWNERS = gql`
     }
 `
 
+export const FETCH_TREE_OWNERS = gql`
+    ${OWNER_FIELDS}
+    ${RECENT_CONTRIBUTOR_FIELDS}
+    ${RECENT_VIEW_FIELDS}
+    ${ASSIGNED_OWNER_FIELDS}
+
+    fragment CodeownersFileEntryFields on CodeownersFileEntry {
+        title
+        description
+        codeownersFile {
+            url
+        }
+        ruleLineMatch
+    }
+    
+    fragment OwnershipConnectionFields on OwnershipConnection {
+        totalOwners
+        nodes {
+            owner {
+                ...OwnerFields
+            }
+            reasons {
+                ...CodeownersFileEntryFields
+                ...RecentContributorOwnershipSignalFields
+                ...RecentViewOwnershipSignalFields
+                ...AssignedOwnerFields
+            }
+        }
+    }
+
+    query FetchTreeOwnership($repo: ID!, $revision: String!, $currentPath: String!) {
+        node(id: $repo) {
+            ... on Repository {
+                commit(rev: $revision) {
+                    blob(path: $currentPath) {
+                        ownership {
+                            ...OwnershipConnectionFields
+                        }
+                    }
+                }
+            }
+        }
+    }
+`
+
 export const FETCH_OWNERS_AND_HISTORY = gql`
     ${OWNER_FIELDS}
     ${gitCommitFragment}


### PR DESCRIPTION
Refactors the owner list so that it can be reused from a different context, notably from a tree instead of a blob. This will be useful for the repo level drilldown page.

## Test plan
Ensure ownership panel is the same after refactor
<img width="1466" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/5090588/b66ed24e-fe2a-4963-8147-a5403330257a">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
