### PR TITLE
ranking: Fix premature reducer exit

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/reducer.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/reducer.go
@@ -128,7 +128,7 @@ set_progress AS (
 	UPDATE codeintel_ranking_progress
 	SET
 		num_count_records_processed = COALESCE(num_count_records_processed, 0) + (SELECT COUNT(*) FROM processed),
-		reducer_completed_at        = CASE WHEN (SELECT COUNT(*) FROM input_ranks) = 0 THEN NOW() ELSE NULL END
+		reducer_completed_at        = CASE WHEN (SELECT COUNT(*) FROM rank_ids) = 0 THEN NOW() ELSE NULL END
 	WHERE id IN (SELECT id FROM progress)
 )
 SELECT


### PR DESCRIPTION
#53101 introduced the edge case that all records in a batch can be filtered out (from the repo block/deleted check), which will cause the reducer to mark itself as done. This PR fixes that condition.

## Test plan

Existing unit tests.