### PR TITLE
Add  Cody Scope Selector Tooltips

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -225,6 +225,7 @@ ts_project(
         "src/cody/components/HistoryList/HistoryList.tsx",
         "src/cody/components/HistoryList/index.tsx",
         "src/cody/components/RepoContainerEditor.ts",
+        "src/cody/components/ScopeSelector/CodyHighQualityIcon.tsx",
         "src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx",
         "src/cody/components/ScopeSelector/ScopeSelector.tsx",
         "src/cody/components/ScopeSelector/backend.ts",

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -209,7 +209,9 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = React.memo(funct
     revision,
 }) {
     return repoName ? (
-        <Link to={`/${repoName}${revision ? `@${revision}` : ''}/-/blob/${path}`}>{path}</Link>
+        <Tooltip content={`${repoName}/-/blob/${path}`}>
+            <Link to={`/${repoName}${revision ? `@${revision}` : ''}/-/blob/${path}`}>{path}</Link>
+        </Tooltip>
     ) : (
         <>{path}</>
     )

--- a/client/web/src/cody/components/ScopeSelector/CodyHighQualityIcon.tsx
+++ b/client/web/src/cody/components/ScopeSelector/CodyHighQualityIcon.tsx
@@ -1,0 +1,19 @@
+import React, { SVGProps } from 'react'
+
+export const CodyHighQualityIcon: React.FunctionComponent<React.PropsWithChildren<SVGProps<SVGSVGElement>>> = (
+    props: SVGProps<SVGSVGElement>
+) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" fill="none" viewBox="0 0 19 19" {...props}>
+        <path
+            fill="url(#a)"
+            d="M16 10.09V4c0-2.21-3.58-4-8-4S0 1.79 0 4v10c0 2.21 3.59 4 8 4 .46 0 .9 0 1.33-.06A5.94 5.94 0 0 1 9 16v-.05c-.32.05-.65.05-1 .05-3.87 0-6-1.5-6-2v-2.23C3.61 12.55 5.72 13 8 13c.65 0 1.27-.04 1.88-.11A5.986 5.986 0 0 1 15 10c.34 0 .67.04 1 .09Zm-2-.64C12.7 10.4 10.42 11 8 11s-4.7-.6-6-1.55V6.64C3.47 7.47 5.61 8 8 8s4.53-.53 6-1.36v2.81ZM8 6C4.13 6 2 4.5 2 4s2.13-2 6-2 6 1.5 6 2-2.13 2-6 2Zm10.5 8.25L13.75 19 11 16l1.16-1.16 1.59 1.59 3.59-3.59 1.16 1.41Z"
+        />
+        <defs>
+            <linearGradient id="a" x1="9.25" x2="9.25" y1="0" y2="19" gradientUnits="userSpaceOnUse">
+                <stop stopColor="#A112FF" />
+                <stop offset=".464" stopColor="#FF5543" />
+                <stop offset="1" stopColor="#00CBEC" />
+            </linearGradient>
+        </defs>
+    </svg>
+)

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -22,14 +22,20 @@
 .repository-names-text {
     display: flex;
     min-width: 0;
-    flex-grow: 1;
-    max-width: 20rem;
     font-size: 0.8rem;
     font-weight: 400;
+
+    svg {
+        min-width: 1rem;
+        min-height: 1rem;
+        max-width: 1rem;
+        max-height: 1rem;
+    }
 }
 
 .filepath-text {
     font-size: 0.8rem;
+    flex: 1;
 }
 
 .tinted-search {
@@ -56,6 +62,20 @@
     color: var(--input-focus-border-color);
 }
 
+.embeddings-status-content {
+    width: 24rem;
+    height: 100%;
+    max-width: 24rem;
+    min-height: 7rem;
+    overflow: hidden;
+    font-size: 0.8rem;
+    line-height: 1rem;
+
+    strong {
+        font-weight: 500;
+    }
+}
+
 .repository-selector-content {
     width: 20rem;
     height: 100%;
@@ -78,6 +98,7 @@
 .header {
     font-size: 0.625rem;
     line-height: 1rem;
+    font-weight: 500;
 }
 
 .repository-list-item {

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -86,6 +86,11 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
         [scope, setScope]
     )
 
+    const resetScope = useCallback(
+        () => setScope({ ...scope, repositories: [], includeInferredRepository: true, includeInferredFile: true }),
+        [scope, setScope]
+    )
+
     return (
         <div className={styles.wrapper}>
             <div className="d-flex text-truncate">
@@ -96,6 +101,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                     inferredFilePath={activeEditor?.filePath || null}
                     additionalRepositories={additionalRepositories}
                     addRepository={addRepository}
+                    resetScope={resetScope}
                     removeRepository={removeRepository}
                     toggleIncludeInferredRepository={toggleIncludeInferredRepository}
                     toggleIncludeInferredFile={toggleIncludeInferredFile}


### PR DESCRIPTION
- Fixed max width of list of repos in scope text below the input box
- Added embeddings status indicator with popover. 
- Added tooltips for embeddings status indicator for each repo in the selector popover. 
- Add reset button in header to reset the scope. 

https://www.loom.com/share/9296f3e1b9ad48abb49c238a89b3b097

## Test plan

- visit /cody
- add repos
- click the embeddings status indicator
- click on reset button in the selector popover