### PR TITLE
SG: fix `DELVE` env var

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -138,7 +138,7 @@ commands:
     cmd: .bin/oss-frontend
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-frontend github.com/sourcegraph/sourcegraph/cmd/frontend
     checkBinary: .bin/oss-frontend
@@ -163,7 +163,7 @@ commands:
       .bin/frontend
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
     checkBinary: .bin/frontend
@@ -186,7 +186,7 @@ commands:
     cmd: .bin/gitserver
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/gitserver github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver
     checkBinary: .bin/gitserver
@@ -203,7 +203,7 @@ commands:
     cmd: .bin/oss-gitserver
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-gitserver github.com/sourcegraph/sourcegraph/cmd/gitserver
     checkBinary: .bin/oss-gitserver
@@ -259,7 +259,7 @@ commands:
     cmd: .bin/github-proxy
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/github-proxy github.com/sourcegraph/sourcegraph/cmd/github-proxy
     checkBinary: .bin/github-proxy
@@ -272,7 +272,7 @@ commands:
     cmd: .bin/oss-worker
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-worker github.com/sourcegraph/sourcegraph/cmd/worker
     watch:
@@ -286,7 +286,7 @@ commands:
       .bin/worker
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/worker github.com/sourcegraph/sourcegraph/enterprise/cmd/worker
     watch:
@@ -300,7 +300,7 @@ commands:
     cmd: .bin/oss-repo-updater
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/oss-repo-updater github.com/sourcegraph/sourcegraph/cmd/repo-updater
     checkBinary: .bin/oss-repo-updater
@@ -315,7 +315,7 @@ commands:
       .bin/repo-updater
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/repo-updater github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
     checkBinary: .bin/repo-updater
@@ -332,7 +332,7 @@ commands:
     cmd: .bin/oss-symbols
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
 
       ./cmd/symbols/build-ctags.sh &&
@@ -351,7 +351,7 @@ commands:
     cmd: .bin/symbols
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
 
       ./cmd/symbols/build-ctags.sh &&
@@ -375,7 +375,7 @@ commands:
       .bin/embeddings
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/embeddings github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings
@@ -391,7 +391,7 @@ commands:
       .bin/cody-gateway
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/cody-gateway github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway
@@ -412,7 +412,7 @@ commands:
     cmd: .bin/searcher
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/searcher github.com/sourcegraph/sourcegraph/cmd/searcher
     checkBinary: .bin/searcher
@@ -589,7 +589,7 @@ commands:
       .bin/codeintel-worker
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/codeintel-worker github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker
     checkBinary: .bin/codeintel-worker
@@ -606,7 +606,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/executor github.com/sourcegraph/sourcegraph/enterprise/cmd/executor
     checkBinary: .bin/executor
@@ -683,7 +683,7 @@ commands:
       # Ensure the old blobstore Docker container is not running
       docker rm -f blobstore
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/blobstore github.com/sourcegraph/sourcegraph/cmd/blobstore
     checkBinary: .bin/blobstore
@@ -905,7 +905,7 @@ commands:
       .bin/sourcegraph
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -ldflags="-X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=app" -o .bin/sourcegraph github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph
     checkBinary: .bin/sourcegraph
@@ -932,7 +932,7 @@ commands:
       .bin/sourcegraph-oss
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='all=-N -l'
+        export GCFLAGS='-N -l'
       fi
       go build -gcflags="$GCFLAGS" -ldflags="-X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=app" -o .bin/sourcegraph-oss github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss
     checkBinary: .bin/sourcegraph-oss


### PR DESCRIPTION
According to the [delve documentation](https://github.com/go-delve/delve/blob/7603e46f75d610e99bd6438f1afe3a945c8292d0/Documentation/usage/dlv_exec.md?plain=1#L12C1-L13), since go 1.10, we should be using `-gcflags="-N -l"` rather than `-gcflags="all=-N -l"`. I can confirm that this fixes the debugging experience when using `dlv attach` on a process started with `sg`.

Now, using `DELVE=true sg start` will correctly disable optimizations and inlining so that stepping through and inspecting variables in a debugger will work correctly.

## Test plan

Manually tested that this fixes the problems I was seeing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
