### PR TITLE
JetBrains plugin: use system property for completions setting

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -97,6 +97,7 @@ tasks {
 
     runIde {
         jvmArgs("-Djdk.module.illegalAccess.silent=true")
+        systemProperty("cody.completions.enabled", "true")
     }
 
     // Configure UI tests plugin

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -29,8 +29,13 @@ public class CodyCompletionsManager {
   // TODO: figure out how to avoid the ugly nested `Future<CompletableFuture<T>>` type.
   private final ConcurrentLinkedQueue<Future<CompletableFuture<Void>>> jobs =
       new ConcurrentLinkedQueue<>();
+
+  // We don't want casual users to turn on completions by discovering a setting in the UI so
+  // we only allow enabling completions via a system property. This property is automatically
+  // configured when running `./gradle :runIde`, and we'll need to document internally for
+  // Sourcegraph team members how to use "Edit Custom VM Options..." to enable completions.
   private static final boolean IS_COMPLETIONS_ENABLED =
-      "true".equals(System.getenv("CODY_COMPLETIONS_ENABLED"));
+      "true".equals(System.getProperty("cody.completions.enabled"));
 
   public static @NotNull CodyCompletionsManager getInstance() {
     return ApplicationManager.getApplication().getService(CodyCompletionsManager.class);


### PR DESCRIPTION
Previously, we used an environment variabl to enable/disable completions. It's more idiomatic to use system properties since users can enable/disable properties with the "Edit VM Options" action. It's more difficult for users to customize environment variables.

## Test plan

Green CI.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
