### PR TITLE
cody site-admin: dedicated link from repositories to embedding jobs

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -1,5 +1,7 @@
 import { FC, useCallback, useEffect, useState } from 'react'
 
+import { useLocation } from 'react-router-dom'
+
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -59,7 +61,11 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         telemetryService.logPageView('SiteAdminCodyPage')
     }, [telemetryService])
 
-    const [searchValue, setSearchValue] = useState('')
+    const location = useLocation()
+    var searchParams = new URLSearchParams(location.search)
+    const queryParam = searchParams.get('query')
+
+    const [searchValue, setSearchValue] = useState(queryParam || '')
     const query = useDebounce(searchValue, 200)
 
     const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useRepoEmbeddingJobsConnection(query)
@@ -94,6 +100,18 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         formApi: form.formAPI,
         validators: { sync: repositoriesValidator },
     })
+
+    const updateQueryParams = (newQueryValue: string) => {
+        if (newQueryValue === '') {
+            searchParams.delete('query')
+        } else {
+            searchParams.set('query', newQueryValue)
+        }
+
+        const queryString = searchParams.toString()
+        const newUrl = queryString === '' ? window.location.pathname : `${window.location.pathname}?${queryString}`
+        window.history.replaceState(null, '', newUrl)
+    }
 
     const [cancelRepoEmbeddingJob, { error: cancelRepoEmbeddingJobError }] = useCancelRepoEmbeddingJob()
 
@@ -155,7 +173,10 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                 <ConnectionContainer>
                     <ConnectionForm
                         inputValue={searchValue}
-                        onInputChange={event => setSearchValue(event.target.value)}
+                        onInputChange={event => {
+                            setSearchValue(event.target.value)
+                            updateQueryParams(event.target.value)
+                        }}
                         inputPlaceholder="Filter embedding jobs..."
                     />
                     {error && <ConnectionError errors={[error.message]} />}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -220,7 +220,17 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                     className="p-2"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
-                                    Embeddings
+                                    Embeddings policies
+                                </MenuItem>
+
+                                <MenuItem
+                                    as={Button}
+                                    disabled={!repoClonedAndHealthy(node)}
+                                    onSelect={() => navigate(`/site-admin/embeddings?query=${node.name}`)}
+                                    className="p-2"
+                                >
+                                    <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
+                                    Embeddings jobs
                                 </MenuItem>
 
                                 <MenuItem


### PR DESCRIPTION
Related to #52983 

- The context menu of a repository gets a new entry "Embedding jobs"
- The link leads to the "Embeddings" page pre-filtered to the repo name

![Kapture 2023-06-06 at 12 49 06](https://github.com/sourcegraph/sourcegraph/assets/26413131/2905d2ad-7489-4a19-ba97-0de134ac7e81)


## Test plan
- The flow is show in the video
- `sg run embeddings`
- site admin > repositories > repository > context menu > Embedding Jobs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
