### PR TITLE
Fix diff stat for Gerrit Batch Changes

### DIFF
--- a/enterprise/internal/batches/sources/gerrit.go
+++ b/enterprise/internal/batches/sources/gerrit.go
@@ -220,6 +220,9 @@ func (s GerritSource) BuildCommitOpts(repo *types.Repo, changeset *btypes.Change
 	if changeID == "" {
 		changeID = GenerateGerritChangeID(*changeset)
 	}
+	// We append the "title" as the first line of the commit message because Gerrit doesn't have a concept of title.
+	opts.CommitInfo.Messages = append([]string{spec.Title}, opts.CommitInfo.Messages...)
+	// We attach the Change ID to the bottom of the commit message because this is how Gerrit creates it's Changes.
 	opts.CommitInfo.Messages = append(opts.CommitInfo.Messages, "Change-Id: "+changeID)
 	return opts
 }

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -726,6 +726,10 @@ func selectReviewState(states map[btypes.ChangesetReviewState]bool) btypes.Chang
 // computeDiffStat computes the up to date diffstat for the changeset, based on
 // the values in c.SyncState.
 func computeDiffStat(ctx context.Context, client gitserver.Client, c *btypes.Changeset, repo api.RepoName) (*diff.Stat, error) {
+	//Code hosts that don't push to branches (like Gerrit), can just skip this.
+	if c.SyncState.BaseRefOid == c.SyncState.HeadRefOid {
+		return c.DiffStat(), nil
+	}
 	iter, err := client.Diff(ctx, authz.DefaultSubRepoPermsChecker, gitserver.DiffOptions{
 		Repo: repo,
 		Base: c.SyncState.BaseRefOid,

--- a/enterprise/internal/batches/testing/mock_sync_state.go
+++ b/enterprise/internal/batches/testing/mock_sync_state.go
@@ -2,7 +2,9 @@ package testing
 
 import (
 	"context"
+	"encoding/hex"
 	"io"
+	"math/rand"
 	"strings"
 
 	"github.com/sourcegraph/go-diff/diff"
@@ -65,11 +67,25 @@ index 884601b..c4886d5 100644
 		return gitserver.NewDiffFileIterator(io.NopCloser(strings.NewReader(testGitHubDiff))), nil
 	})
 	gitserverClient.ResolveRevisionFunc.SetDefaultHook(func(context.Context, api.RepoName, string, gitserver.ResolveRevisionOptions) (api.CommitID, error) {
-		return "mockcommitid", nil
+		return api.CommitID(generateFakeCommitID()), nil
 	})
 
 	state.MockClient = gitserverClient
 	return state
+}
+
+func generateFakeCommitID() string {
+	// Generate a random byte slice with 20 bytes (160 bits)
+	commitBytes := make([]byte, 20)
+	_, err := rand.Read(commitBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Convert the byte slice to a hexadecimal string
+	commitID := hex.EncodeToString(commitBytes)
+
+	return commitID
 }
 
 // Unmock resets the mocks set up by MockGitHubChangesetSync.

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -492,6 +492,8 @@ func (c *Changeset) Title() (string, error) {
 		return m.Title, nil
 	case *gerritbatches.AnnotatedChange:
 		title, _, _ := strings.Cut(m.Change.Subject, "\n")
+		// Remove extra quotes added by the commit message
+		title = strings.TrimPrefix(strings.TrimSuffix(title, "\""), "\"")
 		return title, nil
 	default:
 		return "", errors.New("title unknown changeset type")


### PR DESCRIPTION
Gerrit BC aren't able to get up-to-date diff stats because the code isn't pushed to a branch, so we use the originally calculated diff stats.

## Test plan

Manual:

Before:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/7e11b5d9-7874-4633-87cd-c4297d4965e6)

After:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/b546a02f-95a7-470d-8558-56b4236c02d0)
