### PR TITLE
Cody: Update to log errors from embeddings

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -320,7 +320,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                     this.editor.controllers.inline.reply(highlightedDisplayText)
                 }
                 void this.onCompletionEnd()
-                this.publishEmbeddingsError()
             },
         })
 
@@ -375,13 +374,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.sendTranscript()
         void this.saveTranscriptToChatHistory()
         void vscode.commands.executeCommand('setContext', 'cody.reply.pending', false)
-        if (!this.codebaseContext.checkEmbeddingsConnection()) {
-            this.publishEmbeddingsError()
-            this.sendErrorToWebview(
-                'Error while establishing embeddings server connection. Please try after sometime! If the issue still persists contact support'
-            )
-            return
-        }
+        this.logEmbeddingsSearchErrors()
     }
 
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion'): Promise<void> {
@@ -675,13 +668,12 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     }
 
     /**
-     * Publish embedding connections or results error to webview
+     * Send embedding connections or results error to output
      */
-    private publishEmbeddingsError(): void {
+    private logEmbeddingsSearchErrors(): void {
         const searchErrors = this.codebaseContext.getEmbeddingSearchErrors()
-        if (searchErrors.length) {
-            this.sendErrorToWebview(searchErrors)
-            return
+        if (searchErrors) {
+            debug('ChatViewProvider:onLogEmbeddingsErrors', '', { verbose: searchErrors })
         }
     }
 

--- a/client/cody/test/e2e/auth.test.ts
+++ b/client/cody/test/e2e/auth.test.ts
@@ -20,6 +20,9 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
 
     await expect(sidebar.getByText("Hello! I'm Cody.")).toBeVisible()
 
+    // Check if embeddings server connection error is visible
+    await expect(sidebar.getByText('Error while establishing embeddings server connection.')).not.toBeVisible()
+
     await page.getByRole('button', { name: 'Chat Section' }).hover()
 
     await page.click('[aria-label="Cody: Settings"]')


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/52696
RE https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1685629520228399?thread_ts=1685626165.446539&cid=C04MSD3DP5L

Currently the error messages from the embedding services are being displayed in the UI, which can be disruptive to users using keyword contexts. We will log the errors in debug output instead.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

We can see the embeddings service error in our current test build since we don't have the embedding service mocked:
![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/ad15a073-c05a-4e28-bef9-bad121263790)


Added a test step to confirm the error message is not showing up in UI anymore