### PR TITLE
bzl: remove bazel-qa stamp suffix

### DIFF
--- a/dev/bazel_stamp_vars.sh
+++ b/dev/bazel_stamp_vars.sh
@@ -3,7 +3,7 @@
 build_number="${BUILDKITE_BUILD_NUMBER:-000000}"
 date_fragment="$(date +%y-%m-%d)"
 latest_tag="5.0"
-stamp_version="${build_number}_${date_fragment}_${latest_tag}-$(git rev-parse --short HEAD)-bazel-qa"
+stamp_version="${build_number}_${date_fragment}_${latest_tag}-$(git rev-parse --short HEAD)"
 
 echo STABLE_VERSION "$stamp_version"
 echo VERSION_TIMESTAMP "$(date +%s)"


### PR DESCRIPTION
This removes our marker suffix, as it's not necessary anymore and it breaks update checks on S2. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 