### PR TITLE
ci: propagate exec errors in the report-bundle-diff script

### DIFF
--- a/client/web/scripts/report-bundle-diff.ts
+++ b/client/web/scripts/report-bundle-diff.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
+
+import { execSync } from 'child_process'
 import { promises as fs } from 'fs'
 import path from 'path'
 
 import { Octokit } from 'octokit'
-import { exec } from 'shelljs'
 
 const COMMENT_HEADING = '## Bundle size report 📦'
 
@@ -22,7 +23,7 @@ const ROOT_PATH = path.join(__dirname, '../../../')
 const STATIC_ASSETS_PATH = path.join(ROOT_PATH, process.env.WEB_BUNDLE_PATH || 'ui/assets')
 const STATOSCOPE_BIN = path.join(ROOT_PATH, 'node_modules/@statoscope/cli/bin/cli.js')
 
-const MERGE_BASE = exec('git merge-base HEAD origin/main').toString().trim()
+const MERGE_BASE = execSync('git merge-base HEAD origin/main').toString().trim()
 let COMPARE_REV = ''
 
 async function findFile(root: string, filename: string): Promise<string> {
@@ -61,9 +62,7 @@ async function findFile(root: string, filename: string): Promise<string> {
  */
 function getTarPath(): string | undefined {
     console.log('--- Find a commit to compare the bundle size against')
-    const revisions = exec(`git --no-pager log "${MERGE_BASE}" --pretty=format:"%H" -n 20`, { silent: true })
-        .toString()
-        .split('\n')
+    const revisions = execSync(`git --no-pager log "${MERGE_BASE}" --pretty=format:"%H" -n 20`).toString().split('\n')
 
     for (const revision of revisions) {
         try {
@@ -71,7 +70,7 @@ function getTarPath(): string | undefined {
             const bucket = 'sourcegraph_buildkite_cache'
             const file = `sourcegraph/sourcegraph/bundle_size_cache-${revision}.tar.gz`
 
-            exec(`gsutil -q cp -r "gs://${bucket}/${file}" "${tarPath}"`)
+            execSync(`gsutil -q cp -r "gs://${bucket}/${file}" "${tarPath}"`)
 
             console.log(`Found cached archive for ${revision}:`, tarPath)
             // TODO: remove mutable global variable
@@ -80,7 +79,6 @@ function getTarPath(): string | undefined {
             return tarPath
         } catch (error) {
             console.log(`Cached archive for ${revision} not found:`, error)
-            process.exit(0)
         }
     }
 
@@ -91,8 +89,8 @@ async function prepareStats(): Promise<{ commitFile: string; compareFile: string
     const tarPath = getTarPath()
 
     if (tarPath) {
-        exec(`tar -xf ${tarPath} --strip-components=2 -C ${STATIC_ASSETS_PATH}`)
-        exec(`ls -la ${STATIC_ASSETS_PATH}`)
+        execSync(`tar -xf ${tarPath} --strip-components=2 -C ${STATIC_ASSETS_PATH}`)
+        execSync(`ls -la ${STATIC_ASSETS_PATH}`)
 
         try {
             const commitFile = await findFile(STATIC_ASSETS_PATH, `stats-${BUILDKITE_COMMIT}.json`)
@@ -101,11 +99,11 @@ async function prepareStats(): Promise<{ commitFile: string; compareFile: string
 
             const compareReportPath = path.join(STATIC_ASSETS_PATH, 'compare-report.html')
 
-            exec(`${STATOSCOPE_BIN} generate -i "${commitFile}" -r "${compareFile}" -t ${compareReportPath}`)
+            execSync(`${STATOSCOPE_BIN} generate -i "${commitFile}" -r "${compareFile}" -t ${compareReportPath}`)
 
             const bucket = 'sourcegraph_reports'
             const file = `statoscope-reports/${BUILDKITE_BRANCH}/compare-report.html`
-            exec(`gsutil cp ${compareReportPath} "gs://${bucket}/${file}"`)
+            execSync(`gsutil cp ${compareReportPath} "gs://${bucket}/${file}"`)
 
             return { commitFile, compareFile }
         } catch (error) {
@@ -164,8 +162,8 @@ type Report = [Header, Metric, Metric, Metric, Metric, Metric, Metric, Metric, M
 
 function parseReport(commitFile: string, compareFile: string): Report {
     const queryFile = path.join(__dirname, 'report-bundle-jora-query')
-    const rawReport = exec(`cat "${queryFile}" | ${STATOSCOPE_BIN} query -i "${compareFile}" -i "${commitFile}"`, {
-        silent: true,
+    const rawReport = execSync(`cat "${queryFile}" | ${STATOSCOPE_BIN} query -i "${compareFile}" -i "${commitFile}"`, {
+        encoding: 'utf-8',
     })
 
     return JSON.parse(rawReport) as Report


### PR DESCRIPTION
## Context

`shelljs.exec` returns the result with the error code but does not throw. This PR replaces it with `child_process.execSync`, which throws. This is what we expect when we iterate over `revisions` with bundle size stats on `main`. Should fix the issue reported in [this Slack thread](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1685575081237319).

## Test plan

CI
