### PR TITLE
Assigned owners included in git tree resolver

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -221,6 +221,13 @@ func (r *ownResolver) GitTreeOwnership(
 	}
 	ownerships = append(ownerships, viewerResolvers...)
 
+	// Retrieve assigned owners.
+	assignedOwners, err := r.computeAssignedOwners(ctx, r.logger, r.db, tree, repoID)
+	if err != nil {
+		return nil, err
+	}
+	ownerships = append(ownerships, assignedOwners...)
+
 	return r.ownershipConnection(args, ownerships)
 }
 

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
+
 	owntypes "github.com/sourcegraph/sourcegraph/enterprise/internal/own/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	rbactypes "github.com/sourcegraph/sourcegraph/internal/rbac/types"
@@ -1483,6 +1484,79 @@ func TestOwnership_WithAssignedOwners(t *testing.T) {
 			"repo":        string(graphqlbackend.MarshalRepositoryID(repoID)),
 			"revision":    "revision",
 			"currentPath": "foo/bar.js",
+		},
+	})
+
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Schema:  schema,
+		Context: ctx,
+		Query: `
+			query FetchOwnership($repo: ID!, $revision: String!, $currentPath: String!) {
+				node(id: $repo) {
+					... on Repository {
+						commit(rev: $revision) {
+							blob(path: $currentPath) {
+								ownership {
+									totalOwners
+									totalCount
+									nodes {
+										owner {
+											...on Person {
+												displayName
+												email
+											}
+										}
+										reasons {
+											...on RecentContributorOwnershipSignal {
+											  title
+											  description
+											}
+											... on RecentViewOwnershipSignal {
+											  title
+											  description
+											}
+											... on AssignedOwner {
+											  title
+											  description
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}`,
+		ExpectedResult: `{
+			"node": {
+				"commit": {
+					"blob": {
+						"ownership": {
+							"totalOwners": 1,
+							"totalCount": 1,
+							"nodes": [
+								{
+									"owner": {
+										"displayName": "I am an assigned owner #2",
+										"email": "assigned@owner2.com"
+									},
+									"reasons": [
+										{
+											"title": "assigned owner",
+											"description": "Owner is manually assigned."
+										}
+									]
+								}
+							]
+						}
+					}
+				}
+			}
+		}`,
+		Variables: map[string]any{
+			"repo":        string(graphqlbackend.MarshalRepositoryID(repoID)),
+			"revision":    "revision",
+			"currentPath": "foo",
 		},
 	})
 }


### PR DESCRIPTION
This change adds assigned owners to be served for git tree view:

<img width="1170" alt="Screenshot 2023-06-06 at 11 32 39 AM" src="https://github.com/sourcegraph/sourcegraph/assets/153410/e4696b89-de0a-4f07-a2e9-d25dd06c5350">

This is relevant for assigned ownership. After assigning an owner to a directory, it should be displayed there.

## Test plan

Extend existing graphQL unit tests
