### PR TITLE
cody: add buttton to cancel embedding Job

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react'
 
+import { mdiCancel } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
@@ -15,15 +16,20 @@ import {
     Link,
     H4,
     Alert,
+    Tooltip,
+    Icon,
 } from '@sourcegraph/wildcard'
 
 import { RepoEmbeddingJobFields, RepoEmbeddingJobState } from '../../../graphql-operations'
 
 import styles from './RepoEmbeddingJobNode.module.scss'
 
-interface RepoEmbeddingJobNodeProps extends RepoEmbeddingJobFields {}
+interface RepoEmbeddingJobNodeProps extends RepoEmbeddingJobFields {
+    onCancel: (id: string) => void
+}
 
 export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
+    id,
     state,
     repo,
     revision,
@@ -31,29 +37,42 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
     queuedAt,
     startedAt,
     failureMessage,
+    onCancel: onCancel,
 }) => (
     <li className="list-group-item p-2">
-        <div className="d-flex align-items-center">
-            <div className={styles.badgeWrapper}>
-                <RepoEmbeddingJobStateBadge state={state} />
-            </div>
-            <div className="d-flex flex-column ml-3">
-                {repo && revision ? (
-                    <Link to={`${repo.url}@${revision.oid}`}>
-                        {repo.name}@{revision.abbreviatedOID}
-                    </Link>
-                ) : (
-                    <div>Unknown repository</div>
-                )}
-                <div className="mt-1">
-                    <RepoEmbeddingJobExecutionInfo
-                        state={state}
-                        finishedAt={finishedAt}
-                        queuedAt={queuedAt}
-                        startedAt={startedAt}
-                        failureMessage={failureMessage}
-                    />
+        <div className="d-flex justify-content-between">
+            <div className="d-flex align-items-center">
+                <div className={styles.badgeWrapper}>
+                    <RepoEmbeddingJobStateBadge state={state} />
                 </div>
+                <div className="d-flex flex-column ml-3">
+                    {repo && revision ? (
+                        <Link to={`${repo.url}@${revision.oid}`}>
+                            {repo.name}@{revision.abbreviatedOID}
+                        </Link>
+                    ) : (
+                        <div>Unknown repository</div>
+                    )}
+                    <div className="mt-1">
+                        <RepoEmbeddingJobExecutionInfo
+                            state={state}
+                            finishedAt={finishedAt}
+                            queuedAt={queuedAt}
+                            startedAt={startedAt}
+                            failureMessage={failureMessage}
+                        />
+                    </div>
+                </div>
+            </div>
+            <div className="d-flex align-items-center">
+                {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
+                    <Tooltip content="Cancel repository embedding job">
+                        <Button aria-label="Cancel" onClick={() => onCancel(id)} variant="secondary" size="sm">
+                            <Icon aria-hidden={true} svgPath={mdiCancel} />
+                            {' Cancel'}
+                        </Button>
+                    </Tooltip>
+                ) : null}
             </div>
         </div>
     </li>

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -31,6 +31,7 @@ interface RepoEmbeddingJobNodeProps extends RepoEmbeddingJobFields {
 export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
     id,
     state,
+    cancel,
     repo,
     revision,
     finishedAt,
@@ -56,6 +57,7 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
                     <div className="mt-1">
                         <RepoEmbeddingJobExecutionInfo
                             state={state}
+                            cancel={cancel}
                             finishedAt={finishedAt}
                             queuedAt={queuedAt}
                             startedAt={startedAt}
@@ -79,8 +81,8 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
 )
 
 const RepoEmbeddingJobExecutionInfo: FC<
