### PR TITLE
codygateway: Fix data race in test

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/source_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source_test.go
@@ -3,6 +3,7 @@ package actor
 import (
 	"context"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 )
 
 type mockSourceSyncer struct {
-	syncCount int
+	syncCount atomic.Int32
 }
 
 var _ SourceSyncer = &mockSourceSyncer{}
@@ -33,7 +34,7 @@ func (m *mockSourceSyncer) Get(context.Context, string) (*Actor, error) {
 }
 
 func (m *mockSourceSyncer) Sync(context.Context) (int, error) {
-	m.syncCount++
+	m.syncCount.Add(1)
 	return 10, nil
 }
 
@@ -88,24 +89,24 @@ func TestSourcesWorkers(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	t.Run("only the first worker should be doing work", func(t *testing.T) {
-		assert.NotZero(t, s1.syncCount)
-		assert.Zero(t, s2.syncCount)
+		assert.NotZero(t, s1.syncCount.Load())
+		assert.Zero(t, s2.syncCount.Load())
 	})
 
 	// Stop the first worker and wait a bit
 	close(stop1)
-	count1 := s1.syncCount // Save the count to assert later
+	count1 := s1.syncCount.Load() // Save the count to assert later
 	time.Sleep(100 * time.Millisecond)
 
 	t.Run("first worker does no work after stop", func(t *testing.T) {
 		// Bounded range assertion to avoid flakiness
-		assert.GreaterOrEqual(t, count1, s1.syncCount-1)
-		assert.LessOrEqual(t, count1, s1.syncCount+1)
+		assert.GreaterOrEqual(t, count1, s1.syncCount.Load()-1)
+		assert.LessOrEqual(t, count1, s1.syncCount.Load()+1)
 	})
 
 	// Worker 2 should pick up work
 	t.Run("second worker does work after first worker stops", func(t *testing.T) {
-		assert.NotZero(t, s2.syncCount)
+		assert.NotZero(t, s2.syncCount.Load())
 	})
 
 	// Stop worker 2


### PR DESCRIPTION
This fixes an error in the race detector by making access to the syncCounter synchronized.

## Test plan

go test -race -count=50