### PR TITLE
Update postgres_exporter to 0.12.0

### DIFF
--- a/docker-images/postgres_exporter/Dockerfile
+++ b/docker-images/postgres_exporter/Dockerfile
@@ -1,7 +1,7 @@
-FROM prometheuscommunity/postgres-exporter:v0.11.1@sha256:a7f8f66064b95c2b08dce9a0aaafe78c6639b7546d472fab649e9e7480be0454 as postgres_exporter
+FROM prometheuscommunity/postgres-exporter:v0.12.0@sha256:f34d50a64a4d558ad118ffc73be45a359ac8f30b8daba4b241458bcb9f94e254 as postgres_exporter
 FROM sourcegraph/alpine-3.14:213466_2023-04-17_5.0-bdda34a71619@sha256:6354a4ff578b685e36c8fbde81f62125ae0011b047fb2cc22d1b0de616b3c59a
 # hadolint ignore=DL3048
-LABEL com.sourcegraph.postgres_exporter.version=v0.9.0
+LABEL com.sourcegraph.postgres_exporter.version=v0.12.0
 
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"

--- a/docker-images/postgres_exporter/Dockerfile
+++ b/docker-images/postgres_exporter/Dockerfile
@@ -27,3 +27,5 @@ ENV  PG_EXPORTER_EXTEND_QUERY_PATH=/config/queries.yaml
 EXPOSE 9187
 
 ENTRYPOINT [ "/usr/local/bin/postgres_exporter"]
+
+#

--- a/docker-images/postgres_exporter/Dockerfile
+++ b/docker-images/postgres_exporter/Dockerfile
@@ -27,5 +27,3 @@ ENV  PG_EXPORTER_EXTEND_QUERY_PATH=/config/queries.yaml
 EXPOSE 9187
 
 ENTRYPOINT [ "/usr/local/bin/postgres_exporter"]
-
-#


### PR DESCRIPTION
The breaking changes from 0.11 to 0.12 don't affect us, and already tested this version via Wolfi images



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Built and tested locally
