### PR TITLE
Cody: Do not log events such as install in automated tests

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -158,6 +158,10 @@ export class SourcegraphGraphQLAPIClient {
         argument?: string | {}
         publicArgument?: string | {}
     }): Promise<void | Error> {
+        if (process.env.CODY_TESTING === 'true') {
+            console.log(`not logging ${event.event} in test mode`)
+            return
+        }
         try {
             if (this.config.serverEndpoint === this.dotcomUrl) {
                 await this.fetchSourcegraphAPI<APIResponse<LogEventResponse>>(LOG_EVENT_MUTATION, event).then(


### PR DESCRIPTION
The increasing use of automated tests are skewing production metrics.

## Test plan

```
pnpm test:integration | grep logging
```

Confirm messages like "not logging CodyInstalled in test mode" appear.
