### PR TITLE
batches: commit signing settings UI

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -547,6 +547,8 @@ ts_project(
         "src/enterprise/batches/settings/CodeHostConnectionNode.tsx",
         "src/enterprise/batches/settings/CodeHostConnections.tsx",
         "src/enterprise/batches/settings/CodeHostSshPublicKey.tsx",
+        "src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx",
+        "src/enterprise/batches/settings/CommitSigningIntegrations.tsx",
         "src/enterprise/batches/settings/ModalHeader.tsx",
         "src/enterprise/batches/settings/RemoveCredentialModal.tsx",
         "src/enterprise/batches/settings/RolloutWindowsConfiguration.tsx",

--- a/client/web/src/components/gitHubApps/GitHubAppCard.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppCard.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import { DeleteGitHubAppResult, DeleteGitHubAppVariables } from 'src/graphql-operations'
 
 import { useMutation } from '@sourcegraph/http-client'
-import { Button, Icon, Tooltip, Container, AnchorLink, ButtonLink } from '@sourcegraph/wildcard'
+import { Button, Icon, Container, AnchorLink, ButtonLink } from '@sourcegraph/wildcard'
 
 import { DELETE_GITHUB_APP_BY_ID_QUERY } from './backend'
 
@@ -62,11 +62,9 @@ export const GitHubAppCard: React.FC<GitHubAppCardProps> = ({ app, refetch }) =>
                 <ButtonLink className="mr-2" aria-label="Edit" to={app.id} variant="secondary" size="sm">
                     <Icon aria-hidden={true} svgPath={mdiCogOutline} /> Edit
                 </ButtonLink>
-                <Tooltip content="Delete GitHub App">
-                    <Button aria-label="Delete" onClick={onDelete} disabled={loading} variant="danger" size="sm">
-                        <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete
-                    </Button>
-                </Tooltip>
+                <Button aria-label="Remove GitHub App" onClick={onDelete} disabled={loading} variant="danger" size="sm">
+                    <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
+                </Button>
             </div>
         </Container>
     )

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -36,16 +36,9 @@ import { GITHUB_APP_BY_ID_QUERY, DELETE_GITHUB_APP_BY_ID_QUERY } from './backend
 
 import styles from './GitHubAppCard.module.scss'
 
-interface Props extends TelemetryProps {
-    externalServicesFromFile: boolean
-    allowEditExternalServicesWithFile: boolean
-}
+interface Props extends TelemetryProps {}
 
