### PR TITLE
cody: make embedding jobs searchable 

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -156,7 +156,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                     <ConnectionForm
                         inputValue={searchValue}
                         onInputChange={event => setSearchValue(event.target.value)}
-                        inputPlaceholder="Search embedding jobs..."
+                        inputPlaceholder="Filter embedding jobs..."
                     />
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect } from 'react'
+import { FC, useCallback, useEffect, useState } from 'react'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
@@ -13,11 +13,13 @@ import {
     Validator,
     ErrorAlert,
     Form,
+    useDebounce,
 } from '@sourcegraph/wildcard'
 
 import {
     ConnectionContainer,
     ConnectionError,
+    ConnectionForm,
     ConnectionList,
     ConnectionLoading,
     ConnectionSummary,
@@ -57,7 +59,10 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         telemetryService.logPageView('SiteAdminCodyPage')
     }, [telemetryService])
 
-    const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useRepoEmbeddingJobsConnection()
+    const [searchValue, setSearchValue] = useState('')
+    const query = useDebounce(searchValue, 200)
+
+    const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useRepoEmbeddingJobsConnection(query)
 
     const [scheduleRepoEmbeddingJobs, { loading: repoEmbeddingJobsLoading, error: repoEmbeddingJobsError }] =
         useScheduleRepoEmbeddingJobs()
@@ -144,8 +149,15 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                         />
                     </div>
                 )}
+            </Container>
+            <Container>
                 <H3 className="mt-3">Repository embedding jobs</H3>
                 <ConnectionContainer>
+                    <ConnectionForm
+                        inputValue={searchValue}
+                        onInputChange={event => setSearchValue(event.target.value)}
+                        inputPlaceholder="search embedding jobs..."
+                    />
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}
                     <ConnectionList as="ul" className="list-group" aria-label="Repository embedding jobs">
@@ -160,6 +172,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                                 first={connection.totalCount ?? 0}
                                 centered={true}
                                 connection={connection}
+                                connectionQuery={query}
                                 noun="repository embedding job"
                                 pluralNoun="repository embedding jobs"
                                 hasNextPage={hasNextPage}

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -156,7 +156,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                     <ConnectionForm
                         inputValue={searchValue}
                         onInputChange={event => setSearchValue(event.target.value)}
-                        inputPlaceholder="search embedding jobs..."
+                        inputPlaceholder="Search embedding jobs..."
                     />
                     {error && <ConnectionError errors={[error.message]} />}
                     {loading && !connection && <ConnectionLoading />}

--- a/client/web/src/enterprise/site-admin/cody/backend.ts
+++ b/client/web/src/enterprise/site-admin/cody/backend.ts
@@ -41,8 +41,8 @@ const REPO_EMBEDDING_JOB_FRAGMENT = gql`
 export const REPO_EMBEDDING_JOBS_LIST_QUERY = gql`
     ${REPO_EMBEDDING_JOB_FRAGMENT}
 
