### PR TITLE
ci: disable Go race detection temporarily

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -39,6 +39,3 @@ build --workspace_status_command=./dev/bazel_buildkite_stamp_vars.sh
 
 # temp
 build --test_env=INCLUDE_ADMIN_ONBOARDING=false
-
-# Enable Go race detector
-test --@io_bazel_rules_go//go/config:race


### PR DESCRIPTION
Globally enabling race detection introduced breakage in container building jobs, disabling it for now, will push a fix shortly. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 