### PR TITLE
Update p4-fusion to install at p4-fusion-binary

### DIFF
--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -3,7 +3,7 @@
 package:
   name: p4-fusion
   version: 1.12
-  epoch: 1
+  epoch: 2
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
     - x86_64
@@ -82,4 +82,4 @@ pipeline:
   # Copy p4-fusion binary
   - runs: |
       mkdir -p ${{targets.destdir}}/usr/local/bin/
-      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/
+      cp p4-fusion-src/build/p4-fusion/p4-fusion ${{targets.destdir}}/usr/local/bin/p4-fusion-binary


### PR DESCRIPTION
The new p4-wrapper scripts replace p4-fusion and rename the actual binary to p4-fusion-binary

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Manual testing on local image
- Green CI