### PR TITLE
Cody: Show multiple non-stop Cody highlights in multiple editors

### DIFF
--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -42,10 +42,10 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         this._disposables.push(vscode.commands.registerCommand('cody.fixup.diff', treeItem => this.showDiff(treeItem)))
         // Observe file renaming and deletion
         this.files = new FixupFileObserver()
-        this._disposables.push(vscode.workspace.onDidRenameFiles(this.files.didRenameFiles, this.files))
-        this._disposables.push(vscode.workspace.onDidDeleteFiles(this.files.didDeleteFiles, this.files))
+        this._disposables.push(vscode.workspace.onDidRenameFiles(this.files.didRenameFiles.bind(this.files)))
+        this._disposables.push(vscode.workspace.onDidDeleteFiles(this.files.didDeleteFiles.bind(this.files)))
         // Observe editor focus
-        this._disposables.push(vscode.window.onDidChangeVisibleTextEditors(this.didChangeVisibleTextEditors, this))
+        this._disposables.push(vscode.window.onDidChangeVisibleTextEditors(this.didChangeVisibleTextEditors.bind(this)))
         // Start the fixup tree view provider
         this.taskViewProvider = new TaskViewProvider()
         // Observe file edits

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -42,8 +42,10 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         this._disposables.push(vscode.commands.registerCommand('cody.fixup.diff', treeItem => this.showDiff(treeItem)))
         // Observe file renaming and deletion
         this.files = new FixupFileObserver()
-        this._disposables.push(vscode.workspace.onDidRenameFiles(this.files.didRenameFiles.bind(this.files)))
-        this._disposables.push(vscode.workspace.onDidDeleteFiles(this.files.didDeleteFiles.bind(this.files)))
+        this._disposables.push(vscode.workspace.onDidRenameFiles(this.files.didRenameFiles, this.files))
+        this._disposables.push(vscode.workspace.onDidDeleteFiles(this.files.didDeleteFiles, this.files))
+        // Observe editor focus
+        this._disposables.push(vscode.window.onDidChangeVisibleTextEditors(this.didChangeVisibleTextEditors, this))
         // Start the fixup tree view provider
         this.taskViewProvider = new TaskViewProvider()
         // Observe file edits
@@ -252,10 +254,41 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
     // changed and we need to update diffs.
     private needsDiffUpdate_: Set<FixupTask> = new Set()
 
-    // TODO: Hook up onDidChangeVisibleTextEditors to apply decorations to
-    // editors as they become visible
+    // Files where the editor wasn't visible and we have delayed computing diffs
+    // for tasks.
+    private needsEditor_: Set<FixupFile> = new Set()
 
-    // TODO: Move the core of this method to a separate component
+    private didChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]): void {
+        const editorsByFile = new Map<FixupFile, vscode.TextEditor[]>()
+        for (const editor of editors) {
+            const file = this.files.maybeForUri(editor.document.uri)
+            if (!file) {
+                continue
+            }
+            // Group editors by file so the decorator can apply decorations
+            // in one shot.
+            if (!editorsByFile.has(file)) {
+                editorsByFile.set(file, [])
+            }
+            editorsByFile.get(file)?.push(editor)
+            // If we were waiting for an editor to get text to diff against,
+            // start that process now.
+            if (this.needsEditor_.has(file)) {
+                this.needsEditor_.delete(file)
+                for (const task of this.tasksForFile(file)) {
+                    if (this.needsDiffUpdate_.size === 0) {
+                        void this.scheduler.scheduleIdle(() => this.updateDiffs())
+                    }
+                    this.needsDiffUpdate_.add(task)
+                }
+            }
+        }
+        // Apply any decorations we have to the visible editors.
+        for (const [file, editors] of editorsByFile.entries()) {
+            this.decorator.didChangeVisibleTextEditors(file, editors)
+        }
+    }
+
     private updateDiffs(): void {
         const deadlineMsec = Date.now() + 500
 
@@ -264,6 +297,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
             this.needsDiffUpdate_.delete(task)
             const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === task.fixupFile.uri)
             if (!editor) {
+                this.needsEditor_.add(task.fixupFile)
                 continue
             }
             // TODO: When Cody doesn't suggest any output something has gone
@@ -279,16 +313,28 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
             // Switch to using a gross line-based range and updating it in the
             // FixupDocumentEditObserver.
             const diff = computeDiff(task.original, botText, bufferText, task.selectionRange.start)
