### PR TITLE
nix: fix bazel test

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -8,13 +8,6 @@
 # sourcegraph's developer tools. In particular this is our databases, which
 # are used by both our tests and development server.
 
-if [ -f /etc/NIXOS ]; then
-  cat <<EOF > .bazelrc-nix
-build --extra_toolchains=@zig_sdk//toolchain:linux_amd64_gnu.2.34
-build --action_env=PATH=$BAZEL_ACTION_PATH
-EOF
-fi
-
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null || exit
 
 . ./start-postgres.sh
@@ -24,3 +17,18 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null || exit
 export SRC_DEV_EXCEPT="${SRC_DEV_EXCEPT:-postgres_exporter}"
 
 popd >/dev/null || exit
+
+# We run this check afterwards so we can read the values exported by the
+# start-*.sh scripts. We need to smuggle in these envvars for tests.
+if [ -f /etc/NIXOS ]; then
+  cat <<EOF > .bazelrc-nix
+build --extra_toolchains=@zig_sdk//toolchain:linux_amd64_gnu.2.34
+build --action_env=PATH=$BAZEL_ACTION_PATH
+build --action_env=REDIS_ENDPOINT
+build --action_env=PGHOST
+build --action_env=PGDATA
+build --action_env=PGDATABASE
+build --action_env=PGDATASOURCE
+build --action_env=PGUSER
+EOF
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -128,7 +128,7 @@ mkShell {
   # Some of the bazel actions require some tools assumed to be in the PATH defined by the "strict action env" that we enable
   # through --incompatible_strict_action_env. We can poke a custom PATH through with --action_env=PATH=$BAZEL_ACTION_PATH.
   # See https://sourcegraph.com/github.com/bazelbuild/bazel@6.1.2/-/blob/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java?L532-547
-  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bash stdenv.cc coreutils unzip zip curl gzip gnutar git patch openssh ];
+  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bash stdenv.cc coreutils unzip zip curl gzip gnutar git patch openssh findutils ];
 
   # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
   # so we tell it to h*ck off here.


### PR DESCRIPTION
I had some bazel tests commands which failed to find the "find" binary. Additionally it was not respecting my configured PG* settings. This makes it so we pass those envvars on. To be honest, I'm surprised this isn't the default in a devenv.

Test Plan: bazel test //internal/database:database_test