-    query RepoEmbeddingJobsList($first: Int, $after: String) {
-        repoEmbeddingJobs(first: $first, after: $after) {
+    query RepoEmbeddingJobsList($first: Int, $after: String, $query: String) {
+        repoEmbeddingJobs(first: $first, after: $after, query: $query) {
             nodes {
                 ...RepoEmbeddingJobFields
             }
@@ -55,16 +55,12 @@ export const REPO_EMBEDDING_JOBS_LIST_QUERY = gql`
     }
 `
 
-export const useRepoEmbeddingJobsConnection = (): UseShowMorePaginationResult<
-    RepoEmbeddingJobsListResult,
-    RepoEmbeddingJobFields
-> =>
+export const useRepoEmbeddingJobsConnection = (
+    query: string
+): UseShowMorePaginationResult<RepoEmbeddingJobsListResult, RepoEmbeddingJobFields> =>
     useShowMorePagination<RepoEmbeddingJobsListResult, RepoEmbeddingJobsListVariables, RepoEmbeddingJobFields>({
         query: REPO_EMBEDDING_JOBS_LIST_QUERY,
-        variables: {
-            after: null,
-            first: 10,
-        },
+        variables: { after: null, first: 10, query },
         getConnection: result => {
             const { repoEmbeddingJobs } = dataOrThrowErrors(result)
             return repoEmbeddingJobs

--- a/cmd/frontend/graphqlbackend/embeddings.go
+++ b/cmd/frontend/graphqlbackend/embeddings.go
@@ -58,6 +58,7 @@ type EmbeddingsSearchResultResolver interface {
 
 type ListRepoEmbeddingJobsArgs struct {
 	graphqlutil.ConnectionResolverArgs
+	Query *string
 }
 
 type CancelRepoEmbeddingJobArgs struct {

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -78,6 +78,10 @@ extend type Query {
         also used in conjunction with "last" to return the last N nodes.
         """
         before: String
+        """
+        Filter by the name of the repository.
+        """
+        query: String
     ): RepoEmbeddingJobsConnection!
 }
 

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
@@ -39,10 +39,11 @@ type repoEmbeddingJobsConnectionStore struct {
 	gitserverClient gitserver.Client
 	store           repobg.RepoEmbeddingJobsStore
 	args            graphqlbackend.ListRepoEmbeddingJobsArgs
+	query           *string
 }
 
 func (s *repoEmbeddingJobsConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {
-	count, err := s.store.CountRepoEmbeddingJobs(ctx)
+	count, err := s.store.CountRepoEmbeddingJobs(ctx, repobg.ListOpts{Query: s.args.Query})
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func (s *repoEmbeddingJobsConnectionStore) ComputeTotal(ctx context.Context) (*i
 }
 
 func (s *repoEmbeddingJobsConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]graphqlbackend.RepoEmbeddingJobResolver, error) {
-	jobs, err := s.store.ListRepoEmbeddingJobs(ctx, args)
+	jobs, err := s.store.ListRepoEmbeddingJobs(ctx, repobg.ListOpts{PaginationArgs: args, Query: s.args.Query})
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/embeddings/background/repo/mocks_temp.go
+++ b/enterprise/internal/embeddings/background/repo/mocks_temp.go
@@ -12,7 +12,6 @@ import (
 
 	sqlf "github.com/keegancsmith/sqlf"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
-	database "github.com/sourcegraph/sourcegraph/internal/database"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
@@ -69,7 +68,7 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
-			defaultHook: func(context.Context) (r0 int, r1 error) {
+			defaultHook: func(context.Context, ListOpts) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -109,7 +108,7 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		ListRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc{
-			defaultHook: func(context.Context, *database.PaginationArgs) (r0 []*RepoEmbeddingJob, r1 error) {
+			defaultHook: func(context.Context, ListOpts) (r0 []*RepoEmbeddingJob, r1 error) {
 				return
 			},
 		},
@@ -132,7 +131,7 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
-			defaultHook: func(context.Context) (int, error) {
+			defaultHook: func(context.Context, ListOpts) (int, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CountRepoEmbeddingJobs")
 			},
 		},
@@ -172,7 +171,7 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		ListRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc{
-			defaultHook: func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
+			defaultHook: func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.ListRepoEmbeddingJobs")
 			},
 		},
@@ -338,24 +337,24 @@ func (c RepoEmbeddingJobsStoreCancelRepoEmbeddingJobFuncCall) Results() []interf
 // when the CountRepoEmbeddingJobs method of the parent
 // MockRepoEmbeddingJobsStore instance is invoked.
 type RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc struct {
-	defaultHook func(context.Context) (int, error)
-	hooks       []func(context.Context) (int, error)
+	defaultHook func(context.Context, ListOpts) (int, error)
+	hooks       []func(context.Context, ListOpts) (int, error)
 	history     []RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // CountRepoEmbeddingJobs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockRepoEmbeddingJobsStore) CountRepoEmbeddingJobs(v0 context.Context) (int, error) {
-	r0, r1 := m.CountRepoEmbeddingJobsFunc.nextHook()(v0)
-	m.CountRepoEmbeddingJobsFunc.appendCall(RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall{v0, r0, r1})
+func (m *MockRepoEmbeddingJobsStore) CountRepoEmbeddingJobs(v0 context.Context, v1 ListOpts) (int, error) {
+	r0, r1 := m.CountRepoEmbeddingJobsFunc.nextHook()(v0, v1)
+	m.CountRepoEmbeddingJobsFunc.appendCall(RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // CountRepoEmbeddingJobs method of the parent MockRepoEmbeddingJobsStore
 // instance is invoked and the hook queue is empty.
-func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) SetDefaultHook(hook func(context.Context, ListOpts) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -364,7 +363,7 @@ func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) SetDefaultHook(hook f
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) PushHook(hook func(context.Context) (int, error)) {
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) PushHook(hook func(context.Context, ListOpts) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -373,19 +372,19 @@ func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) PushHook(hook func(co
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context) (int, error) {
+	f.SetDefaultHook(func(context.Context, ListOpts) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context) (int, error) {
+	f.PushHook(func(context.Context, ListOpts) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) nextHook() func(context.Context) (int, error) {
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc) nextHook() func(context.Context, ListOpts) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -423,6 +422,9 @@ type RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 ListOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -434,7 +436,7 @@ type RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
@@ -1211,15 +1213,15 @@ func (c RepoEmbeddingJobsStoreHandleFuncCall) Results() []interface{} {
 // when the ListRepoEmbeddingJobs method of the parent
 // MockRepoEmbeddingJobsStore instance is invoked.
 type RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc struct {
-	defaultHook func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error)
-	hooks       []func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error)
+	defaultHook func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error)
+	hooks       []func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error)
 	history     []RepoEmbeddingJobsStoreListRepoEmbeddingJobsFuncCall
 	mutex       sync.Mutex
 }
 
 // ListRepoEmbeddingJobs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockRepoEmbeddingJobsStore) ListRepoEmbeddingJobs(v0 context.Context, v1 *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
+func (m *MockRepoEmbeddingJobsStore) ListRepoEmbeddingJobs(v0 context.Context, v1 ListOpts) ([]*RepoEmbeddingJob, error) {
 	r0, r1 := m.ListRepoEmbeddingJobsFunc.nextHook()(v0, v1)
 	m.ListRepoEmbeddingJobsFunc.appendCall(RepoEmbeddingJobsStoreListRepoEmbeddingJobsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -1228,7 +1230,7 @@ func (m *MockRepoEmbeddingJobsStore) ListRepoEmbeddingJobs(v0 context.Context, v
 // SetDefaultHook sets function that is called when the
 // ListRepoEmbeddingJobs method of the parent MockRepoEmbeddingJobsStore
 // instance is invoked and the hook queue is empty.
-func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) SetDefaultHook(hook func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error)) {
+func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) SetDefaultHook(hook func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error)) {
 	f.defaultHook = hook
 }
 
@@ -1237,7 +1239,7 @@ func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) SetDefaultHook(hook fu
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) PushHook(hook func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error)) {
+func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) PushHook(hook func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1246,19 +1248,19 @@ func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) PushHook(hook func(con
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) SetDefaultReturn(r0 []*RepoEmbeddingJob, r1 error) {
-	f.SetDefaultHook(func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
+	f.SetDefaultHook(func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) PushReturn(r0 []*RepoEmbeddingJob, r1 error) {
-	f.PushHook(func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
+	f.PushHook(func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) nextHook() func(context.Context, *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
+func (f *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc) nextHook() func(context.Context, ListOpts) ([]*RepoEmbeddingJob, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1298,7 +1300,7 @@ type RepoEmbeddingJobsStoreListRepoEmbeddingJobsFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 *database.PaginationArgs
+	Arg1 ListOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 []*RepoEmbeddingJob

--- a/enterprise/internal/embeddings/background/repo/store.go
+++ b/enterprise/internal/embeddings/background/repo/store.go
@@ -101,8 +101,8 @@ type RepoEmbeddingJobsStore interface {
 	CreateRepoEmbeddingJob(ctx context.Context, repoID api.RepoID, revision api.CommitID) (int, error)
 	GetLastCompletedRepoEmbeddingJob(ctx context.Context, repoID api.RepoID) (*RepoEmbeddingJob, error)
 	GetLastRepoEmbeddingJobForRevision(ctx context.Context, repoID api.RepoID, revision api.CommitID) (*RepoEmbeddingJob, error)
-	ListRepoEmbeddingJobs(ctx context.Context, args *database.PaginationArgs) ([]*RepoEmbeddingJob, error)
-	CountRepoEmbeddingJobs(ctx context.Context) (int, error)
+	ListRepoEmbeddingJobs(ctx context.Context, args ListOpts) ([]*RepoEmbeddingJob, error)
+	CountRepoEmbeddingJobs(ctx context.Context, args ListOpts) (int, error)
 	GetEmbeddableRepos(ctx context.Context, opts EmbeddableRepoOpts) ([]EmbeddableRepo, error)
 	CancelRepoEmbeddingJob(ctx context.Context, job int) error
 }
@@ -188,6 +188,11 @@ type EmbeddableRepoOpts struct {
 	// MinimumInterval is the minimum amount of time that must have passed since the last
 	// successful embedding job.
 	MinimumInterval time.Duration
+}
+
+type ListOpts struct {
+	*database.PaginationArgs
+	Query *string
 }
 
 func init() {
@@ -288,10 +293,27 @@ func (s *repoEmbeddingJobsStore) GetLastRepoEmbeddingJobForRevision(ctx context.
 const countRepoEmbeddingJobsQuery = `
 SELECT COUNT(*)
 FROM repo_embedding_jobs
+JOIN repo ON repo.id = repo_embedding_jobs.repo_id
+%s -- whereClause
 `
 
-func (s *repoEmbeddingJobsStore) CountRepoEmbeddingJobs(ctx context.Context) (int, error) {
-	q := sqlf.Sprintf(countRepoEmbeddingJobsQuery)
+// CountRepoEmbeddingJobs returns the number of repo embedding jobs that match
+// the query. If there is no query, all repo embedding jobs are counted.
+func (s *repoEmbeddingJobsStore) CountRepoEmbeddingJobs(ctx context.Context, opts ListOpts) (int, error) {
+	var conds []*sqlf.Query
+	if opts.Query != nil && *opts.Query != "" {
+		conds = append(conds, sqlf.Sprintf("repo.name LIKE %s", "%"+*opts.Query+"%"))
+
+	}
+
+	var whereClause *sqlf.Query
+	if len(conds) != 0 {
+		whereClause = sqlf.Sprintf("WHERE %s", sqlf.Join(conds, "\n AND "))
+	} else {
+		whereClause = sqlf.Sprintf("")
+	}
+
+	q := sqlf.Sprintf(countRepoEmbeddingJobsQuery, whereClause)
 	var count int
 	if err := s.QueryRow(ctx, q).Scan(&count); err != nil {
 		return 0, err
@@ -302,15 +324,20 @@ func (s *repoEmbeddingJobsStore) CountRepoEmbeddingJobs(ctx context.Context) (in
 const listRepoEmbeddingJobsQueryFmtstr = `
 SELECT %s
 FROM repo_embedding_jobs
+JOIN repo ON repo.id = repo_embedding_jobs.repo_id
 %s -- whereClause
 `
 
-func (s *repoEmbeddingJobsStore) ListRepoEmbeddingJobs(ctx context.Context, paginationArgs *database.PaginationArgs) ([]*RepoEmbeddingJob, error) {
-	pagination := paginationArgs.SQL()
+func (s *repoEmbeddingJobsStore) ListRepoEmbeddingJobs(ctx context.Context, opts ListOpts) ([]*RepoEmbeddingJob, error) {
+	pagination := opts.PaginationArgs.SQL()
 
 	var conds []*sqlf.Query
 	if pagination.Where != nil {
 		conds = append(conds, pagination.Where)
+	}
+
+	if opts.Query != nil && *opts.Query != "" {
+		conds = append(conds, sqlf.Sprintf("repo.name LIKE %s", "%"+*opts.Query+"%"))
 	}
 
 	var whereClause *sqlf.Query

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -35,6 +35,10 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	err := repoStore.Create(ctx, createdRepo)
 	require.NoError(t, err)
 
+	createdRepo2 := &types.Repo{Name: "github.com/sourcegraph/zoekt", URI: "github.com/sourcegraph/zoekt", ExternalRepo: api.ExternalRepoSpec{}}
+	err = repoStore.Create(ctx, createdRepo2)
+	require.NoError(t, err)
+
 	store := NewRepoEmbeddingJobsStore(db)
 
 	// no job exists
@@ -42,16 +46,29 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, exists, false)
 
-	// Create two repo embedding jobs.
+	// Create three repo embedding jobs.
 	id1, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "deadbeef")
 	require.NoError(t, err)
 
 	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
 	require.NoError(t, err)
 
+	id3, err := store.CreateRepoEmbeddingJob(ctx, createdRepo2.ID, "tea")
+	require.NoError(t, err)
+
 	count, err := store.CountRepoEmbeddingJobs(ctx, ListOpts{})
 	require.NoError(t, err)
-	require.Equal(t, 2, count)
+	require.Equal(t, 3, count)
+
+	pattern := "oek" // matching zoekt
+	count, err = store.CountRepoEmbeddingJobs(ctx, ListOpts{Query: &pattern})
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	pattern = "unknown"
+	count, err = store.CountRepoEmbeddingJobs(ctx, ListOpts{Query: &pattern})
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
 
 	first := 10
 	jobs, err := store.ListRepoEmbeddingJobs(ctx, ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}})
@@ -62,10 +79,11 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, exists, false)
 
-	// Expect to get the two repo embedding jobs in the list.
-	require.Equal(t, 2, len(jobs))
+	// Expect to get the three repo embedding jobs in the list.
+	require.Equal(t, 3, len(jobs))
 	require.Equal(t, id1, jobs[0].ID)
 	require.Equal(t, id2, jobs[1].ID)
+	require.Equal(t, id3, jobs[2].ID)
 
 	// Check that we get the correct repo embedding job for repo and revision.
 	lastEmbeddingJobForRevision, err := store.GetLastRepoEmbeddingJobForRevision(ctx, createdRepo.ID, "deadbeef")

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -49,12 +49,12 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
 	require.NoError(t, err)
 
-	count, err := store.CountRepoEmbeddingJobs(ctx)
+	count, err := store.CountRepoEmbeddingJobs(ctx, ListOpts{})
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 
 	first := 10
-	jobs, err := store.ListRepoEmbeddingJobs(ctx, &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true})
+	jobs, err := store.ListRepoEmbeddingJobs(ctx, ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}})
 	require.NoError(t, err)
 
 	// only queued job exists
@@ -118,7 +118,7 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 	require.NoError(t, err)
 
 	first := 10
-	jobs, err := store.ListRepoEmbeddingJobs(ctx, &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true})
+	jobs, err := store.ListRepoEmbeddingJobs(ctx, ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}})
 	require.NoError(t, err)
 
 	// Expect to get the two repo embedding jobs in the list.


### PR DESCRIPTION
This adds a search bar to the list of repo embedding jobs. The patterns are translated to db-queries of the form

```
WHERE repo.name LIKE %<pattern>%
```

UI notes:
  - Now we have two input fields on the page, one for scheduling one-time jobs and one for searching embedding jobs
  - To distinguish the two input fields I put the scheduling form in a separate container which creates a visible gap 

![Kapture 2023-06-05 at 13 17 08](https://github.com/sourcegraph/sourcegraph/assets/26413131/6f141206-05f4-4455-93d8-9e2189cfea1d)

## Test plan
  - `sg start embeddings`
  - site-admin > Cody > embeddings
  - schedule a couple of embedding jobs
  - search over repo names
  - verify that the counts and the query in the summary component match the expectation
