### PR TITLE
do-not-merge: add tag prefix to sg ops

### DIFF
--- a/dev/sg/internal/images/compose.go
+++ b/dev/sg/internal/images/compose.go
@@ -96,7 +96,7 @@ func updateComposeFile(composeFile []byte, creds credentials.Credentials, pinTag
 				return nil
 			}
 
-			newImage, err := getUpdatedSourcegraphImage(originalImage, creds, pinTag)
+			newImage, err := getUpdatedSourcegraphImage(originalImage, creds, pinTag, nil)
 			if err != nil {
 				if errors.Is(err, ErrNoUpdateNeeded) {
 					std.Out.Verbosef("%s: %s", name, err)

--- a/dev/sg/internal/images/images.go
+++ b/dev/sg/internal/images/images.go
@@ -244,6 +244,7 @@ func findImage(r *yaml.RNode, credential credentials.Credentials, pinTag string,
 
 		if opts.SkipUpdates(ir.Name) {
 			std.Out.WriteWarningf("skipping update for %s", ir.Name)
+			return nil
 		}
 
 		updatedImage, err := getUpdatedSourcegraphImage(originalImage, credential, pinTag, opts)

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -39,6 +39,7 @@ var (
 	opsUpdateImagesContainerRegistryPasswordFlag string
 	opsUpdateImagesPinTagFlag                    string
 	opsUpdateImagesTagPrefix                     string
+	opsUpdateImagesSkipImages                    string
 	opsUpdateImagesTagPrefixSkipImages           string
 	opsUpdateImagesCommand                       = &cli.Command{
 		Name:        "update-images",
@@ -58,6 +59,11 @@ var (
 				Aliases:     []string{"t"},
 				Usage:       "pin all images to a specific sourcegraph `tag` (e.g. '3.36.2', 'insiders') (default: latest main branch tag)",
 				Destination: &opsUpdateImagesPinTagFlag,
+			},
+			&cli.StringFlag{
+				Name:        "skip-images",
+				Usage:       "images to skip updating entirely ('k8s' deployment only)",
+				Destination: &opsUpdateImagesSkipImages,
 			},
 			&cli.StringFlag{
 				Name:        "tag-prefix",
@@ -187,10 +193,11 @@ func opsUpdateImage(ctx *cli.Context) error {
 		return flag.ErrHelp
 	}
 
-	skipPrefixOpt := images.TagPrefixOption{
-		Prefix:     opsUpdateImagesTagPrefix,
-		SkipImages: strings.Split(opsUpdateImagesTagPrefixSkipImages, ","),
+	opts := images.Options{
+		Prefix:           opsUpdateImagesTagPrefix,
+		SkipPrefixImages: strings.Split(opsUpdateImagesTagPrefixSkipImages, ","),
+		SkipUpdate:       strings.Split(opsUpdateImagesSkipImages, ","),
 	}
 
-	return images.Update(args[0], *dockerCredentials, images.DeploymentType(opsUpdateImagesDeploymentKindFlag), opsUpdateImagesPinTagFlag, &skipPrefixOpt)
+	return images.Update(args[0], *dockerCredentials, images.DeploymentType(opsUpdateImagesDeploymentKindFlag), opsUpdateImagesPinTagFlag, &opts)
 }


### PR DESCRIPTION
This PR adds support for adding tags prefix and skipping them if needed. 

@willdollman we don't need to merge this PR, the code is ugly and I'd rather build the branch on the fly on the dotcom deployment GHA. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
~/work/deploy-sourcegraph-cloud U release $ ~/work/sourcegraph/sgd ops update-images \
  -cr-username $CR_USERNAME -cr-password $CR_PASSWORD \
  -tag-prefix bazel- -tag-prefix-skip "sourcegraph/redis-cache,sourcegraph/redis-store" \
  -skip-images "sourcegraph/indexed-searcher,sourcegraph/search-indexer" \
  base
```

Locally tested, see diff over: https://sourcegraph.slack.com/archives/C03LUEB7TJS/p1686223791741959?thread_ts=1686223749.365819&cid=C03LUEB7TJS