### PR TITLE
ci: fix image scanning dependencies

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -892,12 +892,25 @@ func trivyScanCandidateImage(app, tag string) operations.Operation {
 	// this step.
 	vulnerabilityExitCode := 27
 
+	// For most images, waiting on the server is fine. But with the recent migration to Bazel,
+	// this can lead to confusing failures. This will be completely refactored soon.
+	//
+	// See https://github.com/sourcegraph/sourcegraph/issues/52833 for the ticket tracking
+	// the cleanup once we're out of the dual building process.
+	dependsOnImage := candidateImageStepKey("server")
+	if app == "syntax-highlighter" {
+		dependsOnImage = candidateImageStepKey("syntax-highlighter")
+	}
+	if app == "symbols" {
+		dependsOnImage = candidateImageStepKey("symbols")
+	}
+
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(fmt.Sprintf(":trivy: :docker: :mag: Scan %s", app),
 			// These are the first images in the arrays we use to build images
 			bk.DependsOn(candidateImageStepKey("alpine-3.14")),
-			bk.DependsOn(candidateImageStepKey("server")),
 			bk.DependsOn(candidateImageStepKey("batcheshelper")),
+			bk.DependsOn(dependsOnImage),
 			bk.Cmd(fmt.Sprintf("docker pull %s", image)),
 
 			// have trivy use a shorter name in its output


### PR DESCRIPTION
Adds two explicit step dependency for symbols and syntax-highlighter.

Previous code for handling dependencies is a bit fragile, which leads to corner case where it tried to scan an image that wasn't built, which is confusing to read.

This will be cleaned up in the future by https://github.com/sourcegraph/sourcegraph/issues/52833

Test Plan: previewed locally + main-dry-run



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
