### PR TITLE
release: add in missing continue when content generator is missing

### DIFF
--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -253,6 +253,7 @@ export const updateUpgradeGuides = (previous: string, next: string): EditFunc =>
             const updateFunc = getUpgradeGuide(mode)
             if (updateFunc === undefined) {
                 console.log(`Skipping upgrade file: ${file} due to missing content generator`)
+                continue
             }
             const guide = getUpgradeGuide(mode)(previous, next)
 


### PR DESCRIPTION
Came across this while releasing 5.0.5.

Test Plan: Can't remember the command I ran for this, but this was the patch I used to unblock me during release.