### PR TITLE
Cb/own/52891/promote owner button

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { mdiEmail } from '@mdi/js'
+import { mdiEmail, mdiPlus } from '@mdi/js'
 
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
@@ -85,7 +85,14 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reas
                 {reasons.map(reason => (
                     <OwnershipBadge key={reason.title} reason={reason} />
                 ))}
-                {displayAssignOwner && <Button>Assign owner</Button>}
+            </td>
+            <td className={containerStyles.fitting}>
+                {displayAssignOwner && (
+                    <Button variant={'primary'} outline={true} size={'sm'}>
+                        <Icon svgPath={mdiPlus} />
+                        Make owner
+                    </Button>
+                )}
             </td>
         </tr>
     )

--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../graphql-operations'
 import { PersonLink } from '../../../person/PersonLink'
 
-import { MakeOwnerButton, MakeOwnerButtonProps } from './MakeOwnerButton'
 import { OwnershipBadge } from './OwnershipBadge'
 
 import containerStyles from './FileOwnershipPanel.module.scss'
@@ -23,7 +22,7 @@ import containerStyles from './FileOwnershipPanel.module.scss'
 interface Props {
     owner: OwnerFields
     reasons: OwnershipReason[]
-    makeOwnerProps?: MakeOwnerButtonProps
+    makeOwnerButton?: React.ReactElement
 }
 
 type OwnershipReason =
@@ -32,7 +31,7 @@ type OwnershipReason =
     | RecentViewOwnershipSignalFields
     | AssignedOwnerFields
 
-export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons, makeOwnerProps }) => {
+export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons, makeOwnerButton }) => {
     const findEmail = (): string | undefined => {
         if (owner.__typename !== 'Person') {
             return undefined
@@ -87,7 +86,7 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reas
                     <OwnershipBadge key={reason.title} reason={reason} />
                 ))}
             </td>
-            <td className={containerStyles.fitting}>{makeOwnerProps && <MakeOwnerButton {...makeOwnerProps} />}</td>
+            <td className={containerStyles.fitting}>{makeOwnerButton}</td>
         </tr>
     )
 }

--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -22,6 +22,7 @@ import containerStyles from './FileOwnershipPanel.module.scss'
 interface Props {
     owner: OwnerFields
     reasons: OwnershipReason[]
+    displayAssignOwner: Boolean
 }
 
 type OwnershipReason =
@@ -30,7 +31,7 @@ type OwnershipReason =
     | RecentViewOwnershipSignalFields
     | AssignedOwnerFields
 
-export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons }) => {
+export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons, displayAssignOwner }) => {
     const findEmail = (): string | undefined => {
         if (owner.__typename !== 'Person') {
             return undefined
@@ -84,6 +85,7 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reas
                 {reasons.map(reason => (
                     <OwnershipBadge key={reason.title} reason={reason} />
                 ))}
+                {displayAssignOwner && <Button>Assign owner</Button>}
             </td>
         </tr>
     )

--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { mdiEmail, mdiPlus } from '@mdi/js'
+import { mdiEmail } from '@mdi/js'
 
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
@@ -15,6 +15,7 @@ import {
 } from '../../../graphql-operations'
 import { PersonLink } from '../../../person/PersonLink'
 
+import { MakeOwnerButton, MakeOwnerButtonProps } from './MakeOwnerButton'
 import { OwnershipBadge } from './OwnershipBadge'
 
 import containerStyles from './FileOwnershipPanel.module.scss'
@@ -22,7 +23,7 @@ import containerStyles from './FileOwnershipPanel.module.scss'
 interface Props {
     owner: OwnerFields
     reasons: OwnershipReason[]
-    displayAssignOwner: Boolean
+    makeOwnerProps?: MakeOwnerButtonProps
 }
 
 type OwnershipReason =
@@ -31,7 +32,7 @@ type OwnershipReason =
     | RecentViewOwnershipSignalFields
     | AssignedOwnerFields
 
-export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons, displayAssignOwner }) => {
+export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reasons, makeOwnerProps }) => {
     const findEmail = (): string | undefined => {
         if (owner.__typename !== 'Person') {
             return undefined
@@ -86,14 +87,7 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({ owner, reas
                     <OwnershipBadge key={reason.title} reason={reason} />
                 ))}
             </td>
-            <td className={containerStyles.fitting}>
-                {displayAssignOwner && (
-                    <Button variant={'primary'} outline={true} size={'sm'}>
-                        <Icon svgPath={mdiPlus} />
-                        Make owner
-                    </Button>
-                )}
-            </td>
+            <td className={containerStyles.fitting}>{makeOwnerProps && <MakeOwnerButton {...makeOwnerProps} />}</td>
         </tr>
     )
 }

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -161,6 +161,7 @@ const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data, displayAssig
                             <th>Contact</th>
                             <th>Owner</th>
                             <th>Reason</th>
+                            <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -19,6 +19,7 @@ import {
     OwnershipConnectionFields,
     SearchPatternType,
 } from '../../../graphql-operations'
+import { OwnershipAssignPermission } from '../../../rbac/constants'
 
 import { FileOwnershipEntry } from './FileOwnershipEntry'
 import { FETCH_OWNERS } from './grapqlQueries'
@@ -61,8 +62,12 @@ export const FileOwnershipPanel: React.FunctionComponent<
         )
     }
 
+    const canAssignOwners = (data?.currentUser?.permissions?.nodes || []).some(
+        permission => permission.displayName === OwnershipAssignPermission
+    )
+
     if (data?.node?.__typename === 'Repository') {
-        return <OwnerList data={data?.node?.commit?.blob?.ownership} />
+        return <OwnerList data={data?.node?.commit?.blob?.ownership} displayAssignOwner={canAssignOwners} />
     }
     return <OwnerList />
 }
