### PR TITLE
cody: fix workspace file path

### DIFF
--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -94,7 +94,9 @@ function getHighlightedTokenHTML(token: HighlightedToken, workspaceRootPath?: st
     let filePath = token.outerValue.trim()
     // Create workspace relative links for existing files (excluding directories)
     if (!token.isHallucinated && workspaceRootPath && filePath.includes('.')) {
-        const fileUri = `file://${workspaceRootPath}/${filePath}`
+        // Need to decode the file path because it's encoded in the markdown
+        filePath = decodeURIComponent(filePath.replace(/["'`]/g, ''))
+        const fileUri = `vscode://file${workspaceRootPath}/${filePath}`
         const uri = new URL(fileUri).href
         filePath = `<a href="${uri}">${filePath}</a>`
     }

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,7 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Open file paths from Cody's responses in workspace with correct portocel. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Open file paths from Cody's responses in a workspace with the correct protocol. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Open file paths from Cody's responses in workspace with correct portocel. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+
 ### Changed
 
 ## [0.2.2]


### PR DESCRIPTION
RE https://sourcegraph.slack.com/archives/C04MZPE4JKD/p1686155491423079?thread_ts=1686153175.633369&cid=C04MZPE4JKD

Close https://github.com/sourcegraph/sourcegraph/issues/52863

Fix the issue introduced in https://github.com/sourcegraph/sourcegraph/pull/53069 where file paths were not clickable 

I pushed a commit that updated the `protocol` from `vscode://` to `file://` accidentally. This PR fixes the issue.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
 
Build Cody from this branch and ask Cody `what files should I edit to add a graphQL type`.
You can try clicking on the file path to validate if they work or not