### PR TITLE
Embeddings: add time budget for search

### DIFF
--- a/cmd/frontend/graphqlbackend/embeddings.go
+++ b/cmd/frontend/graphqlbackend/embeddings.go
@@ -47,6 +47,7 @@ type EmbeddingsMultiSearchInputArgs struct {
 type EmbeddingsSearchResultsResolver interface {
 	CodeResults(ctx context.Context) ([]EmbeddingsSearchResultResolver, error)
 	TextResults(ctx context.Context) ([]EmbeddingsSearchResultResolver, error)
+	BudgetHit() bool
 }
 
 type EmbeddingsSearchResultResolver interface {

--- a/cmd/frontend/graphqlbackend/embeddings.go
+++ b/cmd/frontend/graphqlbackend/embeddings.go
@@ -33,6 +33,7 @@ type EmbeddingsSearchInputArgs struct {
 	Query            string
 	CodeResultsCount int32
 	TextResultsCount int32
+	BudgetSeconds    *int32
 }
 
 type EmbeddingsMultiSearchInputArgs struct {
@@ -40,6 +41,7 @@ type EmbeddingsMultiSearchInputArgs struct {
 	Query            string
 	CodeResultsCount int32
 	TextResultsCount int32
+	BudgetSeconds    *int32
 }
 
 type EmbeddingsSearchResultsResolver interface {

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -21,6 +21,10 @@ extend type Query {
         The number of text results to return. Text results contain Markdown files and similar file types primarily used for writing documentation.
         """
         textResultsCount: Int!
+        """
+        An optional time limit (in seconds) to search before returning the partial set of results
+        """
+        budgetSeconds: Int
     ): EmbeddingsSearchResults!
 
     """
@@ -45,6 +49,10 @@ extend type Query {
         The number of text results to return. Text results contain Markdown files and similar file types primarily used for writing documentation.
         """
         textResultsCount: Int!
+        """
+        An optional time limit (in seconds) to search before returning the partial set of results
+        """
+        budgetSeconds: Int
     ): EmbeddingsSearchResults!
 
     """
@@ -138,6 +146,10 @@ type EmbeddingsSearchResults {
     A list of text file results.
     """
     textResults: [EmbeddingsSearchResult!]!
+    """
+    Whether the search stopped early due to reaching its time budget. If true, the results may be incomplete.
+    """
+    budgetHit: Boolean!
 }
 
 """

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -42,6 +42,10 @@ func searchRepoEmbeddingIndexes(
 	if params.Budget != nil {
 		timer := time.AfterFunc(*params.Budget, func() { budgetExpired.Store(true) })
 		defer timer.Stop()
+		// For tests, make a zero-budget deterministically expire
+		if *params.Budget == 0 {
+			budgetExpired.Store(true)
+		}
 	}
 
 	var result embeddings.EmbeddingCombinedSearchResults

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -42,10 +42,6 @@ func searchRepoEmbeddingIndexes(
 	if params.Budget != nil {
 		timer := time.AfterFunc(*params.Budget, func() { budgetExpired.Store(true) })
 		defer timer.Stop()
-		// For tests, make a zero-budget deterministically expire
-		if *params.Budget == 0 {
-			budgetExpired.Store(true)
-		}
 	}
 
 	var result embeddings.EmbeddingCombinedSearchResults

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/conc/pool"
@@ -60,6 +61,7 @@ func (r *Resolver) EmbeddingsSearch(ctx context.Context, args graphqlbackend.Emb
 		Query:            args.Query,
 		CodeResultsCount: args.CodeResultsCount,
 		TextResultsCount: args.TextResultsCount,
+		BudgetSeconds:    args.BudgetSeconds,
 	})
 }
 
@@ -101,6 +103,13 @@ func (r *Resolver) EmbeddingsMultiSearch(ctx context.Context, args graphqlbacken
 		Query:            args.Query,
 		CodeResultsCount: int(args.CodeResultsCount),
 		TextResultsCount: int(args.TextResultsCount),
+		Budget: func() *time.Duration {
+			if args.BudgetSeconds == nil {
+				return nil
+			}
+			budget := time.Duration(*args.BudgetSeconds) * time.Second
+			return &budget
+		}(),
 	})
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -224,6 +224,10 @@ func (r *embeddingsSearchResultsResolver) TextResults(ctx context.Context) ([]gr
 	return embeddingsSearchResultsToResolvers(ctx, r.logger, r.gitserver, r.results.TextResults)
 }
 
+func (r *embeddingsSearchResultsResolver) BudgetHit() bool {
+	return r.results.BudgetHit
+}
+
 func embeddingsSearchResultsToResolvers(
 	ctx context.Context,
 	logger log.Logger,

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -88,7 +88,6 @@ func TestEmbeddingSearchResolver(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, codeResults, 1)
 	require.Equal(t, "test\nfirst\nfour\nlines", codeResults[0].Content(ctx))
-
 }
 
 func Test_extractLineRange(t *testing.T) {

--- a/enterprise/internal/embeddings/client.go
+++ b/enterprise/internal/embeddings/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -61,6 +62,7 @@ type EmbeddingsSearchParameters struct {
 	Query            string         `json:"query"`
 	CodeResultsCount int            `json:"codeResultsCount"`
 	TextResultsCount int            `json:"textResultsCount"`
+	Budget           *time.Duration `json:"budget"`
 
 	UseDocumentRanks bool `json:"useDocumentRanks"`
 }

--- a/enterprise/internal/embeddings/client.go
+++ b/enterprise/internal/embeddings/client.go
@@ -105,6 +105,7 @@ func (c *client) Search(ctx context.Context, args EmbeddingsSearchParameters) (*
 	for _, result := range allResults {
 		combinedResult.CodeResults.MergeTruncate(result.CodeResults, args.CodeResultsCount)
 		combinedResult.TextResults.MergeTruncate(result.TextResults, args.TextResultsCount)
+		combinedResult.BudgetHit = combinedResult.BudgetHit || result.BudgetHit
 	}
 
 	return &combinedResult, nil

--- a/enterprise/internal/embeddings/similarity_search.go
+++ b/enterprise/internal/embeddings/similarity_search.go
@@ -133,9 +133,10 @@ func (index *EmbeddingIndex) SimilaritySearch(
 	sort.Slice(neighbors, func(i, j int) bool { return neighbors[i].scoreDetails.Score > neighbors[j].scoreDetails.Score })
 
 	// Take top neighbors and return them as results.
-	results := make([]EmbeddingSearchResult, numResults)
+	n := min(numResults, len(neighbors))
+	results := make([]EmbeddingSearchResult, n)
 
-	for idx := 0; idx < min(numResults, len(neighbors)); idx++ {
+	for idx := 0; idx < n; idx++ {
 		metadata := index.RowMetadata[neighbors[idx].index]
 		results[idx] = EmbeddingSearchResult{
 			RepoName:     repoName,

--- a/enterprise/internal/embeddings/types.go
+++ b/enterprise/internal/embeddings/types.go
@@ -85,6 +85,7 @@ type ContextDetectionEmbeddingIndex struct {
 type EmbeddingCombinedSearchResults struct {
 	CodeResults EmbeddingSearchResults `json:"codeResults"`
 	TextResults EmbeddingSearchResults `json:"textResults"`
+	BudgetHit   bool                   `json:"budgetHit"`
 }
 
 type EmbeddingSearchResults []EmbeddingSearchResult


### PR DESCRIPTION
This adds an optional time budget for embeddings search. This is useful so clients can worry less about searching tons of embeddings by returning partial results if we exceed the time budget.

This is implemented as a separate "budget" rather than a "timeout" or via context cancellation because context cancellation and timeout implies "stop doing any more work," but the budget expiration is more of a "don't do extra, but return what you have so far" and we don't want to just blindly propagate context errors up the stack with no results.

Doing this before the merged keyword search / embeddings API because those changes have some dependencies on these.

## Test plan

Added a test and manually tested via the GraphQL API. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
