### PR TITLE
Keyword context: work with arbitrary user input

### DIFF
--- a/enterprise/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//internal/database",
         "//internal/gitserver",
         "//internal/types",
+        "//lib/errors",
         "@com_github_sourcegraph_conc//iter",
     ],
 )

--- a/enterprise/cmd/frontend/internal/context/resolvers/context.go
+++ b/enterprise/cmd/frontend/internal/context/resolvers/context.go
@@ -2,16 +2,16 @@ package resolvers
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/sourcegraph/conc/iter"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	codycontext "github.com/sourcegraph/sourcegraph/enterprise/internal/codycontext"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func NewResolver(db database.DB, gitserverClient gitserver.Client, contextClient *codycontext.CodyContextClient) graphqlbackend.CodyContextResolver {

--- a/enterprise/internal/codycontext/context.go
+++ b/enterprise/internal/codycontext/context.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"regexp"
 	"strconv"
@@ -194,8 +195,8 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 		regexEscapedRepoNames[i] = regexp.QuoteMeta(string(repo.Name))
 	}
 
-	textQuery := "repo:^" + query.UnionRegExps(regexEscapedRepoNames) + "$ " + textFileFilter + ` content:"` + strconv.Quote(args.Query) + `"`
-	codeQuery := "repo:^" + query.UnionRegExps(regexEscapedRepoNames) + "$ -" + textFileFilter + ` content:"` + strconv.Quote(args.Query) + `"`
+	textQuery := fmt.Sprintf(`repo:^%s$ %s content:%s`, query.UnionRegExps(regexEscapedRepoNames), textFileFilter, strconv.Quote(args.Query))
+	codeQuery := fmt.Sprintf(`repo:^%s$ -%s content:%s`, query.UnionRegExps(regexEscapedRepoNames), textFileFilter, strconv.Quote(args.Query))
 
 	doSearch := func(ctx context.Context, query string, limit int) ([]FileChunkContext, error) {
 		if limit == 0 {

--- a/enterprise/internal/codycontext/context.go
+++ b/enterprise/internal/codycontext/context.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -170,8 +169,6 @@ var textFileFilter = func() string {
 	}
 	return `file:(` + strings.Join(extensions, "|") + `)$`
 }()
-
-var wordRegex = lazyregexp.New(`[a-zA-Z0-9]+`)
 
 // getKeywordContext uses keyword search to find relevant bits of context for Cody
 func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs) (_ []FileChunkContext, err error) {

--- a/internal/search/keyword/BUILD.bazel
+++ b/internal/search/keyword/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/keyword",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/lazyregexp",
         "//internal/search",
         "//internal/search/job",
         "//internal/search/query",

--- a/internal/search/keyword/BUILD.bazel
+++ b/internal/search/keyword/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/keyword",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/lazyregexp",
         "//internal/search",
         "//internal/search/job",
         "//internal/search/query",

--- a/internal/search/keyword/query_transformer.go
+++ b/internal/search/keyword/query_transformer.go
@@ -3,7 +3,6 @@ package keyword
 import (
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
@@ -24,8 +23,6 @@ func concatNodeToPatterns(concat query.Operator) []string {
 	}
 	return patterns
 }
-
-var keywordRegex = lazyregexp.New(`[a-zA-Z0-9]+`)
 
 func nodeToPatternsAndParameters(rootNode query.Node) ([]string, []query.Parameter) {
 	operator, ok := rootNode.(query.Operator)
@@ -52,7 +49,7 @@ func nodeToPatternsAndParameters(rootNode query.Node) ([]string, []query.Paramet
 			case query.Parameter:
 				if op.Field == query.FieldContent {
 					// Split any content field into a set of patterns ignoring any punctuation and special characters
-					patterns = append(patterns, keywordRegex.FindAllString(op.Value, 16)...)
+					patterns = append(patterns, strings.Fields(op.Value)...)
 				} else if op.Field != query.FieldCount && op.Field != query.FieldCase && op.Field != query.FieldType {
 					parameters = append(parameters, op)
 				}

--- a/internal/search/keyword/query_transformer.go
+++ b/internal/search/keyword/query_transformer.go
@@ -48,7 +48,7 @@ func nodeToPatternsAndParameters(rootNode query.Node) ([]string, []query.Paramet
 				}
 			case query.Parameter:
 				if op.Field == query.FieldContent {
-					// Split any content field into a set of patterns ignoring any punctuation and special characters
+					// Split any content field on white space into a set of patterns
 					patterns = append(patterns, strings.Fields(op.Value)...)
 				} else if op.Field != query.FieldCount && op.Field != query.FieldCase && op.Field != query.FieldType {
 					parameters = append(parameters, op)

--- a/internal/search/keyword/query_transformer_test.go
+++ b/internal/search/keyword/query_transformer_test.go
@@ -66,6 +66,14 @@ func TestQueryStringToKeywordQuery(t *testing.T) {
 			wantQuery:    autogold.Expect("count:99999999 type:file (cluster OR python)"),
 			wantPatterns: autogold.Expect([]string{"cluster", "python"}),
 		},
+		{
+			query:     `outer content:"inner {with} (special) ^characters$ and keywords like file or repo"`,
+			wantQuery: autogold.Expect("count:99999999 type:file (special OR charact OR keyword OR file OR repo OR outer)"),
+			wantPatterns: autogold.Expect([]string{
+				"special", "charact", "keyword", "file", "repo",
+				"outer",
+			}),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/search/keyword/query_transformer_test.go
+++ b/internal/search/keyword/query_transformer_test.go
@@ -68,9 +68,10 @@ func TestQueryStringToKeywordQuery(t *testing.T) {
 		},
 		{
 			query:     `outer content:"inner {with} (special) ^characters$ and keywords like file or repo"`,
-			wantQuery: autogold.Expect("count:99999999 type:file (special OR charact OR keyword OR file OR repo OR outer)"),
+			wantQuery: autogold.Expect("count:99999999 type:file (special OR ^characters$ OR keyword OR file OR repo OR outer)"),
 			wantPatterns: autogold.Expect([]string{
-				"special", "charact", "keyword", "file", "repo",
+				"special", "^characters$", "keyword", "file",
+				"repo",
 				"outer",
 			}),
 		},


### PR DESCRIPTION
We were previously concatenating the user query to our search query. The problem with this is the search query has syntax rules, and the user query can be anything. To fix this, we pass the quoted user query via the `content:` field, which can handle special characters or keywords.

## Test plan

Added a unit test + manual testing that it fixes the regex error

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
