### PR TITLE
Search: fix regex parsing a literal

### DIFF
--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -318,7 +318,11 @@ func patternsInTree(originalPattern query.Node) (res []string) {
 			res = append(res, patternsInTree(operand)...)
 		}
 	case query.Pattern:
-		res = append(res, v.Value)
+		if v.Annotation.Labels.IsSet(query.Regexp) {
+			res = append(res, v.Value)
+		} else {
+			res = append(res, regexp.QuoteMeta(v.Value))
+		}
 	default:
 		panic(fmt.Sprintf("unknown pattern node type %T", originalPattern))
 	}

--- a/internal/search/job/jobutil/filter_file_contains.go
+++ b/internal/search/job/jobutil/filter_file_contains.go
@@ -43,7 +43,7 @@ func NewFileContainsFilterJob(includePatterns []string, originalPattern query.No
 		includeMatchers = append(includeMatchers, regexp.MustCompile(pattern))
 	}
 
-	originalPatternStrings := patternsInTree(originalPattern)
+	originalPatternStrings := patternsInTreeAsRegex(originalPattern)
 	originalPatternMatchers := make([]*regexp.Regexp, 0, len(originalPatternStrings))
 	for _, originalPatternString := range originalPatternStrings {
 		if !caseSensitive {
@@ -308,14 +308,14 @@ func (j *fileContainsFilterJob) Name() string {
 	return "FileContainsFilterJob"
 }
 
-func patternsInTree(originalPattern query.Node) (res []string) {
+func patternsInTreeAsRegex(originalPattern query.Node) (res []string) {
 	if originalPattern == nil {
 		return nil
 	}
 	switch v := originalPattern.(type) {
 	case query.Operator:
 		for _, operand := range v.Operands {
-			res = append(res, patternsInTree(operand)...)
+			res = append(res, patternsInTreeAsRegex(operand)...)
 		}
 	case query.Pattern:
 		if v.Annotation.Labels.IsSet(query.Regexp) {

--- a/internal/search/job/jobutil/filter_file_contains_test.go
+++ b/internal/search/job/jobutil/filter_file_contains_test.go
@@ -274,3 +274,23 @@ func TestFileContainsFilterJob(t *testing.T) {
 		})
 	}
 }
+
+func TestPatternsInTree(t *testing.T) {
+	cases := []struct {
+		q    query.Node
+		want []string
+	}{{
+		q:    query.Pattern{Value: `test.*literal`, Annotation: query.Annotation{Labels: query.Literal}},
+		want: []string{`test\.\*literal`},
+	}, {
+		q:    query.Pattern{Value: `test.*literal`, Annotation: query.Annotation{Labels: query.Regexp}},
+		want: []string{`test.*literal`},
+	}}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := patternsInTreeAsRegex(tc.q)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
I think this probably fixes a case where we are failing to parse a regex pattern. We were treating a string literal as a valid regex pattern, and wrapping it in `(?i: ... )`, which was causing panics in main.

## Test plan

Added a unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
