### PR TITLE
rcache: add `DeleteHashItem`

### DIFF
--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -132,6 +132,10 @@ func (r *Cache) GetHashItem(key string, hashKey string) (string, error) {
 	return kv().HGet(r.rkeyPrefix()+key, hashKey).String()
 }
 
+func (r *Cache) DeleteHashItem(key string, hashKey string) (int, error) {
+	return kv().HDel(r.rkeyPrefix()+key, hashKey).Int()
+}
+
 // GetHashAll returns the members of the HASH stored at `key`, in no particular order.
 func (r *Cache) GetHashAll(key string) (map[string]string, error) {
 	return kv().HGetAll(r.rkeyPrefix() + key).StringMap()

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -132,6 +132,11 @@ func (r *Cache) GetHashItem(key string, hashKey string) (string, error) {
 	return kv().HGet(r.rkeyPrefix()+key, hashKey).String()
 }
 
+// DeleteHashItem deletes a key in a HASH.
+// It returns an integer representing the amount of deleted hash keys:
+// If the key exists and the hash key exists, it will return 1.
+// If the key exists but the hash key does not, it will return 0.
+// If the key does not exist, it will return 0.
 func (r *Cache) DeleteHashItem(key string, hashKey string) (int, error) {
 	return kv().HDel(r.rkeyPrefix()+key, hashKey).Int()
 }

--- a/internal/rcache/rcache_test.go
+++ b/internal/rcache/rcache_test.go
@@ -252,6 +252,33 @@ func TestCache_Hashes(t *testing.T) {
 	all, err := c.GetHashAll("key")
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]string{"hashKey1": "value1", "hashKey2": "value2"}, all)
+
+	// Test DeleteHashItem
+	// Bit redundant, but double check that the key still exists
+	val1, err = c.GetHashItem("key", "hashKey1")
+	assert.NoError(t, err)
+	assert.Equal(t, "value1", val1)
+	del1, err := c.DeleteHashItem("key", "hashKey1")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, del1)
+	// Verify that it no longer exists
+	val1, err = c.GetHashItem("key", "hashKey1")
+	assert.Error(t, err)
+	assert.Equal(t, "", val1)
+	// Delete nonexistent field: should return 0 (represents deleted items)
+	val3, err = c.GetHashItem("key", "hashKey3")
+	assert.Error(t, err)
+	assert.Equal(t, "", val3)
+	del3, err := c.DeleteHashItem("key", "hashKey3")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, del3)
+	// Delete nonexistent key: should return 0 (represents deleted items)
+	val4, err := c.GetHashItem("nonexistentkey", "nonexistenthashkey")
+	assert.Error(t, err)
+	assert.Equal(t, "", val4)
+	del4, err := c.DeleteHashItem("nonexistentkey", "nonexistenthashkey")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, del4)
 }
 
 func bytes(s ...string) [][]byte {


### PR DESCRIPTION
- Followup of https://github.com/sourcegraph/sourcegraph/pull/53012

Adds deleting a hash item from an `rcache`.

## Test plan
Unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
