### PR TITLE
Cody: Incorporate concurrent human and Cody edits when applying fixups

### DIFF
--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
 
-import { computeDiff } from './diff'
+import { computeDiff, Diff } from './diff'
 import { FixupCodeLenses } from './FixupCodeLenses'
 import { ContentProvider } from './FixupContentStore'
 import { FixupDecorator } from './FixupDecorator'
@@ -86,7 +86,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
 
         // Create a task and then mark it as started
         const fixupFile = this.files.forUri(editor.document.uri)
-        const task = new FixupTask(fixupFile, input, selection, editor)
+        const task = new FixupTask(fixupFile, input, editor)
         void this.setTaskState(task, CodyTaskState.asking)
         // Move the cursor to the start of the selection range to show fixup markups
         editor.selection = new vscode.Selection(task.selectionRange.start, task.selectionRange.start)
@@ -125,7 +125,66 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
             console.error('cannot find task')
             return
         }
+        await this.applyTask(task)
+    }
+
+    // Tries to get a clean, up-to-date diff to apply. If the diff is not
+    // up-to-date, it is synchronously recomputed. If the diff is not clean,
+    // will return undefined. This may update the task with the newly computed
+    // diff.
+    private applicableDiffOrRespin(task: FixupTask, document: vscode.TextDocument): Diff | undefined {
+        const bufferText = document.getText(task.selectionRange)
+        let diff = task.diff
+        if (task.replacement !== undefined && bufferText !== diff?.bufferText) {
+            // The buffer changed since we last computed the diff.
+            task.diff = diff = computeDiff(task.original, task.replacement, bufferText, task.selectionRange.start)
+            this.didUpdateDiff(task)
+        }
+        if (!diff?.clean) {
+            // TODO: Schedule a re-spin for diffs with conflicts.
+            vscode.window.showWarningMessage('applying fixup with incomplete/conflict diff is not yet implemented')
+            return undefined
+        }
+        return diff
+    }
+
+    private async applyTask(task: FixupTask): Promise<void> {
         await this.setTaskState(task, CodyTaskState.applying)
+
+        let editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === task.fixupFile.uri)
+        if (!editor) {
+            editor = await vscode.window.showTextDocument(task.fixupFile.uri)
+        }
+
+        const diff = this.applicableDiffOrRespin(task, editor.document)
+        if (!diff) {
+            return
+        }
+
+        await editor.revealRange(task.selectionRange)
+        const editOk = await editor.edit(editBuilder => {
+            for (const edit of diff.edits) {
+                editBuilder.replace(
+                    new vscode.Range(
+                        new vscode.Position(edit.range.start.line, edit.range.start.character),
+                        new vscode.Position(edit.range.end.line, edit.range.end.character)
+                    ),
+                    edit.text
+                )
+            }
+        })
+
+        if (!editOk) {
+            // TODO: Try to recover, for example by respinning
+            vscode.window.showWarningMessage('edit did not apply')
+            return
+        }
+
+        // TODO: is this the right transition for being all done?
+        // TODO: Consider keeping tasks around to resurrect them if the user
+        // hits undo.
+        // TODO: See if we can discard a FixupFile now.
+        this.setTaskState(task, CodyTaskState.fixed)
     }
 
     // Applying fixups from tree item click
@@ -181,6 +240,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         if (!task) {
             return
         }
+        this.needsDiffUpdate_.delete(task)
         this.codelenses.didDeleteTask(task)
         this.contentStore.delete(id)
         this.decorator.didCompleteTask(task)
@@ -306,11 +366,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
                 continue
             }
             const bufferText = editor.document.getText(task.selectionRange)
-            // TODO: The selection range needs to be updated for edits.
-            // Switch to using a gross line-based range and updating it in the
-            // FixupDocumentEditObserver.
-            const diff = computeDiff(task.original, botText, bufferText, task.selectionRange.start)
-            task.diff = diff
+            task.diff = computeDiff(task.original, botText, bufferText, task.selectionRange.start)
             this.didUpdateDiff(task)
         }
 
@@ -349,19 +405,22 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         if (!task) {
             return
         }
