### PR TITLE
JetBrains: recover from missing Sourcegraph `ACCESS_TOKEN` with a notification

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -17,9 +17,11 @@ import com.sourcegraph.cody.api.CompletionsService;
 import com.sourcegraph.cody.completions.prompt_library.*;
 import com.sourcegraph.cody.vscode.*;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.NotificationActivity;
 import com.sourcegraph.config.SettingsComponent;
 import java.util.Optional;
 import java.util.concurrent.*;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 /** Responsible for triggering and clearing inline code completions. */
@@ -180,8 +182,10 @@ public class CodyCompletionsManager {
     if (accessToken == null) {
       accessToken = System.getenv("SRC_ACCESS_TOKEN");
     }
-    if (accessToken == null) {
-      throw new IllegalArgumentException("ACCESS_TOKEN is null");
+    if (StringUtils.isEmpty(accessToken)) {
+      if (!ConfigUtil.isAccessTokenNotificationDismissed())
+        NotificationActivity.notifyAboutSourcegraphAccessToken(Optional.of(instanceUrl));
+      return null;
     }
     return new CompletionsService(instanceUrl, accessToken);
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -202,8 +202,16 @@ public class ConfigUtil {
     return getApplicationLevelConfig().isUrlNotificationDismissed();
   }
 
+  public static boolean isAccessTokenNotificationDismissed() {
+    return getApplicationLevelConfig().isAccessTokenNotificationDismissed();
+  }
+
   public static void setUrlNotificationDismissed(boolean value) {
     getApplicationLevelConfig().isUrlNotificationDismissed = value;
+  }
+
+  public static void setAccessTokenNotificationDismissed(boolean value) {
+    getApplicationLevelConfig().isAccessTokenNotificationDismissed = value;
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -22,6 +22,7 @@ public class SourcegraphApplicationService
   @Nullable public String anonymousUserId;
   public boolean isInstallEventLogged;
   public boolean isUrlNotificationDismissed;
+  public boolean isAccessTokenNotificationDismissed;
   @Nullable public Boolean authenticationFailedLastTime;
 
   @Nullable
@@ -104,6 +105,10 @@ public class SourcegraphApplicationService
     return isUrlNotificationDismissed;
   }
 
+  public boolean isAccessTokenNotificationDismissed() {
+    return isAccessTokenNotificationDismissed;
+  }
+
   @Nullable
   public Boolean getAuthenticationFailedLastTime() {
     return authenticationFailedLastTime;
@@ -129,6 +134,7 @@ public class SourcegraphApplicationService
     this.remoteUrlReplacements = settings.remoteUrlReplacements;
     this.anonymousUserId = settings.anonymousUserId;
     this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
+    this.isAccessTokenNotificationDismissed = settings.isAccessTokenNotificationDismissed;
     this.authenticationFailedLastTime = settings.authenticationFailedLastTime;
     this.lastUpdateNotificationPluginVersion = settings.lastUpdateNotificationPluginVersion;
   }


### PR DESCRIPTION
Fixes #52770 

<img width="387" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/18601388/cb7f98eb-d49a-42f2-918c-727170a91086">

## Test plan
- having a non-configured or empty Sourcegraph access token should produce a balloon notification instead of an exception
- the `Set Access Token` action on the notification should take the user to the plugin settings
- the `Never Show Again` action should prevent the notification from re-appearing
