### PR TITLE
surface protocol.CreateCommitFromPatchResponse

### DIFF
--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -649,12 +649,13 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			}
 			changeset := bt.CreateChangeset(t, ctx, bstore, changesetOpts)
 
-			var response string
+			var response *gitprotocol.CreateCommitFromPatchResponse
 			var createCommitFromPatchCalled bool
-			state.MockClient.CreateCommitFromPatchFunc.SetDefaultHook(func(_ context.Context, req gitprotocol.CreateCommitFromPatchRequest) (string, error) {
+			state.MockClient.CreateCommitFromPatchFunc.SetDefaultHook(func(_ context.Context, req gitprotocol.CreateCommitFromPatchRequest) (*gitprotocol.CreateCommitFromPatchResponse, error) {
 				createCommitFromPatchCalled = true
 				if changesetSpec != nil {
-					response = changesetSpec.HeadRef
+					response = new(gitprotocol.CreateCommitFromPatchResponse)
+					response.Rev = changesetSpec.HeadRef
 				}
 				return response, tc.gitClientErr
 			})
@@ -1124,9 +1125,9 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 
 			gitserverClient := gitserver.NewMockClient()
 			createCommitFromPatchReq := &gitprotocol.CreateCommitFromPatchRequest{}
-			gitserverClient.CreateCommitFromPatchFunc.SetDefaultHook(func(_ context.Context, req gitprotocol.CreateCommitFromPatchRequest) (string, error) {
+			gitserverClient.CreateCommitFromPatchFunc.SetDefaultHook(func(_ context.Context, req gitprotocol.CreateCommitFromPatchRequest) (*gitprotocol.CreateCommitFromPatchResponse, error) {
 				createCommitFromPatchReq = &req
-				return "", nil
+				return new(gitprotocol.CreateCommitFromPatchResponse), nil
 			})
 
 			_, err := executePlan(

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -128,11 +128,13 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			}
 			changeset := bt.CreateChangeset(t, ctx, store, changesetOpts)
 
-			state.MockClient.CreateCommitFromPatchFunc.SetDefaultHook(func(context.Context, gitprotocol.CreateCommitFromPatchRequest) (string, error) {
+			state.MockClient.CreateCommitFromPatchFunc.SetDefaultHook(func(context.Context, gitprotocol.CreateCommitFromPatchRequest) (*gitprotocol.CreateCommitFromPatchResponse, error) {
+				resp := new(gitprotocol.CreateCommitFromPatchResponse)
 				if changesetSpec != nil {
-					return changesetSpec.HeadRef, nil
+					resp.Rev = changesetSpec.HeadRef
+					return resp, nil
 				}
-				return "", nil
+				return resp, nil
 			})
 
 			// Setup the sourcer that's used to create a Source with which

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -240,7 +240,7 @@ type Client interface {
 
 	// CreateCommitFromPatch will attempt to create a commit from a patch
 	// If possible, the error returned will be of type protocol.CreateCommitFromPatchError
-	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)
+	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error)
 
 	// GetDefaultBranch returns the name of the default branch and the commit it's
 	// currently at from the given repository. If short is true, then `main` instead
@@ -1364,21 +1364,21 @@ func (c *clientImplementor) do(ctx context.Context, repo api.RepoName, method, u
 	return c.httpClient.Do(req)
 }
 
-func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (string, error) {
+func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 	resp, err := c.httpPost(ctx, req.Repo, "create-commit-from-patch-binary", req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read response body")
+		return nil, errors.Wrap(err, "failed to read response body")
 	}
-	var res protocol.CreateCommitFromPatchResponse
-	if err := json.Unmarshal(body, &res); err != nil {
+	res := new(protocol.CreateCommitFromPatchResponse)
+	if err := json.Unmarshal(body, res); err != nil {
 		c.logger.Warn("decoding gitserver create-commit-from-patch response", sglog.Error(err))
-		return "", &url.Error{
+		return nil, &url.Error{
 			URL: resp.Request.URL.String(),
 			Op:  "CreateCommitFromPatch",
 			Err: errors.Errorf("CreateCommitFromPatch: http status %d, %s", resp.StatusCode, string(body)),
@@ -1386,9 +1386,9 @@ func (c *clientImplementor) CreateCommitFromPatch(ctx context.Context, req proto
 	}
 
 	if res.Error != nil {
-		return res.Rev, res.Error
+		return res, res.Error
 	}
-	return res.Rev, nil
+	return res, nil
 }
 
 func (c *clientImplementor) GetObject(ctx context.Context, repo api.RepoName, objectName string) (*gitdomain.GitObject, error) {

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -258,7 +258,7 @@ func NewMockClient() *MockClient {
 			},
 		},
 		CreateCommitFromPatchFunc: &ClientCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (r0 string, r1 error) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (r0 *protocol.CreateCommitFromPatchResponse, r1 error) {
 				return
 			},
 		},
@@ -525,7 +525,7 @@ func NewStrictMockClient() *MockClient {
 			},
 		},
 		CreateCommitFromPatchFunc: &ClientCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 				panic("unexpected invocation of MockClient.CreateCommitFromPatch")
 			},
 		},
@@ -2440,15 +2440,15 @@ func (c ClientContributorCountFuncCall) Results() []interface{} {
 // CreateCommitFromPatch method of the parent MockClient instance is
 // invoked.
 type ClientCreateCommitFromPatchFunc struct {
-	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)
-	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)
+	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error)
+	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error)
 	history     []ClientCreateCommitFromPatchFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateCommitFromPatch delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockClient) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest) (string, error) {
+func (m *MockClient) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 	r0, r1 := m.CreateCommitFromPatchFunc.nextHook()(v0, v1)
 	m.CreateCommitFromPatchFunc.appendCall(ClientCreateCommitFromPatchFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -2457,7 +2457,7 @@ func (m *MockClient) CreateCommitFromPatch(v0 context.Context, v1 protocol.Creat
 // SetDefaultHook sets function that is called when the
 // CreateCommitFromPatch method of the parent MockClient instance is invoked
 // and the hook queue is empty.
-func (f *ClientCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)) {
+func (f *ClientCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error)) {
 	f.defaultHook = hook
 }
 
@@ -2465,7 +2465,7 @@ func (f *ClientCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Conte
 // CreateCommitFromPatch method of the parent MockClient instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ClientCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error)) {
+func (f *ClientCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2473,20 +2473,20 @@ func (f *ClientCreateCommitFromPatchFunc) PushHook(hook func(context.Context, pr
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ClientCreateCommitFromPatchFunc) SetDefaultReturn(r0 string, r1 error) {
-	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error) {
+func (f *ClientCreateCommitFromPatchFunc) SetDefaultReturn(r0 *protocol.CreateCommitFromPatchResponse, r1 error) {
+	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientCreateCommitFromPatchFunc) PushReturn(r0 string, r1 error) {
-	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error) {
+func (f *ClientCreateCommitFromPatchFunc) PushReturn(r0 *protocol.CreateCommitFromPatchResponse, r1 error) {
+	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 		return r0, r1
 	})
 }
 
-func (f *ClientCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest) (string, error) {
+func (f *ClientCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest) (*protocol.CreateCommitFromPatchResponse, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2527,7 +2527,7 @@ type ClientCreateCommitFromPatchFuncCall struct {
 	Arg1 protocol.CreateCommitFromPatchRequest
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 string
+	Result0 *protocol.CreateCommitFromPatchResponse
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error


### PR DESCRIPTION
from gitserver client CreateCommitFromPatch
all the way out to batches executor

This will facilitate accessing values from the patching process, like `Rev`

## Test plan

existing tests should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
