### PR TITLE
Fix repository commits page for Perforce

### DIFF
--- a/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
@@ -354,6 +354,19 @@ export const GitCommitsStory: Story<RepositoryCommitsPageProps> = () => (
 
 GitCommitsStory.storyName = 'Git commits'
 
+export const GitCommitsInPathStory: Story<RepositoryCommitsPageProps> = () => (
+    <MockedTestProvider>
+        <WebStory
+            initialEntries={['/github.com/sourcegraph/sourcegraph/-/commits/somePath']}
+            mocks={[mockRepositoryGitCommitsQuery]}
+        >
+            {props => <RepositoryCommitsPage revision="" repo={gitRepo} {...props} />}
+        </WebStory>
+    </MockedTestProvider>
+)
+
+GitCommitsInPathStory.storyName = 'Git commits in a path'
+
 const perforceRepo: RepositoryFields = {
     id: 'repo-id',
     name: 'github.com/sourcegraph/sourcegraph',
@@ -375,7 +388,7 @@ const perforceRepo: RepositoryFields = {
 export const PerforceChangelistsStory: Story<RepositoryCommitsPageProps> = () => (
     <MockedTestProvider>
         <WebStory
-            initialEntries={['/perforce.sgdev.org/go/-/commits']}
+            initialEntries={['/perforce.sgdev.org/go/-/changelists']}
             mocks={[mockRepositoryPerforceChangelistsQuery]}
         >
             {props => <RepositoryCommitsPage revision="" repo={perforceRepo} {...props} />}
@@ -384,3 +397,16 @@ export const PerforceChangelistsStory: Story<RepositoryCommitsPageProps> = () =>
 )
 
 PerforceChangelistsStory.storyName = 'Perforce changelists'
+
+export const PerforceChangelistsInPathStory: Story<RepositoryCommitsPageProps> = () => (
+    <MockedTestProvider>
+        <WebStory
+            initialEntries={['/perforce.sgdev.org/go/-/changelists/somePath']}
+            mocks={[mockRepositoryPerforceChangelistsQuery]}
+        >
+            {props => <RepositoryCommitsPage revision="" repo={perforceRepo} {...props} />}
+        </WebStory>
+    </MockedTestProvider>
+)
+
+PerforceChangelistsInPathStory.storyName = 'Perforce changelists in a path'

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -231,7 +231,7 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
                     <Heading as="h2" styleAs="h1">
                         {filePath ? (
                             <>
-                                View commits inside <Code>{basename(filePath)}</Code>
+                                View {pluralize(getRefType(sourceType), 0)} inside <Code>{basename(filePath)}</Code>
                             </>
                         ) : (
                             <>

--- a/client/web/src/util/url.ts
+++ b/client/web/src/util/url.ts
@@ -92,6 +92,7 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI & Pick<ParsedRe
     const blobSeparator = pathname.indexOf('/-/blob/')
     const comparisonSeparator = pathname.indexOf('/-/compare/')
     const commitsSeparator = pathname.indexOf('/-/commits/')
+    const changelistsSeparator = pathname.indexOf('/-/changelists/')
     if (treeSeparator !== -1) {
         filePath = decodeURIComponent(pathname.slice(treeSeparator + '/-/tree/'.length))
     }
@@ -103,6 +104,9 @@ export function parseBrowserRepoURL(href: string): ParsedRepoURI & Pick<ParsedRe
     }
     if (commitsSeparator !== -1) {
         filePath = decodeURIComponent(pathname.slice(commitsSeparator + '/-/commits/'.length))
+    }
+    if (changelistsSeparator !== -1) {
+        filePath = decodeURIComponent(pathname.slice(changelistsSeparator + '/-/changelists/'.length))
     }
     let position: Position | undefined
     let range: Range | undefined


### PR DESCRIPTION
When viewing a path in a repository, the repository commits page changes the view a bit: the title becomes "View commits inside {basename(path)}". Fix that so it shows "changelists" instead of "commits" for Perforce repos. Also enable the path `/-/changelists/path` for Perforce depots, which will become necessary as we build out support for Perforce language in URLs.
Update the repository commits page story to show/test these changes.

Screenshot of the story book showing the Perforce with path story:
![Screenshot 2023-06-06 at 10 43 03](https://github.com/sourcegraph/sourcegraph/assets/129280/0368a41f-ba1a-4496-8d8e-f44460e0824e)

## Test plan
story has tests in it
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

