### PR TITLE
site-admin cody: simplify status message

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -91,17 +91,21 @@ const RepoEmbeddingJobExecutionInfo: FC<
         <>
             {state === RepoEmbeddingJobState.COMPLETED && finishedAt && (
                 <small>
-                    Embedding completed successfully <Timestamp date={finishedAt} />.
+                    Completed <Timestamp date={finishedAt} />
                 </small>
             )}
-            {state === RepoEmbeddingJobState.CANCELED && <small>Embedding was canceled.</small>}
+            {state === RepoEmbeddingJobState.CANCELED && finishedAt && (
+                <small>
+                    Stopped <Timestamp date={finishedAt} />
+                </small>
+            )}
             {state === RepoEmbeddingJobState.QUEUED && (
                 <small>
                     {cancel ? (
                         'Cancelling ...'
                     ) : (
                         <>
-                            Embedding was queued <Timestamp date={queuedAt} />.
+                            Queued <Timestamp date={queuedAt} />
                         </>
                     )}
                 </small>
@@ -112,7 +116,7 @@ const RepoEmbeddingJobExecutionInfo: FC<
                         'Cancelling ...'
                     ) : (
                         <>
-                            Embedding started processing <Timestamp date={startedAt} />.
+                            Started processing <Timestamp date={startedAt} />
                         </>
                     )}
                 </small>


### PR DESCRIPTION
I felt the status messsage were too wordy and cluttered the UI. Additionally, now the message is closer to what codeintel has for precise indexes.

Changes
- Remove prefix "Embedding"
- Remove full stop
- Show timestamp for canceled jobs: we don't track when we cancel, but we track when the job finally stopped, hence I chose "stopped" over "canceled"

<img width="935" alt="Screenshot 2023-06-08 at 10 44 51" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/b1b6d204-ebfc-4b1a-ac1d-fa76f5eaf124">

<details><summary>before</summary>
<p>
<img width="921" alt="Screenshot 2023-06-08 at 10 59 12" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/c8212c5d-2aa1-437b-9fc5-a57796724b3d">
</p>
</details> 

## Test plan

Visual inspection
