### PR TITLE
ranking: Fix reducer sort order

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/background/reducer/config.go
+++ b/enterprise/internal/codeintel/ranking/internal/background/reducer/config.go
@@ -15,5 +15,5 @@ type Config struct {
 
 func (c *Config) Load() {
 	c.Interval = c.GetInterval("CODEINTEL_RANKING_REDUCER_INTERVAL", "1s", "How frequently to run the ranking reducer.")
-	c.BatchSize = c.GetInt("CODEINTEL_RANKING_REDUCER_BATCH_SIZE", "100", "How many path counts to reduce at once.")
+	c.BatchSize = c.GetInt("CODEINTEL_RANKING_REDUCER_BATCH_SIZE", "1000", "How many path counts to reduce at once.")
 }

--- a/enterprise/internal/codeintel/ranking/internal/store/reducer.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/reducer.go
@@ -67,7 +67,7 @@ rank_ids AS (
 	WHERE
 		pci.graph_key = %s AND
 		NOT pci.processed
-	ORDER BY pci.graph_key, pci.definition_id, pci.id
+	ORDER BY pci.graph_key, pci.definition_id
 	LIMIT %s
 	FOR UPDATE SKIP LOCKED
 ),


### PR DESCRIPTION
This stops the index from being used pre-sort *somehow*. Also upping the default batch size for the reducer.

Ran a bunch of queries on dotcom and they're all 50ms-100ms at 100 batch size, this seems reasonable. The additional records _read_ should be cheap due to new changes, and the merge is no more expensive at this scale of maps.

## Test plan

Existing unit tests.