### PR TITLE
Cody completions: Various improvements to reliability and logging

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -15,20 +15,20 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Cody Inline Assist: Decorations for `/fix` on light theme [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
-- Cody Inline Assist: Fixes cody processing indefinitely isse [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
+- Cody Inline Assist: Fixes cody processing indefinitely issue [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
 - Cody Inline Assist: Use more than 1 context file for `/touch` [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
-- Cody completions: Various fixes for completion analytics. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Cody completions: Various fixes for completion analytics. [pull/52935](https://github.com/sourcegraph/sourcegraph/pull/52935)
 
 ### Changed
 
-- Cody completions: Improved the number of completions presented and reduced the latency [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Cody completions: Improved the number of completions presented and reduced the latency [pull/52935](https://github.com/sourcegraph/sourcegraph/pull/52935)
 
 ## [0.2.1]
 
 ### Fixed
 
 - Escape Windows path separator in fast file finder path pattern [pull/52754](https://github.com/sourcegraph/sourcegraph/pull/52754)
-- Only display errors from the embeddings clients for users connnected to an indexed codebase [pull/52780](https://github.com/sourcegraph/sourcegraph/pull/52780)
+- Only display errors from the embeddings clients for users connected to an indexed codebase [pull/52780](https://github.com/sourcegraph/sourcegraph/pull/52780)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -15,10 +15,13 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Cody Inline Assist: Decorations for `/fix` on light theme [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
-- Cody Inline Assist: Fixs cody processing indefinitely isse [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
+- Cody Inline Assist: Fixes cody processing indefinitely isse [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
 - Cody Inline Assist: Use more than 1 context file for `/touch` [pull/52796](https://github.com/sourcegraph/sourcegraph/pull/52796)
+- Cody completions: Various fixes for completion analytics. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ### Changed
+
+- Cody completions: Improved the number of completions presented and reduced the latency [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ## [0.2.1]
 

--- a/client/cody/src/completions/logger.ts
+++ b/client/cody/src/completions/logger.ts
@@ -5,7 +5,13 @@ interface CompletionEvent {
     multilineMode: null | 'block'
     startedAt: number
     suggestedAt: number | null
+    // When set, the completion will always be marked as `read`. This helps us
+    // to avoid not counting a suggested event in case where the user accepts
+    // the completion below the default timeout
+    forceRead: boolean
 }
+
+const READ_TIMEOUT = 750
 
 const displayedCompletions: Map<string, CompletionEvent> = new Map()
 
@@ -21,6 +27,7 @@ export function start(
         multilineMode,
         startedAt: Date.now(),
         suggestedAt: null,
+        forceRead: false,
     })
 
     const logParams = { type, multilineMode }
@@ -41,9 +48,19 @@ export function suggest(id: string): void {
 
 export function accept(id: string): void {
     const completionEvent = displayedCompletions.get(id)
-    const logParams = { type: completionEvent?.type, multilineMode: completionEvent?.multilineMode }
+    if (!completionEvent) {
+        return
+    }
+    completionEvent.forceRead = true
+    const logParams = { type: completionEvent.type, multilineMode: completionEvent.multilineMode }
     logSuggestionEvent()
     logEvent('CodyVSCodeExtension:completion:accepted', logParams, logParams)
+}
+
+export function noResponse(id: string): void {
+    const completionEvent = displayedCompletions.get(id)
+    const logParams = { type: completionEvent?.type, multilineMode: completionEvent?.multilineMode }
+    logEvent('CodyVSCodeExtension:completion:noResponse', logParams, logParams)
 }
 
 /**
@@ -61,7 +78,7 @@ function createId(): string {
 function logSuggestionEvent(): void {
     const now = Date.now()
     for (const completionEvent of displayedCompletions.values()) {
-        const { suggestedAt, startedAt, type, multilineMode } = completionEvent
+        const { suggestedAt, startedAt, type, multilineMode, forceRead } = completionEvent
 
         if (!suggestedAt) {
             continue
@@ -69,12 +86,13 @@ function logSuggestionEvent(): void {
 
         const latency = suggestedAt - startedAt
         const displayDuration = now - suggestedAt
+        const read = displayDuration >= READ_TIMEOUT
         const logParams = {
             type,
             multilineMode,
             latency,
             displayDuration,
-            read: displayDuration >= 750,
+            read: forceRead || read,
         }
 
         logEvent('CodyVSCodeExtension:completion:suggested', logParams, logParams)

--- a/client/cody/src/completions/multiline.ts
+++ b/client/cody/src/completions/multiline.ts
@@ -47,9 +47,7 @@ export function truncateMultilineCompletion(
 
     // Normalize responses that start with a newline followed by the exact indentation of
     // the first line.
-    console.log(lines)
     if (lines.length > 1 && lines[0] === '' && indentation(lines[1]) === startIndent) {
-        console.log('WHAT')
         lines.shift()
         lines[0] = lines[0].trimStart()
     }

--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -69,7 +69,7 @@ export abstract class CompletionProvider {
                     },
                     {
                         speaker: 'assistant',
-                        text: `\`\`\`\n// Ok\`\`\``,
+                        text: '```\n// Ok```',
                     },
                 ]
 
@@ -255,19 +255,19 @@ export class InlineCompletionProvider extends CompletionProvider {
                 },
                 {
                     speaker: 'assistant',
-                    text: `\`\`\`\n// Ok\`\`\``,
+                    text: '```\n// Ok```',
                 },
                 {
                     speaker: 'human',
                     text:
-                        `Complete the following file:\n` +
+                        'Complete the following file:\n' +
                         '```' +
                         `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
                         '```',
                 },
                 {
                     speaker: 'assistant',
-                    text: '```' + `\n${prefixLines.slice(endLine).join('\n')}${this.injectPrefix}`,
+                    text: `\`\`\`\n${prefixLines.slice(endLine).join('\n')}${this.injectPrefix}`,
                 },
             ]
         } else {

--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -12,6 +12,13 @@ import { ReferenceSnippet } from './context'
 import { truncateMultilineCompletion } from './multiline'
 import { messagesToText } from './prompts'
 
+const COMPLETIONS_PREAMBLE = `You are Cody, a code completion AI developed by Sourcegraph.
+You only respond in a single Markdown code blocks to all questions.
+All answers must be valid {lang} programs.
+DO NOT respond with anything other than code.`
+
+const BAD_COMPLETION_START = /^(\p{Emoji_Presentation}|\u{200B}|\+ |- |. )+(\s)+/u
+
 export abstract class CompletionProvider {
     constructor(
         protected completionsClient: SourcegraphNodeCompletionsClient,
@@ -62,7 +69,7 @@ export abstract class CompletionProvider {
                     },
                     {
                         speaker: 'assistant',
-                        text: 'Okay, I have added it to my knowledge base.',
+                        text: `\`\`\`\n// Ok\`\`\``,
                     },
                 ]
 
@@ -244,18 +251,23 @@ export class InlineCompletionProvider extends CompletionProvider {
             prefixMessages = [
                 {
                     speaker: 'human',
+                    text: COMPLETIONS_PREAMBLE.replace('{lang}', this.languageId),
+                },
+                {
+                    speaker: 'assistant',
+                    text: `\`\`\`\n// Ok\`\`\``,
+                },
+                {
+                    speaker: 'human',
                     text:
-                        'Complete the following file:\n' +
+                        `Complete the following file:\n` +
                         '```' +
                         `\n${prefixLines.slice(0, endLine).join('\n')}\n` +
                         '```',
                 },
                 {
                     speaker: 'assistant',
-                    text:
-                        'Here is the completion of the file:\n' +
-                        '```' +
-                        `\n${prefixLines.slice(endLine).join('\n')}${this.injectPrefix}`,
+                    text: '```' + `\n${prefixLines.slice(endLine).join('\n')}${this.injectPrefix}`,
                 },
             ]
         } else {
@@ -295,6 +307,15 @@ export class InlineCompletionProvider extends CompletionProvider {
             completion = completion.slice(1)
             hasOddIndentation = true
         }
+
+        // Experimental: Trim start of the completion to remove all trailing whitespace nonsense
+        completion = completion.trimStart()
+
+        // Detect bad completion start
+        if (BAD_COMPLETION_START.test(completion)) {
+            completion = completion.replace(BAD_COMPLETION_START, '')
+        }
+
         // Insert the injected prefix back in
         if (this.injectPrefix.length > 0) {
             completion = this.injectPrefix + completion
@@ -333,14 +354,6 @@ export class InlineCompletionProvider extends CompletionProvider {
         })
         if (matchedLineIndex !== -1) {
             completion = lines.slice(0, matchedLineIndex).join('\n')
-        }
-
-        // Ignore completions that start with a whitespace. These are handled oddly in VS Code
-        // since you can't accept them via tab.
-        //
-        // TODO: Should we trim the response instead?
-        if (completion.trimStart().length !== completion.length) {
-            return null
         }
 
         return completion.trimEnd()


### PR DESCRIPTION
Closes #52686

There are a bunch of small changes in this PR. Here's a summary:

- I changed the default prompt to (hopefully) reduce the number of non-code responses. This works but mostly by gut feel. We'll need @valerybugakov's work to make sure we make some actual progress there. This was mostly used to reduce the number of times the completion starts with a code block end (```) tag so it increases the requests that make it through to the user.
- Filter out some known "bad starters" that we have collected over the last week. E.g. where cody starts the response with `➕     console.log('hi')` for example. 🙃 This means that more requests should make it to the user. 
- Instead of throwing away responses that start with whitespace, we now trim it instead. This should mean that more requests make it through the user.
- Empty responses (those that we filter out in the post process logic) are no longer forwarded to VS Code. This mainly fixes a small annoyance where the completions widget would e.g. show `1/2` completions but the second one being empty. 
- Tweaks based on [this research](https://sourcegraph.slack.com/archives/C05A7PPR07Q/p1685715846764189)
  - We now make 3 requests instead of 2 on empty lines
  - Reduced the debouncing timeout quite significantly so that our latency becomes a lot besser. 
  - ➡ We're working simultaneously to increase the rate-limit for dotcom
- Logging:
  - We now log whenever we have no proper completion to show (so we can assess how rare this is since it happened often in internal tests)
  - We now count completions as `read` when they are accepted (so that we do never count a completion as accepted but not as suggested)
- Removed some debug logging leftover 

## Test plan

Tests still green.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
