### PR TITLE
Tracing: truncate errors

### DIFF
--- a/internal/trace/BUILD.bazel
+++ b/internal/trace/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -30,5 +31,15 @@ go_library(
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_net//trace",
+    ],
+)
+
+go_test(
+    name = "trace_test",
+    srcs = ["attributes_test.go"],
+    embed = [":trace"],
+    deps = [
+        "//lib/errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/trace/attributes_test.go
+++ b/internal/trace/attributes_test.go
@@ -1,0 +1,36 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_truncateError(t *testing.T) {
+	cases := []struct {
+		input  error
+		limit  int
+		output string
+	}{{
+		input:  errors.New("short error"),
+		limit:  100,
+		output: "short error",
+	}, {
+		input:  errors.New("super very very long error"),
+		limit:  10,
+		output: "super ...truncated... error",
+	}}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			err := truncateError(tc.input, tc.limit)
+			require.Equal(t, tc.output, err.Error())
+		})
+	}
+
+	t.Run("nil error", func(t *testing.T) {
+		err := truncateError(nil, 100)
+		require.Nil(t, err)
+	})
+}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -62,6 +62,9 @@ func (t *Trace) SetError(err error) {
 		return
 	}
 
+	// Truncate the error string to avoid tracing massive error messages.
+	err = truncateError(err, defaultErrorRuneLimit)
+
 	t.oteltraceSpan.RecordError(err)
 	t.oteltraceSpan.SetStatus(codes.Error, err.Error())
 
@@ -73,6 +76,7 @@ func (t *Trace) SetError(err error) {
 // context.DeadlineExceeded.
 func (t *Trace) SetErrorIfNotContext(err error) {
 	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+		err = truncateError(err, defaultErrorRuneLimit)
 		t.oteltraceSpan.RecordError(err)
 		t.nettraceTrace.LazyPrintf("error: %v", err)
 		return


### PR DESCRIPTION
I suspect that one of the reasons we're failing to get a lot of our traces on sourcegraph.com is that we're generating very large error strings because we're joining tons of errors together into massive multierrors.

This updates our tracing code to truncate the error string if it's greater than 512 runes.

## Test plan

Added unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
