### PR TITLE
batches: add client methods for duplicate commit workflow

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -142,6 +142,34 @@ func (c *CommitStatus) Key() string {
 	return strconv.FormatInt(int64(fnv1.HashString64(key)), 16)
 }
 
+// A Commit in a Repository, from the REST API.
+type restCommit struct {
+	URL    string `json:"url"`
+	SHA    string `json:"sha"`
+	NodeID string `json:"node_id"`
+	Commit struct {
+		URL          string              `json:"url"`
+		Author       *restAuthorCommiter `json:"author"`
+		Committer    *restAuthorCommiter `json:"committer"`
+		Message      string              `json:"message"`
+		CommentCount int                 `json:"comment_count"`
+		Tree         struct {
+			SHA string `json:"sha"`
+			URL string `json:"url"`
+		} `json:"tree"`
+	}
+	Parents []struct {
+		SHA string `json:"sha"`
+		URL string `json:"url"`
+	} `json:"parents"`
+}
+
+type restAuthorCommiter struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Date  string `json:"date"`
+}
+
 // Context represent the individual commit status context
 type Context struct {
 	ID          string

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -152,33 +152,21 @@ type restCommitRef struct {
 		Author    *restAuthorCommiter `json:"author"`
 		Committer *restAuthorCommiter `json:"committer"`
 		Message   string              `json:"message"`
-		Tree      struct {
-			SHA string `json:"sha"`
-			URL string `json:"url"`
-		} `json:"tree"`
+		Tree      restCommitTree      `json:"tree"`
 	} `json:"commit"`
-	Parents []struct {
-		SHA string `json:"sha"`
-		URL string `json:"url"`
-	} `json:"parents"`
+	Parents []restCommitParent `json:"parents"`
 }
 
 // A single Commit in a Repository, from the REST API.
 type restCommit struct {
-	URL       string              `json:"url"`
-	SHA       string              `json:"sha"`
-	NodeID    string              `json:"node_id"`
-	Author    *restAuthorCommiter `json:"author"`
-	Committer *restAuthorCommiter `json:"committer"`
-	Message   string              `json:"message"`
-	Tree      struct {
-		SHA string `json:"sha"`
-		URL string `json:"url"`
-	} `json:"tree"`
-	Parents []struct {
-		SHA string `json:"sha"`
-		URL string `json:"url"`
-	} `json:"parents"`
+	URL          string              `json:"url"`
+	SHA          string              `json:"sha"`
+	NodeID       string              `json:"node_id"`
+	Author       *restAuthorCommiter `json:"author"`
+	Committer    *restAuthorCommiter `json:"committer"`
+	Message      string              `json:"message"`
+	Tree         restCommitTree      `json:"tree"`
+	Parents      []restCommitParent  `json:"parents"`
 	Verification struct {
 		Verified  bool   `json:"verified"`
 		Reason    string `json:"reason"`
@@ -187,10 +175,31 @@ type restCommit struct {
 	} `json:"verification"`
 }
 
+type restUpdatedRef struct {
+	Ref    string `json:"ref"`
+	NodeID string `json:"node_id"`
+	URL    string `json:"url"`
+	Object struct {
+		Type string `json:"type"`
+		SHA  string `json:"sha"`
+		URL  string `json:"url"`
+	} `json:"object"`
+}
+
 type restAuthorCommiter struct {
 	Name  string `json:"name"`
 	Email string `json:"email"`
 	Date  string `json:"date"`
+}
+
+type restCommitTree struct {
+	URL string `json:"url"`
+	SHA string `json:"sha"`
+}
+
+type restCommitParent struct {
+	URL string `json:"url"`
+	SHA string `json:"sha"`
 }
 
 // Context represent the individual commit status context

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1578,7 +1578,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 		return newHttpResponseState(resp.StatusCode, resp.Header), nil
 	}
 
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusNoContent && result != nil {
 		err = json.NewDecoder(resp.Body).Decode(result)
 	}
 	return newHttpResponseState(resp.StatusCode, resp.Header), err

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -175,6 +175,7 @@ type restCommit struct {
 	} `json:"verification"`
 }
 
