### PR TITLE
gRPC: enable zoekt separately

### DIFF
--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -98,6 +98,13 @@ func FromContext(ctx context.Context) *FlagSet {
 	return nil
 }
 
+func CopyContext(dst, from context.Context) context.Context {
+	if flags := from.Value(flagContextKey{}); flags != nil {
+		return context.WithValue(dst, flagContextKey{}, flags)
+	}
+	return dst
+}
+
 func GetEvaluatedFlagSet(ctx context.Context) EvaluatedFlagSet {
 	if flagSet := FromContext(ctx); flagSet != nil {
 		return getEvaluatedFlagSetFromCache(flagSet)

--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/actor",
         "//internal/api",
         "//internal/conf",
+        "//internal/featureflag",
         "//internal/grpc",
         "//internal/grpc/defaults",
         "//internal/honey",

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -140,7 +140,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	// GobCache exists so we only pay the cost of marshalling a query once
 	// when we aggregate it out over all the replicas. Zoekt's RPC layers
 	// unwrap this before passing it on to the Zoekt evaluation layers.
-	if !grpc.IsGRPCEnabled(ctx) {
+	if !IsZoektGRPCEnabled(ctx) {
 		q = &query.GobCache{Q: q}
 	}
 
@@ -224,7 +224,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	// GobCache exists, so we only pay the cost of marshalling a query once
 	// when we aggregate it out over all the replicas. Zoekt's RPC layers
 	// unwrap this before passing it on to the Zoekt evaluation layers.
-	if !grpc.IsGRPCEnabled(ctx) {
+	if !IsZoektGRPCEnabled(ctx) {
 		q = &query.GobCache{Q: q}
 	}
 

--- a/internal/search/zoekt/BUILD.bazel
+++ b/internal/search/zoekt/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/api",
         "//internal/conf",
         "//internal/database",
+        "//internal/featureflag",
         "//internal/httpcli",
         "//internal/search",
         "//internal/search/backend",

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
@@ -600,6 +601,8 @@ func contextWithoutDeadline(cOld context.Context) (context.Context, context.Canc
 
 	// Set trace context so we still get spans propagated
 	cNew = trace.CopyContext(cNew, cOld)
+
+	cNew = featureflag.CopyContext(cNew, cOld)
 
 	// Copy actor from cOld to cNew.
 	cNew = actor.WithActor(cNew, actor.FromContext(cOld))


### PR DESCRIPTION
I merged/rolled out gRPC for Zoekt yesterday, but it ran into [issues](https://sourcegraph.slack.com/archives/C04HCK4K3DL/p1686100826372909). This feature-flags the gRPC API for Zoekt separately from the primary config option so it can be tested separately (and doesn't require a deployment to enable/disable). In retrospect, I should have rolled it out this way to start. 

## Test plan

Tested that disabling the feature flag does not use gRPC

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
