### PR TITLE
own: skip null references in bag

### DIFF
--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -211,6 +211,9 @@ func (b bag) FindResolved(ref Reference) (codeowners.ResolvedOwner, bool) {
 		if refCtx, ok := b.references[k]; ok {
 			if id := refCtx.resolvedUserID; id != 0 {
 				userRefs := b.resolvedUsers[id]
+				if userRefs == nil {
+					continue
+				}
 				// TODO: Email resolution here is best effort,
 				// we do not know if this is primary email.
 				var email *string


### PR DESCRIPTION
There is is a panic in prod, so adding this skip until we can figure out root cause here. 
I can't actually reproduce this locally, but this seems to be the only possible nil reference in the error stack

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
