### PR TITLE
docs: remove mentions of remote_tags in bzl container

### DIFF
--- a/doc/dev/background-information/bazel_containers.md
+++ b/doc/dev/background-information/bazel_containers.md
@@ -159,14 +159,13 @@ bazel test //enterprise/cmd/worker:image_test --config darwin-docker
 
 Finally, _if and only if_ we want our image to be released on registries, we need to add the `oci_push` rule. It will take care of definining which registry to push on, as well as tagging the image, through a process referred as `stamping` that we will cover a bit further. 
 
-Apart from the `image` attribute which refers to the above `oci_rule`, `remote_tags` refers to a target living at the root of the repository, whose purpose is to handle all the conventional tags we release our images with. As a service owner, you don't have to think about this, as long as you specify it exactly like the example below. Example: 
+Apart from the `image` attribute which refers to the above `oci_rule`, `repository` refers to the internal (development) registry. Example:
 
 
 ```
 oci_push(
     name = "candidate_push",
     image = ":image",
-    remote_tags = "//:tags",
     repository = image_repository("worker"),
 )
 ```


### PR DESCRIPTION
Very small change, remove mention of the `remote_tags` attribute that we recently dropped, to reduce the source of tags when pushing the images.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 