### PR TITLE
doc: helm migrator example consistent with to version

### DIFF
--- a/doc/admin/deploy/kubernetes/helm.md
+++ b/doc/admin/deploy/kubernetes/helm.md
@@ -1022,7 +1022,7 @@ When all pods have restarted and show as Running, you can browse to your Sourceg
 
     **Example:**
     ```bash
-    λ helm upgrade --install -n sourcegraph --set "migrator.args={upgrade,--from=3.41.0,--to=4.5.1}" sourcegraph-migrator sourcegraph/sourcegraph-migrator --version 5.0.5
+    λ helm upgrade --install -n sourcegraph --set "migrator.args={upgrade,--from=3.41.0,--to=4.5.1}" sourcegraph-migrator sourcegraph/sourcegraph-migrator --version 4.5.1
     Release "sourcegraph-migrator" has been upgraded. Happy Helming!
     NAME: sourcegraph-migrator
     LAST DEPLOYED: Tue Mar  7 18:23:56 2023


### PR DESCRIPTION
I updated the string here in releasing 5.0.5 but I think that was incorrect based on the args, example output and commit history. This reverts it back to its original text. I think in future releases it won't get automatically updated now.

Test Plan: n/a

Follow-up from https://github.com/sourcegraph/sourcegraph/pull/52767#discussion_r1213139729