### PR TITLE
app: update settings page

### DIFF
--- a/client/web/src/enterprise/user/routes.tsx
+++ b/client/web/src/enterprise/user/routes.tsx
@@ -1,6 +1,7 @@
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import { RedirectRoute } from '../../components/RedirectRoute'
+import { SiteAdminArea } from '../../site-admin/SiteAdminArea'
 import { userAreaRoutes } from '../../user/area/routes'
 import { UserAreaRoute } from '../../user/area/UserArea'
 import { EditBatchSpecPageProps } from '../batches/batch-spec/edit/EditBatchSpecPage'

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -17,7 +17,9 @@ export interface SiteAdminSideBarGroupContext extends BatchChangesProps {
     ownAnalyticsEnabled: boolean
 }
 
-export interface SiteAdminSideBarGroup extends NavGroupDescriptor<SiteAdminSideBarGroupContext> {}
+export interface SiteAdminSideBarGroup extends NavGroupDescriptor<SiteAdminSideBarGroupContext> {
+    hidden?: (context: SiteAdminSideBarGroupContext) => boolean
+}
 
 export type SiteAdminSideBarGroups = readonly SiteAdminSideBarGroup[]
 
@@ -50,23 +52,33 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
             <SidebarGroup className={classNames(className, 'd-sm-block', !isMobileExpanded && 'd-none')}>
                 <ul className="list-group">
                     {groups.map(
-                        ({ header, items, condition = () => true }, index) =>
+                        ({ header, items, condition = () => true, hidden = () => false }, index) =>
                             condition(props) &&
                             (items.length > 1 ? (
-                                <li className="p-0 list-group-item" key={index}>
+                                <li
+                                    className={classNames('p-0 list-group-item', hidden(props) && 'd-none')}
+                                    key={index}
+                                >
                                     <SidebarCollapseItems
                                         icon={header?.icon}
                                         label={header?.label}
                                         openByDefault={true}
                                     >
                                         {items.map(
-                                            ({ label, to, source = 'client', exact, condition = () => true }) =>
+                                            ({
+                                                label,
+                                                to,
+                                                source = 'client',
+                                                exact,
+
+                                                condition = () => true,
+                                            }) =>
                                                 condition(props) && (
                                                     <SidebarNavItem
                                                         to={to}
                                                         key={label}
                                                         source={source}
-                                                        className={styles.navItem}
+                                                        className={classNames(styles.navItem)}
                                                         onClick={collapseMobileSidebar}
                                                         exact={exact}
                                                     >
@@ -77,7 +89,10 @@ export const SiteAdminSidebar: React.FunctionComponent<React.PropsWithChildren<S
                                     </SidebarCollapseItems>
                                 </li>
                             ) : (
-                                <li className="p-0 list-group-item" key={items[0].label}>
+                                <li
+                                    className={classNames('p-0 list-group-item', hidden(props) && 'd-none')}
+                                    key={items[0].label}
+                                >
                                     <Link
                                         to={items[0].to}
                                         className="bg-2 border-0 d-flex list-group-item-action p-2 w-100"

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -224,6 +224,7 @@ export const apiConsoleGroup: SiteAdminSideBarGroup = {
             to: '/api/console',
         },
     ],
+    hidden: ({ isSourcegraphApp }) => isSourcegraphApp,
 }
 
 export const siteAdminSidebarGroups: SiteAdminSideBarGroups = [

--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { NavLink } from 'react-router-dom'
 
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
-import { Icon, PageHeader } from '@sourcegraph/wildcard'
+import { Icon, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesProps } from '../../batches'
 import { NavItemWithIconDescriptor } from '../../util/contributions'
@@ -60,36 +60,34 @@ export const UserAreaHeader: React.FunctionComponent<React.PropsWithChildren<Pro
         [props.user, props.isSourcegraphApp]
     )
 
+    const filteredNavItems = navItems.filter(({ condition = () => true }) => condition(props))
+
     return (
         <div className={className}>
             <div className="container">
-                <PageHeader className="mb-3">
+                <PageHeader className="mb-3" actions={<Link to="/site-admin/configuration">Advanced settings</Link>}>
                     <PageHeader.Heading as="h2" styleAs="h1">
                         <PageHeader.Breadcrumb icon={path.icon}>{path.text}</PageHeader.Breadcrumb>
                     </PageHeader.Heading>
                 </PageHeader>
-                <nav className="d-flex align-items-end justify-content-between" aria-label="User">
-                    <ul className={classNames('nav nav-tabs w-100', styles.navigation)}>
-                        {navItems.map(
-                            ({ to, label, exact, icon: ItemIcon, condition = () => true }) =>
-                                condition(props) && (
-                                    <li key={label} className="nav-item">
-                                        <NavLink
-                                            to={url + to}
-                                            className={classNames('nav-link', styles.navigationLink)}
-                                        >
-                                            <span>
-                                                {ItemIcon && <Icon as={ItemIcon} aria-hidden={true} />}{' '}
-                                                <span className="text-content" data-tab-content={label}>
-                                                    {label}
-                                                </span>
+                {filteredNavItems.length > 0 && (
+                    <nav className="d-flex align-items-end justify-content-between" aria-label="User">
+                        <ul className={classNames('nav nav-tabs w-100', styles.navigation)}>
+                            {filteredNavItems.map(({ to, label, icon: ItemIcon }) => (
+                                <li key={label} className="nav-item">
+                                    <NavLink to={url + to} className={classNames('nav-link', styles.navigationLink)}>
+                                        <span>
+                                            {ItemIcon && <Icon as={ItemIcon} aria-hidden={true} />}{' '}
+                                            <span className="text-content" data-tab-content={label}>
+                                                {label}
                                             </span>
-                                        </NavLink>
-                                    </li>
-                                )
-                        )}
-                    </ul>
-                </nav>
+                                        </span>
+                                    </NavLink>
+                                </li>
+                            ))}
+                        </ul>
+                    </nav>
+                )}
             </div>
         </div>
     )

--- a/client/web/src/user/area/navitems.ts
+++ b/client/web/src/user/area/navitems.ts
@@ -2,18 +2,11 @@ import AccountIcon from 'mdi-react/AccountIcon'
 import CogOutlineIcon from 'mdi-react/CogOutlineIcon'
 import FeatureSearchOutlineIcon from 'mdi-react/FeatureSearchOutlineIcon'
 
-import { CodyIcon } from '../../cody/components/CodyIcon'
 import { namespaceAreaHeaderNavItems } from '../../namespaces/navitems'
 
 import { UserAreaHeaderNavItem } from './UserAreaHeader'
 
 export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
-    {
-        to: '/app-settings',
-        label: 'Repositories',
-        icon: CodyIcon,
-        condition: ({ isSourcegraphApp }) => isSourcegraphApp,
-    },
     {
         to: '/profile',
         label: 'Profile',
@@ -24,13 +17,13 @@ export const userAreaHeaderNavItems: readonly UserAreaHeaderNavItem[] = [
         to: '/settings',
         label: 'Settings',
         icon: CogOutlineIcon,
-        condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
+        condition: ({ user: { viewerCanAdminister }, isSourcegraphApp }) => viewerCanAdminister && !isSourcegraphApp,
     },
     {
         to: '/searches',
         label: 'Saved searches',
         icon: FeatureSearchOutlineIcon,
-        condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
+        condition: ({ user: { viewerCanAdminister }, isSourcegraphApp }) => viewerCanAdminister && !isSourcegraphApp,
     },
     ...namespaceAreaHeaderNavItems,
 ]

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -123,16 +123,11 @@ export const UserSettingsSidebar: FC<UserSettingsSidebarProps> = props => {
                             API console
                         </SidebarNavItem>
                     )}
-                    {props.authenticatedUser.siteAdmin &&
-                        (props.isSourcegraphApp ? (
-                            <SidebarNavItem to="/site-admin/configuration" onClick={collapseMobileSidebar}>
-                                Advanced settings
-                            </SidebarNavItem>
-                        ) : (
-                            <SidebarNavItem to="/site-admin" onClick={collapseMobileSidebar}>
-                                Site admin
-                            </SidebarNavItem>
-                        ))}
+                    {props.authenticatedUser.siteAdmin && (
+                        <SidebarNavItem to="/site-admin" onClick={collapseMobileSidebar}>
+                            Site admin
+                        </SidebarNavItem>
+                    )}
                 </SidebarGroup>
                 <div>Version: {window.context.version}</div>
             </div>


### PR DESCRIPTION
Closes [#53116](https://github.com/sourcegraph/sourcegraph/issues/53116)

- Remove tabs on the main settings page, only the repo settings are shown
- Add a link to "Advanced settings"
- In "Advanced settings," keep API console but hide the link with "display:none" 

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/206864/16b40c78-d548-450e-99ff-1898e647a6c2)

![image](https://github.com/sourcegraph/sourcegraph/assets/206864/ccdfb03d-dd07-4346-a0b7-6124c4ca5b14)
