### PR TITLE
bzl: remove default_tags from oci_push rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -328,7 +328,7 @@ exports_files([
     "CHANGELOG.md",
 ])
 
-stamp_tags(
-    name = "tags",
-    remote_tags = ["""($stamp.STABLE_VERSION // "0.0.0")"""],
-)
+# stamp_tags(
+#     name = "tags",
+#     remote_tags = ["""($stamp.STABLE_VERSION // "0.0.0")"""],
+# )

--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -114,6 +114,5 @@ oci_tarball(
 oci_push(
     name = "s3_proxy_candidate_push",
     image = ":s3_proxy_image",
-    remote_tags = "//:tags",
     repository = image_repository("blobstore"),
 )

--- a/cmd/github-proxy/BUILD.bazel
+++ b/cmd/github-proxy/BUILD.bazel
@@ -64,6 +64,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("github-proxy"),
 )

--- a/cmd/loadtest/BUILD.bazel
+++ b/cmd/loadtest/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("loadtest"),
 )

--- a/cmd/repo-updater/BUILD.bazel
+++ b/cmd/repo-updater/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("repo-updater"),
 )

--- a/cmd/searcher/BUILD.bazel
+++ b/cmd/searcher/BUILD.bazel
@@ -64,6 +64,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("searcher"),
 )

--- a/docker-images/cadvisor/BUILD.bazel
+++ b/docker-images/cadvisor/BUILD.bazel
@@ -39,6 +39,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("cadvisor"),
 )

--- a/docker-images/codeinsights-db/BUILD.bazel
+++ b/docker-images/codeinsights-db/BUILD.bazel
@@ -56,6 +56,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("codeinsights-db"),
 )

--- a/docker-images/codeintel-db/BUILD.bazel
+++ b/docker-images/codeintel-db/BUILD.bazel
@@ -25,6 +25,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("codeintel-db"),
 )

--- a/docker-images/grafana/BUILD.bazel
+++ b/docker-images/grafana/BUILD.bazel
@@ -48,6 +48,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("grafana"),
 )

--- a/docker-images/indexed-searcher/BUILD.bazel
+++ b/docker-images/indexed-searcher/BUILD.bazel
@@ -51,6 +51,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("indexed-searcher"),
 )

--- a/docker-images/jaeger-agent/BUILD.bazel
+++ b/docker-images/jaeger-agent/BUILD.bazel
@@ -26,6 +26,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("jaeger-agent"),
 )

--- a/docker-images/jaeger-all-in-one/BUILD.bazel
+++ b/docker-images/jaeger-all-in-one/BUILD.bazel
@@ -47,6 +47,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("jaeger-all-in-one"),
 )

--- a/docker-images/node-exporter/BUILD.bazel
+++ b/docker-images/node-exporter/BUILD.bazel
@@ -27,6 +27,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("node-exporter"),
 )

--- a/docker-images/opentelemetry-collector/BUILD.bazel
+++ b/docker-images/opentelemetry-collector/BUILD.bazel
@@ -39,6 +39,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("opentelemetry-collector"),
 )

--- a/docker-images/postgres-12-alpine/BUILD.bazel
+++ b/docker-images/postgres-12-alpine/BUILD.bazel
@@ -60,6 +60,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("postgres-12-alpine"),  # TODO careful, this is not an alpine
 )

--- a/docker-images/postgres_exporter/BUILD.bazel
+++ b/docker-images/postgres_exporter/BUILD.bazel
@@ -45,6 +45,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("postgres_exporter"),
 )

--- a/docker-images/prometheus/BUILD.bazel
+++ b/docker-images/prometheus/BUILD.bazel
@@ -57,6 +57,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("prometheus"),
 )

--- a/docker-images/redis-cache/BUILD.bazel
+++ b/docker-images/redis-cache/BUILD.bazel
@@ -48,6 +48,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("redis-cache"),
 )

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -48,6 +48,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("redis-store"),
 )

--- a/docker-images/redis_exporter/BUILD.bazel
+++ b/docker-images/redis_exporter/BUILD.bazel
@@ -27,6 +27,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("redis_exporter"),
 )

--- a/docker-images/search-indexer/BUILD.bazel
+++ b/docker-images/search-indexer/BUILD.bazel
@@ -48,6 +48,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("search-indexer"),
 )

--- a/docker-images/sg/BUILD.bazel
+++ b/docker-images/sg/BUILD.bazel
@@ -39,6 +39,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("sg"),
 )

--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -113,6 +113,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("syntax-highlighter"),
 )

--- a/enterprise/cmd/batcheshelper/BUILD.bazel
+++ b/enterprise/cmd/batcheshelper/BUILD.bazel
@@ -73,6 +73,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("batcheshelper"),
 )

--- a/enterprise/cmd/bundled-executor/BUILD.bazel
+++ b/enterprise/cmd/bundled-executor/BUILD.bazel
@@ -52,6 +52,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("bundled-executor"),
 )

--- a/enterprise/cmd/cody-gateway/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("cody-gateway"),
 )

--- a/enterprise/cmd/embeddings/BUILD.bazel
+++ b/enterprise/cmd/embeddings/BUILD.bazel
@@ -58,6 +58,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("embeddings"),
 )

--- a/enterprise/cmd/executor-kubernetes/BUILD.bazel
+++ b/enterprise/cmd/executor-kubernetes/BUILD.bazel
@@ -46,6 +46,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("executor-kubernetes"),
 )

--- a/enterprise/cmd/executor/BUILD.bazel
+++ b/enterprise/cmd/executor/BUILD.bazel
@@ -76,6 +76,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("executor"),
 )

--- a/enterprise/cmd/frontend/BUILD.bazel
+++ b/enterprise/cmd/frontend/BUILD.bazel
@@ -78,6 +78,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("frontend"),
 )

--- a/enterprise/cmd/gitserver/BUILD.bazel
+++ b/enterprise/cmd/gitserver/BUILD.bazel
@@ -78,6 +78,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("gitserver"),
 )

--- a/enterprise/cmd/migrator/BUILD.bazel
+++ b/enterprise/cmd/migrator/BUILD.bazel
@@ -68,6 +68,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("migrator"),
 )

--- a/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
+++ b/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("precise-code-intel-worker"),
 )

--- a/enterprise/cmd/repo-updater/BUILD.bazel
+++ b/enterprise/cmd/repo-updater/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("repo-updater"),
 )

--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -180,6 +180,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("server"),
 )

--- a/enterprise/cmd/symbols/BUILD.bazel
+++ b/enterprise/cmd/symbols/BUILD.bazel
@@ -69,6 +69,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("symbols"),
 )

--- a/enterprise/cmd/worker/BUILD.bazel
+++ b/enterprise/cmd/worker/BUILD.bazel
@@ -61,6 +61,5 @@ container_structure_test(
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("worker"),
 )


### PR DESCRIPTION
Having the default tags handled makes it confusing as we're still in a transition phase and having two places to handle those is error prone.



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

local testing + CI