### PR TITLE
executor: Fix Skip File Location on Firecracker

### DIFF
--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -165,7 +165,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, job types.Job) 
 		}
 		if executorutil.IsPreStepKey(spec.CommandSpec.Key) {
 			// Check if there is a skip file. and if so, what the next step is.
-			nextStep, err := runner.NextStep(ws.Path())
+			nextStep, err := runner.NextStep(ws.WorkingDirectory())
 			if err != nil {
 				return errors.Wrap(err, "checking for skip file")
 			}

--- a/enterprise/cmd/executor/internal/worker/mocks_test.go
+++ b/enterprise/cmd/executor/internal/worker/mocks_test.go
@@ -3067,6 +3067,9 @@ type MockWorkspace struct {
 	// ScriptFilenamesFunc is an instance of a mock function object
 	// controlling the behavior of the method ScriptFilenames.
 	ScriptFilenamesFunc *WorkspaceScriptFilenamesFunc
+	// WorkingDirectoryFunc is an instance of a mock function object
+	// controlling the behavior of the method WorkingDirectory.
+	WorkingDirectoryFunc *WorkspaceWorkingDirectoryFunc
 }
 
 // NewMockWorkspace creates a new mock of the Workspace interface. All
@@ -3085,6 +3088,11 @@ func NewMockWorkspace() *MockWorkspace {
 		},
 		ScriptFilenamesFunc: &WorkspaceScriptFilenamesFunc{
 			defaultHook: func() (r0 []string) {
+				return
+			},
+		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: func() (r0 string) {
 				return
 			},
 		},
@@ -3110,6 +3118,11 @@ func NewStrictMockWorkspace() *MockWorkspace {
 				panic("unexpected invocation of MockWorkspace.ScriptFilenames")
 			},
 		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: func() string {
+				panic("unexpected invocation of MockWorkspace.WorkingDirectory")
+			},
+		},
 	}
 }
 
@@ -3125,6 +3138,9 @@ func NewMockWorkspaceFrom(i workspace.Workspace) *MockWorkspace {
 		},
 		ScriptFilenamesFunc: &WorkspaceScriptFilenamesFunc{
 			defaultHook: i.ScriptFilenames,
+		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: i.WorkingDirectory,
 		},
 	}
 }
@@ -3424,5 +3440,104 @@ func (c WorkspaceScriptFilenamesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c WorkspaceScriptFilenamesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// WorkspaceWorkingDirectoryFunc describes the behavior when the
+// WorkingDirectory method of the parent MockWorkspace instance is invoked.
+type WorkspaceWorkingDirectoryFunc struct {
+	defaultHook func() string
+	hooks       []func() string
+	history     []WorkspaceWorkingDirectoryFuncCall
+	mutex       sync.Mutex
+}
+
+// WorkingDirectory delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockWorkspace) WorkingDirectory() string {
+	r0 := m.WorkingDirectoryFunc.nextHook()()
+	m.WorkingDirectoryFunc.appendCall(WorkspaceWorkingDirectoryFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WorkingDirectory
+// method of the parent MockWorkspace instance is invoked and the hook queue
+// is empty.
+func (f *WorkspaceWorkingDirectoryFunc) SetDefaultHook(hook func() string) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WorkingDirectory method of the parent MockWorkspace instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *WorkspaceWorkingDirectoryFunc) PushHook(hook func() string) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *WorkspaceWorkingDirectoryFunc) SetDefaultReturn(r0 string) {
+	f.SetDefaultHook(func() string {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *WorkspaceWorkingDirectoryFunc) PushReturn(r0 string) {
+	f.PushHook(func() string {
+		return r0
+	})
+}
+
+func (f *WorkspaceWorkingDirectoryFunc) nextHook() func() string {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *WorkspaceWorkingDirectoryFunc) appendCall(r0 WorkspaceWorkingDirectoryFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of WorkspaceWorkingDirectoryFuncCall objects
+// describing the invocations of this function.
+func (f *WorkspaceWorkingDirectoryFunc) History() []WorkspaceWorkingDirectoryFuncCall {
+	f.mutex.Lock()
+	history := make([]WorkspaceWorkingDirectoryFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// WorkspaceWorkingDirectoryFuncCall is an object that describes an
+// invocation of method WorkingDirectory on an instance of MockWorkspace.
+type WorkspaceWorkingDirectoryFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c WorkspaceWorkingDirectoryFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c WorkspaceWorkingDirectoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }

--- a/enterprise/cmd/executor/internal/worker/runtime/mocks_test.go
+++ b/enterprise/cmd/executor/internal/worker/runtime/mocks_test.go
@@ -1224,6 +1224,9 @@ type MockWorkspace struct {
 	// ScriptFilenamesFunc is an instance of a mock function object
 	// controlling the behavior of the method ScriptFilenames.
 	ScriptFilenamesFunc *WorkspaceScriptFilenamesFunc
+	// WorkingDirectoryFunc is an instance of a mock function object
+	// controlling the behavior of the method WorkingDirectory.
+	WorkingDirectoryFunc *WorkspaceWorkingDirectoryFunc
 }
 
 // NewMockWorkspace creates a new mock of the Workspace interface. All
@@ -1242,6 +1245,11 @@ func NewMockWorkspace() *MockWorkspace {
 		},
 		ScriptFilenamesFunc: &WorkspaceScriptFilenamesFunc{
 			defaultHook: func() (r0 []string) {
+				return
+			},
+		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: func() (r0 string) {
 				return
 			},
 		},
@@ -1267,6 +1275,11 @@ func NewStrictMockWorkspace() *MockWorkspace {
 				panic("unexpected invocation of MockWorkspace.ScriptFilenames")
 			},
 		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: func() string {
+				panic("unexpected invocation of MockWorkspace.WorkingDirectory")
+			},
+		},
 	}
 }
 
@@ -1282,6 +1295,9 @@ func NewMockWorkspaceFrom(i workspace.Workspace) *MockWorkspace {
 		},
 		ScriptFilenamesFunc: &WorkspaceScriptFilenamesFunc{
 			defaultHook: i.ScriptFilenames,
+		},
+		WorkingDirectoryFunc: &WorkspaceWorkingDirectoryFunc{
+			defaultHook: i.WorkingDirectory,
 		},
 	}
 }
