### PR TITLE
Bag panic root cause fix.

### DIFF
--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -301,12 +301,12 @@ func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) error {
 			// Team resolved
 			if teamRefs != nil {
 				id := teamRefs.team.ID
-				refCtx.resolvedTeamID = id
 				if _, ok := b.resolvedTeams[id]; !ok {
 					b.resolvedTeams[id] = teamRefs
 				}
 				// Team was referred to either by ID or by name, need to link back.
 				teamRefs.linkBack(b)
+				refCtx.resolvedTeamID = id
 			}
 		}
 	}

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -289,7 +289,6 @@ func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) error {
 			}
 			// User resolved
 			if userRefs != nil {
-				refCtx.resolvedUserID = userRefs.id
 				if _, ok := b.resolvedUsers[userRefs.id]; !ok {
 					if err := userRefs.augment(ctx, db); err != nil {
 						return err
@@ -297,6 +296,7 @@ func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) error {
 					b.resolvedUsers[userRefs.id] = userRefs
 					userRefs.linkBack(b)
 				}
+				refCtx.resolvedUserID = userRefs.id
 			}
 			// Team resolved
 			if teamRefs != nil {


### PR DESCRIPTION
Part of #52911 

The bug is when user references augmenting errors. Previously we already linked `resolvedUserID` to the reference (like a handle or email) but actually getting all the other references known to sourcegraph fails, and we have effectively a dangling reference that manifests as nil pointer during map lookup.

## Test plan

TODO: Follow up with unit tests that try to expose issues that could cause panics and errors.