-    Pick<RepoEmbeddingJobFields, 'state' | 'finishedAt' | 'failureMessage' | 'queuedAt' | 'startedAt'>
-> = ({ state, finishedAt, queuedAt, startedAt, failureMessage }) => {
+    Pick<RepoEmbeddingJobFields, 'state' | 'cancel' | 'finishedAt' | 'failureMessage' | 'queuedAt' | 'startedAt'>
+> = ({ state, cancel, finishedAt, queuedAt, startedAt, failureMessage }) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false)
     return (
         <>
@@ -92,12 +94,24 @@ const RepoEmbeddingJobExecutionInfo: FC<
             {state === RepoEmbeddingJobState.CANCELED && <small>Embedding was canceled.</small>}
             {state === RepoEmbeddingJobState.QUEUED && (
                 <small>
-                    Embedding was queued <Timestamp date={queuedAt} />.
+                    {cancel ? (
+                        'Cancelling ...'
+                    ) : (
+                        <>
+                            Embedding was queued <Timestamp date={queuedAt} />.
+                        </>
+                    )}
                 </small>
             )}
             {state === RepoEmbeddingJobState.PROCESSING && startedAt && (
                 <small>
-                    Embedding started processing <Timestamp date={startedAt} />.
+                    {cancel ? (
+                        'Cancelling ...'
+                    ) : (
+                        <>
+                            Embedding started processing <Timestamp date={startedAt} />.
+                        </>
+                    )}
                 </small>
             )}
             {(state === RepoEmbeddingJobState.ERRORED || state === RepoEmbeddingJobState.FAILED) && failureMessage && (

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -37,7 +37,7 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
     queuedAt,
     startedAt,
     failureMessage,
-    onCancel: onCancel,
+    onCancel,
 }) => (
     <li className="list-group-item p-2">
         <div className="d-flex justify-content-between">

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -69,7 +69,13 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
             <div className="d-flex align-items-center">
                 {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
                     <Tooltip content="Cancel repository embedding job">
-                        <Button aria-label="Cancel" onClick={() => onCancel(id)} variant="secondary" size="sm">
+                        <Button
+                            aria-label="Cancel"
+                            onClick={() => onCancel(id)}
+                            variant="secondary"
+                            size="sm"
+                            disabled={cancel}
+                        >
                             <Icon aria-hidden={true} svgPath={mdiCancel} />
                             {' Cancel'}
                         </Button>

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from 'react'
 
-import { mdiCancel } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
@@ -17,7 +16,6 @@ import {
     H4,
     Alert,
     Tooltip,
-    Icon,
 } from '@sourcegraph/wildcard'
 
 import { RepoEmbeddingJobFields, RepoEmbeddingJobState } from '../../../graphql-operations'
@@ -76,8 +74,7 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
                             size="sm"
                             disabled={cancel}
                         >
-                            <Icon aria-hidden={true} svgPath={mdiCancel} />
-                            {' Cancel'}
+                            Cancel
                         </Button>
                     </Tooltip>
                 ) : null}

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -28,6 +28,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { RepositoriesField } from '../../insights/components'
 
 import {
+    useCancelRepoEmbeddingJob,
     useRepoEmbeddingJobsConnection,
     useScheduleContextDetectionEmbeddingJob,
     useScheduleRepoEmbeddingJobs,
@@ -89,6 +90,16 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         validators: { sync: repositoriesValidator },
     })
 
