### PR TITLE
(fix) incorrect codehost icons on search results page

### DIFF
--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -77,12 +77,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                     {/* Add a result type to be read out to screen readers only, so that screen reader users can
                     easily scan the search results list (for example, by navigating by landmarks). */}
                     <span className="sr-only">{resultType ? accessibleResultType[resultType] : 'search'} result,</span>
-                    {repoName && (
-                        <CodeHostIcon
-                            repoName={['gitlab.com', 'github.com', 'bitbucket.org'][index % 3]}
-                            className="flex-shrink-0 mr-1"
-                        />
-                    )}
+                    {repoName && <CodeHostIcon repoName={repoName} className="flex-shrink-0 mr-1" />}
                     <div
                         className={classNames(styles.headerTitle, titleClassName)}
                         data-testid="result-container-header"


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/sourcegraph/pull/52552.  Reported by @efritz. Apparently I forgot my local testing code.

## Test plan
- Check the diff
- `sg start`
- Make search and check that code host icons are shown correctly.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
