### PR TITLE
Fix CommitSigningConfiguration resolver err

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -40,10 +39,11 @@ func (c *batchChangesCodeHostResolver) CommitSigningConfiguration(ctx context.Co
 		domain := itypes.BatchesGitHubAppDomain
 		ghapp, err := gstore.GetByDomain(ctx, &domain, c.codeHost.ExternalServiceID)
 		if err != nil {
-			if strings.Contains(err.Error(), "no app exists matching criteria: {domain = %s AND base_url = %s") {
+			if _, ok := err.(ghstore.ErrNoGitHubAppFound); ok {
 				return nil, nil
+			} else {
+				return nil, err
 			}
-			return nil, err
 		}
 		return &commitSigningConfigResolver{
 			githubApp: ghapp,

--- a/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/code_host.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -39,6 +40,9 @@ func (c *batchChangesCodeHostResolver) CommitSigningConfiguration(ctx context.Co
 		domain := itypes.BatchesGitHubAppDomain
 		ghapp, err := gstore.GetByDomain(ctx, &domain, c.codeHost.ExternalServiceID)
 		if err != nil {
+			if strings.Contains(err.Error(), "no app exists matching criteria: {domain = %s AND base_url = %s") {
+				return nil, nil
+			}
 			return nil, err
 		}
 		return &commitSigningConfigResolver{

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -400,10 +400,11 @@ func TestGetByDomain(t *testing.T) {
 
 	// does not exist
 	fetched, err = store.GetByDomain(ctx, &domain, "https://myCompany.github.com/")
-	_, ok := err.(ErrNoGitHubAppFound)
 	require.Nil(t, fetched)
 	require.Error(t, err)
+	notFoundErr, ok := err.(ErrNoGitHubAppFound)
 	require.Equal(t, ok, true)
+	require.Equal(t, notFoundErr.Error(), "no app exists matching criteria: 'domain = repos AND base_url = https://myCompany.github.com/'")
 
 	domain = types.BatchesGitHubAppDomain
 	fetched, err = store.GetByDomain(ctx, &domain, "https://github.com/")

--- a/enterprise/internal/github_apps/store/store_test.go
+++ b/enterprise/internal/github_apps/store/store_test.go
@@ -400,9 +400,10 @@ func TestGetByDomain(t *testing.T) {
 
 	// does not exist
 	fetched, err = store.GetByDomain(ctx, &domain, "https://myCompany.github.com/")
+	_, ok := err.(ErrNoGitHubAppFound)
 	require.Nil(t, fetched)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "no app exists matching criteria: {domain = %s AND base_url = %s [repos https://myCompany.github.com/]}")
+	require.Equal(t, ok, true)
 
 	domain = types.BatchesGitHubAppDomain
 	fetched, err = store.GetByDomain(ctx, &domain, "https://github.com/")


### PR DESCRIPTION
Fixes github_apps store resolver to not error if an app is not found. Adds `ErrNoGitHubAppFound` type assertion to create a generic error type to re-use for any github_app that can't be found

Partial pair with @courier-new the great 👑 

Before
![image](https://github.com/sourcegraph/sourcegraph/assets/59381432/0049a68d-c0dc-4e0c-8dbd-744149fd8151)

After
![image](https://github.com/sourcegraph/sourcegraph/assets/59381432/04821cc4-1a31-480a-bb80-5239c56bd1ab)


## Test plan
- Updated test
- Buildkite
- Run locally, ensure `/site-admin/batch-changes` route doesn't error on initial state (when you haven't configured any github_apps yet)