### PR TITLE
JetBrains: Fix the `TAB` apply Cody completion in-editor action

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -155,7 +155,7 @@ public class CodyCompletionsManager {
     return isSupported;
   }
 
-  private boolean isEditorInstanceSupported(Editor editor) {
+  public static boolean isEditorInstanceSupported(Editor editor) {
     return !editor.isViewer()
         && !editor.isOneLineMode()
         && !(editor instanceof EditorWindow)


### PR DESCRIPTION
Fixes #52825 

https://github.com/sourcegraph/sourcegraph/assets/18601388/e14f575a-9807-4801-8e2e-65267e51bdfe
The earlier code relied on API requiring a dispatch thread with write access on the EDT, which was called from a read-only thread.
Using an adjacent API seems to do the trick.

## Test plan
- pressing `TAB` after a completion is rendered in the editor should paste the completion
- pressing `TAB` if no completion has been rendered at the moment should just insert a tabulation
- no exceptions should be produced for either case
