### PR TITLE
nix: develop uses non static binaries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,8 @@
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
         in
         {
+          # We set legacyPackages to our custom static binaries so command
+          # like "nix build .#p4-fusion" work.
           legacyPackages = pkgs';
 
           packages = {
@@ -26,7 +28,10 @@
             p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
           };
 
-          devShells.default = pkgs'.callPackage ./shell.nix { };
+          # We use pkgs (not pkgs') intentionally to avoid doing extra work of
+          # building static comby/universal-ctags in our development
+          # environments.
+          devShells.default = pkgs.callPackage ./shell.nix { };
 
           formatter = pkgs.nixpkgs-fmt;
         }) // {

--- a/shell.nix
+++ b/shell.nix
@@ -53,6 +53,13 @@ let
     unshareCgroup = false;
   };
 
+  # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
+  # like zoekt expects.
+  universal-ctags = pkgs.writeScriptBin "universal-ctags" ''
+    #!${pkgs.stdenv.shell}
+    exec ${pkgs.universal-ctags}/bin/ctags "$@"
+  '';
+
   # We have scripts which use gsed on darwin since that is what homebrew calls
   # the binary for GNU sed.
   gsed = pkgs.writeShellScriptBin "gsed" ''exec ${pkgs.gnused}/bin/sed "$@"'';
@@ -106,7 +113,7 @@ mkShell {
     (if hostPlatform.isLinux then bazel-fhs else bazel-wrapper)
     bazel-watcher
     bazel-buildtools
-  ] ++ lib.optional (hostPlatform.system != "aarch64-linux") p4-fusion;
+  ];
 
   # Startup postgres, redis & set nixos specific stuff
   shellHook = ''
@@ -119,7 +126,7 @@ mkShell {
 
   # By explicitly setting this environment variable we avoid starting up
   # universal-ctags via docker.
-  CTAGS_COMMAND = "${pkgs.universal-ctags}/bin/universal-ctags";
+  CTAGS_COMMAND = "${universal-ctags}/bin/universal-ctags";
 
   RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
 


### PR DESCRIPTION
In our flake we expose a bunch of statically compiled binaries. We introduced this to help us ship those binaries that are quite hard to build outside of nix. With our recent re-organization we started using them in the devenv. The downside of this is we now have to do things like recompile ocaml. Even on my beast linux desktop this feels like overkill.

This commit switches us to using the normal nix packages. Additionally it:
- removes p4-fusion from our devenv since no nix users dev with it.
- re-introduces the universal-ctags wrapper

Test Plan: checked ctags in the devenv:

``` shell
nix develop
file $CTAGS_COMMAND
which universal-ctags
```
