### PR TITLE
codeintel: Move expensive braindot components into menu contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code intelligence background jobs did not correctly use an internal context, causing SCIP data to sometimes be prematurely deleted. [#51591](https://github.com/sourcegraph/sourcegraph/pull/51591)
 - Slow request logs now have the correct trace and span IDs attached if a trace is present on the request. [#51826](https://github.com/sourcegraph/sourcegraph/pull/51826)
 - SAML assertions to get user display name are now compared case insensitively and we do not always return an error. [#52992](https://github.com/sourcegraph/sourcegraph/pull/52992)
+- The braindot menu on the blob view no longer fetches data eagerly to prevent performance issues for larger monorepo users. [#53039](https://github.com/sourcegraph/sourcegraph/pull/53039)
 
 ### Removed
 

--- a/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 
 import { mdiArrowRightThin, mdiBrain } from '@mdi/js'
 import classNames from 'classnames'
 
 import {
-    Button,
     Position,
     Icon,
     Link,
@@ -20,11 +19,7 @@ import {
     Code,
 } from '@sourcegraph/wildcard'
 
-import { INDEX_COMPLETED_STATES, INDEX_FAILURE_STATES } from '../constants'
-import { useRepoCodeIntelStatus } from '../hooks/useRepoCodeIntelStatus'
 import { useVisibleIndexes } from '../hooks/useVisibleIndexes'
-
-import { getIndexerKey, getIndexRoot, sanitizePath } from './tree/util'
 
 import styles from './BrainDot.module.scss'
 
@@ -34,50 +29,33 @@ export interface BrainDotProps {
     path?: string
 }
 
-export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName, commit, path }) => {
-    const { data: statusData } = useRepoCodeIntelStatus({ repository: repoName })
+export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName, commit, path }) => (
+    <Menu>
+        <Tooltip content="View code intelligence summary">
+            <MenuButton className={classNames('text-decoration-none', styles.braindot)} aria-label="Code graph">
+                <Icon aria-hidden={true} svgPath={mdiBrain} />
+            </MenuButton>
+        </Tooltip>
+        <MenuList position={Position.bottomEnd} className={styles.dropdownMenu}>
+            <MenuHeader>
+                Click to view code intelligence summary
+                <span className="float-right">
+                    <Tooltip content="View code intelligence summary">
+                        <Link to={`/${repoName}/-/code-graph/dashboard`}>
+                            <Icon aria-hidden={true} svgPath={mdiArrowRightThin} />
+                        </Link>
+                    </Tooltip>
+                </span>
+            </MenuHeader>
 
-    const indexes = useMemo(() => {
-        if (!statusData) {
-            return []
-        }
+            <MenuDivider />
 
-        return statusData.summary.recentActivity
-    }, [statusData])
+            <BrainDotContent repoName={repoName} commit={commit} path={path} />
+        </MenuList>
+    </Menu>
+)
 
-    const suggestedIndexers = useMemo(() => {
-        if (!statusData) {
-            return []
-        }
-
-        return statusData.summary.availableIndexers
-            .flatMap(({ rootsWithKeys, indexer }) =>
-                rootsWithKeys.map(({ root, comparisonKey }) => ({ root, comparisonKey, ...indexer }))
-            )
-            .filter(
-                ({ root, key }) =>
-                    !indexes.some(index => getIndexRoot(index) === sanitizePath(root) && getIndexerKey(index) === key)
-            )
-    }, [statusData, indexes])
-
-    const dotStyle = useMemo((): string => {
-        if (!indexes || !suggestedIndexers) {
-            return ''
-        }
-
-        const numCompletedIndexes = indexes.filter(index => INDEX_COMPLETED_STATES.has(index.state)).length
-        const numFailedIndexes = indexes.filter(index => INDEX_FAILURE_STATES.has(index.state)).length
-        const numUnconfiguredProjects = suggestedIndexers.length
-
-        return numFailedIndexes > 0
-            ? styles.braindotDanger
-            : numUnconfiguredProjects > 0
-            ? styles.braindotWarning
-            : numCompletedIndexes > 0
-            ? styles.braindotSuccess
-            : ''
-    }, [indexes, suggestedIndexers])
-
+const BrainDotContent: React.FunctionComponent<BrainDotProps> = ({ repoName, commit, path }) => {
     const { data: visibleIndexes, loading: visibleIndexesLoading } = useVisibleIndexes({
         repository: repoName,
         commit,
@@ -93,92 +71,52 @@ export const BrainDot: React.FunctionComponent<BrainDotProps> = ({ repoName, com
         visibleIndexID = undefined
     }
 
-    // TODO(nsc) - add a feature flag to enable nerd controls
-    // https://github.com/sourcegraph/sourcegraph/pull/49128/files#diff-04df7090c83826679f92f4ee2881b626422057a8e6b59750937e2888d74e411cL152
-    const forNerds = true
-
-    return forNerds ? (
-        <Menu>
-            <>
-                <Tooltip content="View code intelligence summary">
-                    <MenuButton
-                        className={classNames('text-decoration-none', styles.braindot, dotStyle)}
-                        aria-label="Code graph"
-                    >
-                        <Icon aria-hidden={true} svgPath={mdiBrain} />
-                    </MenuButton>
-                </Tooltip>
-                <MenuList position={Position.bottomEnd} className={styles.dropdownMenu}>
-                    <MenuHeader>
-                        Click to view code intelligence summary
-                        <span className="float-right">
-                            <Tooltip content="View code intelligence summary">
-                                <Link to={`/${repoName}/-/code-graph/dashboard`}>
-                                    <Icon aria-hidden={true} svgPath={mdiArrowRightThin} />
-                                </Link>
-                            </Tooltip>
-                        </span>
-                    </MenuHeader>
-
-                    <MenuDivider />
-
-                    {visibleIndexesLoading && <LoadingSpinner className="mx-2" />}
-                    {visibleIndexes && visibleIndexes.length > 0 && (
-                        <MenuHeader>
-                            <Tooltip content="Not intended for regular use">
-                                <span>Display debug information for uploaded index.</span>
-                            </Tooltip>
-                            {[
+    return (
+        <>
+            {visibleIndexesLoading && <LoadingSpinner className="mx-2" />}
+            {visibleIndexes && visibleIndexes.length > 0 && (
+                <MenuHeader>
+                    <Tooltip content="Not intended for regular use">
+                        <span>Display debug information for uploaded index.</span>
+                    </Tooltip>
+                    {[
+                        <RadioButton
+                            id="none"
+                            key="none"
+                            name="none"
+                            label="None"
+                            wrapperClassName="py-1"
+                            checked={visibleIndexID === undefined}
+                            onChange={() => {
+                                delete indexIDsForSnapshotData[repoName]
+                                setIndexIDForSnapshotData(indexIDsForSnapshotData)
+                            }}
+                        />,
+                        ...visibleIndexes.map(index => (
+                            <Tooltip content={`Uploaded at ${index.uploadedAt}`} key={index.id}>
                                 <RadioButton
-                                    id="none"
-                                    key="none"
-                                    name="none"
-                                    label="None"
+                                    id={index.id}
+                                    name={index.id}
+                                    checked={visibleIndexID === index.id}
                                     wrapperClassName="py-1"
-                                    checked={visibleIndexID === undefined}
+                                    label={
+                                        <>
+                                            Index at <Code>{index.inputCommit.slice(0, 7)}</Code>
+                                        </>
+                                    }
                                     onChange={() => {
-                                        delete indexIDsForSnapshotData[repoName]
+                                        indexIDsForSnapshotData[repoName] = index.id
                                         setIndexIDForSnapshotData(indexIDsForSnapshotData)
                                     }}
-                                />,
-                                ...visibleIndexes.map(index => (
-                                    <Tooltip content={`Uploaded at ${index.uploadedAt}`} key={index.id}>
-                                        <RadioButton
-                                            id={index.id}
-                                            name={index.id}
-                                            checked={visibleIndexID === index.id}
-                                            wrapperClassName="py-1"
-                                            label={
-                                                <>
-                                                    Index at <Code>{index.inputCommit.slice(0, 7)}</Code>
-                                                </>
-                                            }
-                                            onChange={() => {
-                                                indexIDsForSnapshotData[repoName] = index.id
-                                                setIndexIDForSnapshotData(indexIDsForSnapshotData)
-                                            }}
-                                        />
-                                    </Tooltip>
-                                )),
-                            ]}
-                        </MenuHeader>
-                    )}
-                    {(visibleIndexes?.length ?? 0) === 0 && !visibleIndexesLoading && (
-                        <MenuHeader>No precise indexes to display debug information for.</MenuHeader>
-                    )}
-                </MenuList>
-            </>
-        </Menu>
-    ) : (
-        <Tooltip content="View code intelligence summary">
-            <Link to={`/${repoName}/-/code-graph/dashboard`}>
-                <Button
-                    className={classNames('text-decoration-none', styles.braindot, dotStyle)}
-                    aria-label="Code graph"
-                >
-                    <Icon aria-hidden={true} svgPath={mdiBrain} />
-                </Button>
-            </Link>
-        </Tooltip>
+                                />
+                            </Tooltip>
+                        )),
+                    ]}
+                </MenuHeader>
+            )}
+            {(visibleIndexes?.length ?? 0) === 0 && !visibleIndexesLoading && (
+                <MenuHeader>No precise indexes to display debug information for.</MenuHeader>
+            )}
+        </>
     )
 }


### PR DESCRIPTION
Hypothesis: The brain dot's style calculation requires some rather heavy-weight GraphQL calls for large repos (including tag commands associated with a particular index).

This PR removes the style and moves the GraphQL calls into the brain dot menu itself so that it only makes the API calls when the menu is visible (on user interaction, not on all user _blob_ interactions). Fixes #51675.

## Test plan

Tested locally.