### PR TITLE
Search: enable cross-repo ranking by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Batch Changes now supports per-batch-change control for pushing to a fork of the upstream repository when the property `changesetTemplate.fork` is specified in the batch spec. [#51572](https://github.com/sourcegraph/sourcegraph/pull/51572)
 - Executors can now be configured to process multiple queues. [#52016](https://github.com/sourcegraph/sourcegraph/pull/52016)
 - Added `isCodyEnabled` as a new GraphQL field to `Site`. [#52941](https://github.com/sourcegraph/sourcegraph/pull/52941)
+- Enabled improved search ranking by default. This feature can be disabled through the `search-ranking` feature flag.[#53031](https://github.com/sourcegraph/sourcegraph/pull/53031)
 
 ### Changed
 

--- a/client/shared/src/settings/temporary/TemporarySettings.ts
+++ b/client/shared/src/settings/temporary/TemporarySettings.ts
@@ -58,17 +58,10 @@ export interface TemporarySettingsSchema {
      */
     'search.input.usedExamples': string[]
     'search.input.usedInlineHistory': boolean
-    // This is a temporary setting to allow users to easily switch
-    // between  having search  results be ranked or not. It's only
-    // used when the feature flag `search-ranking` is enabled.
-    'search.ranking.experimental': boolean
     // This is a temporary (no pun intended) setting to allow users to easily
     // switch been the current and the new search input. It's only used when
     // the feature flag `"searchQueryInput": "experimental"` is set.
     'search.input.experimental': boolean
-    // TODO #41002: Remove this temporary setting.
-    // This temporary setting is now turned on by default with no UI to toggle it off.
-    'coreWorkflowImprovements.enabled_deprecated': boolean
     'batches.minSavedPerChangeset': number
     'search.notebooks.minSavedPerView': number
     'repo.commitPage.diffMode': DiffMode

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -28,8 +28,6 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     setSidebarCollapsed: noop,
     sidebarCollapsed: false,
     isSourcegraphDotCom: true,
-    isRankingEnabled: true,
-    setRankingEnabled: noop,
     options: {
         version: 'V3',
         patternType: SearchPatternType.standard,
@@ -53,8 +51,6 @@ describe('SearchResultsInfoBar', () => {
             renderSearchResultsInfoBar({
                 query: 'foo type:diff',
                 enableCodeMonitoring: false,
-                isRankingEnabled: true,
-                setRankingEnabled: noop,
             }).asFragment()
         ).toMatchSnapshot()
     })

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -4,17 +4,15 @@ import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiThumbUp, mdiThumbDown, mdi
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
-import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { CaseSensitivityProps, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Icon, Label, Alert, useSessionStorage, Link, Text } from '@sourcegraph/wildcard'
+import { Button, Icon, Alert, useSessionStorage, Link, Text } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../batches/utils'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { eventLogger } from '../../tracking/eventLogger'
 
 import {
@@ -68,9 +66,6 @@ export interface SearchResultsInfoBarProps
     setSidebarCollapsed: (collapsed: boolean) => void
 
     isSourcegraphDotCom: boolean
-
-    isRankingEnabled: boolean
-    setRankingEnabled: (enabled: boolean) => void
 }
 
 /**
@@ -138,9 +133,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
         setShowMobileFilters(newShowFilters)
         props.onShowMobileFiltersChanged?.(newShowFilters)
     }
-
-    // Show/hide ranking toggle
-    const [rankingEnabled] = useFeatureFlag('search-ranking')
 
     const location = useLocation()
     const refFromCodySearch = new URLSearchParams(location.search).get('ref') === 'cody-search'
@@ -215,17 +207,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
 
                 <div className={styles.expander} />
 
-                {rankingEnabled && (
-                    <Label className={styles.toggle}>
-                        Intelligent ranking{' '}
-                        <Toggle
-                            value={props.isRankingEnabled}
-                            onToggle={() => props.setRankingEnabled(!props.isRankingEnabled)}
-                            title="Enable Ranking"
-                            className="mr-2"
-                        />
-                    </Label>
-                )}
                 <ul className="nav align-items-center">
                     <SearchActionsMenu
                         authenticatedUser={props.authenticatedUser}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -91,8 +91,8 @@ func TestSearch(t *testing.T) {
 
 	testSearchOther(t)
 
-	// Run the search tests with file-based ranking enabled
-	err = client.SetFeatureFlag("search-ranking", true)
+	// Run the search tests with file-based ranking disabled
+	err = client.SetFeatureFlag("search-ranking", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/doc/dev/background-information/architecture/indexed-ranking.md
+++ b/doc/dev/background-information/architecture/indexed-ranking.md
@@ -1,48 +1,59 @@
 # Indexed ranking
 
-This document describes the current strategies used in Sourcegraph to rank results.
+This document describes the current strategies used in Sourcegraph to rank results. Currently, ranking only
+applies to indexed (Zoekt-based) search. When a search is unindexed, for example when searching at an old
+revision, the results are not ranked.
 
 > Note: this is an area of active research and is subject to change.
 
-## Streaming note
+## Streaming-based search
 
-We are streaming based internally. However, this does not mean we can't do ranking. We have buffers in several layers which collect results and based on heuristics send out the buffered results in a ranked order. Additionally when creating indexes we lay out files and repositories such that we search more important files and repositories first. This means when streaming we receive likely more important results first.
+Zoekt takes a streaming approach to executing searches. This makes ranking results more challenging, as the search
+doesn't visit the full set of matching documents before returning results. As a compromise, Zoekt performs an initial
+non-streamed search step, then ranks and returns those candidates before streaming the rest of the results.
 
-When searching in general there are limits you hit before you inspect the full corpus of code. These limits are usually time or result based. As such searching more important code first is a normal strategy employed such that the candidate documents are more likely to be relevant.
+Specifically, each Zoekt replica:
+1. Collects candidate matches until a certain time limit (default of 500ms)
+2. Ranks and streams back the ranked matches
+3. Then switches to streaming execution, where matching results are immediately returned
 
-## Repository Ranking
+Frontend waits until it has received at least one response from every replica, then merges and ranks the results
+before returning them. After this initial ranked batch, frontend switches to immediately streaming out results.
 
-We sort results bucketed by repositories. We then sort those buckets based on repository priority. So any ranking based on file contents or query only happens within those buckets.
-
-The [repository priority](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+stars+reporank&patternType=regexp) is the number of stars a repository has received. Additionally an admin can adjust the priority of a repository via [configuration](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+repoRankFromConfig&patternType=regexp).
-
-This has the downside of a poor result in a highly ranked repository will appear before a good result in a poorly ranked repository. The upside is normally it does the right thing and leads to more deterministic ordering in results.
+Because the Zoekt limit is time-based, it's possible that executing the same search twice can result in different
+ranked results. To mitigate this issue, you can increase the time limit through the site config `experimentalFeatures.ranking.flushWallTimeMS`.
+Larger values give a more stable ranking, but searches can take longer to return an initial result.
 
 ## Result Ranking
 
-Zoekt [ranks](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/zoekt%24+func+rank&patternType=literal) documents before storing them in the index. It uses this rank to ensure more important documents are searched first. The current heuristic signals in order of importance:
-
-- down rank generated code :: This code is usually the least interesting in results.
-- down rank vendored code :: Developers are normally looking for code written by their organisation.
-- down rank test code :: Developers normally prefer results in non-test code over test code.
-- up rank files with lots of symbols :: These files are usually edited a lot.
-- up rank small files :: if you have similiar symbol levels, prefer the shorter file.
-- up rank short names :: The closer to the project root the likely more important you are.
-- up rank branch count :: if the same document appears on multiple branches its likely more important.
-
-This ranking is used to decide the order we search the documents, so is most important when hitting limits. However, the order of documents is used as a signal when ranking so is used to distingiush similar looking results in different files. IE a match for the symbol `MyClass` for the query `MyClass` will be ranked higher in normal code vs test code.
-
 Zoekt creates a [score for a match](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/zoekt%24+matchScore&patternType=literal) based on a few heuristics. In order of importance:
 
-- Is your match a symbol. eg exactly matching the name of a class.
-- Is your match at the start or end of a symbol. eg you search `Foo` is better than `Bar` for a class called `FooBarBaz`.
-- Is your match partially in a symbol. Symbols are a sign of something important, so any overlap is better than none.
-- Word match on any text. eg `ranking` is better than `rank` for the text `search result ranking`.
-- Partial word match. eg `rank` is better than `ank` for the text `search result ranking`.
+- It matches a symbol, such as an exact match on the name of a class.
+- The match is at the start or end of a symbol. For example if you search for `Indexed`, then a class called `IndexedRepo` will score more highly than one named `NonIndexedRepo`.
+- It partially matches a symbol. Symbols are a sign of something important, so any overlap is better than none.
+- It matches a full word. For example, if you search `rank`, then `result rank` will score more highly than `ranked list`.
+- It partially matches a word. For example, if you search `rank`, then `result rank` will score more highly than `ranked list`.
 
-These are the main inputs for deciding the rank of a match. There is some minor signals based on the file rank (described at the start of the section), the number of matches in a file, etc. These are used more as tiebreaking, where the above ranking is close.
+We also incorporate smaller signals based on the repository and file importance (described in the next section), as well as the number of query components that match (in the case of OR queries).
+
+## Ordering files by importance
+
+When creating indexes, we lay out the files such that we search more important files and repositories first. This means when streaming we're more likely to encounter important candidates first, leading to a better set of ranked results.
+
+Zoekt indexes are partitioned by repository. The search proceeds through each repository in order of their priority.
+The [repository priority](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+stars+reporank&patternType=regexp) is the number of stars a repository has received. Admins can manually adjust the priority of a repository through a [site configuration option](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+repoRankFromConfig&patternType=regexp).
+
+Within each repository, files are ordered in terms of importance:
+- Down rank generated code. This code is usually the least interesting in results.
+- Down rank vendored code. Developers are normally looking for code written by their organisation.
+- Down rank test code. Developers normally prefer results in non-test code over test code.
+- Up rank files with lots of symbols. These files are usually edited a lot.
+- Up rank small files. If you have similiar symbol levels, prefer the shorter file.
+- Up rank short names. The closer to the project root the likely more important you are.
+- Up rank branch count. if the same document appears on multiple branches its likely more important.
 
 ## References
 
 - [RFC 359](https://docs.google.com/document/d/1EiD_dKkogqBNAbKN3BbanII4lQwROI7a0aGaZ7i-0AU/edit#heading=h.trqab8y0kufp): Search Result Ranking
-- Zoekt Design :: [Ranking](https://github.com/sourcegraph/zoekt/blob/master/doc/design.md#ranking)
+- [Zoekt design reference](https://github.com/sourcegraph/zoekt/blob/master/doc/design.md#ranking)
+

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -402,9 +402,8 @@ func SearchDocumentRanksWeight() float64 {
 	}
 }
 
-// SearchFlushWallTime controls the amount of time that Zoekt shards collect and rank results when
-// the 'search-ranking' feature is enabled. We plan to eventually remove this, once we experiment
-// on real data to find a good default.
+// SearchFlushWallTime controls the amount of time that Zoekt shards collect and rank results. For
+// larger codebases, it can be helpful to increase this to improve the ranking stability and quality.
 func SearchFlushWallTime() time.Duration {
 	ranking := ExperimentalFeatures().Ranking
 	if ranking != nil && ranking.FlushWallTimeMS > 0 {

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -292,7 +292,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		CodeOwnershipSearch:     flagSet.GetBoolOr("search-ownership", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", true), // can remove flag in 4.5
-		Ranking:                 flagSet.GetBoolOr("search-ranking", false),
+		Ranking:                 flagSet.GetBoolOr("search-ranking", true),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1806,9 +1806,9 @@ type QuickLink struct {
 
 // Ranking description: Experimental search result ranking options.
 type Ranking struct {
-	// DocumentRanksWeight description: Controls the impact of document ranks on the final ranking when the 'search-ranking' feature is enabled. This is intended for internal testing purposes only, it's not recommended for users to change this.
+	// DocumentRanksWeight description: Controls the impact of document ranks on the final ranking. This is intended for internal testing purposes only, it's not recommended for users to change this.
 	DocumentRanksWeight *float64 `json:"documentRanksWeight,omitempty"`
-	// FlushWallTimeMS description: Controls the amount of time that Zoekt shards collect and rank results when the 'search-ranking' feature is enabled. Larger values give a more stable ranking, but searches can take longer to return an initial result.
+	// FlushWallTimeMS description: Controls the amount of time that Zoekt shards collect and rank results. Larger values give a more stable ranking, but searches can take longer to return an initial result.
 	FlushWallTimeMS int `json:"flushWallTimeMS,omitempty"`
 	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -449,7 +449,7 @@
               "group": "Search"
             },
             "documentRanksWeight": {
-              "description": "Controls the impact of document ranks on the final ranking when the 'search-ranking' feature is enabled. This is intended for internal testing purposes only, it's not recommended for users to change this.",
+              "description": "Controls the impact of document ranks on the final ranking. This is intended for internal testing purposes only, it's not recommended for users to change this.",
               "type": "number",
               "default": 4500,
               "group": "Search",
@@ -458,7 +458,7 @@
               }
             },
             "flushWallTimeMS": {
-              "description": "Controls the amount of time that Zoekt shards collect and rank results when the 'search-ranking' feature is enabled. Larger values give a more stable ranking, but searches can take longer to return an initial result.",
+              "description": "Controls the amount of time that Zoekt shards collect and rank results. Larger values give a more stable ranking, but searches can take longer to return an initial result.",
               "type": "integer",
               "default": 500,
               "group": "Search"


### PR DESCRIPTION
This PR updates the `search-ranking` feature flag to default to 'true'. This greatly improves the result ranking search ranking for cross-repo searches, or for very large repos.

We feel ready to GA this since it's been running successfully on dot com and S2 for several months, and had a successful customer trial.

Note: this enables only **part** of the "Intelligent ranking" feature. The code intel jobs to produce file ranks are still not enabled by default. We'll make a separate "GA" decision for those jobs.

## Test plan

Sourcegraph CI (already several tests exercising ranking). Dogfooding on dot com, S2, customer site.