### PR TITLE
[Backport 5.0] executors: Add maven to bundled executor

### DIFF
--- a/enterprise/cmd/bundled-executor/Dockerfile
+++ b/enterprise/cmd/bundled-executor/Dockerfile
@@ -42,7 +42,9 @@ RUN set -ex && \
 # Install additional common tools for running batch changes.
 RUN apk add --no-cache \
     xmlstarlet \
-    python3 py3-pip
+    python3 py3-pip \
+    openjdk11 \
+    maven
 
 # Install batcheshelper.
 COPY batcheshelper /usr/local/bin/

--- a/enterprise/cmd/bundled-executor/README.md
+++ b/enterprise/cmd/bundled-executor/README.md
@@ -1,0 +1,29 @@
+# Bundled Executor
+
+The bundled executor is a simple executor that runs commands on the container instead of delegating to spawned
+containers.
+
+The runtime of this executor is `shell`.
+
+## Configuration
+
+Since the bundled executor does not spawn Docker Containers to run Jobs, `src` cannot be used for Batch Changes. To run
+Batch Changes, Native Execution must be enabled.
+
+### Native Execution
+
+See [Documentation](../../../doc/admin/executors/native_execution.md) on how to enable Native Execution.
+
+## Clean Workspace
+
+To ensure a clean workspace, the executor will exit with code `0` once a Job is complete. It depends on the Platform to
+create a new instance when it exits.
+
+## Available Commands
+
+- `batcheshelper`
+- `xmlstarlet`
+- Python 3
+- `pip`
+- Java 11 (OpenJDK)
+- Maven 3.6.3


### PR DESCRIPTION
Add Maven 3.6.3 with Java 11.

Also add a `README.md` to help give context for the image.

## Test plan

Local testing.

![Screenshot 2023-06-07 at 09 56 27](https://github.com/sourcegraph/sourcegraph/assets/38407415/6feabb42-d4f7-4a12-ba4a-39c4eefbd662)
