### PR TITLE
batches: properly name `GitHupAppDomain` constants for github apps

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver.go
@@ -107,10 +107,10 @@ func parseDomain(s *string) (*itypes.GitHubAppDomain, error) {
 	}
 	switch strings.ToUpper(*s) {
 	case "REPOS":
-		domain := itypes.ReposDomain
+		domain := itypes.ReposGitHubAppDomain
 		return &domain, nil
 	case "BATCHES":
-		domain := itypes.BatchesDomain
+		domain := itypes.BatchesGitHubAppDomain
 		return &domain, nil
 	default:
 		return nil, errors.Errorf("unknown domain %q", *s)

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
@@ -173,7 +173,7 @@ func TestResolver_GitHubApps(t *testing.T) {
 					}
 				}`,
 			Variables: map[string]any{
-				"domain": types.ReposDomain.ToGraphQL(),
+				"domain": types.ReposGitHubAppDomain.ToGraphQL(),
 			},
 			ExpectedResult: fmt.Sprintf(`{
 				"gitHubApps": {

--- a/enterprise/internal/github_apps/store/store.go
+++ b/enterprise/internal/github_apps/store/store.go
@@ -92,7 +92,7 @@ func (s *gitHubAppsStore) Create(ctx context.Context, app *ghtypes.GitHubApp) (i
 	}
 	domain := app.Domain
 	if domain == "" {
-		domain = types.ReposDomain
+		domain = types.ReposGitHubAppDomain
 	}
 
 	query := sqlf.Sprintf(`INSERT INTO

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -354,7 +354,7 @@ func TestListGitHubApp(t *testing.T) {
 	repoApp := &ghtypes.GitHubApp{
 		AppID:        1234,
 		Name:         "Test App 1",
-		Domain:       types.ReposDomain,
+		Domain:       types.ReposGitHubAppDomain,
 		Slug:         "test-app-1",
 		BaseURL:      "https://github.com",
 		AppURL:       "https://github.com/apps/testapp",
@@ -367,7 +367,7 @@ func TestListGitHubApp(t *testing.T) {
 	batchesApp := &ghtypes.GitHubApp{
 		AppID:        5678,
 		Name:         "Test App 2",
-		Domain:       types.BatchesDomain,
+		Domain:       types.BatchesGitHubAppDomain,
 		Slug:         "test-app-2",
 		BaseURL:      "https://enterprise.github.com",
 		AppURL:       "https://enterprise.github.com/apps/testapp",
@@ -405,7 +405,7 @@ func TestListGitHubApp(t *testing.T) {
 	})
 
 	t.Run("domain-filtered github apps", func(t *testing.T) {
-		domain := types.ReposDomain
+		domain := types.ReposGitHubAppDomain
 		fetched, err := store.List(ctx, &domain)
 		require.NoError(t, err)
 		require.Len(t, fetched, 1)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -84,14 +84,14 @@ type Repo struct {
 	KeyValuePairs map[string]*string `json:",omitempty"`
 }
 
-const (
-	ReposDomain   GitHubAppDomain = "repos"
-	BatchesDomain GitHubAppDomain = "batches"
-)
-
 type GitHubAppDomain string
 
 func (s GitHubAppDomain) ToGraphQL() string { return strings.ToUpper(string(s)) }
+
+const (
+	ReposGitHubAppDomain   GitHubAppDomain = "repos"
+	BatchesGitHubAppDomain GitHubAppDomain = "batches"
+)
 
 // RepoCommit is a record of a repo and a corresponding commit.
 type RepoCommit struct {


### PR DESCRIPTION
We have a named type called `GitHubAppDomain`. However, the constants that we create of the named type are called `Domain`; this can lead to confusion in the future when there's a named type called `Domain`.

I've renamed `BatchesDomain` and `ReposDomain` to `BatchesGitHubAppDomain` and `ReposGitHubAppDomain` to ensure the constants follow the naming of the named type.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Every GitHub app-related operation should work as is.
* Just a variable name change.
