### PR TITLE
own: add GraphQL mutations for adding/removing team ownership.

### DIFF
--- a/client/web/src/repo/blob/own/OwnershipBadge.tsx
+++ b/client/web/src/repo/blob/own/OwnershipBadge.tsx
@@ -4,6 +4,7 @@ import { Badge, BadgeProps, BadgeVariantType, Link } from '@sourcegraph/wildcard
 
 import {
     AssignedOwnerFields,
+    AssignedTeamFields,
     CodeownersFileEntryFields,
     RecentContributorOwnershipSignalFields,
     RecentViewOwnershipSignalFields,
@@ -17,6 +18,7 @@ interface Props {
         | RecentContributorOwnershipSignalFields
         | RecentViewOwnershipSignalFields
         | AssignedOwnerFields
+        | AssignedTeamFields
 }
 
 const BADGE_VARIANT_BY_REASON: Partial<Record<NonNullable<Props['reason']['__typename']>, BadgeVariantType>> = {
@@ -24,6 +26,7 @@ const BADGE_VARIANT_BY_REASON: Partial<Record<NonNullable<Props['reason']['__typ
     CodeownersFileEntry: 'warning',
     // Purple badge for assigned owners and teams.
     AssignedOwner: 'merged',
+    AssignedTeam: 'merged',
 }
 
 // OwnershipBadge displays a badge like CODEOWNERS or RECENT CONTRIBUTOR

--- a/client/web/src/repo/blob/own/OwnershipBadge.tsx
+++ b/client/web/src/repo/blob/own/OwnershipBadge.tsx
@@ -4,7 +4,6 @@ import { Badge, BadgeProps, BadgeVariantType, Link } from '@sourcegraph/wildcard
 
 import {
     AssignedOwnerFields,
-    AssignedTeamFields,
     CodeownersFileEntryFields,
     RecentContributorOwnershipSignalFields,
     RecentViewOwnershipSignalFields,
@@ -18,7 +17,6 @@ interface Props {
         | RecentContributorOwnershipSignalFields
         | RecentViewOwnershipSignalFields
         | AssignedOwnerFields
-        | AssignedTeamFields
 }
 
 const BADGE_VARIANT_BY_REASON: Partial<Record<NonNullable<Props['reason']['__typename']>, BadgeVariantType>> = {
@@ -26,7 +24,6 @@ const BADGE_VARIANT_BY_REASON: Partial<Record<NonNullable<Props['reason']['__typ
     CodeownersFileEntry: 'warning',
     // Purple badge for assigned owners and teams.
     AssignedOwner: 'merged',
-    AssignedTeam: 'merged',
 }
 
 // OwnershipBadge displays a badge like CODEOWNERS or RECENT CONTRIBUTOR

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -184,7 +184,7 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
 `
 
 export const ASSIGN_OWNER = gql`
-    mutation AssignOwner($input: AssignOwnerInput!) {
+    mutation AssignOwner($input: AssignOwnerOrTeamInput!) {
         assignOwner(input: $input) {
             alwaysNil
         }

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -50,11 +50,19 @@ export const ASSIGNED_OWNER_FIELDS = gql`
     }
 `
 
+export const ASSIGNED_TEAM_FIELDS = gql`
+    fragment AssignedTeamFields on AssignedTeam {
+        title
+        description
+    }
+`
+
 export const FETCH_OWNERS = gql`
     ${OWNER_FIELDS}
     ${RECENT_CONTRIBUTOR_FIELDS}
     ${RECENT_VIEW_FIELDS}
     ${ASSIGNED_OWNER_FIELDS}
+    ${ASSIGNED_TEAM_FIELDS}
 
     fragment CodeownersFileEntryFields on CodeownersFileEntry {
         title
@@ -81,6 +89,7 @@ export const FETCH_OWNERS = gql`
                                     ...RecentContributorOwnershipSignalFields
                                     ...RecentViewOwnershipSignalFields
                                     ...AssignedOwnerFields
+                                    ...AssignedTeamFields
                                 }
                             }
                         }

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -50,19 +50,11 @@ export const ASSIGNED_OWNER_FIELDS = gql`
     }
 `
 
-export const ASSIGNED_TEAM_FIELDS = gql`
-    fragment AssignedTeamFields on AssignedTeam {
-        title
-        description
-    }
-`
-
 export const FETCH_OWNERS = gql`
     ${OWNER_FIELDS}
     ${RECENT_CONTRIBUTOR_FIELDS}
     ${RECENT_VIEW_FIELDS}
     ${ASSIGNED_OWNER_FIELDS}
-    ${ASSIGNED_TEAM_FIELDS}
 
     fragment CodeownersFileEntryFields on CodeownersFileEntry {
         title
@@ -89,7 +81,6 @@ export const FETCH_OWNERS = gql`
                                     ...RecentContributorOwnershipSignalFields
                                     ...RecentViewOwnershipSignalFields
                                     ...AssignedOwnerFields
-                                    ...AssignedTeamFields
                                 }
                             }
                         }

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -64,8 +64,10 @@ type OwnResolver interface {
 	DeleteCodeownersFiles(context.Context, *DeleteCodeownersFileArgs) (*EmptyResponse, error)
 
 	// Assigned ownership mutations.
-	AssignOwner(context.Context, *AssignOwnerArgs) (*EmptyResponse, error)
-	RemoveAssignedOwner(context.Context, *AssignOwnerArgs) (*EmptyResponse, error)
+	AssignOwner(context.Context, *AssignOwnerOrTeamArgs) (*EmptyResponse, error)
+	RemoveAssignedOwner(context.Context, *AssignOwnerOrTeamArgs) (*EmptyResponse, error)
+	AssignTeam(context.Context, *AssignOwnerOrTeamArgs) (*EmptyResponse, error)
+	RemoveAssignedTeam(context.Context, *AssignOwnerOrTeamArgs) (*EmptyResponse, error)
 
 	// Config.
 	OwnSignalConfigurations(ctx context.Context) ([]SignalConfigurationResolver, error)
@@ -155,12 +157,12 @@ type DeleteCodeownersFilesInput struct {
 	RepoName *string
 }
 
-type AssignOwnerArgs struct {
-	Input AssignOwnerInput
+type AssignOwnerOrTeamArgs struct {
+	Input AssignOwnerOrTeamInput
 }
 
-type AssignOwnerInput struct {
-	// AssignedOwnerID is an ID of a user who is assigned as an owner.
+type AssignOwnerOrTeamInput struct {
+	// AssignedOwnerID is an ID of a user or a team who is assigned as an owner.
 	AssignedOwnerID graphql.ID
 	RepoID          graphql.ID
 	AbsolutePath    string

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -269,11 +269,19 @@ extend type Mutation {
     """
     assignOwner creates a new assigned owner.
     """
-    assignOwner(input: AssignOwnerInput!): EmptyResponse
+    assignOwner(input: AssignOwnerOrTeamInput!): EmptyResponse
     """
     removeAssignedOwner removes an assigned owner.
     """
-    removeAssignedOwner(input: AssignOwnerInput!): EmptyResponse
+    removeAssignedOwner(input: AssignOwnerOrTeamInput!): EmptyResponse
+    """
+    assignTeam creates a new assigned team.
+    """
+    assignTeam(input: AssignOwnerOrTeamInput!): EmptyResponse
+    """
+    removeAssignedTeam removes an assigned owner.
+    """
+    removeAssignedTeam(input: AssignOwnerOrTeamInput!): EmptyResponse
 }
 
 """
@@ -377,11 +385,11 @@ input UpdateSignalConfigurationsInput {
 }
 
 """
-AssignOwnerInput represents the input for assigning or deleting an owner.
+AssignOwnerOrTeamInput represents the input for assigning or deleting an owner team or person.
 """
-input AssignOwnerInput {
+input AssignOwnerOrTeamInput {
     """
-    ID of an assigned owner.
+    ID of an assigned owner or team.
     """
     assignedOwnerID: ID!
     """

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -1433,6 +1433,10 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											  title
 											  description
 											}
+											... on AssignedTeam {
+											  title
+											  description
+											}
 										}
 									}
 								}
