### PR TITLE
Remove Bag's resolution errors

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -289,10 +289,7 @@ func (r *ownResolver) computeCodeowners(ctx context.Context, blob *graphqlbacken
 			ruleToRefs[rule] = append(ruleToRefs[rule], ref)
 		}
 	}
-	err = bag.Resolve(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
+	bag.Resolve(ctx, r.db)
 	for rule, refs := range ruleToRefs {
 		for _, ref := range refs {
 			resolvedOwner, found := bag.FindResolved(ref)

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -112,7 +112,7 @@ type Bag interface {
 	// Resolve retrieves all users it can find that are associated
 	// with references that are in the Bag by means of Add or ByTextReference
 	// constructor.
-	Resolve(context.Context, edb.EnterpriseDB) error
+	Resolve(context.Context, edb.EnterpriseDB)
 }
 
 func EmptyBag() *bag {
@@ -129,7 +129,7 @@ func EmptyBag() *bag {
 // that the database reveals.
 // TODO(#52141): Search by code host handle.
 // TODO(#52246): ByTextReference uses fewer queries.
-func ByTextReference(ctx context.Context, db edb.EnterpriseDB, text ...string) (Bag, error) {
+func ByTextReference(ctx context.Context, db edb.EnterpriseDB, text ...string) Bag {
 	b := EmptyBag()
 	for _, t := range text {
 		// Empty text does not resolve at all.
@@ -142,10 +142,8 @@ func ByTextReference(ctx context.Context, db edb.EnterpriseDB, text ...string) (
 			b.add(refKey{handle: strings.TrimPrefix(t, "@")})
 		}
 	}
-	if err := b.Resolve(ctx, db); err != nil {
-		return nil, err
-	}
-	return b, nil
+	b.Resolve(ctx, db)
+	return b
 }
 
 // bag is implemented as a map of resolved users and map of references.
@@ -279,20 +277,18 @@ func (b *bag) add(k refKey) {
 // Fetched users are augmented with all the other references that
 // can point to them (also from the database), and the newly fetched
 // references are then linked back to the bag.
-func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) error {
+func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) {
 	for k, refCtx := range b.references {
 		if !refCtx.resolutionDone {
 			userRefs, teamRefs, err := k.fetch(ctx, db)
 			refCtx.resolutionDone = true
 			if err != nil {
-				return err
+				refCtx.appendErr(err)
 			}
 			// User resolved
 			if userRefs != nil {
 				if _, ok := b.resolvedUsers[userRefs.id]; !ok {
-					if err := userRefs.augment(ctx, db); err != nil {
-						return err
-					}
+					userRefs.augment(ctx, db)
 					b.resolvedUsers[userRefs.id] = userRefs
 					userRefs.linkBack(b)
 				}
@@ -310,7 +306,6 @@ func (b *bag) Resolve(ctx context.Context, db edb.EnterpriseDB) error {
 			}
 		}
 	}
-	return nil
 }
 
 // userReferences represents all the references found for a given user in the database.
@@ -322,35 +317,41 @@ type userReferences struct {
 	// codeHostHandles are handles on the code-host that are linked with the user
 	codeHostHandles []string
 	verifiedEmails  []string
+	errs            []error
+}
+
+func (r *userReferences) appendErr(err error) {
+	r.errs = append(r.errs, err)
 }
 
 // augment fetches all the references for this user that are missing.
 // These can then be linked back into the bag using `linkBack`.
 // In order to call augment, `id`
-func (r *userReferences) augment(ctx context.Context, db edb.EnterpriseDB) error {
+func (r *userReferences) augment(ctx context.Context, db edb.EnterpriseDB) {
+	// User references has to have an ID
 	if r.id == 0 {
-		return errors.New("userReferences needs id set for augmenting")
+		r.appendErr(errors.New("userReferences needs id set for augmenting"))
+		return
 	}
 	var err error
 	if r.user == nil {
 		r.user, err = db.Users().GetByID(ctx, r.id)
 		if err != nil {
-			return errors.Wrap(err, "augmenting user")
+			r.appendErr(errors.Wrap(err, "augmenting user"))
 		}
 	}
 	if len(r.codeHostHandles) == 0 {
 		r.codeHostHandles, err = fetchCodeHostHandles(ctx, db, r.id)
 		if err != nil {
-			return errors.Wrap(err, "augmenting code host handles")
+			r.appendErr(errors.Wrap(err, "augmenting code host handles"))
 		}
 	}
 	if len(r.verifiedEmails) == 0 {
 		r.verifiedEmails, err = fetchVerifiedEmails(ctx, db, r.id)
 		if err != nil {
-			return errors.Wrap(err, "augmenting verified emails")
+			r.appendErr(errors.Wrap(err, "augmenting verified emails"))
 		}
 	}
-	return nil
 }
 
 func fetchVerifiedEmails(ctx context.Context, db edb.EnterpriseDB, userID int32) ([]string, error) {
@@ -567,11 +568,16 @@ type refContext struct {
 	// resolutionDone is set to true after the reference pointing at this refContext
 	// has been attempted to be resolved.
 	resolutionDone bool
+	resolutionErrs []error
 }
 
 // successfullyResolved context either points to a team or to a user.
 func (c refContext) successfullyResolved() bool {
 	return c.resolvedUserID != 0 || c.resolvedTeamID != 0
+}
+
+func (c *refContext) appendErr(err error) {
+	c.resolutionErrs = append(c.resolutionErrs, err)
 }
 
 func (c refContext) resolvedIDForDebugging() string {

--- a/enterprise/internal/own/ownref_test.go
+++ b/enterprise/internal/own/ownref_test.go
@@ -120,8 +120,7 @@ func TestSearchFilteringExample(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			// Do this at first during search and hold references to all the known entities
 			// that can be referred to by given search term.
-			bag, err := ByTextReference(ctx, db, testCase.searchTerm)
-			require.NoError(t, err)
+			bag := ByTextReference(ctx, db, testCase.searchTerm)
 			for name, r := range ownerReferences {
 				t.Run(name, func(t *testing.T) {
 					assert.True(t, bag.Contains(r), fmt.Sprintf("%s.Contains(%s), want true, got false", bag, r))
@@ -139,8 +138,7 @@ func TestBagNoUser(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
 	ctx := context.Background()
-	bag, err := ByTextReference(ctx, db, "userdoesnotexist")
-	require.NoError(t, err)
+	bag := ByTextReference(ctx, db, "userdoesnotexist")
 	for name, r := range map[string]Reference{
 		"same handle matches even when there is no user": {
 			Handle: "userdoesnotexist",
@@ -249,8 +247,7 @@ func TestBagUserFoundNoMatches(t *testing.T) {
 	}
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			bag, err := ByTextReference(ctx, db, testCase.searchTerm)
-			require.NoError(t, err)
+			bag := ByTextReference(ctx, db, testCase.searchTerm)
 			// Check test is valid by verifying user can be found by handle/email.
 			require.True(t, bag.Contains(testCase.validationRef), fmt.Sprintf("validation: Contains(%s), want true, got false", testCase.validationRef))
 			for name, r := range ownerReferences {
@@ -296,8 +293,7 @@ func TestBagUnverifiedEmailOnlyMatchesWithItself(t *testing.T) {
 
 	// Imagine this is the search with filter
 	// `file:has.owner(john-the-unverified@example.com)`.
-	bag, err := ByTextReference(ctx, db, unverifiedEmail)
-	require.NoError(t, err)
+	bag := ByTextReference(ctx, db, unverifiedEmail)
 	for name, r := range ownerReferences {
 		t.Run(name, func(t *testing.T) {
 			if r.Email == unverifiedEmail {
@@ -321,8 +317,7 @@ func TestBagRetrievesTeamsByName(t *testing.T) {
 	require.NoError(t, err)
 	team, err := db.Teams().GetTeamByName(ctx, "team-name")
 	require.NoError(t, err)
-	bag, err := ByTextReference(ctx, db, "team-name")
-	require.NoError(t, err)
+	bag := ByTextReference(ctx, db, "team-name")
 	ref := Reference{TeamID: team.ID}
 	assert.True(t, bag.Contains(ref), "%s contains %s", bag, ref)
 }
@@ -347,8 +342,7 @@ func TestBagManyUsers(t *testing.T) {
 		EmailIsVerified: true,
 	})
 	require.NoError(t, err)
-	bag, err := ByTextReference(ctx, db, "jdoe", "ssmith")
-	require.NoError(t, err)
+	bag := ByTextReference(ctx, db, "jdoe", "ssmith")
 	assert.True(t, bag.Contains(Reference{Handle: "ssmith"}))
 	assert.True(t, bag.Contains(Reference{Handle: "jdoe"}))
 }

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -59,18 +59,12 @@ func (s *fileHasOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, 
 	// need to match for ownership. Therefore we create a single bag per entry.
 	var includeBags []own.Bag
 	for _, o := range s.includeOwners {
-		b, err := own.ByTextReference(ctx, database.NewEnterpriseDB(clients.DB), o)
-		if err != nil {
-			return nil, errors.Wrap(err, "failure trying to resolve search term")
-		}
+		b := own.ByTextReference(ctx, database.NewEnterpriseDB(clients.DB), o)
 		includeBags = append(includeBags, b)
 	}
 	var excludeBags []own.Bag
 	for _, o := range s.excludeOwners {
-		b, err := own.ByTextReference(ctx, database.NewEnterpriseDB(clients.DB), o)
-		if err != nil {
-			return nil, errors.Wrap(err, "failure trying to resolve search term")
-		}
+		b := own.ByTextReference(ctx, database.NewEnterpriseDB(clients.DB), o)
 		excludeBags = append(excludeBags, b)
 	}
 

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -408,14 +408,12 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 
 			var includeBags []own.Bag
 			for _, o := range tt.args.includeOwners {
-				b, err := own.ByTextReference(ctx, db, o)
-				require.NoError(t, err)
+				b := own.ByTextReference(ctx, db, o)
 				includeBags = append(includeBags, b)
 			}
 			var excludeBags []own.Bag
 			for _, o := range tt.args.excludeOwners {
-				b, err := own.ByTextReference(ctx, db, o)
-				require.NoError(t, err)
+				b := own.ByTextReference(ctx, db, o)
 				excludeBags = append(excludeBags, b)
 			}
 			matches, _ := applyCodeOwnershipFiltering(


### PR DESCRIPTION
Part of #52911
Waits for #52859 to go in first

`Bag.Resolve` and all related methods do not return errors. Instead errors are accumulated in the data structure, so that in https://github.com/sourcegraph/sourcegraph/issues/52255 we can serve these appropriately.

## Test plan

Existing test cases. We're going to add an extra set of tests in a follow-up PR.