-        // show diff view between the current document and replacement
-        const origin = task?.selection.selectedText
-        const replacement = task?.replacement
-        if (!origin || !replacement) {
-            await this.setTaskState(task, CodyTaskState.error)
+        // Get an up-to-date diff
+        const editor = vscode.window.visibleTextEditors.find(editor => editor.document.uri === task.fixupFile.uri)
+        if (!editor) {
             return
         }
+        const diff = this.applicableDiffOrRespin(task, editor.document)
+        if (!diff || diff.mergedText === undefined) {
+            return
+        }
+        // show diff view between the current document and replacement
         // Add replacement content to the temp document
         const tempDocUri = vscode.Uri.parse(`cody-fixup:${task.fixupFile.uri.fsPath}#${task.id}`)
         const doc = await vscode.workspace.openTextDocument(tempDocUri)
         const edit = new vscode.WorkspaceEdit()
-        const range = task.getSelectionRange()
-        edit.replace(tempDocUri, range, replacement)
+        const range = task.selectionRange
+        edit.replace(tempDocUri, range, diff.mergedText)
         await vscode.workspace.applyEdit(edit)
         await doc.save()
 
@@ -382,6 +441,9 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
     }
 
     private async setTaskState(task: FixupTask, state: CodyTaskState): Promise<FixupTask | null> {
+        // TODO: Something is abusing this method to refresh code lenses. Find
+        // the state 2->2 (and maybe more) callers, work out what they are
+        // actually notifying, and just notify about that.
         console.log(task.id, 'changing state from', task.state, 'to', state)
         switch (state) {
             case CodyTaskState.queued:
@@ -397,18 +459,13 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
                 task.marking()
                 break
             case CodyTaskState.fixed:
-                this.discard(task.id)
+                task.fixed()
                 break
             case CodyTaskState.error:
                 task.error()
                 break
             case CodyTaskState.applying:
-                // NOTE: task.apply() handles replacing the text in the document
-                // TODO (dom) add new method for replacement
-                await task.apply()
-                if (task.state !== CodyTaskState.fixed) {
-                    task.error('Failed to apply fixup')
-                }
+                task.apply()
                 break
         }
         console.log(task.id, 'current state', task.state)

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -142,7 +142,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         }
         if (!diff?.clean) {
             // TODO: Schedule a re-spin for diffs with conflicts.
-            vscode.window.showWarningMessage('applying fixup with incomplete/conflict diff is not yet implemented')
+            void vscode.window.showWarningMessage('applying fixup with incomplete/conflict diff is not yet implemented')
             return undefined
         }
         return diff
@@ -161,7 +161,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
             return
         }
 
