### PR TITLE
graphqlbackend: Add perforce changelist related properties

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -465,6 +465,7 @@ go_test(
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/database/dbtest",
+        "//internal/database/dbutil",
         "//internal/database/fakedb",
         "//internal/encryption",
         "//internal/extsvc",

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -134,7 +134,7 @@ func (r *GitCommitResolver) PerforceChangelist(ctx context.Context) (*PerforceCh
 		return nil, err
 	}
 
-	return toPerforceChangelistResolver(ctx, r.repoResolver, commit.Message.Body())
+	return toPerforceChangelistResolver(ctx, r.repoResolver, commit)
 }
 
 func (r *GitCommitResolver) Author(ctx context.Context) (*signatureResolver, error) {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -688,15 +688,8 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 			ExternalRepo: api.ExternalRepoSpec{ServiceType: extsvc.TypePerforce},
 		}
 
-		repos := database.NewMockRepoStore()
 		repos.GetFunc.SetDefaultReturn(repo, nil)
 		repos.GetByNameFunc.SetDefaultReturn(repo, nil)
-		db.ReposFunc.SetDefaultReturn(repos)
-
-		repos.GetFunc.SetDefaultReturn(
-			repo,
-			nil,
-		)
 
 		// git-p4 commit.
 		c1 := gitdomain.Commit{

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -389,6 +389,7 @@ func TestGitCommitAncestors(t *testing.T) {
 						  abbreviatedOID
 						  perforceChangelist {
 							cid
+                            canonicalURL
 						  }
 						}
 						pageInfo {
@@ -654,6 +655,7 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 									oid
 									perforceChangelist {
 										cid
+                                        canonicalURL
 									}
 								}
 							}
