### PR TITLE
Cody walkthrough: Remove redundant completion event

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -88,10 +88,7 @@
             "description": "Get started by logging into Sourcegraph and setting up Cody.\n[Setup Cody](command:cody.walkthrough.showLogin)",
             "media": {
               "markdown": "walkthroughs/setup.md"
-            },
-            "completionEvents": [
-              "onContext:cody.activated"
-            ]
+            }
           },
           {
             "id": "chat",


### PR DESCRIPTION
## Description

Noticed behaviour was different on a fresh install to local development. We set `cody.activated` to `false` on install so this will automatically complete itself and the 2nd step will be loaded first for the user.

Thought about fixing the completion event but it actually doesn't really add much value, as VS Code will automatically mark the item as completed when the step is read - it's the first step so it'll always be completed already.

## Test plan

Build app, check that 1st step isn't skipped when user sees the walkthrough screen.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
