### PR TITLE
sg: make embeddings part of default runset

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -38,7 +38,6 @@ Available comamndsets in `sg.config.yaml`:
 * codeintel-kubernetes
 * cody-gateway
 * dotcom
-* embeddings
 * enterprise
 * enterprise-bazel
 * enterprise-codeinsights

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1229,6 +1229,7 @@ commandsets:
       - zoekt-web-0
       - zoekt-web-1
       - blobstore
+      - embeddings
 
   enterprise-e2e:
     <<: *enterprise_set
@@ -1264,6 +1265,7 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - cody-gateway
+      - embeddings
     env:
       SOURCEGRAPHDOTCOM_MODE: true
 
@@ -1537,33 +1539,6 @@ commandsets:
       - blobstore
       - batches-executor-kubernetes
       - batcheshelper-builder
-
-  embeddings:
-    requiresDevPrivate: true
-    checks:
-      - docker
-      - redis
-      - postgres
-      - git
-    commands:
-      - embeddings
-      - frontend
-      - worker
-      - repo-updater
-      - web
-      - gitserver-0
-      - gitserver-1
-      - searcher
-      - symbols
-      - caddy
-      - docsite
-      - syntax-highlighter
-      - github-proxy
-      - zoekt-index-0
-      - zoekt-index-1
-      - zoekt-web-0
-      - zoekt-web-1
-      - blobstore
 
   iam:
     requiresDevPrivate: true


### PR DESCRIPTION
Now that embeddings is going to be part of the standard installation, we should be running it by default in the dev environment. Running the service is quite cheap if it's not being used, so it should not cause a noticeable increase in resource usage.

## Test plan

Ran `sg start` and confirmed that embeddings search works. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
