### PR TITLE
Add the Cody troubleshooting guide to nav

### DIFF
--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -75,6 +75,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Quickstart](cody/quickstart.md)
   - [Explanations](cody/explanations/index.md)
   - [FAQ](cody/faq.md)
+  - [Troubleshooting](cody/troubleshooting.md)
   - [Completions (experimental)](cody/completions.md)
 - [App (beta)](app/index.md)
 - [Own (experimental)](own/index.md)


### PR DESCRIPTION
The Cody troubleshooting guide is missing from the docs nav. This adds it in.

| Before | After |
| - | - |
| <img width="305" alt="Screenshot 2023-06-01 at 8 17 28 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/d6943f72-18eb-4904-912a-42225973398d"> | <img width="276" alt="Screenshot 2023-06-01 at 8 17 17 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/d2f28c6e-af3c-4930-964c-1dd2cf6da497"> |

Spotted in #52206

## Test plan

- Loaded locally
- Checked nav