-export const GitHubAppPage: FC<Props> = ({
-    telemetryService,
-    externalServicesFromFile,
-    allowEditExternalServicesWithFile,
-}) => {
+export const GitHubAppPage: FC<Props> = ({ telemetryService }) => {
     const { appID } = useParams()
     const navigate = useNavigate()
 

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
@@ -65,6 +65,23 @@ export const Overview: Story = () => (
                                     externalServiceURL: 'https://github.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: true,
+                                    commitSigningConfiguration: {
+                                        __typename: 'GitHubAppConfiguration',
+                                        appID: 123,
+                                        name: 'Sourcegraph Commit Signing',
+                                        appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                        logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                                    },
+                                },
+                                {
+                                    credential: null,
+                                    externalServiceKind: ExternalServiceKind.GITHUB,
+                                    externalServiceURL: 'https://github.mycompany.com/',
+                                    requiresSSH: false,
+                                    requiresUsername: false,
+                                    supportsCommitSigning: true,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: null,
@@ -72,6 +89,8 @@ export const Overview: Story = () => (
                                     externalServiceURL: 'https://gitlab.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: sshCredential(true),
@@ -79,6 +98,8 @@ export const Overview: Story = () => (
                                     externalServiceURL: 'https://bitbucket.sgdev.org/',
                                     requiresSSH: true,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: null,
@@ -86,6 +107,8 @@ export const Overview: Story = () => (
                                     externalServiceURL: 'https://bitbucket.org/',
                                     requiresSSH: false,
                                     requiresUsername: true,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 }
                             ),
                         },
@@ -126,6 +149,14 @@ export const ConfigAdded: Story = () => (
                                     externalServiceURL: 'https://github.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: true,
+                                    commitSigningConfiguration: {
+                                        __typename: 'GitHubAppConfiguration',
+                                        appID: 123,
+                                        name: 'Sourcegraph Commit Signing',
+                                        appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                        logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                                    },
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -133,6 +164,8 @@ export const ConfigAdded: Story = () => (
                                     externalServiceURL: 'https://gitlab.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -140,6 +173,8 @@ export const ConfigAdded: Story = () => (
                                     externalServiceURL: 'https://bitbucket.sgdev.org/',
                                     requiresSSH: true,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -147,6 +182,8 @@ export const ConfigAdded: Story = () => (
                                     externalServiceURL: 'https://bitbucket.org/',
                                     requiresSSH: false,
                                     requiresUsername: true,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 }
                             ),
                         },
@@ -189,6 +226,14 @@ export const RolloutWindowsConfigurationStory: Story = () => (
                                     externalServiceURL: 'https://github.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: true,
+                                    commitSigningConfiguration: {
+                                        __typename: 'GitHubAppConfiguration',
+                                        appID: 123,
+                                        name: 'Sourcegraph Commit Signing',
+                                        appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                        logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                                    },
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -196,6 +241,8 @@ export const RolloutWindowsConfigurationStory: Story = () => (
                                     externalServiceURL: 'https://gitlab.com/',
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -203,6 +250,8 @@ export const RolloutWindowsConfigurationStory: Story = () => (
                                     externalServiceURL: 'https://bitbucket.sgdev.org/',
                                     requiresSSH: true,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                                 {
                                     credential: sshCredential(false),
@@ -210,6 +259,8 @@ export const RolloutWindowsConfigurationStory: Story = () => (
                                     externalServiceURL: 'https://bitbucket.org/',
                                     requiresSSH: false,
                                     requiresUsername: true,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 }
                             ),
                         },

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
@@ -6,6 +6,7 @@ import { PageTitle } from '../../../components/PageTitle'
 import { UserAreaUserFields } from '../../../graphql-operations'
 
 import { UserCodeHostConnections } from './CodeHostConnections'
+import { UserCommitSigningIntegrations } from './CommitSigningIntegrations'
 import { RolloutWindowsConfiguration } from './RolloutWindowsConfiguration'
 
 export interface BatchChangesSettingsAreaProps {
@@ -24,5 +25,6 @@ export const BatchChangesSettingsArea: React.FunctionComponent<
             headerLine={<Text>Add access tokens to enable Batch Changes changeset creation on your code hosts.</Text>}
             userID={props.user.id}
         />
+        <UserCommitSigningIntegrations userID={props.user.id} />
     </div>
 )

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -64,6 +64,23 @@ export const Overview: Story = () => (
                             externalServiceURL: 'https://github.com/',
                             requiresSSH: false,
                             requiresUsername: false,
+                            supportsCommitSigning: true,
+                            commitSigningConfiguration: {
+                                __typename: 'GitHubAppConfiguration',
+                                appID: 123,
+                                name: 'Sourcegraph Commit Signing',
+                                appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                            },
+                        },
+                        {
+                            credential: null,
+                            externalServiceKind: ExternalServiceKind.GITHUB,
+                            externalServiceURL: 'https://github.mycompany.com/',
+                            requiresSSH: false,
+                            requiresUsername: false,
+                            supportsCommitSigning: true,
+                            commitSigningConfiguration: null,
                         },
                         {
                             credential: null,
@@ -71,6 +88,8 @@ export const Overview: Story = () => (
                             externalServiceURL: 'https://gitlab.com/',
                             requiresSSH: false,
                             requiresUsername: false,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         },
                         {
                             credential: null,
@@ -78,6 +97,8 @@ export const Overview: Story = () => (
                             externalServiceURL: 'https://bitbucket.sgdev.org/',
                             requiresSSH: true,
                             requiresUsername: false,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         },
                         {
                             credential: null,
@@ -85,6 +106,8 @@ export const Overview: Story = () => (
                             externalServiceURL: 'https://bitbucket.org/',
                             requiresSSH: false,
                             requiresUsername: true,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         }
                     ),
                 ]}
@@ -113,6 +136,14 @@ export const ConfigAdded: Story = () => (
                             externalServiceURL: 'https://github.com/',
                             requiresSSH: false,
                             requiresUsername: false,
+                            supportsCommitSigning: true,
+                            commitSigningConfiguration: {
+                                __typename: 'GitHubAppConfiguration',
+                                appID: 123,
+                                name: 'Sourcegraph Commit Signing',
+                                appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                            },
                         },
                         {
                             credential: {
@@ -125,6 +156,8 @@ export const ConfigAdded: Story = () => (
                             externalServiceURL: 'https://gitlab.com/',
                             requiresSSH: false,
                             requiresUsername: false,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         },
                         {
                             credential: {
@@ -137,6 +170,8 @@ export const ConfigAdded: Story = () => (
                             externalServiceURL: 'https://bitbucket.sgdev.org/',
                             requiresSSH: true,
                             requiresUsername: false,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         },
                         {
                             credential: {
@@ -149,6 +184,8 @@ export const ConfigAdded: Story = () => (
                             externalServiceURL: 'https://bitbucket.org/',
                             requiresSSH: false,
                             requiresUsername: true,
+                            supportsCommitSigning: false,
+                            commitSigningConfiguration: null,
                         }
                     ),
                 ]}

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -1,15 +1,11 @@
-import { MockedResponse } from '@apollo/client/testing'
 import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { MATCH_ANY_PARAMETERS, WildcardMockedResponse, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
-import {
-    BatchChangesCodeHostFields,
-    ExternalServiceKind,
-    GlobalBatchChangesCodeHostsResult,
-} from '../../../graphql-operations'
+import { BatchChangesCodeHostFields, ExternalServiceKind } from '../../../graphql-operations'
 import { BATCH_CHANGES_SITE_CONFIGURATION } from '../backend'
 import { rolloutWindowConfigMockResult } from '../mocks'
 
@@ -30,15 +26,13 @@ const ROLLOUT_WINDOWS_CONFIGURATION_MOCK = {
         query: getDocumentNode(BATCH_CHANGES_SITE_CONFIGURATION),
     },
     result: rolloutWindowConfigMockResult,
+    nMatches: Number.POSITIVE_INFINITY,
 }
 
-const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<GlobalBatchChangesCodeHostsResult> => ({
+const createMock = (...hosts: BatchChangesCodeHostFields[]): WildcardMockedResponse => ({
     request: {
         query: getDocumentNode(GLOBAL_CODE_HOSTS),
-        variables: {
-            after: null,
-            first: 15,
-        },
+        variables: MATCH_ANY_PARAMETERS,
     },
     result: {
         data: {
@@ -49,68 +43,71 @@ const createMock = (...hosts: BatchChangesCodeHostFields[]): MockedResponse<Glob
             },
         },
     },
+    nMatches: Number.POSITIVE_INFINITY,
 })
 
 export const Overview: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                mocks={[
-                    ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
-                    createMock(
-                        {
-                            credential: null,
-                            externalServiceKind: ExternalServiceKind.GITHUB,
-                            externalServiceURL: 'https://github.com/',
-                            requiresSSH: false,
-                            requiresUsername: false,
-                            supportsCommitSigning: true,
-                            commitSigningConfiguration: {
-                                __typename: 'GitHubAppConfiguration',
-                                appID: 123,
-                                name: 'Sourcegraph Commit Signing',
-                                appURL: 'https://github.com/apps/sourcegraph-commit-signing',
-                                logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                link={
+                    new WildcardMockLink([
+                        ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
+                        createMock(
+                            {
+                                credential: null,
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.com/',
+                                requiresSSH: false,
+                                requiresUsername: false,
+                                supportsCommitSigning: true,
+                                commitSigningConfiguration: {
+                                    __typename: 'GitHubAppConfiguration',
+                                    appID: 123,
+                                    name: 'Sourcegraph Commit Signing',
+                                    appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                    logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                                },
                             },
-                        },
-                        {
-                            credential: null,
-                            externalServiceKind: ExternalServiceKind.GITHUB,
-                            externalServiceURL: 'https://github.mycompany.com/',
-                            requiresSSH: false,
-                            requiresUsername: false,
-                            supportsCommitSigning: true,
-                            commitSigningConfiguration: null,
-                        },
-                        {
-                            credential: null,
-                            externalServiceKind: ExternalServiceKind.GITLAB,
-                            externalServiceURL: 'https://gitlab.com/',
-                            requiresSSH: false,
-                            requiresUsername: false,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        },
-                        {
-                            credential: null,
-                            externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
-                            externalServiceURL: 'https://bitbucket.sgdev.org/',
-                            requiresSSH: true,
-                            requiresUsername: false,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        },
-                        {
-                            credential: null,
-                            externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
-                            externalServiceURL: 'https://bitbucket.org/',
-                            requiresSSH: false,
-                            requiresUsername: true,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        }
-                    ),
-                ]}
+                            {
+                                credential: null,
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.mycompany.com/',
+                                requiresSSH: false,
+                                requiresUsername: false,
+                                supportsCommitSigning: true,
+                                commitSigningConfiguration: null,
+                            },
+                            {
+                                credential: null,
+                                externalServiceKind: ExternalServiceKind.GITLAB,
+                                externalServiceURL: 'https://gitlab.com/',
+                                requiresSSH: false,
+                                requiresUsername: false,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
+                            },
+                            {
+                                credential: null,
+                                externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
+                                externalServiceURL: 'https://bitbucket.sgdev.org/',
+                                requiresSSH: true,
+                                requiresUsername: false,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
+                            },
+                            {
+                                credential: null,
+                                externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
+                                externalServiceURL: 'https://bitbucket.org/',
+                                requiresSSH: false,
+                                requiresUsername: true,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
+                            }
+                        ),
+                    ])
+                }
             >
                 <BatchChangesSiteConfigSettingsArea {...props} />
             </MockedTestProvider>
@@ -122,73 +119,75 @@ export const ConfigAdded: Story = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
-                mocks={[
-                    ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
-                    createMock(
-                        {
-                            credential: {
-                                id: '123',
-                                isSiteCredential: true,
-                                sshPublicKey:
-                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                link={
+                    new WildcardMockLink([
+                        ROLLOUT_WINDOWS_CONFIGURATION_MOCK,
+                        createMock(
+                            {
+                                credential: {
+                                    id: '123',
+                                    isSiteCredential: true,
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                                },
+                                externalServiceKind: ExternalServiceKind.GITHUB,
+                                externalServiceURL: 'https://github.com/',
+                                requiresSSH: false,
+                                requiresUsername: false,
+                                supportsCommitSigning: true,
+                                commitSigningConfiguration: {
+                                    __typename: 'GitHubAppConfiguration',
+                                    appID: 123,
+                                    name: 'Sourcegraph Commit Signing',
+                                    appURL: 'https://github.com/apps/sourcegraph-commit-signing',
+                                    logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                                },
                             },
-                            externalServiceKind: ExternalServiceKind.GITHUB,
-                            externalServiceURL: 'https://github.com/',
-                            requiresSSH: false,
-                            requiresUsername: false,
-                            supportsCommitSigning: true,
-                            commitSigningConfiguration: {
-                                __typename: 'GitHubAppConfiguration',
-                                appID: 123,
-                                name: 'Sourcegraph Commit Signing',
-                                appURL: 'https://github.com/apps/sourcegraph-commit-signing',
-                                logo: 'https://github.com/identicons/app/app/commit-testing-local',
+                            {
+                                credential: {
+                                    id: '123',
+                                    isSiteCredential: true,
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                                },
+                                externalServiceKind: ExternalServiceKind.GITLAB,
+                                externalServiceURL: 'https://gitlab.com/',
+                                requiresSSH: false,
+                                requiresUsername: false,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
                             },
-                        },
-                        {
-                            credential: {
-                                id: '123',
-                                isSiteCredential: true,
-                                sshPublicKey:
-                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                            {
+                                credential: {
+                                    id: '123',
+                                    isSiteCredential: true,
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                                },
+                                externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
+                                externalServiceURL: 'https://bitbucket.sgdev.org/',
+                                requiresSSH: true,
+                                requiresUsername: false,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
                             },
-                            externalServiceKind: ExternalServiceKind.GITLAB,
-                            externalServiceURL: 'https://gitlab.com/',
-                            requiresSSH: false,
-                            requiresUsername: false,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        },
-                        {
-                            credential: {
-                                id: '123',
-                                isSiteCredential: true,
-                                sshPublicKey:
-                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                            },
-                            externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
-                            externalServiceURL: 'https://bitbucket.sgdev.org/',
-                            requiresSSH: true,
-                            requiresUsername: false,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        },
-                        {
-                            credential: {
-                                id: '123',
-                                isSiteCredential: true,
-                                sshPublicKey:
-                                    'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                            },
-                            externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
-                            externalServiceURL: 'https://bitbucket.org/',
-                            requiresSSH: false,
-                            requiresUsername: true,
-                            supportsCommitSigning: false,
-                            commitSigningConfiguration: null,
-                        }
-                    ),
-                ]}
+                            {
+                                credential: {
+                                    id: '123',
+                                    isSiteCredential: true,
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+                                },
+                                externalServiceKind: ExternalServiceKind.BITBUCKETCLOUD,
+                                externalServiceURL: 'https://bitbucket.org/',
+                                requiresSSH: false,
+                                requiresUsername: true,
+                                supportsCommitSigning: false,
+                                commitSigningConfiguration: null,
+                            }
+                        ),
+                    ])
+                }
             >
                 <BatchChangesSiteConfigSettingsArea {...props} />
             </MockedTestProvider>

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
@@ -5,6 +5,7 @@ import { PageHeader, Alert, Text } from '@sourcegraph/wildcard'
 import { PageTitle } from '../../../components/PageTitle'
 
 import { GlobalCodeHostConnections } from './CodeHostConnections'
+import { GlobalCommitSigningIntegrations } from './CommitSigningIntegrations'
 import { RolloutWindowsConfiguration } from './RolloutWindowsConfiguration'
 
 export interface BatchChangesSiteConfigSettingsAreaProps {}
@@ -28,5 +29,6 @@ export const BatchChangesSiteConfigSettingsArea: React.FunctionComponent<
                 </>
             }
         />
+        <GlobalCommitSigningIntegrations />
     </>
 )

--- a/client/web/src/enterprise/batches/settings/CheckButton.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.tsx
@@ -21,7 +21,13 @@ export const CheckButton: React.FunctionComponent<React.PropsWithChildren<CheckB
 }) => {
     if (!loading && !successMessage && !failedMessage) {
         return (
-            <Button className="text-primary text-nowrap" onClick={onClick} variant="link" aria-label={label}>
+            <Button
+                className="text-primary text-nowrap font-weight-normal"
+                onClick={onClick}
+                variant="link"
+                size="sm"
+                aria-label={label}
+            >
                 Check
             </Button>
         )
@@ -35,14 +41,14 @@ export const CheckButton: React.FunctionComponent<React.PropsWithChildren<CheckB
     }
     if (successMessage && !failedMessage) {
         return (
-            <Alert className="text-success">
+            <Alert className="text-success m-0 small">
                 <Icon svgPath={mdiCheck} inline={false} aria-hidden={true} /> {successMessage}
             </Alert>
         )
     }
     if (failedMessage) {
         return (
-            <Alert className="text-danger">
+            <Alert className="text-danger m-0 small">
                 <Icon svgPath={mdiClose} inline={false} aria-hidden={true} /> {failedMessage}
             </Alert>
         )

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.module.scss
@@ -2,9 +2,7 @@
     &__container {
         padding: 0;
         border: none;
-        &:not(:last-child) {
-            padding-bottom: 1rem;
-        }
+        padding-bottom: 1rem;
         &:not(:first-child) {
             padding-top: 1rem;
             border-top: 1px solid var(--border-color);

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
@@ -63,6 +63,8 @@ export const Overview: Story = () => (
                         externalServiceURL: 'https://github.com/',
                         requiresSSH: false,
                         requiresUsername: false,
+                        supportsCommitSigning: false,
+                        commitSigningConfiguration: null,
                     }}
                     refetchAll={() => {}}
                     userID="123"

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react'
 
 import { ApolloError } from '@apollo/client'
-import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline } from '@mdi/js'
+import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiDelete, mdiEye } from '@mdi/js'
 import classNames from 'classnames'
 
 import { logger } from '@sourcegraph/common'
@@ -146,18 +146,25 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                                     successMessage={checkCredData ? 'Credential is valid' : undefined}
                                     failedMessage={checkCredError ? 'Credential is not authorized' : undefined}
                                 />
+
                                 <Button
-                                    className="text-danger text-nowrap test-code-host-connection-node-btn-remove"
-                                    onClick={onClickRemove}
-                                    variant="link"
+                                    className="ml-2 text-nowrap test-code-host-connection-node-btn-remove"
                                     aria-label={`Remove credentials for ${codeHostDisplayName}`}
+                                    onClick={onClickRemove}
+                                    variant="danger"
+                                    size="sm"
                                     ref={buttonReference}
                                 >
-                                    Remove
+                                    <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
                                 </Button>
                                 {node.requiresSSH && (
-                                    <Button onClick={onClickView} className="text-nowrap ml-2" variant="secondary">
-                                        View public key
+                                    <Button
+                                        onClick={onClickView}
+                                        className="text-nowrap ml-2"
+                                        variant="secondary"
+                                        size="sm"
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiEye} /> View public key
                                     </Button>
                                 )}
                             </>
@@ -173,6 +180,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<React.PropsWithChil
                                 aria-label={`Add credentials for ${codeHostDisplayName}`}
                                 variant="success"
                                 ref={buttonReference}
+                                size="sm"
                             >
                                 Add credentials
                             </Button>

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -55,7 +55,7 @@ const CodeHostConnections: React.FunctionComponent<React.PropsWithChildren<CodeH
 }) => {
     const { loading, hasNextPage, fetchMore, connection, error, refetchAll } = connectionResult
     return (
-        <Container>
+        <Container className="mb-3">
             <H3>Code host tokens</H3>
             {headerLine}
             <ConnectionContainer className="mb-3">

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
@@ -1,0 +1,53 @@
+.node {
+    padding: 0;
+    border: none;
+    &:not(:last-child) {
+        padding-bottom: 1rem;
+    }
+    &:not(:first-child) {
+        padding-top: 1rem;
+        border-top: 1px solid var(--border-color);
+    }
+}
+
+.wrapper {
+    gap: 0.5rem;
+}
+
+.app-details {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    margin-left: auto;
+    padding-left: 0.5rem;
+    gap: 0.5rem;
+}
+
+.app-details-column {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex-shrink: 0;
+    padding-left: 0.5rem;
+}
+
+.app-details-stack-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.app-logo,
+.app-logo-large {
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 50%;
+    background-color: var(--gray-02);
+    border: 2px solid var(--gray-02);
+}
+
+.app-logo-large {
+    width: 2.125rem;
+    height: 2.125rem;
+}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
@@ -1,9 +1,7 @@
 .node {
     padding: 0;
     border: none;
-    &:not(:last-child) {
-        padding-bottom: 1rem;
-    }
+    padding-bottom: 1rem;
     &:not(:first-child) {
         padding-top: 1rem;
         border-top: 1px solid var(--border-color);
@@ -20,6 +18,7 @@
     align-items: center;
     margin-left: auto;
     padding-left: 0.5rem;
+    height: 2rem;
     gap: 0.5rem;
 }
 

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
@@ -12,11 +12,10 @@
     gap: 0.5rem;
 }
 
-.app-details {
+.readonly-app-details {
     display: flex;
     flex-shrink: 0;
     align-items: center;
-    margin-left: auto;
     padding-left: 0.5rem;
     height: 2rem;
     gap: 0.5rem;

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -83,16 +83,22 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                     </small>
                 </AnchorLink>
                 {/* TODO: Hook up delete button */}
-                <Tooltip content="Delete GitHub App">
-                    <Button aria-label="Delete" onClick={noop} disabled={false} variant="danger" size="sm">
-                        <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete
+                <Tooltip content="Remove GitHub App">
+                    <Button aria-label="Remove" onClick={noop} disabled={false} variant="danger" size="sm">
+                        <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
                     </Button>
                 </Tooltip>
             </div>
         </>
     ) : (
         // TODO: Hook up create button
-        <ButtonLink to="/batch-changes/new-github-app" className="ml-auto text-nowrap" variant="success" as={Link}>
+        <ButtonLink
+            to="/batch-changes/new-github-app"
+            className="ml-auto text-nowrap"
+            variant="success"
+            as={Link}
+            size="sm"
+        >
             Create GitHub App
         </ButtonLink>
     )

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiCogOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
+import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 import { noop } from 'lodash'
 
@@ -82,10 +82,6 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                         View In GitHub <Icon inline={true} svgPath={mdiOpenInNew} aria-hidden={true} />
                     </small>
                 </AnchorLink>
-                {/* TODO: */}
-                <ButtonLink className="mr-2" aria-label="Edit" variant="secondary" size="sm">
-                    <Icon aria-hidden={true} svgPath={mdiCogOutline} /> Edit
-                </ButtonLink>
                 {/* TODO: */}
                 <Tooltip content="Delete GitHub App">
                     <Button aria-label="Delete" onClick={noop} disabled={false} variant="danger" size="sm">

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -82,7 +82,7 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                         View In GitHub <Icon inline={true} svgPath={mdiOpenInNew} aria-hidden={true} />
                     </small>
                 </AnchorLink>
-                {/* TODO: */}
+                {/* TODO: Hook up delete button */}
                 <Tooltip content="Delete GitHub App">
                     <Button aria-label="Delete" onClick={noop} disabled={false} variant="danger" size="sm">
                         <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete
@@ -91,7 +91,7 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
             </div>
         </>
     ) : (
-        // TODO:
+        // TODO: Hook up create button
         <ButtonLink to="/batch-changes/new-github-app" className="ml-auto text-nowrap" variant="success" as={Link}>
             Create GitHub App
         </ButtonLink>

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+
+import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiCogOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
+import classNames from 'classnames'
+import { noop } from 'lodash'
+
+import { AnchorLink, Button, ButtonLink, H3, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
+
+import { defaultExternalServices } from '../../../components/externalServices/externalServices'
+import { BatchChangesCodeHostFields } from '../../../graphql-operations'
+
+import styles from './CommitSigningIntegrationNode.module.scss'
+
+interface CommitSigningIntegrationNodeProps {
+    readOnly: boolean
+    node: BatchChangesCodeHostFields
+}
+
+export const CommitSigningIntegrationNode: React.FunctionComponent<
+    React.PropsWithChildren<CommitSigningIntegrationNodeProps>
+> = ({ node, readOnly }) => {
+    const ExternalServiceIcon = defaultExternalServices[node.externalServiceKind].icon
+    return (
+        <li className={classNames(styles.node, 'list-group-item')}>
+            <div
+                className={classNames(
+                    styles.wrapper,
+                    'd-flex justify-content-between align-items-center flex-wrap mb-0'
+                )}
+            >
+                <div className="text-nowrap d-flex flex-1 mb-0 align-items-center">
+                    <H3 className="mb-0">
+                        {node.commitSigningConfiguration ? (
+                            <Icon
+                                aria-label="This code host has commit signing enabled with a GitHub App."
+                                className="text-success"
+                                svgPath={mdiCheckCircleOutline}
+                            />
+                        ) : (
+                            <Icon
+                                aria-label="This code host does not have a GitHub App connected for commit signing."
+                                className="text-danger"
+                                svgPath={mdiCheckboxBlankCircleOutline}
+                            />
+                        )}
+
+                        <Icon className="mx-2" aria-hidden={true} as={ExternalServiceIcon} />
+                        {node.externalServiceURL}
+                    </H3>
+                    {readOnly ? (
+                        <ReadOnlyAppDetails config={node.commitSigningConfiguration} />
+                    ) : (
+                        <AppDetailsControls config={node.commitSigningConfiguration} />
+                    )}
+                </div>
+            </div>
+        </li>
+    )
+}
+
+interface AppDetailsControlsProps {
+    config: BatchChangesCodeHostFields['commitSigningConfiguration']
+}
+
+const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ config }) =>
+    config ? (
+        <>
+            <div className="d-flex align-items-center ml-3">
+                <img className={styles.appLogoLarge} src={config.logo} alt="app logo" aria-hidden={true} />
+                <div className={styles.appDetailsColumn}>
+                    <Text size="small" className="font-weight-bold mb-0">
+                        {config.name}
+                    </Text>
+                    <Text size="small" className="text-muted mb-0">
+                        AppID: {config.appID}
+                    </Text>
+                </div>
+            </div>
+            <div className="ml-auto">
+                <AnchorLink to={config.appURL} target="_blank" className="mr-3">
+                    <small>
+                        View In GitHub <Icon inline={true} svgPath={mdiOpenInNew} aria-hidden={true} />
+                    </small>
+                </AnchorLink>
+                {/* TODO: */}
+                <ButtonLink className="mr-2" aria-label="Edit" variant="secondary" size="sm">
+                    <Icon aria-hidden={true} svgPath={mdiCogOutline} /> Edit
+                </ButtonLink>
+                {/* TODO: */}
+                <Tooltip content="Delete GitHub App">
+                    <Button aria-label="Delete" onClick={noop} disabled={false} variant="danger" size="sm">
+                        <Icon aria-hidden={true} svgPath={mdiDelete} /> Delete
+                    </Button>
+                </Tooltip>
+            </div>
+        </>
+    ) : (
+        // TODO:
+        <ButtonLink to="/batch-changes/new-github-app" className="ml-auto text-nowrap" variant="success" as={Link}>
+            Create GitHub App
+        </ButtonLink>
+    )
+
+interface ReadOnlyAppDetailsProps {
+    config: BatchChangesCodeHostFields['commitSigningConfiguration']
+}
+
+const ReadOnlyAppDetails: React.FunctionComponent<ReadOnlyAppDetailsProps> = ({ config }) =>
+    config ? (
+        <div className={styles.appDetails}>
+            <img className={styles.appLogo} src={config.logo} alt="app logo" aria-hidden={true} />
+            <Text size="small" className="font-weight-bold m-0">
+                {config.name}
+            </Text>
+        </div>
+    ) : (
+        <div className={styles.appDetails}>
+            <Text size="small" className="m-0">
+                No App configured
+            </Text>
+        </div>
+    )

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -28,31 +28,29 @@ export const CommitSigningIntegrationNode: React.FunctionComponent<
                     'd-flex justify-content-between align-items-center flex-wrap mb-0'
                 )}
             >
-                <div className="text-nowrap d-flex flex-1 mb-0 align-items-center">
-                    <H3 className="mb-0">
-                        {node.commitSigningConfiguration ? (
-                            <Icon
-                                aria-label="This code host has commit signing enabled with a GitHub App."
-                                className="text-success"
-                                svgPath={mdiCheckCircleOutline}
-                            />
-                        ) : (
-                            <Icon
-                                aria-label="This code host does not have a GitHub App connected for commit signing."
-                                className="text-danger"
-                                svgPath={mdiCheckboxBlankCircleOutline}
-                            />
-                        )}
-
-                        <Icon className="mx-2" aria-hidden={true} as={ExternalServiceIcon} />
-                        {node.externalServiceURL}
-                    </H3>
-                    {readOnly ? (
-                        <ReadOnlyAppDetails config={node.commitSigningConfiguration} />
+                <H3 className="mb-0 mr-2">
+                    {node.commitSigningConfiguration ? (
+                        <Icon
+                            aria-label="This code host has commit signing enabled with a GitHub App."
+                            className="text-success"
+                            svgPath={mdiCheckCircleOutline}
+                        />
                     ) : (
-                        <AppDetailsControls config={node.commitSigningConfiguration} />
+                        <Icon
+                            aria-label="This code host does not have a GitHub App connected for commit signing."
+                            className="text-danger"
+                            svgPath={mdiCheckboxBlankCircleOutline}
+                        />
                     )}
-                </div>
+
+                    <Icon className="mx-2" aria-hidden={true} as={ExternalServiceIcon} />
+                    {node.externalServiceURL}
+                </H3>
+                {readOnly ? (
+                    <ReadOnlyAppDetails config={node.commitSigningConfiguration} />
+                ) : (
+                    <AppDetailsControls config={node.commitSigningConfiguration} />
+                )}
             </div>
         </li>
     )
@@ -65,7 +63,7 @@ interface AppDetailsControlsProps {
 const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ config }) =>
     config ? (
         <>
-            <div className="d-flex align-items-center ml-3">
+            <div className="d-flex align-items-center">
                 <img className={styles.appLogoLarge} src={config.logo} alt="app logo" aria-hidden={true} />
                 <div className={styles.appDetailsColumn}>
                     <Text size="small" className="font-weight-bold mb-0">
@@ -109,14 +107,14 @@ interface ReadOnlyAppDetailsProps {
 
 const ReadOnlyAppDetails: React.FunctionComponent<ReadOnlyAppDetailsProps> = ({ config }) =>
     config ? (
-        <div className={styles.appDetails}>
+        <div className={styles.readonlyAppDetails}>
             <img className={styles.appLogo} src={config.logo} alt="app logo" aria-hidden={true} />
             <Text size="small" className="font-weight-bold m-0">
                 {config.name}
             </Text>
         </div>
     ) : (
-        <div className={styles.appDetails}>
+        <div className={styles.readonlyAppDetails}>
             <Text size="small" className="m-0">
                 No App configured
             </Text>

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Container, H3, Text } from '@sourcegraph/wildcard'
+import { Container, H3, Link, Text } from '@sourcegraph/wildcard'
 
 import { UseShowMorePaginationResult } from '../../../components/FilteredConnection/hooks/useShowMorePagination'
 import {
@@ -51,6 +51,7 @@ export const CommitSigningIntegrations: React.FunctionComponent<
     return (
         <Container>
             <H3>Commit signing integrations</H3>
+            {/* TODO: Link to docs if it's admin viewing (readOnly = false) */}
             <Text>
                 Connect GitHub Apps to enable Batch Changes to sign commits for your changesets. Contact your site admin
                 to manage connections.
@@ -84,6 +85,14 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                     </SummaryContainer>
                 )}
             </ConnectionContainer>
+            <Text className="mb-0">
+                Code host not present? Batch Changes only supports commit signing on GitHub code hosts today.{' '}
+                {/* TODO: Fill in docs link */}
+                <Link to="/help/admin/commit_signing_intergrations" target="_blank" rel="noopener noreferrer">
+                    See the docs
+                </Link>{' '}
+                for more information.
+            </Text>
         </Container>
     )
 }

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+
+import { Container, H3, Text } from '@sourcegraph/wildcard'
+
+import { UseShowMorePaginationResult } from '../../../components/FilteredConnection/hooks/useShowMorePagination'
+import {
+    ConnectionContainer,
+    ConnectionError,
+    ConnectionList,
+    ConnectionLoading,
+    ConnectionSummary,
+    ShowMoreButton,
+    SummaryContainer,
+} from '../../../components/FilteredConnection/ui'
+import {
+    BatchChangesCodeHostFields,
+    GlobalBatchChangesCodeHostsResult,
+    Scalars,
+    UserBatchChangesCodeHostsResult,
+} from '../../../graphql-operations'
+
+import { useGlobalBatchChangesCodeHostConnection, useUserBatchChangesCodeHostConnection } from './backend'
+import { CommitSigningIntegrationNode } from './CommitSigningIntegrationNode'
+
+export const GlobalCommitSigningIntegrations: React.FunctionComponent<React.PropsWithChildren<{}>> = () => (
+    <CommitSigningIntegrations connectionResult={useGlobalBatchChangesCodeHostConnection()} readOnly={false} />
+)
+
+interface UserCommitSigningIntegrationsProps {
+    userID: Scalars['ID']
+}
+
+export const UserCommitSigningIntegrations: React.FunctionComponent<
+    React.PropsWithChildren<UserCommitSigningIntegrationsProps>
+> = ({ userID }) => (
+    <CommitSigningIntegrations connectionResult={useUserBatchChangesCodeHostConnection(userID)} readOnly={true} />
+)
+
+interface CommitSigningIntegrationsProps {
+    readOnly: boolean
+    connectionResult: UseShowMorePaginationResult<
+        GlobalBatchChangesCodeHostsResult | UserBatchChangesCodeHostsResult,
+        BatchChangesCodeHostFields
+    >
+}
+
+export const CommitSigningIntegrations: React.FunctionComponent<
+    React.PropsWithChildren<CommitSigningIntegrationsProps>
+> = ({ connectionResult, readOnly }) => {
+    const { loading, hasNextPage, fetchMore, connection, error } = connectionResult
+    return (
+        <Container>
+            <H3>Commit signing integrations</H3>
+            <Text>
+                Connect GitHub Apps to enable Batch Changes to sign commits for your changesets. Contact your site admin
+                to manage connections.
+            </Text>
+            <ConnectionContainer className="mb-3">
+                {error && <ConnectionError errors={[error.message]} />}
+                {loading && !connection && <ConnectionLoading />}
+                <ConnectionList as="ul" className="list-group" aria-label="commit signing integrations">
+                    {connection?.nodes?.map(node =>
+                        node.supportsCommitSigning ? (
+                            <CommitSigningIntegrationNode
+                                key={node.externalServiceURL}
+                                node={node}
+                                readOnly={readOnly}
+                            />
+                        ) : null
+                    )}
+                </ConnectionList>
+                {connection && (
+                    <SummaryContainer className="mt-2">
+                        <ConnectionSummary
+                            noSummaryIfAllNodesVisible={true}
+                            first={15}
+                            centered={true}
+                            connection={connection}
+                            noun="code host"
+                            pluralNoun="code host connections"
+                            hasNextPage={hasNextPage}
+                        />
+                        {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}
+                    </SummaryContainer>
+                )}
+            </ConnectionContainer>
+        </Container>
+    )
+}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -76,11 +76,11 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                     <SummaryContainer className="mt-2">
                         <ConnectionSummary
                             noSummaryIfAllNodesVisible={true}
-                            first={15}
+                            first={30}
                             centered={true}
                             connection={connection}
-                            noun="code host"
-                            pluralNoun="code host connections"
+                            noun="code host commit signing integration"
+                            pluralNoun="code host commit signing integrations"
                             hasNextPage={hasNextPage}
                         />
                         {hasNextPage && <ShowMoreButton centered={true} onClick={fetchMore} />}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -51,10 +51,12 @@ export const CommitSigningIntegrations: React.FunctionComponent<
     return (
         <Container>
             <H3>Commit signing integrations</H3>
-            {/* TODO: Link to docs if it's admin viewing (readOnly = false) */}
+            {/* TODO: Link to docs */}
             <Text>
-                Connect GitHub Apps to enable Batch Changes to sign commits for your changesets. Contact your site admin
-                to manage connections.
+                Connect GitHub Apps to enable Batch Changes to sign commits for your changesets.{' '}
+                {readOnly
+                    ? 'Contact your site admin to manage connections.'
+                    : 'See how Batch Changes GitHub App configuration works.'}
             </Text>
             <ConnectionContainer className="mb-3">
                 {error && <ConnectionError errors={[error.message]} />}

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -84,8 +84,17 @@ const CODE_HOST_FIELDS_FRAGMENT = gql`
         externalServiceURL
         requiresSSH
         requiresUsername
+        supportsCommitSigning
         credential {
             ...BatchChangesCredentialFields
+        }
+        commitSigningConfiguration {
+            ... on GitHubAppConfiguration {
+                appID
+                name
+                appURL
+                logo
+            }
         }
     }
 

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -169,7 +169,7 @@ export const useGlobalBatchChangesCodeHostConnection = (): UseShowMorePagination
         query: GLOBAL_CODE_HOSTS,
         variables: {
             after: null,
-            first: 15,
+            first: 30,
         },
         options: {
             useURL: true,

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -1009,6 +1009,8 @@ describe('Batches', () => {
                                         : null,
                                     requiresSSH: false,
                                     requiresUsername: false,
+                                    supportsCommitSigning: false,
+                                    commitSigningConfiguration: null,
                                 },
                             ],
                         },

--- a/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
+++ b/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
@@ -48,16 +48,7 @@ export const SiteAdminGitHubAppsArea: FC<Props> = props => {
             <Route index={true} element={<GitHubAppsPage batchChangesEnabled={props.batchChangesEnabled} />} />
 
             <Route path="new" element={<CreateGitHubAppPage {...props} />} />
-            <Route
-                path=":appID"
-                element={
-                    <GitHubAppPage
-                        {...props}
-                        externalServicesFromFile={data?.site?.externalServicesFromFile}
-                        allowEditExternalServicesWithFile={data?.site?.allowEditExternalServicesWithFile}
-                    />
-                }
-            />
+            <Route path=":appID" element={<GitHubAppPage {...props} />} />
         </Routes>
     )
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -39,7 +39,11 @@ func (c *batchChangesCodeHostResolver) CommitSigningConfiguration(ctx context.Co
 		domain := itypes.BatchesGitHubAppDomain
 		ghapp, err := gstore.GetByDomain(ctx, &domain, c.codeHost.ExternalServiceID)
 		if err != nil {
-			return nil, err
+			if _, ok := err.(ghstore.ErrNoGitHubAppFound); ok {
+				return nil, nil
+			} else {
+				return nil, err
+			}
 		}
 		return &commitSigningConfigResolver{
 			githubApp: ghapp,

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -402,7 +402,9 @@ func TestGetByDomain(t *testing.T) {
 	fetched, err = store.GetByDomain(ctx, &domain, "https://myCompany.github.com/")
 	require.Nil(t, fetched)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "no app exists matching criteria: {domain = %s AND base_url = %s [repos https://myCompany.github.com/]}")
+	notFoundErr, ok := err.(ErrNoGitHubAppFound)
+	require.Equal(t, ok, true)
+	require.Equal(t, notFoundErr.Error(), "no app exists matching criteria: 'domain = repos AND base_url = https://myCompany.github.com/'")
 
 	domain = types.BatchesGitHubAppDomain
 	fetched, err = store.GetByDomain(ctx, &domain, "https://github.com/")


### PR DESCRIPTION
This PR introduces the initial settings UI components to list out GitHub App connections. As you'll see there's lots of TODOs in here to hook up parts of the workflow or link to docs as those things become available. I decided to open the PR up at this state to avoid bloating it, so treat this mostly as a UI review. 🙂

### Screenshots

As a user:

<img width="809" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/f992d8e4-0699-4475-ae31-311ccbd630ae">

As an admin:

<img width="1161" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/0164a636-2c3b-47ee-8af9-b3fb21f84daa">

Demonstrating some of the clean up/consistency work:

<img width="1133" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/7ad533f0-e215-46dc-8d78-b651e40f8691">


## Test plan

Storybook coverage.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
