### PR TITLE
gRPC: skip GobCache everywhere

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -224,7 +224,9 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	// GobCache exists, so we only pay the cost of marshalling a query once
 	// when we aggregate it out over all the replicas. Zoekt's RPC layers
 	// unwrap this before passing it on to the Zoekt evaluation layers.
-	q = &query.GobCache{Q: q}
+	if !grpc.IsGRPCEnabled(ctx) {
+		q = &query.GobCache{Q: q}
+	}
 
 	ch := make(chan error, len(clients))
 	for endpoint, c := range clients {


### PR DESCRIPTION
I missed a spot where we wrap with GobCache. This was causing panics in backend integration tests and is blocking main.

## Test plan

CI.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
