### PR TITLE
gateway: Add more models to set of valid entries

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
@@ -24,11 +24,16 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             // for currently available Anthropic models. Note that we also need to
             // allow list the models on the Cody Gateway side.
             case 'anthropic/claude-v1':
+            case 'anthropic/claude-v1-100k':
             case 'anthropic/claude-v1.0':
             case 'anthropic/claude-v1.2':
             case 'anthropic/claude-v1.3':
+            case 'anthropic/claude-v1.3-100k':
             case 'anthropic/claude-instant-v1':
+            case 'anthropic/claude-instant-v1-100k':
             case 'anthropic/claude-instant-v1.0':
+            case 'anthropic/claude-instant-v1.1':
+            case 'anthropic/claude-instant-v1.1-100k':
             // See here: https://platform.openai.com/docs/models/model-endpoint-compatibility
             // for currently available Anthropic models. Note that we also need to
             // allow list the models on the Cody Gateway side.

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -77,11 +77,16 @@ func (c *Config) Load() {
 	c.Anthropic.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_ANTHROPIC_ALLOWED_MODELS",
 		strings.Join([]string{
 			"claude-v1",
+			"claude-v1-100k",
 			"claude-v1.0",
 			"claude-v1.2",
 			"claude-v1.3",
+			"claude-v1.3-100k",
 			"claude-instant-v1",
+			"claude-instant-v1-100k",
 			"claude-instant-v1.0",
+			"claude-instant-v1.1",
+			"claude-instant-v1.1-100k",
 		}, ","),
 		"Anthropic models that can be used."))
 


### PR DESCRIPTION
This doesn't enable it for anyone, but allows us to switch things on for separate licenses. This can become useful in dev.

## Test plan

n/a