### PR TITLE
cody: add button to cancel embedding job

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react'
 
+import { mdiCancel } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
@@ -15,6 +16,8 @@ import {
     Link,
     H4,
     Alert,
+    Tooltip,
+    Icon,
 } from '@sourcegraph/wildcard'
 
 import { RepoEmbeddingJobFields, RepoEmbeddingJobState } from '../../../graphql-operations'
@@ -25,31 +28,56 @@ interface RepoEmbeddingJobNodeProps {
     node: RepoEmbeddingJobFields
 }
 
-export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({ node }) => {
-    const { state, repo, revision, finishedAt, queuedAt, startedAt, failureMessage } = node
+export interface RepoEmbeddingJobFieldsProps {
+    onDelete(id: string): void
+}
+
+export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps & RepoEmbeddingJobFieldsProps> = ({
+    node,
+    onDelete,
+}) => {
+    const { id, state, repo, revision, finishedAt, queuedAt, startedAt, failureMessage } = node
     return (
         <li className="list-group-item p-2">
-            <div className="d-flex align-items-center">
-                <div className={styles.badgeWrapper}>
-                    <RepoEmbeddingJobStateBadge state={state} />
-                </div>
-                <div className="d-flex flex-column ml-3">
-                    {repo && revision ? (
-                        <Link to={`${repo.url}@${revision.oid}`}>
-                            {repo.name}@{revision.abbreviatedOID}
-                        </Link>
-                    ) : (
-                        <div>Unknown repository</div>
-                    )}
-                    <div className="mt-1">
-                        <RepoEmbeddingJobExecutionInfo
-                            state={state}
-                            finishedAt={finishedAt}
-                            queuedAt={queuedAt}
-                            startedAt={startedAt}
-                            failureMessage={failureMessage}
-                        />
+            <div className="d-flex justify-content-between">
+                <div className="d-flex align-items-center">
+                    <div className={styles.badgeWrapper}>
+                        <RepoEmbeddingJobStateBadge state={state} />
                     </div>
+                    <div className="d-flex flex-column ml-3">
+                        {repo && revision ? (
+                            <Link to={`${repo.url}@${revision.oid}`}>
+                                {repo.name}@{revision.abbreviatedOID}
+                            </Link>
+                        ) : (
+                            <div>Unknown repository</div>
+                        )}
+                        <div className="mt-1">
+                            <RepoEmbeddingJobExecutionInfo
+                                state={state}
+                                finishedAt={finishedAt}
+                                queuedAt={queuedAt}
+                                startedAt={startedAt}
+                                failureMessage={failureMessage}
+                            />
+                        </div>
+                    </div>
+                </div>
+                <div className="d-flex align-items-center">
+                    {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
+                        <Tooltip content="Cancel repository embedding job">
+                            <Button
+                                aria-label="Cancel"
+                                className="test-delete-external-service-button"
+                                onClick={() => onDelete(id)}
+                                variant="secondary"
+                                size="sm"
+                            >
+                                <Icon aria-hidden={true} svgPath={mdiCancel} />
+                                {' Cancel'}
+                            </Button>
+                        </Tooltip>
+                    ) : null}
                 </div>
             </div>
         </li>

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -86,7 +86,8 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
 
     const onDelete = useCallback(
         async (id: string) => {
-            await cancelRepoEmbeddingJob({ variables: { id } }), refresh.next()
+            await cancelRepoEmbeddingJob({ variables: { id } })
+            refresh.next()
         },
         [cancelRepoEmbeddingJob, refresh]
     )

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -26,8 +26,13 @@ import { PageTitle } from '../../../components/PageTitle'
 import { RepoEmbeddingJobConnectionFields, RepoEmbeddingJobFields } from '../../../graphql-operations'
 import { RepositoriesField } from '../../insights/components'
 
-import { repoEmbeddingJobs, useScheduleContextDetectionEmbeddingJob, useScheduleRepoEmbeddingJobs } from './backend'
-import { RepoEmbeddingJobNode } from './RepoEmbeddingJobNode'
+import {
+    useCancelRepoEmbeddingJob,
+    repoEmbeddingJobs,
+    useScheduleContextDetectionEmbeddingJob,
+    useScheduleRepoEmbeddingJobs,
+} from './backend'
+import { RepoEmbeddingJobNode, RepoEmbeddingJobFieldsProps } from './RepoEmbeddingJobNode'
 
 import styles from './SiteAdminCodyPage.module.scss'
 
@@ -55,6 +60,8 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
     const [scheduleRepoEmbeddingJobs, { loading: repoEmbeddingJobsLoading, error: repoEmbeddingJobsError }] =
         useScheduleRepoEmbeddingJobs()
 
+    const [cancelRepoEmbeddingJob] = useCancelRepoEmbeddingJob()
+
     const [
         scheduleContextDetectionEmbeddingJob,
         { loading: contextDetectionEmbeddingJobLoading, error: contextDetectionEmbeddingJobError },
@@ -76,6 +83,13 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         touched: false,
         onSubmit: values => onSubmit(values.repositories),
     })
+
+    const onDelete = useCallback(
+        async (id: string) => {
+            await cancelRepoEmbeddingJob({ variables: { id } }), refresh.next()
+        },
+        [cancelRepoEmbeddingJob, refresh]
+    )
 
     const repositories = useField({
         name: 'repositories',
@@ -133,7 +147,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                 <H3 className="mt-3">Repository embedding jobs</H3>
                 <FilteredConnection<
                     RepoEmbeddingJobFields,
-                    RepoEmbeddingJobFields,
+                    RepoEmbeddingJobFieldsProps,
                     {},
                     RepoEmbeddingJobConnectionFields
                 >
@@ -146,6 +160,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                     defaultFirst={10}
                     queryConnection={queryConnection}
                     nodeComponent={RepoEmbeddingJobNode}
+                    nodeComponentProps={{ onDelete }}
                     hideSearch={true}
                     updates={refresh}
                     emptyElement={<EmtpyList />}

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -60,7 +60,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
     const [scheduleRepoEmbeddingJobs, { loading: repoEmbeddingJobsLoading, error: repoEmbeddingJobsError }] =
         useScheduleRepoEmbeddingJobs()
 
-    const [cancelRepoEmbeddingJob] = useCancelRepoEmbeddingJob()
+    const [cancelRepoEmbeddingJob, { error: cancelRepoEmbeddingJobError }] = useCancelRepoEmbeddingJob()
 
     const [
         scheduleContextDetectionEmbeddingJob,
@@ -137,11 +137,15 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                         </div>
                     </div>
                 </Form>
-                {(repoEmbeddingJobsError || contextDetectionEmbeddingJobError) && (
+                {(repoEmbeddingJobsError || contextDetectionEmbeddingJobError || cancelRepoEmbeddingJobError) && (
                     <div className="mt-1">
                         <ErrorAlert
                             prefix="Error scheduling embedding jobs"
-                            error={repoEmbeddingJobsError || contextDetectionEmbeddingJobError}
+                            error={
+                                repoEmbeddingJobsError ||
+                                contextDetectionEmbeddingJobError ||
+                                cancelRepoEmbeddingJobError
+                            }
                         />
                     </div>
                 )}

--- a/client/web/src/enterprise/site-admin/cody/backend.ts
+++ b/client/web/src/enterprise/site-admin/cody/backend.ts
@@ -13,6 +13,8 @@ import {
     ScheduleContextDetectionEmbeddingJobVariables,
     ScheduleRepoEmbeddingJobsResult,
     ScheduleRepoEmbeddingJobsVariables,
+    CancelRepoEmbeddingJobResult,
+    CancelRepoEmbeddingJobVariables,
 } from '../../../graphql-operations'
 
 const REPO_EMBEDDING_JOB_FRAGMENT = gql`
@@ -73,6 +75,21 @@ export function repoEmbeddingJobs(
         map(dataOrThrowErrors),
         map(data => data.repoEmbeddingJobs)
     )
+}
+
+export const CANCEL_REPO_EMBEDDING_JOB = gql`
+    mutation CancelRepoEmbeddingJob($id: ID!) {
+        cancelRepoEmbeddingJob(job: $id) {
+            alwaysNil
+        }
+    }
+`
+
+export function useCancelRepoEmbeddingJob(): MutationTuple<
+    CancelRepoEmbeddingJobResult,
+    CancelRepoEmbeddingJobVariables
+> {
+    return useMutation<CancelRepoEmbeddingJobResult, CancelRepoEmbeddingJobVariables>(CANCEL_REPO_EMBEDDING_JOB)
 }
 
 export const SCHEDULE_REPO_EMBEDDING_JOBS = gql`


### PR DESCRIPTION
Stacked on top of #52756 

This adds a button to cancel an embedding job that is in the state "queued" or "processing".

Cancel button visible for "queued" but not for "completed" 
![cancel_1](https://github.com/sourcegraph/sourcegraph/assets/26413131/d7bedd98-a8b8-40fc-8345-8b8ce78f228f)

Canceled
![cancel_2](https://github.com/sourcegraph/sourcegraph/assets/26413131/5590cd6a-3a27-4ccd-a6f7-6e3d09b4e2a0)

## Test plan
- `sg start embeddings`
- Schedule a longer running embedding job
- cancel job while in status "queued" or "processsing"
- Check the db that the column "cancel" is set to `TRUE`


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
