### PR TITLE
web: Add dotcom host check to event logger

### DIFF
--- a/client/web/src/cody/search/CodySearchPage.tsx
+++ b/client/web/src/cody/search/CodySearchPage.tsx
@@ -13,6 +13,7 @@ import { Alert, Form, Input, LoadingSpinner, Text, Badge, Link, useSessionStorag
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { useURLSyncedString } from '../../hooks/useUrlSyncedString'
 import { eventLogger } from '../../tracking/eventLogger'
+import { DOTCOM_URL } from '../../tracking/util'
 import { CodyIcon } from '../components/CodyIcon'
 import { useIsCodyEnabled } from '../useIsCodyEnabled'
 
@@ -50,12 +51,18 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
 
     const onSubmit = useCallback(() => {
         const sanitizedInput = input.trim()
+        const dotcomHost = DOTCOM_URL.href
+        const isPrivateInstance = window.location.host !== dotcomHost
 
         if (!sanitizedInput) {
             return
         }
 
-        eventLogger.log('web:codySearch:submit', { input: sanitizedInput }, { input: sanitizedInput })
+        eventLogger.log(
+            'web:codySearch:submit',
+            !isPrivateInstance ? { input: sanitizedInput } : null,
+            !isPrivateInstance ? { input: sanitizedInput } : null
+        )
         setLoading(true)
         translateToQuery(sanitizedInput, authenticatedUser).then(
             query => {
@@ -64,8 +71,8 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
                 if (query) {
                     eventLogger.log(
                         'web:codySearch:submitSucceeded',
-                        { input: sanitizedInput, translatedQuery: query },
-                        { input: sanitizedInput, translatedQuery: query }
+                        !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null,
+                        !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null
                     )
                     setCodySearchInput(JSON.stringify({ input: sanitizedInput, translatedQuery: query }))
                     navigate({
@@ -75,8 +82,8 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
                 } else {
                     eventLogger.log(
                         'web:codySearch:submitFailed',
-                        { input: sanitizedInput, reason: 'untranslatable' },
-                        { input: sanitizedInput, reason: 'untranslatable' }
+                        !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null,
+                        !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null
                     )
                     setInputError('Cody does not understand this query. Try rephrasing it.')
                 }
@@ -84,16 +91,20 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
             error => {
                 eventLogger.log(
                     'web:codySearch:submitFailed',
-                    {
-                        input: sanitizedInput,
-                        reason: 'unreachable',
-                        error: error?.message,
-                    },
-                    {
-                        input: sanitizedInput,
-                        reason: 'unreachable',
-                        error: error?.message,
-                    }
+                    !isPrivateInstance
+                        ? {
+                              input: sanitizedInput,
+                              reason: 'unreachable',
+                              error: error?.message,
+                          }
+                        : null,
+                    !isPrivateInstance
+                        ? {
+                              input: sanitizedInput,
+                              reason: 'unreachable',
+                              error: error?.message,
+                          }
+                        : null
                 )
                 setLoading(false)
                 setInputError(`Unable to reach Cody. Error: ${error?.message}`)

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,3 +1,5 @@
+import { URL } from 'url'
+
 import React, { useMemo, useState } from 'react'
 
 import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiThumbUp, mdiThumbDown, mdiOpenInNew } from '@mdi/js'
@@ -14,6 +16,7 @@ import { Button, Icon, Alert, useSessionStorage, Link, Text } from '@sourcegraph
 import { AuthenticatedUser } from '../../auth'
 import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../batches/utils'
 import { eventLogger } from '../../tracking/eventLogger'
+import { DOTCOM_URL } from '../../tracking/util'
 
 import {
     CreateAction,
@@ -26,6 +29,7 @@ import { SearchActionsMenu } from './SearchActionsMenu'
 
 import styles from './SearchResultsInfoBar.module.scss'
 
+console.log(DOTCOM_URL)
 export interface SearchResultsInfoBarProps
     extends TelemetryProps,
         PlatformContextProps<'settings' | 'sourcegraphURL'>,
@@ -135,10 +139,13 @@ export const SearchResultsInfoBar: React.FunctionComponent<
     }
 
     const location = useLocation()
+    const dotcomHost = DOTCOM_URL.href
+    const isPrivateInstance = window.location.host !== dotcomHost
     const refFromCodySearch = new URLSearchParams(location.search).get('ref') === 'cody-search'
     const [codySearchInputString] = useSessionStorage<string>('cody-search-input', '')
     const codySearchInput: { input?: string; translatedQuery?: string } = JSON.parse(codySearchInputString || '{}')
     const [codyFeedback, setCodyFeedback] = useState<null | boolean>(null)
+    //check if url equals dotcom endpoint, set boolean
 
     const collectCodyFeedback = (positive: boolean): void => {
         if (codyFeedback !== null) {
@@ -147,8 +154,8 @@ export const SearchResultsInfoBar: React.FunctionComponent<
 
         eventLogger.log(
             'web:codySearch:feedbackSubmitted',
-            { ...codySearchInput, positive },
-            { ...codySearchInput, positive }
+            !isPrivateInstance ? { ...codySearchInput, positive } : null,
+            !isPrivateInstance ? { ...codySearchInput, positive } : null
         )
         setCodyFeedback(positive)
     }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,5 +1,3 @@
-import { URL } from 'url'
-
 import React, { useMemo, useState } from 'react'
 
 import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiThumbUp, mdiThumbDown, mdiOpenInNew } from '@mdi/js'
@@ -29,7 +27,6 @@ import { SearchActionsMenu } from './SearchActionsMenu'
 
 import styles from './SearchResultsInfoBar.module.scss'
 
-console.log(DOTCOM_URL)
 export interface SearchResultsInfoBarProps
     extends TelemetryProps,
         PlatformContextProps<'settings' | 'sourcegraphURL'>,
@@ -145,7 +142,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<
     const [codySearchInputString] = useSessionStorage<string>('cody-search-input', '')
     const codySearchInput: { input?: string; translatedQuery?: string } = JSON.parse(codySearchInputString || '{}')
     const [codyFeedback, setCodyFeedback] = useState<null | boolean>(null)
-    //check if url equals dotcom endpoint, set boolean
 
     const collectCodyFeedback = (positive: boolean): void => {
         if (codyFeedback !== null) {

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -1,5 +1,7 @@
 import { formatISO, startOfWeek } from 'date-fns'
 
+export const DOTCOM_URL = new URL('https://sourcegraph.com')
+
 /**
  * Strip provided URL parameters and update window history
  */


### PR DESCRIPTION
Check if the current host is sourcegraph.com before logging events. This ensures we do not log events on Sourcegraph Cloud instances, since those events are logged by the hosted service.



## Test plan

Deploy locally
Verify in event log
Verify in BigQuery event table for dotcom.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
