### PR TITLE
goroutine: Add support for concurrency

### DIFF
--- a/internal/goroutine/BUILD.bazel
+++ b/internal/goroutine/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//internal/observation",
         "//lib/errors",
         "@com_github_derision_test_glock//:glock",
+        "@com_github_sourcegraph_conc//:conc",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/derision-test/glock"
+	"github.com/sourcegraph/conc"
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/goroutine/recorder"
@@ -13,6 +14,7 @@ import (
 )
 
 type getIntervalFunc func() time.Duration
+type getConcurrencyFunc func() int
 
 // PeriodicGoroutine represents a goroutine whose main behavior is reinvoked periodically.
 //
@@ -21,17 +23,20 @@ type getIntervalFunc func() time.Duration
 // for more information and a step-by-step guide on how to implement a
 // PeriodicBackgroundRoutine.
 type PeriodicGoroutine struct {
-	name        string
-	description string
-	jobName     string
-	recorder    *recorder.Recorder
-	getInterval getIntervalFunc
-	handler     unifiedHandler
-	operation   *observation.Operation
-	clock       glock.Clock
-	ctx         context.Context    // root context passed to the handler
-	cancel      context.CancelFunc // cancels the root context
-	finished    chan struct{}      // signals that Start has finished
+	name             string
+	description      string
+	jobName          string
+	recorder         *recorder.Recorder
+	getInterval      getIntervalFunc
+	getConcurrency   getConcurrencyFunc
+	handler          unifiedHandler
+	operation        *observation.Operation
+	clock            glock.Clock
+	concurrencyClock glock.Clock
+	ctx              context.Context    // root context passed to the handler
+	cancel           context.CancelFunc // cancels the root context
+	finished         chan struct{}      // signals that Start has finished
+	reinvocations    int
 }
 
 var _ recorder.Recordable = &PeriodicGoroutine{}
@@ -111,6 +116,14 @@ func WithIntervalFunc(getInterval getIntervalFunc) Option {
 	return func(p *PeriodicGoroutine) { p.getInterval = getInterval }
 }
 
+func WithConcurrency(concurrency int) Option {
+	return WithConcurrencyFunc(func() int { return concurrency })
+}
+
+func WithConcurrencyFunc(getConcurrency getConcurrencyFunc) Option {
+	return func(p *PeriodicGoroutine) { p.getConcurrency = getConcurrency }
+}
+
 func WithOperation(operation *observation.Operation) Option {
 	return func(p *PeriodicGoroutine) { p.operation = operation }
 }
@@ -138,11 +151,13 @@ func NewPeriodicGoroutine(ctx context.Context, handler Handler, options ...Optio
 
 func newDefaultPeriodicRoutine() *PeriodicGoroutine {
 	return &PeriodicGoroutine{
-		name:        "",
-		description: "",
-		getInterval: func() time.Duration { return time.Second },
-		operation:   nil,
-		clock:       glock.NewRealClock(),
+		name:             "<unnamed periodic routine>",
+		description:      "<no description provided>",
+		getInterval:      func() time.Duration { return time.Second },
+		getConcurrency:   func() int { return 1 },
+		operation:        nil,
+		clock:            glock.NewRealClock(),
+		concurrencyClock: glock.NewRealClock(),
 	}
 }
 
@@ -158,7 +173,14 @@ func wrapHandler(handler Handler, name, description string) unifiedHandler {
 	}
 }
 
-const MaxConsecutiveReinvocations = 100
+func (r *PeriodicGoroutine) Name() string                                 { return r.name }
+func (r *PeriodicGoroutine) Type() recorder.RoutineType                   { return typeFromOperations(r.operation) }
+func (r *PeriodicGoroutine) Description() string                          { return r.description }
+func (r *PeriodicGoroutine) Interval() time.Duration                      { return r.getInterval() }
+func (r *PeriodicGoroutine) Concurrency() int                             { return r.getConcurrency() }
+func (r *PeriodicGoroutine) JobName() string                              { return r.jobName }
+func (r *PeriodicGoroutine) SetJobName(jobName string)                    { r.jobName = jobName }
+func (r *PeriodicGoroutine) RegisterRecorder(recorder *recorder.Recorder) { r.recorder = recorder }
 
 // Start begins the process of calling the registered handler in a loop. This process will
 // wait the interval supplied at construction between invocations.
@@ -168,47 +190,7 @@ func (r *PeriodicGoroutine) Start() {
 	}
 	defer close(r.finished)
 
