### PR TITLE
scip-symbols: emit enclosing ranges for go

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a83e6ef20d1de75bea46dc774af1b413e4dfde7f02a62f8321ecbe812c120317",
+  "checksum": "4bfa765a044fc92f413e344aa867440354868963378db633f56c473e0d6ce36b",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -9535,7 +9535,7 @@
         "Git": {
           "remote": "https://github.com/sourcegraph/scip",
           "commitish": {
-            "Rev": "3856df76147ca4b86df7821a881594358d4ba870"
+            "Rev": "6b5114f74b063baf7bde5ede67dba79690f28fc0"
           },
           "strip_prefix": "bindings/rust"
         }

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "scip"
 version = "0.1.1"
-source = "git+https://github.com/sourcegraph/scip?rev=3856df76147ca4b86df7821a881594358d4ba870#3856df76147ca4b86df7821a881594358d4ba870"
+source = "git+https://github.com/sourcegraph/scip?rev=6b5114f74b063baf7bde5ede67dba79690f28fc0#6b5114f74b063baf7bde5ede67dba79690f28fc0"
 dependencies = [
  "protobuf",
 ]

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -56,7 +56,7 @@ tree-sitter = "0.20.9"
 tree-sitter-highlight = "0.20"
 
 # Since there is no version tag, we pin the dependency to a specific revision
-scip = { git = "https://github.com/sourcegraph/scip", rev="3856df76147ca4b86df7821a881594358d4ba870" }
+scip = { git = "https://github.com/sourcegraph/scip", rev="6b5114f74b063baf7bde5ede67dba79690f28fc0" }
 protobuf = "3"
 
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/go/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/go/scip-tags.scm
@@ -1,23 +1,23 @@
 (source_file (package_clause (package_identifier) @descriptor.namespace)) @scope
 
 (function_declaration
- name: (identifier) @descriptor.method)
+ name: (identifier) @descriptor.method) @enclosing
 
 (method_declaration
  receiver: (parameter_list
             (parameter_declaration
              type: (pointer_type
                      (type_identifier) @descriptor.type)))
- name: (field_identifier) @descriptor.method)
+ name: (field_identifier) @descriptor.method) @enclosing
 
 (method_declaration
   receiver: (parameter_list
                (parameter_declaration type: (type_identifier) @descriptor.type))
-  name: (field_identifier) @descriptor.method)
+  name: (field_identifier) @descriptor.method) @enclosing
 
 (type_declaration (type_spec name: (type_identifier) @descriptor.type)) @scope
 
-(field_declaration_list (field_declaration name: (_) @descriptor.term))
+(field_declaration_list (field_declaration name: (_) @descriptor.term) @enclosing)
 
-(const_spec name: (_) @descriptor.term)
-(import_spec name: (_) @descriptor.term)
+(const_spec name: (_) @descriptor.term) @enclosing
+(import_spec name: (_) @descriptor.term) @enclosing

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__enclosing_range.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__enclosing_range.snap
@@ -1,0 +1,20 @@
+---
+source: crates/scip-syntax/src/globals.rs
+expression: dumped
+---
+  package scopes_of_go
+//^^^^^^^^^^^^^^^^^^^^ 0:0..10:0 definition scip-ctags scopes_of_go/
+  
+  func Something() int {
+//^^^^^^^^^^^^^^^^^^^^^^ 2:0..4:1 definition scip-ctags scopes_of_go/Something().
+   return 1
+  }
+  
+  type SomethingElse struct {
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^ 6:0..9:1 definition scip-ctags scopes_of_go/SomethingElse#
+   a int
+// ^^^^^ definition scip-ctags scopes_of_go/SomethingElse#a.
+   b string
+// ^^^^^^^^ definition scip-ctags scopes_of_go/SomethingElse#b.
+  }
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/scopes_of_go.go
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/scopes_of_go.go
@@ -1,0 +1,10 @@
+package scopes_of_go
+
+func Something() int {
+	return 1
+}
+
+type SomethingElse struct {
+	a int
+	b string
+}

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -519,7 +519,7 @@ fn new_occurence(range: Vec<i32>, syntax_kind: SyntaxKind, scope: Scope) -> Occu
         symbol,
         override_documentation: vec![],
         diagnostics: vec![],
-        special_fields: SpecialFields::default(),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION

## Test plan

- [ ] look over test snapshots and make sure they make sense to you @efritz @Numbers88s 
- [ ] You can also pull this locally and run it manually (or even just pull and build the binary, then run that)
