### PR TITLE
github apps: sleep before redirecting to `installations/new`

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -276,6 +277,10 @@ func newServeMux(db edb.EnterpriseDB, prefix string, cache *rcache.Cache) http.H
 		}
 		cache.Set(state, []byte(strconv.Itoa(id)))
 
+		// The installations page often takes a few seconds to become available after the
+		// app is first created, so we sleep for a bit to give it time to load. The exact
+		// length of time to sleep was determined empirically.
+		time.Sleep(3 * time.Second)
 		redirectURL, err := url.JoinPath(app.AppURL, "installations/new")
 		if err != nil {
 			// if there is an error, try to redirect to app url, which should show Install button as well


### PR DESCRIPTION
I noticed that every once in a while (~5-10% of the time?), GitHub would 404 after it creates the new app and attempts to redirect to the page to install it. I'd think I did something wrong at first, but I would come back to the page a minute later and it'd be functional again. I think there's just a small race condition between GitHub finishing creating the app on their end and Sourcegraph redirecting to the new app's install page.

This PR just introduces a small delay before the redirect event to try to smooth this out. The sleep delay amount was chosen purely based on empirical evidence. I didn't see the 404s after adding a 3s delay and creating about ~20 new Apps. It's possible an even smaller delay would suffice, given we probably also have lower-than-normal latency when following the workflow from our locally-running instances, but 3s doesn't feel too long to wait.

## Test plan

Aggressive manual testing. 😛

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
