### PR TITLE
bzl: stamp with 12 chars sha

### DIFF
--- a/dev/bazel_stamp_vars.sh
+++ b/dev/bazel_stamp_vars.sh
@@ -3,7 +3,12 @@
 build_number="${BUILDKITE_BUILD_NUMBER:-000000}"
 date_fragment="$(date +%Y-%m-%d)"
 latest_tag="5.0"
-stamp_version="${build_number}_${date_fragment}_${latest_tag}-$(git rev-parse --short HEAD)"
+
+# We historicall use 12 chars for short commits.
+commit="$(git rev-parse HEAD)"
+commit="${commit:0:12}"
+
+stamp_version="${build_number}_${date_fragment}_${latest_tag}-${commit}"
 
 echo STABLE_VERSION "$stamp_version"
 echo VERSION_TIMESTAMP "$(date +%s)"


### PR DESCRIPTION
Just noticed while debugging S2 deployment issues with @willdollman and @filiphaftek that our version string that we stamp binaries with was missing two chars. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested + CI 