### PR TITLE
executors: Multi-queue Kubernetes

### DIFF
--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Deployment.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Deployment.yml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sg-executor-multiqueue
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: sg-executor-multiqueue
+  template:
+    metadata:
+      namespace: default
+      labels:
+        app: sg-executor-multiqueue
+    spec:
+      # For development purposes - lets the executor pod use the namespace of the host system instead of creating a new one.
+      hostNetwork: true
+      serviceAccountName: sg-executor-service-account
+      containers:
+        - name: sg-executor-multiqueue
+          image: sourcegraph/executor-kubernetes:insiders
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: EXECUTOR_FRONTEND_URL
+              # For development purposes. We usually run Sourcegraph in Docker.
+              value: http://host.docker.internal:3082
+            - name: EXECUTOR_FRONTEND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: executor-frontend-password
+                  key: EXECUTOR_FRONTEND_PASSWORD
+            - name: EXECUTOR_QUEUE_NAMES
+              value: batches,codeintel
+            # Each job will consume 1Gi of memory. Need to make sure not to consume the whole node's memory.
+            - name: EXECUTOR_MAXIMUM_NUM_JOBS
+              value: "5"
+            - name: SRC_LOG_LEVEL
+              value: info
+            - name: SRC_LOG_FORMAT
+              value: condensed
+            - name: SRC_TRACE_LOG
+              value: "false"
+            - name: EXECUTOR_KUBERNETES_RESOURCE_REQUEST_MEMORY
+              value: 1Gi
+            # Match the name of the volume in executor-multiqueue.PersistentVolumeClaim.yml.
+            - name: EXECUTOR_KUBERNETES_PERSISTENCE_VOLUME_NAME
+              value: sg-executor-multiqueue-pvc
+              # Since the host is 'host.docker.internal', this needs to be true.
+            - name: EXECUTOR_DOCKER_ADD_HOST_GATEWAY
+              value: "true"
+              # Ensure that the job pods are scheduled on the same node as the executor pod.
+#            - name: EXECUTOR_KUBERNETES_POD_AFFINITY
+#              value: '[{"labelSelector": {"matchExpressions": [{"key": "app", "operator": "In", "values": ["sg-executor-multiqueue"]}]}, "topologyKey": "kubernetes.io/hostname"}]'
+            # Another option to ensure that the job pods are scheduled on the same node as the executor pod.
+            - name: EXECUTOR_KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Useful for debugging.
+#            - name: KUBERNETES_KEEP_JOBS
+#              value: "true"
+#            - name: EXECUTOR_KEEP_WORKSPACES
+#              value: "true"
+          volumeMounts:
+            - mountPath: /data
+              name: sg-executor-multiqueue-volume
+      volumes:
+        - name: sg-executor-multiqueue-volume
+          persistentVolumeClaim:
+            claimName: sg-executor-multiqueue-pvc

--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.PersistentVolumeClaim.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.PersistentVolumeClaim.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sg-executor-multiqueue-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 25Gi

--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Role.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Role.yml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sg-executor-multiqueue-role
+  namespace: default
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+    verbs:
+      - get
+      - list
+      - watch

--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Rolebinding.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sg-executor-multiqueue-role-binding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: sg-executor-service-account
+    namespace: default
+roleRef:
+  kind: Role
+  name: sg-executor-multiqueue-role
+  apiGroup: rbac.authorization.k8s.io

--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Service.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.Service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sg-executor-multiqueue
+  namespace: default
+  labels:
+    app: sg-executor-multiqueue
+spec:
+  selector:
+    app: sg-executor-multiqueue
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  # For development purposes.
+  type: LoadBalancer

--- a/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.ServiceAccount.yml
+++ b/enterprise/cmd/executor/kubernetes/multiqueue/executor-multiqueue.ServiceAccount.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sg-executor-service-account
+  namespace: default

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -719,6 +719,11 @@ commands:
       EXECUTOR_QUEUE_NAMES: "codeintel,batches"
       EXECUTOR_MAXIMUM_NUM_JOBS: 8
 
+  multiqueue-executor-kubernetes:
+    <<: *executor_kubernetes_template
+    env:
+      MANIFEST_PATH: ./enterprise/cmd/executor/kubernetes/multiqueue
+
   blobstore:
     cmd: .bin/blobstore
     install: |
@@ -1362,7 +1367,7 @@ commandsets:
       - jaeger
       - grafana
       - prometheus
-  enterprise-codeintel-multi-queue-executor:
+  multiqueue-executor:
     <<: *codeintel_set
     commands:
       - frontend
@@ -1384,6 +1389,34 @@ commandsets:
       - blobstore
       - codeintel-worker
       - multiqueue-executor
+      - batcheshelper-builder
+      # - otel-collector
+      - jaeger
+      - grafana
+      - prometheus
+  multiqueue-executor-kubernetes:
+    <<: *codeintel_set
+    commands:
+      - frontend
+      - worker
+      - repo-updater
+      - web
+      - gitserver-0
+      - gitserver-1
+      - searcher
+      - symbols
+      - caddy
+      - docsite
+      - syntax-highlighter
+      - github-proxy
+      - zoekt-index-0
+      - zoekt-index-1
+      - zoekt-web-0
+      - zoekt-web-1
+      - blobstore
+      - codeintel-worker
+      - multiqueue-executor-kubernetes
+      - batcheshelper-builder
       # - otel-collector
       - jaeger
       - grafana


### PR DESCRIPTION
Added multi-queue Kubernetes manifests.

## Changes

- Added YAML files for a multi-queue (`batches,codeintel`) executor
- Added a `sg` target for the K8s multi-queue executor (`multiqueue-executor-kubernetes`)
- Renamed `enterprise-codeintel-multi-queue-executor` to `multiqueue-executor`

## Test plan

No tests needed.