### PR TITLE
App: skip creation of scip-ctags parser pool

### DIFF
--- a/cmd/symbols/internal/api/handler_test.go
+++ b/cmd/symbols/internal/api/handler_test.go
@@ -56,7 +56,7 @@ func TestHandler(t *testing.T) {
 		}
 		return newMockParser(pathToEntries), nil
 	}
-	parserPool, err := parser.NewParserPool(parserFactory, 15)
+	parserPool, err := parser.NewParserPool(parserFactory, 15, parser.DefaultParserTypes)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -295,7 +295,7 @@ func SpawnCtags(logger log.Logger, ctagsConfig types.CtagsConfig, source ctags_c
 
 	parser, err := ctags.New(options)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create new ctags parser")
+		return nil, errors.Wrapf(err, "failed to create new ctags parser %q using bin path %q ", ctags_config.ParserTypeToName(source), options.Bin)
 	}
 
 	return NewFilteringParser(parser, ctagsConfig.MaxFileSize, ctagsConfig.MaxSymbols), nil

--- a/cmd/symbols/parser/parser_pool.go
+++ b/cmd/symbols/parser/parser_pool.go
@@ -18,7 +18,7 @@ type parserPool struct {
 
 var DefaultParserTypes = []ctags_config.ParserType{ctags_config.UniversalCtags, ctags_config.ScipCtags}
 
-func NewParserPool(newParser ParserFactory, numParserProcesses int, parserTypes ...ctags_config.ParserType) (*parserPool, error) {
+func NewParserPool(newParser ParserFactory, numParserProcesses int, parserTypes []ctags_config.ParserType) (*parserPool, error) {
 	pool := make(map[ctags_config.ParserType]chan ctags.Parser)
 
 	if len(parserTypes) == 0 {

--- a/cmd/symbols/parser/parser_pool.go
+++ b/cmd/symbols/parser/parser_pool.go
@@ -16,11 +16,17 @@ type parserPool struct {
 	pool      map[ctags_config.ParserType]chan ctags.Parser
 }
 
-func NewParserPool(newParser ParserFactory, numParserProcesses int) (*parserPool, error) {
+var DefaultParserTypes = []ctags_config.ParserType{ctags_config.UniversalCtags, ctags_config.ScipCtags}
+
+func NewParserPool(newParser ParserFactory, numParserProcesses int, parserTypes ...ctags_config.ParserType) (*parserPool, error) {
 	pool := make(map[ctags_config.ParserType]chan ctags.Parser)
 
+	if len(parserTypes) == 0 {
+		parserTypes = DefaultParserTypes
+	}
+
 	// NOTE: We obviously don't make `NoCtags` available in the pool.
-	for _, parserType := range []ctags_config.ParserType{ctags_config.UniversalCtags, ctags_config.ScipCtags} {
+	for _, parserType := range parserTypes {
 		pool[parserType] = make(chan ctags.Parser, numParserProcesses)
 		for i := 0; i < numParserProcesses; i++ {
 			parser, err := newParser(parserType)

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -58,7 +58,8 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	parserFactory := func(source ctags_config.ParserType) (ctags.Parser, error) {
 		return symbolparser.SpawnCtags(logger, config.Ctags, source)
 	}
-	parserPool, err := symbolparser.NewParserPool(parserFactory, config.NumCtagsProcesses)
+
+	parserPool, err := symbolparser.NewParserPool(parserFactory, config.NumCtagsProcesses, parserTypesForDeployment()...)
 	if err != nil {
 		logger.Fatal("failed to create parser pool", log.Error(err))
 	}
@@ -78,4 +79,14 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	cacheEvicter := janitor.NewCacheEvicter(evictionInterval, cache, cacheSizeBytes, janitor.NewMetrics(observationCtx))
 
 	return searchFunc, nil, []goroutine.BackgroundRoutine{cacheEvicter}, config.Ctags.UniversalCommand, nil
+}
+
+func parserTypesForDeployment() []ctags_config.ParserType {
+	if deploy.IsSingleBinary() {
+		// ScipCtags is not available
+		// TODO(burmudar): make it available
+		return []ctags_config.ParserType{ctags_config.UniversalCtags}
+	}
+
+	return symbolparser.DefaultParserTypes
 }

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -59,7 +59,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 		return symbolparser.SpawnCtags(logger, config.Ctags, source)
 	}
 
-	parserPool, err := symbolparser.NewParserPool(parserFactory, config.NumCtagsProcesses, parserTypesForDeployment()...)
+	parserPool, err := symbolparser.NewParserPool(parserFactory, config.NumCtagsProcesses, parserTypesForDeployment())
 	if err != nil {
 		logger.Fatal("failed to create parser pool", log.Error(err))
 	}

--- a/internal/ctags_config/ctags_config.go
+++ b/internal/ctags_config/ctags_config.go
@@ -11,6 +11,19 @@ const (
 	ScipCtags
 )
 
+func ParserTypeToName(pType ParserType) string {
+	switch pType {
+	case NoCtags:
+		return "off"
+	case UniversalCtags:
+		return "universal-ctags"
+	case ScipCtags:
+		return "scip-ctags"
+	default:
+		return "unknown-ctags-type"
+	}
+}
+
 func ParserNameToParserType(name string) (ParserType, error) {
 	switch name {
 	case "off":


### PR DESCRIPTION
We had a slight regression on app we would get the following failure
```
1685704884811209000     FATAL   symbols.sqlite.setup    shared/sqlite.go:68     github.com/sourcegraph/sourcegraph/cmd/symbols/shared.SetupSqlite       failed to create parser pool    {"Resource": {"service.name": "sourcegraph-backend-x86_64-apple-darwin", "service.version": "2023.0.0+dev", "service.instance.id": "Williams-MacBook-Pro"}, "Attributes": {"error": "failed to create new ctags parser: exec: \"universal-ctags\": executable file not found in $PATH"}}
```
The actual failure isn't that `universal-ctags` isn't available, it's because `scip-ctags` isn't available and with an empty bin, `go-ctags` uses `universal-ctags` expecting it to be on the path.

Short term:
1. On App, we only register the `universal-ctags` parser pool
2. Everything else uses `universal-ctags` and `scip-ctags`

Longer term:
1. Bundle `scip-ctags` with app, but that requires cross compiling it for 3 platforms.

I also cleaned up the error message to make it more obvious what is wrong
```
1685707730734676000     FATAL   symbols.sqlite.setup    shared/sqlite.go:64     github.com/sourcegraph/sourcegraph/cmd/symbols/shared.SetupSqlite       failed to create parser pool    {"Resource": {"service.name": "sourcegraph-backend-x86_64-apple-darwin", "service.version": "2023.0.0+dev", "service.instance.id": "Williams-MacBook-Pro"}, "Attributes": {"error": "failed to create new ctags parser \"scip-ctags\" using bin path \"\" : exec: \"universal-ctags\": executable file not found in $PATH"}}
```

## Test plan
1. Compile for Intel Mac `PLATFORM=x86_64-apple-darwin CROSS_COMPILE_X86_64_MACOS=1 ./enterprise/dev/app/build-backend.sh && .bin/sourcegraph-backend-x86_64-apple-darwin`
2. Check that the backend starts up and doesn't crash with the above error
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
