### PR TITLE
cody-gateway/actor: fixup ErrNotFromSource detection

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/source_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/redigo"
 	"github.com/gomodule/redigo/redis"
+	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -114,4 +115,18 @@ func TestSourcesWorkers(t *testing.T) {
 
 	// Wait for everyone to go home for the weekend
 	g.Wait()
+}
+
+func TestIsErrNotFromSource(t *testing.T) {
+	var err error
+	err = ErrNotFromSource{Reason: "foo"}
+	assert.True(t, IsErrNotFromSource(err))
+	autogold.Expect("token not from source: foo").Equal(t, err.Error())
+
+	err = errors.Wrap(err, "wrap")
+	assert.True(t, IsErrNotFromSource(err))
+	autogold.Expect("wrap: token not from source: foo").Equal(t, err.Error())
+
+	err = errors.New("foo")
+	assert.False(t, IsErrNotFromSource(err))
 }


### PR DESCRIPTION
We were previously not detecting `ErrNotFromSource` correctly, and returning it as an error when instead we should just skip over it and check the next available source.

## Test plan

Unit tests on new helper
