### PR TITLE
bzl: fix missing year digits when stamping

### DIFF
--- a/dev/bazel_stamp_vars.sh
+++ b/dev/bazel_stamp_vars.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 build_number="${BUILDKITE_BUILD_NUMBER:-000000}"
-date_fragment="$(date +%y-%m-%d)"
+date_fragment="$(date +%Y-%m-%d)"
 latest_tag="5.0"
 stamp_version="${build_number}_${date_fragment}_${latest_tag}-$(git rev-parse --short HEAD)"
 


### PR DESCRIPTION
@filiphaftek noticed that we were missing digits on the `version` string, which this PR fixes. Thanks so much for catching this @filiphaftek 🙏 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + local test