### PR TITLE
own: use search alerts aggregation instead of errors.

### DIFF
--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -3,7 +3,6 @@ package search
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -48,10 +47,7 @@ func (s *fileHasOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, 
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer finish(alert, err)
 
-	var (
-		mu         sync.Mutex
-		maxAlerter search.MaxAlerter
-	)
+	var maxAlerter search.MaxAlerter
 
 	rules := NewRulesCache(clients.Gitserver, clients.DB)
 
@@ -78,9 +74,7 @@ func (s *fileHasOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, 
 		var err error
 		event.Results, err = applyCodeOwnershipFiltering(ctx, &rules, includeBags, s.includeOwners, excludeBags, s.excludeOwners, event.Results)
 		if err != nil {
-			mu.Lock()
 			maxAlerter.Add(search.AlertForOwnershipSearchError())
-			mu.Unlock()
 		}
 		stream.Send(event)
 	})

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -426,7 +426,6 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				excludeBags,
 				tt.args.excludeOwners,
 				tt.args.matches)
-			//require.NoError(t, err)
 			tt.want.Equal(t, matches)
 		})
 	}

--- a/enterprise/internal/own/search/rules_cache.go
+++ b/enterprise/internal/own/search/rules_cache.go
@@ -68,7 +68,7 @@ func (c *RulesCache) AssignedOwners(ctx context.Context, repoID api.RepoID, comm
 	if _, ok := c.assigned[key]; !ok {
 		assigned, err := c.ownService.AssignedOwnership(ctx, repoID, commitID)
 		if err != nil {
-			// TODO: Consider error condition
+			// Error is picked up on a call site and in most cases a search alert is created.
 			return nil, err
 		}
 		c.assigned[key] = assigned

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -52,9 +52,7 @@ func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	filteredStream := streaming.StreamFunc(func(event streaming.SearchEvent) {
 		matches, ok, err := getCodeOwnersFromMatches(ctx, &rules, event.Results)
 		if err != nil {
-			mu.Lock()
 			maxAlerter.Add(search.AlertForOwnershipSearchError())
-			mu.Unlock()
 		}
 		mu.Lock()
 		if ok {

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -40,12 +40,11 @@ func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	var (
 		mu                    sync.Mutex
 		hasResultWithNoOwners bool
-		errs                  error
+		maxAlerter            search.MaxAlerter
 		bagMu                 sync.Mutex // TODO(#52553): Make bag thread-safe
 	)
 
 	dedup := result.NewDeduper()
-	var maxAlerter search.MaxAlerter
 
 	rules := NewRulesCache(clients.Gitserver, clients.DB)
 	bag := own.EmptyBag()
@@ -54,7 +53,7 @@ func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, s
 		matches, ok, err := getCodeOwnersFromMatches(ctx, &rules, event.Results)
 		if err != nil {
 			mu.Lock()
-			errs = errors.Append(errs, err)
+			maxAlerter.Add(search.AlertForOwnershipSearchError())
 			mu.Unlock()
 		}
 		mu.Lock()
@@ -80,7 +79,7 @@ func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, s
 					guess := r.ResolutionGuess()
 					// No text references found to make a guess, something is wrong.
 					if guess == nil {
-						// TODO: Handle error condition
+						maxAlerter.Add(search.AlertForOwnershipSearchError())
 						continue nextReference
 					}
 					ro = guess
@@ -105,16 +104,13 @@ func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	})
 
 	alert, err = s.child.Run(ctx, clients, filteredStream)
-	if err != nil {
-		errs = errors.Append(errs, err)
-	}
 	maxAlerter.Add(alert)
 
 	if hasResultWithNoOwners {
 		maxAlerter.Add(search.AlertForUnownedResult())
 	}
 
-	return maxAlerter.Alert, errs
+	return maxAlerter.Alert, err
 }
 
 func (s *selectOwnersJob) Name() string {

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -7,7 +7,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -167,20 +166,6 @@ func AlertForInvalidRevision(revision string) *Alert {
 	}
 }
 
-func AlertForUnindexedLockfile(repoName api.RepoName, revisions []string) *Alert {
-	var description strings.Builder
-	fmt.Fprintf(&description, "No lockfile indexed in **%s** at these revisions yet:\n", repoName)
-	for _, r := range revisions {
-		fmt.Fprintf(&description, "- `%s`", r)
-	}
-
-	return &Alert{
-		PrometheusType: "unindexed_dependency_search",
-		Title:          "Lockfile not indexed",
-		Description:    description.String(),
-	}
-}
-
 func AlertForUnownedResult() *Alert {
 	return &Alert{
 		Kind:        "unowned-results",
@@ -188,5 +173,16 @@ func AlertForUnownedResult() *Alert {
 		Description: "For some results, no ownership data was found, or no rule applied to the result. [Learn more about configuring Sourcegraph Own](https://docs.sourcegraph.com/own).",
 		// Explicitly set a low priority, so other alerts take precedence.
 		Priority: 0,
+	}
+}
+
+// AlertForOwnershipSearchError returns an alert related to ownership search
+// error. This alert has higher priority than `AlertForUnownedResult`.
+func AlertForOwnershipSearchError() *Alert {
+	return &Alert{
+		Kind:        "ownership-search-error",
+		Title:       "Error during ownership search",
+		Description: "Ownership search returned an error.",
+		Priority:    1,
 	}
 }


### PR DESCRIPTION
Test plan:
CI.
Local sg run and check that no errors are returned.

Before:
![image](https://github.com/sourcegraph/sourcegraph/assets/94846361/4784c587-608c-4576-9318-27469f5c0188)

After:
<img width="1300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/30c809ec-c26d-443e-983e-d3dbb693d396">


Closes https://github.com/sourcegraph/sourcegraph/issues/52255