### PR TITLE
Cody: Escape Windows path separator in fast file finder path pattern

### DIFF
--- a/client/cody/src/chat/fastFileFinder.test.ts
+++ b/client/cody/src/chat/fastFileFinder.test.ts
@@ -1,4 +1,15 @@
-import { filePathContains } from './fastFileFinder'
+import { filePathContains, makeTrimRegex } from './fastFileFinder'
+
+describe('makeTrimRegex', () => {
+    it('should not fail using the Windows path separator', () => {
+        expect(makeTrimRegex('\\').test('foo\\*')).toBe(true)
+        expect(makeTrimRegex('\\').test('foo\\*\\bar')).toBe(false)
+    })
+    it('should trim leading and trailing path separators and wildcards', () => {
+        expect('**\\foo\\bar'.replace(makeTrimRegex('\\'), '')).toBe('foo\\bar')
+        expect('//foo/bar/**'.replace(makeTrimRegex('/'), '')).toBe('foo/bar')
+    })
+})
 
 describe('filePathContains', () => {
     it('should handle exact matches', () => {

--- a/client/cody/src/chat/fastFileFinder.ts
+++ b/client/cody/src/chat/fastFileFinder.ts
@@ -19,8 +19,15 @@ export async function fastFilesExist(
     return processRgOutput(rgOutput, filePaths)
 }
 
+export function makeTrimRegex(sep: string): RegExp {
+    if (sep === '\\') {
+        sep = '\\\\' // Regex escape this character
+    }
+    return new RegExp(`(^[*${sep}]+)|([*${sep}]+$)`, 'g')
+}
+
 // Regex to match '**', '*' or path.sep at the start (^) or end ($) of the string.
-const trimRegex = new RegExp(`^([*${path.sep}]*)|([*${path.sep}]*)$`, 'g')
+const trimRegex = makeTrimRegex(path.sep)
 /**
  * Constructs a search pattern for the 'rg' tool.
  *


### PR DESCRIPTION
This is breaking the Cody extension on Windows.

Fixes #52730

## Test plan

```
cd client/cody
pnpm test:unit
```