+// An updated reference in a Repository, returned from the REST API `update-ref` endpoint.
 type restUpdatedRef struct {
 	Ref    string `json:"ref"`
 	NodeID string `json:"node_id"`

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -142,26 +142,49 @@ func (c *CommitStatus) Key() string {
 	return strconv.FormatInt(int64(fnv1.HashString64(key)), 16)
 }
 
-// A Commit in a Repository, from the REST API.
-type restCommit struct {
+// A single Commit reference in a Repository, from the REST API.
+type restCommitRef struct {
 	URL    string `json:"url"`
 	SHA    string `json:"sha"`
 	NodeID string `json:"node_id"`
 	Commit struct {
-		URL          string              `json:"url"`
-		Author       *restAuthorCommiter `json:"author"`
-		Committer    *restAuthorCommiter `json:"committer"`
-		Message      string              `json:"message"`
-		CommentCount int                 `json:"comment_count"`
-		Tree         struct {
+		URL       string              `json:"url"`
+		Author    *restAuthorCommiter `json:"author"`
+		Committer *restAuthorCommiter `json:"committer"`
+		Message   string              `json:"message"`
+		Tree      struct {
 			SHA string `json:"sha"`
 			URL string `json:"url"`
 		} `json:"tree"`
-	}
+	} `json:"commit"`
 	Parents []struct {
 		SHA string `json:"sha"`
 		URL string `json:"url"`
 	} `json:"parents"`
+}
+
+// A single Commit in a Repository, from the REST API.
+type restCommit struct {
+	URL       string              `json:"url"`
+	SHA       string              `json:"sha"`
+	NodeID    string              `json:"node_id"`
+	Author    *restAuthorCommiter `json:"author"`
+	Committer *restAuthorCommiter `json:"committer"`
+	Message   string              `json:"message"`
+	Tree      struct {
+		SHA string `json:"sha"`
+		URL string `json:"url"`
+	} `json:"tree"`
+	Parents []struct {
+		SHA string `json:"sha"`
+		URL string `json:"url"`
+	} `json:"parents"`
+	Verification struct {
+		Verified  bool   `json:"verified"`
+		Reason    string `json:"reason"`
+		Signature string `json:"signature"`
+		Payload   string `json:"payload"`
+	} `json:"verification"`
 }
 
 type restAuthorCommiter struct {

--- a/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_failure
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_failure
@@ -1,0 +1,6 @@
+{
+  "URL": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits",
+  "Code": 422,
+  "Message": "The tree parameter must be exactly 40 characters and contain only [0-9a-f].",
+  "documentation_url": "https://docs.github.com/rest/reference/git#create-a-commit"
+ }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_success
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_success
@@ -14,13 +14,13 @@
   },
   "message": "I'm a new commit from a VCR test!",
   "tree": {
-   "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935",
-   "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"
+   "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935",
+   "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935"
   },
   "parents": [
    {
-    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
-    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
+    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
    }
   ],
   "verification": {

--- a/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_success
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_CreateCommit_success
@@ -1,0 +1,32 @@
+{
+  "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9f815d128eae9f1066353ca41c297cdc0ef94662",
+  "sha": "9f815d128eae9f1066353ca41c297cdc0ef94662",
+  "node_id": "C_kwDODS5xedoAKDlmODE1ZDEyOGVhZTlmMTA2NjM1M2NhNDFjMjk3Y2RjMGVmOTQ2NjI",
+  "author": {
+   "name": "Sourcegraph VCR Test",
+   "email": "dev@sourcegraph.com",
+   "date": "2023-06-01T12:00:00Z"
+  },
+  "committer": {
+   "name": "Sourcegraph VCR Test",
+   "email": "dev@sourcegraph.com",
+   "date": "2023-06-01T12:00:00Z"
+  },
+  "message": "I'm a new commit from a VCR test!",
+  "tree": {
+   "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935",
+   "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"
+  },
+  "parents": [
+   {
+    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
+   }
+  ],
+  "verification": {
+   "verified": false,
+   "reason": "unsigned",
+   "signature": "",
+   "payload": ""
+  }
+ }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_failure
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_failure
@@ -1,0 +1,6 @@
+{
+  "URL": "https://api.github.com/repos/sourcegraph/automation-testing/commits/refs/heads/butterfly-sponge-sandwich-rotation-technique-12345678-lol",
+  "Code": 422,
+  "Message": "No commit found for SHA: refs/heads/butterfly-sponge-sandwich-rotation-technique-12345678-lol",
+  "documentation_url": "https://docs.github.com/rest/commits/commits#get-a-commit"
+ }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_success
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_success
@@ -1,0 +1,30 @@
+{
+  "url": "https://api.github.com/repos/sourcegraph/automation-testing/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c",
+  "sha": "37406e7dfa4466b80d1da183d6477aac16b1e58c",
+  "node_id": "MDY6Q29tbWl0MjIxMTQ3NTEzOjM3NDA2ZTdkZmE0NDY2YjgwZDFkYTE4M2Q2NDc3YWFjMTZiMWU1OGM=",
+  "Commit": {
+   "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c",
+   "author": {
+    "name": "Thorsten Ball",
+    "email": "mrnugget@gmail.com",
+    "date": "2019-11-12T06:39:23Z"
+   },
+   "committer": {
+    "name": "Thorsten Ball",
+    "email": "mrnugget@gmail.com",
+    "date": "2019-11-12T06:39:23Z"
+   },
+   "message": "Test commit to always have a open PR",
+   "comment_count": 0,
+   "tree": {
+    "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935",
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"
+   }
+  },
+  "parents": [
+   {
+    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
+   }
+  ]
+ }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_success
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_GetRef_success
@@ -2,7 +2,7 @@
   "url": "https://api.github.com/repos/sourcegraph/automation-testing/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c",
   "sha": "37406e7dfa4466b80d1da183d6477aac16b1e58c",
   "node_id": "MDY6Q29tbWl0MjIxMTQ3NTEzOjM3NDA2ZTdkZmE0NDY2YjgwZDFkYTE4M2Q2NDc3YWFjMTZiMWU1OGM=",
-  "Commit": {
+  "commit": {
    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c",
    "author": {
     "name": "Thorsten Ball",
@@ -15,16 +15,15 @@
     "date": "2019-11-12T06:39:23Z"
    },
    "message": "Test commit to always have a open PR",
-   "comment_count": 0,
    "tree": {
-    "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935",
-    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935",
+    "sha": "851e666a00cd0cf74f1558ac5664fe431d3b1935"
    }
   },
   "parents": [
    {
-    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
-    "url": "https://api.github.com/repos/sourcegraph/automation-testing/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
+    "url": "https://api.github.com/repos/sourcegraph/automation-testing/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975",
+    "sha": "9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
    }
   ]
  }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_UpdateRef_failure
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_UpdateRef_failure
@@ -1,0 +1,6 @@
+{
+  "URL": "https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update",
+  "Code": 422,
+  "Message": "The sha parameter must be exactly 40 characters and contain only [0-9a-f].",
+  "documentation_url": "https://docs.github.com/rest/reference/git#update-a-reference"
+ }

--- a/internal/extsvc/github/testdata/golden/TestV3Client_UpdateRef_success
+++ b/internal/extsvc/github/testdata/golden/TestV3Client_UpdateRef_success
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/ready-to-update",
+  "node_id": "MDM6UmVmMjIxMTQ3NTEzOnJlZnMvaGVhZHMvcmVhZHktdG8tdXBkYXRl",
+  "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update",
+  "object": {
+   "type": "commit",
+   "sha": "58377a8785c955d5f61293dda65657afddbc8dfc",
+   "url": "https://api.github.com/repos/sourcegraph/automation-testing/git/commits/58377a8785c955d5f61293dda65657afddbc8dfc"
+  }
+ }

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_failure.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_failure.yaml
@@ -32,7 +32,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jun 2023 23:55:29 GMT
+      - Fri, 02 Jun 2023 00:52:50 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -51,17 +51,17 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - E556:2B5E:22CCF:47D8E:64792FF1
+      - EA1C:521F:00E5:02B4:64793D62
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
-      - "4962"
+      - "4948"
       X-Ratelimit-Reset:
-      - "1685664959"
+      - "1685668692"
       X-Ratelimit-Resource:
       - core
       X-Ratelimit-Used:
-      - "38"
+      - "52"
       X-Xss-Protection:
       - "0"
     status: 422 Unprocessable Entity

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_failure.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_failure.yaml
@@ -1,0 +1,69 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"message":"I''m not going to work!","tree":"loltotallynotatree","parents":["loltotallynotacommit"]}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/commits
+    method: POST
+  response:
+    body: '{"message":"The tree parameter must be exactly 40 characters and contain
+      only [0-9a-f].","documentation_url":"https://docs.github.com/rest/reference/git#create-a-commit"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - "170"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Jun 2023 23:55:29 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E556:2B5E:22CCF:47D8E:64792FF1
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4962"
+      X-Ratelimit-Reset:
+      - "1685664959"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "38"
+      X-Xss-Protection:
+      - "0"
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_success.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_success.yaml
@@ -1,0 +1,80 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"message":"I''m a new commit from a VCR test!","tree":"851e666a00cd0cf74f1558ac5664fe431d3b1935","parents":["9d04a0d8733dafbb5d75e594a9ec525c49dfc975"],"author":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"committer":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/commits
+    method: POST
+  response:
+    body: '{"sha":"9f815d128eae9f1066353ca41c297cdc0ef94662","node_id":"C_kwDODS5xedoAKDlmODE1ZDEyOGVhZTlmMTA2NjM1M2NhNDFjMjk3Y2RjMGVmOTQ2NjI","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9f815d128eae9f1066353ca41c297cdc0ef94662","html_url":"https://github.com/sourcegraph/automation-testing/commit/9f815d128eae9f1066353ca41c297cdc0ef94662","author":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"committer":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"tree":{"sha":"851e666a00cd0cf74f1558ac5664fe431d3b1935","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"},"message":"I''m
+      a new commit from a VCR test!","parents":[{"sha":"9d04a0d8733dafbb5d75e594a9ec525c49dfc975","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975","html_url":"https://github.com/sourcegraph/automation-testing/commit/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "1173"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Jun 2023 23:55:29 GMT
+      Etag:
+      - '"2435b8e0f39290910f74525e227054da3b2f8f42cb251c028290f6dc8c8fec61"'
+      Location:
+      - https://api.github.com/repos/sourcegraph/automation-testing/git/commits/9f815d128eae9f1066353ca41c297cdc0ef94662
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E556:2B5E:22C9D:47D20:64792FF1
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4963"
+      X-Ratelimit-Reset:
+      - "1685664959"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "37"
+      X-Xss-Protection:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_success.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_CreateCommit_success.yaml
@@ -38,7 +38,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jun 2023 23:55:29 GMT
+      - Fri, 02 Jun 2023 00:52:50 GMT
       Etag:
       - '"2435b8e0f39290910f74525e227054da3b2f8f42cb251c028290f6dc8c8fec61"'
       Location:
@@ -62,17 +62,17 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - E556:2B5E:22C9D:47D20:64792FF1
+      - EA1C:521F:00D2:028C:64793D62
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
-      - "4963"
+      - "4949"
       X-Ratelimit-Reset:
-      - "1685664959"
+      - "1685668692"
       X-Ratelimit-Resource:
       - core
       X-Ratelimit-Used:
-      - "37"
+      - "51"
       X-Xss-Protection:
       - "0"
     status: 201 Created

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_failure.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_failure.yaml
@@ -1,0 +1,70 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/commits/refs/heads/butterfly-sponge-sandwich-rotation-technique-12345678-lol
+    method: GET
+  response:
+    body: '{"message":"No commit found for SHA: refs/heads/butterfly-sponge-sandwich-rotation-technique-12345678-lol","documentation_url":"https://docs.github.com/rest/commits/commits#get-a-commit"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - "187"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Jun 2023 23:35:19 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E3F5:1C8B:304E39C:31D9AAE:64792B37
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4981"
+      X-Ratelimit-Reset:
+      - "1685664959"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "19"
+      X-Varied-Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      X-Xss-Protection:
+      - "0"
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_failure.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_failure.yaml
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jun 2023 23:35:19 GMT
+      - Fri, 02 Jun 2023 00:49:01 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -50,17 +50,17 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - E3F5:1C8B:304E39C:31D9AAE:64792B37
+      - E9BD:02CA:67484C:D339E1:64793C7D
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
-      - "4981"
+      - "4956"
       X-Ratelimit-Reset:
-      - "1685664959"
+      - "1685668692"
       X-Ratelimit-Resource:
       - core
       X-Ratelimit-Used:
-      - "19"
+      - "44"
       X-Varied-Accept:
       - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
       X-Xss-Protection:

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_success.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_success.yaml
@@ -35,7 +35,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jun 2023 23:35:19 GMT
+      - Fri, 02 Jun 2023 00:49:01 GMT
       Etag:
       - W/"78ef7c948a5a9bc3a3a13cf4c18f41e5fcb2d6e441d854cd6339b92a92445b4f"
       Last-Modified:
@@ -59,17 +59,17 @@ interactions:
       - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
         format=json
       X-Github-Request-Id:
-      - E3F5:1C8B:304E364:31D9A77:64792B37
+      - E9BD:02CA:67481D:D33991:64793C7D
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
-      - "4982"
+      - "4957"
       X-Ratelimit-Reset:
-      - "1685664959"
+      - "1685668692"
       X-Ratelimit-Resource:
       - core
       X-Ratelimit-Used:
-      - "18"
+      - "43"
       X-Varied-Accept:
       - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
       X-Xss-Protection:

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_success.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_GetRef_success.yaml
@@ -1,0 +1,79 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/commits/refs/heads/always-open-pr
+    method: GET
+  response:
+    body: '{"sha":"37406e7dfa4466b80d1da183d6477aac16b1e58c","node_id":"MDY6Q29tbWl0MjIxMTQ3NTEzOjM3NDA2ZTdkZmE0NDY2YjgwZDFkYTE4M2Q2NDc3YWFjMTZiMWU1OGM=","commit":{"author":{"name":"Thorsten
+      Ball","email":"mrnugget@gmail.com","date":"2019-11-12T06:39:23Z"},"committer":{"name":"Thorsten
+      Ball","email":"mrnugget@gmail.com","date":"2019-11-12T06:39:23Z"},"message":"Test
+      commit to always have a open PR","tree":{"sha":"851e666a00cd0cf74f1558ac5664fe431d3b1935","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/trees/851e666a00cd0cf74f1558ac5664fe431d3b1935"},"url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/sourcegraph/automation-testing/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c","html_url":"https://github.com/sourcegraph/automation-testing/commit/37406e7dfa4466b80d1da183d6477aac16b1e58c","comments_url":"https://api.github.com/repos/sourcegraph/automation-testing/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c/comments","author":{"login":"mrnugget","id":1185253,"node_id":"MDQ6VXNlcjExODUyNTM=","avatar_url":"https://avatars.githubusercontent.com/u/1185253?v=4","gravatar_id":"","url":"https://api.github.com/users/mrnugget","html_url":"https://github.com/mrnugget","followers_url":"https://api.github.com/users/mrnugget/followers","following_url":"https://api.github.com/users/mrnugget/following{/other_user}","gists_url":"https://api.github.com/users/mrnugget/gists{/gist_id}","starred_url":"https://api.github.com/users/mrnugget/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mrnugget/subscriptions","organizations_url":"https://api.github.com/users/mrnugget/orgs","repos_url":"https://api.github.com/users/mrnugget/repos","events_url":"https://api.github.com/users/mrnugget/events{/privacy}","received_events_url":"https://api.github.com/users/mrnugget/received_events","type":"User","site_admin":false},"committer":{"login":"mrnugget","id":1185253,"node_id":"MDQ6VXNlcjExODUyNTM=","avatar_url":"https://avatars.githubusercontent.com/u/1185253?v=4","gravatar_id":"","url":"https://api.github.com/users/mrnugget","html_url":"https://github.com/mrnugget","followers_url":"https://api.github.com/users/mrnugget/followers","following_url":"https://api.github.com/users/mrnugget/following{/other_user}","gists_url":"https://api.github.com/users/mrnugget/gists{/gist_id}","starred_url":"https://api.github.com/users/mrnugget/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mrnugget/subscriptions","organizations_url":"https://api.github.com/users/mrnugget/orgs","repos_url":"https://api.github.com/users/mrnugget/repos","events_url":"https://api.github.com/users/mrnugget/events{/privacy}","received_events_url":"https://api.github.com/users/mrnugget/received_events","type":"User","site_admin":false},"parents":[{"sha":"9d04a0d8733dafbb5d75e594a9ec525c49dfc975","url":"https://api.github.com/repos/sourcegraph/automation-testing/commits/9d04a0d8733dafbb5d75e594a9ec525c49dfc975","html_url":"https://github.com/sourcegraph/automation-testing/commit/9d04a0d8733dafbb5d75e594a9ec525c49dfc975"}],"stats":{"total":1,"additions":1,"deletions":0},"files":[{"sha":"323fae03f4606ea9991df8befbb2fca795e648fa","filename":"foobar.md","status":"added","additions":1,"deletions":0,"changes":1,"blob_url":"https://github.com/sourcegraph/automation-testing/blob/37406e7dfa4466b80d1da183d6477aac16b1e58c/foobar.md","raw_url":"https://github.com/sourcegraph/automation-testing/raw/37406e7dfa4466b80d1da183d6477aac16b1e58c/foobar.md","contents_url":"https://api.github.com/repos/sourcegraph/automation-testing/contents/foobar.md?ref=37406e7dfa4466b80d1da183d6477aac16b1e58c","patch":"@@
+      -0,0 +1 @@\n+foobar"}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 01 Jun 2023 23:35:19 GMT
+      Etag:
+      - W/"78ef7c948a5a9bc3a3a13cf4c18f41e5fcb2d6e441d854cd6339b92a92445b4f"
+      Last-Modified:
+      - Tue, 12 Nov 2019 06:39:23 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E3F5:1C8B:304E364:31D9A77:64792B37
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4982"
+      X-Ratelimit-Reset:
+      - "1685664959"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "18"
+      X-Varied-Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_UpdateRef_failure.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_UpdateRef_failure.yaml
@@ -1,0 +1,69 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"sha":"fakeshalolfakeshalolfakeshalolfakeshalol","force":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update
+    method: PATCH
+  response:
+    body: '{"message":"The sha parameter must be exactly 40 characters and contain
+      only [0-9a-f].","documentation_url":"https://docs.github.com/rest/reference/git#update-a-reference"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - "172"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Jun 2023 00:22:00 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E6EB:3B26:37B0F18:397681E:64793627
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4988"
+      X-Ratelimit-Reset:
+      - "1685668692"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "12"
+      X-Xss-Protection:
+      - "0"
+    status: 422 Unprocessable Entity
+    code: 422
+    duration: ""

--- a/internal/extsvc/github/testdata/vcr/TestV3Client_UpdateRef_success.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestV3Client_UpdateRef_success.yaml
@@ -1,0 +1,216 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"message":"New commit from VCR test!","tree":"9398082230ccd0ea7249b601d364e518dcd89271","parents":["58dd8da9d9099a823c814c528b29b72c9b2ac98b"],"author":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"committer":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/commits
+    method: POST
+  response:
+    body: '{"sha":"58377a8785c955d5f61293dda65657afddbc8dfc","node_id":"C_kwDODS5xedoAKDU4Mzc3YTg3ODVjOTU1ZDVmNjEyOTNkZGE2NTY1N2FmZGRiYzhkZmM","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/58377a8785c955d5f61293dda65657afddbc8dfc","html_url":"https://github.com/sourcegraph/automation-testing/commit/58377a8785c955d5f61293dda65657afddbc8dfc","author":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"committer":{"name":"Sourcegraph
+      VCR Test","email":"dev@sourcegraph.com","date":"2023-06-01T12:00:00Z"},"tree":{"sha":"9398082230ccd0ea7249b601d364e518dcd89271","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/trees/9398082230ccd0ea7249b601d364e518dcd89271"},"message":"New
+      commit from VCR test!","parents":[{"sha":"58dd8da9d9099a823c814c528b29b72c9b2ac98b","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/58dd8da9d9099a823c814c528b29b72c9b2ac98b","html_url":"https://github.com/sourcegraph/automation-testing/commit/58dd8da9d9099a823c814c528b29b72c9b2ac98b"}],"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "1165"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Jun 2023 00:21:59 GMT
+      Etag:
+      - '"cdb3a3ff85d83e3465ad2751b1db276fea9e6ec3d0cb10f640c13bbc76283b6d"'
+      Location:
+      - https://api.github.com/repos/sourcegraph/automation-testing/git/commits/58377a8785c955d5f61293dda65657afddbc8dfc
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E6EB:3B26:37B0D47:397662E:64793627
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4991"
+      X-Ratelimit-Reset:
+      - "1685668692"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "9"
+      X-Xss-Protection:
+      - "0"
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"sha":"58377a8785c955d5f61293dda65657afddbc8dfc","force":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update
+    method: PATCH
+  response:
+    body: '{"ref":"refs/heads/ready-to-update","node_id":"MDM6UmVmMjIxMTQ3NTEzOnJlZnMvaGVhZHMvcmVhZHktdG8tdXBkYXRl","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update","object":{"sha":"58377a8785c955d5f61293dda65657afddbc8dfc","type":"commit","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/58377a8785c955d5f61293dda65657afddbc8dfc"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Jun 2023 00:21:59 GMT
+      Etag:
+      - W/"ac7ee35847853e99968ca8eaa05cf5e76a9278acd18fb3df2f67f457ff5db745"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E6EB:3B26:37B0D89:397666C:64793627
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4990"
+      X-Ratelimit-Reset:
+      - "1685668692"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "10"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"sha":"c2f0a019668a800df480f07dba5d9dcaa0f64350","force":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.jean-grey-preview+json,application/vnd.github.mercy-preview+json
+      - application/vnd.github.machine-man-preview+json
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update
+    method: PATCH
+  response:
+    body: '{"ref":"refs/heads/ready-to-update","node_id":"MDM6UmVmMjIxMTQ3NTEzOnJlZnMvaGVhZHMvcmVhZHktdG8tdXBkYXRl","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/refs/heads/ready-to-update","object":{"sha":"c2f0a019668a800df480f07dba5d9dcaa0f64350","type":"commit","url":"https://api.github.com/repos/sourcegraph/automation-testing/git/commits/c2f0a019668a800df480f07dba5d9dcaa0f64350"}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 02 Jun 2023 00:22:00 GMT
+      Etag:
+      - W/"1e739eeb0851df1e4c1da3af8fee8716386c2f692927753be53e54f1e7796bc0"
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Api-Version-Selected:
+      - "2022-11-28"
+      X-Github-Media-Type:
+      - github.v3; param=jean-grey-preview; format=json, github.mercy-preview; param=machine-man-preview;
+        format=json
+      X-Github-Request-Id:
+      - E6EB:3B26:37B0DD9:39766C3:64793627
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4989"
+      X-Ratelimit-Reset:
+      - "1685668692"
+      X-Ratelimit-Resource:
+      - core
+      X-Ratelimit-Used:
+      - "11"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -851,14 +851,15 @@ func (c *V3Client) CreateCommit(ctx context.Context, owner, repo, message, tree 
 
 // UpdateRef updates the ref of a branch to point to the given commit. The ref should be
 // supplied in a fully qualified format, such as `refs/heads/branch` or `refs/tags/tag`.
-func (c *V3Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) error {
+func (c *V3Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) (*restUpdatedRef, error) {
+	var updatedRef restUpdatedRef
 	if _, err := c.patch(ctx, "repos/"+owner+"/"+repo+"/git/"+ref, struct {
 		SHA   string `json:"sha"`
 		Force bool   `json:"force"`
-	}{SHA: commit, Force: true}, nil); err != nil {
-		return err
+	}{SHA: commit, Force: true}, &updatedRef); err != nil {
+		return nil, err
 	}
-	return nil
+	return &updatedRef, nil
 }
 
 // GetAppInstallation gets information of a GitHub App installation.

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -824,8 +824,8 @@ func (c *V3Client) DeleteBranch(ctx context.Context, owner, repo, branch string)
 // GetRef gets the contents of a single commit reference in a repository. The ref should
 // be supplied in a fully qualified format, such as `refs/heads/branch` or
 // `refs/tags/tag`.
-func (c *V3Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommit, error) {
-	var commit restCommit
+func (c *V3Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommitRef, error) {
+	var commit restCommitRef
 	if _, err := c.get(ctx, "repos/"+owner+"/"+repo+"/commits/"+ref, &commit); err != nil {
 		return nil, err
 	}

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -821,6 +821,46 @@ func (c *V3Client) DeleteBranch(ctx context.Context, owner, repo, branch string)
 	return nil
 }
 
+// GetRef gets the contents of a single commit reference in a repository. The ref should
+// be supplied in a fully qualified format, such as `refs/heads/branch` or
+// `refs/tags/tag`.
+func (c *V3Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommit, error) {
+	var commit restCommit
+	if _, err := c.get(ctx, "repos/"+owner+"/"+repo+"/commits/"+ref, &commit); err != nil {
+		return nil, err
+	}
+	return &commit, nil
+}
+
+// CreateCommit creates a commit in the given repository based on a tree object.
+func (c *V3Client) CreateCommit(ctx context.Context, owner, repo, message, tree string, parents []string, author, committer *restAuthorCommiter) (*restCommit, error) {
+	payload := struct {
+		Message   string              `json:"message"`
+		Tree      string              `json:"tree"`
+		Parents   []string            `json:"parents"`
+		Author    *restAuthorCommiter `json:"author,omitempty"`
+		Committer *restAuthorCommiter `json:"committer,omitempty"`
+	}{Message: message, Tree: tree, Parents: parents, Author: author, Committer: committer}
+
+	var commit restCommit
+	if _, err := c.post(ctx, "repos/"+owner+"/"+repo+"/git/commits", payload, &commit); err != nil {
+		return nil, err
+	}
+	return &commit, nil
+}
+
+// UpdateRef updates the ref of a branch to point to the given commit. The ref should be
+// supplied in a fully qualified format, such as `refs/heads/branch` or `refs/tags/tag`.
+func (c *V3Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) error {
+	if _, err := c.patch(ctx, "repos/"+owner+"/"+repo+"/git/"+ref, struct {
+		SHA   string `json:"sha"`
+		Force bool   `json:"force"`
+	}{SHA: commit, Force: true}, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetAppInstallation gets information of a GitHub App installation.
 //
 // API docs: https://docs.github.com/en/rest/reference/apps#get-an-installation-for-the-authenticated-app

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -177,6 +177,22 @@ func (c *V3Client) post(ctx context.Context, requestURI string, payload, result 
 	return c.request(ctx, req, result)
 }
 
+func (c *V3Client) patch(ctx context.Context, requestURI string, payload, result any) (*httpResponseState, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling payload")
+	}
+
+	req, err := http.NewRequest("PATCH", requestURI, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	return c.request(ctx, req, result)
+}
+
 func (c *V3Client) delete(ctx context.Context, requestURI string) (*httpResponseState, error) {
 	req, err := http.NewRequest("DELETE", requestURI, bytes.NewReader(make([]byte, 0)))
 	if err != nil {

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -781,6 +781,162 @@ func TestV3Client_Fork(t *testing.T) {
 	})
 }
 
+func TestV3Client_GetRef(t *testing.T) {
+	ctx := context.Background()
+	t.Run("success", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_GetRef_success")
+		defer save()
+
+		// For this test, we need the ref for a branch that exists. We'll use the
+		// "always-open-pr" branch of https://github.com/sourcegraph/automation-testing.
+		commit, err := cli.GetRef(ctx, "sourcegraph", "automation-testing", "refs/heads/always-open-pr")
+		assert.Nil(t, err)
+		assert.NotNil(t, commit)
+
+		// Check that a couple properties on the commit are what we expect.
+		assert.Equal(t, commit.SHA, "37406e7dfa4466b80d1da183d6477aac16b1e58c")
+		assert.Equal(t, commit.URL, "https://api.github.com/repos/sourcegraph/automation-testing/commits/37406e7dfa4466b80d1da183d6477aac16b1e58c")
+		assert.Equal(t, commit.Commit.Author.Name, "Thorsten Ball")
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_GetRef_success"), update("TestV3Client_GetRef_success"), commit)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_GetRef_failure")
+		defer save()
+
+		// For this test, we need the ref for a branch that definitely does not exist.
+		nonexistentBranch := "refs/heads/butterfly-sponge-sandwich-rotation-technique-12345678-lol"
+		commit, err := cli.GetRef(ctx, "sourcegraph", "automation-testing", nonexistentBranch)
+		assert.Nil(t, commit)
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "No commit found for SHA: "+nonexistentBranch)
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_GetRef_failure"), update("TestV3Client_GetRef_failure"), err)
+	})
+}
+
+func TestV3Client_CreateCommit(t *testing.T) {
+	ctx := context.Background()
+	t.Run("success", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_CreateCommit_success")
+		defer save()
+
+		// For this test, we'll create a commit on
+		// https://github.com/sourcegraph/automation-testing based on this existing commit:
+		// https://github.com/sourcegraph/automation-testing/commit/37406e7dfa4466b80d1da183d6477aac16b1e58c.
+		treeSha := "851e666a00cd0cf74f1558ac5664fe431d3b1935"
+		parentSha := "9d04a0d8733dafbb5d75e594a9ec525c49dfc975"
+		author := &restAuthorCommiter{
+			Name:  "Sourcegraph VCR Test",
+			Email: "dev@sourcegraph.com",
+			Date:  "2023-06-01T12:00:00Z",
+		}
+		commit, err := cli.CreateCommit(ctx, "sourcegraph", "automation-testing", "I'm a new commit from a VCR test!", treeSha, []string{parentSha}, author, author)
+		assert.Nil(t, err)
+		assert.NotNil(t, commit)
+
+		// Check that a couple properties on the commit are what we expect.
+		// The SHA will be different every time, so we just check that it's not the
+		// same as the commit we based this one on.
+		assert.NotEqual(t, commit.SHA, "37406e7dfa4466b80d1da183d6477aac16b1e58c")
+		assert.Equal(t, commit.Message, "I'm a new commit from a VCR test!")
+		assert.Equal(t, commit.Tree.SHA, treeSha)
+		assert.Len(t, commit.Parents, 1)
+		assert.Equal(t, commit.Parents[0].SHA, parentSha)
+		assert.Equal(t, commit.Author, author)
+		assert.Equal(t, commit.Committer, author)
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_CreateCommit_success"), update("TestV3Client_CreateCommit_success"), commit)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_CreateCommit_failure")
+		defer save()
+
+		// For this test, we'll create a commit on
+		// https://github.com/sourcegraph/automation-testing with bogus values for several of its properties.
+		commit, err := cli.CreateCommit(ctx, "sourcegraph", "automation-testing", "I'm not going to work!", "loltotallynotatree", []string{"loltotallynotacommit"}, nil, nil)
+		assert.Nil(t, commit)
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "The tree parameter must be exactly 40 characters and contain only [0-9a-f]")
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_CreateCommit_failure"), update("TestV3Client_CreateCommit_failure"), err)
+	})
+}
+
+func TestV3Client_UpdateRef(t *testing.T) {
+	ctx := context.Background()
+	t.Run("success", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_UpdateRef_success")
+		defer save()
+
+		// For this test, we'll use the "ready-to-update" branch of
+		// https://github.com/sourcegraph/automation-testing, duplicate the commit that's
+		// currently at its HEAD, and update the branch to point to the new commit. Then
+		// we'll put it back to the original commit so this test can easily be run again.
+
+		originalCommit := &restCommit{
+			URL: "https://api.github.com/repos/sourcegraph/automation-testing/commits/c2f0a019668a800df480f07dba5d9dcaa0f64350",
+			SHA: "c2f0a019668a800df480f07dba5d9dcaa0f64350",
+			Tree: restCommitTree{
+				SHA: "9398082230ccd0ea7249b601d364e518dcd89271",
+			},
+			Parents: []restCommitParent{
+				{SHA: "58dd8da9d9099a823c814c528b29b72c9b2ac98b"},
+			},
+		}
+		author := &restAuthorCommiter{
+			Name:  "Sourcegraph VCR Test",
+			Email: "dev@sourcegraph.com",
+			Date:  "2023-06-01T12:00:00Z",
+		}
+
+		// Create the new commit we'll use to update the branch with.
+		newCommit, err := cli.CreateCommit(ctx, "sourcegraph", "automation-testing", "New commit from VCR test!", originalCommit.Tree.SHA, []string{originalCommit.Parents[0].SHA}, author, author)
+
+		assert.Nil(t, err)
+		assert.NotNil(t, newCommit)
+		assert.NotEqual(t, originalCommit.SHA, newCommit.SHA)
+		assert.Equal(t, newCommit.Message, "New commit from VCR test!")
+
+		updatedRef, err := cli.UpdateRef(ctx, "sourcegraph", "automation-testing", "refs/heads/ready-to-update", newCommit.SHA)
+		assert.Nil(t, err)
+		assert.NotNil(t, updatedRef)
+
+		// Check that a couple properties on the updated ref are what we expect.
+		assert.Equal(t, updatedRef.Ref, "refs/heads/ready-to-update")
+		assert.Equal(t, updatedRef.Object.Type, "commit")
+		assert.Equal(t, updatedRef.Object.SHA, newCommit.SHA)
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_UpdateRef_success"), update("TestV3Client_UpdateRef_success"), updatedRef)
+
+		// Now put the branch back to its original commit.
+		updatedRef, err = cli.UpdateRef(ctx, "sourcegraph", "automation-testing", "refs/heads/ready-to-update", originalCommit.SHA)
+		assert.Nil(t, err)
+		assert.NotNil(t, updatedRef)
+
+		// Check that a couple properties on the updated ref are what we expect.
+		assert.Equal(t, updatedRef.Ref, "refs/heads/ready-to-update")
+		assert.Equal(t, updatedRef.Object.Type, "commit")
+		assert.Equal(t, updatedRef.Object.SHA, originalCommit.SHA)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		cli, save := newV3TestClient(t, "TestV3Client_UpdateRef_failure")
+		defer save()
+
+		// For this test, we'll try to update the "ready-to-update" branch of
+		// https://github.com/sourcegraph/automation-testing to point to a bogus commit
+		updatedRef, err := cli.UpdateRef(ctx, "sourcegraph", "automation-testing", "refs/heads/ready-to-update", "fakeshalolfakeshalolfakeshalolfakeshalol")
+		assert.Nil(t, updatedRef)
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "The sha parameter must be exactly 40 characters and contain only [0-9a-f]")
+
+		testutil.AssertGolden(t, filepath.Join("testdata", "golden", "TestV3Client_UpdateRef_failure"), update("TestV3Client_UpdateRef_failure"), err)
+	})
+}
+
 func newV3TestClient(t testing.TB, name string) (*V3Client, func()) {
 	t.Helper()
 

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -665,6 +665,34 @@ func (c *V4Client) DeleteBranch(ctx context.Context, owner, repo, branch string)
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).DeleteBranch(ctx, owner, repo, branch)
 }
 
