### PR TITLE
JetBrains: add a separate setting for the (optional) dotcom access token

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -16,9 +16,9 @@
 
 ## [3.0.0-alpha.2]
 
-<!-- Document changes here -->
-
 ### Added
+
+- A separate setting for the (optional) dotcom access token. [pull/53018](https://github.com/sourcegraph/sourcegraph/pull/53018)
 
 ### Changed
 

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -52,9 +52,15 @@ The plugin works with all JetBrains IDEs, including:
 
 - **Sourcegraph URL**: The URL of your Sourcegraph instance if you use a private instance.
   - To use Sourcegraph.com and search in public repos, just choose "Use sourcegraph.com".
-- **Access token**: If you want to use your private Sourcegraph instance, you'll need an access token to authorize
-  yourself.
-  - See our [user docs](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) for a video guide.
+- **Access token**: 
+  - If you want to use your private Sourcegraph instance, you'll need an access token to authorize 
+    yourself.
+  - If you use Sourcegraph.com, using an access token is optional (and only necessary to use Cody).
+  - The configuration for an access token to use with Sourcegraph.com & a private instance is separate, 
+    you can switch between them on the fly.
+  - You can override the access token with the `SRC_ACCESS_TOKEN` environment variable.
+  - See our [user docs](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) for a video guide on how to
+    create an access token.
 - **Custom request headers**: Any custom headers to send with every request to Sourcegraph.
   - Use any number of pairs: `header1, value1, header2, value2, ...`.
   - Example: `Authorization, Bearer 1234567890, X-My-Header, My-Value`.
@@ -110,7 +116,7 @@ These settings have the highest priority. You can set them in a less than intuit
      <component name="Config">
        <option name="instanceType" value="DOTCOM" />
        <option name="url" value="https://company.sourcegraph.com/" />
-       <option name="accessToken" value="" />
+       <option name="enterpriseAccessToken" value="" />
        <option name="defaultBranch" value="main" />
        <option name="remoteUrlReplacements" value="" />
        <option name="isGlobbingEnabled" value="false" />

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -52,11 +52,11 @@ The plugin works with all JetBrains IDEs, including:
 
 - **Sourcegraph URL**: The URL of your Sourcegraph instance if you use a private instance.
   - To use Sourcegraph.com and search in public repos, just choose "Use sourcegraph.com".
-- **Access token**: 
-  - If you want to use your private Sourcegraph instance, you'll need an access token to authorize 
+- **Access token**:
+  - If you want to use your private Sourcegraph instance, you'll need an access token to authorize
     yourself.
   - If you use Sourcegraph.com, using an access token is optional (and only necessary to use Cody).
-  - The configuration for an access token to use with Sourcegraph.com & a private instance is separate, 
+  - The configuration for an access token to use with Sourcegraph.com & a private instance is separate,
     you can switch between them on the fly.
   - You can override the access token with the `SRC_ACCESS_TOKEN` environment variable.
   - See our [user docs](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) for a video guide on how to

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -269,7 +269,7 @@ class CodyToolWindowContent implements UpdatableChat {
     String accessToken =
         isEnterprise
             ? ConfigUtil.getEnterpriseAccessToken(project)
-            : ConfigUtil.getDotcomAccessToken(project);
+            : ConfigUtil.getDotComAccessToken(project);
     System.out.println("isEnterprise: " + isEnterprise);
 
     var chat = new Chat("", instanceUrl, accessToken != null ? accessToken : "");

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -175,7 +175,7 @@ public class CodyCompletionsManager {
     String accessToken =
         isEnterprise
             ? ConfigUtil.getEnterpriseAccessToken(project)
-            : ConfigUtil.getDotcomAccessToken(project);
+            : ConfigUtil.getDotComAccessToken(project);
     if (!instanceUrl.endsWith("/")) {
       instanceUrl = instanceUrl + "/";
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -21,8 +21,8 @@ public class ConfigUtil {
     configAsJson.addProperty(
         "accessToken",
         ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE
-            ? ConfigUtil.getAccessToken(project)
-            : null);
+            ? ConfigUtil.getDotComAccessToken(project)
+            : ConfigUtil.getEnterpriseAccessToken(project));
     configAsJson.addProperty(
         "customRequestHeadersAsString", ConfigUtil.getCustomRequestHeaders(project));
     configAsJson.addProperty("pluginVersion", ConfigUtil.getPluginVersion());
@@ -82,15 +82,6 @@ public class ConfigUtil {
     // User level or default
     String userLevelUrl = UserLevelConfig.getSourcegraphUrl();
     return !userLevelUrl.equals("") ? addSlashIfNeeded(userLevelUrl) : "";
-  }
-
-  @Nullable
-  public static String getAccessToken(Project project) {
-    // Project level → application level
-    String projectLevelAccessToken = getProjectLevelConfig(project).getAccessToken();
-    return projectLevelAccessToken != null
-        ? projectLevelAccessToken
-        : getApplicationLevelConfig().getAccessToken();
   }
 
   @NotNull
@@ -248,10 +239,18 @@ public class ConfigUtil {
   }
 
   public static String getEnterpriseAccessToken(Project project) {
-    return getAccessToken(project);
+    // Project level → application level
+    String projectLevelAccessToken = getProjectLevelConfig(project).getEnterpriseAccessToken();
+    return projectLevelAccessToken != null
+        ? projectLevelAccessToken
+        : getApplicationLevelConfig().getEnterpriseAccessToken();
   }
 
-  public static String getDotcomAccessToken(Project project) {
-    return getAccessToken(project);
+  public static String getDotComAccessToken(Project project) {
+    // Project level → application level
+    String projectLevelAccessToken = getProjectLevelConfig(project).getDotComAccessToken();
+    return projectLevelAccessToken != null
+        ? projectLevelAccessToken
+        : getApplicationLevelConfig().getDotComAccessToken();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -5,24 +5,30 @@ import org.jetbrains.annotations.Nullable;
 public class PluginSettingChangeContext {
   @Nullable public final String oldUrl;
 
-  @Nullable public final String oldAccessToken;
+  @Nullable public final String oldDotComAccessToken;
+  @Nullable public final String oldEnterpriseAccessToken;
 
   @Nullable public final String newUrl;
 
-  @Nullable public final String newAccessToken;
+  @Nullable public final String newDotComAccessToken;
+  @Nullable public final String newEnterpriseAccessToken;
 
   @Nullable public final String newCustomRequestHeaders;
 
   public PluginSettingChangeContext(
       @Nullable String oldUrl,
-      @Nullable String oldAccessToken,
+      @Nullable String oldDotComAccessToken,
+      @Nullable String oldEnterpriseAccessToken,
       @Nullable String newUrl,
-      @Nullable String newAccessToken,
+      @Nullable String newDotComAccessToken,
+      @Nullable String newEnterpriseAccessToken,
       @Nullable String newCustomRequestHeaders) {
     this.oldUrl = oldUrl;
-    this.oldAccessToken = oldAccessToken;
+    this.oldDotComAccessToken = oldDotComAccessToken;
+    this.oldEnterpriseAccessToken = oldEnterpriseAccessToken;
     this.newUrl = newUrl;
-    this.newAccessToken = newAccessToken;
+    this.newDotComAccessToken = newDotComAccessToken;
+    this.newEnterpriseAccessToken = newEnterpriseAccessToken;
     this.newCustomRequestHeaders = newCustomRequestHeaders;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -53,16 +53,22 @@ public class SettingsChangeListener implements Disposable {
             // Log install events
             if (!Objects.equals(context.oldUrl, context.newUrl)) {
               GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
-            } else if (!Objects.equals(context.oldAccessToken, context.newAccessToken)
+            } else if ((!Objects.equals(context.oldDotComAccessToken, context.newDotComAccessToken)
+                    || !Objects.equals(
+                        context.oldEnterpriseAccessToken, context.newEnterpriseAccessToken))
                 && !ConfigUtil.isInstallEventLogged()) {
               GraphQlLogger.logInstallEvent(project, ConfigUtil::setInstallEventLogged);
             }
 
             // Notify user about a successful connection
             if (context.newUrl != null) {
+              final String accessToken =
+                  ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.DOTCOM
+                      ? context.newDotComAccessToken
+                      : context.newEnterpriseAccessToken;
               ApiAuthenticator.testConnection(
                   context.newUrl,
-                  context.newAccessToken,
+                  accessToken,
                   context.newCustomRequestHeaders,
                   (status) -> {
                     if (ConfigUtil.didAuthenticationFailLastTime()

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -29,10 +29,10 @@ public class SettingsComponent {
   private final JPanel panel;
   private ButtonGroup instanceTypeButtonGroup;
   private JBTextField urlTextField;
-  private JBTextField accessTokenTextField;
+  private JBTextField enterpriseAccessTokenTextField;
   private JBTextField dotComAccessTokenTextField;
   private JBLabel userDocsLinkComment;
-  private JBLabel accessTokenLinkComment;
+  private JBLabel enterpriseAccessTokenLinkComment;
   private JBTextField customRequestHeadersTextField;
   private JBTextField defaultBranchNameTextField;
   private JBTextField remoteUrlReplacementsTextField;
@@ -100,13 +100,13 @@ public class SettingsComponent {
 
     // Create access token field
     JBLabel accessTokenLabel = new JBLabel("Access token:");
-    accessTokenTextField = new JBTextField();
-    accessTokenTextField.getEmptyText().setText("Paste your access token here");
+    enterpriseAccessTokenTextField = new JBTextField();
+    enterpriseAccessTokenTextField.getEmptyText().setText("Paste your access token here");
     addValidation(
-        accessTokenTextField,
+        enterpriseAccessTokenTextField,
         () ->
-            !isValidAccessToken(accessTokenTextField.getText())
-                ? new ValidationInfo("Invalid access token", accessTokenTextField)
+            !isValidAccessToken(enterpriseAccessTokenTextField.getText())
+                ? new ValidationInfo("Invalid access token", enterpriseAccessTokenTextField)
                 : null);
 
     // Create access token field
@@ -133,9 +133,9 @@ public class SettingsComponent {
             UIUtil.ComponentStyle.SMALL,
             UIUtil.FontColor.BRIGHTER);
     userDocsLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
-    accessTokenLinkComment =
+    enterpriseAccessTokenLinkComment =
         new JBLabel("", UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
-    accessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
+    enterpriseAccessTokenLinkComment.setBorder(JBUI.Borders.emptyLeft(10));
 
     // Set up radio buttons
     ActionListener actionListener =
@@ -177,9 +177,9 @@ public class SettingsComponent {
         FormBuilder.createFormBuilder()
             .addLabeledComponent(urlLabel, urlTextField, 1)
             .addTooltip("If your company uses a private Sourcegraph instance, set its URL here")
-            .addLabeledComponent(accessTokenLabel, accessTokenTextField, 1)
+            .addLabeledComponent(accessTokenLabel, enterpriseAccessTokenTextField, 1)
             .addComponentToRightColumn(userDocsLinkComment, 1)
-            .addComponentToRightColumn(accessTokenLinkComment, 1)
+            .addComponentToRightColumn(enterpriseAccessTokenLinkComment, 1)
             .getPanel();
     enterprisePanelContent.setBorder(IdeBorderFactory.createEmptyBorder(JBUI.insets(1, 30, 0, 0)));
     JPanel enterprisePanel =
@@ -244,18 +244,21 @@ public class SettingsComponent {
   }
 
   @NotNull
-  public String getAccessToken() {
-    return getInstanceType() == InstanceType.DOTCOM
-        ? dotComAccessTokenTextField.getText()
-        : accessTokenTextField.getText();
+  public String getDotComAccessToken() {
+    return dotComAccessTokenTextField.getText();
   }
 
-  public void setAccessToken(@NotNull String value) {
-    if (getInstanceType() == InstanceType.DOTCOM) {
-      dotComAccessTokenTextField.setText(value);
-    } else {
-      accessTokenTextField.setText(value);
-    }
+  public void setDotComAccessToken(@NotNull String value) {
+    dotComAccessTokenTextField.setText(value);
+  }
+
+  @NotNull
+  public String getEnterpriseAccessToken() {
+    return enterpriseAccessTokenTextField.getText();
+  }
+
+  public void setEnterpriseAccessToken(@NotNull String value) {
+    enterpriseAccessTokenTextField.setText(value);
   }
 
   @NotNull
@@ -295,11 +298,11 @@ public class SettingsComponent {
 
   private void setEnterpriseSettingsEnabled(boolean enable) {
     urlTextField.setEnabled(enable);
-    accessTokenTextField.setEnabled(enable);
+    enterpriseAccessTokenTextField.setEnabled(enable);
     userDocsLinkComment.setEnabled(enable);
     userDocsLinkComment.setCopyable(enable);
-    accessTokenLinkComment.setEnabled(enable);
-    accessTokenLinkComment.setCopyable(enable);
+    enterpriseAccessTokenLinkComment.setEnabled(enable);
+    enterpriseAccessTokenLinkComment.setCopyable(enable);
 
     // dotCom stuff
     dotComAccessTokenTextField.setEnabled(!enable);
@@ -344,15 +347,7 @@ public class SettingsComponent {
   private void updateAccessTokenLinkCommentText() {
     String baseUrl = urlTextField.getText();
     String settingsUrl = (baseUrl.endsWith("/") ? baseUrl : baseUrl + "/") + "settings";
-    accessTokenLinkComment.setText(
-        isUrlValid(baseUrl)
-            ? "<html><body>or go to <a href=\""
-                + settingsUrl
-                + "\">"
-                + settingsUrl
-                + "</a> | \"Access tokens\" to create one.</body></html>"
-            : "");
-    dotComAccessTokenTextField.setText(
+    enterpriseAccessTokenLinkComment.setText(
         isUrlValid(baseUrl)
             ? "<html><body>or go to <a href=\""
                 + settingsUrl

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -38,9 +38,16 @@ public class SettingsConfigurable implements Configurable {
   public boolean isModified() {
     return !mySettingsComponent.getInstanceType().equals(ConfigUtil.getInstanceType(project))
         || !mySettingsComponent.getEnterpriseUrl().equals(ConfigUtil.getEnterpriseUrl(project))
-        || !(mySettingsComponent.getAccessToken().equals(ConfigUtil.getAccessToken(project))
-            || mySettingsComponent.getAccessToken().isEmpty()
-                && ConfigUtil.getAccessToken(project) == null)
+        || !(mySettingsComponent
+                .getDotComAccessToken()
+                .equals(ConfigUtil.getDotComAccessToken(project))
+            || mySettingsComponent.getDotComAccessToken().isEmpty()
+                && ConfigUtil.getDotComAccessToken(project) == null)
+        || !(mySettingsComponent
+                .getEnterpriseAccessToken()
+                .equals(ConfigUtil.getEnterpriseAccessToken(project))
+            || mySettingsComponent.getEnterpriseAccessToken().isEmpty()
+                && ConfigUtil.getEnterpriseAccessToken(project) == null)
         || !mySettingsComponent
             .getCustomRequestHeaders()
             .equals(ConfigUtil.getCustomRequestHeaders(project))
@@ -64,13 +71,21 @@ public class SettingsConfigurable implements Configurable {
     SourcegraphProjectService pSettings = SourcegraphService.getInstance(project);
 
     String oldUrl = ConfigUtil.getSourcegraphUrl(project);
-    String oldAccessToken = ConfigUtil.getAccessToken(project);
+    String oldDotComAccessToken = ConfigUtil.getDotComAccessToken(project);
+    String oldEnterpriseAccessToken = ConfigUtil.getEnterpriseAccessToken(project);
     String newUrl = mySettingsComponent.getEnterpriseUrl();
-    String newAccessToken = mySettingsComponent.getAccessToken();
+    String newDotComAccessToken = mySettingsComponent.getDotComAccessToken();
+    String newEnterpriseAccessToken = mySettingsComponent.getEnterpriseAccessToken();
     String newCustomRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
     PluginSettingChangeContext context =
         new PluginSettingChangeContext(
-            oldUrl, oldAccessToken, newUrl, newAccessToken, newCustomRequestHeaders);
+            oldUrl,
+            oldDotComAccessToken,
+            oldEnterpriseAccessToken,
+            newUrl,
+            newDotComAccessToken,
+            newEnterpriseAccessToken,
+            newCustomRequestHeaders);
 
     publisher.beforeAction(context);
 
@@ -84,10 +99,15 @@ public class SettingsConfigurable implements Configurable {
     } else {
       aSettings.url = newUrl;
     }
-    if (pSettings.accessToken != null) {
-      pSettings.accessToken = newAccessToken;
+    if (pSettings.dotComAccessToken != null) {
+      pSettings.dotComAccessToken = newDotComAccessToken;
     } else {
-      aSettings.accessToken = newAccessToken;
+      aSettings.dotComAccessToken = newDotComAccessToken;
+    }
+    if (pSettings.enterpriseAccessToken != null) {
+      pSettings.enterpriseAccessToken = newEnterpriseAccessToken;
+    } else {
+      aSettings.enterpriseAccessToken = newEnterpriseAccessToken;
     }
     if (pSettings.customRequestHeaders != null) {
       pSettings.customRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
@@ -113,8 +133,11 @@ public class SettingsConfigurable implements Configurable {
   public void reset() {
     mySettingsComponent.setInstanceType(ConfigUtil.getInstanceType(project));
     mySettingsComponent.setEnterpriseUrl(ConfigUtil.getEnterpriseUrl(project));
-    String accessToken = ConfigUtil.getAccessToken(project);
-    mySettingsComponent.setAccessToken(accessToken != null ? accessToken : "");
+    String dotComAccessToken = ConfigUtil.getDotComAccessToken(project);
+    mySettingsComponent.setDotComAccessToken(dotComAccessToken != null ? dotComAccessToken : "");
+    String enterpriseAccessToken = ConfigUtil.getEnterpriseAccessToken(project);
+    mySettingsComponent.setEnterpriseAccessToken(
+        enterpriseAccessToken != null ? enterpriseAccessToken : "");
     mySettingsComponent.setCustomRequestHeaders(ConfigUtil.getCustomRequestHeaders(project));
     String defaultBranchName = ConfigUtil.getDefaultBranchName(project);
     mySettingsComponent.setDefaultBranchName(defaultBranchName);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -15,7 +15,8 @@ public class SourcegraphApplicationService
     implements PersistentStateComponent<SourcegraphApplicationService>, SourcegraphService {
   @Nullable public String instanceType;
   @Nullable public String url;
-  @Nullable public String accessToken;
+  @Nullable public String dotComAccessToken;
+  @Nullable public String enterpriseAccessToken;
   @Nullable public String customRequestHeaders;
   @Nullable public String defaultBranch;
   @Nullable public String remoteUrlReplacements;
@@ -47,8 +48,8 @@ public class SourcegraphApplicationService
   }
 
   @Nullable
-  public String getAccessToken() {
-    return accessToken;
+  public String getDotComAccessToken() {
+    return dotComAccessToken;
   }
 
   @Nullable
@@ -75,9 +76,9 @@ public class SourcegraphApplicationService
   }
 
   @Override
+  @Nullable
   public String getEnterpriseAccessToken() {
-    // TODO
-    return null;
+    return enterpriseAccessToken;
   }
 
   @Override
@@ -128,7 +129,8 @@ public class SourcegraphApplicationService
   public void loadState(@NotNull SourcegraphApplicationService settings) {
     this.instanceType = settings.instanceType;
     this.url = settings.url;
-    this.accessToken = settings.accessToken;
+    this.dotComAccessToken = settings.dotComAccessToken;
+    this.enterpriseAccessToken = settings.enterpriseAccessToken;
     this.customRequestHeaders = settings.customRequestHeaders;
     this.defaultBranch = settings.defaultBranch;
     this.remoteUrlReplacements = settings.remoteUrlReplacements;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -14,7 +14,8 @@ public class SourcegraphProjectService
     implements PersistentStateComponent<SourcegraphProjectService>, SourcegraphService {
   @Nullable public String instanceType;
   @Nullable public String url;
-  @Nullable public String accessToken;
+  @Nullable public String dotComAccessToken;
+  @Nullable public String enterpriseAccessToken;
   @Nullable public String customRequestHeaders;
   @Nullable public String defaultBranch;
   @Nullable public String remoteUrlReplacements;
@@ -37,11 +38,11 @@ public class SourcegraphProjectService
 
   @Override
   @Nullable
-  public String getAccessToken() {
-    if (accessToken == null) {
+  public String getDotComAccessToken() {
+    if (dotComAccessToken == null) {
       return System.getenv("SRC_ACCESS_TOKEN");
     }
-    return accessToken;
+    return dotComAccessToken;
   }
 
   @Override
@@ -83,7 +84,8 @@ public class SourcegraphProjectService
   public void loadState(@NotNull SourcegraphProjectService settings) {
     this.instanceType = settings.instanceType;
     this.url = settings.url;
-    this.accessToken = settings.accessToken;
+    this.dotComAccessToken = settings.dotComAccessToken;
+    this.enterpriseAccessToken = settings.enterpriseAccessToken;
     this.customRequestHeaders = settings.customRequestHeaders;
     this.defaultBranch = settings.defaultBranch;
     this.remoteUrlReplacements = settings.remoteUrlReplacements;
@@ -97,7 +99,9 @@ public class SourcegraphProjectService
 
   @Override
   public String getEnterpriseAccessToken() {
-    return getAccessToken();
+    return enterpriseAccessToken == null
+        ? System.getenv("SRC_ACCESS_TOKEN")
+        : enterpriseAccessToken;
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.sourcegraph.find.Search;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -14,6 +15,11 @@ public class SourcegraphProjectService
     implements PersistentStateComponent<SourcegraphProjectService>, SourcegraphService {
   @Nullable public String instanceType;
   @Nullable public String url;
+
+  @Nullable
+  @Deprecated(since = "3.0.0-alpha.2", forRemoval = true)
+  public String accessToken; // kept for backwards compatibility
+
   @Nullable public String dotComAccessToken;
   @Nullable public String enterpriseAccessToken;
   @Nullable public String customRequestHeaders;
@@ -84,6 +90,7 @@ public class SourcegraphProjectService
   public void loadState(@NotNull SourcegraphProjectService settings) {
     this.instanceType = settings.instanceType;
     this.url = settings.url;
+    this.accessToken = settings.accessToken;
     this.dotComAccessToken = settings.dotComAccessToken;
     this.enterpriseAccessToken = settings.enterpriseAccessToken;
     this.customRequestHeaders = settings.customRequestHeaders;
@@ -99,9 +106,13 @@ public class SourcegraphProjectService
 
   @Override
   public String getEnterpriseAccessToken() {
-    return enterpriseAccessToken == null
+    // configuring enterpriseAccessToken overrides the deprecated accessToken field
+    String configuredEnterpriseAccessToken =
+        StringUtils.isEmpty(enterpriseAccessToken) ? accessToken : enterpriseAccessToken;
+    // defaulting to SRC_ACCESS_TOKEN env if nothing else was configured
+    return configuredEnterpriseAccessToken == null
         ? System.getenv("SRC_ACCESS_TOKEN")
-        : enterpriseAccessToken;
+        : configuredEnterpriseAccessToken;
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphService.java
@@ -18,7 +18,7 @@ public interface SourcegraphService {
   String getSourcegraphUrl();
 
   @Nullable
-  String getAccessToken();
+  String getDotComAccessToken();
 
   @Nullable
   String getCustomRequestHeaders();

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -41,8 +41,8 @@ public class GraphQlLogger {
     String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
     String accessToken =
         ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE
-            ? ConfigUtil.getAccessToken(project)
-            : null;
+            ? ConfigUtil.getEnterpriseAccessToken(project)
+            : ConfigUtil.getDotComAccessToken(project);
     String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
     new Thread(
             () -> {


### PR DESCRIPTION
![image](https://github.com/sourcegraph/sourcegraph/assets/18601388/7b5014a7-aa37-4320-942b-43f545feee8a)

https://github.com/sourcegraph/sourcegraph/assets/18601388/ae45b022-887d-4f3f-83a5-6802e7cd0186
The video doesn't cover all the test scenarios, as I'd have to edit the token string out to cover everything.

## Test plan
(I've tested these things locally, but it is generally advised to double check on another machine, since we don't have UI tests set-up)
- the dotcom/enterprise radio should enable/disable the contained settings
- plugin settings should save both dotcom & enterprise access token between restarts (regardless which one is currently set to be used)
- the `SRC_ACCESS_TOKEN` env var should still override either token for now
- Cody should use the currently set token when calling the API (and not the other)
- the "no access token set" notification should show if the access token isn't set for the current instance type
- validation should work the same for both access token text fields
- there might be some other edge cases, feel free to try and break it
