### PR TITLE
Fix Gerrit Changesets having blank diffs once published

### DIFF
--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/externallink"
 	bgql "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/graphql"
@@ -478,7 +477,8 @@ func (r *changesetResolver) Diff(ctx context.Context) (graphqlbackend.Repository
 	}
 
 	db := r.store.DatabaseDB()
-	if r.changeset.Unpublished() {
+	// If the Changeset is from a code host that doesn't push to branches (like Gerrit), we can just use the branch spec description.
+	if r.changeset.Unpublished() || r.changeset.SyncState.BaseRefOid == r.changeset.SyncState.HeadRefOid {
 		desc, err := r.getBranchSpecDescription(ctx)
 		if err != nil {
 			return nil, err

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -104,6 +104,10 @@ func BuildChangeset(opts TestChangesetOpts) *btypes.Changeset {
 		NumResets:       opts.NumResets,
 
 		Metadata: opts.Metadata,
+		SyncState: btypes.ChangesetSyncState{
+			HeadRefOid: generateFakeCommitID(),
+			BaseRefOid: generateFakeCommitID(),
+		},
 	}
 
 	if opts.SyncErrorMessage != "" {


### PR DESCRIPTION
Once published, Gerrit Changeset diffs were coming up as blank in the UI.

## Test plan

Manual

Before:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/4c8183ce-fd5e-40e4-a3ba-4e5aefc4fccb)


After:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/7eaf9dfa-6e4b-4e66-a7d8-29728c9f3428)
