### PR TITLE
App - Remove Cody license check for App 

### DIFF
--- a/enterprise/internal/cody/feature_flag.go
+++ b/enterprise/internal/cody/feature_flag.go
@@ -21,10 +21,6 @@ import (
 // If it is an unauthenticated request, cody is disabled.
 // If authenticated it checks if cody is enabled for the deployment type
 func IsCodyEnabled(ctx context.Context) bool {
-	if err := licensing.Check(licensing.FeatureCody); err != nil {
-		return false
-	}
-
 	a := actor.FromContext(ctx)
 	if !a.IsAuthenticated() {
 		return false
@@ -39,12 +35,16 @@ func IsCodyEnabled(ctx context.Context) bool {
 
 // isCodyEnabled determines if cody is enabled for the actor in the given context
 // for all deployment types except "app".
+// If the license does not have the Cody feature, cody is disabled.
 // If Completions aren't configured, cody is disabled.
 // If Completions are not enabled, cody is disabled
 // If CodyRestrictUsersFeatureFlag is set, the cody-experimental featureflag
 // will determine access.
 // Otherwise, all authenticated users are granted access.
 func isCodyEnabled(ctx context.Context) bool {
+	if err := licensing.Check(licensing.FeatureCody); err != nil {
+		return false
+	}
 	completionsConfig := conf.Get().Completions
 	if completionsConfig == nil {
 		return false

--- a/enterprise/internal/cody/feature_flag_test.go
+++ b/enterprise/internal/cody/feature_flag_test.go
@@ -9,12 +9,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestIsCodyEnabled(t *testing.T) {
 	oldMock := licensing.MockCheckFeature
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {
+		// App doesn't have license to return a error always for this check
+		if deploy.IsApp() {
+			return errors.New("Mock check feature error")
+		}
 		return nil
 	}
 	t.Cleanup(func() {

--- a/enterprise/internal/cody/feature_flag_test.go
+++ b/enterprise/internal/cody/feature_flag_test.go
@@ -16,7 +16,7 @@ import (
 func TestIsCodyEnabled(t *testing.T) {
 	oldMock := licensing.MockCheckFeature
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {
-		// App doesn't have license to return a error always for this check
+		// App doesn't have a proper license so always return an error when checking
 		if deploy.IsApp() {
 			return errors.New("Mock check feature error")
 		}


### PR DESCRIPTION
Sourcegraph App should not do a license check for Cody because app does not maintain a specific license per user.  This moves the license check out of the branch of code that runs for App 
## Test plan
Unit test added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
