### PR TITLE
Improve readability of chatTranscript in feedback logging

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -727,13 +727,14 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     public sendEvent(event: string, value: string): void {
         const isPrivateInstance = new URL(this.config.serverEndpoint).href !== DOTCOM_URL.href
         const endpointUri = { serverEndpoint: this.config.serverEndpoint }
+        const chatTranscript = { chatTranscript: this.transcript.toChat() }
         switch (event) {
             case 'feedback':
                 // Only include context for dot com users with connected codebase
                 logEvent(
                     `CodyVSCodeExtension:codyFeedback:${value}`,
                     null,
-                    !isPrivateInstance && this.codebaseContext.getCodebase() ? this.transcript.toChat() : null
+                    !isPrivateInstance && this.codebaseContext.getCodebase() ? chatTranscript : null
                 )
                 break
             case 'token':


### PR DESCRIPTION
Previously when codyFeedback was getting logged, for our dotcom users we would send chatTranscript but it wasnt formatted properly and looked like the below:
![image](https://github.com/sourcegraph/sourcegraph/assets/32119652/75e52c18-f864-4537-9f4f-07cad2095ab0)

now with the new change it will live under a proper key called `chatTranscript` and the chat will be an array within that
![image](https://github.com/sourcegraph/sourcegraph/assets/32119652/f3fc2ebc-f674-40ce-9b19-f4c695ccc2c2)

## Test plan

tested locally
