### PR TITLE
Cody: Add default VS Code test settings and hardcode mock server

### DIFF
--- a/client/cody/test/fixtures/.vscode/settings.json
+++ b/client/cody/test/fixtures/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "cody.codebase": "http://localhost:49300",
   "cody.debug.enable": true,
-  "cody.debug.verbose": true
+  "cody.debug.verbose": true,
 }

--- a/client/cody/test/fixtures/.vscode/settings.json
+++ b/client/cody/test/fixtures/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cody.codebase": "http://localhost:49300",
+  "cody.debug.enable": true,
+  "cody.debug.verbose": true
+}


### PR DESCRIPTION
This should avoid us starting the extension with the default codebase setting and thus counting it as a prod event log

## Test plan

this will need manual verification that I haven't done yet.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
