### PR TITLE
completions: return non-ok status codes and response headers to clients

### DIFF
--- a/enterprise/cmd/frontend/internal/completions/init.go
+++ b/enterprise/cmd/frontend/internal/completions/init.go
@@ -24,14 +24,14 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	logger := log.Scoped("completions", "")
+	logger := log.Scoped("completions", "Cody completions")
 
 	enterpriseServices.NewChatCompletionsStreamHandler = func() http.Handler {
-		completionsHandler := httpapi.NewChatCompletionsStreamHandler(logger, db)
+		completionsHandler := httpapi.NewChatCompletionsStreamHandler(logger.Scoped("chat", "chat completions handler"), db)
 		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, completionsHandler)
 	}
 	enterpriseServices.NewCodeCompletionsHandler = func() http.Handler {
-		codeCompletionsHandler := httpapi.NewCodeCompletionsHandler(logger, db)
+		codeCompletionsHandler := httpapi.NewCodeCompletionsHandler(logger.Scoped("code", "code completions handler"), db)
 		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, codeCompletionsHandler)
 	}
 	enterpriseServices.CompletionsResolver = resolvers.NewCompletionsResolver(db, observationCtx.Logger)

--- a/enterprise/internal/completions/client/anthropic/anthropic.go
+++ b/enterprise/internal/completions/client/anthropic/anthropic.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
@@ -149,9 +148,7 @@ func (a *anthropicClient) makeRequest(ctx context.Context, requestParams types.C
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, errors.Errorf("Anthropic API failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, types.NewErrStatusNotOK("Anthropic", resp)
 	}
 
 	return resp, nil

--- a/enterprise/internal/completions/client/anthropic/anthropic_test.go
+++ b/enterprise/internal/completions/client/anthropic/anthropic_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
 )
