### PR TITLE
batches: add rollout window configuration section to global (site) settings page

### DIFF
--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -10,6 +10,8 @@ import {
     ExternalServiceKind,
     GlobalBatchChangesCodeHostsResult,
 } from '../../../graphql-operations'
+import { BATCH_CHANGES_SITE_CONFIGURATION } from '../backend'
+import { rolloutWindowConfigMockResult } from '../mocks'
 
 import { GLOBAL_CODE_HOSTS } from './backend'
 import { BatchChangesSiteConfigSettingsArea } from './BatchChangesSiteConfigSettingsArea'
@@ -23,61 +25,69 @@ const config: Meta = {
 
 export default config
 
-const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<GlobalBatchChangesCodeHostsResult>[] => [
-    {
-        request: {
-            query: getDocumentNode(GLOBAL_CODE_HOSTS),
-            variables: {
-                after: null,
-                first: 15,
-            },
+const ROLLOUT_WINDOWS_CONFIGURATION_MOCK = {
+    request: {
+        query: getDocumentNode(BATCH_CHANGES_SITE_CONFIGURATION),
+    },
+    result: rolloutWindowConfigMockResult,
+}
+
+const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<GlobalBatchChangesCodeHostsResult> => ({
+    request: {
+        query: getDocumentNode(GLOBAL_CODE_HOSTS),
+        variables: {
+            after: null,
+            first: 15,
         },
-        result: {
-            data: {
-                batchChangesCodeHosts: {
-                    totalCount: hosts.length,
-                    pageInfo: { endCursor: null, hasNextPage: false },
-                    nodes: hosts,
-                },
+    },
+    result: {
+        data: {
+            batchChangesCodeHosts: {
+                totalCount: hosts.length,
+                pageInfo: { endCursor: null, hasNextPage: false },
+                nodes: hosts,
             },
         },
     },
-]
+})
 
 export const Overview: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                mocks={createMock(
-                    {
-                        credential: null,
-                        externalServiceKind: ExternalServiceKind.GITHUB,
-                        externalServiceURL: 'https://github.com/',
-                        requiresSSH: false,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: null,
-                        externalServiceKind: ExternalServiceKind.GITLAB,
-                        externalServiceURL: 'https://gitlab.com/',
-                        requiresSSH: false,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: null,
-                        externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
-                        externalServiceURL: 'https://bitbucket.sgdev.org/',
-                        requiresSSH: true,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: null,
-                        externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
-                        externalServiceURL: 'https://bitbucket.org/',
-                        requiresSSH: false,
-                        requiresUsername: true,
-                    }
-                )}
+                mocks={[
+                    ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
+                    createMock(
+                        {
+                            credential: null,
+                            externalServiceKind: ExternalServiceKind.GITHUB,
+                            externalServiceURL: 'https://github.com/',
+                            requiresSSH: false,
+                            requiresUsername: false,
+                        },
+                        {
+                            credential: null,
+                            externalServiceKind: ExternalServiceKind.GITLAB,
+                            externalServiceURL: 'https://gitlab.com/',
+                            requiresSSH: false,
+                            requiresUsername: false,
+                        },
+                        {
+                            credential: null,
+                            externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
+                            externalServiceURL: 'https://bitbucket.sgdev.org/',
+                            requiresSSH: true,
+                            requiresUsername: false,
+                        },
+                        {
+                            credential: null,
+                            externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
+                            externalServiceURL: 'https://bitbucket.org/',
+                            requiresSSH: false,
+                            requiresUsername: true,
+                        }
+                    ),
+                ]}
             >
                 <BatchChangesSiteConfigSettingsArea {...props} />
             </MockedTestProvider>
@@ -89,56 +99,59 @@ export const ConfigAdded: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                mocks={createMock(
-                    {
-                        credential: {
-                            id: '123',
-                            isSiteCredential: true,
-                            sshPublicKey:
-                                'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                mocks={[
+                    ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
+                    createMock(
+                        {
+                            credential: {
+                                id: '123',
+                                isSiteCredential: true,
+                                sshPublicKey:
+                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                            },
+                            externalServiceKind: ExternalServiceKind.GITHUB,
+                            externalServiceURL: 'https://github.com/',
+                            requiresSSH: false,
+                            requiresUsername: false,
                         },
-                        externalServiceKind: ExternalServiceKind.GITHUB,
-                        externalServiceURL: 'https://github.com/',
-                        requiresSSH: false,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: {
-                            id: '123',
-                            isSiteCredential: true,
-                            sshPublicKey:
-                                'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                        {
+                            credential: {
+                                id: '123',
+                                isSiteCredential: true,
+                                sshPublicKey:
+                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                            },
+                            externalServiceKind: ExternalServiceKind.GITLAB,
+                            externalServiceURL: 'https://gitlab.com/',
+                            requiresSSH: false,
+                            requiresUsername: false,
                         },
-                        externalServiceKind: ExternalServiceKind.GITLAB,
-                        externalServiceURL: 'https://gitlab.com/',
-                        requiresSSH: false,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: {
-                            id: '123',
-                            isSiteCredential: true,
-                            sshPublicKey:
-                                'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                        {
+                            credential: {
+                                id: '123',
+                                isSiteCredential: true,
+                                sshPublicKey:
+                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                            },
+                            externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
+                            externalServiceURL: 'https://bitbucket.sgdev.org/',
+                            requiresSSH: true,
+                            requiresUsername: false,
                         },
-                        externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
-                        externalServiceURL: 'https://bitbucket.sgdev.org/',
-                        requiresSSH: true,
-                        requiresUsername: false,
-                    },
-                    {
-                        credential: {
-                            id: '123',
-                            isSiteCredential: true,
-                            sshPublicKey:
-                                'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                        },
-                        externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
-                        externalServiceURL: 'https://bitbucket.org/',
-                        requiresSSH: false,
-                        requiresUsername: true,
-                    }
-                )}
+                        {
+                            credential: {
+                                id: '123',
+                                isSiteCredential: true,
+                                sshPublicKey:
+                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                            },
+                            externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
+                            externalServiceURL: 'https://bitbucket.org/',
+                            requiresSSH: false,
+                            requiresUsername: true,
+                        }
+                    ),
+                ]}
             >
                 <BatchChangesSiteConfigSettingsArea {...props} />
             </MockedTestProvider>

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
@@ -5,6 +5,7 @@ import { PageHeader, Alert, Text } from '@sourcegraph/wildcard'
 import { PageTitle } from '../../../components/PageTitle'
 
 import { GlobalCodeHostConnections } from './CodeHostConnections'
+import { RolloutWindowsConfiguration } from './RolloutWindowsConfiguration'
 
 export interface BatchChangesSiteConfigSettingsAreaProps {}
 
@@ -15,6 +16,7 @@ export const BatchChangesSiteConfigSettingsArea: React.FunctionComponent<
     <>
         <PageTitle title="Batch changes settings" />
         <PageHeader headingElement="h2" path={[{ text: 'Batch Changes settings' }]} className="mb-3" />
+        <RolloutWindowsConfiguration />
         <GlobalCodeHostConnections
             headerLine={
                 <>

--- a/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.tsx
+++ b/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiPulse } from '@mdi/js'
 
-import { Text, H3, Container, Icon, LoadingSpinner, ErrorAlert, Link } from '@sourcegraph/wildcard'
+import { Text, H3, Container, Icon, LoadingSpinner, ErrorAlert, Link, Code } from '@sourcegraph/wildcard'
 
 import { useBatchChangesRolloutWindowConfig } from '../backend'
 
@@ -33,7 +33,7 @@ export const RolloutWindowsConfiguration: React.FunctionComponent = () => {
                             Configuring rollout windows allows changesets to be reconciled at a slower or faster rate
                             based on the time of day and/or the day of the week. These windows are applied to changesets
                             across all code hosts and can be configured with the{' '}
-                            <strong>batchChanges.rolloutWindows</strong>{' '}
+                            <Code>batchChanges.rolloutWindows</Code>{' '}
                             <Link to="/help/admin/config/batch_changes#rollout-windows">
                                 site configuration option.
                             </Link>


### PR DESCRIPTION
I noticed we only added the rollout window configuration section to the user settings page for Batch Changes. At the time I assumed that same page component fed both the user and the admin/global/site version of the page, but I realized that's not the case. I think it makes sense to show the rollout window config in both places, so in this PR I added it to that admin/global/site settings page, too, and updated the Storybook stories.

I also changed the mention of the site config option to be `<code />` instead of `<strong />`, which seemed slightly more appropriate given it's a literal reference to the site config JSON key.

## Test plan

Storybook story coverage. Verified that rollout windows configuration appears on both settings pages in the same fashion.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
