### PR TITLE
cody-gateway: rewrite upstream 429 to 503

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/upstream.go
@@ -173,12 +173,11 @@ func makeUpstreamHandler[ReqT any](
 			// should retry.
 			logger.Warn("upstream returned 429, rewriting to 503")
 			resolvedStatusCode = http.StatusServiceUnavailable
-			w.WriteHeader(resolvedStatusCode)
 		} else {
 			// Otherwise, write the upstream's status code back as-is.
 			resolvedStatusCode = upstreamStatusCode
-			w.WriteHeader(resolvedStatusCode)
 		}
+		w.WriteHeader(resolvedStatusCode)
 
 		// Set up a buffer to capture the response as it's streamed and sent to the client.
 		var responseBuf bytes.Buffer


### PR DESCRIPTION
We don't want clients retrying on upstream 429 errors.

Closes https://github.com/sourcegraph/sourcegraph/issues/52518

## Test plan


n/a, simple change. We have no test coverage on this handler yet, might be something to follow-up on, but at the moment it's a bit involved