@@ -1511,6 +1515,28 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											"ruleLineMatch": 1
 										}
 									]
+								},
+								{
+									"owner": {
+										"name": "assigned team 1"
+									},
+									"reasons": [
+										{
+											"title": "assigned team",
+											"description": "Team is manually assigned."
+										}
+									]
+								},
+								{
+									"owner": {
+										"name": "assigned team 2"
+									},
+									"reasons": [
+										{
+											"title": "assigned team",
+											"description": "Team is manually assigned."
+										}
+									]
 								}
 							]
 						}
@@ -1560,6 +1586,10 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											  title
 											  description
 											}
+											... on AssignedTeam {
+											  title
+											  description
+											}
 										}
 									}
 								}
@@ -1596,6 +1626,17 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 										{
 											"title": "assigned owner",
 											"description": "Owner is manually assigned."
+										}
+									]
+								},
+								{
+									"owner": {
+										"name": "assigned team 2"
+									},
+									"reasons": [
+										{
+											"title": "assigned team",
+											"description": "Team is manually assigned."
 										}
 									]
 								}

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -1589,17 +1589,6 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 								},
 								{
 									"owner": {
-										"name": "assigned team 2"
-									},
-									"reasons": [
-										{
-											"title": "assigned owner",
-											"description": "Owner is manually assigned."
-										}
-									]
-								},
-								{
-									"owner": {
 										"displayName": "I am an assigned owner #2",
 										"email": "assigned@owner2.com"
 									},

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -1433,10 +1433,6 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											  title
 											  description
 											}
