### PR TITLE
JetBrains: Adjust the chat ui to figma design - first version

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -5,8 +5,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTabbedPane;
-import com.intellij.ui.scale.JBUIScale;
-import com.sourcegraph.cody.api.Speaker;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatBubble;
 import com.sourcegraph.cody.chat.ChatMessage;
@@ -71,7 +69,7 @@ class CodyToolWindowContent implements UpdatableChat {
     recipesPanel.add(releaseNotesButton);
 
     // Chat panel
-    messagesPanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 10, true, true));
+    messagesPanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, true));
     JBScrollPane chatPanel =
         new JBScrollPane(
             messagesPanel,
@@ -101,7 +99,7 @@ class CodyToolWindowContent implements UpdatableChat {
 
     // Main content panel
     contentPanel.setLayout(new BorderLayout(0, 20));
-    contentPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+    contentPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
     contentPanel.add(chatPanel, BorderLayout.CENTER);
     contentPanel.add(controlsPanel, BorderLayout.SOUTH);
 
@@ -115,18 +113,12 @@ class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
-              boolean isHuman = message.getSpeaker() == Speaker.HUMAN;
-
               // Bubble panel
               var bubblePanel = new JPanel();
               bubblePanel.setLayout(
                   new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
-              bubblePanel.setBorder(
-                  BorderFactory.createEmptyBorder(
-                      0, isHuman ? JBUIScale.scale(20) : 0, 0, !isHuman ? JBUIScale.scale(20) : 0));
-
               // Chat bubble
-              ChatBubble bubble = new ChatBubble(10, message);
+              ChatBubble bubble = new ChatBubble(message);
               bubblePanel.add(bubble, VerticalFlowLayout.TOP);
               messagesPanel.add(bubblePanel);
               messagesPanel.revalidate();
@@ -151,7 +143,7 @@ class CodyToolWindowContent implements UpdatableChat {
                 JPanel lastBubblePanel =
                     (JPanel) messagesPanel.getComponent(messagesPanel.getComponentCount() - 1);
                 ChatBubble lastBubble = (ChatBubble) lastBubblePanel.getComponent(0);
-                lastBubble.updateText(message.getDisplayText());
+                lastBubble.updateText(message);
                 messagesPanel.revalidate();
                 messagesPanel.repaint();
               }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
@@ -1,65 +1,38 @@
 package com.sourcegraph.cody.chat;
 
-import com.intellij.ui.JBColor;
-import com.intellij.util.ui.JBInsets;
-import com.intellij.util.ui.UIUtil;
-import com.sourcegraph.cody.api.Speaker;
 import java.awt.*;
 import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import org.commonmark.node.Node;
+import org.commonmark.node.*;
 import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
 import org.jetbrains.annotations.NotNull;
 
 public class ChatBubble extends JPanel {
-  private final int radius;
+  private static final int GRADIENT_WIDTH = 2;
 
-  public ChatBubble(int radius, @NotNull ChatMessage message) {
+  public ChatBubble(@NotNull ChatMessage message) {
     super();
-
-    boolean isHuman = message.getSpeaker() == Speaker.HUMAN;
-    JBColor background = isHuman ? JBColor.BLUE : JBColor.GRAY;
-    this.radius = radius;
-    this.setBackground(background);
     this.setLayout(new BorderLayout());
-    this.setBorder(new EmptyBorder(new JBInsets(10, 10, 10, 10)));
 
-    JEditorPane pane = new JEditorPane();
-    pane.setContentType("text/html");
-    pane.setText(convertToHtml(message.getDisplayText()));
-    pane.setEditable(false);
-    pane.setFont(UIUtil.getLabelFont());
-    pane.setBackground(background);
-    pane.setForeground(isHuman ? JBColor.WHITE : JBColor.BLACK);
-    pane.setComponentOrientation(
-        isHuman ? ComponentOrientation.RIGHT_TO_LEFT : ComponentOrientation.LEFT_TO_RIGHT);
-    pane.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
-    this.add(pane, BorderLayout.CENTER);
+    JPanel messagePanel = buildMessagePanel(message);
+    this.add(messagePanel);
   }
 
-  public void updateText(@NotNull String newMarkdownText) {
-    JEditorPane pane = (JEditorPane) this.getComponent(0);
-    pane.setText(convertToHtml(newMarkdownText));
-  }
-
-  private @NotNull String convertToHtml(@NotNull String markdown) {
-    // Parse markdown
+  @NotNull
+  private JPanel buildMessagePanel(@NotNull ChatMessage message) {
+    MessagePanel messagePanel = new MessagePanel(message, GRADIENT_WIDTH);
     Parser parser = Parser.builder().build();
-    Node node = parser.parse(markdown);
-    HtmlRenderer renderer = HtmlRenderer.builder().build();
-    String messageAsHtml = renderer.render(node);
-
-    // Build HTML
-    return "<html data-gramm=\"false\"><head><style>p { margin:0; }</style></head><body>"
-        + messageAsHtml
-        + "</body></html>";
+    Node document = parser.parse(message.getDisplayText());
+    MessageContentCreatorFromMarkdownNodes messageContentCreator =
+        new MessageContentCreatorFromMarkdownNodes(messagePanel, GRADIENT_WIDTH);
+    document.accept(messageContentCreator);
+    return messagePanel;
   }
 
-  @Override
-  protected void paintComponent(@NotNull Graphics g) {
-    final Graphics2D g2d = (Graphics2D) g;
-    g2d.setColor(getBackground());
-    g2d.fillRoundRect(0, 0, this.getWidth() - 1, this.getHeight() - 1, this.radius, this.radius);
+  public void updateText(@NotNull ChatMessage message) {
+    JPanel newMessage = buildMessagePanel(message);
+    this.remove(0);
+    this.add(newMessage, BorderLayout.CENTER, 0);
+    this.revalidate();
+    this.repaint();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -1,0 +1,238 @@
+package com.sourcegraph.cody.chat;
+
+import com.intellij.ide.highlighter.HighlighterFactory;
+import com.intellij.lang.Language;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.EditorFactory;
+import com.intellij.openapi.editor.EditorSettings;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.highlighter.EditorHighlighter;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.openapi.fileTypes.PlainTextFileType;
+import com.intellij.ui.BrowserHyperlinkListener;
+import com.intellij.ui.ColorUtil;
+import com.intellij.util.ui.JBInsets;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import java.awt.*;
+import java.util.Optional;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import org.commonmark.node.*;
+import org.commonmark.node.Image;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.jetbrains.annotations.NotNull;
+
+public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
+  private final HtmlRenderer htmlRenderer = HtmlRenderer.builder().build();
+  private final JPanel messagePanel;
+  private final int gradientWidth;
+  private StringBuilder htmlContent = new StringBuilder();
+  private int textPaneIndex = 0;
+  private JEditorPane textPane;
+
+  public MessageContentCreatorFromMarkdownNodes(JPanel messagePanel, int gradientWidth) {
+    this.messagePanel = messagePanel;
+    this.gradientWidth = gradientWidth;
+    textPane = createNewEmptyTextPane();
+  }
+
+  @NotNull
+  private JEditorPane createNewEmptyTextPane() {
+    JEditorPane jEditorPane = new JEditorPane();
+    jEditorPane.setFont(UIUtil.getLabelFont());
+    jEditorPane.setContentType("text/html");
+    jEditorPane.setEditable(false);
+    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE);
+    jEditorPane.setOpaque(false);
+    jEditorPane.setMargin(JBInsets.create(new Insets(14, 20, 14, 20)));
+    textPane = jEditorPane;
+    messagePanel.add(textPane, textPaneIndex++);
+    return jEditorPane;
+  }
+
+  @Override
+  public void visit(Code code) {
+    addContentOfNodeAsHtml(htmlRenderer.render(code));
+
+    super.visit(code);
+  }
+
+  @Override
+  public void visit(IndentedCodeBlock indentedCodeBlock) {
+    insertCodeEditor(indentedCodeBlock.getLiteral(), "");
+    super.visit(indentedCodeBlock);
+  }
+
+  @Override
+  public void visit(Text text) {
+    addContentOfNodeAsHtml(htmlRenderer.render(text));
+    super.visit(text);
+  }
+
+  @Override
+  public void visit(BlockQuote blockQuote) {
+    addContentOfNodeAsHtml(htmlRenderer.render(blockQuote));
+    super.visit(blockQuote);
+  }
+
+  @Override
+  public void visit(BulletList bulletList) {
+    addContentOfNodeAsHtml(htmlRenderer.render(bulletList));
+  }
+
+  @Override
+  public void visit(Emphasis emphasis) {
+    addContentOfNodeAsHtml(htmlRenderer.render(emphasis));
+    super.visit(emphasis);
+  }
+
+  @Override
+  public void visit(FencedCodeBlock fencedCodeBlock) {
+    insertCodeEditor(fencedCodeBlock.getLiteral(), fencedCodeBlock.getInfo());
+    super.visit(fencedCodeBlock);
+  }
+
+  private void insertCodeEditor(String codeContent, String languageName) {
+    JPanel editorPanel = new JPanel(new BorderLayout());
+    Document codeDocument = EditorFactory.getInstance().createDocument(codeContent);
+    EditorEx editor = (EditorEx) EditorFactory.getInstance().createEditor(codeDocument);
+    setHighlighting(editor, languageName);
+    fillEditorSettings(editor.getSettings());
+    editorPanel.setBorder(new EmptyBorder(JBUI.insetsLeft(gradientWidth)));
+    editorPanel.add(editor.getComponent(), BorderLayout.CENTER);
+    editorPanel.setOpaque(false);
+    messagePanel.add(editorPanel, BorderLayout.CENTER, textPaneIndex++);
+    htmlContent = new StringBuilder();
+    textPane = createNewEmptyTextPane();
+  }
+
+  @Override
+  public void visit(HardLineBreak hardLineBreak) {
+    addContentOfNodeAsHtml(htmlRenderer.render(hardLineBreak));
+    super.visit(hardLineBreak);
+  }
+
+  @Override
+  public void visit(Heading heading) {
+    addContentOfNodeAsHtml(htmlRenderer.render(heading));
+    super.visit(heading);
+  }
+
+  @Override
+  public void visit(ThematicBreak thematicBreak) {
+    addContentOfNodeAsHtml(htmlRenderer.render(thematicBreak));
+    super.visit(thematicBreak);
+  }
+
+  @Override
+  public void visit(HtmlInline htmlInline) {
+    addContentOfNodeAsHtml(htmlRenderer.render(htmlInline));
+    super.visit(htmlInline);
+  }
+
+  @Override
+  public void visit(HtmlBlock htmlBlock) {
+    addContentOfNodeAsHtml(htmlRenderer.render(htmlBlock));
+    super.visit(htmlBlock);
+  }
+
+  @Override
+  public void visit(Image image) {
+    String html = htmlRenderer.render(image);
+    htmlContent.append(html);
+    textPane.setText(wrapWithHtmlTag(htmlContent.toString()));
+    super.visit(image);
+  }
+
+  @Override
+  public void visit(Link link) {
+    addContentOfNodeAsHtml(htmlRenderer.render(link));
+  }
+
+  @Override
+  public void visit(ListItem listItem) {
+    addContentOfNodeAsHtml(htmlRenderer.render(listItem));
+    super.visit(listItem);
+  }
+
+  @Override
+  public void visit(OrderedList orderedList) {
+    addContentOfNodeAsHtml(htmlRenderer.render(orderedList));
+    super.visit(orderedList);
+  }
+
+  @Override
+  public void visit(SoftLineBreak softLineBreak) {
+    addContentOfNodeAsHtml(htmlRenderer.render(softLineBreak));
+    super.visit(softLineBreak);
+  }
+
+  @Override
+  public void visit(StrongEmphasis strongEmphasis) {
+    addContentOfNodeAsHtml(htmlRenderer.render(strongEmphasis));
+    super.visit(strongEmphasis);
+  }
+
+  @Override
+  public void visit(LinkReferenceDefinition linkReferenceDefinition) {
+    addContentOfNodeAsHtml(htmlRenderer.render(linkReferenceDefinition));
+    super.visit(linkReferenceDefinition);
+  }
+
+  @Override
+  public void visit(CustomBlock customBlock) {
+    addContentOfNodeAsHtml(htmlRenderer.render(customBlock));
+    super.visit(customBlock);
+  }
+
+  private void addContentOfNodeAsHtml(String renderedHtml) {
+    htmlContent.append(renderedHtml);
+    textPane.setText(wrapWithHtmlTag(htmlContent.toString()));
+  }
+
+  private @NotNull String wrapWithHtmlTag(@NotNull String htmlContent) {
+    String labelTextColor = ColorUtil.toHex(UIUtil.getLabelForeground());
+    String linkColor = ColorUtil.toHex(UIUtil.getHeaderActiveColor());
+
+    // Build HTML
+    return "<html data-gramm=\"false\"><head><style>"
+        + "body{ color:"
+        + labelTextColor
+        + "; },"
+        + " p { margin:0; },"
+        + " a { color:"
+        + linkColor
+        + "; }"
+        + "</style></head><body>"
+        + htmlContent
+        + "</body></html>";
+  }
+
+  private static void setHighlighting(EditorEx editor, String languageName) {
+    FileType fileType =
+        Language.getRegisteredLanguages().stream()
+            .filter(it -> it.getDisplayName().equalsIgnoreCase(languageName))
+            .findFirst()
+            .flatMap(
+                it -> Optional.ofNullable(FileTypeManager.getInstance().findFileTypeByLanguage(it)))
+            .orElse(PlainTextFileType.INSTANCE);
+
+    EditorHighlighter editorHighlighter =
+        HighlighterFactory.createHighlighter(
+            fileType, EditorColorsManager.getInstance().getSchemeForCurrentUITheme(), null);
+    editor.setHighlighter(editorHighlighter);
+  }
+
+  private static void fillEditorSettings(final EditorSettings editorSettings) {
+    editorSettings.setWhitespacesShown(false);
+    editorSettings.setLineMarkerAreaShown(false);
+    editorSettings.setIndentGuidesShown(false);
+    editorSettings.setLineNumbersShown(true);
+    editorSettings.setFoldingOutlineShown(false);
+    editorSettings.setAdditionalLinesCount(1);
+    editorSettings.setUseSoftWraps(false);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessagePanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessagePanel.java
@@ -1,0 +1,56 @@
+package com.sourcegraph.cody.chat;
+
+import com.intellij.openapi.ui.VerticalFlowLayout;
+import com.intellij.ui.ColorUtil;
+import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.cody.api.Speaker;
+import com.sourcegraph.cody.ui.Colors;
+import java.awt.*;
+import javax.swing.*;
+import javax.swing.border.Border;
+import org.jetbrains.annotations.NotNull;
+
+public class MessagePanel extends JPanel {
+
+  private final boolean isHuman;
+  private final int gradientWidth;
+
+  public MessagePanel(ChatMessage message, int gradientWidth) {
+    super();
+    this.gradientWidth = gradientWidth;
+    Border emptyBorder = BorderFactory.createEmptyBorder(0, 0, 0, 0);
+    Color background = UIUtil.getPanelBackground();
+    Border topBorder =
+        BorderFactory.createMatteBorder(1, 0, 0, 0, ColorUtil.brighter(background, 2));
+    Border bottomBorder =
+        BorderFactory.createMatteBorder(0, 0, 1, 0, ColorUtil.brighter(background, 3));
+    Border topAndBottomBorder = BorderFactory.createCompoundBorder(topBorder, bottomBorder);
+
+    isHuman = message.getSpeaker().equals(Speaker.HUMAN);
+    this.setBorder(isHuman ? emptyBorder : topAndBottomBorder);
+    this.setBackground(isHuman ? ColorUtil.darker(background, 2) : background);
+    this.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
+  }
+
+  @Override
+  protected void paintComponent(@NotNull Graphics g) {
+    super.paintComponent(g);
+    paintLeftBorderGradient(g);
+  }
+
+  private void paintLeftBorderGradient(Graphics g) {
+    if (isHuman) return;
+    int panelHeight = getHeight();
+    int halfOfHeight = panelHeight / 2;
+
+    GradientPaint firstPartGradient =
+        new GradientPaint(0, 0, Colors.PURPLE, 0, halfOfHeight, Colors.ORANGE);
+    GradientPaint secondPartGradient =
+        new GradientPaint(0, halfOfHeight, Colors.ORANGE, 0, panelHeight, Colors.CYAN);
+    final Graphics2D g2d = (Graphics2D) g;
+    g2d.setPaint(firstPartGradient);
+    g2d.fillRect(0, 0, gradientWidth, halfOfHeight);
+    g2d.setPaint(secondPartGradient);
+    g2d.fillRect(0, halfOfHeight, gradientWidth, panelHeight);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/ui/Colors.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/ui/Colors.java
@@ -1,0 +1,10 @@
+package com.sourcegraph.cody.ui;
+
+import com.intellij.ui.JBColor;
+import java.awt.*;
+
+public class Colors {
+  public static final Color CYAN = new JBColor(new Color(0, 203, 236), new Color(0, 203, 236));
+  public static final Color PURPLE = new JBColor(new Color(161, 18, 255), new Color(161, 18, 255));
+  public static final Color ORANGE = new JBColor(new Color(255, 85, 67), new Color(255, 85, 67));
+}


### PR DESCRIPTION
This is a first version of the new chat ui, changes applied only in the messages look. Based on figma design https://www.figma.com/file/m9Yvgv6W3aPRLfXnxgwnEz/IntelliJ?type=design&node-id=0-1&t=Bvrpocr5UuxkwtZn-0

## Test plan
- Green CI, because the code changes only the UI look


Preview of the new UI
<img width="485" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/be19cb19-82c3-4aa4-bbc8-12f679afbf98">
