### PR TITLE
fix cody nightly build script

### DIFF
--- a/client/cody/scripts/release.ts
+++ b/client/cody/scripts/release.ts
@@ -66,7 +66,7 @@ export const commands = {
     vscode_package: 'pnpm run vsce:package',
     vscode_publish: 'vsce publish --packagePath dist/cody.vsix --pat $VSCODE_MARKETPLACE_TOKEN',
     // Nightly release: publish to VS Code Marketplace with today's date as patch number
-    vscode_package_nightly: `pnpm --silent build && vsce package ${tonightVersion} --no-dependencies -o dist/cody.vsix`,
+    vscode_package_nightly: `pnpm --silent build && vsce package ${tonightVersion} --pre-release --no-dependencies -o dist/cody.vsix`,
     vscode_nightly: 'vsce publish --pre-release --packagePath dist/cody.vsix --pat $VSCODE_MARKETPLACE_TOKEN',
     // To publish to the open-vsx registry
     openvsx_publish: 'npx ovsx publish dist/cody.vsix --pat $VSCODE_OPENVSX_TOKEN',


### PR DESCRIPTION
Day 2: failed

Error:
```sh
ERROR  Cannot use '--pre-release' flag with a package that was not packaged as pre-release. Please package it using the '--pre-release' flag and publish again.
Error: Command failed: vsce publish --pre-release --packagePath dist/cody.vsix --pat $VSCODE_MARKETPLACE_TOKEN
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

TODO: Will run each command manually to make sure all of them works with my other account

1. package the extension as pre-release with a customized version number
2. publish the packaged extension as pre-release to make sure it works

Update:

```sh
❯ vsce package 0.1.0 --pre-release --no-dependencies -o out/bee-test.vsix
Executing prepublish script 'npm run vscode:prepublish'...

> codelens-bee-test@0.0.1 vscode:prepublish
> npm run compile


> codelens-bee-test@0.0.1 compile
> tsc -p ./

v0.1.0
 WARNING  Using '*' activation is usually a bad idea as it impacts performance.
More info: https://code.visualstudio.com/api/references/activation-events#Start-up
Do you want to continue? [y/N] y
 WARNING  LICENSE.md, LICENSE.txt or LICENSE not found
Do you want to continue? [y/N] y
 DONE  Packaged: out/bee-test.vsix (16 files, 460.47KB)

❯ vsce publish --pre-release --packagePath out/bee-test.vsix --pat TOKEN
 INFO  Publishing 'beatrix.codelens-bee-test v0.1.0'...
 ERROR  Failed request: (401)
 ```