### PR TITLE
settings: unexport Latest

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -54,17 +54,17 @@ func Final(ctx context.Context, db database.DB, subject api.SettingsSubject) (_ 
 	}
 
 	allSettings, err := iter.MapErr(subjects, func(subject *api.SettingsSubject) (*schema.Settings, error) {
-		return Latest(ctx, db, *subject)
+		return latest(ctx, db, *subject)
 	})
 
 	return mergeSettings(allSettings...), nil
 }
 
-// Latest gets the latest settings specific to a given subject. Most consumers
+// latest gets the latest settings specific to a given subject. Most consumers
 // of this package will want to use Final or CurrentUserFinal instead because
 // those properly merge all settings relevant to a subject. If no settings
-// have been defined for a subject, Latest will return nil.
-func Latest(ctx context.Context, db database.DB, subject api.SettingsSubject) (*schema.Settings, error) {
+// have been defined for a subject, latest will return nil.
+func latest(ctx context.Context, db database.DB, subject api.SettingsSubject) (*schema.Settings, error) {
 	// The store does not handle the default settings subject
 	if subject.Default {
 		return defaultSettings(), nil


### PR DESCRIPTION
This is unused outside of the package and the docstring already warns against using it directly.

Test Plan: CI
