### PR TITLE
executors: More detailed watch error logging

### DIFF
--- a/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/worker/command/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/resource",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/watch",
         "@io_k8s_client_go//kubernetes",
         "@io_k8s_utils//pointer",
         "@io_opentelemetry_go_otel//attribute",


### PR DESCRIPTION
When a watch error is type `ERROR`, the type _should_ be _*metav1.Status_. If this is a case, we should log the details of the error to capture why this is happening.

Also, updated the existing logging from `WARN` to `ERROR` (feels more correct).

Again, I don't feel we have sufficient information to understand why this is happening. So that is why we `continue` to keep watch, just in case things start working.

The only time I have seen this behavior is when I initially switched from watching Jobs to Pods. Not sure why though 🤔 .

## Test plan

Added additional tests.