-	reinvocations := 0
-
-loop:
-	for {
-		start := time.Now()
-		shutdown, reinvoke, err := runPeriodicHandler(r.ctx, r.handler, r.operation)
-		duration := time.Since(start)
-		if r.recorder != nil {
-			go r.recorder.LogRun(r, duration, err)
-			r.recorder.SaveKnownRoutine(r)
-		}
-
-		if shutdown {
-			break
-		} else if h, ok := r.handler.(ErrorHandler); ok && err != nil {
-			h.HandleError(err)
-		}
-
-		if reinvoke {
-			select {
-			case <-r.ctx.Done():
-				break loop
-
-			default:
-				reinvocations++
-
-				if reinvocations < MaxConsecutiveReinvocations {
-					continue loop
-				}
-
-			}
-		}
-
-		reinvocations = 0
-
-		select {
-		case <-r.clock.After(r.getInterval()):
-		case <-r.ctx.Done():
-			break loop
-		}
-	}
+	r.runHandlerPool()
 
 	if h, ok := r.handler.(Finalizer); ok {
 		h.OnShutdown()
@@ -226,59 +208,205 @@ func (r *PeriodicGoroutine) Stop() {
 	<-r.finished
 }
 
-func (r *PeriodicGoroutine) Name() string {
-	return r.name
+func (r *PeriodicGoroutine) runHandlerPool() {
+	drain := func() {}
+
+	for concurrency := range r.concurrencyUpdates() {
+		// drain previous pool
+		drain()
+
+		// create new pool with updated concurrency
+		drain = r.startPool(concurrency)
+	}
+
+	// channel closed, drain pool
+	drain()
 }
 
-func (r *PeriodicGoroutine) Type() recorder.RoutineType {
-	if r.operation != nil {
-		return recorder.PeriodicWithMetrics
-	} else {
-		return recorder.PeriodicRoutine
+const concurrencyRecheckInterval = time.Second * 30
+
+func (r *PeriodicGoroutine) concurrencyUpdates() <-chan int {
+	var (
+		ch        = make(chan int, 1)
+		prevValue = 0
+	)
+
+	go func() {
+		defer close(ch)
+
+		for {
+			if newValue := r.getConcurrency(); newValue != prevValue {
+				prevValue = newValue
+				forciblyWriteToBufferedChannel(ch, newValue)
+			}
+
+			select {
+			case <-r.concurrencyClock.After(concurrencyRecheckInterval):
+			case <-r.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch
+}
+
+func (r *PeriodicGoroutine) startPool(concurrency int) func() {
+	g := conc.NewWaitGroup()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	for i := 0; i < concurrency; i++ {
+		g.Go(func() { r.runHandlerPeriodically(ctx) })
+	}
+
+	return func() {
+		cancel()
+		g.Wait()
 	}
 }
 
-func (r *PeriodicGoroutine) Description() string {
-	return r.description
+func (r *PeriodicGoroutine) runHandlerPeriodically(monitorCtx context.Context) {
+	for {
+		interval, ok := r.runHandlerAndDetermineBackoff()
+		if !ok {
+			// Goroutine is shutting down
+			// (the handler returned the context's error)
+			return
+		}
+
+		select {
+		// Sleep - might be a zero-duration value if we're immediately reinvoking,
+		// but this gives us a nice chance to check the context to see if we should
+		// exit naturally.
+		case <-r.clock.After(interval):
+
+		case <-r.ctx.Done():
+			// Goroutine is shutting down
+			return
+
+		case <-monitorCtx.Done():
+			// Caller is requesting we return to resize the pool
+			return
+		}
+	}
 }
 
-func (r *PeriodicGoroutine) Interval() time.Duration {
+const maxConsecutiveReinvocations = 100
+
+func (r *PeriodicGoroutine) runHandlerAndDetermineBackoff() (time.Duration, bool) {
+	handlerErr := r.runHandler(r.ctx)
+	if handlerErr != nil {
+		if isShutdownError(r.ctx, handlerErr) {
+			// Caller is exiting
+			return 0, false
+		}
+
+		if filteredErr := errorFilter(r.ctx, handlerErr); filteredErr != nil {
+			// It's a real error, see if we need to handle it
+			if h, ok := r.handler.(ErrorHandler); ok {
+				h.HandleError(filteredErr)
+			}
+		}
+	}
+
+	return r.getNextInterval(isReinvokeImmediatelyError(handlerErr)), true
+}
+
+func (r *PeriodicGoroutine) getNextInterval(tryReinvoke bool) time.Duration {
+	if tryReinvoke {
+		r.reinvocations++
+
+		if r.reinvocations < maxConsecutiveReinvocations {
+			// Return zero, do not sleep any significant time
+			return 0
+		}
+	}
+
+	// We're not immediately re-invoking or we would've exited earlier.
+	// Reset our count so we can begin fresh on the next call
+	r.reinvocations = 0
+
+	// Return our configured interval
 	return r.getInterval()
 }
 
-func (r *PeriodicGoroutine) JobName() string {
-	return r.jobName
+func (r *PeriodicGoroutine) runHandler(ctx context.Context) error {
+	return r.withOperation(ctx, func(ctx context.Context) error {
+		return r.withRecorder(ctx, r.handler.Handle)
+	})
 }
 
-func (r *PeriodicGoroutine) SetJobName(jobName string) {
-	r.jobName = jobName
+func (r *PeriodicGoroutine) withOperation(ctx context.Context, f func(ctx context.Context) error) error {
+	if r.operation == nil {
+		return f(ctx)
+	}
+
+	var observedError error
+	ctx, _, endObservation := r.operation.With(ctx, &observedError, observation.Args{})
+	err := f(ctx)
+	observedError = errorFilter(ctx, err)
+	endObservation(1, observation.Args{})
+
+	return err
 }
 
-func (r *PeriodicGoroutine) RegisterRecorder(recorder *recorder.Recorder) {
-	r.recorder = recorder
+func (r *PeriodicGoroutine) withRecorder(ctx context.Context, f func(ctx context.Context) error) error {
+	if r.recorder == nil {
+		return f(ctx)
+	}
+
+	start := time.Now()
+	err := f(ctx)
+	duration := time.Since(start)
+
+	go func() {
+		r.recorder.SaveKnownRoutine(r)
+		r.recorder.LogRun(r, duration, errorFilter(ctx, err))
+	}()
+
+	return err
+}
+
+func typeFromOperations(operation *observation.Operation) recorder.RoutineType {
+	if operation != nil {
+		return recorder.PeriodicWithMetrics
+	}
+
+	return recorder.PeriodicRoutine
+}
+
+func isShutdownError(ctx context.Context, err error) bool {
+	return ctx.Err() != nil && errors.Is(err, ctx.Err())
 }
 
 var ErrReinvokeImmediately = errors.New("periodic handler wishes to be immediately re-invoked")
 
-func runPeriodicHandler(ctx context.Context, handler Handler, operation *observation.Operation) (shutdown, reinvoke bool, err error) {
-	if operation != nil {
-		tmpCtx, _, endObservation := operation.With(ctx, &err, observation.Args{})
-		defer endObservation(1, observation.Args{})
-		ctx = tmpCtx
+func isReinvokeImmediatelyError(err error) bool {
+	return errors.Is(err, ErrReinvokeImmediately)
+}
+
+func errorFilter(ctx context.Context, err error) error {
+	if isShutdownError(ctx, err) || isReinvokeImmediatelyError(err) {
+		return nil
 	}
 
-	err = handler.Handle(ctx)
-	if err != nil {
-		if ctx.Err() != nil && errors.Is(err, ctx.Err()) {
-			// If the error is due to the loop being shut down, break
-			// from the run loop in the calling function
-			return true, false, nil
-		}
+	return err
+}
 
-		if errors.Is(err, ErrReinvokeImmediately) {
-			return false, true, nil
+func forciblyWriteToBufferedChannel[T any](ch chan T, value T) {
+	for {
+		select {
+		case ch <- value:
+			// Write succeeded
+			return
+
+		default:
+			select {
+			// Buffer is full
+			// Pop item if we can and retry the write on the next iteration
+			case <-ch:
+			default:
+			}
 		}
 	}
-
-	return false, false, err
 }

--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -158,8 +158,6 @@ func TestPeriodicGoroutineConcurrency(t *testing.T) {
 }
 
 func TestPeriodicGoroutineWithDynamicConcurrency(t *testing.T) {
-	// TODO
-
 	clock := glock.NewMockClock()
 	concurrencyClock := glock.NewMockClock()
 	handler := NewMockHandler()

--- a/internal/goroutine/periodic_test.go
+++ b/internal/goroutine/periodic_test.go
@@ -52,7 +52,7 @@ func TestPeriodicGoroutineReinvoke(t *testing.T) {
 	})
 
 	witnessHandler := func() {
-		for i := 0; i < MaxConsecutiveReinvocations; i++ {
+		for i := 0; i < maxConsecutiveReinvocations; i++ {
 			<-called
 		}
 	}
@@ -74,8 +74,8 @@ func TestPeriodicGoroutineReinvoke(t *testing.T) {
 	witnessHandler()
 	goroutine.Stop()
 
-	if calls := len(handler.HandleFunc.History()); calls != 4*MaxConsecutiveReinvocations {
-		t.Errorf("unexpected number of handler invocations. want=%d have=%d", 4*MaxConsecutiveReinvocations, calls)
+	if calls := len(handler.HandleFunc.History()); calls != 4*maxConsecutiveReinvocations {
+		t.Errorf("unexpected number of handler invocations. want=%d have=%d", 4*maxConsecutiveReinvocations, calls)
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to control the _concurrency_ of periodic background routines registered and recorded from the worker container. The periodic background routines have recently gained support for the ability to be re-invoked immediately (in the case of having data to process, we don't need to sleep between attempts).

The ranking background jobs have some low throughput, and instead of spinning up a second entire worker with just the ranking background jobs for DotCom, I'm opting to run more than one goroutine in the background job.

The lower-effort way to do this would be to stick a pool in the `Handle` method of the job itself. However, this has the issue of _on every tick_ we start a new pool. This means that if we have a concurrency level > 1 and a high variance of runtimes, we'll tank our throughput as each tick takes the time required by the longest goroutine invocation.

The higher-effort/proper way to do this (which is reflected in this PR) is to allow the periodic goroutines to configure their own concurrency. Then, each of the pool routines will control their own sleep schedule and is independent of other routines executing in parallel.

Changes in this PR:
- Misc. refactors so we're not a rats nest of `ifs` (please read new version instead of diff)
- Wrap the main invocation loop within a pool
- Check the concurrency level periodically and drain the old pool then start up a new pool with the new settings
- Add tests :)

## Test plan

Verified changing pool sizes works locally.