### PR TITLE
Add message to community members about embeddings

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -8,6 +8,8 @@ Cody reads relevant code files to increase the accuracy and quality of the respo
 
 ### Embeddings
 
+> **Community users:** If you want to enable embeddings for an open source project, please [join our Discord server](https://discord.gg/sourcegraph-969688426372825169) and request them in the `#cody-embeddings` channel.
+
 Embeddings are a semantic representation of text that allow us to create a search index over an entire codebase. The process of creating embeddings involves us splitting the entire codebase into searchable chunks and sending them to the external service specified in the site config for embedding. The final embedding index is stored in a managed object storage service.
 
 Embeddings for relevant code files must be enabled for each repository that you'd like Cody to have context on.


### PR DESCRIPTION
When a community user is in VS Code and sees **NOT INDEXED**, it links to [this page](https://docs.sourcegraph.com/cody/explanations/code_graph_context) that doesn't mention anything about how they can request embeddings.

<img width="434" alt="Image 2023-06-02 at 4 34 06 PM" src="https://github.com/sourcegraph/sourcegraph/assets/398230/da85387d-57a8-4d71-a0a9-20d6b3ddf645">

## Test plan

* Links 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
