### PR TITLE
bzl: fix warnings on eslint tests w/ timeout=short

### DIFF
--- a/dev/eslint.bzl
+++ b/dev/eslint.bzl
@@ -192,6 +192,7 @@ def eslint_test_with_types(name, **kwargs):
         srcs = ["//dev:eslint-report-test.sh"],
         args = ["$(location %s)" % lint_target_name],
         data = [lint_target_name],
+        timeout = "short",
     )
 
 # This function provides the path to the client package, assuming


### PR DESCRIPTION
Removes warnings attached to all eslint test targets, by adding a `timeout=short` on the underlying `sh_test` rule. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

BEFORE

<img width="1234" alt="CleanShot 2023-06-05 at 14 19 39@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/7600a8b0-cc62-4a59-90c6-6b2dafa7cac2">


AFTER

<img width="1050" alt="CleanShot 2023-06-05 at 14 15 36@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/81ed5cae-fe83-4857-9413-6481b85c17ce">
