### PR TITLE
Cody-gateway - Dotcom user actor source 

### DIFF
--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -30,6 +30,7 @@ type DotcomResolver interface {
 	ProductLicenses(context.Context, *ProductLicensesArgs) (ProductLicenseConnection, error)
 	ProductLicenseByID(ctx context.Context, id graphql.ID) (ProductLicense, error)
 	ProductSubscriptionByID(ctx context.Context, id graphql.ID) (ProductSubscription, error)
+	DotcomCodyGatewayUserByToken(context.Context, *CodyGatewayUsersByAccessTokenArgs) (CodyGatewayUser, error)
 }
 
 // ProductSubscription is the interface for the GraphQL type ProductSubscription.
@@ -145,6 +146,15 @@ type UpdateCodyGatewayAccessInput struct {
 	EmbeddingsRateLimit                     *int32
 	EmbeddingsRateLimitIntervalSeconds      *int32
 	EmbeddingsAllowedModels                 *[]string
+}
+
+type CodyGatewayUsersByAccessTokenArgs struct {
+	Token string
+}
+
+type CodyGatewayUser interface {
+	Username() string
+	CodyGatewayAccess() CodyGatewayAccess
 }
 
 type CodyGatewayAccess interface {

--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -30,7 +30,7 @@ type DotcomResolver interface {
 	ProductLicenses(context.Context, *ProductLicensesArgs) (ProductLicenseConnection, error)
 	ProductLicenseByID(ctx context.Context, id graphql.ID) (ProductLicense, error)
 	ProductSubscriptionByID(ctx context.Context, id graphql.ID) (ProductSubscription, error)
-	DotcomCodyGatewayUserByToken(context.Context, *CodyGatewayUsersByAccessTokenArgs) (CodyGatewayUser, error)
+	CodyGatewayDotcomUserByToken(context.Context, *CodyGatewayUsersByAccessTokenArgs) (CodyGatewayUser, error)
 }
 
 // ProductSubscription is the interface for the GraphQL type ProductSubscription.

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -125,6 +125,7 @@ type DotcomQuery {
     """
     A user for purposes of connecting to the Cody Gateway.
     Only Sourcegraph.com site admins or service accounts may perform this query.
+    Token is a Cody Gateway token, not a Sourcegraph instance access token.
     FOR INTERNAL USE ONLY.
     """
     dotcomCodyGatewayUserByToken(token: String!): DotcomCodyGatewayUser

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -121,6 +121,13 @@ type DotcomQuery {
         """
         productSubscriptionID: ID
     ): ProductLicenseConnection!
+
+    """
+    A user for purposes of connecting to the Cody Gateway.
+    Only Sourcegraph.com site admins may perform this query.
+    FOR INTERNAL USE ONLY.
+    """
+    dotcomCodyGatewayUserByToken(token: String!): DotcomCodyGatewayUser
 }
 
 extend type Mutation {
@@ -483,4 +490,9 @@ input UpdateCodyGatewayAccessInput {
     Override the set of allowed models for embeddings generation for this subscription.
     """
     embeddingsAllowedModels: [String!]
+}
+
+type DotcomCodyGatewayUser {
+    userName: String!
+    codyGatewayAccess: CodyGatewayAccess!
 }

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -124,7 +124,7 @@ type DotcomQuery {
 
     """
     A user for purposes of connecting to the Cody Gateway.
-    Only Sourcegraph.com site admins may perform this query.
+    Only Sourcegraph.com site admins or service accounts may perform this query.
     FOR INTERNAL USE ONLY.
     """
     dotcomCodyGatewayUserByToken(token: String!): DotcomCodyGatewayUser

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -123,12 +123,12 @@ type DotcomQuery {
     ): ProductLicenseConnection!
 
     """
-    A user for purposes of connecting to the Cody Gateway.
+    A dotcom user for purposes of connecting to the Cody Gateway.
     Only Sourcegraph.com site admins or service accounts may perform this query.
     Token is a Cody Gateway token, not a Sourcegraph instance access token.
     FOR INTERNAL USE ONLY.
     """
-    dotcomCodyGatewayUserByToken(token: String!): DotcomCodyGatewayUser
+    codyGatewayDotcomUserByToken(token: String!): CodyGatewayDotcomUser
 }
 
 extend type Mutation {
@@ -497,7 +497,7 @@ input UpdateCodyGatewayAccessInput {
 A dotcom user allowed to access the Cody Gateway
 FOR INTERNAL USE ONLY.
 """
-type DotcomCodyGatewayUser {
+type CodyGatewayDotcomUser {
     """
     The user name of the user
     """

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -492,7 +492,17 @@ input UpdateCodyGatewayAccessInput {
     embeddingsAllowedModels: [String!]
 }
 
+"""
+A dotcom user allowed to access the Cody Gateway
+FOR INTERNAL USE ONLY.
+"""
 type DotcomCodyGatewayUser {
+    """
+    The user name of the user
+    """
     userName: String!
+    """
+    Cody Gateway access granted to this user. Properties may be inferred from dotcom site config, or be defined in overrides on the user.
+    """
     codyGatewayAccess: CodyGatewayAccess!
 }

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -501,7 +501,7 @@ type DotcomCodyGatewayUser {
     """
     The user name of the user
     """
-    userName: String!
+    username: String!
     """
     Cody Gateway access granted to this user. Properties may be inferred from dotcom site config, or be defined in overrides on the user.
     """

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "dotcomuser",
+    srcs = ["dotcomuser.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor/dotcomuser",
+    visibility = ["//enterprise/cmd/cody-gateway:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/cody-gateway/internal/actor",
+        "//enterprise/cmd/cody-gateway/internal/dotcom",
+        "//enterprise/internal/codygateway",
+        "//enterprise/internal/completions/types",
+        "//internal/hashutil",
+        "//lib/errors",
+        "@com_github_gregjones_httpcache//:httpcache",
+        "@com_github_khan_genqlient//graphql",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -9,11 +10,19 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/actor",
         "//enterprise/cmd/cody-gateway/internal/dotcom",
         "//enterprise/internal/codygateway",
-        "//enterprise/internal/completions/types",
-        "//internal/hashutil",
         "//lib/errors",
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",
         "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "dotcomuser_test",
+    srcs = ["dotcomuser_test.go"],
+    embed = [":dotcomuser"],
+    deps = [
+        "//enterprise/cmd/cody-gateway/internal/dotcom",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -29,7 +29,7 @@ var (
 
 type Source struct {
 	log    log.Logger
-	cache  httpcache.Cache // TODO: add something to regularly clean up the cache
+	cache  httpcache.Cache
 	dotcom graphql.Client
 }
 
@@ -86,10 +86,10 @@ func (s *Source) fetchAndCache(ctx context.Context, token, cacheKey string) (*ac
 	resp, checkErr := dotcom.CheckDotcomUserAccessToken(ctx, s.dotcom, token)
 	if checkErr != nil {
 		// Generate a stateless actor so that we aren't constantly hitting the dotcom API
-		act = NewActor(s, cacheKey, dotcom.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser{})
+		act = NewActor(s, cacheKey, dotcom.DotcomUserState{})
 	} else {
 		act = NewActor(s, cacheKey,
-			*resp.Dotcom.DotcomCodyGatewayUserByToken)
+			resp.Dotcom.DotcomCodyGatewayUserByToken.DotcomUserState)
 	}
 
 	if data, err := json.Marshal(act); err != nil {
@@ -106,7 +106,7 @@ func (s *Source) fetchAndCache(ctx context.Context, token, cacheKey string) (*ac
 }
 
 // NewActor creates an actor from Sourcegraph.com user.
-func NewActor(source *Source, cacheKey string, user dotcom.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) *actor.Actor {
+func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *actor.Actor {
 	now := time.Now()
 	a := &actor.Actor{
 		Key:           cacheKey,

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -112,7 +112,7 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 		Key:           cacheKey,
 		ID:            user.UserName,
 		AccessEnabled: user.GetCodyGatewayAccess().Enabled,
-		RateLimits:    defaultUserRateLimits(),
+		RateLimits:    zeroRequestsAllowed(),
 		LastUpdated:   &now,
 		Source:        source,
 	}
@@ -136,17 +136,9 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 	return a
 }
 
-func defaultUserRateLimits() map[types.CompletionsFeature]actor.RateLimit {
+func zeroRequestsAllowed() map[types.CompletionsFeature]actor.RateLimit {
 	return map[types.CompletionsFeature]actor.RateLimit{
-		types.CompletionsFeatureChat: {
-			AllowedModels: []string{"claude-v1"},
-			Limit:         50,
-			Interval:      24 * time.Hour,
-		},
-		types.CompletionsFeatureCode: {
-			AllowedModels: []string{"claude-instant-v1"},
-			Limit:         500,
-			Interval:      24 * time.Hour,
-		},
+		types.CompletionsFeatureChat: {},
+		types.CompletionsFeatureCode: {},
 	}
 }

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -1,0 +1,152 @@
+package dotcomuser
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/Khan/genqlient/graphql"
+	"github.com/gregjones/httpcache"
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/hashutil"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// user tokens are always a prefix of 4 characters (sgp_)
+// followed by a 40-character hex-encoded SHA256 hash
+const tokenLength = 4 + 40
+
+var (
+	defaultUpdateInterval = 24 * time.Hour
+)
+
+type Source struct {
+	log    log.Logger
+	cache  httpcache.Cache // TODO: add something to regularly clean up the cache
+	dotcom graphql.Client
+}
+
+var _ actor.Source = &Source{}
+
+func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client) *Source {
+	return &Source{
+		log:    logger.Scoped("dotcomuser", "dotcom user actor source"),
+		cache:  cache,
+		dotcom: dotComClient,
+	}
+}
+
+func (s *Source) Name() string { return string(codygateway.ActorSourceDotcomUser) }
+
+func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
+	// "sgp_" is sourcegraph user token
+	if token == "" || !strings.HasPrefix(token, "sgp_") {
+		return nil, actor.ErrNotFromSource{}
+	}
+
+	if len(token) != tokenLength {
+		return nil, errors.New("invalid token format")
+	}
+	hash := hashutil.ToSHA256Bytes([]byte(token))
+	digest := hex.EncodeToString(hash)
+
+	data, hit := s.cache.Get(digest)
+	if !hit {
+		return s.fetchAndCache(ctx, token, digest)
+	}
+
+	var act *actor.Actor
+	if err := json.Unmarshal(data, &act); err != nil || act == nil {
+		s.log.Error("failed to unmarshal subscription", log.Error(err))
+
+		// Delete the corrupted record.
+		s.cache.Delete(token)
+
+		return s.fetchAndCache(ctx, token, digest)
+	}
+
+	if act.LastUpdated != nil && time.Since(*act.LastUpdated) > defaultUpdateInterval {
+		return s.fetchAndCache(ctx, token, digest)
+	}
+
+	act.Source = s
+	return act, nil
+}
+
+// fetchAndCache fetches the dotcom user data for the given user token and caches it using the cacheKey
+func (s *Source) fetchAndCache(ctx context.Context, token, cacheKey string) (*actor.Actor, error) {
+	var act *actor.Actor
+	resp, checkErr := dotcom.CheckDotcomUserAccessToken(ctx, s.dotcom, token)
+	if checkErr != nil {
+		// Generate a stateless actor so that we aren't constantly hitting the dotcom API
+		act = NewActor(s, cacheKey, dotcom.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser{})
+	} else {
+		act = NewActor(s, cacheKey,
+			*resp.Dotcom.DotcomCodyGatewayUserByToken)
+	}
+
+	if data, err := json.Marshal(act); err != nil {
+		s.log.Error("failed to marshal actor",
+			log.Error(err))
+	} else {
+		s.cache.Set(token, data)
+	}
+
+	if checkErr != nil {
+		return nil, errors.Wrap(checkErr, "failed to validate access token")
+	}
+	return act, nil
+}
+
+// NewActor creates an actor from Sourcegraph.com user.
+func NewActor(source *Source, cacheKey string, user dotcom.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) *actor.Actor {
+	now := time.Now()
+	a := &actor.Actor{
+		Key:           cacheKey,
+		ID:            user.UserName,
+		AccessEnabled: user.GetCodyGatewayAccess().Enabled,
+		RateLimits:    defaultUserRateLimits(),
+		LastUpdated:   &now,
+		Source:        source,
+	}
+
+	if user.CodyGatewayAccess.ChatCompletionsRateLimit != nil {
+		a.RateLimits[types.CompletionsFeatureChat] = actor.RateLimit{
+			AllowedModels: user.CodyGatewayAccess.ChatCompletionsRateLimit.AllowedModels,
+			Limit:         user.CodyGatewayAccess.ChatCompletionsRateLimit.Limit,
+			Interval:      time.Duration(user.CodyGatewayAccess.ChatCompletionsRateLimit.IntervalSeconds) * time.Second,
+		}
+	}
+
+	if user.CodyGatewayAccess.CodeCompletionsRateLimit != nil {
+		a.RateLimits[types.CompletionsFeatureCode] = actor.RateLimit{
+			AllowedModels: user.CodyGatewayAccess.CodeCompletionsRateLimit.AllowedModels,
+			Limit:         user.CodyGatewayAccess.CodeCompletionsRateLimit.Limit,
+			Interval:      time.Duration(user.CodyGatewayAccess.CodeCompletionsRateLimit.IntervalSeconds) * time.Second,
+		}
+	}
+
+	return a
+}
+
+func defaultUserRateLimits() map[types.CompletionsFeature]actor.RateLimit {
+	return map[types.CompletionsFeature]actor.RateLimit{
+		types.CompletionsFeatureChat: {
+			AllowedModels: []string{"claude-v1"},
+			Limit:         50,
+			Interval:      24 * time.Hour,
+		},
+		types.CompletionsFeatureCode: {
+			AllowedModels: []string{"claude-instant-v1"},
+			Limit:         500,
+			Interval:      24 * time.Hour,
+		},
+	}
+}

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -114,7 +113,7 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 	}
 
 	if user.CodyGatewayAccess.ChatCompletionsRateLimit != nil {
-		a.RateLimits[types.CompletionsFeatureChat] = actor.RateLimit{
+		a.RateLimits[codygateway.FeatureChatCompletions] = actor.RateLimit{
 			AllowedModels: user.CodyGatewayAccess.ChatCompletionsRateLimit.AllowedModels,
 			Limit:         user.CodyGatewayAccess.ChatCompletionsRateLimit.Limit,
 			Interval:      time.Duration(user.CodyGatewayAccess.ChatCompletionsRateLimit.IntervalSeconds) * time.Second,
@@ -122,19 +121,28 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 	}
 
 	if user.CodyGatewayAccess.CodeCompletionsRateLimit != nil {
-		a.RateLimits[types.CompletionsFeatureCode] = actor.RateLimit{
+		a.RateLimits[codygateway.FeatureCodeCompletions] = actor.RateLimit{
 			AllowedModels: user.CodyGatewayAccess.CodeCompletionsRateLimit.AllowedModels,
 			Limit:         user.CodyGatewayAccess.CodeCompletionsRateLimit.Limit,
 			Interval:      time.Duration(user.CodyGatewayAccess.CodeCompletionsRateLimit.IntervalSeconds) * time.Second,
 		}
 	}
 
+	if user.CodyGatewayAccess.EmbeddingsRateLimit != nil {
+		a.RateLimits[codygateway.FeatureEmbeddings] = actor.RateLimit{
+			AllowedModels: user.CodyGatewayAccess.EmbeddingsRateLimit.AllowedModels,
+			Limit:         user.CodyGatewayAccess.EmbeddingsRateLimit.Limit,
+			Interval:      time.Duration(user.CodyGatewayAccess.EmbeddingsRateLimit.IntervalSeconds) * time.Second,
+		}
+	}
+
 	return a
 }
 
-func zeroRequestsAllowed() map[types.CompletionsFeature]actor.RateLimit {
-	return map[types.CompletionsFeature]actor.RateLimit{
-		types.CompletionsFeatureChat: {},
-		types.CompletionsFeatureCode: {},
+func zeroRequestsAllowed() map[codygateway.Feature]actor.RateLimit {
+	return map[codygateway.Feature]actor.RateLimit{
+		codygateway.FeatureChatCompletions: {},
+		codygateway.FeatureCodeCompletions: {},
+		codygateway.FeatureEmbeddings:      {},
 	}
 }

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -84,7 +84,7 @@ func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor,
 		act = NewActor(s, token, dotcom.DotcomUserState{})
 	} else {
 		act = NewActor(s, token,
-			resp.Dotcom.DotcomCodyGatewayUserByToken.DotcomUserState)
+			resp.Dotcom.CodyGatewayDotcomUserByToken.DotcomUserState)
 	}
 
 	if data, err := json.Marshal(act); err != nil {

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -105,7 +105,7 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 	now := time.Now()
 	a := &actor.Actor{
 		Key:           cacheKey,
-		ID:            user.UserName,
+		ID:            user.Username,
 		AccessEnabled: user.GetCodyGatewayAccess().Enabled,
 		RateLimits:    zeroRequestsAllowed(),
 		LastUpdated:   &now,

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -67,7 +67,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 		return s.fetchAndCache(ctx, token)
 	}
 
-	if act.LastUpdated != nil && time.Since(*act.LastUpdated) > defaultUpdateInterval {
+	if act.LastUpdated == nil || time.Since(*act.LastUpdated) > defaultUpdateInterval {
 		return s.fetchAndCache(ctx, token)
 	}
 

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -59,7 +59,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 
 	var act *actor.Actor
 	if err := json.Unmarshal(data, &act); err != nil || act == nil {
-		s.log.Error("failed to unmarshal subscription", log.Error(err))
+		s.log.Error("failed to unmarshal actor", log.Error(err))
 
 		// Delete the corrupted record.
 		s.cache.Delete(token)

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
@@ -1,0 +1,101 @@
+package dotcomuser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
+)
+
+func TestNewActor(t *testing.T) {
+	type args struct {
+		s dotcom.DotcomUserState
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantEnabled   bool
+		wantChatLimit int
+		wantCodeLimit int
+	}{
+		{
+			name: "enabled with rate limits",
+			args: args{
+				dotcom.DotcomUserState{
+					UserName: "user",
+					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
+						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
+							Enabled: true,
+							ChatCompletionsRateLimit: &dotcom.CodyGatewayAccessFieldsChatCompletionsRateLimitCodyGatewayRateLimit{
+								RateLimitFields: dotcom.RateLimitFields{
+									Limit:           10,
+									IntervalSeconds: 10,
+								},
+							},
+							CodeCompletionsRateLimit: &dotcom.CodyGatewayAccessFieldsCodeCompletionsRateLimitCodyGatewayRateLimit{
+								RateLimitFields: dotcom.RateLimitFields{
+									Limit:           20,
+									IntervalSeconds: 20,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantEnabled:   true,
+			wantChatLimit: 10,
+			wantCodeLimit: 20,
+		},
+		{
+			name: "disabled with rate limits",
+			args: args{
+				dotcom.DotcomUserState{
+					UserName: "user",
+					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
+						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
+							Enabled: false,
+							ChatCompletionsRateLimit: &dotcom.CodyGatewayAccessFieldsChatCompletionsRateLimitCodyGatewayRateLimit{
+								RateLimitFields: dotcom.RateLimitFields{
+									Limit:           10,
+									IntervalSeconds: 10,
+								},
+							},
+							CodeCompletionsRateLimit: &dotcom.CodyGatewayAccessFieldsCodeCompletionsRateLimitCodyGatewayRateLimit{
+								RateLimitFields: dotcom.RateLimitFields{
+									Limit:           20,
+									IntervalSeconds: 20,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantEnabled:   false,
+			wantChatLimit: 10,
+			wantCodeLimit: 20,
+		},
+		{
+			name: "enabled no limits",
+			args: args{
+				dotcom.DotcomUserState{
+					UserName: "user",
+					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
+						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			wantEnabled:   true,
+			wantChatLimit: 0,
+			wantCodeLimit: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act := NewActor(nil, "", tt.args.s)
+			assert.Equal(t, act.AccessEnabled, tt.wantEnabled)
+		})
+	}
+}

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
@@ -23,7 +23,7 @@ func TestNewActor(t *testing.T) {
 			name: "enabled with rate limits",
 			args: args{
 				dotcom.DotcomUserState{
-					UserName: "user",
+					Username: "user",
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: true,
@@ -51,7 +51,7 @@ func TestNewActor(t *testing.T) {
 			name: "disabled with rate limits",
 			args: args{
 				dotcom.DotcomUserState{
-					UserName: "user",
+					Username: "user",
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: false,
@@ -79,7 +79,7 @@ func TestNewActor(t *testing.T) {
 			name: "enabled no limits",
 			args: args{
 				dotcom.DotcomUserState{
-					UserName: "user",
+					Username: "user",
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: true,

--- a/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -55,7 +55,7 @@ func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Cl
 	}
 }
 
-func (s *Source) Name() string { return codygateway.ProductSubscriptionActorSourceName }
+func (s *Source) Name() string { return string(codygateway.ActorSourceProductSubscription) }
 
 func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 	if token == "" {

--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -36,6 +36,11 @@ func (e ErrNotFromSource) Error() string {
 
 func IsErrNotFromSource(err error) bool { return errors.As(err, &ErrNotFromSource{}) }
 
+func (e ErrNotFromSource) Is(err error) bool {
+	_, ok := err.(ErrNotFromSource)
+	return ok
+}
+
 // Source is the interface for actor sources.
 type Source interface {
 	Name() string

--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -37,7 +37,7 @@ func (e ErrNotFromSource) Error() string {
 func IsErrNotFromSource(err error) bool { return errors.As(err, &ErrNotFromSource{}) }
 
 func (e ErrNotFromSource) Is(err error) bool {
-	_, ok := err.(ErrNotFromSource)
+	_, ok := errors.Cause(err).(ErrNotFromSource)
 	return ok
 }
 

--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -36,11 +36,6 @@ func (e ErrNotFromSource) Error() string {
 
 func IsErrNotFromSource(err error) bool { return errors.As(err, &ErrNotFromSource{}) }
 
-func (e ErrNotFromSource) Is(err error) bool {
-	_, ok := errors.Cause(err).(ErrNotFromSource)
-	return ok
-}
-
 // Source is the interface for actor sources.
 type Source interface {
 	Name() string

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
@@ -130,6 +130,98 @@ type CheckAccessTokenResponse struct {
 // GetDotcom returns CheckAccessTokenResponse.Dotcom, and is useful for accessing the field via an interface.
 func (v *CheckAccessTokenResponse) GetDotcom() CheckAccessTokenDotcomDotcomQuery { return v.Dotcom }
 
+// CheckDotcomUserAccessTokenDotcomDotcomQuery includes the requested fields of the GraphQL type DotcomQuery.
+// The GraphQL type's documentation follows.
+//
+// Mutations that are only used on Sourcegraph.com.
+// FOR INTERNAL USE ONLY.
+type CheckDotcomUserAccessTokenDotcomDotcomQuery struct {
+	// A user for purposes of connecting to the Cody Gateway.
+	// Only Sourcegraph.com site admins may perform this query.
+	// FOR INTERNAL USE ONLY.
+	DotcomCodyGatewayUserByToken *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser `json:"dotcomCodyGatewayUserByToken"`
+}
+
+// GetDotcomCodyGatewayUserByToken returns CheckDotcomUserAccessTokenDotcomDotcomQuery.DotcomCodyGatewayUserByToken, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQuery) GetDotcomCodyGatewayUserByToken() *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser {
+	return v.DotcomCodyGatewayUserByToken
+}
+
+// CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser includes the requested fields of the GraphQL type DotcomCodyGatewayUser.
+type CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
+	DotcomUserState `json:"-"`
+}
+
+// GetUserName returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.UserName, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetUserName() string {
+	return v.DotcomUserState.UserName
+}
+
+// GetCodyGatewayAccess returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.CodyGatewayAccess, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
+	return v.DotcomUserState.CodyGatewayAccess
+}
+
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.DotcomUserState)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
+	UserName string `json:"userName"`
+
+	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
+}
+
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) __premarshalJSON() (*__premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser, error) {
+	var retval __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser
+
+	retval.UserName = v.DotcomUserState.UserName
+	retval.CodyGatewayAccess = v.DotcomUserState.CodyGatewayAccess
+	return &retval, nil
+}
+
+// CheckDotcomUserAccessTokenResponse is returned by CheckDotcomUserAccessToken on success.
+type CheckDotcomUserAccessTokenResponse struct {
+	// Queries that are only used on Sourcegraph.com.
+	//
+	// FOR INTERNAL USE ONLY.
+	Dotcom CheckDotcomUserAccessTokenDotcomDotcomQuery `json:"dotcom"`
+}
+
+// GetDotcom returns CheckDotcomUserAccessTokenResponse.Dotcom, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenResponse) GetDotcom() CheckDotcomUserAccessTokenDotcomDotcomQuery {
+	return v.Dotcom
+}
+
 // CodyGatewayAccessFields includes the GraphQL fields of CodyGatewayAccess requested by the fragment CodyGatewayAccessFields.
 // The GraphQL type's documentation follows.
 //
@@ -420,6 +512,94 @@ const (
 	// Indicates that the rate limit is inferred by the subscriptions active plan.
 	CodyGatewayRateLimitSourcePlan CodyGatewayRateLimitSource = "PLAN"
 )
+
+// DotcomUserState includes the GraphQL fields of DotcomCodyGatewayUser requested by the fragment DotcomUserState.
+type DotcomUserState struct {
+	UserName          string                           `json:"userName"`
+	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
+}
+
+// GetUserName returns DotcomUserState.UserName, and is useful for accessing the field via an interface.
+func (v *DotcomUserState) GetUserName() string { return v.UserName }
+
+// GetCodyGatewayAccess returns DotcomUserState.CodyGatewayAccess, and is useful for accessing the field via an interface.
+func (v *DotcomUserState) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
+	return v.CodyGatewayAccess
+}
+
+// DotcomUserStateCodyGatewayAccess includes the requested fields of the GraphQL type CodyGatewayAccess.
+// The GraphQL type's documentation follows.
+//
+// Cody Gateway access granted to a subscription.
+// FOR INTERNAL USE ONLY.
+type DotcomUserStateCodyGatewayAccess struct {
+	CodyGatewayAccessFields `json:"-"`
+}
+
+// GetEnabled returns DotcomUserStateCodyGatewayAccess.Enabled, and is useful for accessing the field via an interface.
+func (v *DotcomUserStateCodyGatewayAccess) GetEnabled() bool {
+	return v.CodyGatewayAccessFields.Enabled
+}
+
+// GetChatCompletionsRateLimit returns DotcomUserStateCodyGatewayAccess.ChatCompletionsRateLimit, and is useful for accessing the field via an interface.
+func (v *DotcomUserStateCodyGatewayAccess) GetChatCompletionsRateLimit() *CodyGatewayAccessFieldsChatCompletionsRateLimitCodyGatewayRateLimit {
+	return v.CodyGatewayAccessFields.ChatCompletionsRateLimit
+}
+
+// GetCodeCompletionsRateLimit returns DotcomUserStateCodyGatewayAccess.CodeCompletionsRateLimit, and is useful for accessing the field via an interface.
+func (v *DotcomUserStateCodyGatewayAccess) GetCodeCompletionsRateLimit() *CodyGatewayAccessFieldsCodeCompletionsRateLimitCodyGatewayRateLimit {
+	return v.CodyGatewayAccessFields.CodeCompletionsRateLimit
+}
+
+func (v *DotcomUserStateCodyGatewayAccess) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*DotcomUserStateCodyGatewayAccess
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.DotcomUserStateCodyGatewayAccess = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.CodyGatewayAccessFields)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalDotcomUserStateCodyGatewayAccess struct {
+	Enabled bool `json:"enabled"`
+
+	ChatCompletionsRateLimit *CodyGatewayAccessFieldsChatCompletionsRateLimitCodyGatewayRateLimit `json:"chatCompletionsRateLimit"`
+
+	CodeCompletionsRateLimit *CodyGatewayAccessFieldsCodeCompletionsRateLimitCodyGatewayRateLimit `json:"codeCompletionsRateLimit"`
+}
+
+func (v *DotcomUserStateCodyGatewayAccess) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *DotcomUserStateCodyGatewayAccess) __premarshalJSON() (*__premarshalDotcomUserStateCodyGatewayAccess, error) {
+	var retval __premarshalDotcomUserStateCodyGatewayAccess
+
+	retval.Enabled = v.CodyGatewayAccessFields.Enabled
+	retval.ChatCompletionsRateLimit = v.CodyGatewayAccessFields.ChatCompletionsRateLimit
+	retval.CodeCompletionsRateLimit = v.CodyGatewayAccessFields.CodeCompletionsRateLimit
+	return &retval, nil
+}
 
 // ListProductSubscriptionFields includes the GraphQL fields of ProductSubscription requested by the fragment ListProductSubscriptionFields.
 // The GraphQL type's documentation follows.
@@ -892,6 +1072,14 @@ type __CheckAccessTokenInput struct {
 // GetToken returns __CheckAccessTokenInput.Token, and is useful for accessing the field via an interface.
 func (v *__CheckAccessTokenInput) GetToken() string { return v.Token }
 
+// __CheckDotcomUserAccessTokenInput is used internally by genqlient
+type __CheckDotcomUserAccessTokenInput struct {
+	Token string `json:"token"`
+}
+
+// GetToken returns __CheckDotcomUserAccessTokenInput.Token, and is useful for accessing the field via an interface.
+func (v *__CheckDotcomUserAccessTokenInput) GetToken() string { return v.Token }
+
 // CheckAccessToken returns traits of the product subscription associated with
 // the given access token.
 func CheckAccessToken(
@@ -948,6 +1136,63 @@ fragment RateLimitFields on CodyGatewayRateLimit {
 	var err error
 
 	var data CheckAccessTokenResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// CheckDotcomUserAccessToken returns traits of the product subscription associated with
+// the given access token.
+func CheckDotcomUserAccessToken(
+	ctx context.Context,
+	client graphql.Client,
+	token string,
+) (*CheckDotcomUserAccessTokenResponse, error) {
+	req := &graphql.Request{
+		OpName: "CheckDotcomUserAccessToken",
+		Query: `
+query CheckDotcomUserAccessToken ($token: String!) {
+	dotcom {
+		dotcomCodyGatewayUserByToken(token: $token) {
+			... DotcomUserState
+		}
+	}
+}
+fragment DotcomUserState on DotcomCodyGatewayUser {
+	userName
+	codyGatewayAccess {
+		... CodyGatewayAccessFields
+	}
+}
+fragment CodyGatewayAccessFields on CodyGatewayAccess {
+	enabled
+	chatCompletionsRateLimit {
+		... RateLimitFields
+	}
+	codeCompletionsRateLimit {
+		... RateLimitFields
+	}
+}
+fragment RateLimitFields on CodyGatewayRateLimit {
+	allowedModels
+	source
+	limit
+	intervalSeconds
+}
+`,
+		Variables: &__CheckDotcomUserAccessTokenInput{
+			Token: token,
+		},
+	}
+	var err error
+
+	var data CheckDotcomUserAccessTokenResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
@@ -137,7 +137,7 @@ func (v *CheckAccessTokenResponse) GetDotcom() CheckAccessTokenDotcomDotcomQuery
 // FOR INTERNAL USE ONLY.
 type CheckDotcomUserAccessTokenDotcomDotcomQuery struct {
 	// A user for purposes of connecting to the Cody Gateway.
-	// Only Sourcegraph.com site admins may perform this query.
+	// Only Sourcegraph.com site admins or service accounts may perform this query.
 	// FOR INTERNAL USE ONLY.
 	DotcomCodyGatewayUserByToken *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser `json:"dotcomCodyGatewayUserByToken"`
 }
@@ -148,6 +148,10 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQuery) GetDotcomCodyGatewayUserBy
 }
 
 // CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser includes the requested fields of the GraphQL type DotcomCodyGatewayUser.
+// The GraphQL type's documentation follows.
+//
+// A dotcom user allowed to access the Cody Gateway
+// FOR INTERNAL USE ONLY.
 type CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
 	DotcomUserState `json:"-"`
 }
@@ -514,8 +518,14 @@ const (
 )
 
 // DotcomUserState includes the GraphQL fields of DotcomCodyGatewayUser requested by the fragment DotcomUserState.
+// The GraphQL type's documentation follows.
+//
+// A dotcom user allowed to access the Cody Gateway
+// FOR INTERNAL USE ONLY.
 type DotcomUserState struct {
-	UserName          string                           `json:"userName"`
+	// The user name of the user
+	UserName string `json:"userName"`
+	// Cody Gateway access granted to this user. Properties may be inferred from dotcom site config, or be defined in overrides on the user.
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
 
@@ -551,6 +561,11 @@ func (v *DotcomUserStateCodyGatewayAccess) GetCodeCompletionsRateLimit() *CodyGa
 	return v.CodyGatewayAccessFields.CodeCompletionsRateLimit
 }
 
+// GetEmbeddingsRateLimit returns DotcomUserStateCodyGatewayAccess.EmbeddingsRateLimit, and is useful for accessing the field via an interface.
+func (v *DotcomUserStateCodyGatewayAccess) GetEmbeddingsRateLimit() *CodyGatewayAccessFieldsEmbeddingsRateLimitCodyGatewayRateLimit {
+	return v.CodyGatewayAccessFields.EmbeddingsRateLimit
+}
+
 func (v *DotcomUserStateCodyGatewayAccess) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -582,6 +597,8 @@ type __premarshalDotcomUserStateCodyGatewayAccess struct {
 	ChatCompletionsRateLimit *CodyGatewayAccessFieldsChatCompletionsRateLimitCodyGatewayRateLimit `json:"chatCompletionsRateLimit"`
 
 	CodeCompletionsRateLimit *CodyGatewayAccessFieldsCodeCompletionsRateLimitCodyGatewayRateLimit `json:"codeCompletionsRateLimit"`
+
+	EmbeddingsRateLimit *CodyGatewayAccessFieldsEmbeddingsRateLimitCodyGatewayRateLimit `json:"embeddingsRateLimit"`
 }
 
 func (v *DotcomUserStateCodyGatewayAccess) MarshalJSON() ([]byte, error) {
@@ -598,6 +615,7 @@ func (v *DotcomUserStateCodyGatewayAccess) __premarshalJSON() (*__premarshalDotc
 	retval.Enabled = v.CodyGatewayAccessFields.Enabled
 	retval.ChatCompletionsRateLimit = v.CodyGatewayAccessFields.ChatCompletionsRateLimit
 	retval.CodeCompletionsRateLimit = v.CodyGatewayAccessFields.CodeCompletionsRateLimit
+	retval.EmbeddingsRateLimit = v.CodyGatewayAccessFields.EmbeddingsRateLimit
 	return &retval, nil
 }
 
@@ -1176,6 +1194,9 @@ fragment CodyGatewayAccessFields on CodyGatewayAccess {
 		... RateLimitFields
 	}
 	codeCompletionsRateLimit {
+		... RateLimitFields
+	}
+	embeddingsRateLimit {
 		... RateLimitFields
 	}
 }

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
@@ -136,48 +136,48 @@ func (v *CheckAccessTokenResponse) GetDotcom() CheckAccessTokenDotcomDotcomQuery
 // Mutations that are only used on Sourcegraph.com.
 // FOR INTERNAL USE ONLY.
 type CheckDotcomUserAccessTokenDotcomDotcomQuery struct {
-	// A user for purposes of connecting to the Cody Gateway.
+	// A dotcom user for purposes of connecting to the Cody Gateway.
 	// Only Sourcegraph.com site admins or service accounts may perform this query.
 	// Token is a Cody Gateway token, not a Sourcegraph instance access token.
 	// FOR INTERNAL USE ONLY.
-	DotcomCodyGatewayUserByToken *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser `json:"dotcomCodyGatewayUserByToken"`
+	CodyGatewayDotcomUserByToken *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser `json:"codyGatewayDotcomUserByToken"`
 }
 
-// GetDotcomCodyGatewayUserByToken returns CheckDotcomUserAccessTokenDotcomDotcomQuery.DotcomCodyGatewayUserByToken, and is useful for accessing the field via an interface.
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQuery) GetDotcomCodyGatewayUserByToken() *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser {
-	return v.DotcomCodyGatewayUserByToken
+// GetCodyGatewayDotcomUserByToken returns CheckDotcomUserAccessTokenDotcomDotcomQuery.CodyGatewayDotcomUserByToken, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQuery) GetCodyGatewayDotcomUserByToken() *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser {
+	return v.CodyGatewayDotcomUserByToken
 }
 
-// CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser includes the requested fields of the GraphQL type DotcomCodyGatewayUser.
+// CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser includes the requested fields of the GraphQL type CodyGatewayDotcomUser.
 // The GraphQL type's documentation follows.
 //
 // A dotcom user allowed to access the Cody Gateway
 // FOR INTERNAL USE ONLY.
-type CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
+type CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser struct {
 	DotcomUserState `json:"-"`
 }
 
-// GetUsername returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.Username, and is useful for accessing the field via an interface.
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetUsername() string {
+// GetUsername returns CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser.Username, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) GetUsername() string {
 	return v.DotcomUserState.Username
 }
 
-// GetCodyGatewayAccess returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.CodyGatewayAccess, and is useful for accessing the field via an interface.
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
+// GetCodyGatewayAccess returns CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser.CodyGatewayAccess, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
 	return v.DotcomUserState.CodyGatewayAccess
 }
 
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) UnmarshalJSON(b []byte) error {
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
 		return nil
 	}
 
 	var firstPass struct {
-		*CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser
+		*CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser
 		graphql.NoUnmarshalJSON
 	}
-	firstPass.CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser = v
+	firstPass.CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser = v
 
 	err := json.Unmarshal(b, &firstPass)
 	if err != nil {
@@ -192,13 +192,13 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByToken
 	return nil
 }
 
-type __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
+type __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser struct {
 	Username string `json:"username"`
 
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
 
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) MarshalJSON() ([]byte, error) {
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -206,8 +206,8 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByToken
 	return json.Marshal(premarshaled)
 }
 
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) __premarshalJSON() (*__premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser, error) {
-	var retval __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) __premarshalJSON() (*__premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser, error) {
+	var retval __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser
 
 	retval.Username = v.DotcomUserState.Username
 	retval.CodyGatewayAccess = v.DotcomUserState.CodyGatewayAccess
@@ -518,7 +518,7 @@ const (
 	CodyGatewayRateLimitSourcePlan CodyGatewayRateLimitSource = "PLAN"
 )
 
-// DotcomUserState includes the GraphQL fields of DotcomCodyGatewayUser requested by the fragment DotcomUserState.
+// DotcomUserState includes the GraphQL fields of CodyGatewayDotcomUser requested by the fragment DotcomUserState.
 // The GraphQL type's documentation follows.
 //
 // A dotcom user allowed to access the Cody Gateway
@@ -1178,12 +1178,12 @@ func CheckDotcomUserAccessToken(
 		Query: `
 query CheckDotcomUserAccessToken ($token: String!) {
 	dotcom {
-		dotcomCodyGatewayUserByToken(token: $token) {
+		codyGatewayDotcomUserByToken(token: $token) {
 			... DotcomUserState
 		}
 	}
 }
-fragment DotcomUserState on DotcomCodyGatewayUser {
+fragment DotcomUserState on CodyGatewayDotcomUser {
 	username
 	codyGatewayAccess {
 		... CodyGatewayAccessFields

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
@@ -138,6 +138,7 @@ func (v *CheckAccessTokenResponse) GetDotcom() CheckAccessTokenDotcomDotcomQuery
 type CheckDotcomUserAccessTokenDotcomDotcomQuery struct {
 	// A user for purposes of connecting to the Cody Gateway.
 	// Only Sourcegraph.com site admins or service accounts may perform this query.
+	// Token is a Cody Gateway token, not a Sourcegraph instance access token.
 	// FOR INTERNAL USE ONLY.
 	DotcomCodyGatewayUserByToken *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser `json:"dotcomCodyGatewayUserByToken"`
 }
@@ -156,9 +157,9 @@ type CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotc
 	DotcomUserState `json:"-"`
 }
 
-// GetUserName returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.UserName, and is useful for accessing the field via an interface.
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetUserName() string {
-	return v.DotcomUserState.UserName
+// GetUsername returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.Username, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) GetUsername() string {
+	return v.DotcomUserState.Username
 }
 
 // GetCodyGatewayAccess returns CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser.CodyGatewayAccess, and is useful for accessing the field via an interface.
@@ -192,7 +193,7 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByToken
 }
 
 type __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser struct {
-	UserName string `json:"userName"`
+	Username string `json:"username"`
 
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
@@ -208,7 +209,7 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByToken
 func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser) __premarshalJSON() (*__premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser, error) {
 	var retval __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryDotcomCodyGatewayUserByTokenDotcomCodyGatewayUser
 
-	retval.UserName = v.DotcomUserState.UserName
+	retval.Username = v.DotcomUserState.Username
 	retval.CodyGatewayAccess = v.DotcomUserState.CodyGatewayAccess
 	return &retval, nil
 }
@@ -524,13 +525,13 @@ const (
 // FOR INTERNAL USE ONLY.
 type DotcomUserState struct {
 	// The user name of the user
-	UserName string `json:"userName"`
+	Username string `json:"username"`
 	// Cody Gateway access granted to this user. Properties may be inferred from dotcom site config, or be defined in overrides on the user.
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
 
-// GetUserName returns DotcomUserState.UserName, and is useful for accessing the field via an interface.
-func (v *DotcomUserState) GetUserName() string { return v.UserName }
+// GetUsername returns DotcomUserState.Username, and is useful for accessing the field via an interface.
+func (v *DotcomUserState) GetUsername() string { return v.Username }
 
 // GetCodyGatewayAccess returns DotcomUserState.CodyGatewayAccess, and is useful for accessing the field via an interface.
 func (v *DotcomUserState) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
@@ -1183,7 +1184,7 @@ query CheckDotcomUserAccessToken ($token: String!) {
 	}
 }
 fragment DotcomUserState on DotcomCodyGatewayUser {
-	userName
+	username
 	codyGatewayAccess {
 		... CodyGatewayAccessFields
 	}

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
@@ -61,3 +61,20 @@ query ListProductSubscriptions {
         }
     }
 }
+
+fragment DotcomUserState on DotcomCodyGatewayUser {
+    userName
+    codyGatewayAccess {
+        ...CodyGatewayAccessFields
+    }
+}
+
+# CheckDotcomUserAccessToken returns traits of the product subscription associated with
+# the given access token.
+query CheckDotcomUserAccessToken($token: String!) {
+    dotcom {
+        dotcomCodyGatewayUserByToken(token: $token) {
+            ...DotcomUserState
+        }
+    }
+}

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
@@ -63,7 +63,7 @@ query ListProductSubscriptions {
 }
 
 fragment DotcomUserState on DotcomCodyGatewayUser {
-    userName
+    username
     codyGatewayAccess {
         ...CodyGatewayAccessFields
     }

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
@@ -62,7 +62,7 @@ query ListProductSubscriptions {
     }
 }
 
-fragment DotcomUserState on DotcomCodyGatewayUser {
+fragment DotcomUserState on CodyGatewayDotcomUser {
     username
     codyGatewayAccess {
         ...CodyGatewayAccessFields
@@ -73,7 +73,7 @@ fragment DotcomUserState on DotcomCodyGatewayUser {
 # the given access token.
 query CheckDotcomUserAccessToken($token: String!) {
     dotcom {
-        dotcomCodyGatewayUserByToken(token: $token) {
+        codyGatewayDotcomUserByToken(token: $token) {
             ...DotcomUserState
         }
     }

--- a/enterprise/cmd/cody-gateway/shared/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/shared/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//enterprise/cmd/cody-gateway/internal/actor",
         "//enterprise/cmd/cody-gateway/internal/actor/anonymous",
+        "//enterprise/cmd/cody-gateway/internal/actor/dotcomuser",
         "//enterprise/cmd/cody-gateway/internal/actor/productsubscription",
         "//enterprise/cmd/cody-gateway/internal/auth",
         "//enterprise/cmd/cody-gateway/internal/dotcom",

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -69,17 +69,19 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		}
 	}
 
+	dotcomClient := dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken)
+
 	// Supported actor/auth sources
 	sources := actor.Sources{
 		anonymous.NewSource(config.AllowAnonymous),
 		productsubscription.NewSource(
 			obctx.Logger,
 			rcache.New("product-subscriptions"),
-			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
+			dotcomClient,
 			config.Dotcom.InternalMode),
 		dotcomuser.NewSource(obctx.Logger,
 			rcache.New("dotcom-users"),
-			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
+			dotcomClient,
 		),
 	}
 

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor/anonymous"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor/dotcomuser"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor/productsubscription"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi"
@@ -76,6 +77,10 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			rcache.New("product-subscriptions"),
 			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
 			config.Dotcom.InternalMode),
+		dotcomuser.NewSource(obctx.Logger,
+			rcache.New("dotcom-users"),
+			dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken),
+		),
 	}
 
 	authr := &auth.Authenticator{

--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -19,6 +19,7 @@ import (
 // dotcomRootResolver implements the GraphQL types DotcomMutation and DotcomQuery.
 type dotcomRootResolver struct {
 	productsubscription.ProductSubscriptionLicensingResolver
+	productsubscription.CodyGatewayDotcomUserResolver
 }
 
 func (d dotcomRootResolver) Dotcom() graphqlbackend.DotcomResolver {
@@ -50,6 +51,9 @@ func Init(
 	if envvar.SourcegraphDotComMode() {
 		enterpriseServices.DotcomRootResolver = dotcomRootResolver{
 			ProductSubscriptionLicensingResolver: productsubscription.ProductSubscriptionLicensingResolver{
+				DB: db,
+			},
+			CodyGatewayDotcomUserResolver: productsubscription.CodyGatewayDotcomUserResolver{
 				DB: db,
 			},
 		}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
 go_test(
     name = "productsubscription_test",
     srcs = [
+        "codygateway_dotcom_user_test.go",
         "codygateway_graphql_test.go",
         "license_check_handler_test.go",
         "license_expiration_test.go",
@@ -82,11 +83,14 @@ go_test(
         "//enterprise/internal/licensing",
         "//enterprise/internal/productsubscription",
         "//internal/actor",
+        "//internal/auth",
+        "//internal/authz",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/errcode",
         "//internal/featureflag",
+        "//internal/hashutil",
         "//internal/slack",
         "//internal/timeutil",
         "//internal/types",

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "productsubscription",
     srcs = [
+        "codygateway_dotcom_user.go",
         "codygateway_graphql.go",
         "codygateway_service.go",
         "doc.go",
@@ -41,6 +42,7 @@ go_library(
         "//internal/gqlutil",
         "//internal/redispool",
         "//internal/slack",
+        "//internal/types",
         "//lib/errors",
         "@com_github_derision_test_glock//:glock",
         "@com_github_gomodule_redigo//redis",

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -76,7 +76,7 @@ func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Cont
 	if !r.Enabled() {
 		return nil, nil
 	}
-	rateLimit, rateLimitSource, err := getRateLimt(ctx, r.db, r.user.ID, types.CompletionsFeatureChat)
+	rateLimit, rateLimitSource, err := getRateLimit(ctx, r.db, r.user.ID, types.CompletionsFeatureChat)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Cont
 		return nil, nil
 	}
 
-	rateLimit, rateLimitSource, err := getRateLimt(ctx, r.db, r.user.ID, types.CompletionsFeatureCode)
+	rateLimit, rateLimitSource, err := getRateLimit(ctx, r.db, r.user.ID, types.CompletionsFeatureCode)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Cont
 	}, nil
 }
 
-func getRateLimt(ctx context.Context, db database.DB, userID int32, scope types.CompletionsFeature) (licensing.CodyGatewayRateLimit, graphqlbackend.CodyGatewayRateLimitSource, error) {
+func getRateLimit(ctx context.Context, db database.DB, userID int32, scope types.CompletionsFeature) (licensing.CodyGatewayRateLimit, graphqlbackend.CodyGatewayRateLimitSource, error) {
 	var limit *int
 	var err error
 	source := graphqlbackend.CodyGatewayRateLimitSourceOverride

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -73,6 +73,7 @@ type codyUserGatewayAccessResolver struct {
 func (r codyUserGatewayAccessResolver) Enabled() bool { return r.user.SiteAdmin || r.verifiedEmail }
 
 func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
+	// If the user isn't enabled return a rate limit with 0 requests available
 	if !r.Enabled() {
 		return nil, nil
 	}
@@ -91,6 +92,7 @@ func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Cont
 }
 
 func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
+	// If the user isn't enabled return a rate limit with 0 requests available
 	if !r.Enabled() {
 		return nil, nil
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
-	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	dbtypes "github.com/sourcegraph/sourcegraph/internal/types"
@@ -24,13 +23,13 @@ func (r CodyGatewayDotcomUserResolver) DotcomCodyGatewayUserByToken(ctx context.
 	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
 		return nil, err
 	}
-
-	userID, err := r.DB.AccessTokens().Lookup(ctx, args.Token, authz.ScopeUserAll)
+	dbTokens := newDBTokens(r.DB)
+	userID, err := dbTokens.LookupDotcomUserIDByAccessToken(ctx, args.Token)
 	if err != nil {
 		return nil, err
 	}
 
-	user, err := r.DB.Users().GetByID(ctx, userID)
+	user, err := r.DB.Users().GetByID(ctx, int32(userID))
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -1,0 +1,168 @@
+package productsubscription
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	dbtypes "github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// CodyGatewayDotcomUserResolver implements the GraphQL Query and Mutation fields related to Cody gateway users.
+type CodyGatewayDotcomUserResolver struct {
+	DB database.DB
+}
+
+func (r CodyGatewayDotcomUserResolver) DotcomCodyGatewayUserByToken(ctx context.Context, args *graphqlbackend.CodyGatewayUsersByAccessTokenArgs) (graphqlbackend.CodyGatewayUser, error) {
+	// 🚨 SECURITY: Only site admins or the service accounts may check users.
+	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
+		return nil, err
+	}
+
+	userID, err := r.DB.AccessTokens().Lookup(ctx, args.Token, authz.ScopeUserAll)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := r.DB.Users().GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	verified, err := r.DB.UserEmails().HasVerifiedEmail(ctx, user.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &dotcomCodyUserResolver{
+		db:            r.DB,
+		user:          user,
+		verifiedEmail: verified,
+	}, nil
+
+}
+
+type dotcomCodyUserResolver struct {
+	db            database.DB
+	user          *dbtypes.User
+	verifiedEmail bool
+}
+
+func (u *dotcomCodyUserResolver) Username() string {
+	return u.user.Username
+}
+
+func (u *dotcomCodyUserResolver) CodyGatewayAccess() graphqlbackend.CodyGatewayAccess {
+	return &codyUserGatewayAccessResolver{
+		db:            u.db,
+		user:          u.user,
+		verifiedEmail: u.verifiedEmail,
+	}
+}
+
+type codyUserGatewayAccessResolver struct {
+	db            database.DB
+	user          *dbtypes.User
+	verifiedEmail bool
+}
+
+func (r codyUserGatewayAccessResolver) Enabled() bool { return r.user.SiteAdmin || r.verifiedEmail }
+
+func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
+	if !r.Enabled() {
+		return nil, nil
+	}
+	rateLimit, rateLimitSource, err := getRateLimt(ctx, r.db, r.user.ID, types.CompletionsFeatureChat)
+	if err != nil {
+		return nil, err
+	}
+
+	return &codyGatewayRateLimitResolver{
+		feature:     types.CompletionsFeatureChat,
+		actorID:     r.user.Username,
+		actorSource: codygateway.ActorSourceDotcomUser,
+		source:      rateLimitSource,
+		v:           rateLimit,
+	}, nil
+}
+
+func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
+	if !r.Enabled() {
+		return nil, nil
+	}
+
+	rateLimit, rateLimitSource, err := getRateLimt(ctx, r.db, r.user.ID, types.CompletionsFeatureCode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &codyGatewayRateLimitResolver{
+		feature:     types.CompletionsFeatureCode,
+		actorID:     r.user.Username,
+		actorSource: codygateway.ActorSourceDotcomUser,
+		source:      rateLimitSource,
+		v:           rateLimit,
+	}, nil
+}
+
+func getRateLimt(ctx context.Context, db database.DB, userID int32, scope types.CompletionsFeature) (licensing.CodyGatewayRateLimit, graphqlbackend.CodyGatewayRateLimitSource, error) {
+	var limit *int
+	var err error
+	source := graphqlbackend.CodyGatewayRateLimitSourceOverride
+
+	switch scope {
+	case types.CompletionsFeatureChat:
+		limit, err = db.Users().GetChatCompletionsQuota(ctx, userID)
+	case types.CompletionsFeatureCode:
+		limit, err = db.Users().GetCodeCompletionsQuota(ctx, userID)
+	default:
+		return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, errors.Newf("unknown scope: %s", scope)
+	}
+	if err != nil {
+		return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, err
+	}
+	if limit == nil {
+		source = graphqlbackend.CodyGatewayRateLimitSourcePlan
+		// Otherwise, fall back to the global limit.
+		cfg := conf.Get()
+		switch scope {
+		case types.CompletionsFeatureChat:
+			if cfg.Completions != nil && cfg.Completions.PerUserDailyLimit > 0 {
+				limit = iPtr(cfg.Completions.PerUserDailyLimit)
+			}
+		case types.CompletionsFeatureCode:
+			if cfg.Completions != nil && cfg.Completions.PerUserCodeCompletionsDailyLimit > 0 {
+				limit = iPtr(cfg.Completions.PerUserCodeCompletionsDailyLimit)
+			}
+		default:
+			return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, errors.Newf("unknown scope: %s", scope)
+		}
+	}
+	if limit == nil {
+		limit = iPtr(0)
+	}
+	return licensing.CodyGatewayRateLimit{
+		AllowedModels:   allowedModels(scope),
+		Limit:           int32(*limit),
+		IntervalSeconds: 86400, // Daily limit
+	}, source, nil
+}
+
+func allowedModels(scope types.CompletionsFeature) []string {
+	switch scope {
+	case types.CompletionsFeatureChat:
+		return []string{"claude-v1"}
+	case types.CompletionsFeatureCode:
+		return []string{"claude-instant-v1"}
+	default:
+		return []string{}
+	}
+}
+
+func iPtr(i int) *int {
+	return &i
+}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -172,7 +172,7 @@ func getCompletionsRateLimit(ctx context.Context, db database.DB, userID int32, 
 	return licensing.CodyGatewayRateLimit{
 		AllowedModels:   allowedModels(scope),
 		Limit:           int32(*limit),
-		IntervalSeconds: 86400, // Daily limit
+		IntervalSeconds: 86400, // Daily limit TODO(davejrt)
 	}, source, nil
 }
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -19,7 +19,7 @@ type CodyGatewayDotcomUserResolver struct {
 	DB database.DB
 }
 
-func (r CodyGatewayDotcomUserResolver) DotcomCodyGatewayUserByToken(ctx context.Context, args *graphqlbackend.CodyGatewayUsersByAccessTokenArgs) (graphqlbackend.CodyGatewayUser, error) {
+func (r CodyGatewayDotcomUserResolver) CodyGatewayDotcomUserByToken(ctx context.Context, args *graphqlbackend.CodyGatewayUsersByAccessTokenArgs) (graphqlbackend.CodyGatewayUser, error) {
 	// 🚨 SECURITY: Only site admins or the service accounts may check users.
 	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -73,7 +73,7 @@ type codyUserGatewayAccessResolver struct {
 func (r codyUserGatewayAccessResolver) Enabled() bool { return r.user.SiteAdmin || r.verifiedEmail }
 
 func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
-	// If the user isn't enabled return a rate limit with 0 requests available
+	// If the user isn't enabled return no rate limit
 	if !r.Enabled() {
 		return nil, nil
 	}
@@ -92,7 +92,7 @@ func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Cont
 }
 
 func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
-	// If the user isn't enabled return a rate limit with 0 requests available
+	// If the user isn't enabled return no rate limit
 	if !r.Enabled() {
 		return nil, nil
 	}
@@ -114,7 +114,7 @@ func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Cont
 const tokensPerDollar = int(1 / (0.0004 / 1_000))
 
 func (r codyUserGatewayAccessResolver) EmbeddingsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
-	// If the user isn't enabled so they don't get the rate limit
+	// If the user isn't enabled return no rate limit
 	if !r.Enabled() {
 		return nil, nil
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -179,9 +179,9 @@ func getCompletionsRateLimit(ctx context.Context, db database.DB, userID int32, 
 func allowedModels(scope types.CompletionsFeature) []string {
 	switch scope {
 	case types.CompletionsFeatureChat:
-		return []string{"claude-v1"}
+		return []string{"anthropic/claude-v1"}
 	case types.CompletionsFeatureCode:
-		return []string{"claude-instant-v1"}
+		return []string{"anthropic/claude-instant-v1"}
 	default:
 		return []string{}
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -1,0 +1,190 @@
+package productsubscription_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/dotcom/productsubscription"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestCodyGatewayDotcomUserResolver(t *testing.T) {
+	var chatOverrideLimit int = 200
+	var codeOverrideLimit int = 400
+
+	cfg := &conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			Completions: &schema.Completions{
+				PerUserCodeCompletionsDailyLimit: 20,
+				PerUserDailyLimit:                10,
+			},
+		},
+	}
+	conf.Mock(cfg)
+	defer func() {
+		conf.Mock(nil)
+	}()
+
+	ctx := context.Background()
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+
+	// User with default rate limits
+	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})
+	require.NoError(t, err)
+
+	// Verified User with default rate limits
+	verifiedUser, err := db.Users().Create(ctx, database.NewUser{Username: "verified", EmailIsVerified: true, Email: "verified@test.com"})
+	require.NoError(t, err)
+
+	// Unverified User with default rate limits
+	unverifiedUser, err := db.Users().Create(ctx, database.NewUser{Username: "unverified", EmailIsVerified: false, Email: "christopher.warwick@sourcegraph.com", EmailVerificationCode: "CODE"})
+	require.NoError(t, err)
+
+	// User with rate limit overrides
+	overrideUser, err := db.Users().Create(ctx, database.NewUser{Username: "override", EmailIsVerified: true, Email: "override@test.com"})
+	require.NoError(t, err)
+	err = db.Users().SetChatCompletionsQuota(context.Background(), overrideUser.ID, iPtr(chatOverrideLimit))
+	require.NoError(t, err)
+	err = db.Users().SetCodeCompletionsQuota(context.Background(), overrideUser.ID, iPtr(codeOverrideLimit))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		user        *types.User
+		wantChat    int32
+		wantCode    int32
+		wantEnabled bool
+	}{
+		{
+			name:        "admin user",
+			user:        adminUser,
+			wantChat:    int32(cfg.Completions.PerUserDailyLimit),
+			wantCode:    int32(cfg.Completions.PerUserCodeCompletionsDailyLimit),
+			wantEnabled: true,
+		},
+		{
+			name:        "verified user default limits",
+			user:        verifiedUser,
+			wantChat:    int32(cfg.Completions.PerUserDailyLimit),
+			wantCode:    int32(cfg.Completions.PerUserCodeCompletionsDailyLimit),
+			wantEnabled: true,
+		},
+		{
+			name:        "unverified user",
+			user:        unverifiedUser,
+			wantChat:    0,
+			wantCode:    0,
+			wantEnabled: false,
+		},
+		{
+			name:        "override user",
+			user:        overrideUser,
+			wantChat:    int32(chatOverrideLimit),
+			wantCode:    int32(codeOverrideLimit),
+			wantEnabled: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Create an admin context to use for the request
+			adminContext := actor.WithActor(context.Background(), actor.FromActualUser(adminUser))
+
+			// Generate a token for the test user
+			_, token, err := db.AccessTokens().Create(context.Background(), test.user.ID, []string{authz.ScopeUserAll}, test.name, test.user.ID)
+			require.NoError(t, err)
+
+			// Make request from the admin checking the test user's token
+			r := productsubscription.CodyGatewayDotcomUserResolver{DB: db}
+			userResolver, err := r.DotcomCodyGatewayUserByToken(adminContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: token})
+			require.NoError(t, err)
+
+			chat, err := userResolver.CodyGatewayAccess().ChatCompletionsRateLimit(adminContext)
+			require.NoError(t, err)
+			if chat != nil {
+				require.Equal(t, test.wantChat, chat.Limit())
+			} else {
+				require.False(t, test.wantEnabled) // If there is no limit make sure it's expected to be disabled
+			}
+
+			code, err := userResolver.CodyGatewayAccess().CodeCompletionsRateLimit(adminContext)
+			require.NoError(t, err)
+			if chat != nil {
+				require.Equal(t, test.wantCode, code.Limit())
+			} else {
+				require.False(t, test.wantEnabled) // If there is no limit make sure it's expected to be disabled
+			}
+
+			assert.Equal(t, test.wantEnabled, userResolver.CodyGatewayAccess().Enabled())
+		})
+	}
+}
+
+func TestCodyGatewayDotcomUserResolverRequestAccess(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+
+	// Admin
+	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})
+	require.NoError(t, err)
+
+	// Not Admin
+	notAdminUser, err := db.Users().Create(ctx, database.NewUser{Username: "verified", EmailIsVerified: true, Email: "verified@test.com"})
+	require.NoError(t, err)
+
+	// cody user
+	coydUser, err := db.Users().Create(ctx, database.NewUser{Username: "cody", EmailIsVerified: true, Email: "cody@test.com"})
+	require.NoError(t, err)
+	// Generate a token for the cody user
+	_, codyUserToken, err := db.AccessTokens().Create(context.Background(), coydUser.ID, []string{authz.ScopeUserAll}, "cody", coydUser.ID)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		user    *types.User
+		wantErr error
+	}{
+		{
+			name:    "admin user",
+			user:    adminUser,
+			wantErr: nil,
+		},
+		{
+			name:    "not admin user",
+			user:    notAdminUser,
+			wantErr: auth.ErrMustBeSiteAdmin,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Create a request context from the user
+			requestContext := actor.WithActor(context.Background(), actor.FromActualUser(test.user))
+
+			// Make request from the test user
+			r := productsubscription.CodyGatewayDotcomUserResolver{DB: db}
+			_, err := r.DotcomCodyGatewayUserByToken(requestContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: codyUserToken})
+
+			require.ErrorIs(t, err, test.wantErr)
+
+		})
+	}
+}
+
+func iPtr(i int) *int {
+	return &i
+}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -114,7 +114,7 @@ func TestCodyGatewayDotcomUserResolver(t *testing.T) {
 
 			// Make request from the admin checking the test user's token
 			r := productsubscription.CodyGatewayDotcomUserResolver{DB: db}
-			userResolver, err := r.DotcomCodyGatewayUserByToken(adminContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: gatewayToken})
+			userResolver, err := r.CodyGatewayDotcomUserByToken(adminContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: gatewayToken})
 			require.NoError(t, err)
 
 			chat, err := userResolver.CodyGatewayAccess().ChatCompletionsRateLimit(adminContext)
@@ -183,7 +183,7 @@ func TestCodyGatewayDotcomUserResolverRequestAccess(t *testing.T) {
 
 			// Make request from the test user
 			r := productsubscription.CodyGatewayDotcomUserResolver{DB: db}
-			_, err := r.DotcomCodyGatewayUserByToken(requestContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: codyUserGatewayToken})
+			_, err := r.CodyGatewayDotcomUserByToken(requestContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: codyUserGatewayToken})
 
 			require.ErrorIs(t, err, test.wantErr)
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_service.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_service.go
@@ -72,7 +72,7 @@ type codyGatewayService struct {
 	opts CodyGatewayServiceOptions
 }
 
-func (s *codyGatewayService) CompletionsUsageForSubscription(ctx context.Context, feature types.CompletionsFeature, uuid string) ([]SubscriptionUsage, error) {
+func (s *codyGatewayService) CompletionsUsageForActor(ctx context.Context, feature types.CompletionsFeature, actorSource codygateway.ActorSource, actorID string) ([]SubscriptionUsage, error) {
 	if !s.opts.BigQuery.IsConfigured() {
 		// Not configured, nothing we can do.
 		return nil, nil
@@ -150,11 +150,11 @@ ORDER BY
 	q.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "source",
-			Value: codygateway.ProductSubscriptionActorSourceName,
+			Value: actorSource,
 		},
 		{
 			Name:  "identifier",
-			Value: uuid,
+			Value: actorID,
 		},
 		{
 			Name:  "eventName",
@@ -194,7 +194,7 @@ ORDER BY
 	return results, nil
 }
 
-func (s *codyGatewayService) EmbeddingsUsageForSubscription(ctx context.Context, uuid string) ([]SubscriptionUsage, error) {
+func (s *codyGatewayService) EmbeddingsUsageForActor(ctx context.Context, actorSource codygateway.ActorSource, actorID string) ([]SubscriptionUsage, error) {
 	if !s.opts.BigQuery.IsConfigured() {
 		// Not configured, nothing we can do.
 		return nil, nil
@@ -273,11 +273,11 @@ ORDER BY
 	q.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "source",
-			Value: codygateway.ProductSubscriptionActorSourceName,
+			Value: actorSource,
 		},
 		{
 			Name:  "identifier",
-			Value: uuid,
+			Value: actorID,
 		},
 		{
 			Name:  "eventName",

--- a/enterprise/internal/codygateway/consts.go
+++ b/enterprise/internal/codygateway/consts.go
@@ -1,6 +1,11 @@
 package codygateway
 
-const ProductSubscriptionActorSourceName = "dotcom-product-subscriptions"
+type ActorSource string
+
+const (
+	ActorSourceProductSubscription ActorSource = "dotcom-product-subscriptions"
+	ActorSourceDotcomUser          ActorSource = "dotcom-user"
+)
 
 const CompletionsEventFeatureMetadataField = "feature"
 const EmbeddingsTokenUsageMetadataField = "tokens_used"


### PR DESCRIPTION
This adds a new actor source for the cody gateway that accepts verified dotcom users and allows them to utilize chat, completions and embeddings. 

The main use case for this is so that App will be able to talk directly to the cody-gateway to avoid App users needing to provide their own api keys and knowledge of completions/embeddings apis.

Access:

This actor uses a derived key generated from a user api token, this allows disable gateway access by deleting the api token.  I did not expose an endpoint to create these cody-gateway specific user tokens because the main use case is for the Cody app, which runs the sourcegraph backend and can generate this token directly from the api token the user created to connect App to dotcom.

Rate limits:

- **Chat & Code completions** utilize the rate limits that have defaults on dotcom and also allows an override per user.  This rate limit is separate from the limit imposed when on dotcom because it is imposed directly at the gateway.  Effectively this means any user can get 2x the limit split evenly between dotcom usage and Cody App usage.
- **Embeddings** utilize a hard coded default "lifetime" limit as was previously determined 


## Test plan
Tests Added

- Successful completed chats when using a derived user token
- Successful created embeddings using a derived user token
- Verified that chats & embeddings failed when rate limit was exceeded
- Verified bigquery events recorded for user level tokens.
- Verified generating a new access token did not grant an additional batch of requests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
