### PR TITLE
subscription: Fix error generating a new license when no previous license exists

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -37,7 +37,7 @@ interface License extends Omit<ProductLicenseFields, 'subscription' | 'info'> {
 interface Props {
     subscriptionID: Scalars['ID']
     subscriptionAccount: string
-    latestLicense: License
+    latestLicense: License | undefined
     onGenerate: () => void
     onCancel: () => void
 }
@@ -53,11 +53,11 @@ interface FormData {
     expiresAt: Date
 }
 
-const getEmptyFormData = (account: string, latestLicense: License): FormData => ({
+const getEmptyFormData = (account: string, latestLicense: License | undefined): FormData => ({
     tags: '',
     customer: account,
-    salesforceSubscriptionID: latestLicense.info?.salesforceSubscriptionID ?? '',
-    salesforceOpportunityID: latestLicense.info?.salesforceOpportunityID ?? '',
+    salesforceSubscriptionID: latestLicense?.info?.salesforceSubscriptionID ?? '',
+    salesforceOpportunityID: latestLicense?.info?.salesforceOpportunityID ?? '',
     plan: 'enterprise-1',
     userCount: 1,
     expiresAt: endOfDay(addDays(Date.now(), 366)),

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -204,7 +204,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                 <SiteAdminGenerateProductLicenseForSubscriptionForm
                     subscriptionID={productSubscription.id}
                     subscriptionAccount={productSubscription.account?.username || ''}
-                    latestLicense={productSubscription.productLicenses?.nodes[0]}
+                    latestLicense={productSubscription.productLicenses?.nodes[0] ?? undefined}
                     onGenerate={onLicenseUpdate}
                     onCancel={() => setShowGenerate(false)}
                 />


### PR DESCRIPTION
This fixes an issue where we typescript didn't catch that license can be empty.

https://sourcegraph.slack.com/archives/C04DM1NAGDS/p1686092555406589

## Test plan

Creating a new license for an empty subscription now works. 