### PR TITLE
ci: fix wrong step dep for backend integ tests

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -404,7 +404,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// Temporary: on main branches, we build images with bazel binaries based on their toolchain and/or purpose. This step key is the first image in the array.
 		// This will be removed once we build images with wolfi.
 		ops.Merge(operations.NewNamedSet("Integration tests",
-			backendIntegrationTests(c.candidateImageTag(), "symbols"),
+			backendIntegrationTests(c.candidateImageTag(), "server"),
 			codeIntelQA(c.candidateImageTag()),
 		))
 		// End-to-end tests


### PR DESCRIPTION
Missed a key in the previous PR. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

`sg ci preview` 

before: 
```
       - :bazel: BackCompat Tests → _depends on bazel-configure_
                - :bazel::docker: :chains: Backend integration tests (gRPC) → _depends on symbols:candidate_
                - :bazel::docker: :chains: Backend integration tests → _depends on symbols:candidate_
```

after: 
```
        - :bazel: BackCompat Tests → _depends on bazel-configure_
                - :bazel::docker: :chains: Backend integration tests (gRPC) → _depends on server:candidate_
                - :bazel::docker: :chains: Backend integration tests → _depends on server:candidate_
```