### PR TITLE
Cody: Release 0.2.1

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,14 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+### Changed
+
+## [0.2.1]
+
+### Added
+
+### Fixed
+
 - Escape Windows path separator in fast file finder path pattern [pull/52754](https://github.com/sourcegraph/sourcegraph/pull/52754)
 - Only display errors from the embeddings clients for users connnected to an indexed codebase [pull/52780](https://github.com/sourcegraph/sourcegraph/pull/52780)
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,8 +14,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ## [0.2.1]
 
-### Added
-
 ### Fixed
 
 - Escape Windows path separator in fast file finder path pattern [pull/52754](https://github.com/sourcegraph/sourcegraph/pull/52754)

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI by Sourcegraph",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
This patch should unblock Windows users reported in https://github.com/sourcegraph/sourcegraph/issues/52730

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested package in Windows.

Built before https://github.com/sourcegraph/sourcegraph/pull/52780 
<img width="1019" alt="Screenshot 2023-06-01 093451" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/9e90f146-69bf-412f-bf2e-890fd036b2ae">


Built after https://github.com/sourcegraph/sourcegraph/pull/52780
<img width="1017" alt="Screenshot 2023-06-01 093713" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/6a27ce04-926d-4091-a569-1a82cf29db66">
