### PR TITLE
release: prepare 5.0.6

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -17,8 +17,8 @@
         "2023-09-20T10:00:00.000-07:00"
       ],
       "current": "5.1.0",
-      "captainGitHubUsername": "coury-clark",
-      "captainSlackUsername": "coury"
+      "captainGitHubUsername": "unknwon",
+      "captainSlackUsername": "joe"
     },
     "5.0.6": {
       "codeFreezeDate": "2023-06-07T10:00:00.000-07:00",

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -19,6 +19,14 @@
       "current": "5.1.0",
       "captainGitHubUsername": "coury-clark",
       "captainSlackUsername": "coury"
+    },
+    "5.0.6": {
+      "codeFreezeDate": "2023-06-07T10:00:00.000-07:00",
+      "securityApprovalDate": "2023-06-07T10:00:00.000-07:00",
+      "releaseDate": "2023-06-14T10:00:00.000-07:00",
+      "current": "5.0.6",
+      "captainGitHubUsername": "camdencheek",
+      "captainSlackUsername": "camden"
     }
   },
   "dryRun": {


### PR DESCRIPTION
According to the calendar Joe and Camden are up next. I am just guessing that Joe is taking the minor release and Camden is doing the patch.

Generated from "pnpm run release release:prepare".

Test Plan: n/a