-            // TODO: Cache the source text and diff edits for application
-            console.log(botText)
-            // TODO: Cache the diff output on the fixup so it can be applied;
-            // have the decorator reapply decorations to visible editors
-            this.decorator.decorate(editor, diff)
-            if (!diff.clean) {
-                // TODO: If this isn't an in-progress diff, then schedule
-                // a re-spin or notify failure
-                continue
-            }
+            task.diff = diff
+            this.didUpdateDiff(task)
+        }
+
+        if (this.needsDiffUpdate_.size) {
+            // We did not get through the work; schedule more later.
+            void this.scheduler.scheduleIdle(() => this.updateDiffs())
+        }
+    }
+
+    private didUpdateDiff(task: FixupTask): void {
+        if (!task.diff) {
+            // Once we have a diff, we never go back to not having a diff.
+            // If adding that transition, you must un-apply old highlights for
+            // this task.
+            throw new Error('unreachable')
+        }
+        this.decorator.didUpdateDiff(task)
+        if (!task.diff.clean) {
+            // TODO: If this isn't an in-progress diff, then schedule
+            // a re-spin or notify failure
+            return
         }
     }
 }

--- a/client/cody/src/non-stop/FixupDecorator.ts
+++ b/client/cody/src/non-stop/FixupDecorator.ts
@@ -1,11 +1,45 @@
 import * as vscode from 'vscode'
 
 import { Diff } from './diff'
+import { FixupFile } from './FixupFile'
+import { FixupTask } from './FixupTask'
 
