### PR TITLE
gitserver: replace spyGitserverServiceClient for mockClient within the archive test

### DIFF
--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -433,12 +433,20 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 				source := gitserver.NewTestClientSource(t, addrs, func(o *gitserver.TestClientSourceOptions) {
 					o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+						base := proto.NewGitserverServiceClient(cc)
+
 						mockArchive := func(ctx context.Context, in *proto.ArchiveRequest, opts ...grpc.CallOption) (proto.GitserverService_ArchiveClient, error) {
 							called = true
-							base := proto.NewGitserverServiceClient(cc)
 							return base.Archive(ctx, in, opts...)
 						}
-						return &mockClient{mockArchive: mockArchive}
+						mockRepoUpdate := func(ctx context.Context, in *proto.RepoUpdateRequest, opts ...grpc.CallOption) (*proto.RepoUpdateResponse, error) {
+							called = true
+							base := proto.NewGitserverServiceClient(cc)
+							return base.RepoUpdate(ctx, in, opts...)
+						}
+						return &mockClient{mockArchive: mockArchive,
+							mockRepoUpdate: mockRepoUpdate}
+
 					}
 				})
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -326,7 +326,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		},
 	}
 
-	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(t *testing.T, addrs []string) gitserver.Client, name api.RepoName, test test) {
+	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(t *testing.T, addrs []string) gitserver.Client, name api.RepoName, test test, called *bool) {
 		t.Run(string(name), func(t *testing.T) {
 			// Setup: Prepare the test Gitserver server + register the gRPC server
 			s := &server.Server{
@@ -426,26 +426,27 @@ func TestClient_ArchiveReader(t *testing.T) {
 		})
 		for _, test := range tests {
 			repoName := api.RepoName(test.name)
-
-			spy := &spyGitserverServiceClient{}
+			called := false
 
 			mkClient := func(t *testing.T, addrs []string) gitserver.Client {
-
 				t.Helper()
 
 				source := gitserver.NewTestClientSource(t, addrs, func(o *gitserver.TestClientSourceOptions) {
 					o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
-						spy.base = proto.NewGitserverServiceClient(cc)
-
-						return spy
+						mockArchive := func(ctx context.Context, in *proto.ArchiveRequest, opts ...grpc.CallOption) (proto.GitserverService_ArchiveClient, error) {
+							called = true
+							base := proto.NewGitserverServiceClient(cc)
+							return base.Archive(ctx, in, opts...)
+						}
+						return &mockClient{mockArchive: mockArchive}
 					}
 				})
 
 				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
-			runArchiveReaderTestfunc(t, mkClient, repoName, test)
-			if !spy.archiveCalled {
+			runArchiveReaderTestfunc(t, mkClient, repoName, test, &called)
+			if !called {
 				t.Error("archiveReader: GitserverServiceClient should have been called")
 			}
 
@@ -463,28 +464,30 @@ func TestClient_ArchiveReader(t *testing.T) {
 
 		for _, test := range tests {
 			repoName := api.RepoName(test.name)
+			called := false
 
-			var spyGitserverService *spyGitserverServiceClient
 			mkClient := func(t *testing.T, addrs []string) gitserver.Client {
 				t.Helper()
 
-				spy := &spyGitserverServiceClient{}
-
 				source := gitserver.NewTestClientSource(t, addrs, func(o *gitserver.TestClientSourceOptions) {
 					o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
-						spy.base = proto.NewGitserverServiceClient(cc)
-
-						return spy
+						mockArchive := func(ctx context.Context, in *proto.ArchiveRequest, opts ...grpc.CallOption) (proto.GitserverService_ArchiveClient, error) {
+							called = true
+							base := proto.NewGitserverServiceClient(cc)
+							return base.Archive(ctx, in, opts...)
+						}
+						return &mockClient{mockArchive: mockArchive}
 					}
 				})
 
 				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
-			runArchiveReaderTestfunc(t, mkClient, repoName, test)
-			if spyGitserverService != nil {
-				t.Error("archiveReader: GitserverServiceClient should have not been initialized")
+			runArchiveReaderTestfunc(t, mkClient, repoName, test, &called)
+			if called {
+				t.Error("archiveReader: GitserverServiceClient should have been called")
 			}
+
 		}
 
 	})
@@ -1408,102 +1411,6 @@ func TestGitserverClient_RepoClone(t *testing.T) {
 		t.Fatal("RepoClone: grpc client not called")
 	}
 }
-
-type spyGitserverServiceClient struct {
-	batchlogCalled                    bool
-	createCommitFromPatchBinaryCalled bool
-	execCalled                        bool
-	getObjectCalled                   bool
-	isRepoCloneable                   bool
-	searchCalled                      bool
-	archiveCalled                     bool
-	listGitoliteCalled                bool
-	repoClone                         bool
-	repoCloneProgress                 bool
-	repoDelete                        bool
-	repoUpdate                        bool
-	reposStatsCalled                  bool
-	p4ExecCalled                      bool
-	base                              proto.GitserverServiceClient
-}
-
-// BatchLog implements v1.GitserverServiceClient.
-func (s *spyGitserverServiceClient) BatchLog(ctx context.Context, in *proto.BatchLogRequest, opts ...grpc.CallOption) (*proto.BatchLogResponse, error) {
-	return s.base.BatchLog(ctx, in, opts...)
-}
-
-// GetObject implements v1.GitserverServiceClient.
-func (s *spyGitserverServiceClient) GetObject(ctx context.Context, in *proto.GetObjectRequest, opts ...grpc.CallOption) (*proto.GetObjectResponse, error) {
-	s.getObjectCalled = true
-	return s.base.GetObject(ctx, in, opts...)
-}
-
-// ListGitolite implements v1.GitserverServiceClient.
-func (s *spyGitserverServiceClient) ListGitolite(ctx context.Context, in *proto.ListGitoliteRequest, opts ...grpc.CallOption) (*proto.ListGitoliteResponse, error) {
-	s.listGitoliteCalled = true
-	return s.base.ListGitolite(ctx, in, opts...)
-}
-
-// P4Exec implements v1.GitserverServiceClient.
-func (s *spyGitserverServiceClient) P4Exec(ctx context.Context, in *proto.P4ExecRequest, opts ...grpc.CallOption) (proto.GitserverService_P4ExecClient, error) {
-	s.p4ExecCalled = true
-	return s.base.P4Exec(ctx, in, opts...)
-}
-
-// CreateCommitFromPatchBinary implements v1.GitserverServiceClient.
-func (s *spyGitserverServiceClient) CreateCommitFromPatchBinary(ctx context.Context, in *proto.CreateCommitFromPatchBinaryRequest, opts ...grpc.CallOption) (*proto.CreateCommitFromPatchBinaryResponse, error) {
-	s.createCommitFromPatchBinaryCalled = true
-	return s.base.CreateCommitFromPatchBinary(ctx, in, opts...)
-}
-
-// RepoUpdate implements v1.GitserverServiceClient
-func (s *spyGitserverServiceClient) RepoUpdate(ctx context.Context, in *proto.RepoUpdateRequest, opts ...grpc.CallOption) (*proto.RepoUpdateResponse, error) {
-	s.repoUpdate = true
-	return s.base.RepoUpdate(ctx, in, opts...)
-}
-
-// RepoDelete implements v1.GitserverServiceClient
-func (s *spyGitserverServiceClient) RepoDelete(ctx context.Context, in *proto.RepoDeleteRequest, opts ...grpc.CallOption) (*proto.RepoDeleteResponse, error) {
-	return s.base.RepoDelete(ctx, in, opts...)
-}
-
-// RepoCloneProgress implements v1.GitserverServiceClient
-func (s *spyGitserverServiceClient) RepoCloneProgress(ctx context.Context, in *proto.RepoCloneProgressRequest, opts ...grpc.CallOption) (*proto.RepoCloneProgressResponse, error) {
-	s.repoCloneProgress = true
-	return s.base.RepoCloneProgress(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) Exec(ctx context.Context, in *proto.ExecRequest, opts ...grpc.CallOption) (proto.GitserverService_ExecClient, error) {
-	s.execCalled = true
-	return s.base.Exec(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) RepoClone(ctx context.Context, in *proto.RepoCloneRequest, opts ...grpc.CallOption) (*proto.RepoCloneResponse, error) {
-	s.repoClone = true
-	return s.base.RepoClone(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) IsRepoCloneable(ctx context.Context, in *proto.IsRepoCloneableRequest, opts ...grpc.CallOption) (*proto.IsRepoCloneableResponse, error) {
-	s.isRepoCloneable = true
-	return s.base.IsRepoCloneable(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) Search(ctx context.Context, in *proto.SearchRequest, opts ...grpc.CallOption) (proto.GitserverService_SearchClient, error) {
-	s.searchCalled = true
-	return s.base.Search(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) Archive(ctx context.Context, in *proto.ArchiveRequest, opts ...grpc.CallOption) (proto.GitserverService_ArchiveClient, error) {
-	s.archiveCalled = true
-	return s.base.Archive(ctx, in, opts...)
-}
-
-func (s *spyGitserverServiceClient) ReposStats(ctx context.Context, in *proto.ReposStatsRequest, opts ...grpc.CallOption) (*proto.ReposStatsResponse, error) {
-	s.reposStatsCalled = true
-	return s.base.ReposStats(ctx, in, opts...)
-}
-
-var _ proto.GitserverServiceClient = &spyGitserverServiceClient{}
 
 type mockClient struct {
 	mockBatchLog                    func(ctx context.Context, in *proto.BatchLogRequest, opts ...grpc.CallOption) (*proto.BatchLogResponse, error)

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -440,7 +440,6 @@ func TestClient_ArchiveReader(t *testing.T) {
 							return base.Archive(ctx, in, opts...)
 						}
 						mockRepoUpdate := func(ctx context.Context, in *proto.RepoUpdateRequest, opts ...grpc.CallOption) (*proto.RepoUpdateResponse, error) {
-							called = true
 							base := proto.NewGitserverServiceClient(cc)
 							return base.RepoUpdate(ctx, in, opts...)
 						}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -326,7 +326,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 		},
 	}
 
-	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(t *testing.T, addrs []string) gitserver.Client, name api.RepoName, test test, called *bool) {
+	runArchiveReaderTestfunc := func(t *testing.T, mkClient func(t *testing.T, addrs []string) gitserver.Client, name api.RepoName, test test) {
 		t.Run(string(name), func(t *testing.T) {
 			// Setup: Prepare the test Gitserver server + register the gRPC server
 			s := &server.Server{
@@ -444,16 +444,17 @@ func TestClient_ArchiveReader(t *testing.T) {
 							base := proto.NewGitserverServiceClient(cc)
 							return base.RepoUpdate(ctx, in, opts...)
 						}
-						return &mockClient{mockArchive: mockArchive,
-							mockRepoUpdate: mockRepoUpdate}
-
+						return &mockClient{
+							mockArchive:    mockArchive,
+							mockRepoUpdate: mockRepoUpdate,
+						}
 					}
 				})
 
 				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
-			runArchiveReaderTestfunc(t, mkClient, repoName, test, &called)
+			runArchiveReaderTestfunc(t, mkClient, repoName, test)
 			if !called {
 				t.Error("archiveReader: GitserverServiceClient should have been called")
 			}
@@ -491,7 +492,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 				return gitserver.NewTestClient(&http.Client{}, source)
 			}
 
-			runArchiveReaderTestfunc(t, mkClient, repoName, test, &called)
+			runArchiveReaderTestfunc(t, mkClient, repoName, test)
 			if called {
 				t.Error("archiveReader: GitserverServiceClient should have been called")
 			}


### PR DESCRIPTION
replacing spyGitserverServiceClient struct for the mockClient struct used in the rest of the gitserver client tests. 
## Test plan
unit test passed
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
