### PR TITLE
github app: better "delete App" UX

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -366,6 +366,7 @@ ts_project(
         "src/components/gitHubApps/GitHubAppPage.tsx",
         "src/components/gitHubApps/GitHubAppSelector.tsx",
         "src/components/gitHubApps/GitHubAppsPage.tsx",
+        "src/components/gitHubApps/RemoveGitHubAppModal.tsx",
         "src/components/gitHubApps/backend.ts",
         "src/components/shared.tsx",
         "src/components/time/Duration.tsx",

--- a/client/web/src/components/gitHubApps/GitHubAppCard.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppCard.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback } from 'react'
+import React, { useState } from 'react'
 
 import { mdiDelete, mdiOpenInNew, mdiCogOutline } from '@mdi/js'
 import classNames from 'classnames'
-import { DeleteGitHubAppResult, DeleteGitHubAppVariables } from 'src/graphql-operations'
 
-import { useMutation } from '@sourcegraph/http-client'
 import { Button, Icon, Container, AnchorLink, ButtonLink } from '@sourcegraph/wildcard'
 
-import { DELETE_GITHUB_APP_BY_ID_QUERY } from './backend'
+import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
 
 import styles from './GitHubAppCard.module.scss'
 
@@ -27,25 +25,13 @@ interface GitHubAppCardProps {
 }
 
 export const GitHubAppCard: React.FC<GitHubAppCardProps> = ({ app, refetch }) => {
-    const [deleteGitHubApp, { loading }] = useMutation<DeleteGitHubAppResult, DeleteGitHubAppVariables>(
-        DELETE_GITHUB_APP_BY_ID_QUERY
-    )
-
-    const onDelete = useCallback<React.MouseEventHandler>(async () => {
-        if (!window.confirm(`Delete the GitHub App "${app.name}"?`)) {
-            return
-        }
-        try {
-            await deleteGitHubApp({
-                variables: { gitHubApp: app.id },
-            })
-        } finally {
-            refetch()
-        }
-    }, [app, deleteGitHubApp, refetch])
+    const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
 
     return (
         <Container className="d-flex align-items-center mb-2 p-3">
+            {removeModalOpen && (
+                <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={app} />
+            )}
             <span className={classNames(styles.appLink, 'd-flex align-items-center')}>
                 <img className={classNames('mr-3', styles.logo)} src={app.logo} alt="app logo" aria-hidden={true} />
                 <span>
@@ -62,7 +48,12 @@ export const GitHubAppCard: React.FC<GitHubAppCardProps> = ({ app, refetch }) =>
                 <ButtonLink className="mr-2" aria-label="Edit" to={app.id} variant="secondary" size="sm">
                     <Icon aria-hidden={true} svgPath={mdiCogOutline} /> Edit
                 </ButtonLink>
-                <Button aria-label="Remove GitHub App" onClick={onDelete} disabled={loading} variant="danger" size="sm">
+                <Button
+                    aria-label="Remove GitHub App"
+                    onClick={() => setRemoveModalOpen(true)}
+                    variant="danger"
+                    size="sm"
+                >
                     <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
                 </Button>
             </div>

--- a/client/web/src/components/gitHubApps/RemoveGitHubAppModal.tsx
+++ b/client/web/src/components/gitHubApps/RemoveGitHubAppModal.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback } from 'react'
+
+import { useMutation } from '@sourcegraph/http-client'
+import { Button, Modal, Text, ErrorAlert, H3, AnchorLink, Alert } from '@sourcegraph/wildcard'
+
+import { DeleteGitHubAppResult, DeleteGitHubAppVariables, GitHubAppByIDFields } from '../../graphql-operations'
+import { LoaderButton } from '../LoaderButton'
+
+import { DELETE_GITHUB_APP_BY_ID_QUERY } from './backend'
+
+export interface RemoveGitHubAppModalProps {
+    app: Pick<GitHubAppByIDFields, 'id' | 'name' | 'appURL'>
+    onCancel: () => void
+    afterDelete: () => void
+}
+
+export const RemoveGitHubAppModal: React.FunctionComponent<React.PropsWithChildren<RemoveGitHubAppModalProps>> = ({
+    app,
+    onCancel,
+    afterDelete,
+}) => {
+    const labelId = 'removeGitHubApp'
+    const [deleteGitHubApp, { loading, error }] = useMutation<DeleteGitHubAppResult, DeleteGitHubAppVariables>(
+        DELETE_GITHUB_APP_BY_ID_QUERY
+    )
+
+    const onDelete = useCallback<React.MouseEventHandler>(async () => {
+        await deleteGitHubApp({ variables: { gitHubApp: app.id } })
+        afterDelete()
+    }, [afterDelete, app.id, deleteGitHubApp])
+
+    return (
+        <Modal onDismiss={onCancel} aria-labelledby={labelId}>
+            <H3 className="mb-3">Remove the GitHub App "{app.name}"?</H3>
+            {error && <ErrorAlert error={error} />}
+            <Alert variant="warning">
+                This will remove the App from Sourcegraph, but it will still exist on GitHub.
+            </Alert>
+            <Text>While not necessary, if you wish to completely remove the App on GitHub, you must:</Text>
+            <ul>
+                <li>Uninstall it from the individual user(s) or organization(s) where it is installed, and/or</li>
+                <li>
+                    {/* TODO: We could route this directly to the Advanced settings page once we can distinguish organization apps from user apps. */}
+                    Delete the App entirely.
+                </li>
+            </ul>
+
+            <Text>
+                <AnchorLink to={app.appURL} target="_blank" rel="noopener noreferrer">
+                    View the App on GitHub
+                </AnchorLink>{' '}
+                to uninstall or delete it. You must be an owner of the App on GitHub in order to perform these actions.
+            </Text>
+            <div className="d-flex justify-content-end pt-1">
+                <Button disabled={loading} className="mr-2" onClick={onCancel} outline={true} variant="secondary">
+                    Cancel
+                </Button>
+                <LoaderButton
+                    disabled={loading}
+                    onClick={onDelete}
+                    variant="danger"
+                    loading={loading}
+                    alwaysShowLabel={true}
+                    label="Remove GitHub App"
+                />
+            </div>
+        </Modal>
+    )
+}

--- a/client/web/src/components/gitHubApps/backend.ts
+++ b/client/web/src/components/gitHubApps/backend.ts
@@ -46,41 +46,49 @@ export const GITHUB_APPS_WITH_INSTALLATIONS_QUERY = gql`
     }
 `
 
-export const GITHUB_APP_BY_ID_QUERY = gql`
+const GITHUB_APP_BY_ID_FRAGMENT = gql`
+    fragment GitHubAppByIDFields on GitHubApp {
+        id
+        appID
+        domain
+        baseURL
+        name
+        slug
+        appURL
+        baseURL
+        clientID
+        logo
+        createdAt
+        updatedAt
+        installations {
+            id
+            url
+            account {
+                login
+                avatarURL
+                url
+                type
+            }
+            externalServices(first: 100) {
+                nodes {
+                    ...ListExternalServiceFields
+                }
+                totalCount
+            }
+        }
+        webhook {
+            id
+        }
+    }
+
     ${LIST_EXTERNAL_SERVICE_FRAGMENT}
+`
+
+export const GITHUB_APP_BY_ID_QUERY = gql`
+    ${GITHUB_APP_BY_ID_FRAGMENT}
     query GitHubAppByID($id: ID!) {
         gitHubApp(id: $id) {
-            id
-            appID
-            domain
-            baseURL
-            name
-            slug
-            appURL
-            baseURL
-            clientID
-            logo
-            createdAt
-            updatedAt
-            installations {
-                id
-                url
-                account {
-                    login
-                    avatarURL
-                    url
-                    type
-                }
-                externalServices(first: 100) {
-                    nodes {
-                        ...ListExternalServiceFields
-                    }
-                    totalCount
-                }
-            }
-            webhook {
-                id
-            }
+            ...GitHubAppByIDFields
         }
     }
 `


### PR DESCRIPTION
**Note:** This branch is temporarily based on https://github.com/sourcegraph/sourcegraph/pull/52979 to avoid merge conflicts with myself. I'll rebase it on the feature branch once that's merged.

Refactors "delete App" action logic to a shared `<Modal />` component and uses the extra real estate of the modal to explain that this only deletes the app on Sourcegraph, not on GitHub. Demo:

https://github.com/sourcegraph/sourcegraph/assets/8942601/ef850a71-94ae-43e0-8dbd-fc0a7d9fdba4

## Test plan

Manual testing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