-        await editor.revealRange(task.selectionRange)
+        editor.revealRange(task.selectionRange)
         const editOk = await editor.edit(editBuilder => {
             for (const edit of diff.edits) {
                 editBuilder.replace(
@@ -176,7 +176,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
 
         if (!editOk) {
             // TODO: Try to recover, for example by respinning
-            vscode.window.showWarningMessage('edit did not apply')
+            void vscode.window.showWarningMessage('edit did not apply')
             return
         }
 
@@ -184,7 +184,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         // TODO: Consider keeping tasks around to resurrect them if the user
         // hits undo.
         // TODO: See if we can discard a FixupFile now.
-        this.setTaskState(task, CodyTaskState.fixed)
+        await this.setTaskState(task, CodyTaskState.fixed)
     }
 
     // Applying fixups from tree item click
@@ -440,7 +440,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         )
     }
 
-    private async setTaskState(task: FixupTask, state: CodyTaskState): Promise<FixupTask | null> {
+    private setTaskState(task: FixupTask, state: CodyTaskState): Promise<FixupTask | null> {
         // TODO: Something is abusing this method to refresh code lenses. Find
         // the state 2->2 (and maybe more) callers, work out what they are
         // actually notifying, and just notify about that.
@@ -471,7 +471,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         console.log(task.id, 'current state', task.state)
         if (task.state === CodyTaskState.fixed) {
             this.discard(task.id)
-            return null
+            return Promise.resolve(null)
         }
         // Save states of the task
         this.codelenses.didUpdateTask(task)
@@ -479,7 +479,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         // creation.
         this.tasks.set(task.id, task)
         this.taskViewProvider.setTreeItem(task)
-        return task
+        return Promise.resolve(task)
     }
 
     private reset(): void {

--- a/client/cody/src/non-stop/FixupDocumentEditObserver.ts
+++ b/client/cody/src/non-stop/FixupDocumentEditObserver.ts
@@ -1,7 +1,47 @@
 import * as vscode from 'vscode'
 
+import { Edit, Position, Range } from './diff'
 import { FixupFileCollection, FixupTextChanged } from './roles'
 import { TextChange, updateRangeMultipleChanges } from './tracked-range'
+
+// This does some thunking to manage the two range types: diff ranges, and
+// text change ranges.
+function updateDiffRange(range: Range, changes: TextChange[]): Range {
+    return toDiffRange(updateRangeMultipleChanges(toVsCodeRange(range), changes))
+}
+
+function toDiffRange(range: vscode.Range): Range {
+    return {
+        start: toDiffPosition(range.start),
+        end: toDiffPosition(range.end),
+    }
+}
+
+function toDiffPosition(position: vscode.Position): Position {
+    return { line: position.line, character: position.character }
+}
+
+function toVsCodeRange(range: Range): vscode.Range {
+    return new vscode.Range(toVsCodePosition(range.start), toVsCodePosition(range.end))
+}
+
+function toVsCodePosition(position: Position): vscode.Position {
+    return new vscode.Position(position.line, position.character)
+}
+
+// Updates the ranges in a diff.
+function updateRanges(ranges: Range[], changes: TextChange[]): void {
+    for (let i = 0; i < ranges.length; i++) {
+        ranges[i] = updateDiffRange(ranges[i], changes)
+    }
+}
+
+// Updates the range in an edit.
+function updateEdits(edits: Edit[], changes: TextChange[]): void {
+    for (let i = 0; i < edits.length; i++) {
+        edits[i].range = updateDiffRange(edits[i].range, changes)
+    }
+}
 
 /**
  * Observes text document changes and updates the regions with active fixups.
@@ -31,10 +71,16 @@ export class FixupDocumentEditObserver {
                 this.provider_.textDidChange(task)
                 break
             }
-            const updatedRange = updateRangeMultipleChanges(
-                task.selectionRange,
-                new Array<TextChange>(...event.contentChanges)
-            )
+            const changes = new Array<TextChange>(...event.contentChanges)
+            const updatedRange = updateRangeMultipleChanges(task.selectionRange, changes)
+            if (task.diff) {
+                updateRanges(task.diff.conflicts, changes)
+                updateEdits(task.diff.edits, changes)
+                updateRanges(task.diff.highlights, changes)
+                // Note, we may not notify the decorator of range changes here
+                // if the gross range has not changed. That is OK because
+                // VScode moves decorations and we can reproduce them lazily.
+            }
             if (!updatedRange.isEqual(task.selectionRange)) {
                 task.selectionRange = updatedRange
                 this.provider_.rangeDidChange(task)

--- a/client/cody/src/non-stop/FixupDocumentEditObserver.ts
+++ b/client/cody/src/non-stop/FixupDocumentEditObserver.ts
@@ -38,8 +38,8 @@ function updateRanges(ranges: Range[], changes: TextChange[]): void {
 
 // Updates the range in an edit.
 function updateEdits(edits: Edit[], changes: TextChange[]): void {
-    for (let i = 0; i < edits.length; i++) {
-        edits[i].range = updateDiffRange(edits[i].range, changes)
+    for (const [i, edit] of edits.entries()) {
+        edits[i].range = updateDiffRange(edit.range, changes)
     }
 }
 

--- a/client/cody/src/non-stop/FixupFile.ts
+++ b/client/cody/src/non-stop/FixupFile.ts
@@ -17,6 +17,10 @@ export class FixupFile {
         return this.uri_
     }
 
+    public get fileName(): string {
+        return this.uri_.fsPath
+    }
+
     public toString(): string {
         return `FixupFile${this.id_}(${this.uri_})`
     }

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -1,10 +1,6 @@
 import * as vscode from 'vscode'
 
-import { contentSanitizer } from '@sourcegraph/cody-shared/src/chat/recipes/helpers'
-import { ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
-
 import { debug } from '../log'
-import { editDocByUri } from '../services/InlineAssist'
 
 import { Diff } from './diff'
 import { FixupFile } from './FixupFile'
@@ -34,14 +30,14 @@ export class FixupTask {
     constructor(
         public readonly fixupFile: FixupFile,
         public readonly instruction: string,
-        public selection: ActiveTextEditorSelection,
         public readonly editor: vscode.TextEditor
     ) {
         this.id = Date.now().toString(36).replace(/\d+/g, '')
         this.selectionRange = editor.selection
-        this.original = selection.selectedText
+        this.original = editor.document.getText(editor.selection)
         this.queue()
     }
+
     /**
      * Set latest state for task and then update icon accordingly
      */
@@ -61,19 +57,22 @@ export class FixupTask {
     public stop(): void {
         this.setState(CodyTaskState.ready)
         this.output(`Task #${this.id} is ready for fixup...`)
+        // TODO: Make FixupTask a data object and handle the effect of state
+        // changes in the FixupController.
         void vscode.commands.executeCommand('setContext', 'cody.fixup.running', false)
     }
 
     public error(text: string = ''): void {
         this.setState(CodyTaskState.error)
         this.output(`Error for Task #${this.id} - ` + text)
+        // TODO: Make FixupTask a data object and handle the effect of state
+        // changes in the FixupController.
         void vscode.commands.executeCommand('setContext', 'cody.fixup.running', false)
     }
 
     public async apply(): Promise<void> {
         this.setState(CodyTaskState.applying)
         this.output(`Task #${this.id} is being applied...`)
-        await this.replaceSelection()
     }
 
     public queue(): void {
@@ -86,45 +85,15 @@ export class FixupTask {
         this.output(`Cody is making the fixups for #${this.id}...`)
     }
 
-    private fixed(): void {
+    public fixed(): void {
         this.setState(CodyTaskState.fixed)
         this.output(`Task #${this.id} is fixed and completed.`)
     }
+
     /**
      * Print output to the VS Code Output Channel under Cody AI by Sourcegraph
      */
     private output(text: string): void {
         this.outputChannel('Cody Fixups:', text)
-    }
-    /**
-     * Return latest selection
-     */
-    public getSelection(): ActiveTextEditorSelection | null {
-        return this.selection
-    }
-    /**
-     * Return latest selection range
-     */
-    public getSelectionRange(): vscode.Range | vscode.Selection {
-        return this.selectionRange
-    }
-
-    // TODO (dom) delete this once the new replacement edit method is in place
-    private async replaceSelection(): Promise<void> {
-        console.log('replacing start')
-        const { editor, selectionRange, replacement } = this
-        if (!editor || !replacement) {
-            this.error()
-            return
-        }
-        const newRange = await editDocByUri(
-            editor.document.uri,
-            { start: selectionRange.start.line, end: selectionRange.end.line + 1 },
-            contentSanitizer(replacement)
-        )
-        this.selectionRange = newRange
-        this.output('opening fixed doc')
-        await vscode.window.showTextDocument(editor.document.uri, { selection: newRange })
-        this.fixed()
     }
 }

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -70,7 +70,7 @@ export class FixupTask {
         void vscode.commands.executeCommand('setContext', 'cody.fixup.running', false)
     }
 
-    public async apply(): Promise<void> {
+    public apply(): void {
         this.setState(CodyTaskState.applying)
         this.output(`Task #${this.id} is being applied...`)
     }

--- a/client/cody/src/non-stop/TaskViewProvider.ts
+++ b/client/cody/src/non-stop/TaskViewProvider.ts
@@ -54,9 +54,9 @@ export class TaskViewProvider implements vscode.TreeDataProvider<FixupTaskTreeIt
         this.treeItems.set(task.id, treeItem)
 
         // Add fsPath to treeNodes
-        const treeNode = this.treeNodes.get(task.selection.fileName) || new FixupTaskTreeItem(task.selection.fileName)
+        const treeNode = this.treeNodes.get(task.fixupFile.fileName) || new FixupTaskTreeItem(task.fixupFile.fileName)
         treeNode.addChildren(task.id, task.state)
-        this.treeNodes.set(task.selection.fileName, treeNode)
+        this.treeNodes.set(task.fixupFile.fileName, treeNode)
 
         this.refresh()
     }
@@ -136,7 +136,7 @@ export class FixupTaskTreeItem extends vscode.TreeItem {
         }
         this.state = task.state
         this.id = task.id
-        this.fsPath = task.selection.fileName
+        this.fsPath = task.fixupFile.fileName
         // TODO: Files change URIs when they are renamed, so add a change
         // notification and don't cache this here.
         this.resourceUri = task.fixupFile.uri

--- a/client/cody/src/non-stop/diff.ts
+++ b/client/cody/src/non-stop/diff.ts
@@ -222,6 +222,9 @@ export interface Edit {
 }
 
 export interface Diff {
+    bufferText: string
+    mergedText: string | undefined
+    // TODO: We can use the presence of mergedText to indicate clean
     clean: boolean
     conflicts: Range[]
     edits: Edit[]
@@ -248,6 +251,9 @@ function updatedPosition(position: Position, text: string): Position {
 // - Whether the diff can be applied without conflicts.
 // - A set of insertions and deletions to apply in b.
 // - A set of ranges to highlight in the merged text, explaining edits in a.
+// "a" is the text produced by Cody, which is treated as "foreign".
+// "b" is the text produced by the human (perhaps applying Cody), which is
+// treated as known.
 export function computeDiff(original: string, a: string, b: string, bStart: Position): Diff {
     const chunks = computeChunks(original, a, b)
     const edits = []
@@ -256,11 +262,11 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
     let clean = true
     let originalPos = bStart
     let mergedPos = bStart
+    let mergedText: string[] = []
     for (const chunk of chunks) {
         const originalEnd = updatedPosition(originalPos, chunk[2])
         if (chunk[1] === chunk[2] && chunk[0] !== chunk[1]) {
             // Changed by robot
-            // TODO, do we need to treat deletions differently to replacements to insertions?
             edits.push({
                 kind: 'insert',
                 text: chunk[0],
@@ -269,6 +275,7 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
                     end: originalEnd,
                 },
             })
+            mergedText.push(chunk[0])
             const mergedEnd = updatedPosition(mergedPos, chunk[0])
             if (clean) {
                 postEditHighlights.push({ start: mergedPos, end: mergedEnd })
@@ -277,9 +284,11 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
         } else if (chunk[1] === chunk[0] && chunk[1] !== chunk[2]) {
             // Changed by human
             mergedPos = updatedPosition(mergedPos, chunk[2])
+            mergedText.push(chunk[2])
         } else if (chunk[0] === chunk[2]) {
             // Changed by both, to the same thing
             mergedPos = updatedPosition(mergedPos, chunk[2])
+            mergedText.push(chunk[2])
         } else {
             // Conflict! chunk[0]/chunk[2]`
             conflicts.push({ start: originalPos, end: originalEnd })
@@ -289,6 +298,8 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
         originalPos = originalEnd
     }
     return {
+        bufferText: b,
+        mergedText: clean ? mergedText.join('') : undefined,
         clean,
         conflicts,
         edits,

--- a/client/cody/src/non-stop/diff.ts
+++ b/client/cody/src/non-stop/diff.ts
@@ -262,7 +262,7 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
     let clean = true
     let originalPos = bStart
     let mergedPos = bStart
-    let mergedText: string[] = []
+    const mergedText: string[] = []
     for (const chunk of chunks) {
         const originalEnd = updatedPosition(originalPos, chunk[2])
         if (chunk[1] === chunk[2] && chunk[0] !== chunk[1]) {

--- a/client/cody/src/testSetup/vscode.ts
+++ b/client/cody/src/testSetup/vscode.ts
@@ -74,6 +74,9 @@ class Range {
     public get endCharacter(): number {
         return this.end.character
     }
+    public isEqual(other: Range): boolean {
+        return this.start.isEqual(other.start) && this.end.isEqual(other.end)
+    }
 }
 
 class Uri {


### PR DESCRIPTION
Up to this point we had been using Cody's output to replace the fixup region. But that obliterates any concurrent edits made by a human. This uses the merged text of the edits to unify concurrent human and Cody edits.

There are no re-spins for Cody edits with conflicts yet.

## Test plan

1. Write some code (or get Cody to.)
2. Select it, tell Cody to change it in some way, like add comments to it.
3. While Cody is working, also do some editing in ways that don't produce orange rectangles.
4. Apply Cody's changes.

You should see your edits and Cody's edits merged into one. Diff view should also reflect this.