### PR TITLE
Search: ignore context canceled error from repo hydration

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -677,7 +677,9 @@ func (h *eventHandler) Send(event streaming.SearchEvent) {
 
 	repoMetadata, err := getEventRepoMetadata(h.ctx, h.db, event)
 	if err != nil {
-		h.logger.Error("failed to get repo metadata", log.Error(err))
+		if !errors.IsContextCanceled(err) {
+			h.logger.Error("failed to get repo metadata", log.Error(err))
+		}
 		return
 	}
 


### PR DESCRIPTION
I've been ignoring this sentry error for like a year because it happens basically every time someone cancels a search from the UI 🙈. Time to do something about it.

## Test plan

It compiles.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