+type TaskDecorations = {
+    edits: vscode.Range[]
+    conflicts: vscode.Range[]
+}
+
+function makeDecorations(diff: Diff | undefined): TaskDecorations {
+    if (!diff) {
+        return {
+            edits: [],
+            conflicts: [],
+        }
+    }
+    return {
+        edits: diff.edits.map(
+            edit =>
+                new vscode.Range(
+                    new vscode.Position(edit.range.start.line, edit.range.start.character),
+                    new vscode.Position(edit.range.end.line, edit.range.end.character)
+                )
+        ),
+        conflicts: diff.conflicts.map(
+            conflict =>
+                new vscode.Range(
+                    new vscode.Position(conflict.start.line, conflict.start.character),
+                    new vscode.Position(conflict.end.line, conflict.end.character)
+                )
+        ),
+    }
+}
+
+// TODO: Consider constraining decorations to visible ranges.
 export class FixupDecorator implements vscode.Disposable {
     private decorationCodyConflictMarker_: vscode.TextEditorDecorationType
     private decorationCodyConflicted_: vscode.TextEditorDecorationType
     private decorationCodyIncoming_: vscode.TextEditorDecorationType
+    private decorations_: Map<FixupFile, Map<FixupTask, TaskDecorations>> = new Map()
 
     constructor() {
         this.decorationCodyConflictMarker_ = vscode.window.createTextEditorDecorationType({
@@ -34,33 +68,65 @@ export class FixupDecorator implements vscode.Disposable {
         this.decorationCodyIncoming_.dispose()
     }
 
-    public decorate(editor: vscode.TextEditor, diff: Diff): void {
-        // TODO: Multiple fixups per file, multiple files
-        if (diff.clean) {
-            editor.setDecorations(this.decorationCodyConflicted_, [])
-            editor.setDecorations(this.decorationCodyConflictMarker_, [])
-        } else {
-            editor.setDecorations(this.decorationCodyIncoming_, [])
+    public didChangeVisibleTextEditors(file: FixupFile, editors: vscode.TextEditor[]): void {
+        this.applyDecorations(editors, this.decorations_.get(file)?.values() || [].values())
+    }
+
+    public didUpdateDiff(task: FixupTask): void {
+        this.updateTaskDecorations(task, task.diff)
+    }
+
+    // TODO: Call this so we can delete old decorations some time.
+    public didCompleteTask(task: FixupTask): void {
+        this.updateTaskDecorations(task, undefined)
+    }
+
+    private updateTaskDecorations(task: FixupTask, diff: Diff | undefined): void {
+        const decorations = makeDecorations(diff)
+        const isEmpty = decorations.edits.length === 0 && decorations.conflicts.length === 0
+        let fileTasks = this.decorations_.get(task.fixupFile)
+        if (!fileTasks && isEmpty) {
+            // The file was not decorated; we have no decorations. Do nothing.
+            return
         }
-        editor.setDecorations(
-            diff.clean ? this.decorationCodyIncoming_ : this.decorationCodyConflicted_,
-            diff.edits.map(
-                edit =>
-                    new vscode.Range(
-                        new vscode.Position(edit.range.start.line, edit.range.start.character),
-                        new vscode.Position(edit.range.end.line, edit.range.end.character)
-                    )
-            )
-        )
-        editor.setDecorations(
-            this.decorationCodyConflictMarker_,
-            diff.conflicts.map(
-                conflict =>
-                    new vscode.Range(
-                        new vscode.Position(conflict.start.line, conflict.start.character),
-                        new vscode.Position(conflict.end.line, conflict.end.character)
-                    )
-            )
-        )
+        if (isEmpty) {
+            if (fileTasks?.has(task)) {
+                // There were old decorations; remove them.
+                fileTasks.delete(task)
+                this.didChangeFileDecorations(task.fixupFile)
+            }
+            return
+        }
+        if (!fileTasks) {
+            // Create the map to hold this file's decorations.
+            fileTasks = new Map()
+            this.decorations_.set(task.fixupFile, fileTasks)
+        }
+        fileTasks.set(task, decorations)
+        this.didChangeFileDecorations(task.fixupFile)
+    }
+
+    private didChangeFileDecorations(file: FixupFile): void {
+        // TODO: Cache the changed files and update the decorations together.
+        const editors = vscode.window.visibleTextEditors.filter(editor => editor.document.uri === file.uri)
+        if (!editors.length) {
+            return
+        }
+        this.applyDecorations(editors, this.decorations_.get(file)?.values() || [].values())
+    }
+
+    private applyDecorations(editors: vscode.TextEditor[], decorations: IterableIterator<TaskDecorations>) {
+        const incoming: vscode.Range[] = []
+        const conflicted: vscode.Range[] = []
+        const conflicts: vscode.Range[] = []
+        for (const decoration of decorations) {
+            ;(decoration.conflicts.length ? conflicted : incoming).push(...decoration.edits)
+            conflicts.push(...decoration.conflicts)
+        }
+        for (const editor of editors) {
+            editor.setDecorations(this.decorationCodyConflictMarker_, conflicts)
+            editor.setDecorations(this.decorationCodyConflicted_, conflicted)
+            editor.setDecorations(this.decorationCodyIncoming_, incoming)
+        }
     }
 }

--- a/client/cody/src/non-stop/FixupDecorator.ts
+++ b/client/cody/src/non-stop/FixupDecorator.ts
@@ -4,7 +4,7 @@ import { Diff } from './diff'
 import { FixupFile } from './FixupFile'
 import { FixupTask } from './FixupTask'
 
-type TaskDecorations = {
+interface TaskDecorations {
     edits: vscode.Range[]
     conflicts: vscode.Range[]
 }
@@ -115,7 +115,7 @@ export class FixupDecorator implements vscode.Disposable {
         this.applyDecorations(editors, this.decorations_.get(file)?.values() || [].values())
     }
 
-    private applyDecorations(editors: vscode.TextEditor[], decorations: IterableIterator<TaskDecorations>) {
+    private applyDecorations(editors: vscode.TextEditor[], decorations: IterableIterator<TaskDecorations>): void {
         const incoming: vscode.Range[] = []
         const conflicted: vscode.Range[] = []
         const conflicts: vscode.Range[] = []

--- a/client/cody/test/e2e/BUILD.bazel
+++ b/client/cody/test/e2e/BUILD.bazel
@@ -10,6 +10,7 @@ ts_project(
     srcs = [
         "auth.test.ts",
         "common.ts",
+        "fixup-decorator.test.ts",
         "helpers.ts",
         "history.test.ts",
         "inline-assist.test.ts",

--- a/client/cody/test/e2e/fixup-decorator.test.ts
+++ b/client/cody/test/e2e/fixup-decorator.test.ts
@@ -19,7 +19,7 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
     // TODO: When communication from the background process to the test runner
     // is possible, extract the FixupDecorator's decoration fields' keys and
     // select these exactly.
-    let decorations = page.locator(DECORATION_SELECTOR)
+    const decorations = page.locator(DECORATION_SELECTOR)
     expect(await decorations.count()).toBe(0)
 
     // Find the text hello cody, and then highlight the text
@@ -45,12 +45,12 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
     // Extract the key of the decoration
     const decorationClassName = (await decorations.first().getAttribute('class'))
         ?.split(' ')
-        .find(className => /TextEditorDecorationType/.test(className))
+        .find(className => className.includes('TextEditorDecorationType'))
     expect(decorationClassName).toBeDefined()
 
     // Edit where Cody planned to type
     await page.keyboard.type('who needs titles?')
 
     // The decorations should change to conflict markers.
-    page.waitForSelector(`${DECORATION_SELECTOR}:not([class*="${decorationClassName}"])`)
+    await page.waitForSelector(`${DECORATION_SELECTOR}:not([class*="${decorationClassName}"])`)
 })

--- a/client/cody/test/e2e/fixup-decorator.test.ts
+++ b/client/cody/test/e2e/fixup-decorator.test.ts
@@ -1,0 +1,56 @@
+import { expect } from '@playwright/test'
+
+import { sidebarExplorer, sidebarSignin } from './common'
+import { test } from './helpers'
+
+const DECORATION_SELECTOR = 'div.view-overlays[role="presentation"] div[class*="TextEditorDecorationType"]'
+
+test('decorations from un-applied Cody changes appear', async ({ page, sidebar }) => {
+    // Sign into Cody
+    await sidebarSignin(page, sidebar)
+
+    // Open the Explorer view from the sidebar
+    await sidebarExplorer(page).click()
+
+    // Open the index.html file from the tree view
+    await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
+
+    // Count the existing decorations in the file; there should be none.
+    // TODO: When communication from the background process to the test runner
+    // is possible, extract the FixupDecorator's decoration fields' keys and
+    // select these exactly.
+    let decorations = page.locator(DECORATION_SELECTOR)
+    expect(await decorations.count()).toBe(0)
+
+    // Find the text hello cody, and then highlight the text
+    await page.getByText('<title>Hello Cody</title>').click()
+
+    // Highlight the whole line
+    await page.keyboard.down('Shift')
+    await page.keyboard.press('ArrowDown')
+
+    // Open the command palette by clicking on the Cody Icon
+    await page.getByRole('button', { name: /Cody: Fixup.*/ }).click()
+
+    // Wait for the input box to appear
+    await page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.').click()
+    // Type in the instruction for fixup
+    await page.keyboard.type('replace hello with goodbye')
+    // Press enter to submit the fixup
+    await page.keyboard.press('Enter')
+
+    // Decorations should appear
+    await page.waitForSelector(DECORATION_SELECTOR)
+
+    // Extract the key of the decoration
+    const decorationClassName = (await decorations.first().getAttribute('class'))
+        ?.split(' ')
+        .find(className => /TextEditorDecorationType/.test(className))
+    expect(decorationClassName).toBeDefined()
+
+    // Edit where Cody planned to type
+    await page.keyboard.type('who needs titles?')
+
+    // The decorations should change to conflict markers.
+    page.waitForSelector(`${DECORATION_SELECTOR}:not([class*="${decorationClassName}"])`)
+})


### PR DESCRIPTION
For non-stop Cody to be truly non-stop, we need to show incoming Cody edits from multiple fixup tasks in multiple files and editors simultaneously. This does that.

## Test plan

`pnpm test:e2e -- fixup-decorator.test.ts` &larr; Smoke test that decorations appear for one edit.

*Manual test:*

Create and save a file "A". Right click on the editor title and Split Right. Select content and make a Cody: Fixup (Experimental) suggestion. The highlight should appear in both editors.

Edit in one editor to cause a conflict. The conflict highlight should appear in both editors.

Close one editor, re-split the editor, the highlight should appear in both editors.

Close one editor. Open a different file "B". Select content and make a Cody: Fixup (Experimental) suggestion. Before the Cody response is done (or even started) switch to file A. Wait for the task to stop spinning. Switch back to file B. The highlight should appear in the editor.

Finally, multiple fixups. Make a file with "hello, world" ten times. Select all. Cody: Fixup (Experimental) and tell Cody to replace "hello" with "hola". Wait for the task to finish churning. (Having to stop will go away later so we are truly "non-stop.") Select all. Cody: Fixup (Experimental) and tell Cody to replace "world" with "peeps". Verify that both changes show incoming markers, and editing to cause conflicts in one change shows conflict highlights *just* in that change.