+    const [cancelRepoEmbeddingJob, { error: cancelRepoEmbeddingJobError }] = useCancelRepoEmbeddingJob()
+
+    const onCancel = useCallback(
+        async (id: string) => {
+            await cancelRepoEmbeddingJob({ variables: { id } })
+            refetchAll()
+        },
+        [cancelRepoEmbeddingJob, refetchAll]
+    )
+
     return (
         <>
             <PageTitle title="Cody" />
@@ -121,11 +132,15 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                         </div>
                     </div>
                 </Form>
-                {(repoEmbeddingJobsError || contextDetectionEmbeddingJobError) && (
+                {(repoEmbeddingJobsError || contextDetectionEmbeddingJobError || cancelRepoEmbeddingJobError) && (
                     <div className="mt-1">
                         <ErrorAlert
                             prefix="Error scheduling embedding jobs"
-                            error={repoEmbeddingJobsError || contextDetectionEmbeddingJobError}
+                            error={
+                                repoEmbeddingJobsError ||
+                                contextDetectionEmbeddingJobError ||
+                                cancelRepoEmbeddingJobError
+                            }
                         />
                     </div>
                 )}
@@ -135,7 +150,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                     {loading && !connection && <ConnectionLoading />}
                     <ConnectionList as="ul" className="list-group" aria-label="Repository embedding jobs">
                         {connection?.nodes?.map(node => (
-                            <RepoEmbeddingJobNode key={node.id} {...node} />
+                            <RepoEmbeddingJobNode key={node.id} {...node} onCancel={onCancel} />
                         ))}
                     </ConnectionList>
                     {connection && (

--- a/client/web/src/enterprise/site-admin/cody/backend.ts
+++ b/client/web/src/enterprise/site-admin/cody/backend.ts
@@ -7,6 +7,8 @@ import {
     UseShowMorePaginationResult,
 } from '../../../components/FilteredConnection/hooks/useShowMorePagination'
 import {
+    CancelRepoEmbeddingJobResult,
+    CancelRepoEmbeddingJobVariables,
     RepoEmbeddingJobFields,
     RepoEmbeddingJobsListResult,
     RepoEmbeddingJobsListVariables,
@@ -100,4 +102,19 @@ export function useScheduleContextDetectionEmbeddingJob(): MutationTuple<
     return useMutation<ScheduleContextDetectionEmbeddingJobResult, ScheduleContextDetectionEmbeddingJobVariables>(
         SCHEDULE_CONTEXT_DETECTION_EMBEDDING_JOB
     )
+}
+
+export const CANCEL_REPO_EMBEDDING_JOB = gql`
+    mutation CancelRepoEmbeddingJob($id: ID!) {
+        cancelRepoEmbeddingJob(job: $id) {
+            alwaysNil
+        }
+    }
+`
+
+export function useCancelRepoEmbeddingJob(): MutationTuple<
+    CancelRepoEmbeddingJobResult,
+    CancelRepoEmbeddingJobVariables
+> {
+    return useMutation<CancelRepoEmbeddingJobResult, CancelRepoEmbeddingJobVariables>(CANCEL_REPO_EMBEDDING_JOB)
 }

--- a/client/web/src/enterprise/site-admin/cody/backend.ts
+++ b/client/web/src/enterprise/site-admin/cody/backend.ts
@@ -26,6 +26,7 @@ const REPO_EMBEDDING_JOB_FRAGMENT = gql`
         finishedAt
         queuedAt
         startedAt
+        cancel
         repo {
             name
             url


### PR DESCRIPTION
This adds a button to cancel an embedding job that is in the state "queued" or "processing". This is a must-have for long running embedding jobs of large repos. 

We already have a GraphQL endpoint we can target for this.

EDIT: In the meantime I have removed the icon on the Cancel button based on a review comment. I haven't updated the screenshots though.

Cancel button visible for jobs in status "processing" or "queued" 
![Processing-not_yet_canceled](https://github.com/sourcegraph/sourcegraph/assets/26413131/5a139f6e-f459-48af-80fd-2f27a9176f59)

There is a lag between marking a job for cancellation and the job actually stopping. In the meantime we indicate that the we are in the process of cancelling the job ("Cancelling ...") and the cancel button is disabled.
![cancel_button_disabled](https://github.com/sourcegraph/sourcegraph/assets/26413131/b42feb08-1d4d-4626-befd-9e1ce1c97ed1)

Canceled
![canceled](https://github.com/sourcegraph/sourcegraph/assets/26413131/29c28f1c-bd8d-4b30-8106-7c269d95a508)

## Test plan
- `sg start embeddings`
- Schedule a longer running embedding job
- cancel job while in status "queued" or "processsing"
- Check the db that the column "cancel" is set to `TRUE`
