### PR TITLE
Embeddings: allow tests to access network

### DIFF
--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -64,6 +64,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":embeddings"],
+    tags = [
+        # Test requires localhost database
+        "requires-network",
+    ],
     deps = [
         "//enterprise/internal/embeddings/background/repo",
         "//internal/api",


### PR DESCRIPTION
In #52888 we added a test that requires DB access. This failed on bazel builds, since we didn't specify the test needed network access.

## Test plan

Test already worked locally on macOS, now check it consistently passes on CI. (I'm not sure why it passed CI before!)
