### PR TITLE
Own analytics GraphQL wiring

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -405,12 +405,26 @@ type ownStatsResolver struct {
 	path   string
 }
 
+func (r *ownStatsResolver) opts() database.TreeLocationOpts {
+	return database.TreeLocationOpts{
+		RepoID: r.repoID,
+		Path:   r.path,
+	}
+}
+
 func (r *ownStatsResolver) TotalFiles(ctx context.Context) (int32, error) {
-	return 0, nil // TODO(#52826): Implement graphQL resolver with db lookup.
+	return r.db.RepoPaths().AggregateFileCount(ctx, r.opts())
 }
 
 func (r *ownStatsResolver) TotalCodeownedFiles(ctx context.Context) (int32, error) {
-	return 0, nil // TODO(#52826): Implement graphQL resolver with db lookup.
+	counts, err := r.db.OwnershipStats().QueryAggregateCounts(ctx, r.opts())
+	if err != nil {
+		return 0, err
+	}
+	if len(counts) == 0 {
+		return 0, nil
+	}
+	return int32(counts[0].CodeownedFileCount), nil
 }
 
 type ownershipConnectionResolver struct {

--- a/internal/database/ownership_stats.go
+++ b/internal/database/ownership_stats.go
@@ -180,7 +180,7 @@ func (s *ownershipStats) UpdateAggregateCounts(ctx context.Context, repoID api.R
 }
 
 var aggregateOwnershipFmtstr = `
-	SELECT o.reference, SUM(s.tree_owned_files_count)
+	SELECT o.reference, SUM(COALESCE(s.tree_owned_files_count, 0))
 	FROM codeowners_individual_stats AS s
 	INNER JOIN repo_paths AS p ON s.file_path_id = p.id
 	INNER JOIN codeowners_owners AS o ON o.id = s.owner_id
@@ -203,14 +203,14 @@ func (s *ownershipStats) QueryIndividualCounts(ctx context.Context, opts TreeLoc
 }
 
 var treeAggregateCountsFmtstr = `
-	SELECT SUM(s.tree_codeowned_files_count)
+	SELECT SUM(COALESCE(s.tree_codeowned_files_count, 0))
 	FROM ownership_path_stats AS s
 	INNER JOIN repo_paths AS p ON s.file_path_id = p.id
 	WHERE p.absolute_path = %s
 `
 var treeAggregateCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (PathAggregateCounts, error) {
 	var cs PathAggregateCounts
-	err := s.Scan(&cs.CodeownedFileCount)
+	err := s.Scan(&dbutil.NullInt{&cs.CodeownedFileCount})
 	return cs, err
 })
 

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -190,6 +190,29 @@ func TestQueryAggregateCounts(t *testing.T) {
 	// 1. Setup repo and paths:
 	repo1 := mustCreate(ctx, t, d, &types.Repo{Name: "a/b"})
 	repo2 := mustCreate(ctx, t, d, &types.Repo{Name: "a/c"})
+
+	t.Run("no data - query single repo", func(t *testing.T) {
+		opts := TreeLocationOpts{
+			RepoID: repo1.ID,
+		}
+		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
+		require.NoError(t, err)
+		want := []PathAggregateCounts{
+			{CodeownedFileCount: 0},
+		}
+		assert.DeepEqual(t, want, got)
+	})
+
+	t.Run("no data - query all", func(t *testing.T) {
+		opts := TreeLocationOpts{}
+		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
+		require.NoError(t, err)
+		want := []PathAggregateCounts{
+			{CodeownedFileCount: 0},
+		}
+		assert.DeepEqual(t, want, got)
+	})
+
 	// 2. Insert aggregate counts:
 	timestamp := time.Now()
 	repo1Counts := fakeAggregateStatsIterator{

--- a/internal/database/repo_paths.go
+++ b/internal/database/repo_paths.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -173,7 +174,7 @@ func (s *repoPathStore) AggregateFileCount(ctx context.Context, opts TreeLocatio
 		qs = append(qs, sqlf.Sprintf("AND p.repo_id = %s", repoID))
 	}
 	var count int32
-	if err := s.Store.QueryRow(ctx, sqlf.Join(qs, "\n")).Scan(&count); err != nil {
+	if err := s.Store.QueryRow(ctx, sqlf.Join(qs, "\n")).Scan(&dbutil.NullInt32{&count}); err != nil {
 		return 0, err
 	}
 	return count, nil

--- a/internal/database/repo_paths_test.go
+++ b/internal/database/repo_paths_test.go
@@ -62,14 +62,18 @@ func TestAggregateFileCounts(t *testing.T) {
 	repo1 := mustCreate(ctx, t, d, &types.Repo{Name: "a/b"})
 	repo2 := mustCreate(ctx, t, d, &types.Repo{Name: "c/d"})
 
-	// Insert paths and counts for repo1
+	// Check counts without data.
+	count, err := d.RepoPaths().AggregateFileCount(ctx, TreeLocationOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), count)
+
 	counts1 := fakeRepoTreeCounts{
 		"":      30,
 		"path1": 10,
 		"path2": 20,
 	}
 	timestamp := time.Now()
-	_, err := d.RepoPaths().UpdateFileCounts(ctx, repo1.ID, counts1, timestamp)
+	_, err = d.RepoPaths().UpdateFileCounts(ctx, repo1.ID, counts1, timestamp)
 	require.NoError(t, err)
 	counts2 := fakeRepoTreeCounts{
 		"":      50,
@@ -79,7 +83,7 @@ func TestAggregateFileCounts(t *testing.T) {
 	require.NoError(t, err)
 
 	// Aggregate counts for single path in repo1
-	count, err := d.RepoPaths().AggregateFileCount(ctx, TreeLocationOpts{
+	count, err = d.RepoPaths().AggregateFileCount(ctx, TreeLocationOpts{
 		Path:   "path1",
 		RepoID: repo1.ID,
 	})


### PR DESCRIPTION
This pull-request wires up analytics resolves with database storage.

It also amends the stores to prevent failures due to lack of data.

<img width="1138" alt="Screenshot 2023-06-08 at 2 30 43 PM" src="https://github.com/sourcegraph/sourcegraph/assets/153410/1ecd6ed1-bfc8-42fc-b373-54b42d0876ad">

## Test plan

Extend database and GraphQL tests