@@ -69,4 +70,34 @@ func TestInvalidAnthropicStream(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	assert.Contains(t, err.Error(), "failed to decode event payload")
+}
+
+func TestErrStatusNotOK(t *testing.T) {
+	mockClient := NewClient(&mockDoer{
+		func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(bytes.NewReader([]byte("oh no, please slow down!"))),
+			}, nil
+		},
+	}, "", "")
+
+	t.Run("Complete", func(t *testing.T) {
+		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{})
+		require.Error(t, err)
+		assert.Nil(t, resp)
+
+		autogold.Expect("Anthropic: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil })
+		require.Error(t, err)
+
+		autogold.Expect("Anthropic: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
 }

--- a/enterprise/internal/completions/client/codygateway/codygateway.go
+++ b/enterprise/internal/completions/client/codygateway/codygateway.go
@@ -60,6 +60,8 @@ func (c *codyGatewayClient) Complete(ctx context.Context, feature types.Completi
 	if err != nil {
 		return nil, err
 	}
+	// Passthrough error directly, ErrStatusNotOK should be implemented by the
+	// underlying client.
 	return cc.Complete(ctx, feature, requestParams)
 }
 

--- a/enterprise/internal/completions/client/dotcom/BUILD.bazel
+++ b/enterprise/internal/completions/client/dotcom/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "dotcom",
@@ -10,5 +10,17 @@ go_library(
         "//internal/httpcli",
         "//internal/search/streaming/http",
         "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "dotcom_test",
+    srcs = ["dotcom_test.go"],
+    embed = [":dotcom"],
+    deps = [
+        "//enterprise/internal/completions/types",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/internal/completions/client/dotcom/dotcom.go
+++ b/enterprise/internal/completions/client/dotcom/dotcom.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
@@ -57,8 +56,7 @@ func (a *dotcomClient) Complete(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, errors.Errorf("API failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, types.NewErrStatusNotOK("Sourcegraph.com", resp)
 	}
 
 	var result types.CompletionResponse
@@ -91,8 +89,7 @@ func (a *dotcomClient) Stream(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return errors.Errorf("API failed with status %d: %s", resp.StatusCode, string(respBody))
+		return types.NewErrStatusNotOK("sourcegraph.com", resp)
 	}
 
 	dec := streamhttp.NewDecoder(resp.Body)

--- a/enterprise/internal/completions/client/dotcom/dotcom_test.go
+++ b/enterprise/internal/completions/client/dotcom/dotcom_test.go
@@ -1,0 +1,53 @@
+package dotcom
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
+)
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func TestErrStatusNotOK(t *testing.T) {
+	mockClient := NewClient(&mockDoer{
+		func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(bytes.NewReader([]byte("oh no, please slow down!"))),
+			}, nil
+		},
+	}, "")
+
+	t.Run("Complete", func(t *testing.T) {
+		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{})
+		require.Error(t, err)
+		assert.Nil(t, resp)
+
+		autogold.Expect("Sourcegraph.com: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil })
+		require.Error(t, err)
+
+		autogold.Expect("sourcegraph.com: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+}

--- a/enterprise/internal/completions/client/openai/BUILD.bazel
+++ b/enterprise/internal/completions/client/openai/BUILD.bazel
@@ -17,7 +17,15 @@ go_library(
 
 go_test(
     name = "openai_test",
-    srcs = ["decoder_test.go"],
+    srcs = [
+        "decoder_test.go",
+        "openai_test.go",
+    ],
     embed = [":openai"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//enterprise/internal/completions/types",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/enterprise/internal/completions/client/openai/openai.go
+++ b/enterprise/internal/completions/client/openai/openai.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"strings"
 
@@ -166,9 +165,7 @@ func (c *openAIChatCompletionStreamClient) makeRequest(ctx context.Context, requ
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, errors.Errorf("OpenAI API failed with status %d: %s", resp.StatusCode, string(respBody))
+		return nil, types.NewErrStatusNotOK("OpenAI", resp)
 	}
 
 	return resp, nil

--- a/enterprise/internal/completions/client/openai/openai_test.go
+++ b/enterprise/internal/completions/client/openai/openai_test.go
@@ -1,0 +1,53 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
+)
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func TestErrStatusNotOK(t *testing.T) {
+	mockClient := NewClient(&mockDoer{
+		func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(bytes.NewReader([]byte("oh no, please slow down!"))),
+			}, nil
+		},
+	}, "", "")
+
+	t.Run("Complete", func(t *testing.T) {
+		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{})
+		require.Error(t, err)
+		assert.Nil(t, resp)
+
+		autogold.Expect("OpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil })
+		require.Error(t, err)
+
+		autogold.Expect("OpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+}

--- a/enterprise/internal/completions/httpapi/codecompletion.go
+++ b/enterprise/internal/completions/httpapi/codecompletion.go
@@ -10,22 +10,34 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // NewCodeCompletionsHandler is an http handler which sends back code completion results
-func NewCodeCompletionsHandler(_ log.Logger, db database.DB) http.Handler {
+func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
+	logger = logger.Scoped("code", "chat completions handler")
+
 	rl := NewRateLimiter(db, redispool.Store, types.CompletionsFeatureCode)
-	return newCompletionsHandler(rl, "codeCompletions", func(requestParams types.CompletionRequestParameters, c *schema.Completions) string {
+	return newCompletionsHandler(rl, "code", func(requestParams types.CompletionRequestParameters, c *schema.Completions) string {
 		// No user defined models for now.
 		// TODO(eseliger): Look into reviving this, but it was unused so far.
 		return c.CompletionModel
 	}, func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter) {
 		completion, err := cc.Complete(ctx, types.CompletionsFeatureCode, requestParams)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			trace.Logger(ctx, logger).Error("error on completion", log.Error(err))
+
+			// Propagate the upstream headers to the client if available.
+			if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
+				errNotOK.WriteResponseHeaders(w)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			_, _ = w.Write([]byte(err.Error()))
 			return
 		}
+
 		completionBytes, err := json.Marshal(completion)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/enterprise/internal/completions/httpapi/codecompletion.go
+++ b/enterprise/internal/completions/httpapi/codecompletion.go
@@ -30,7 +30,7 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
 
 			// Propagate the upstream headers to the client if available.
 			if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
-				errNotOK.WriteResponseHeaders(w)
+				errNotOK.WriteHeader(w)
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
 			}

--- a/enterprise/internal/completions/httpapi/stream.go
+++ b/enterprise/internal/completions/httpapi/stream.go
@@ -41,7 +41,7 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 
 			// Propagate the upstream headers to the client if available.
 			if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
-				errNotOK.WriteResponseHeaders(w)
+				errNotOK.WriteHeader(w)
 			} else {
 				w.WriteHeader(http.StatusInternalServerError)
 			}

--- a/enterprise/internal/completions/httpapi/stream.go
+++ b/enterprise/internal/completions/httpapi/stream.go
@@ -16,8 +16,10 @@ import (
 
 // NewChatCompletionsStreamHandler is an http handler which streams back completions results.
 func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Handler {
+	logger = logger.Scoped("chat", "chat completions handler")
 	rl := NewRateLimiter(db, redispool.Store, types.CompletionsFeatureChat)
-	return newCompletionsHandler(rl, "stream", func(requestParams types.CompletionRequestParameters, c *schema.Completions) string {
+
+	return newCompletionsHandler(rl, "chat", func(requestParams types.CompletionRequestParameters, c *schema.Completions) string {
 		// No user defined models for now.
 		return c.ChatModel
 	}, func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter) {
@@ -32,9 +34,17 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 			_ = eventWriter.Event("done", map[string]any{})
 		}()
 
-		err = cc.Stream(ctx, types.CompletionsFeatureChat, requestParams, func(event types.CompletionResponse) error { return eventWriter.Event("completion", event) })
+		err = cc.Stream(ctx, types.CompletionsFeatureChat, requestParams,
+			func(event types.CompletionResponse) error { return eventWriter.Event("completion", event) })
 		if err != nil {
 			trace.Logger(ctx, logger).Error("error while streaming completions", log.Error(err))
+
+			// Propagate the upstream headers to the client if available.
+			if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
+				errNotOK.WriteResponseHeaders(w)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
 			_ = eventWriter.Event("error", map[string]string{"error": err.Error()})
 			return
 		}

--- a/enterprise/internal/completions/types/BUILD.bazel
+++ b/enterprise/internal/completions/types/BUILD.bazel
@@ -1,9 +1,23 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "types",
-    srcs = ["types.go"],
+    srcs = [
+        "errors.go",
+        "types.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types",
     visibility = ["//enterprise:__subpackages__"],
     deps = ["//lib/errors"],
+)
+
+go_test(
+    name = "types_test",
+    srcs = ["errors_test.go"],
+    embed = [":types"],
+    deps = [
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/enterprise/internal/completions/types/errors.go
+++ b/enterprise/internal/completions/types/errors.go
@@ -64,14 +64,15 @@ func IsErrStatusNotOK(err error) (*ErrStatusNotOK, bool) {
 	return nil, false
 }
 
-// WriteResponseHeaders writes the error code and headers to the response.
+// WriteHeader writes the error code and headers to the response.
 // It does not write the response body, to allow different handlers to provide
 // the message in different formats.
-func (e *ErrStatusNotOK) WriteResponseHeaders(w http.ResponseWriter) {
-	w.WriteHeader(e.statusCode)
+func (e *ErrStatusNotOK) WriteHeader(w http.ResponseWriter) {
 	for k, vs := range e.responseHeader {
 		for _, v := range vs {
 			w.Header().Set(k, v)
 		}
 	}
+	// WriteHeader must come last, since it flushes the headers.
+	w.WriteHeader(e.statusCode)
 }

--- a/enterprise/internal/completions/types/errors.go
+++ b/enterprise/internal/completions/types/errors.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// ErrStatusNotOK is returned when the server responds with a non-200 status code.
+//
+// Implementations of CompletionsClient should return this error with
+// NewErrStatusNotOK the server responds with a non-OK status.
+//
+// Callers of CompletionsClient should check for this error with AsErrStatusNotOK
+// and handle it appropriately, typically with (*ErrStatusNotOK).WriteResponse.
+type ErrStatusNotOK struct {
+	source     string
+	statusCode int
+	// responseBody is a truncated copy of the response body, read on a best-effort basis.
+	responseBody   string
+	responseHeader http.Header
+}
+
+var _ error = &ErrStatusNotOK{}
+
+func (e *ErrStatusNotOK) Error() string {
+	return fmt.Sprintf("%s: unexpected status code %d: %s",
+		e.source, e.statusCode, e.responseBody)
+}
+
+// NewErrStatusNotOK parses reads resp body and closes it to return an ErrStatusNotOK
+// based on the response.
+func NewErrStatusNotOK(source string, resp *http.Response) error {
+	// Callers shouldn't be using this function if the response is OK, but let's
+	// sanity-check anyway.
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	// Do a partial read of what we've got.
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+
+	return &ErrStatusNotOK{
+		source:         source,
+		statusCode:     resp.StatusCode,
+		responseBody:   string(respBody),
+		responseHeader: resp.Header,
+	}
+}
+
+func IsErrStatusNotOK(err error) (*ErrStatusNotOK, bool) {
+	if err == nil {
+		return nil, false
+	}
+
+	e := &ErrStatusNotOK{}
+	if errors.As(err, &e) {
+		return e, true
+	}
+
+	return nil, false
+}
+
+// WriteResponseHeaders writes the error code and headers to the response.
+// It does not write the response body, to allow different handlers to provide
+// the message in different formats.
+func (e *ErrStatusNotOK) WriteResponseHeaders(w http.ResponseWriter) {
+	w.WriteHeader(e.statusCode)
+	for k, vs := range e.responseHeader {
+		for _, v := range vs {
+			w.Header().Set(k, v)
+		}
+	}
+}

--- a/enterprise/internal/completions/types/errors_test.go
+++ b/enterprise/internal/completions/types/errors_test.go
@@ -39,7 +39,7 @@ func TestErrStatusNotOK(t *testing.T) {
 
 		t.Run("WriteResponseHeaders", func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			errNotOK.WriteResponseHeaders(rec)
+			errNotOK.WriteHeader(rec)
 
 			// Should have written status code and headers.
 			writtenResp := rec.Result()

--- a/enterprise/internal/completions/types/errors_test.go
+++ b/enterprise/internal/completions/types/errors_test.go
@@ -1,0 +1,55 @@
+package types
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrStatusNotOK(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(http.StatusTooManyRequests)
+	rec.Header().Set("X-RateLimit-Limit", "100")
+	rec.Write([]byte("oh no, please slow down!"))
+	resp := rec.Result()
+
+	var err error
+	err = NewErrStatusNotOK(t.Name(), resp)
+
+	// Check that it's safe to close the body multiple times, since callsites
+	// might have a defer resp.Body.Close() and also call NewErrStatusNotOK.
+	assert.NoError(t, resp.Body.Close())
+
+	t.Run("NewErrStatusNotOK", func(t *testing.T) {
+		assert.Error(t, err)
+		autogold.Expect("TestErrStatusNotOK: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+	})
+
+	t.Run("IsErrStatusNotOK", func(t *testing.T) {
+		errNotOK, ok := IsErrStatusNotOK(err)
+		require.True(t, ok)
+		assert.Equal(t, resp.StatusCode, errNotOK.statusCode)
+		assert.Equal(t, resp.Header, errNotOK.responseHeader)
+		assert.Equal(t, "oh no, please slow down!", errNotOK.responseBody)
+
+		t.Run("WriteResponseHeaders", func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			errNotOK.WriteResponseHeaders(rec)
+
+			// Should have written status code and headers.
+			writtenResp := rec.Result()
+			assert.Equal(t, resp.StatusCode, writtenResp.StatusCode)
+			assert.Equal(t, resp.Header, writtenResp.Header)
+
+			// Should not have written the response body.
+			writtenBody, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.Empty(t, writtenBody)
+		})
+	})
+}

--- a/enterprise/internal/completions/types/types.go
+++ b/enterprise/internal/completions/types/types.go
@@ -75,6 +75,10 @@ func (b CompletionsFeature) IsValid() bool {
 }
 
 type CompletionsClient interface {
+	// Stream executions a completions request, streaming results to the callback.
+	// Callers should check for ErrStatusNotOK and handle the error appropriately.
 	Stream(context.Context, CompletionsFeature, CompletionRequestParameters, SendCompletionEvent) error
+	// Complete executions a completions request until done. Callers should check
+	// for ErrStatusNotOK and handle the error appropriately.
 	Complete(context.Context, CompletionsFeature, CompletionRequestParameters) (*CompletionResponse, error)
 }


### PR DESCRIPTION
Right now, all errors from completions providers are provided back to the client with status 500, or worse, status 200 when streaming responses (where we never write any header, so the default 200 is sent on the first write). This change ensures we are propagating non-ok status codes and response headers (important for rate limiting) appropriately back to the client:

1. If status 429, write back 429 to help support rate limit handling in clients
2. If any other non-okay status, write back 503 Service Unavailable to avoid confusion with Sourcegraph status codes while indicating the upstream service encountered a problem

Closes https://github.com/sourcegraph/sourcegraph/issues/52633

## Test plan

Unit tests on error utilities and unit tests on each client to ensure all `CompletionsClient` methods propagate the new typed error.
