### PR TITLE
cody: add `Debugging with Chrome Devtools` docs

### DIFF
--- a/client/cody/CONTRIBUTING.md
+++ b/client/cody/CONTRIBUTING.md
@@ -132,3 +132,27 @@ Visit the following pages to follow the build status for:
 - [VS Code UX Guidelines](https://code.visualstudio.com/api/ux-guidelines/webviews)
 - [VS Code Webview UI Toolkit](https://microsoft.github.io/vscode-webview-ui-toolkit)
 - [VS Code Icons - Codicons](https://microsoft.github.io/vscode-codicons/dist/codicon.html)
+
+## Debugging with dedicated Node DevTools
+
+1. **Initialize the Build Watcher**: Run the following command from the monorepo root to start the build watcher:
+
+```sh
+pnpm --filter cody-ai run watch
+```
+
+2. **Launch the VSCode Extension Host**: Next, start the VSCode extension host by executing the command below from the monorepo root:
+
+```sh
+pnpm --filter cody-ai run start:debug
+```
+
+3. **Access the Chrome Inspector**: Open up your Google Chrome browser and navigate to `chrome://inspect/#devices`.
+4. **Open Node DevTools**: Look for and click on the option that says "Open dedicated DevTools for Node".
+5. **Specify the Debugging Endpoint**: At this point, DevTools aren't initialized yet. Therefore, you need to specify [the debugging endpoint](https://nodejs.org/en/docs/inspector/) `localhost:9333` (the port depends on the `--inspect-extensions` CLI flag used in the `start:debug` npm script)
+6. **Start Debugging Like a PRO**: yay!
+
+### Moar tips
+
+1. To open the webviews developer tools: cmd+shift+p and select `Developer: Toggle Developer Tools`
+2. To reload extension sources: cmd+shift+p and select `Developer: Reload Window`. If you have the watcher running it should be enough to get the latest changes to the extension host.

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -7,6 +7,28 @@
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
   "description": "AI code assistant that writes code and answers questions for you",
+  "scripts": {
+    "start:debug": "NODE_ENV=development CODY_FOCUS_ON_STARTUP=1 code --extensionDevelopmentPath=\"$INIT_CWD/client/cody\" --disable-extension=sourcegraph.cody-ai --inspect-extensions=9333 . --goto ./src/local-app-detector.ts:12:59",
+    "build": "pnpm esbuild --minify && vite build --mode production",
+    "build:dev": "concurrently \"pnpm esbuild --sourcemap\" \"vite build --mode development\"",
+    "download-rg": "scripts/download-rg.sh",
+    "esbuild": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
+    "lint": "pnpm run lint:js",
+    "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
+    "release": "ts-node ./scripts/release.ts",
+    "release:dry-run": "CODY_RELEASE_TYPE=dry-run ts-node ./scripts/release.ts",
+    "storybook": "STORIES_GLOB='client/cody/webviews/**/*.story.tsx' pnpm --filter @sourcegraph/storybook run start",
+    "test:e2e": "npx playwright install && pnpm run --silent build:dev && playwright test",
+    "test:integration": "tsc -b ./test/integration && pnpm run --silent build:dev && node --inspect -r ts-node/register out/test/integration/main.js",
+    "test:unit": "jest",
+    "vscode:prepublish": "scripts/check-rg.sh",
+    "vsce:package": "pnpm --silent build && vsce package --no-dependencies -o dist/cody.vsix",
+    "vsce:prerelease": "pnpm --silent build && vsce package patch --pre-release --no-dependencies -o dist/cody.vsix",
+    "watch": "concurrently \"pnpm watch:esbuild\" \"pnpm watch:webview\"",
+    "watch:esbuild": "pnpm esbuild --sourcemap --watch",
+    "watch:webview": "vite build --mode development --watch"
+  },
+  "main": "./dist/extension.js",
   "categories": [
     "Programming Languages",
     "Machine Learning",
@@ -50,27 +72,6 @@
   "engines": {
     "vscode": "^1.74.0"
   },
-  "scripts": {
-    "build": "pnpm esbuild --minify && vite build --mode production",
-    "build:dev": "concurrently \"pnpm esbuild --sourcemap\" \"vite build --mode development\"",
-    "download-rg": "scripts/download-rg.sh",
-    "esbuild": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node",
-    "lint": "pnpm run lint:js",
-    "lint:js": "eslint --cache '**/*.[tj]s?(x)'",
-    "release": "ts-node ./scripts/release.ts",
-    "release:dry-run": "CODY_RELEASE_TYPE=dry-run ts-node ./scripts/release.ts",
-    "storybook": "STORIES_GLOB='client/cody/webviews/**/*.story.tsx' pnpm --filter @sourcegraph/storybook run start",
-    "test:e2e": "npx playwright install && pnpm run --silent build:dev && playwright test",
-    "test:integration": "tsc -b ./test/integration && pnpm run --silent build:dev && node --inspect -r ts-node/register out/test/integration/main.js",
-    "test:unit": "jest",
-    "vscode:prepublish": "scripts/check-rg.sh",
-    "vsce:package": "pnpm --silent build && vsce package --no-dependencies -o dist/cody.vsix",
-    "vsce:prerelease": "pnpm --silent build && vsce package patch --pre-release --no-dependencies -o dist/cody.vsix",
-    "watch": "concurrently \"pnpm watch:esbuild\" \"pnpm watch:webview\"",
-    "watch:esbuild": "pnpm esbuild --sourcemap --watch",
-    "watch:webview": "vite build --mode development --watch"
-  },
-  "main": "./dist/extension.js",
   "activationEvents": [
     "onStartupFinished"
   ],


### PR DESCRIPTION
## Context

Being new to VSCode extension development, I found it wasn't obvious how to utilize Chrome DevTools for background process debugging.  It might be known info, but it's helpful to have it documented, especially for those new to this area or needing a refresher. 

What's cool about the setup:

1. **Start from CLI**: using the newly added npm script, we can start the extension host from the CLI.
2. **Iteration speed**: by running the build watcher in a separate terminal window, we can reload the already started extension host to test recent changes without rebuilding the extension + web views from scratch before starting the extension host (that's what the launch command does now).
3. **Immediate File Access**: The npm script automatically opens a workspace with a source file at a specific line and column in the extension host to test Cody's features immediately. 
4. **Advanced debugging**: though the VSCode launch script does enable debugging mode where breakpoints and logs are available in the VSCode UI, it doesn't come close to the flexibility of the standalone version of Chrome DevTools.

## Test plan

Follow the added instructions locally. 
