### PR TITLE
productsubscriptions: add hr between token and completions

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
@@ -133,6 +133,8 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
 
                         {codyGatewayAccess.enabled && (
                             <>
+                                <hr className="my-3" />
+
                                 <H4>Completions</H4>
                                 <Label className="mb-2">Rate limits</Label>
                                 <table className={styles.limitsTable}>


### PR DESCRIPTION
Minor nit for my eyeballs. The `hr` is the same used to separate the embeddings section

## Test plan

n/a?