-											... on AssignedTeam {
-											  title
-											  description
-											}
 										}
 									}
 								}
@@ -1515,28 +1511,6 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											"ruleLineMatch": 1
 										}
 									]
-								},
-								{
-									"owner": {
-										"name": "assigned team 1"
-									},
-									"reasons": [
-										{
-											"title": "assigned team",
-											"description": "Team is manually assigned."
-										}
-									]
-								},
-								{
-									"owner": {
-										"name": "assigned team 2"
-									},
-									"reasons": [
-										{
-											"title": "assigned team",
-											"description": "Team is manually assigned."
-										}
-									]
 								}
 							]
 						}
@@ -1586,10 +1560,6 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 											  title
 											  description
 											}
-											... on AssignedTeam {
-											  title
-											  description
-											}
 										}
 									}
 								}
@@ -1619,8 +1589,7 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 								},
 								{
 									"owner": {
-										"displayName": "I am an assigned owner #2",
-										"email": "assigned@owner2.com"
+										"name": "assigned team 2"
 									},
 									"reasons": [
 										{
@@ -1631,12 +1600,13 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 								},
 								{
 									"owner": {
-										"name": "assigned team 2"
+										"displayName": "I am an assigned owner #2",
+										"email": "assigned@owner2.com"
 									},
 									"reasons": [
 										{
-											"title": "assigned team",
-											"description": "Team is manually assigned."
+											"title": "assigned owner",
+											"description": "Owner is manually assigned."
 										}
 									]
 								}

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -1194,10 +1194,10 @@ func Test_SignalConfigurations(t *testing.T) {
 
 	ctx := context.Background()
 
-	admin, err := db.Users().Create(context.Background(), database.NewUser{Username: "admin"})
+	admin, err := db.Users().Create(ctx, database.NewUser{Username: "admin"})
 	require.NoError(t, err)
 
-	user, err := db.Users().Create(context.Background(), database.NewUser{Username: "non-admin"})
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "non-admin"})
 	require.NoError(t, err)
 
 	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
@@ -1635,9 +1635,9 @@ func TestAssignOwner(t *testing.T) {
 	err := db.Repos().Create(ctx, &repo)
 	require.NoError(t, err)
 	// Creating 2 users, only "hasPermission" user has rights to assign owners.
-	hasPermission, err := db.Users().Create(context.Background(), database.NewUser{Username: "has-permission"})
+	hasPermission, err := db.Users().Create(ctx, database.NewUser{Username: "has-permission"})
 	require.NoError(t, err)
-	noPermission, err := db.Users().Create(context.Background(), database.NewUser{Username: "no-permission"})
+	noPermission, err := db.Users().Create(ctx, database.NewUser{Username: "no-permission"})
 	require.NoError(t, err)
 	// RBAC stuff below.
 	permission, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
@@ -1671,7 +1671,7 @@ func TestAssignOwner(t *testing.T) {
 			Context: userCtx,
 			Schema:  schema,
 			Query: `
-				mutation assignOwner($input:AssignOwnerInput!) {
+				mutation assignOwner($input:AssignOwnerOrTeamInput!) {
 				  assignOwner(input:$input) {
 					alwaysNil
 				  }
@@ -1762,9 +1762,9 @@ func TestDeleteAssignedOwner(t *testing.T) {
 	err := db.Repos().Create(ctx, &repo)
 	require.NoError(t, err)
 	// Creating 2 users, only "hasPermission" user has rights to assign owners.
-	hasPermission, err := db.Users().Create(context.Background(), database.NewUser{Username: "has-permission"})
+	hasPermission, err := db.Users().Create(ctx, database.NewUser{Username: "has-permission"})
 	require.NoError(t, err)
-	noPermission, err := db.Users().Create(context.Background(), database.NewUser{Username: "non-permission"})
+	noPermission, err := db.Users().Create(ctx, database.NewUser{Username: "non-permission"})
 	require.NoError(t, err)
 	// Creating an existing assigned owner.
 	require.NoError(t, db.AssignedOwners().Insert(ctx, noPermission.ID, repo.ID, "", hasPermission.ID))
@@ -1800,7 +1800,7 @@ func TestDeleteAssignedOwner(t *testing.T) {
 			Context: userCtx,
 			Schema:  schema,
 			Query: `
-				mutation removeAssignedOwner($input:AssignOwnerInput!) {
+				mutation removeAssignedOwner($input:AssignOwnerOrTeamInput!) {
 				  removeAssignedOwner(input:$input) {
 					alwaysNil
 				  }
@@ -1888,10 +1888,287 @@ func TestDeleteAssignedOwner(t *testing.T) {
 	})
 }
 
+func TestAssignTeam(t *testing.T) {
+	logger := logtest.Scoped(t)
+	testDB := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDB)
+	git := fakeGitserver{}
+	own := fakeOwnService{}
+	ctx := context.Background()
+	repo := types.Repo{Name: "test-repo-1", ID: 101}
+	err := db.Repos().Create(ctx, &repo)
+	require.NoError(t, err)
+	// Creating 2 users, only "hasPermission" user has rights to assign owners.
+	hasPermission, err := db.Users().Create(ctx, database.NewUser{Username: "has-permission"})
+	require.NoError(t, err)
+	noPermission, err := db.Users().Create(ctx, database.NewUser{Username: "no-permission"})
+	require.NoError(t, err)
+	// Creating a team.
+	team := createTeam(t, ctx, db, "team-A")
+	// RBAC stuff below.
+	permission, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
+		Namespace: rbactypes.OwnershipNamespace,
+		Action:    rbactypes.OwnershipAssignAction,
+	})
+	require.NoError(t, err)
+	role, err := db.Roles().Create(ctx, "Can assign owners", false)
+	require.NoError(t, err)
+	err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
+		RoleID:       role.ID,
+		PermissionID: permission.ID,
+	})
+	require.NoError(t, err)
+	err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
+		UserID: hasPermission.ID,
+		RoleID: role.ID,
+	})
+	require.NoError(t, err)
+	// RBAC stuff finished. Creating a GraphQL schema.
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adminCtx := actor.WithActor(ctx, actor.FromUser(hasPermission.ID))
+	userCtx := actor.WithActor(ctx, actor.FromUser(noPermission.ID))
+
+	getBaseTest := func() *graphqlbackend.Test {
+		return &graphqlbackend.Test{
+			Context: userCtx,
+			Schema:  schema,
+			Query: `
+				mutation assignTeam($input:AssignOwnerOrTeamInput!) {
+				  assignTeam(input:$input) {
+					alwaysNil
+				  }
+				}`,
+			Variables: map[string]any{"input": map[string]any{
+				"assignedOwnerID": string(graphqlbackend.MarshalTeamID(team.ID)),
+				"repoID":          string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+				"absolutePath":    "",
+			}},
+		}
+	}
+
+	removeTeams := func() {
+		t.Helper()
+		_, err := testDB.ExecContext(ctx, "DELETE FROM assigned_teams")
+		require.NoError(t, err)
+	}
+
+	assertAssignedTeam := func(t *testing.T, ownerID, whoAssigned int32, repoID api.RepoID, path string) {
+		t.Helper()
+		owners, err := db.AssignedTeams().ListAssignedTeamsForRepo(ctx, repoID)
+		require.NoError(t, err)
+		require.Len(t, owners, 1)
+		owner := owners[0]
+		assert.Equal(t, ownerID, owner.OwnerTeamID)
+		assert.Equal(t, whoAssigned, owner.WhoAssignedUserID)
+		assert.Equal(t, path, owner.FilePath)
+	}
+
+	assertNoAssignedOwners := func(t *testing.T, repoID api.RepoID) {
+		t.Helper()
+		owners, err := db.AssignedTeams().ListAssignedTeamsForRepo(ctx, repoID)
+		require.NoError(t, err)
+		require.Empty(t, owners)
+	}
+
+	t.Run("non-admin cannot assign a team", func(t *testing.T) {
+		t.Cleanup(removeTeams)
+		baseTest := getBaseTest()
+		expectedErrs := []*gqlerrors.QueryError{{
+			Message: "user is missing permission OWNERSHIP#ASSIGN",
+			Path:    []any{"assignTeam"},
+		}}
+		baseTest.ExpectedErrors = expectedErrs
+		baseTest.ExpectedResult = `{"assignTeam":null}`
+		graphqlbackend.RunTest(t, baseTest)
+		assertNoAssignedOwners(t, repo.ID)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		t.Cleanup(removeTeams)
+		baseTest := getBaseTest()
+		baseTest.Context = adminCtx
+		expectedErrs := []*gqlerrors.QueryError{{
+			Message: "assigned team ID should not be 0",
+			Path:    []any{"assignTeam"},
+		}}
+		baseTest.ExpectedErrors = expectedErrs
+		baseTest.ExpectedResult = `{"assignTeam":null}`
+		baseTest.Variables = map[string]any{"input": map[string]any{
+			"assignedOwnerID":   string(graphqlbackend.MarshalTeamID(0)),
+			"repoID":            string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+			"absolutePath":      "",
+			"whoAssignedUserID": string(graphqlbackend.MarshalUserID(hasPermission.ID)),
+		}}
+		graphqlbackend.RunTest(t, baseTest)
+		assertNoAssignedOwners(t, repo.ID)
+	})
+
+	t.Run("successfully assigned a team", func(t *testing.T) {
+		t.Cleanup(removeTeams)
+		baseTest := getBaseTest()
+		baseTest.Context = adminCtx
+		baseTest.ExpectedResult = `{"assignTeam":{"alwaysNil": null}}`
+		graphqlbackend.RunTest(t, baseTest)
+		assertAssignedTeam(t, team.ID, hasPermission.ID, repo.ID, "")
+	})
+}
+
+func TestDeleteAssignedTeam(t *testing.T) {
+	logger := logtest.Scoped(t)
+	testDB := dbtest.NewDB(logger, t)
+	db := database.NewDB(logger, testDB)
+	git := fakeGitserver{}
+	own := fakeOwnService{}
+	ctx := context.Background()
+	repo := types.Repo{Name: "test-repo-1", ID: 101}
+	err := db.Repos().Create(ctx, &repo)
+	require.NoError(t, err)
+	// Creating 2 users, only "hasPermission" user has rights to assign owners.
+	hasPermission, err := db.Users().Create(ctx, database.NewUser{Username: "has-permission"})
+	require.NoError(t, err)
+	noPermission, err := db.Users().Create(ctx, database.NewUser{Username: "non-permission"})
+	require.NoError(t, err)
+	// Creating a team.
+	team := createTeam(t, ctx, db, "team-A")
+	// Creating an existing assigned team.
+	require.NoError(t, db.AssignedTeams().Insert(ctx, team.ID, repo.ID, "", hasPermission.ID))
+	// RBAC stuff below.
+	permission, err := db.Permissions().Create(ctx, database.CreatePermissionOpts{
+		Namespace: rbactypes.OwnershipNamespace,
+		Action:    rbactypes.OwnershipAssignAction,
+	})
+	require.NoError(t, err)
+	role, err := db.Roles().Create(ctx, "Can assign owners", false)
+	require.NoError(t, err)
+	err = db.RolePermissions().Assign(ctx, database.AssignRolePermissionOpts{
+		RoleID:       role.ID,
+		PermissionID: permission.ID,
+	})
+	require.NoError(t, err)
+	err = db.UserRoles().Assign(ctx, database.AssignUserRoleOpts{
+		UserID: hasPermission.ID,
+		RoleID: role.ID,
+	})
+	require.NoError(t, err)
+	// RBAC stuff finished. Creating a GraphQL schema.
+	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adminCtx := actor.WithActor(ctx, actor.FromUser(hasPermission.ID))
+	userCtx := actor.WithActor(ctx, actor.FromUser(noPermission.ID))
+
+	getBaseTest := func() *graphqlbackend.Test {
+		return &graphqlbackend.Test{
+			Context: userCtx,
+			Schema:  schema,
+			Query: `
+				mutation removeAssignedTeam($input:AssignOwnerOrTeamInput!) {
+				  removeAssignedTeam(input:$input) {
+					alwaysNil
+				  }
+				}`,
+			Variables: map[string]any{"input": map[string]any{
+				"assignedOwnerID": string(graphqlbackend.MarshalTeamID(team.ID)),
+				"repoID":          string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+				"absolutePath":    "",
+			}},
+		}
+	}
+
+	assertTeamExists := func(t *testing.T) {
+		t.Helper()
+		teams, err := db.AssignedTeams().ListAssignedTeamsForRepo(ctx, repo.ID)
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		owner := teams[0]
+		assert.Equal(t, team.ID, owner.OwnerTeamID)
+		assert.Equal(t, hasPermission.ID, owner.WhoAssignedUserID)
+		assert.Equal(t, "", owner.FilePath)
+	}
+
+	assertNoAssignedTeams := func(t *testing.T) {
+		t.Helper()
+		owners, err := db.AssignedTeams().ListAssignedTeamsForRepo(ctx, repo.ID)
+		require.NoError(t, err)
+		require.Empty(t, owners)
+	}
+
+	t.Run("cannot delete assigned owner without permission", func(t *testing.T) {
+		baseTest := getBaseTest()
+		expectedErrs := []*gqlerrors.QueryError{{
+			Message: "user is missing permission OWNERSHIP#ASSIGN",
+			Path:    []any{"removeAssignedTeam"},
+		}}
+		baseTest.ExpectedErrors = expectedErrs
+		baseTest.ExpectedResult = `{"removeAssignedTeam":null}`
+		graphqlbackend.RunTest(t, baseTest)
+		assertTeamExists(t)
+	})
+
+	t.Run("bad request", func(t *testing.T) {
+		baseTest := getBaseTest()
+		baseTest.Context = adminCtx
+		expectedErrs := []*gqlerrors.QueryError{{
+			Message: "assigned team ID should not be 0",
+			Path:    []any{"removeAssignedTeam"},
+		}}
+		baseTest.ExpectedErrors = expectedErrs
+		baseTest.ExpectedResult = `{"removeAssignedTeam":null}`
+		baseTest.Variables = map[string]any{"input": map[string]any{
+			"assignedOwnerID": string(graphqlbackend.MarshalUserID(0)),
+			"repoID":          string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+			"absolutePath":    "",
+		}}
+		graphqlbackend.RunTest(t, baseTest)
+		assertTeamExists(t)
+	})
+
+	t.Run("assigned owner not found", func(t *testing.T) {
+		baseTest := getBaseTest()
+		baseTest.Context = adminCtx
+		expectedErrs := []*gqlerrors.QueryError{{
+			Message: `deleting assigned team: cannot delete assigned owner team with ID=1337 for "" path for repo with ID=1`,
+			Path:    []any{"removeAssignedTeam"},
+		}}
+		baseTest.ExpectedErrors = expectedErrs
+		baseTest.ExpectedResult = `{"removeAssignedTeam":null}`
+		baseTest.Variables = map[string]any{"input": map[string]any{
+			"assignedOwnerID": string(graphqlbackend.MarshalUserID(1337)),
+			"repoID":          string(graphqlbackend.MarshalRepositoryID(repo.ID)),
+			"absolutePath":    "",
+		}}
+		graphqlbackend.RunTest(t, baseTest)
+		assertTeamExists(t)
+	})
+
+	t.Run("assigned owner successfully deleted", func(t *testing.T) {
+		baseTest := getBaseTest()
+		baseTest.Context = adminCtx
+		baseTest.ExpectedResult = `{"removeAssignedTeam":{"alwaysNil": null}}`
+		graphqlbackend.RunTest(t, baseTest)
+		assertNoAssignedTeams(t)
+	})
+}
+
 func Test(t *testing.T) {
 	fmt.Println(string(graphqlbackend.MarshalUserID(1)))
 	fmt.Println(string(graphqlbackend.MarshalUserID(62)))
 	fmt.Println(string(graphqlbackend.MarshalUserID(69)))
 	fmt.Println(string(graphqlbackend.MarshalUserID(70)))
 	fmt.Println(string(graphqlbackend.MarshalRepositoryID(7)))
+}
+
+func createTeam(t *testing.T, ctx context.Context, db database.DB, teamName string) *types.Team {
+	t.Helper()
+	err := db.Teams().CreateTeam(ctx, &types.Team{Name: teamName})
+	require.NoError(t, err)
+	team, err := db.Teams().GetTeamByName(ctx, teamName)
+	require.NoError(t, err)
+	return team
 }


### PR DESCRIPTION
Test plan:
GraphQL tests added.

Closes https://github.com/sourcegraph/sourcegraph/issues/52988.

Depends on https://github.com/sourcegraph/sourcegraph/pull/53022.