### PR TITLE
scip-ctags: copy binary from alpine container

### DIFF
--- a/cmd/server/Dockerfile.bazel
+++ b/cmd/server/Dockerfile.bazel
@@ -73,6 +73,7 @@ RUN apk add --no-cache --verbose \
 COPY --from=comby/comby:alpine-3.14-1.8.1@sha256:a5e80d6bad6af008478679809dc8327ebde7aeff7b23505b11b20e36aa62a0b2 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=docker.io/sourcegraph/syntax-highlighter:223909_2023-06-02_5.0-6fd7735ab9c2 /syntax_highlighter /usr/local/bin/
+# hadolint ignore=DL3022
 COPY --from=docker.io/sourcegraph/symbols:223909_2023-06-02_5.0-6fd7735ab9c2 /usr/local/bin/scip-ctags /usr/local/bin/scip-ctags
 
 

--- a/cmd/server/Dockerfile.bazel
+++ b/cmd/server/Dockerfile.bazel
@@ -72,7 +72,8 @@ RUN apk add --no-cache --verbose \
 # hadolint ignore=DL3022
 COPY --from=comby/comby:alpine-3.14-1.8.1@sha256:a5e80d6bad6af008478679809dc8327ebde7aeff7b23505b11b20e36aa62a0b2 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
-COPY --from=docker.io/sourcegraph/syntax-highlighter:186324_2022-12-01_02d3b4384446 /syntax_highlighter /usr/local/bin/
+COPY --from=docker.io/sourcegraph/syntax-highlighter:223909_2023-06-02_5.0-6fd7735ab9c2 /syntax_highlighter /usr/local/bin/
+COPY --from=docker.io/sourcegraph/symbols:223909_2023-06-02_5.0-6fd7735ab9c2 /usr/local/bin/scip-ctags /usr/local/bin/scip-ctags
 
 
 # install blobstore (keep this up to date with the upstream Docker image

--- a/cmd/server/build-bazel.sh
+++ b/cmd/server/build-bazel.sh
@@ -47,7 +47,6 @@ ENTERPRISE_TARGETS=(
   //enterprise/cmd/repo-updater
   //enterprise/cmd/precise-code-intel-worker
   //enterprise/cmd/server
-  //docker-images/syntax-highlighter:scip-ctags
 )
 
 MUSL_TARGETS=(


### PR DESCRIPTION
Copy the scip-ctags binary from a pre-built container the same as syntax-higligher

Fixes 
```
2023-06-01T15:01:05.315027853Z [0;34m15:01:05                   symbols | [0mscip-ctags: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by scip-ctags)
2023-06-01T15:01:05.315056702Z [0;34m15:01:05                   symbols | [0mscip-ctags: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by scip-ctags)
2023-06-01T15:01:05.315062326Z [0;34m15:01:05                   symbols | [0mscip-ctags: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by scip-ctags)
2023-06-01T15:01:05.315066789Z [0;34m15:01:05                   symbols | [0mscip-ctags: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.27' not found (required by scip-ctags)
```
## Test plan

no more errors in logs during upgrade test
