### PR TITLE
Setup release protector for 5.1

### DIFF
--- a/.github/workflows/release-protector.yml
+++ b/.github/workflows/release-protector.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check if latest release branch exists
         id: checkout
         run: |
-          branch="5.0"
+          branch="5.1"
           if curl --silent -I "https://api.github.com/repos/sourcegraph/sourcegraph/git/refs/heads/${branch}" | grep "HTTP/2 200"; then
             echo "::set-output name=exists::true"
           else


### PR DESCRIPTION



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Will test once this is merged. The release protector will block merging PRs after branch cut.