### PR TITLE
Cody: Make the non-stop Cody highlighting theme-able

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -75,6 +75,56 @@
     "onStartupFinished"
   ],
   "contributes": {
+    "colors": [
+      {
+        "id": "cody.fixup.conflictBackground",
+        "description": "The background of text Cody will edit where there is a specific conflict with your changes.",
+        "defaults": {
+          "light": "mergeEditor.conflictingLines.background",
+          "dark": "mergeEditor.conflictingLines.background"
+        }
+      },
+      {
+        "id": "cody.fixup.conflictBorder",
+        "description": "The border of text Cody will edit, if there is a conflict with your changes.",
+        "defaults": {
+          "light": "mergeEditor.conflict.unhandledFocused.border",
+          "dark": "mergeEditor.conflict.unhandledFocused.border"
+        }
+      },
+      {
+        "id": "cody.fixup.conflictedBackground",
+        "description": "The background of text Cody will edit, if there is a conflict with your changes.",
+        "defaults": {
+          "light": "#ffffff00",
+          "dark": "#00000000"
+        }
+      },
+      {
+        "id": "cody.fixup.conflictedBorder",
+        "description": "The border of text Cody will edit, if there is a conflict with your changes.",
+        "defaults": {
+          "light": "mergeEditor.conflict.unhandledUnfocused.border",
+          "dark": "mergeEditor.conflict.unhandledUnfocused.border"
+        }
+      },
+      {
+        "id": "cody.fixup.incomingBackground",
+        "description": "The background of text Cody will edit.",
+        "defaults": {
+          "light": "merge.incomingContentBackground",
+          "dark": "merge.incomingContentBackground"
+        }
+      },
+      {
+        "id": "cody.fixup.incomingBorder",
+        "description": "The border around text Cody will edit.",
+        "defaults": {
+          "light": "#436EB1",
+          "dark": "#436EB1"
+        }
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/client/cody/src/non-stop/FixupDecorator.ts
+++ b/client/cody/src/non-stop/FixupDecorator.ts
@@ -5,37 +5,33 @@ import { Diff } from './diff'
 export class FixupDecorator implements vscode.Disposable {
     private decorationCodyConflictMarker_: vscode.TextEditorDecorationType
     private decorationCodyConflicted_: vscode.TextEditorDecorationType
-    private decorationCodyEdited_: vscode.TextEditorDecorationType
+    private decorationCodyIncoming_: vscode.TextEditorDecorationType
 
     constructor() {
-        // TODO: Switch colors depending on the theme
         this.decorationCodyConflictMarker_ = vscode.window.createTextEditorDecorationType({
-            borderColor: 'orange',
+            backgroundColor: new vscode.ThemeColor('cody.fixup.conflictBackground'),
+            borderColor: new vscode.ThemeColor('cody.fixup.conflictBorder'),
             borderStyle: 'solid',
             borderWidth: '1px',
-            backgroundColor: 'lightorange',
-            before: {
-                contentText: '\u{1F4A5}',
-            },
         })
         this.decorationCodyConflicted_ = vscode.window.createTextEditorDecorationType({
-            borderColor: '#FBBF77',
-            backgroundColor: '#F17829',
+            backgroundColor: new vscode.ThemeColor('cody.fixup.conflictedBackground'),
+            borderColor: new vscode.ThemeColor('cody.fixup.conflictedBorder'),
             borderStyle: 'solid',
             borderWidth: '1px',
         })
-        this.decorationCodyEdited_ = vscode.window.createTextEditorDecorationType({
-            borderColor: '#9CDCFE',
+        this.decorationCodyIncoming_ = vscode.window.createTextEditorDecorationType({
+            backgroundColor: new vscode.ThemeColor('cody.fixup.incomingBackground'),
+            borderColor: new vscode.ThemeColor('cody.fixup.incomingBorder'),
             borderStyle: 'solid',
             borderWidth: '1px',
-            backgroundColor: '#569CD6',
         })
     }
 
     public dispose(): void {
         this.decorationCodyConflictMarker_.dispose()
         this.decorationCodyConflicted_.dispose()
-        this.decorationCodyEdited_.dispose()
+        this.decorationCodyIncoming_.dispose()
     }
 
     public decorate(editor: vscode.TextEditor, diff: Diff): void {
@@ -44,10 +40,10 @@ export class FixupDecorator implements vscode.Disposable {
             editor.setDecorations(this.decorationCodyConflicted_, [])
             editor.setDecorations(this.decorationCodyConflictMarker_, [])
         } else {
-            editor.setDecorations(this.decorationCodyEdited_, [])
+            editor.setDecorations(this.decorationCodyIncoming_, [])
         }
         editor.setDecorations(
-            diff.clean ? this.decorationCodyEdited_ : this.decorationCodyConflicted_,
+            diff.clean ? this.decorationCodyIncoming_ : this.decorationCodyConflicted_,
             diff.edits.map(
                 edit =>
                     new vscode.Range(

--- a/client/cody/src/non-stop/diff.ts
+++ b/client/cody/src/non-stop/diff.ts
@@ -282,7 +282,7 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
             mergedPos = updatedPosition(mergedPos, chunk[2])
         } else {
             // Conflict! chunk[0]/chunk[2]`
-            conflicts.push({ start: originalPos, end: originalPos })
+            conflicts.push({ start: originalPos, end: originalEnd })
             clean = false
             // We give up on tracking positions.
         }


### PR DESCRIPTION
## Test plan

Enter the following in a file called `main.rs`:

```
fn main() {
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
    println!("Hello, world!");
}
```

Select all, Cody: Fixup (Experimental), "reduce duplication by adding a for loop". Highlights should appear.

Resize the window so you will be able to see the command palette and the highlighted text.

Preferences: Color Theme and use the arrow keys to skim through the various themes, check the highlights make sense.

Edit some of the highlighted text to create a conflict. The highlighting should change; again skim through the themes to check they look OK.

Preferences: Open User Settings (JSON) and save a color customization:

```
  "workbench.colorCustomizations": {
    "cody.fixup.conflictBorder": "#00ff00"
  }
```

While entering this text you can verify that various cody.fixup colors autocomplete. Regenerate the highlights to see the change in effect.

Caveat: Highlights are not re-applied as editors gain focus, just edit the file to trigger decoration re-application.