### PR TITLE
Cody: Track the range non-stop fixup is editing

### DIFF
--- a/client/cody/src/non-stop/FixupDocumentEditObserver.ts
+++ b/client/cody/src/non-stop/FixupDocumentEditObserver.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { FixupFileCollection, FixupTextChanged } from './roles'
+import { TextChange, updateRangeMultipleChanges } from './tracked-range'
 
 /**
  * Observes text document changes and updates the regions with active fixups.
@@ -30,15 +31,15 @@ export class FixupDocumentEditObserver {
                 this.provider_.textDidChange(task)
                 break
             }
+            const updatedRange = updateRangeMultipleChanges(
+                task.selectionRange,
+                new Array<TextChange>(...event.contentChanges)
+            )
+            if (!updatedRange.isEqual(task.selectionRange)) {
+                task.selectionRange = updatedRange
+                // We don't notify about this range change. vscode will update
+                // any text decorations.
+            }
         }
-        // TODO: Update the selection ranges which were edited, see
-        // ./tracked-range or consider using simpler line-based
-        // ranges. Until this is implemented adding/deleting lines
-        // before fixups will cause conflicts.
-        //
-        // Need to clarify whether multi-range edits are progressive in the
-        // sense that edit 2 refers to ranges updated after edit 1, or if
-        // all the edits refer to ranges in the original document.
-        // TODO: Create new code lenses with updated ranges for each task with .set()
     }
 }

--- a/client/cody/src/non-stop/FixupDocumentEditObserver.ts
+++ b/client/cody/src/non-stop/FixupDocumentEditObserver.ts
@@ -19,7 +19,7 @@ export class FixupDocumentEditObserver {
             return
         }
         const tasks = this.provider_.tasksForFile(file)
-        // Notify which tasks have changed text
+        // Notify which tasks have changed text or the range edits apply to
         for (const task of tasks) {
             for (const edit of event.contentChanges) {
                 if (
@@ -37,8 +37,7 @@ export class FixupDocumentEditObserver {
             )
             if (!updatedRange.isEqual(task.selectionRange)) {
                 task.selectionRange = updatedRange
-                // We don't notify about this range change. vscode will update
-                // any text decorations.
+                this.provider_.rangeDidChange(task)
             }
         }
     }

--- a/client/cody/src/non-stop/roles.ts
+++ b/client/cody/src/non-stop/roles.ts
@@ -34,4 +34,5 @@ export interface FixupIdleTaskRunner {
  */
 export interface FixupTextChanged {
     textDidChange(task: FixupTask): void
+    rangeDidChange(task: FixupTask): void
 }

--- a/client/cody/src/non-stop/tracked-range.ts
+++ b/client/cody/src/non-stop/tracked-range.ts
@@ -1,15 +1,38 @@
 import * as vscode from 'vscode'
 
 // See vscode.TextDocumentContentChangeEvent
-interface TextChange {
+export interface TextChange {
     range: vscode.Range
     text: string
 }
 
+// Given a range and *multiple* edits, update the range for the edit. This
+// works by adjusting the range of each successive edit so that the edits
+// "stack."
+//
+// vscode's edit operations don't allow overlapping ranges. So we can just
+// adjust apply the edits in reverse order and end up with the right
+// adjustment for a compound edit.
+//
+// Note, destructively mutates the `changes` array.
+export function updateRangeMultipleChanges(range: vscode.Range, changes: TextChange[]): vscode.Range {
+    changes.sort((a, b) => (b.range.start.isBefore(a.range.start) ? -1 : 1))
+    for (let i = 0; i < changes.length - 1; i++) {
+        console.assert(
+            changes[i].range.start.isAfterOrEqual(changes[i + 1].range.end),
+            'vscode edit model assumption incorrect'
+        )
+    }
+    for (const change of changes) {
+        range = updateRange(range, change)
+    }
+    return range
+}
+
 // Given a range and an edit, updates the range for the edit. Edits at the
-// start or end of the range shrink the range. If the range is deleted, returns
-// null.
-export function updateRange(range: vscode.Range, change: TextChange): vscode.Range | null {
+// start or end of the range shrink the range. If the range is deleted, return a
+// zero-width range at the start of the edit.
+export function updateRange(range: vscode.Range, change: TextChange): vscode.Range {
     const lines = change.text.split(/\r\n|\r|\n/m)
     const insertedLastLine = lines.at(-1)?.length
     if (typeof insertedLastLine === 'undefined') {
@@ -45,7 +68,7 @@ export function updateRange(range: vscode.Range, change: TextChange): vscode.Ran
     }
     // ...around
     else if (change.range.start.isBeforeOrEqual(range.start) && change.range.end.isAfterOrEqual(range.end)) {
-        return null
+        return new vscode.Range(change.range.start, change.range.start)
     }
     // ...within
     else if (change.range.start.isAfterOrEqual(range.start) && change.range.end.isBeforeOrEqual(range.end)) {
@@ -84,5 +107,5 @@ export function updateRange(range: vscode.Range, change: TextChange): vscode.Ran
             change.range.start
         )
     }
-    return range.start.isEqual(range.end) ? null : range
+    return range
 }

--- a/client/cody/test/e2e/fixup-decorator.test.ts
+++ b/client/cody/test/e2e/fixup-decorator.test.ts
@@ -48,8 +48,11 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
         .find(className => className.includes('TextEditorDecorationType'))
     expect(decorationClassName).toBeDefined()
 
-    // Edit where Cody planned to type
-    await page.keyboard.type('who needs titles?')
+    // Spray edits over where Cody planned to type to cause conflicts
+    for (const ch of 'who needs titles?') {
+        await page.keyboard.type(ch)
+        await page.keyboard.press('ArrowRight')
+    }
 
     // The decorations should change to conflict markers.
     await page.waitForSelector(`${DECORATION_SELECTOR}:not([class*="${decorationClassName}"])`)


### PR DESCRIPTION
In classic Fixup, you could not touch the selection while Cody was working. The premise of non-stop Cody is that you never have to stop editing while Cody is doing fixups. So as you edit a file, we need to keep track of the range in the file Cody's diffs should stream into. This does that tracking.

## Test plan

````
pnpm test:unit -- tracked-range.test.ts
pnpm test:unit && pnpm test:integration && pnpm test:e2e
````

Manual test:

1. Set up Cody; set `"cody.experimental.nonStop": true` in user JSON.
2. Open a file with a bunch of code
3. Select a function in the middle of the file and Cody: Fixup (Experimental), instruct Cody to make some change

Then, while the edits are streaming in, and after they are done:

- Add or remove lines before where Cody is editing, then edit within the region Cody is editing
- Edit in the region where Cody is editing with and without causing conflicts
- Add or remove lines after where Cody is editing, then edit within the region Cody is editing

The CodeLens should move around so it appears in the right place in the file.

Edits before/after the region Cody is editing don't trigger diff recalculation; we are simply relying on vscode to shift our decorations around. So to trigger diff recalculation to see if the range tracking was effective, briefly edit within the region Cody edited to trigger diff recalculation.

Before this change we don't track the range so the test described above reports many spurious conflicts because the diff is out of alignment. After this change, the recomputed diff is accurate.