@@ -1581,6 +1597,105 @@ func (c WorkspaceScriptFilenamesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c WorkspaceScriptFilenamesFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// WorkspaceWorkingDirectoryFunc describes the behavior when the
+// WorkingDirectory method of the parent MockWorkspace instance is invoked.
+type WorkspaceWorkingDirectoryFunc struct {
+	defaultHook func() string
+	hooks       []func() string
+	history     []WorkspaceWorkingDirectoryFuncCall
+	mutex       sync.Mutex
+}
+
+// WorkingDirectory delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockWorkspace) WorkingDirectory() string {
+	r0 := m.WorkingDirectoryFunc.nextHook()()
+	m.WorkingDirectoryFunc.appendCall(WorkspaceWorkingDirectoryFuncCall{r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the WorkingDirectory
+// method of the parent MockWorkspace instance is invoked and the hook queue
+// is empty.
+func (f *WorkspaceWorkingDirectoryFunc) SetDefaultHook(hook func() string) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// WorkingDirectory method of the parent MockWorkspace instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *WorkspaceWorkingDirectoryFunc) PushHook(hook func() string) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *WorkspaceWorkingDirectoryFunc) SetDefaultReturn(r0 string) {
+	f.SetDefaultHook(func() string {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *WorkspaceWorkingDirectoryFunc) PushReturn(r0 string) {
+	f.PushHook(func() string {
+		return r0
+	})
+}
+
+func (f *WorkspaceWorkingDirectoryFunc) nextHook() func() string {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *WorkspaceWorkingDirectoryFunc) appendCall(r0 WorkspaceWorkingDirectoryFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of WorkspaceWorkingDirectoryFuncCall objects
+// describing the invocations of this function.
+func (f *WorkspaceWorkingDirectoryFunc) History() []WorkspaceWorkingDirectoryFuncCall {
+	f.mutex.Lock()
+	history := make([]WorkspaceWorkingDirectoryFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// WorkspaceWorkingDirectoryFuncCall is an object that describes an
+// invocation of method WorkingDirectory on an instance of MockWorkspace.
+type WorkspaceWorkingDirectoryFuncCall struct {
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c WorkspaceWorkingDirectoryFuncCall) Args() []interface{} {
+	return []interface{}{}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c WorkspaceWorkingDirectoryFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/cmd/executor/internal/worker/workspace/docker.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/docker.go
@@ -67,6 +67,10 @@ func (w dockerWorkspace) Path() string {
 	return w.workspaceDir
 }
 
+func (w dockerWorkspace) WorkingDirectory() string {
+	return w.workspaceDir
+}
+
 func (w dockerWorkspace) ScriptFilenames() []string {
 	return w.scriptFilenames
 }

--- a/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/firecracker.go
@@ -22,6 +22,7 @@ type firecrackerWorkspace struct {
 	scriptFilenames []string
 	blockDeviceFile string
 	blockDevice     string
+	tmpMountDir     string
 	logger          command.Logger
 }
 
@@ -81,6 +82,7 @@ func NewFirecrackerWorkspace(
 		scriptFilenames: scriptPaths,
 		blockDeviceFile: blockDeviceFile,
 		blockDevice:     blockDevice,
+		tmpMountDir:     tmpMountDir,
 		logger:          logger,
 	}, err
 }
@@ -186,6 +188,10 @@ func detachLoopDevice(ctx context.Context, cmdRunner util.CmdRunner, blockDevice
 
 func (w firecrackerWorkspace) Path() string {
 	return w.blockDevice
+}
+
+func (w firecrackerWorkspace) WorkingDirectory() string {
+	return w.tmpMountDir
 }
 
 func (w firecrackerWorkspace) ScriptFilenames() []string {

--- a/enterprise/cmd/executor/internal/worker/workspace/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/kubernetes.go
@@ -57,6 +57,10 @@ func (w kubernetesWorkspace) Path() string {
 	return w.workspaceDir
 }
 
+func (w kubernetesWorkspace) WorkingDirectory() string {
+	return w.workspaceDir
+}
+
 func (w kubernetesWorkspace) ScriptFilenames() []string {
 	return w.scriptFilenames
 }

--- a/enterprise/cmd/executor/internal/worker/workspace/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace/workspace.go
@@ -15,6 +15,8 @@ type Workspace interface {
 	// Path represents the block device path when firecracker is enabled and the
 	// directory when firecracker is disabled where the workspace is configured.
 	Path() string
+	// WorkingDirectory returns the working directory where the repository, scripts, and supporting files are located.
+	WorkingDirectory() string
 	// ScriptFilenames holds the ordered set of script filenames to be invoked.
 	ScriptFilenames() []string
 	// Remove cleans up the workspace post execution. If keep workspace is true,


### PR DESCRIPTION
Found while testing wolfi images. When running on firecracker, the workspace `Path()` returns the block device. When we really need the tmp mount directory.

Added a new function to return the working directory to lookup the skip file from.

## Test plan

Function testing on dogfood.

![Screenshot 2023-06-07 at 12 34 10](https://github.com/sourcegraph/sourcegraph/assets/38407415/43a193b4-7b35-4d81-b1b9-aeab0860e6be)