@@ -140,9 +145,10 @@ const resolveOwnerSearchPredicate = (owners?: OwnerFields[]): string => {
 
 interface OwnerListProps {
     data?: OwnershipConnectionFields
+    displayAssignOwner?: Boolean
 }
 
-const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
+const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data, displayAssignOwner }) => {
     if (data?.nodes && data.nodes.length) {
         const nodes = data.nodes
         const totalCount = data.totalOwners
@@ -180,7 +186,11 @@ const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
                                 // eslint-disable-next-line react/no-array-index-key
                                 <React.Fragment key={index}>
                                     {index > 0 && <tr className={styles.bordered} />}
-                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                                    <FileOwnershipEntry
+                                        owner={ownership.owner}
+                                        reasons={ownership.reasons}
+                                        displayAssignOwner={false}
+                                    />
                                 </React.Fragment>
                             ))}
                         {
@@ -214,7 +224,11 @@ const OwnerList: React.FunctionComponent<OwnerListProps> = ({ data }) => {
                                 // eslint-disable-next-line react/no-array-index-key
                                 <React.Fragment key={index}>
                                     {index > 0 && <tr className={styles.bordered} />}
-                                    <FileOwnershipEntry owner={ownership.owner} reasons={ownership.reasons} />
+                                    <FileOwnershipEntry
+                                        owner={ownership.owner}
+                                        reasons={ownership.reasons}
+                                        displayAssignOwner={displayAssignOwner || false}
+                                    />
                                 </React.Fragment>
                             ))}
                     </tbody>

--- a/client/web/src/repo/blob/own/MakeOwnerButton.tsx
+++ b/client/web/src/repo/blob/own/MakeOwnerButton.tsx
@@ -1,16 +1,54 @@
-import { mdiPlus } from '@mdi/js'
+import { mdiLoading, mdiPlus } from '@mdi/js'
 
-import { Button, Icon } from '@sourcegraph/wildcard'
+import { useMutation } from '@sourcegraph/http-client'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
+
+import { AssignOwnerResult, AssignOwnerVariables } from '../../../graphql-operations'
+
+import { ASSIGN_OWNER } from './grapqlQueries'
 
 export interface MakeOwnerButtonProps {
     onSuccess: () => Promise
+    onError: (e: Error) => void
+    repoId: string
+    path: string
+    userId?: string // TODO make optional, user ID is not always known
 }
 
-export const MakeOwnerButton: React.FC<MakeOwnerButtonProps> = ({}) => {
+export const MakeOwnerButton: React.FC<MakeOwnerButtonProps> = ({ onSuccess, onError, path, userId, repoId }) => {
+    const [requestAssignOwner, { loading }] = useMutation<AssignOwnerResult, AssignOwnerVariables>(ASSIGN_OWNER, {})
+
+    const assignOwner = async () => {
+        if (userId !== undefined) {
+            const result = await requestAssignOwner({
+                variables: {
+                    input: {
+                        absolutePath: path,
+                        assignedOwnerID: userId,
+                        repoID: repoId,
+                    },
+                },
+            })
+            if (result.errors) {
+                onError(new Error('Failed to make owner.'))
+            } else {
+                await onSuccess()
+            }
+        }
+    }
+
+    const tooltipContent =
+        userId === undefined
+            ? 'Only ownership entries that are recognized as Sourcegraph users can be assigned ownership.'
+            : null
+
     return (
-        <Button variant={'primary'} outline={true} size={'sm'}>
-            <Icon svgPath={mdiPlus} />
-            Make owner
-        </Button>
+        // TODO: Add tooltip
+        <Tooltip content={tooltipContent}>
+            <Button variant={'primary'} outline={true} size={'sm'} disabled={userId === undefined}>
+                <Icon svgPath={loading ? mdiLoading : mdiPlus} />
+                Make owner
+            </Button>
+        </Tooltip>
     )
 }

--- a/client/web/src/repo/blob/own/MakeOwnerButton.tsx
+++ b/client/web/src/repo/blob/own/MakeOwnerButton.tsx
@@ -1,0 +1,16 @@
+import { mdiPlus } from '@mdi/js'
+
+import { Button, Icon } from '@sourcegraph/wildcard'
+
+export interface MakeOwnerButtonProps {
+    onSuccess: () => Promise
+}
+
+export const MakeOwnerButton: React.FC<MakeOwnerButtonProps> = ({}) => {
+    return (
+        <Button variant={'primary'} outline={true} size={'sm'}>
+            <Icon svgPath={mdiPlus} />
+            Make owner
+        </Button>
+    )
+}

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -86,6 +86,13 @@ export const FETCH_OWNERS = gql`
                 }
             }
         }
+        currentUser {
+            permissions {
+                nodes {
+                    displayName
+                }
+            }
+        }
     }
 `
 

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -10,6 +10,7 @@ export const OWNER_FIELDS = gql`
             email
             avatarURL
             user {
+                id
                 username
                 displayName
                 url
@@ -170,6 +171,14 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
                     }
                 }
             }
+        }
+    }
+`
+
+export const ASSIGN_OWNER = gql`
+    mutation AssignOwner($input: AssignOwnerInput!) {
+        assignOwner(input: $input) {
+            alwaysNil
         }
     }
 `


### PR DESCRIPTION
Part of [#52891](https://github.com/sourcegraph/sourcegraph/issues/52891)

This pull request introduces a button in the ownership panel on the right-hand side that allows promoting a potential owner - indicated by inference signal - to owner.

TODO: Mutation to assign owner and refreshing panel state afterwards.

## Test plan

Visual assessment and Looms:

- Button states and how it behaves: https://www.loom.com/share/d2c0d8101fa54718a97b377e93608028
- Promotion to owner: **TODO**
