### PR TITLE
bzl: enable go test race detector

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -39,3 +39,6 @@ build --workspace_status_command=./dev/bazel_buildkite_stamp_vars.sh
 
 # temp
 build --test_env=INCLUDE_ADMIN_ONBOARDING=false
+
+# Enable Go race detector
+test --@io_bazel_rules_go//go/config:race

--- a/enterprise/cmd/cody-gateway/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/BUILD.bazel
@@ -44,5 +44,6 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -74,7 +74,7 @@ copy_file(
 # gazelle:exclude testdata
 go_test(
     name = "shared_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "context_detection_test.go",
         "context_qa_test.go",


### PR DESCRIPTION
I accidentally have overlooked enabling this when we transitioned to Bazel. 

Huge thanks to @unknwon for fixing the only race condition that slipped in. It was only happening inside tests. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 