### PR TITLE
Aggregate CODEOWNERS stats per file - stores

### DIFF
--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -38691,6 +38691,9 @@ type MockOwnershipStatsStore struct {
 	// QueryIndividualCountsFunc is an instance of a mock function object
 	// controlling the behavior of the method QueryIndividualCounts.
 	QueryIndividualCountsFunc *OwnershipStatsStoreQueryIndividualCountsFunc
+	// UpdateAggregateCountsFunc is an instance of a mock function object
+	// controlling the behavior of the method UpdateAggregateCounts.
+	UpdateAggregateCountsFunc *OwnershipStatsStoreUpdateAggregateCountsFunc
 	// UpdateIndividualCountsFunc is an instance of a mock function object
 	// controlling the behavior of the method UpdateIndividualCounts.
 	UpdateIndividualCountsFunc *OwnershipStatsStoreUpdateIndividualCountsFunc
@@ -38702,7 +38705,12 @@ type MockOwnershipStatsStore struct {
 func NewMockOwnershipStatsStore() *MockOwnershipStatsStore {
 	return &MockOwnershipStatsStore{
 		QueryIndividualCountsFunc: &OwnershipStatsStoreQueryIndividualCountsFunc{
-			defaultHook: func(context.Context, TreeLocationOpts, *LimitOffset) (r0 []TreeCounts, r1 error) {
+			defaultHook: func(context.Context, TreeLocationOpts, *LimitOffset) (r0 []TreeCodeownersCounts, r1 error) {
+				return
+			},
+		},
+		UpdateAggregateCountsFunc: &OwnershipStatsStoreUpdateAggregateCountsFunc{
+			defaultHook: func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -38720,8 +38728,13 @@ func NewMockOwnershipStatsStore() *MockOwnershipStatsStore {
 func NewStrictMockOwnershipStatsStore() *MockOwnershipStatsStore {
 	return &MockOwnershipStatsStore{
 		QueryIndividualCountsFunc: &OwnershipStatsStoreQueryIndividualCountsFunc{
-			defaultHook: func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error) {
+			defaultHook: func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error) {
 				panic("unexpected invocation of MockOwnershipStatsStore.QueryIndividualCounts")
+			},
+		},
+		UpdateAggregateCountsFunc: &OwnershipStatsStoreUpdateAggregateCountsFunc{
+			defaultHook: func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error) {
+				panic("unexpected invocation of MockOwnershipStatsStore.UpdateAggregateCounts")
 			},
 		},
 		UpdateIndividualCountsFunc: &OwnershipStatsStoreUpdateIndividualCountsFunc{
@@ -38740,6 +38753,9 @@ func NewMockOwnershipStatsStoreFrom(i OwnershipStatsStore) *MockOwnershipStatsSt
 		QueryIndividualCountsFunc: &OwnershipStatsStoreQueryIndividualCountsFunc{
 			defaultHook: i.QueryIndividualCounts,
 		},
+		UpdateAggregateCountsFunc: &OwnershipStatsStoreUpdateAggregateCountsFunc{
+			defaultHook: i.UpdateAggregateCounts,
+		},
 		UpdateIndividualCountsFunc: &OwnershipStatsStoreUpdateIndividualCountsFunc{
 			defaultHook: i.UpdateIndividualCounts,
 		},
@@ -38750,15 +38766,15 @@ func NewMockOwnershipStatsStoreFrom(i OwnershipStatsStore) *MockOwnershipStatsSt
 // the QueryIndividualCounts method of the parent MockOwnershipStatsStore
 // instance is invoked.
 type OwnershipStatsStoreQueryIndividualCountsFunc struct {
-	defaultHook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error)
-	hooks       []func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error)
+	defaultHook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error)
+	hooks       []func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error)
 	history     []OwnershipStatsStoreQueryIndividualCountsFuncCall
 	mutex       sync.Mutex
 }
 
 // QueryIndividualCounts delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockOwnershipStatsStore) QueryIndividualCounts(v0 context.Context, v1 TreeLocationOpts, v2 *LimitOffset) ([]TreeCounts, error) {
+func (m *MockOwnershipStatsStore) QueryIndividualCounts(v0 context.Context, v1 TreeLocationOpts, v2 *LimitOffset) ([]TreeCodeownersCounts, error) {
 	r0, r1 := m.QueryIndividualCountsFunc.nextHook()(v0, v1, v2)
 	m.QueryIndividualCountsFunc.appendCall(OwnershipStatsStoreQueryIndividualCountsFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -38767,7 +38783,7 @@ func (m *MockOwnershipStatsStore) QueryIndividualCounts(v0 context.Context, v1 T
 // SetDefaultHook sets function that is called when the
 // QueryIndividualCounts method of the parent MockOwnershipStatsStore
 // instance is invoked and the hook queue is empty.
-func (f *OwnershipStatsStoreQueryIndividualCountsFunc) SetDefaultHook(hook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error)) {
+func (f *OwnershipStatsStoreQueryIndividualCountsFunc) SetDefaultHook(hook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error)) {
 	f.defaultHook = hook
 }
 
@@ -38776,7 +38792,7 @@ func (f *OwnershipStatsStoreQueryIndividualCountsFunc) SetDefaultHook(hook func(
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *OwnershipStatsStoreQueryIndividualCountsFunc) PushHook(hook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error)) {
+func (f *OwnershipStatsStoreQueryIndividualCountsFunc) PushHook(hook func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -38784,20 +38800,20 @@ func (f *OwnershipStatsStoreQueryIndividualCountsFunc) PushHook(hook func(contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OwnershipStatsStoreQueryIndividualCountsFunc) SetDefaultReturn(r0 []TreeCounts, r1 error) {
-	f.SetDefaultHook(func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error) {
+func (f *OwnershipStatsStoreQueryIndividualCountsFunc) SetDefaultReturn(r0 []TreeCodeownersCounts, r1 error) {
+	f.SetDefaultHook(func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OwnershipStatsStoreQueryIndividualCountsFunc) PushReturn(r0 []TreeCounts, r1 error) {
-	f.PushHook(func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error) {
+func (f *OwnershipStatsStoreQueryIndividualCountsFunc) PushReturn(r0 []TreeCodeownersCounts, r1 error) {
+	f.PushHook(func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error) {
 		return r0, r1
 	})
 }
 
-func (f *OwnershipStatsStoreQueryIndividualCountsFunc) nextHook() func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCounts, error) {
+func (f *OwnershipStatsStoreQueryIndividualCountsFunc) nextHook() func(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -38843,7 +38859,7 @@ type OwnershipStatsStoreQueryIndividualCountsFuncCall struct {
 	Arg2 *LimitOffset
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []TreeCounts
+	Result0 []TreeCodeownersCounts
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -38858,6 +38874,124 @@ func (c OwnershipStatsStoreQueryIndividualCountsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c OwnershipStatsStoreQueryIndividualCountsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// OwnershipStatsStoreUpdateAggregateCountsFunc describes the behavior when
+// the UpdateAggregateCounts method of the parent MockOwnershipStatsStore
+// instance is invoked.
+type OwnershipStatsStoreUpdateAggregateCountsFunc struct {
+	defaultHook func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error)
+	hooks       []func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error)
+	history     []OwnershipStatsStoreUpdateAggregateCountsFuncCall
+	mutex       sync.Mutex
+}
+
+// UpdateAggregateCounts delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockOwnershipStatsStore) UpdateAggregateCounts(v0 context.Context, v1 api.RepoID, v2 TreeAggregateOwnership, v3 time.Time) (int, error) {
+	r0, r1 := m.UpdateAggregateCountsFunc.nextHook()(v0, v1, v2, v3)
+	m.UpdateAggregateCountsFunc.appendCall(OwnershipStatsStoreUpdateAggregateCountsFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// UpdateAggregateCounts method of the parent MockOwnershipStatsStore
+// instance is invoked and the hook queue is empty.
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) SetDefaultHook(hook func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// UpdateAggregateCounts method of the parent MockOwnershipStatsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) PushHook(hook func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) nextHook() func(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) appendCall(r0 OwnershipStatsStoreUpdateAggregateCountsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// OwnershipStatsStoreUpdateAggregateCountsFuncCall objects describing the
+// invocations of this function.
+func (f *OwnershipStatsStoreUpdateAggregateCountsFunc) History() []OwnershipStatsStoreUpdateAggregateCountsFuncCall {
+	f.mutex.Lock()
+	history := make([]OwnershipStatsStoreUpdateAggregateCountsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// OwnershipStatsStoreUpdateAggregateCountsFuncCall is an object that
+// describes an invocation of method UpdateAggregateCounts on an instance of
+// MockOwnershipStatsStore.
+type OwnershipStatsStoreUpdateAggregateCountsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoID
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 TreeAggregateOwnership
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 time.Time
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c OwnershipStatsStoreUpdateAggregateCountsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c OwnershipStatsStoreUpdateAggregateCountsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/database/ownership_stats.go
+++ b/internal/database/ownership_stats.go
@@ -12,29 +12,32 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// FileOwnershipAggregate allows iterating through the file tree
+// TreeCodeownersStats allows iterating through the file tree
 // of a repository, providing ownership counts for every owner
 // and every directory.
-type FileOwnershipAggregate interface {
-	Iterate(func(path string, counts TreeCodeownersCounts) error) error
+type TreeCodeownersStats interface {
+	Iterate(func(path string, counts PathCodeownersCounts) error) error
 }
 
-// TreeCodeownersCounts describes ownership magnitude by file count for given owner.
+// PathCodeownersCounts describes ownership magnitude by file count for given owner.
 // The scope of ownership is contextual, and can range from a file tree
-// in case of FileOwnershipAggregate to whole instance when querying
+// in case of TreeCodeownersStats to whole instance when querying
 // without restrictions through QueryIndividualCounts.
-type TreeCodeownersCounts struct {
+type PathCodeownersCounts struct {
 	// CodeownersReference is the text found in CODEOWNERS files that matched the counted files in this file tree.
 	CodeownersReference string
 	// CodeownedFileCount is the number of files that matched given owner in this file tree.
 	CodeownedFileCount int
 }
 
-type TreeAggregateOwnership interface {
-	Iterate(func(path string, counts TreeAggregateCounts) error) error
+// TreeAggregateStats allows iterating through the file tree of a repository
+// providing ownership data that is aggregated by file path only (as opposed
+// to )
+type TreeAggregateStats interface {
+	Iterate(func(path string, counts PathAggregateCounts) error) error
 }
 
-type TreeAggregateCounts struct {
+type PathAggregateCounts struct {
 	// CodeownedFileCount is the total number of files nested within given tree root
 	// that are owned via CODEOWNERS.
 	CodeownedFileCount int
@@ -55,22 +58,22 @@ type TreeLocationOpts struct {
 type OwnershipStatsStore interface {
 	// UpdateIndividualCounts iterates given data about individual CODEOWNERS ownership
 	// and persists it in the database. All the counts are marked by given update timestamp.
-	UpdateIndividualCounts(context.Context, api.RepoID, FileOwnershipAggregate, time.Time) (int, error)
+	UpdateIndividualCounts(context.Context, api.RepoID, TreeCodeownersStats, time.Time) (int, error)
 
 	// UpdateAggregateCounts iterates given data about aggregate ownership over
 	// a given file tree, and persists it in the database. All the counts are marked
 	// by given update timestamp.
-	UpdateAggregateCounts(context.Context, api.RepoID, TreeAggregateOwnership, time.Time) (int, error)
+	UpdateAggregateCounts(context.Context, api.RepoID, TreeAggregateStats, time.Time) (int, error)
 
 	// QueryIndividualCounts looks up and aggregates data for individual stats of located file trees.
 	// To find ownership for the whole instance, use empty TreeLocationOpts.
 	// To find ownership for the repo root, only specify RepoID in TreeLocationOpts.
 	// To find ownership for specific file tree, specify RepoID and Path in TreeLocationOpts.
-	QueryIndividualCounts(context.Context, TreeLocationOpts, *LimitOffset) ([]TreeCodeownersCounts, error)
+	QueryIndividualCounts(context.Context, TreeLocationOpts, *LimitOffset) ([]PathCodeownersCounts, error)
 
 	// QueryAggregateCounts looks up ownership aggregate data for a file tree.
 	// At this point these include total count of files that are owned via CODEOWNERS.
-	QueryAggregateCounts(context.Context, TreeLocationOpts) ([]TreeAggregateCounts, error)
+	QueryAggregateCounts(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error)
 }
 
 var _ OwnershipStatsStore = &ownershipStats{}
@@ -104,10 +107,10 @@ var codeownerUpsertCountsFmtstr = `
 		updated_at = EXCLUDED.updated_at
 `
 
-func (s *ownershipStats) UpdateIndividualCounts(ctx context.Context, repoID api.RepoID, data FileOwnershipAggregate, timestamp time.Time) (int, error) {
+func (s *ownershipStats) UpdateIndividualCounts(ctx context.Context, repoID api.RepoID, data TreeCodeownersStats, timestamp time.Time) (int, error) {
 	codeownersCache := map[string]int{} // Cache codeowner ID by reference
 	var totalRows int
-	err := data.Iterate(func(path string, counts TreeCodeownersCounts) error {
+	err := data.Iterate(func(path string, counts PathCodeownersCounts) error {
 		ownerID := codeownersCache[counts.CodeownersReference]
 		if ownerID == 0 {
 			q := sqlf.Sprintf(codeownerQueryFmtstr, counts.CodeownersReference, counts.CodeownersReference)
@@ -152,9 +155,9 @@ var aggregateCountsUpdateFmtstr = `
 	last_updated_at = EXCLUDED.last_updated_at
 `
 
-func (s *ownershipStats) UpdateAggregateCounts(ctx context.Context, repoID api.RepoID, data TreeAggregateOwnership, timestamp time.Time) (int, error) {
+func (s *ownershipStats) UpdateAggregateCounts(ctx context.Context, repoID api.RepoID, data TreeAggregateStats, timestamp time.Time) (int, error) {
 	var totalUpdates int
-	err := data.Iterate(func(path string, counts TreeAggregateCounts) error {
+	err := data.Iterate(func(path string, counts PathAggregateCounts) error {
 		pathIDs, err := ensureRepoPaths(ctx, s.Store, []string{path}, repoID)
 		if err != nil {
 			return err
@@ -183,13 +186,13 @@ var aggregateOwnershipFmtstr = `
 	INNER JOIN codeowners_owners AS o ON o.id = s.owner_id
 	WHERE p.absolute_path = %s
 `
-var treeCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (TreeCodeownersCounts, error) {
-	var cs TreeCodeownersCounts
+var treeCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (PathCodeownersCounts, error) {
+	var cs PathCodeownersCounts
 	err := s.Scan(&cs.CodeownersReference, &cs.CodeownedFileCount)
 	return cs, err
 })
 
-func (s *ownershipStats) QueryIndividualCounts(ctx context.Context, opts TreeLocationOpts, limitOffset *LimitOffset) ([]TreeCodeownersCounts, error) {
+func (s *ownershipStats) QueryIndividualCounts(ctx context.Context, opts TreeLocationOpts, limitOffset *LimitOffset) ([]PathCodeownersCounts, error) {
 	qs := []*sqlf.Query{sqlf.Sprintf(aggregateOwnershipFmtstr, opts.Path)}
 	if repoID := opts.RepoID; repoID != 0 {
 		qs = append(qs, sqlf.Sprintf("AND p.repo_id = %s", repoID))
@@ -205,13 +208,13 @@ var treeAggregateCountsFmtstr = `
 	INNER JOIN repo_paths AS p ON s.file_path_id = p.id
 	WHERE p.absolute_path = %s
 `
-var treeAggregateCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (TreeAggregateCounts, error) {
-	var cs TreeAggregateCounts
+var treeAggregateCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (PathAggregateCounts, error) {
+	var cs PathAggregateCounts
 	err := s.Scan(&cs.CodeownedFileCount)
 	return cs, err
 })
 
-func (s *ownershipStats) QueryAggregateCounts(ctx context.Context, opts TreeLocationOpts) ([]TreeAggregateCounts, error) {
+func (s *ownershipStats) QueryAggregateCounts(ctx context.Context, opts TreeLocationOpts) ([]PathAggregateCounts, error) {
 	qs := []*sqlf.Query{sqlf.Sprintf(treeAggregateCountsFmtstr, opts.Path)}
 	if repoID := opts.RepoID; repoID != 0 {
 		qs = append(qs, sqlf.Sprintf("AND p.repo_id = %s", repoID))

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-type fakeCodeownersWalk map[string][]TreeCounts
+type fakeCodeownersWalk map[string][]TreeCodeownersCounts
 
-func (w fakeCodeownersWalk) Iterate(f func(string, TreeCounts) error) error {
+func (w fakeCodeownersWalk) Iterate(f func(string, TreeCodeownersCounts) error) error {
 	for path, owners := range w {
 		for _, o := range owners {
 			if err := f(path, o); err != nil {
@@ -110,7 +110,7 @@ func TestQueryIndividualCountsAggregation(t *testing.T) {
 		var limitOffset *LimitOffset
 		got, err := d.OwnershipStats().QueryIndividualCounts(ctx, opts, limitOffset)
 		require.NoError(t, err)
-		want := []TreeCounts{
+		want := []TreeCodeownersCounts{
 			{CodeownersReference: "ownerA", CodeownedFileCount: 1},
 			{CodeownersReference: "ownerB", CodeownedFileCount: 1},
 		}
@@ -123,7 +123,7 @@ func TestQueryIndividualCountsAggregation(t *testing.T) {
 		var limitOffset *LimitOffset
 		got, err := d.OwnershipStats().QueryIndividualCounts(ctx, opts, limitOffset)
 		require.NoError(t, err)
-		want := []TreeCounts{
+		want := []TreeCodeownersCounts{
 			{CodeownersReference: "ownerA", CodeownedFileCount: 2},
 			{CodeownersReference: "ownerB", CodeownedFileCount: 1},
 		}
@@ -134,7 +134,7 @@ func TestQueryIndividualCountsAggregation(t *testing.T) {
 		var limitOffset *LimitOffset
 		got, err := d.OwnershipStats().QueryIndividualCounts(ctx, opts, limitOffset)
 		require.NoError(t, err)
-		want := []TreeCounts{
+		want := []TreeCodeownersCounts{
 			{CodeownersReference: "ownerA", CodeownedFileCount: 22}, // from both repos
 			{CodeownersReference: "ownerC", CodeownedFileCount: 10}, // only repo2
 			{CodeownersReference: "ownerB", CodeownedFileCount: 1},  // only repo1


### PR DESCRIPTION
Part of #52826

This pull request introduces a repository to handle total CODEOWNERS-owned file counts per directory tree. This is used to power the analytics site admin page.

## Test plan

Database tests.
