### PR TITLE
Fix issues with commenting out redacted site config fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Slow request logs now have the correct trace and span IDs attached if a trace is present on the request. [#51826](https://github.com/sourcegraph/sourcegraph/pull/51826)
 - SAML assertions to get user display name are now compared case insensitively and we do not always return an error. [#52992](https://github.com/sourcegraph/sourcegraph/pull/52992)
 - The braindot menu on the blob view no longer fetches data eagerly to prevent performance issues for larger monorepo users. [#53039](https://github.com/sourcegraph/sourcegraph/pull/53039)
+- Fixed an issue where commenting out redacted site-config secrets would re-add the secrets. [#53152](https://github.com/sourcegraph/sourcegraph/pull/53152)
 
 ### Removed
 

--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "@com_github_hashicorp_cronexpr//:cronexpr",
         "@com_github_sourcegraph_jsonx//:jsonx",
         "@com_github_sourcegraph_log//:log",
-        "@com_github_tidwall_gjson//:gjson",
         "@com_github_xeipuuv_gojsonschema//:gojsonschema",
     ],
 )

--- a/internal/conf/validate.go
+++ b/internal/conf/validate.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tidwall/gjson"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
@@ -282,12 +281,25 @@ func UnredactSecrets(input string, raw conftypes.RawUnified) (string, error) {
 	}
 
 	for _, secret := range siteConfigSecrets {
-		v := gjson.Get(unredactedSite, secret.readPath).String()
-		if v != redactedSecret {
+		v, err := jsonc.ReadProperty(unredactedSite, secret.editPaths...)
+		if err != nil {
+			continue
+		}
+		val, ok := v.(string)
+		if ok && val != redactedSecret {
 			continue
 		}
 
-		unredactedSite, err = jsonc.Edit(unredactedSite, gjson.Get(raw.Site, secret.readPath).String(), secret.editPaths...)
+		v, err = jsonc.ReadProperty(raw.Site, secret.editPaths...)
+		if err != nil {
+			continue
+		}
+		val, ok = v.(string)
+		if !ok {
+			continue
+		}
+
+		unredactedSite, err = jsonc.Edit(unredactedSite, val, secret.editPaths...)
 		if err != nil {
 			return input, errors.Wrapf(err, `unredact %q`, strings.Join(secret.editPaths, " > "))
 		}
@@ -355,8 +367,21 @@ func redactConfSecrets(raw conftypes.RawUnified, hashSecrets bool) (empty confty
 	}
 
 	for _, secret := range siteConfigSecrets {
-		val := gjson.Get(redactedSite, secret.readPath).String()
-		if val == "" {
+		v, err := jsonc.ReadProperty(redactedSite, secret.editPaths...)
+		if err != nil {
+			continue
+		}
+		val, ok := v.(string)
+		if ok && val == "" {
+			continue
+		}
+
+		v, err = jsonc.ReadProperty(raw.Site, secret.editPaths...)
+		if err != nil {
+			continue
+		}
+		val, ok = v.(string)
+		if !ok {
 			continue
 		}
 

--- a/internal/conf/validate_test.go
+++ b/internal/conf/validate_test.go
@@ -296,6 +296,42 @@ func TestRedactConfSecrets(t *testing.T) {
 	}
 }
 
+func TestRedactConfSecretsWithCommentedOutSecret(t *testing.T) {
+	conf := `{
+  // "executors.accessToken": "supersecret",
+  "executors.frontendURL": "http://host.docker.internal:3082"
+}`
+
+	want := `{
+  // "executors.accessToken": "supersecret",
+  "executors.frontendURL": "http://host.docker.internal:3082"
+}`
+
+	testCases := []struct {
+		name           string
+		hashSecrets    bool
+		redactedFmtStr string
+	}{
+		{
+			name:        "hashSecrets true",
+			hashSecrets: true,
+		},
+		{
+			name:        "hashSecrets false",
+			hashSecrets: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			redacted, err := redactConfSecrets(conftypes.RawUnified{Site: conf}, tc.hashSecrets)
+			require.NoError(t, err)
+
+			assert.Equal(t, want, redacted.Site)
+		})
+	}
+}
+
 func TestRedactSecrets_AuthProvidersSectionNotAdded(t *testing.T) {
 	const cfgWithoutAuthProviders = `{
   "executors.accessToken": "%s"
@@ -549,5 +585,4 @@ func getTestSiteWithSecrets(testSecrets testSecrets, optionalEdit ...string) str
 		testSecrets.dotcomSrcCliVersionCacheGitHubWebhookSecret,
 		testSecrets.authUnlockAccountLinkSigningKey,
 	)
-
 }


### PR DESCRIPTION
Site config reads used to be done with the `gjson` library, but the `gjson` library does not understand the `jsonc` format. So it returns fields even if they are commented out.

This PR changes the RedactSecrets and UnredactSecrets functions to use the `jsonc` library to do reads instead, which understands fields that are commented out.

## Test plan

Manual verification and tests should still be passing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
