### PR TITLE
settings: introduce Service interface

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -265,14 +265,14 @@ func (m mock) RelevantSubjects(ctx context.Context, subject api.SettingsSubject)
 // CurrentUserFinal returns the merged settings for the current user.
 // If there is no active user, it returns the site settings.
 //
-// Deprecated: use a settings.Service instead.
+// NOTE: use a settings.Service instead.
 func CurrentUserFinal(ctx context.Context, db database.DB) (*schema.Settings, error) {
 	return NewService(db).UserFromContext(ctx)
 }
 
 // Final returns the merged settings for the given subject.
 //
-// Deprecated: use a settings.Service instead.
+// NOTE: use a settings.Service instead.
 func Final(ctx context.Context, db database.DB, subject api.SettingsSubject) (*schema.Settings, error) {
 	return NewService(db).ForSubject(ctx, subject)
 }
@@ -281,7 +281,7 @@ func Final(ctx context.Context, db database.DB, subject api.SettingsSubject) (*s
 // These are returned in priority order, with the lowest priority first.
 // The order of priority is default < site < org < user.
 //
-// Deprecated: use a settings.Service instead.
+// NOTE: use a settings.Service instead.
 func RelevantSubjects(ctx context.Context, db database.DB, subject api.SettingsSubject) ([]api.SettingsSubject, error) {
 	return NewService(db).RelevantSubjects(ctx, subject)
 }

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -22,6 +22,7 @@ func defaultSettings() *schema.Settings {
 	}
 }
 
+// Deprecated: use Mock
 var MockCurrentUserFinal *schema.Settings
 
 // Service calculates settings for users and other subjects.
@@ -240,6 +241,25 @@ func mergeLeft(left, right reflect.Value, depth int) reflect.Value {
 
 	// Type is not mergeable, so clobber existing value
 	return right
+}
+
+// Mock will return itself for UserFromContext and ForSubject.
+func Mock(settings *schema.Settings) Service {
+	return mock{settings: settings}
+}
+
+type mock struct {
+	settings *schema.Settings
+}
+
+func (m mock) UserFromContext(ctx context.Context) (*schema.Settings, error) {
+	return m.settings, nil
+}
+func (m mock) ForSubject(ctx context.Context, subject api.SettingsSubject) (*schema.Settings, error) {
+	return m.settings, nil
+}
+func (m mock) RelevantSubjects(ctx context.Context, subject api.SettingsSubject) ([]api.SettingsSubject, error) {
+	return nil, nil
 }
 
 // CurrentUserFinal returns the merged settings for the current user.

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -24,6 +24,34 @@ func defaultSettings() *schema.Settings {
 
 var MockCurrentUserFinal *schema.Settings
 
+// Service is introduced to so we can more cleanly pass in the dependencies of
+// a service which wants to fetch user settings. This would also make mocking
+// cleaner/etc.
+type Service interface {
+	// UserFromContext is the CurrentUserFinal function but without the need
+	// to pass in a DB. I expect this name will read better at callsites, eg:
+	//
+	//   c.settingsService.UserFromContext(ctx)
+	//
+	// Alternative name is ActorFromContext, but when referring to settings in
+	// our app we often call it user settings. Open to other suggestions for
+	// service and method names which better convey intent.
+	UserFromContext(context.Context) (*schema.Settings, error)
+
+	// ForSubject is the Final function but without the need to pass in a DB.
+	// I expect this name will read better at callsites, eg:
+	//
+	//   c.settingsService.ForSubject(ctx, subj)
+	ForSubject(context.Context, api.SettingsSubject) (*schema.Settings, error)
+
+	// RelevantSubjects is the RelevantSubjects function but without the need
+	// to pass in a DB.
+	//
+	// Note: this only has one call site in graphql. I wonder if anyone
+	// actually reads this field anymore?
+	RelevantSubjects(context.Context, api.SettingsSubject) ([]api.SettingsSubject, error)
+}
+
 // CurrentUserFinal returns the merged settings for the current user.
 // If there is no active user, it returns the site settings.
 func CurrentUserFinal(ctx context.Context, db database.DB) (*schema.Settings, error) {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -18,6 +18,7 @@ func TestRelevantSettings(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	settingsService := NewService(db)
 
 	createOrg := func(name string) *types.Org {
 		org, err := db.Orgs().Create(ctx, name, nil)
@@ -95,7 +96,7 @@ func TestRelevantSettings(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.subject.String(), func(t *testing.T) {
-			got, err := RelevantSubjects(ctx, db, tc.subject)
+			got, err := settingsService.RelevantSubjects(ctx, tc.subject)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, got)
 		})


### PR DESCRIPTION
This is a stub interface which is a proposal for how we use the settings API. The intention is to remove the currently exported functions. From reading call sites on the existing functions this should be easy to introduce.

Please look at the code which has comments and please give feedback. Based on that I will follow up with implementing it or closing.

Test Plan: CI