### PR TITLE
cody docs: remove line about enabling account

### DIFF
--- a/doc/cody/explanations/indexing.md
+++ b/doc/cody/explanations/indexing.md
@@ -14,7 +14,6 @@ To generate an index for your codebase and enable codebase-aware answers for Cod
 
 - [Configure Code Graph Context](code_graph_context.md) for your Sourcegraph instance
 - [Enable Cody for your Sourcegraph instance](enabling_cody_enterprise.md#step-1-enable-cody-on-your-sourcegraph-instance)
-- [Enable Cody for your Sourcegraph account](enabling_cody_enterprise.md#turning-cody-off)
 
 ### Sourcegraph.com
 


### PR DESCRIPTION
I ran into this while reading docs and was confused because

1. it links to "turning cody off" and not something on how to enable an account
2. enabling/disabling accounts is unrelated to generation of embeddings

## Test plan

- N/A