+// GetRef gets the contents of a single commit reference in a repository. The ref should
+// be supplied in a fully qualified format, such as `refs/heads/branch` or
+// `refs/tags/tag`.
+func (c *V4Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommit, error) {
+	logger := c.log.Scoped("GetRef", "temporary client for getting a ref on GitHub")
+	// We technically don't need to use the REST API for this but it's just a bit easier.
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).GetRef(ctx, owner, repo, ref)
+}
+
+// CreateCommit creates a commit in the given repository based on a tree object.
+func (c *V4Client) CreateCommit(ctx context.Context, owner, repo, message, tree string, parents []string, author, committer *restAuthorCommiter) (*restCommit, error) {
+	logger := c.log.Scoped("CreateCommit", "temporary client for creating a commit on GitHub")
+	// As of May 2023, the GraphQL API does not expose any mutations for creating commits
+	// other than one which requires sending the entire file contents for any files
+	// changed by the commit, which is not feasible for creating large commits. Therefore,
+	// we fall back on a REST API endpoint which allows us to create a commit based on a
+	// tree object.
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).CreateCommit(ctx, owner, repo, message, tree, parents, author, committer)
+}
+
+// UpdateRef updates the ref of a branch to point to the given commit. The ref should be
+// supplied in a fully qualified format, such as `refs/heads/branch` or `refs/tags/tag`.
+func (c *V4Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) error {
+	logger := c.log.Scoped("UpdateRef", "temporary client for updating a ref on GitHub")
+	// We technically don't need to use the REST API for this but it's just a bit easier.
+	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).UpdateRef(ctx, owner, repo, ref, commit)
+}
+
 type RecentCommittersParams struct {
 	// Repository name
 	Name string

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -668,7 +668,7 @@ func (c *V4Client) DeleteBranch(ctx context.Context, owner, repo, branch string)
 // GetRef gets the contents of a single commit reference in a repository. The ref should
 // be supplied in a fully qualified format, such as `refs/heads/branch` or
 // `refs/tags/tag`.
-func (c *V4Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommit, error) {
+func (c *V4Client) GetRef(ctx context.Context, owner, repo, ref string) (*restCommitRef, error) {
 	logger := c.log.Scoped("GetRef", "temporary client for getting a ref on GitHub")
 	// We technically don't need to use the REST API for this but it's just a bit easier.
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).GetRef(ctx, owner, repo, ref)

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -687,7 +687,7 @@ func (c *V4Client) CreateCommit(ctx context.Context, owner, repo, message, tree 
 
 // UpdateRef updates the ref of a branch to point to the given commit. The ref should be
 // supplied in a fully qualified format, such as `refs/heads/branch` or `refs/tags/tag`.
-func (c *V4Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) error {
+func (c *V4Client) UpdateRef(ctx context.Context, owner, repo, ref, commit string) (*restUpdatedRef, error) {
 	logger := c.log.Scoped("UpdateRef", "temporary client for updating a ref on GitHub")
 	// We technically don't need to use the REST API for this but it's just a bit easier.
 	return NewV3Client(logger, c.urn, c.apiURL, c.auth, c.httpClient).UpdateRef(ctx, owner, repo, ref, commit)


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52488.

This PR adds support for three methods to the GitHub V3 (REST) Client: `GetRef`, `CreateCommit`, and `UpdateRef`. When chained together, these methods facilitate duplicating an existing commit and replacing it on a branch.

## Test plan

Added VCR success/failure tests for each of the new client methods.

Manually tested with https://github.com/sourcegraph/sourcegraph/pull/52492 and confirmed a branch with one signed commit was produced at the end:

![image](https://github.com/sourcegraph/sourcegraph/assets/8942601/73d1b02a-d85e-4caf-a402-0842232ddb19)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
