### PR TITLE
executors: Warn instead of error if the type is not expected

### DIFF
--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -176,7 +177,8 @@ func (c *KubernetesCommand) WaitForPodToSucceed(ctx context.Context, namespace s
 	for event := range watch.ResultChan() {
 		pod, ok := event.Object.(*corev1.Pod)
 		if !ok {
-			return nil, errors.New("unexpected object type")
+			c.Logger.Warn("Unexpected object type", log.String("type", fmt.Sprintf("%T", event.Object)))
+			continue
 		}
 		c.Logger.Debug(
 			"Watching pod",

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -177,6 +177,9 @@ func (c *KubernetesCommand) WaitForPodToSucceed(ctx context.Context, namespace s
 	for event := range watch.ResultChan() {
 		pod, ok := event.Object.(*corev1.Pod)
 		if !ok {
+			// If we get an event for something other than a pod, log it for now and try again. We don't have enough
+			// information to know if this is a problem or not. We have seen this happen in the wild, but hard to
+			// replicate.
 			c.Logger.Warn("Unexpected object type", log.String("type", fmt.Sprintf("%T", event.Object)))
 			continue
 		}


### PR DESCRIPTION
We don't need to bail out right away. We can warn and log the type we get. Logging will help us better understand why this should happen and not block events we actually care about.

## Test plan

Manual testing.