### PR TITLE
Move concurrency limit into RateLimit type

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -25,18 +25,20 @@ var (
 )
 
 type Source struct {
-	log    log.Logger
-	cache  httpcache.Cache
-	dotcom graphql.Client
+	log               log.Logger
+	cache             httpcache.Cache
+	dotcom            graphql.Client
+	concurrencyConfig codygateway.ActorConcurrencyLimitConfig
 }
 
 var _ actor.Source = &Source{}
 
-func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client) *Source {
+func NewSource(logger log.Logger, cache httpcache.Cache, dotComClient graphql.Client, concurrencyConfig codygateway.ActorConcurrencyLimitConfig) *Source {
 	return &Source{
-		log:    logger.Scoped("dotcomuser", "dotcom user actor source"),
-		cache:  cache,
-		dotcom: dotComClient,
+		log:               logger.Scoped("dotcomuser", "dotcom user actor source"),
+		cache:             cache,
+		dotcom:            dotComClient,
+		concurrencyConfig: concurrencyConfig,
 	}
 }
 
@@ -81,9 +83,9 @@ func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor,
 	resp, checkErr := dotcom.CheckDotcomUserAccessToken(ctx, s.dotcom, token)
 	if checkErr != nil {
 		// Generate a stateless actor so that we aren't constantly hitting the dotcom API
-		act = NewActor(s, token, dotcom.DotcomUserState{})
+		act = newActor(s, token, dotcom.DotcomUserState{})
 	} else {
-		act = NewActor(s, token,
+		act = newActor(s, token,
 			resp.Dotcom.CodyGatewayDotcomUserByToken.DotcomUserState)
 	}
 
@@ -100,8 +102,8 @@ func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor,
 	return act, nil
 }
 
-// NewActor creates an actor from Sourcegraph.com user.
-func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *actor.Actor {
+// newActor creates an actor from Sourcegraph.com user.
+func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *actor.Actor {
 	now := time.Now()
 	a := &actor.Actor{
 		Key:           cacheKey,
@@ -112,27 +114,27 @@ func NewActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 		Source:        source,
 	}
 
-	if user.CodyGatewayAccess.ChatCompletionsRateLimit != nil {
+	if rl := user.CodyGatewayAccess.ChatCompletionsRateLimit; rl != nil {
 		a.RateLimits[codygateway.FeatureChatCompletions] = actor.RateLimit{
-			AllowedModels: user.CodyGatewayAccess.ChatCompletionsRateLimit.AllowedModels,
-			Limit:         user.CodyGatewayAccess.ChatCompletionsRateLimit.Limit,
-			Interval:      time.Duration(user.CodyGatewayAccess.ChatCompletionsRateLimit.IntervalSeconds) * time.Second,
+			AllowedModels: rl.AllowedModels,
+			Limit:         rl.Limit,
+			Interval:      time.Duration(rl.IntervalSeconds) * time.Second,
 		}
 	}
 
-	if user.CodyGatewayAccess.CodeCompletionsRateLimit != nil {
+	if rl := user.CodyGatewayAccess.CodeCompletionsRateLimit; rl != nil {
 		a.RateLimits[codygateway.FeatureCodeCompletions] = actor.RateLimit{
-			AllowedModels: user.CodyGatewayAccess.CodeCompletionsRateLimit.AllowedModels,
-			Limit:         user.CodyGatewayAccess.CodeCompletionsRateLimit.Limit,
-			Interval:      time.Duration(user.CodyGatewayAccess.CodeCompletionsRateLimit.IntervalSeconds) * time.Second,
+			AllowedModels: rl.AllowedModels,
+			Limit:         rl.Limit,
+			Interval:      time.Duration(rl.IntervalSeconds) * time.Second,
 		}
 	}
 
-	if user.CodyGatewayAccess.EmbeddingsRateLimit != nil {
+	if rl := user.CodyGatewayAccess.EmbeddingsRateLimit; rl != nil {
 		a.RateLimits[codygateway.FeatureEmbeddings] = actor.RateLimit{
-			AllowedModels: user.CodyGatewayAccess.EmbeddingsRateLimit.AllowedModels,
-			Limit:         user.CodyGatewayAccess.EmbeddingsRateLimit.Limit,
-			Interval:      time.Duration(user.CodyGatewayAccess.EmbeddingsRateLimit.IntervalSeconds) * time.Second,
+			AllowedModels: rl.AllowedModels,
+			Limit:         rl.Limit,
+			Interval:      time.Duration(rl.IntervalSeconds) * time.Second,
 		}
 	}
 

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
@@ -94,7 +94,7 @@ func TestNewActor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			act := NewActor(nil, "", tt.args.s)
+			act := newActor(nil, "", tt.args.s)
 			assert.Equal(t, act.AccessEnabled, tt.wantEnabled)
 		})
 	}

--- a/enterprise/cmd/cody-gateway/internal/actor/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/productsubscription/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":productsubscription"],
     deps = [
         "//enterprise/cmd/cody-gateway/internal/dotcom",
+        "//enterprise/internal/codygateway",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription_test.go
@@ -2,13 +2,19 @@ package productsubscription
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 )
 
 func TestNewActor(t *testing.T) {
+	concurrencyConfig := codygateway.ActorConcurrencyLimitConfig{
+		Percentage: 50,
+		Interval:   24 * time.Hour,
+	}
 	type args struct {
 		s               dotcom.ProductSubscriptionState
 		devLicensesOnly bool
@@ -104,7 +110,7 @@ func TestNewActor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			act := NewActor(nil, "", tt.args.s, tt.args.devLicensesOnly)
+			act := newActor(nil, "", tt.args.s, tt.args.devLicensesOnly, concurrencyConfig)
 			assert.Equal(t, act.AccessEnabled, tt.wantEnabled)
 		})
 	}

--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/httpapi/embeddings",
         "//enterprise/cmd/cody-gateway/internal/limiter",
         "//enterprise/cmd/cody-gateway/internal/response",
-        "//enterprise/internal/codygateway",
         "//internal/redispool",
         "//internal/trace",
         "//internal/version",

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/client/anthropic"
 )
 
