### PR TITLE
wolfi: update http-server-stabilizer to 1.1.0

### DIFF
--- a/wolfi-images/syntax-highlighter.yaml
+++ b/wolfi-images/syntax-highlighter.yaml
@@ -10,4 +10,4 @@ contents:
     - libstdc++
     - http-server-stabilizer@sourcegraph
 
-# MANUAL REBUILD: 
+# MANUAL REBUILD: Mon Jun  5 16:47:55 CEST 2023

--- a/wolfi-packages/http-server-stabilizer.yaml
+++ b/wolfi-packages/http-server-stabilizer.yaml
@@ -31,6 +31,6 @@ pipeline:
       expected-sha256: 4d0d2e4e36d20441abc898fd87031c0b4e40ce25057b6023c929bb0ffa0de4f7
   - uses: go/build
     with:
-      packages: main.go
+      packages: ./...
       prefix: /usr/local
       output: http-server-stabilizer

--- a/wolfi-packages/http-server-stabilizer.yaml
+++ b/wolfi-packages/http-server-stabilizer.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: http-server-stabilizer
-  version: 1.0.5
+  version: 1.1.0
   epoch: 1
   description: "HTTP server stabilizer for unruly servers"
   target-architecture:
@@ -28,7 +28,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/sourcegraph/http-server-stabilizer/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: e568f2b407a09d288abfc41057e6b76a68d00f0cfe2d461d629263fa2fbba94e
+      expected-sha256: 4d0d2e4e36d20441abc898fd87031c0b4e40ce25057b6023c929bb0ffa0de4f7
   - uses: go/build
     with:
       packages: main.go


### PR DESCRIPTION
The 1.1.0 release fixes the logging issue, we missed the update when migrating to Wolfi/Bazel/OCI. This corrects it.

Test Plan: CI

@willdollman this is the PR that will be merged, I'll fire up a wolfi build on the side. 