### PR TITLE
cody-gateway: remove support for use of 'llmproxy' as provider

### DIFF
--- a/enterprise/internal/completions/client/client.go
+++ b/enterprise/internal/completions/client/client.go
@@ -21,7 +21,7 @@ func Get(endpoint, provider, accessToken string) (types.CompletionsClient, error
 		return openai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
 	case dotcom.ProviderName:
 		return dotcom.NewClient(httpcli.ExternalDoer, accessToken), nil
-	case codygateway.ProviderName, "llmproxy": // temporary back-compat
+	case codygateway.ProviderName:
 		return codygateway.NewClient(httpcli.ExternalDoer, endpoint, accessToken)
 	default:
 		return nil, errors.Newf("unknown completion stream provider: %s", provider)

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2422,7 +2422,7 @@
           "type": "string",
           "description": "The external completions provider.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai", "sourcegraph", "llmproxy"]
+          "enum": ["anthropic", "openai", "sourcegraph"]
         },
         "endpoint": {
           "type": "string",


### PR DESCRIPTION
I'll be removing this from all current instances soon

Part of https://github.com/sourcegraph/sourcegraph/issues/52258 

## Test plan

n/a