### PR TITLE
shell: /bin/bash -> /usr/bin/env bash

### DIFF
--- a/client/cody/scripts/check-rg.sh
+++ b/client/cody/scripts/check-rg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 run() {
 

--- a/client/cody/scripts/download-rg.sh
+++ b/client/cody/scripts/download-rg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION="v13.0.0-8"
 

--- a/cmd/migrator/schema_descriptions_test.sh
+++ b/cmd/migrator/schema_descriptions_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Path to the schema_descriptions tool
 generate_bin="$1"

--- a/dev/ci/bazel.sh
+++ b/dev/ci/bazel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "${CI:-false}" == "true" ]]; then
   if [[ "$1"  == "build" || "$1" == "test" || "$1" == "run" ]]; then

--- a/dev/ci/integration/code-intel/install-src.sh
+++ b/dev/ci/integration/code-intel/install-src.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is called by test.sh to install an up-to-date
 # version of src-cli as required by the codeintel-qa pipeline. The target binary

--- a/docker-images/codeinsights-db/rootfs/patch-conf.sh
+++ b/docker-images/codeinsights-db/rootfs/patch-conf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # In Wolfi, unix_socket_directories defaults to /tmp. In previous Alpine images, this defaulted to /var/run/postgres.
 # /tmp may not be writable, so any existing postgresql.conf configs that predate the Wolfi migration should be patched to update this setting.

--- a/docker-images/postgres-12-alpine/rootfs/patch-conf.sh
+++ b/docker-images/postgres-12-alpine/rootfs/patch-conf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # In Wolfi, unix_socket_directories defaults to /tmp. In previous Alpine images, this defaulted to /var/run/postgres.
 # /tmp may not be writable, so any existing postgresql.conf configs that predate the Wolfi migration should be patched to update this setting.

--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 

--- a/enterprise/dev/ci/scripts/annotate.sh
+++ b/enterprise/dev/ci/scripts/annotate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Convenience script for https://buildkite.com/docs/agent/v3/cli-annotate
 # If you are writing a pipeline step DO NOT use this script directly - instead, use

--- a/enterprise/dev/ci/scripts/sentry-capture.sh
+++ b/enterprise/dev/ci/scripts/sentry-capture.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function capture {
   (

--- a/enterprise/dev/ci/scripts/upload-test-report.sh
+++ b/enterprise/dev/ci/scripts/upload-test-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 xml_file=$1
 xml=$(cat "$xml_file")

--- a/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euf -o pipefail
 

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euf -o pipefail
 

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -u
 

--- a/monitoring/generate_config_test.sh
+++ b/monitoring/generate_config_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Path to the monitoring tool
 monitoring_bin="$1"

--- a/testing/backend_integration_test.sh
+++ b/testing/backend_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 source ./testing/tools/integration_runner.sh || exit 1

--- a/testing/codeintel_integration_test.sh
+++ b/testing/codeintel_integration_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 source ./testing/tools/integration_runner.sh || exit 1

--- a/testing/e2e_test.sh
+++ b/testing/e2e_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu
 source ./testing/tools/integration_runner.sh || exit 1

--- a/testing/tools/integration_runner.sh
+++ b/testing/tools/integration_runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Changes interpreter in shell scripts to not hard-code bash location, for portability

## Test plan

Previously `DOCKER_BAZEL=true IMAGE=strum355/frontend VERSION=5.0.5 ./enterprise/cmd/frontend/build.sh` wouldn't work for me, now it does : )
