### PR TITLE
cody-gateway: add temporary workaround for model prefix migration

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/upstream.go
@@ -100,6 +100,17 @@ func makeUpstreamHandler[ReqT any](
 				return
 			}
 
+			// TEMPORARY: Add provider prefixes to AllowedModels for back-compat
+			// if it doesn't look like there is a prefix yet.
+			//
+			// This isn't very robust, but should tide us through a brief transition
+			// period until everything deploys and our caches refresh.
+			for i := range rateLimit.AllowedModels {
+				if !strings.Contains(rateLimit.AllowedModels[i], "/") {
+					rateLimit.AllowedModels[i] = fmt.Sprintf("%s/%s", upstreamName, rateLimit.AllowedModels[i])
+				}
+			}
+
 			// Parse the request body.
 			var body ReqT
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/enterprise/internal/completions/client/codygateway/codygateway_test.go
+++ b/enterprise/internal/completions/client/codygateway/codygateway_test.go
@@ -19,8 +19,8 @@ func TestGetProviderFromGatewayModel(t *testing.T) {
 			expectProvider: "openai", expectModel: "gpt4"},
 
 		// Edge cases
-		{gatewayModel: "openai/",
-			expectProvider: "openai", expectModel: ""},
+		{gatewayModel: "claude-v1",
+			expectProvider: "", expectModel: "claude-v1"},
 		{gatewayModel: "openai/unexpectednamewith/slash",
 			expectProvider: "openai", expectModel: "unexpectednamewith/slash"},
 	} {


### PR DESCRIPTION
#52972 introduced some breakages since our redis caches still retain the old AllowedModels - for now we work around this by simply pretending all models are prefixed with the provider. The per-handler `allowedModels` already have this

## Test plan

n/a