@@ -20,7 +19,6 @@ func NewAnthropicHandler(
 	logger log.Logger,
 	eventLogger events.Logger,
 	rs limiter.RedisStore,
-	concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig,
 	accessToken string,
 	allowedModels []string,
 ) http.Handler {
@@ -28,7 +26,6 @@ func NewAnthropicHandler(
 		logger,
 		eventLogger,
 		rs,
-		concurrencyLimitConfig,
 		anthropic.ProviderName,
 		anthropicAPIURL,
 		allowedModels,

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/limiter.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/limiter.go
@@ -20,7 +20,6 @@ func rateLimit(
 	baseLogger log.Logger,
 	eventLogger events.Logger,
 	cache limiter.RedisStore,
-	concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig,
 	next http.Handler,
 ) http.Handler {
 	baseLogger = baseLogger.Scoped("rateLimit", "rate limit handler")
@@ -35,7 +34,7 @@ func rateLimit(
 			return
 		}
 
-		l, ok := act.Limiter(logger, cache, feature, concurrencyLimitConfig)
+		l, ok := act.Limiter(logger, cache, feature)
 		if !ok {
 			response.JSONError(logger, w, http.StatusForbidden, errors.Newf("no access to feature %s", feature))
 			return

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/client/openai"
 )
 
@@ -20,7 +19,6 @@ func NewOpenAIHandler(
 	logger log.Logger,
 	eventLogger events.Logger,
 	rs limiter.RedisStore,
-	concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig,
 	accessToken string,
 	orgID string,
 	allowedModels []string,
@@ -29,7 +27,6 @@ func NewOpenAIHandler(
 		logger,
 		eventLogger,
 		rs,
-		concurrencyLimitConfig,
 		openai.ProviderName,
 		openAIURL,
 		allowedModels,

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -48,7 +48,6 @@ func makeUpstreamHandler[ReqT any](
 	baseLogger log.Logger,
 	eventLogger events.Logger,
 	rs limiter.RedisStore,
-	concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig,
 
 	// upstreamName is the name of the upstream provider. It MUST match the
 	// provider names defined clientside, i.e. "anthropic" or "openai".
@@ -80,7 +79,6 @@ func makeUpstreamHandler[ReqT any](
 		baseLogger,
 		eventLogger,
 		limiter.NewPrefixRedisStore("rate_limit:", rs),
-		concurrencyLimitConfig,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			act := actor.FromContext(r.Context())
 			logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -26,13 +26,12 @@ func NewHandler(
 	baseLogger log.Logger,
 	eventLogger events.Logger,
 	rs limiter.RedisStore,
-	concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig,
 	mf ModelFactory,
 	allowedModels []string,
 ) http.Handler {
 	baseLogger = baseLogger.Scoped("embeddingshandler", "The HTTP API handler for the embeddings endpoint.")
 
-	return rateLimit(baseLogger, eventLogger, limiter.NewPrefixRedisStore("rate_limit:", rs), concurrencyLimitConfig, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return rateLimit(baseLogger, eventLogger, limiter.NewPrefixRedisStore("rate_limit:", rs), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/limiter.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/limiter.go
@@ -15,14 +15,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func rateLimit(baseLogger log.Logger, eventLogger events.Logger, cache limiter.RedisStore, concurrencyLimitConfig codygateway.ActorConcurrencyLimitConfig, next http.Handler) http.Handler {
+func rateLimit(baseLogger log.Logger, eventLogger events.Logger, cache limiter.RedisStore, next http.Handler) http.Handler {
 	baseLogger = baseLogger.Scoped("rateLimit", "rate limit handler")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
 
-		l, ok := act.Limiter(logger, cache, codygateway.FeatureEmbeddings, concurrencyLimitConfig)
+		l, ok := act.Limiter(logger, cache, codygateway.FeatureEmbeddings)
 		if !ok {
 			response.JSONError(logger, w, http.StatusForbidden, errors.New("no access to embeddings"))
 			return

--- a/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
@@ -12,11 +12,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/completions"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/embeddings"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 )
 
 type Config struct {
-	ConcurrencyLimit        codygateway.ActorConcurrencyLimitConfig
 	AnthropicAccessToken    string
 	AnthropicAllowedModels  []string
 	OpenAIAccessToken       string
@@ -34,14 +32,14 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 	if config.AnthropicAccessToken != "" {
 		v1router.Path("/completions/anthropic").Methods(http.MethodPost).Handler(
 			authr.Middleware(
-				completions.NewAnthropicHandler(logger, eventLogger, rs, config.ConcurrencyLimit, config.AnthropicAccessToken, config.AnthropicAllowedModels),
+				completions.NewAnthropicHandler(logger, eventLogger, rs, config.AnthropicAccessToken, config.AnthropicAllowedModels),
 			),
 		)
 	}
 	if config.OpenAIAccessToken != "" {
 		v1router.Path("/completions/openai").Methods(http.MethodPost).Handler(
 			authr.Middleware(
-				completions.NewOpenAIHandler(logger, eventLogger, rs, config.ConcurrencyLimit, config.OpenAIAccessToken, config.OpenAIOrgID, config.OpenAIAllowedModels),
+				completions.NewOpenAIHandler(logger, eventLogger, rs, config.OpenAIAccessToken, config.OpenAIOrgID, config.OpenAIAllowedModels),
 			),
 		)
 
@@ -57,7 +55,6 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 					logger,
 					eventLogger,
 					rs,
-					config.ConcurrencyLimit,
 					embeddings.ModelFactoryMap{
 						embeddings.ModelNameOpenAIAda: embeddings.NewOpenAIClient(config.OpenAIAccessToken),
 					},

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -73,15 +73,18 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 
 	// Supported actor/auth sources
 	sources := actor.Sources{
-		anonymous.NewSource(config.AllowAnonymous),
+		anonymous.NewSource(config.AllowAnonymous, config.ActorConcurrencyLimit),
 		productsubscription.NewSource(
 			obctx.Logger,
 			rcache.New("product-subscriptions"),
 			dotcomClient,
-			config.Dotcom.InternalMode),
+			config.Dotcom.InternalMode,
+			config.ActorConcurrencyLimit,
+		),
 		dotcomuser.NewSource(obctx.Logger,
 			rcache.New("dotcom-users"),
 			dotcomClient,
+			config.ActorConcurrencyLimit,
 		),
 	}
 
@@ -100,7 +103,6 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	// Set up our handler chain, which is run from the bottom up. Application handlers
 	// come last.
 	handler := httpapi.NewHandler(obctx.Logger, eventLogger, rs, authr, &httpapi.Config{
-		ConcurrencyLimit:        config.ActorConcurrencyLimit,
 		AnthropicAccessToken:    config.Anthropic.AccessToken,
 		AnthropicAllowedModels:  config.Anthropic.AllowedModels,
 		OpenAIAccessToken:       config.OpenAI.AccessToken,

--- a/enterprise/internal/licensing/codygateway.go
+++ b/enterprise/internal/licensing/codygateway.go
@@ -68,7 +68,7 @@ func NewCodyGatewayCodeRateLimit(plan Plan, userCount *int, licenseTags []string
 		PlanEnterprise0:
 		return CodyGatewayRateLimit{
 			AllowedModels:   models,
-			Limit:           int32(500 * uc),
+			Limit:           int32(1000 * uc),
 			IntervalSeconds: 60 * 60 * 24, // day
 		}
 

--- a/enterprise/internal/licensing/codygateway_test.go
+++ b/enterprise/internal/licensing/codygateway_test.go
@@ -79,7 +79,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"openai/gpt-3.5-turbo"},
-				Limit:           25000,
+				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},
@@ -89,7 +89,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			userCount: intPtr(50),
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"anthropic/claude-instant-v1"},
-				Limit:           25000,
+				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},
@@ -98,7 +98,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			plan: PlanEnterprise1,
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"anthropic/claude-instant-v1"},
-				Limit:           500,
+				Limit:           1000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},


### PR DESCRIPTION
This makes it so that we can do special computations based on the source, and also potentially send overwrites for concurrency from the dotcom side later. This is mostly in preparation for separating interactive and background embedding jobs, to make sure that interactive requests stay functional and allow higher concurrency, while we will be way stricter about the heavy bulk jobs.

## Test plan

Tests are still passing.