@@ -680,14 +682,18 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 	})
 
 	t.Run("perforce depot", func(t *testing.T) {
+		repo := &types.Repo{
+			ID:           2,
+			Name:         "github.com/gorilla/mux",
+			ExternalRepo: api.ExternalRepoSpec{ServiceType: extsvc.TypePerforce},
+		}
+
+		repos := database.NewMockRepoStore()
+		repos.GetFunc.SetDefaultReturn(repo, nil)
+		db.ReposFunc.SetDefaultReturn(repos)
+
 		repos.GetFunc.SetDefaultReturn(
-			&types.Repo{
-				ID:   2,
-				Name: "github.com/gorilla/mux",
-				ExternalRepo: api.ExternalRepoSpec{
-					ServiceType: extsvc.TypePerforce,
-				},
-			},
+			repo,
 			nil,
 		)
 
@@ -712,13 +718,18 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 			Query: `
 				{
 				  repository(name: "github.com/gorilla/mux") {
+						name
+						isFork
+						sourceType
 						commit(rev: "aabbc12345") {
 							ancestors(first: 10) {
 								nodes {
 									id
 									oid
+									canonicalURL
 									perforceChangelist {
 										cid
+                                        canonicalURL
 									}
 								}
 							}
@@ -734,15 +745,19 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 									{
 										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3ciLCJjIjoiYWFiYmMxMjM0NSJ9",
 										"oid": "aabbc12345",
+										"canonicalURL": "abcd",
 										"perforceChangelist": {
-											"cid": "87654"
+											"cid": "87654",
+											"canonicalURL": "/github.com/gorilla/mux/-/changelist/87654"
 										}
 									},
 									{
 										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3ciLCJjIjoiY2NkZGUxMjM0NSJ9",
 										"oid": "ccdde12345",
+										"canonicalURL": "abcd",
 										"perforceChangelist": {
-											"cid": "87655"
+											"cid": "87655",
+											"canonicalURL": "/github.com/gorilla/mux/-/changelist/87655"
 										}
 									}
 								]

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -690,6 +690,7 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 
 		repos := database.NewMockRepoStore()
 		repos.GetFunc.SetDefaultReturn(repo, nil)
+		repos.GetByNameFunc.SetDefaultReturn(repo, nil)
 		db.ReposFunc.SetDefaultReturn(repos)
 
 		repos.GetFunc.SetDefaultReturn(
@@ -718,15 +719,11 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 			Query: `
 				{
 				  repository(name: "github.com/gorilla/mux") {
-						name
-						isFork
-						sourceType
 						commit(rev: "aabbc12345") {
 							ancestors(first: 10) {
 								nodes {
 									id
 									oid
-									canonicalURL
 									perforceChangelist {
 										cid
                                         canonicalURL
@@ -743,18 +740,16 @@ func TestGitCommitPerforceChangelist(t *testing.T) {
 							"ancestors": {
 								"nodes": [
 									{
-										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3ciLCJjIjoiYWFiYmMxMjM0NSJ9",
+										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3kiLCJjIjoiYWFiYmMxMjM0NSJ9",
 										"oid": "aabbc12345",
-										"canonicalURL": "abcd",
 										"perforceChangelist": {
 											"cid": "87654",
 											"canonicalURL": "/github.com/gorilla/mux/-/changelist/87654"
 										}
 									},
 									{
-										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3ciLCJjIjoiY2NkZGUxMjM0NSJ9",
+										"id": "R2l0Q29tbWl0OnsiciI6IlVtVndiM05wZEc5eWVUb3kiLCJjIjoiY2NkZGUxMjM0NSJ9",
 										"oid": "ccdde12345",
-										"canonicalURL": "abcd",
 										"perforceChangelist": {
 											"cid": "87655",
 											"canonicalURL": "/github.com/gorilla/mux/-/changelist/87655"

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -15,20 +15,29 @@ import (
 )
 
 type PerforceChangelistResolver struct {
+	// logger is a logger - what more needs to be said. 🪵
 	logger log.Logger
 
+	// repositoryResolver is the backlink to which this change list belongs.
 	repositoryResolver *RepositoryResolver
 
-	cid          string
+	// cid is the changelist ID.
+	cid string
+	// canonicalURL is the canonical URL of this changelist ID, similar to the canonical URL of a Git commit.
 	canonicalURL string
-	commitSHA    string
+	// commitSHA is the corresponding commit SHA. This is required to look up the commitID object using ResolveRev.
+	commitSHA string
 
-	commitID   api.CommitID
+	// commitID is set when the Commit property is accessed on the resolver.
+	commitID api.CommitID
+	// commitOnce will ensure that we resolve the revision only once.
 	commitOnce sync.Once
-	commitErr  error
+	// commitErr is used to return an error that may have occured during resolving the revision when
+	// the Commit property is looked up on the resolver.
+	commitErr error
 }
 
-func newPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, changelistID, commitSHA string) *PerforceChangelistResolver {
+func newPerforceChangelistResolver(r *RepositoryResolver, changelistID, commitSHA string) *PerforceChangelistResolver {
 	repoURL := r.url()
 	canonicalURL := repoURL.Path + "/-/changelist/" + changelistID
 
@@ -53,7 +62,7 @@ func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, co
 		return nil, errors.Wrap(err, "failed to generate perforceChangelistID")
 	}
 
-	return newPerforceChangelistResolver(ctx, r, changelistID, string(commit.ID)), nil
+	return newPerforceChangelistResolver(r, changelistID, string(commit.ID)), nil
 }
 
 func (r *PerforceChangelistResolver) CID() string {

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -39,7 +40,9 @@ type PerforceChangelistResolver struct {
 
 func newPerforceChangelistResolver(r *RepositoryResolver, changelistID, commitSHA string) *PerforceChangelistResolver {
 	repoURL := r.url()
-	canonicalURL := repoURL.Path + "/-/changelist/" + changelistID
+
+	// Example: /perforce.sgdev.org/foobar/-/changelist/99999
+	canonicalURL := filepath.Join(repoURL.Path, "-", "changelist", changelistID)
 
 	return &PerforceChangelistResolver{
 		logger:             r.logger.Scoped("PerforceChangelistResolver", "resolve a specific changelist"),

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -16,7 +16,7 @@ type PerforceChangelistResolver struct {
 	canonicalURL string
 }
 
-func newPerforceChangelistResolver(ctx context.Context, changelistID, repoPath string) *PerforceChangelistResolver {
+func newPerforceChangelistResolver(changelistID, repoPath string) *PerforceChangelistResolver {
 	canonicalURL := repoPath + "/-/changelist/" + changelistID
 	return &PerforceChangelistResolver{
 		cid:          changelistID,

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -16,6 +16,14 @@ type PerforceChangelistResolver struct {
 	canonicalURL string
 }
 
+func newPerforceChangelistResolver(ctx context.Context, changelistID, repoPath string) *PerforceChangelistResolver {
+	canonicalURL := repoPath + "/-/changelist/" + changelistID
+	return &PerforceChangelistResolver{
+		cid:          changelistID,
+		canonicalURL: canonicalURL,
+	}
+}
+
 func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, commitBody string) (*PerforceChangelistResolver, error) {
 	if source, err := r.SourceType(ctx); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -12,7 +12,8 @@ import (
 )
 
 type PerforceChangelistResolver struct {
-	cid string
+	cid          string
+	canonicalURL string
 }
 
 func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, commitBody string) (*PerforceChangelistResolver, error) {
@@ -27,11 +28,21 @@ func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, co
 		return nil, errors.Wrap(err, "failed to generate perforceChangelistID")
 	}
 
-	return &PerforceChangelistResolver{cid: changelistID}, nil
+	repoURL := r.url()
+	repoURL.Path += "/-/changelist/" + changelistID
+
+	return &PerforceChangelistResolver{
+		cid:          changelistID,
+		canonicalURL: repoURL.String(),
+	}, nil
 }
 
 func (r *PerforceChangelistResolver) CID() string {
 	return r.cid
+}
+
+func (r *PerforceChangelistResolver) CanonicalURL() string {
+	return r.canonicalURL
 }
 
 var p4FusionCommitSubjectPattern = lazyregexp.New(`^(\d+) - (.*)$`)

--- a/cmd/frontend/graphqlbackend/perforce_changelist_test.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist_test.go
@@ -1,8 +1,100 @@
 package graphqlbackend
 
 import (
+	"context"
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+func TestToPerforceChangelistResolver(t *testing.T) {
+	repo := &types.Repo{
+		ID:           2,
+		Name:         "perforce.sgdev.org/foo/bar",
+		ExternalRepo: api.ExternalRepoSpec{ServiceType: extsvc.TypePerforce},
+	}
+
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(repo, nil)
+
+	db := database.NewMockDB()
+	db.ReposFunc.SetDefaultReturn(repos)
+
+	repoResolver := NewRepositoryResolver(db, nil, repo)
+
+	testCases := []struct {
+		name             string
+		inputCommitBody  string
+		expectedResolver *PerforceChangelistResolver
+		expectedErr      error
+	}{
+		{
+			name:            "p4-fusion",
+			inputCommitBody: `[p4-fusion: depot-paths = "//test-perms/": change = 80972]`,
+			expectedResolver: &PerforceChangelistResolver{
+				cid:          "80972",
+				canonicalURL: "/perforce.sgdev.org/foo/bar/-/changelist/80972",
+			},
+		},
+		{
+			name:            "git-p4",
+			inputCommitBody: `[git-p4: depot-paths = "//test-perms/": change = 80999]`,
+			expectedResolver: &PerforceChangelistResolver{
+				cid:          "80999",
+				canonicalURL: "/perforce.sgdev.org/foo/bar/-/changelist/80999",
+			},
+		},
+		{
+			name:             "error",
+			inputCommitBody:  `foo bar`,
+			expectedResolver: nil,
+			expectedErr:      errors.Wrap(errors.New(`failed to retrieve changelist ID from commit body: "foo bar"`), "failed to generate perforceChangelistID"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotResolver, gotErr := toPerforceChangelistResolver(context.Background(), repoResolver, tc.inputCommitBody)
+
+			if !errors.Is(gotErr, tc.expectedErr) {
+				t.Fatalf("mismatched errors, \nwant: %v\n got: %v", tc.expectedErr, gotErr)
+				return
+			}
+
+			// Checks after this point are for non-nil expectedResolver test cases.
+			if tc.expectedResolver == nil {
+				return
+			}
+
+			// Note: We cannot compare the struct directly because we have unexported fields. It is
+			// simpler to compare the two fields instead of implmenting a custom comparer to use
+			// with cmp.Diff.
+			//
+			// If the resolver evolves to have more fields, then it might make more sense to
+			// implement the custom comparison func in the future.
+			if gotResolver.cid != tc.expectedResolver.cid {
+				t.Errorf("mismatched cid, \nwant: %v\n got: %v", tc.expectedResolver.cid, gotResolver.cid)
+			}
+
+			if gotResolver.canonicalURL != tc.expectedResolver.canonicalURL {
+				t.Errorf("mismatched canonicalURL, \nwant: %v\n got: %v", tc.expectedResolver.canonicalURL, gotResolver.canonicalURL)
+			}
+
+			// Now test the exported methods of the resolver too.
+			if value := gotResolver.CID(); value != tc.expectedResolver.cid {
+				t.Errorf("mismatched value from method CID(), \nwant: %v\n got: %v", tc.expectedResolver.cid, value)
+			}
+
+			if value := gotResolver.CanonicalURL(); value != tc.expectedResolver.canonicalURL {
+				t.Errorf("mismatched value from method CanonicalURL(), \nwant: %v\n got: %v", tc.expectedResolver.canonicalURL, value)
+			}
+		})
+	}
+}
 
 func TestParseP4FusionCommitSubject(t *testing.T) {
 	testCases := []struct {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -280,7 +280,12 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 		return nil, err
 	}
 
-	return newPerforceChangelistResolver(fmt.Sprintf("%d", rc.PerforceChangelistID), r.url().Path), nil
+	return newPerforceChangelistResolver(
+		ctx,
+		r,
+		fmt.Sprintf("%d", rc.PerforceChangelistID),
+		string(rc.CommitSHA),
+	), nil
 }
 
 func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (_ *GitCommitResolver, err error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -281,7 +281,6 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 	}
 
 	return newPerforceChangelistResolver(
-		ctx,
 		r,
 		fmt.Sprintf("%d", rc.PerforceChangelistID),
 		string(rc.CommitSHA),

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -280,7 +280,7 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 		return nil, err
 	}
 
-	return newPerforceChangelistResolver(ctx, fmt.Sprintf("%d", rc.PerforceChangelistID), r.url().Path), nil
+	return newPerforceChangelistResolver(fmt.Sprintf("%d", rc.PerforceChangelistID), r.url().Path), nil
 }
 
 func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (_ *GitCommitResolver, err error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -249,6 +251,36 @@ func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitA
 	}
 
 	return r.CommitFromID(ctx, args, commitID)
+}
+
+type RepositoryChangelistArgs struct {
+	CID string
+}
+
+func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryChangelistArgs) (_ *PerforceChangelistResolver, err error) {
+	tr, ctx := trace.New(ctx, "RepositoryResolver", "Changelist",
+		attribute.String("changelist", args.CID))
+	defer tr.FinishWithErr(&err)
+
+	cid, err := strconv.ParseInt(args.CID, 10, 64)
+	if err != nil {
+		return nil, &perforce.BadChangelistError{}
+	}
+
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	rc, err := r.db.RepoCommitsChangelists().GetRepoCommitChangelist(ctx, repo.ID, cid)
+	if err != nil {
+		if errors.HasType(err, &perforce.ChangelistNotFoundError{}) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return newPerforceChangelistResolver(ctx, fmt.Sprintf("%d", rc.PerforceChangelistID), r.url().Path), nil
 }
 
 func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (_ *GitCommitResolver, err error) {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -42,10 +43,9 @@ func TestRepository_Commit(t *testing.T) {
 	db := database.NewMockDB()
 	db.ReposFunc.SetDefaultReturn(repos)
 
-	RunTests(t, []*Test{
-		{
-			Schema: mustParseGraphQLSchema(t, db),
-			Query: `
+	RunTest(t, &Test{
+		Schema: mustParseGraphQLSchema(t, db),
+		Query: `
 				{
 					repository(name: "github.com/gorilla/mux") {
 						commit(rev: "abc") {
@@ -54,7 +54,7 @@ func TestRepository_Commit(t *testing.T) {
 					}
 				}
 			`,
-			ExpectedResult: `
+		ExpectedResult: `
 				{
 					"repository": {
 						"commit": {
@@ -63,7 +63,50 @@ func TestRepository_Commit(t *testing.T) {
 					}
 				}
 			`,
-		},
+	})
+}
+
+func TestRepository_Changelist(t *testing.T) {
+	repo := &types.Repo{ID: 2, Name: "github.com/gorilla/mux"}
+
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(repo, nil)
+	repos.GetByNameFunc.SetDefaultReturn(repo, nil)
+
+	repoCommitsChangelists := database.NewMockRepoCommitsChangelistsStore()
+	repoCommitsChangelists.GetRepoCommitChangelistFunc.SetDefaultReturn(&types.RepoCommit{
+		ID:                   1,
+		RepoID:               2,
+		CommitSHA:            dbutil.CommitBytea(exampleCommitSHA1),
+		PerforceChangelistID: 123,
+	}, nil)
+
+	db := database.NewMockDB()
+	db.ReposFunc.SetDefaultReturn(repos)
+	db.RepoCommitsChangelistsFunc.SetDefaultReturn(repoCommitsChangelists)
+
+	RunTest(t, &Test{
+		Schema: mustParseGraphQLSchema(t, db),
+		Query: `
+				{
+					repository(name: "github.com/gorilla/mux") {
+						changelist(cid: "123") {
+							cid
+							canonicalURL
+						}
+					}
+				}
+			`,
+		ExpectedResult: `
+				{
+					"repository": {
+						"changelist": {
+							"cid": "123",
+							"canonicalURL": "/github.com/gorilla/mux/-/changelist/123"
+						}
+					}
+				}
+			`,
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10239,4 +10239,5 @@ type PerforceChangelist {
     The changelist ID.
     """
     cid: String!
+    canonicalURL: String!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10246,5 +10246,12 @@ type PerforceChangelist {
     The changelist ID.
     """
     cid: String!
+    """
+    The canonical URL to this changelist.
+    """
     canonicalURL: String!
+    """
+    The corresponding git commit of this changelist.
+    """
+    commit: GitCommit!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3553,6 +3553,15 @@ type Repository implements Node & GenericSearchResultInterface {
         """
         inputRevspec: String
     ): GitCommit
+
+    """
+    EXPERIMENTAL: Returns infomration about the given changelist of the perforce depot, or null if
+    no changelist exists with the given cid or it is not a perforce depot.
+    """
+    changelist(
+        cid: String!
+    ): PerforceChangelist
+
     """
     The first commit inside the repo
     """
@@ -4983,7 +4992,7 @@ type GitCommit implements Node {
     """
     abbreviatedOID: String!
     """
-    The perforce changelist ID if this git commit was originally converted from a perforce depot.
+    EXPERIMENTAL: The perforce changelist ID if this git commit was originally converted from a perforce depot.
     """
     perforceChangelist: PerforceChangelist
     """
@@ -10232,7 +10241,7 @@ type CodeIntelCommit {
 }
 
 """
-A Perforce changelist.
+EXPERIMENTAL: A Perforce changelist.
 """
 type PerforceChangelist {
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3558,9 +3558,7 @@ type Repository implements Node & GenericSearchResultInterface {
     EXPERIMENTAL: Returns infomration about the given changelist of the perforce depot, or null if
     no changelist exists with the given cid or it is not a perforce depot.
     """
-    changelist(
-        cid: String!
-    ): PerforceChangelist
+    changelist(cid: String!): PerforceChangelist
 
     """
     The first commit inside the repo

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -44795,6 +44795,9 @@ type MockRepoCommitsChangelistsStore struct {
 	// GetLatestForRepoFunc is an instance of a mock function object
 	// controlling the behavior of the method GetLatestForRepo.
 	GetLatestForRepoFunc *RepoCommitsChangelistsStoreGetLatestForRepoFunc
+	// GetRepoCommitChangelistFunc is an instance of a mock function object
+	// controlling the behavior of the method GetRepoCommitChangelist.
+	GetRepoCommitChangelistFunc *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc
 }
 
 // NewMockRepoCommitsChangelistsStore creates a new mock of the
@@ -44809,6 +44812,11 @@ func NewMockRepoCommitsChangelistsStore() *MockRepoCommitsChangelistsStore {
 		},
 		GetLatestForRepoFunc: &RepoCommitsChangelistsStoreGetLatestForRepoFunc{
 			defaultHook: func(context.Context, api.RepoID) (r0 *types.RepoCommit, r1 error) {
+				return
+			},
+		},
+		GetRepoCommitChangelistFunc: &RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc{
+			defaultHook: func(context.Context, api.RepoID, int64) (r0 *types.RepoCommit, r1 error) {
 				return
 			},
 		},
@@ -44830,6 +44838,11 @@ func NewStrictMockRepoCommitsChangelistsStore() *MockRepoCommitsChangelistsStore
 				panic("unexpected invocation of MockRepoCommitsChangelistsStore.GetLatestForRepo")
 			},
 		},
+		GetRepoCommitChangelistFunc: &RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc{
+			defaultHook: func(context.Context, api.RepoID, int64) (*types.RepoCommit, error) {
+				panic("unexpected invocation of MockRepoCommitsChangelistsStore.GetRepoCommitChangelist")
+			},
+		},
 	}
 }
 
@@ -44843,6 +44856,9 @@ func NewMockRepoCommitsChangelistsStoreFrom(i RepoCommitsChangelistsStore) *Mock
 		},
 		GetLatestForRepoFunc: &RepoCommitsChangelistsStoreGetLatestForRepoFunc{
 			defaultHook: i.GetLatestForRepo,
+		},
+		GetRepoCommitChangelistFunc: &RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc{
+			defaultHook: i.GetRepoCommitChangelist,
 		},
 	}
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -45091,6 +45091,122 @@ func (c RepoCommitsChangelistsStoreGetLatestForRepoFuncCall) Results() []interfa
 	return []interface{}{c.Result0, c.Result1}
 }
 
+// RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc describes the
+// behavior when the GetRepoCommitChangelist method of the parent
+// MockRepoCommitsChangelistsStore instance is invoked.
+type RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc struct {
+	defaultHook func(context.Context, api.RepoID, int64) (*types.RepoCommit, error)
+	hooks       []func(context.Context, api.RepoID, int64) (*types.RepoCommit, error)
+	history     []RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall
+	mutex       sync.Mutex
+}
+
+// GetRepoCommitChangelist delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockRepoCommitsChangelistsStore) GetRepoCommitChangelist(v0 context.Context, v1 api.RepoID, v2 int64) (*types.RepoCommit, error) {
+	r0, r1 := m.GetRepoCommitChangelistFunc.nextHook()(v0, v1, v2)
+	m.GetRepoCommitChangelistFunc.appendCall(RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetRepoCommitChangelist method of the parent
+// MockRepoCommitsChangelistsStore instance is invoked and the hook queue is
+// empty.
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) SetDefaultHook(hook func(context.Context, api.RepoID, int64) (*types.RepoCommit, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetRepoCommitChangelist method of the parent
+// MockRepoCommitsChangelistsStore instance invokes the hook at the front of
+// the queue and discards it. After the queue is empty, the default hook
+// function is invoked for any future action.
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) PushHook(hook func(context.Context, api.RepoID, int64) (*types.RepoCommit, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) SetDefaultReturn(r0 *types.RepoCommit, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, int64) (*types.RepoCommit, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) PushReturn(r0 *types.RepoCommit, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID, int64) (*types.RepoCommit, error) {
+		return r0, r1
+	})
+}
+
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) nextHook() func(context.Context, api.RepoID, int64) (*types.RepoCommit, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) appendCall(r0 RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall objects
+// describing the invocations of this function.
+func (f *RepoCommitsChangelistsStoreGetRepoCommitChangelistFunc) History() []RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall is an object
+// that describes an invocation of method GetRepoCommitChangelist on an
+// instance of MockRepoCommitsChangelistsStore.
+type RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 int64
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *types.RepoCommit
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoCommitsChangelistsStoreGetRepoCommitChangelistFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // MockRepoPathStore is a mock implementation of the RepoPathStore interface
 // (from the package github.com/sourcegraph/sourcegraph/internal/database)
 // used for unit testing.

--- a/internal/database/repo_commits_changelists_test.go
+++ b/internal/database/repo_commits_changelists_test.go
@@ -130,7 +130,29 @@ func TestRepoCommitsChangelists(t *testing.T) {
 			repoCommit, err := s.GetLatestForRepo(ctx, api.RepoID(2))
 			require.Error(t, err)
 			require.True(t, errors.Is(err, sql.ErrNoRows))
-			require.Equal(t, &types.RepoCommit{}, repoCommit)
+			require.Nil(t, repoCommit)
+		})
+	})
+
+	t.Run("GetRepoCommit", func(t *testing.T) {
+		t.Run("existing row", func(t *testing.T) {
+			gotRow, err := s.GetRepoCommitChangelist(ctx, 1, 123)
+			require.NoError(t, err)
+			if diff := cmp.Diff(&types.RepoCommit{
+				ID:                   1,
+				RepoID:               api.RepoID(1),
+				CommitSHA:            dbutil.CommitBytea(commitSHA1),
+				PerforceChangelistID: 123,
+			}, gotRow); diff != "" {
+				t.Errorf("mismatched row, (-want, +got)\n%s", diff)
+			}
+		})
+
+		t.Run("non existing row", func(t *testing.T) {
+			gotRow, err := s.GetRepoCommitChangelist(ctx, 2, 999)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, sql.ErrNoRows))
+			require.Nil(t, gotRow)
 		})
 	})
 }

--- a/internal/perforce/BUILD.bazel
+++ b/internal/perforce/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/perforce",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/api",
         "//internal/lazyregexp",
         "//lib/errors",
     ],

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -1,6 +1,9 @@
 package perforce
 
 import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -19,4 +22,31 @@ func GetP4ChangelistID(body string) (string, error) {
 	}
 
 	return matches[2], nil
+}
+
+// ChangelistNotFoundError is an error that reports a revision doesn't exist.
+type ChangelistNotFoundError struct {
+	Repo api.RepoName
+	ID   string
+}
+
+func (e *ChangelistNotFoundError) Error() string {
+	return fmt.Sprintf("revision not found: %s@%s", e.Repo, e.ID)
+}
+
+func (e *ChangelistNotFoundError) HTTPStatusCode() int {
+	return 404
+}
+
+func (e *ChangelistNotFoundError) NotFound() bool {
+	return true
+}
+
+type BadChangelistError struct {
+	CID  string
+	Repo api.RepoName
+}
+
+func (e *BadChangelistError) Error() string {
+	return fmt.Sprintf("invalid changelist ID %q for repo %q", e.Repo, e.CID)
 }

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -34,14 +34,6 @@ func (e *ChangelistNotFoundError) Error() string {
 	return fmt.Sprintf("revision not found: %s@%s", e.Repo, e.ID)
 }
 
-func (e *ChangelistNotFoundError) HTTPStatusCode() int {
-	return 404
-}
-
-func (e *ChangelistNotFoundError) NotFound() bool {
-	return true
-}
-
 type BadChangelistError struct {
 	CID  string
 	Repo api.RepoName


### PR DESCRIPTION
Part of #40330. 

## What

In this PR we add two GraphQL API changes:

- The `Repository` node can now support querying `changelists` by changelist ID similar to the `commits` API
- The `PerforceChangelist` node has two new properties:
    1. `canonicalURL` - similar to the `GitCommit` node but uses `/changelist/<cid>` 
    2. `commit` - the corresponding `GitCommit` from the repo

## Why

In the UI we want to be able to lookup a changelist by ID and display all properties from the corresponding git commit


## Test plan

- Tested manually
- Added tests
- Tested with UI changes ([separate PR](https://github.com/sourcegraph/sourcegraph/pull/53253))

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
