### PR TITLE
Fix up how Gerrit Changeset title is displayed

### DIFF
--- a/enterprise/internal/batches/sources/gerrit.go
+++ b/enterprise/internal/batches/sources/gerrit.go
@@ -220,6 +220,9 @@ func (s GerritSource) BuildCommitOpts(repo *types.Repo, changeset *btypes.Change
 	if changeID == "" {
 		changeID = GenerateGerritChangeID(*changeset)
 	}
+	// We append the "title" as the first line of the commit message because Gerrit doesn't have a concept of title.
+	opts.CommitInfo.Messages = append([]string{spec.Title}, opts.CommitInfo.Messages...)
+	// We attach the Change ID to the bottom of the commit message because this is how Gerrit creates it's Changes.
 	opts.CommitInfo.Messages = append(opts.CommitInfo.Messages, "Change-Id: "+changeID)
 	return opts
 }

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -492,6 +492,8 @@ func (c *Changeset) Title() (string, error) {
 		return m.Title, nil
 	case *gerritbatches.AnnotatedChange:
 		title, _, _ := strings.Cut(m.Change.Subject, "\n")
+		// Remove extra quotes added by the commit message
+		title = strings.TrimPrefix(strings.TrimSuffix(title, "\""), "\"")
 		return title, nil
 	default:
 		return "", errors.New("title unknown changeset type")


### PR DESCRIPTION
Gerrit doesn't really have titles, it uses the commit message as the title/description. So we are gaming it here by prefixing the commit message with out Changeset title 😄.

## Test plan

Manual

Before:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/d5e5991d-886c-43cc-b773-c8efc8750285)


After:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/e6fbb58f-54ab-4b90-8a8b-34ff75061656)
