### PR TITLE
App: Improve log messages when backend terminates

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -221,11 +221,21 @@ fn start_embedded_services(handle: &tauri::AppHandle) {
                 }
                 CommandEvent::Error(err) => {
                     show_error_screen(&app);
-                    log::error!("Command Error: {:#?}", err)
+                    log::error!("Error running the Sourcegraph app backend: {:#?}", err)
                 }
                 CommandEvent::Terminated(payload) => {
                     show_error_screen(&app);
-                    log::error!("Command Terminated: {:#?}", payload)
+
+                    if let Some(code) = payload.code {
+                        log::error!("Sourcegraph app backend terminated with exit code {}", code);
+                    }
+
+                    if let Some(signal) = payload.signal {
+                        log::error!(
+                            "Sourcegraph app backend terminated due to signal {}",
+                            signal
+                        );
+                    }
                 }
                 _ => continue,
             };


### PR DESCRIPTION
Make the log messages a bit more informative when the app backend terminates. This makes the log view more useful for end users.

## Test plan

- simulate a crash of the backend
- check the log messages