### PR TITLE
search: remove repeated arguments in client.New

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -33,7 +33,7 @@ func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db databa
 		return nil, err
 	}
 
-	cli := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs)
+	cli := client.New(logger, db, enterpriseJobs)
 	inputs, err := cli.Plan(
 		ctx,
 		args.Version,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -322,7 +322,7 @@ func TestSearchResultsHydration(t *testing.T) {
 
 	query := `foobar index:only count:350`
 	literalPatternType := "literal"
-	cli := client.NewSearchClient(logtest.Scoped(t), db, z, nil, nil, jobutil.NewUnimplementedEnterpriseJobs())
+	cli := client.MockedZoekt(logtest.Scoped(t), db, z)
 	searchInputs, err := cli.Plan(
 		ctx,
 		"V2",
@@ -560,7 +560,7 @@ func TestEvaluateAnd(t *testing.T) {
 			db.ReposFunc.SetDefaultReturn(repos)
 
 			literalPatternType := "literal"
-			cli := client.NewSearchClient(logtest.Scoped(t), db, z, nil, nil, jobutil.NewUnimplementedEnterpriseJobs())
+			cli := client.MockedZoekt(logtest.Scoped(t), db, z)
 			searchInputs, err := cli.Plan(
 				context.Background(),
 				"V2",
@@ -665,7 +665,7 @@ func TestSubRepoFiltering(t *testing.T) {
 			})
 
 			literalPatternType := "literal"
-			cli := client.NewSearchClient(logtest.Scoped(t), db, mockZoekt, nil, nil, jobutil.NewUnimplementedEnterpriseJobs())
+			cli := client.MockedZoekt(logtest.Scoped(t), db, mockZoekt)
 			searchInputs, err := cli.Plan(
 				context.Background(),
 				"V2",

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -354,7 +354,7 @@ func BenchmarkSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			client: client.NewSearchClient(logtest.Scoped(b), db, z, nil, nil, jobutil.NewUnimplementedEnterpriseJobs()),
+			client: client.MockedZoekt(logtest.Scoped(b), db, z),
 			db:     db,
 			SearchInputs: &search.Inputs{
 				Plan:         plan,

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -46,7 +46,7 @@ func StreamHandler(db database.DB, enterpriseJobs jobutil.EnterpriseJobs) http.H
 	return &streamHandler{
 		logger:              logger,
 		db:                  db,
-		searchClient:        client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs),
+		searchClient:        client.New(logger, db, enterpriseJobs),
 		flushTickerInternal: 100 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
 	}

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -45,7 +45,7 @@ func run(w io.Writer, args []string) error {
 	conf.Mock(&conf.Unified{})
 	logger := log.Scoped("search-plan", "")
 
-	cli := client.NewSearchClient(logger, nil, nil, nil, nil, nil)
+	cli := client.MockedZoekt(logger, nil, nil)
 
 	inputs, err := cli.Plan(
 		context.Background(),

--- a/enterprise/cmd/frontend/internal/compute/streaming/compute.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/compute.go
@@ -75,7 +75,7 @@ func NewComputeStream(ctx context.Context, logger log.Logger, db database.DB, en
 	}
 
 	patternType := "regexp"
-	searchClient := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs)
+	searchClient := client.New(logger, db, enterpriseJobs)
 	inputs, err := searchClient.Plan(
 		ctx,
 		"",

--- a/enterprise/cmd/frontend/internal/context/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/context/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/observation",
-        "//internal/search",
         "//internal/search/client",
     ],
 )

--- a/enterprise/cmd/frontend/internal/context/init.go
+++ b/enterprise/cmd/frontend/internal/context/init.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 )
 
@@ -25,12 +24,9 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	embeddingsClient := embeddings.NewDefaultClient()
-	searchClient := client.NewSearchClient(
+	searchClient := client.New(
 		observationCtx.Logger,
 		db,
-		search.Indexed(),
-		search.SearcherURLs(),
-		search.SearcherGRPCConnectionCache(),
 		enterpriseServices.EnterpriseSearchJobs,
 	)
 	contextClient := codycontext.NewCodyContextClient(

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
-	searchClient := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs)
+	searchClient := client.New(logger, db, enterpriseJobs)
 	inputs, err := searchClient.Plan(
 		ctx,
 		"V3",
@@ -80,7 +80,7 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 // On subsequent runs, this allows us to treat all new repos or sets of args as something new that should
 // be searched from the beginning.
 func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64, settings *schema.Settings) error {
-	searchClient := client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs)
+	searchClient := client.New(logger, db, enterpriseJobs)
 	inputs, err := searchClient.Plan(
 		ctx,
 		"V3",

--- a/enterprise/internal/insights/query/streaming/search_client.go
+++ b/enterprise/internal/insights/query/streaming/search_client.go
@@ -22,7 +22,7 @@ func NewInsightsSearchClient(db database.DB, enterpriseJobs jobutil.EnterpriseJo
 	logger := log.Scoped("insightsSearchClient", "")
 	return &insightsSearchClient{
 		db:           db,
-		searchClient: client.NewSearchClient(logger, db, search.Indexed(), search.SearcherURLs(), search.SearcherGRPCConnectionCache(), enterpriseJobs),
+		searchClient: client.New(logger, db, enterpriseJobs),
 	}
 }
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -50,14 +50,26 @@ type SearchClient interface {
 	JobClients() job.RuntimeClients
 }
 
-func NewSearchClient(logger log.Logger, db database.DB, zoektStreamer zoekt.Streamer, searcherURLs *endpoint.Map, searcherGRPCConnectionCache *defaults.ConnectionCache, enterpriseJobs jobutil.EnterpriseJobs) SearchClient {
+// New will create a search client with a zoekt and searcher backed by conf.
+func New(logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs) SearchClient {
 	return &searchClient{
 		logger:                      logger,
 		db:                          db,
-		zoekt:                       zoektStreamer,
-		searcherURLs:                searcherURLs,
-		searcherGRPCConnectionCache: searcherGRPCConnectionCache,
+		zoekt:                       search.Indexed(),
+		searcherURLs:                search.SearcherURLs(),
+		searcherGRPCConnectionCache: search.SearcherGRPCConnectionCache(),
 		enterpriseJobs:              enterpriseJobs,
+	}
+}
+
+// MockedZoekt will return a search client for tests which uses the mocked
+// zoektStreamer.
+func MockedZoekt(logger log.Logger, db database.DB, zoektStreamer zoekt.Streamer) SearchClient {
+	return &searchClient{
+		logger:         logger,
+		db:             db,
+		zoekt:          zoektStreamer,
+		enterpriseJobs: jobutil.NewUnimplementedEnterpriseJobs(),
 	}
 }
 


### PR DESCRIPTION
This commit updates all calls to client.NewSearchClient to not specify zoektStreamer, searcherURLs and searcherGRPCConnectionCache anymore. We always passed exactly the same values everytime, so we might as well simplify the call site.

In tests we only ever mocked zoekt, so we add a new constructor for tests which capture the pattern used there.

Additionally we rename the method from client.NewSearchClient to just client.New to avoid the stutter. Call sites generally make it clear the variable being captured is related to search, so this reads better.

Test Plan: CI