### PR TITLE
codgygw: re-enable previously skipped test

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/events/buffered_test.go
+++ b/enterprise/cmd/cody-gateway/internal/events/buffered_test.go
@@ -16,10 +16,6 @@ import (
 )
 
 func TestBufferedLogger(t *testing.T) {
-	// Disabled because of race condition, see https://sourcegraph.slack.com/archives/C05497E9MDW/p1685955562994269
-	// Skipping because it enables to re-enable the race condition detector and allow the team to fix this in a different PR.
-	t.Skip()
-
 	t.Parallel()
 	ctx := context.Background()
 


### PR DESCRIPTION
This was previously triggering the race detector, but it was fixed in https://github.com/sourcegraph/sourcegraph/pull/52951/files

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 