### PR TITLE
[Backport 5.0] completions/client: update default cody-gateway endpoint (#52626)

### DIFF
--- a/enterprise/internal/completions/client/llmproxy/llmproxy.go
+++ b/enterprise/internal/completions/client/llmproxy/llmproxy.go
@@ -16,12 +16,17 @@ import (
 )
 
 const (
-	ProviderName         = "llmproxy"
-	DefaultEndpoint      = "https://completions.sourcegraph.com"
+	// ProviderName is 'sourcegraph', since this is a Sourcegraph-provided service,
+	// backed by Cody Gateway. This is the value accepted in site configuration.
+	ProviderName    = "sourcegraph"
+	DefaultEndpoint = "https://cody-gateway.sourcegraph.com"
+
 	openAIModelPrefix    = "openai/"
 	anthropicModelPrefix = "anthropic/"
 )
 
+// NewClient instantiates a completions provider backed by Sourcegraph's managed
+// Cody Gateway service.
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) (types.CompletionsClient, error) {
 	// TODO: Backcompat with older configs: We can remove this once S2 and k8s are migrated.
 	endpoint = strings.TrimSuffix(endpoint, "/v1/completions/anthropic")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -555,7 +555,7 @@ type Completions struct {
 	CompletionModel string `json:"completionModel,omitempty"`
 	// Enabled description: Toggles whether completions are enabled.
 	Enabled bool `json:"enabled"`
-	// Endpoint description: The endpoint under which to reach the provider. Currently only used for provider types "llmproxy", "openai" and "anthropic". The default values are "https://completions.sourcegraph.com", "https://api.openai.com/v1/chat/completions", and "https://api.anthropic.com/v1/complete" for LLM proxy, OpenAI, and Anthropic, respectively.
+	// Endpoint description: The endpoint under which to reach the provider. Currently only used for provider types "sourcegraph", "openai" and "anthropic". The default values are "https://cody-gateway.sourcegraph.com", "https://api.openai.com/v1/chat/completions", and "https://api.anthropic.com/v1/complete" for Sourcegraph, OpenAI, and Anthropic, respectively.
 	Endpoint string `json:"endpoint,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2119,11 +2119,11 @@
           "type": "string",
           "description": "The external completions provider.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai", "llmproxy"]
+          "enum": ["anthropic", "openai", "sourcegraph", "llmproxy"]
         },
         "endpoint": {
           "type": "string",
-          "description": "The endpoint under which to reach the provider. Currently only used for provider types \"llmproxy\", \"openai\" and \"anthropic\". The default values are \"https://completions.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/complete\" for LLM proxy, OpenAI, and Anthropic, respectively."
+          "description": "The endpoint under which to reach the provider. Currently only used for provider types \"sourcegraph\", \"openai\" and \"anthropic\". The default values are \"https://cody-gateway.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/complete\" for Sourcegraph, OpenAI, and Anthropic, respectively."
         },
         "perUserDailyLimit": {
           "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/52258

Tested new endpoint on s2

(cherry picked from commit b01f9bef7790d3930be7d7ec9c08bce85c63812f aka https://github.com/sourcegraph/sourcegraph/pull/52626)

## Test plan

CI
