### PR TITLE
gitserver: fix nil reference error in CreateCommitFromPatch

### DIFF
--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -176,6 +176,24 @@ func TestProtoRoundTrip(t *testing.T) {
 		t.Errorf("RepoUpdateResponse proto roundtrip failed (-want +got):\n%s", diff)
 	}
 
+	createCommit := func(original protocol.CreateCommitFromPatchResponse) bool {
+		var converted protocol.CreateCommitFromPatchResponse
+		fmt.Printf("Orginal: %+v\n", original)
+		fmt.Println(original.ToProto())
+
+		converted.FromProto(original.ToProto())
+
+		if diff = cmp.Diff(original, converted); diff != "" {
+			return false
+		}
+
+		return true
+	}
+
+	if err := quick.Check(createCommit, nil); err != nil {
+		t.Errorf("CreateCommitFromPatchRequest proto roundtrip failed (-want +got):\n%s", diff)
+	}
+
 }
 
 func TestClient_Remove(t *testing.T) {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -178,8 +178,6 @@ func TestProtoRoundTrip(t *testing.T) {
 
 	createCommit := func(original protocol.CreateCommitFromPatchResponse) bool {
 		var converted protocol.CreateCommitFromPatchResponse
-		fmt.Printf("Orginal: %+v\n", original)
-		fmt.Println(original.ToProto())
 
 		converted.FromProto(original.ToProto())
 

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -691,10 +691,13 @@ func (r *CreateCommitFromPatchResponse) ToProto() *proto.CreateCommitFromPatchBi
 }
 
 func (r *CreateCommitFromPatchResponse) FromProto(p *proto.CreateCommitFromPatchBinaryResponse) {
-	*r = CreateCommitFromPatchResponse{
-		Rev:   p.GetRev(),
-		Error: CreateCommitFromPatchErrorFromProto(p.GetError()),
+	if p.GetError() == nil {
+		r.Error = &CreateCommitFromPatchError{}
+	} else {
+		r.Error = &CreateCommitFromPatchError{}
+		r.Error.FromProto(p.GetError())
 	}
+	r.Rev = p.GetRev()
 }
 
 // SetError adds the supplied error related details to e.
@@ -732,11 +735,8 @@ func (e *CreateCommitFromPatchError) ToProto() *proto.CreateCommitFromPatchError
 	}
 }
 
-func CreateCommitFromPatchErrorFromProto(p *proto.CreateCommitFromPatchError) *CreateCommitFromPatchError {
-	if p == nil {
-		return nil
-	}
-	return &CreateCommitFromPatchError{
+func (e *CreateCommitFromPatchError) FromProto(p *proto.CreateCommitFromPatchError) {
+	*e = CreateCommitFromPatchError{
 		RepositoryName: p.GetRepositoryName(),
 		InternalError:  p.GetInternalError(),
 		Command:        p.GetCommand(),

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -684,15 +684,21 @@ type CreateCommitFromPatchResponse struct {
 }
 
 func (r *CreateCommitFromPatchResponse) ToProto() *proto.CreateCommitFromPatchBinaryResponse {
+	var err *proto.CreateCommitFromPatchError
+	if r.Error != nil {
+		err = r.Error.ToProto()
+	} else {
+		err = nil
+	}
 	return &proto.CreateCommitFromPatchBinaryResponse{
 		Rev:   r.Rev,
-		Error: r.Error.ToProto(),
+		Error: err,
 	}
 }
 
 func (r *CreateCommitFromPatchResponse) FromProto(p *proto.CreateCommitFromPatchBinaryResponse) {
 	if p.GetError() == nil {
-		r.Error = &CreateCommitFromPatchError{}
+		r.Error = nil
 	} else {
 		r.Error = &CreateCommitFromPatchError{}
 		r.Error.FromProto(p.GetError())


### PR DESCRIPTION
relates to : https://github.com/sourcegraph/sourcegraph/pull/52715#issuecomment-1575094232

There was an nil reference error with converting CreateCommitFromPatchError from Proto
## Test plan
unit test : TestProtoRoundTrip in client_test.go
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
