### PR TITLE
Cody repositories selector design cleanups

### DIFF
--- a/client/web/src/cody/components/ScopeSelector/CodyHighQualityIcon.tsx
+++ b/client/web/src/cody/components/ScopeSelector/CodyHighQualityIcon.tsx
@@ -1,19 +1,25 @@
 import React, { SVGProps } from 'react'
 
+import { mdiDatabaseCheckOutline } from '@mdi/js'
+
 export const CodyHighQualityIcon: React.FunctionComponent<React.PropsWithChildren<SVGProps<SVGSVGElement>>> = (
     props: SVGProps<SVGSVGElement>
 ) => (
-    <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" fill="none" viewBox="0 0 19 19" {...props}>
-        <path
-            fill="url(#a)"
-            d="M16 10.09V4c0-2.21-3.58-4-8-4S0 1.79 0 4v10c0 2.21 3.59 4 8 4 .46 0 .9 0 1.33-.06A5.94 5.94 0 0 1 9 16v-.05c-.32.05-.65.05-1 .05-3.87 0-6-1.5-6-2v-2.23C3.61 12.55 5.72 13 8 13c.65 0 1.27-.04 1.88-.11A5.986 5.986 0 0 1 15 10c.34 0 .67.04 1 .09Zm-2-.64C12.7 10.4 10.42 11 8 11s-4.7-.6-6-1.55V6.64C3.47 7.47 5.61 8 8 8s4.53-.53 6-1.36v2.81ZM8 6C4.13 6 2 4.5 2 4s2.13-2 6-2 6 1.5 6 2-2.13 2-6 2Zm10.5 8.25L13.75 19 11 16l1.16-1.16 1.59 1.59 3.59-3.59 1.16 1.41Z"
-        />
+    <svg width="24" height="24" viewBox="0 0 24 24" {...props}>
         <defs>
-            <linearGradient id="a" x1="9.25" x2="9.25" y1="0" y2="19" gradientUnits="userSpaceOnUse">
+            <linearGradient
+                id="cody-high-quality-icon-gradient"
+                x1="12"
+                x2="12"
+                y1="0"
+                y2="24"
+                gradientUnits="userSpaceOnUse"
+            >
                 <stop stopColor="#A112FF" />
-                <stop offset=".464" stopColor="#FF5543" />
+                <stop offset=".5" stopColor="#FF5543" />
                 <stop offset="1" stopColor="#00CBEC" />
             </linearGradient>
         </defs>
+        <path d={mdiDatabaseCheckOutline} fill="url(#cody-high-quality-icon-gradient)" />
     </svg>
 )

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -130,7 +130,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                 as={Button}
                 outline={false}
                 className={classNames(
-                    'd-flex justify-content-between p-0 align-items-center w-100',
+                    'd-flex justify-content-between p-0 pr-1 align-items-center w-100',
                     styles.repositoryNamesText
                 )}
             >
@@ -485,7 +485,7 @@ const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; 
         if (!totalReposCount) {
             return (
                 <div className="mr-1">
-                    <Icon aria-hidden={true} className="text-muted" svgPath={mdiDatabaseOutline} />
+                    <Icon aria-hidden={true} className="text-muted align-center" svgPath={mdiDatabaseOutline} />
                 </div>
             )
         }
@@ -503,7 +503,11 @@ const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; 
                     }
                 >
                     {reposWithoutEmbeddingsCount ? (
-                        <Icon aria-hidden={true} className="text-warning" svgPath={mdiDatabaseRemoveOutline} />
+                        <Icon
+                            aria-hidden={true}
+                            className="text-warning align-center"
+                            svgPath={mdiDatabaseRemoveOutline}
+                        />
                     ) : (
                         <CodyHighQualityIcon />
                     )}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -249,8 +249,11 @@ export const RepositoriesSelectorPopover: React.FC<{
                                         <div className="d-flex flex-column">
                                             <Text
                                                 className={classNames(
-                                                    'mt-1 mb-0 px-2 py-1 text-muted d-flex justify-content-between',
-                                                    styles.subHeader
+                                                    'mb-0 px-2 py-1 text-muted d-flex justify-content-between',
+                                                    styles.subHeader,
+                                                    {
+                                                        'mt-1': inferredRepository || inferredFilePath,
+                                                    }
                                                 )}
                                             >
                                                 <span className="small">
@@ -318,7 +321,9 @@ export const RepositoriesSelectorPopover: React.FC<{
                             spellCheck="false"
                             placeholder={
                                 additionalRepositoriesLeft
-                                    ? 'Add additional repositories...'
+                                    ? inferredRepository
+                                        ? 'Add additional repositories...'
+                                        : 'Add repositories...'
                                     : 'Maximum additional repositories added'
                             }
                             variant="small"

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -125,6 +125,8 @@ export const RepositoriesSelectorPopover: React.FC<{
 
     const additionalRepositoriesLeft = Math.max(MAX_ADDITIONAL_REPOSITORIES - additionalRepositories.length, 0)
 
+    const scopeChanged = additionalRepositories.length !== 0 || !includeInferredFile || !includeInferredRepository
+
     return (
         <Popover isOpen={isPopoverOpen} onOpenChange={onOpenChange}>
             <PopoverTrigger
@@ -170,15 +172,17 @@ export const RepositoriesSelectorPopover: React.FC<{
                             <>
                                 <div className="d-flex justify-content-between p-2 border-bottom mb-1">
                                     <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
-                                    <Button
-                                        onClick={resetScope}
-                                        variant="icon"
-                                        aria-label="Reset scope"
-                                        title="Reset scope"
-                                        className={styles.header}
-                                    >
-                                        Reset
-                                    </Button>
+                                    {scopeChanged && (
+                                        <Button
+                                            onClick={resetScope}
+                                            variant="icon"
+                                            aria-label="Reset scope"
+                                            title="Reset scope"
+                                            className={styles.header}
+                                        >
+                                            Reset
+                                        </Button>
+                                    )}
                                 </div>
                                 <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
                                     {inferredRepository && (

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -249,12 +249,14 @@ export const RepositoriesSelectorPopover: React.FC<{
                                         <div className="d-flex flex-column">
                                             <Text
                                                 className={classNames(
-                                                    'mb-1 px-2 py-1 text-muted d-flex justify-content-between',
+                                                    'mt-1 mb-0 px-2 py-1 text-muted d-flex justify-content-between',
                                                     styles.subHeader
                                                 )}
                                             >
-                                                <span>{inferredRepository ? 'Additional' : ''} Repositories</span>
-                                                <span>({additionalRepositories.length}/10)</span>
+                                                <span className="small">
+                                                    {inferredRepository ? 'Additional repositories' : 'Repositories'}
+                                                </span>
+                                                <span className="small">{additionalRepositories.length}/10</span>
                                             </Text>
                                             {additionalRepositories.map(repository => (
                                                 <AdditionalRepositoriesListItem
@@ -281,7 +283,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                 <div className="d-flex justify-content-between p-2 border-bottom mb-1">
                                     <Text className={classNames('m-0', styles.header)}>
                                         {additionalRepositoriesLeft
-                                            ? `Add up to ${additionalRepositoriesLeft} Additional Repositories`
+                                            ? `Add up to ${additionalRepositoriesLeft} additional repositories`
                                             : 'Maximum additional repositories added'}
                                     </Text>
                                 </div>
@@ -316,7 +318,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                             spellCheck="false"
                             placeholder={
                                 additionalRepositoriesLeft
-                                    ? 'Add repositories...'
+                                    ? 'Add additional repositories...'
                                     : 'Maximum additional repositories added'
                             }
                             variant="small"

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -284,14 +284,6 @@ export const RepositoriesSelectorPopover: React.FC<{
                                             ? `Add up to ${additionalRepositoriesLeft} Additional Repositories`
                                             : 'Maximum additional epositories added'}
                                     </Text>
-                                    <Button
-                                        onClick={() => setIsPopoverOpen(false)}
-                                        variant="icon"
-                                        aria-label="Close"
-                                        className="text-muted"
-                                    >
-                                        <Icon aria-hidden={true} svgPath={mdiClose} />
-                                    </Button>
                                 </div>
                                 <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
                                     {searchResults.length ? (

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -320,7 +320,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                     : 'Maximum additional repositories added'
                             }
                             variant="small"
-                            disabled={!additionalRepositoriesLeft}
+                            disabled={!searchText && !additionalRepositoriesLeft}
                             value={searchText}
                             onChange={onSearch}
                         />

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -169,9 +169,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                         {!searchText && (
                             <>
                                 <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                    <Text className={classNames('m-0 text-uppercase', styles.header)}>
-                                        Chat Context
-                                    </Text>
+                                    <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
                                     <Button
                                         onClick={resetScope}
                                         variant="icon"
@@ -179,7 +177,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                         title="Reset scope"
                                         className={styles.header}
                                     >
-                                        RESET
+                                        Reset
                                     </Button>
                                 </div>
                                 <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
@@ -281,7 +279,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                         {searchText && (
                             <>
                                 <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                    <Text className={classNames('m-0 text-uppercase', styles.header)}>
+                                    <Text className={classNames('m-0', styles.header)}>
                                         {additionalRepositoriesLeft
                                             ? `Add up to ${additionalRepositoriesLeft} Additional Repositories`
                                             : 'Maximum additional epositories added'}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -186,7 +186,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                             <button
                                                 type="button"
                                                 className={classNames(
-                                                    'd-flex justify-content-between flex-row bg-transparent outline-none border-0 text-truncate w-100 px-2 py-1',
+                                                    'd-flex justify-content-between flex-row text-truncate px-2 py-1',
                                                     styles.repositoryListItem,
                                                     {
                                                         [styles.notIncludedInContext]: !includeInferredRepository,
@@ -216,7 +216,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                 <button
                                                     type="button"
                                                     className={classNames(
-                                                        'd-flex justify-content-between flex-row bg-transparent outline-none border-0 text-truncate w-100 px-2 py-1 mt-1',
+                                                        'd-flex justify-content-between flex-row text-truncate px-2 py-1 mt-1',
                                                         styles.repositoryListItem,
                                                         {
                                                             [styles.notIncludedInContext]: !includeInferredFile,
@@ -364,7 +364,7 @@ const AdditionalRepositoriesListItem: React.FC<{
         <button
             type="button"
             className={classNames(
-                'd-flex justify-content-between flex-row bg-transparent outline-none border-0 text-truncate w-100 px-2 py-1 mb-1',
+                'd-flex justify-content-between flex-row text-truncate px-2 py-1 mb-1',
                 styles.repositoryListItem
             )}
             onClick={onClick}
@@ -415,7 +415,7 @@ const SearchResultsListItem: React.FC<{
         <button
             type="button"
             className={classNames(
-                'd-flex justify-content-between flex-row bg-transparent outline-none border-0 text-truncate w-100 px-2 py-1 mb-1',
+                'd-flex justify-content-between flex-row text-truncate px-2 py-1 mb-1',
                 styles.repositoryListItem,
                 { [styles.disabledSearchResult]: disabled }
             )}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -201,7 +201,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                 <div className="d-flex align-items-center text-truncate">
                                                     <Icon
                                                         aria-hidden={true}
-                                                        className={classNames('mr-2 text-muted', {
+                                                        className={classNames('mr-1 text-muted', {
                                                             [styles.visibilityHidden]: !includeInferredRepository,
                                                         })}
                                                         svgPath={mdiCheck}
@@ -231,7 +231,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                     <div className="d-flex align-items-center text-truncate">
                                                         <Icon
                                                             aria-hidden={true}
-                                                            className={classNames('mr-2 text-muted', {
+                                                            className={classNames('mr-1 text-muted', {
                                                                 [styles.visibilityHidden]: !includeInferredFile,
                                                             })}
                                                             svgPath={mdiCheck}
@@ -370,7 +370,7 @@ const AdditionalRepositoriesListItem: React.FC<{
             <div className="d-flex align-items-center text-truncate">
                 <Icon
                     aria-hidden={true}
-                    className={classNames('mr-2 text-muted', styles.removeRepoIcon)}
+                    className={classNames('mr-1 text-muted', styles.removeRepoIcon)}
                     svgPath={mdiMinusCircleOutline}
                 />
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
@@ -423,7 +423,7 @@ const SearchResultsListItem: React.FC<{
             <div className="text-truncate">
                 <Icon
                     aria-hidden={true}
-                    className={classNames('mr-2 text-muted', { [styles.visibilityHidden]: !selected })}
+                    className={classNames('mr-1 text-muted', { [styles.visibilityHidden]: !selected })}
                     svgPath={mdiCheck}
                 />
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -467,7 +467,7 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
                 content={
                     embeddingExists
                         ? 'Embeddings enabled'
-                        : 'Embeddings are missing for this repository. Enable embeddings to increase the quality of Cody’s responses.'
+                        : 'Embeddings are missing for this repository. Enable embeddings to improve the quality of Cody’s responses.'
                 }
             >
                 <Icon
@@ -497,7 +497,7 @@ const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; 
                 <Tooltip
                     content={`Embeddings are missing for ${
                         totalReposCount === 1 ? 'this repository' : 'some repositories'
-                    }. Enable embeddings to increase the quality of Cody’s responses.`}
+                    }. Enable embeddings to improve the quality of Cody’s responses.`}
                 >
                     <Icon
                         svgPath={mdiDatabaseRemoveOutline}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -134,10 +134,12 @@ export const RepositoriesSelectorPopover: React.FC<{
                     styles.repositoryNamesText
                 )}
             >
-                <EmbeddingStatusIndicator
-                    reposWithoutEmbeddingsCount={reposWithoutEmbeddings.length}
-                    totalReposCount={netRepositories.length}
-                />
+                <div className="mr-1">
+                    <EmbeddingStatusIndicator
+                        reposWithoutEmbeddingsCount={reposWithoutEmbeddings.length}
+                        totalReposCount={netRepositories.length}
+                    />
+                </div>
                 <div
                     className={classNames('text-truncate mr-1', {
                         'text-muted': !netRepositories.length,
@@ -464,7 +466,7 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
             <Tooltip
                 content={
                     embeddingExists
-                        ? 'Embeddings are enabled for this repository'
+                        ? 'Embeddings enabled'
                         : 'Embeddings are missing for this repository. Enable embeddings to increase the quality of Cody’s responses.'
                 }
             >
@@ -484,35 +486,32 @@ const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; 
     function EmbeddingsStatusIndicatorContent({ reposWithoutEmbeddingsCount, totalReposCount }) {
         if (!totalReposCount) {
             return (
-                <div className="mr-1">
-                    <Icon aria-hidden={true} className="text-muted align-center" svgPath={mdiDatabaseOutline} />
-                </div>
+                <Tooltip content="Add repositories for Cody to reference">
+                    <Icon aria-label="Database icon" className="text-muted align-center" svgPath={mdiDatabaseOutline} />
+                </Tooltip>
             )
         }
-        return (
-            <div className="mr-1">
+
+        if (reposWithoutEmbeddingsCount) {
+            return (
                 <Tooltip
-                    content={
-                        reposWithoutEmbeddingsCount
-                            ? `Embeddings are missing for ${
-                                  totalReposCount === 1 ? 'this repository' : 'some repositories'
-                              }. Enable embeddings to increase the quality of Cody’s responses.`
-                            : totalReposCount === 1
-                            ? 'Embeddings are enabled for this repository'
-                            : 'Embeddings are enabled' // Doesn't use 'all repos' otherwise it might sound system-wide
-                    }
+                    content={`Embeddings are missing for ${
+                        totalReposCount === 1 ? 'this repository' : 'some repositories'
+                    }. Enable embeddings to increase the quality of Cody’s responses.`}
                 >
-                    {reposWithoutEmbeddingsCount ? (
-                        <Icon
-                            aria-hidden={true}
-                            className="text-warning align-center"
-                            svgPath={mdiDatabaseRemoveOutline}
-                        />
-                    ) : (
-                        <CodyHighQualityIcon />
-                    )}
+                    <Icon
+                        svgPath={mdiDatabaseRemoveOutline}
+                        aria-label="Database icon with a cross"
+                        className="text-warning align-center"
+                    />
                 </Tooltip>
-            </div>
+            )
+        }
+
+        return (
+            <Tooltip content="Embeddings enabled">
+                <Icon as={CodyHighQualityIcon} aria-label="Database icon with a check mark" className="align-center" />
+            </Tooltip>
         )
     }
 )

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -282,7 +282,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                     <Text className={classNames('m-0', styles.header)}>
                                         {additionalRepositoriesLeft
                                             ? `Add up to ${additionalRepositoriesLeft} Additional Repositories`
-                                            : 'Maximum additional epositories added'}
+                                            : 'Maximum additional repositories added'}
                                     </Text>
                                 </div>
                                 <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -417,7 +417,7 @@ const SearchResultsListItem: React.FC<{
             <div className="text-truncate">
                 <Icon
                     aria-hidden={true}
-                    className={classNames('mr-2 text-success', { [styles.visibilityHidden]: !selected })}
+                    className={classNames('mr-2 text-muted', { [styles.visibilityHidden]: !selected })}
                     svgPath={mdiCheck}
                 />
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -204,7 +204,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                     />
                                                     <ExternalRepositoryIcon
                                                         externalRepo={inferredRepository.externalRepository}
-                                                        className="text-muted"
+                                                        className={styles.repoIcon}
                                                     />
                                                     <span className="text-truncate">
                                                         {getRepoName(inferredRepository.name)}
@@ -234,7 +234,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         />
                                                         <ExternalRepositoryIcon
                                                             externalRepo={inferredRepository.externalRepository}
-                                                            className="text-muted"
+                                                            className={styles.repoIcon}
                                                         />
                                                         <span className="text-truncate">
                                                             {getFileName(inferredFilePath)}
@@ -375,7 +375,7 @@ const AdditionalRepositoriesListItem: React.FC<{
                     className={classNames('mr-2 text-muted', styles.removeRepoIcon)}
                     svgPath={mdiMinusCircleOutline}
                 />
-                <ExternalRepositoryIcon externalRepo={repository.externalRepository} className="text-muted" />
+                <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 <span className="text-truncate">{getRepoName(repository.name)}</span>
             </div>
             <EmbeddingExistsIcon repo={repository} />
@@ -428,7 +428,7 @@ const SearchResultsListItem: React.FC<{
                     className={classNames('mr-2 text-success', { [styles.visibilityHidden]: !selected })}
                     svgPath={mdiCheck}
                 />
-                <ExternalRepositoryIcon externalRepo={repository.externalRepository} className="text-muted" />
+                <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 {getTintedText(getRepoName(repository.name), searchText)}
             </div>
             <EmbeddingExistsIcon repo={repository} />
@@ -483,8 +483,7 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
                 <Icon
                     aria-hidden={true}
                     className={classNames({
-                        'text-muted': embeddingExists,
-                        'text-warning': !embeddingExists,
+                        [styles.embeddingIconNoEmbeddings]: !embeddingExists,
                     })}
                     svgPath={embeddingExists ? mdiDatabaseCheckOutline : mdiDatabaseRemoveOutline}
                 />

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -458,8 +458,8 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
             <Tooltip
                 content={
                     embeddingExists
-                        ? 'Embeddings are enabled for this repository. When embeddings are running, you’ll see how amazing the results are!'
-                        : 'Embeddings are not enabled for this repository. You can still use Cody, but the quality of Cody’s responses may be low.'
+                        ? 'Embeddings are enabled for this repository'
+                        : 'Embeddings are missing for this repository. Enable embeddings to increase the quality of Cody’s responses.'
                 }
             >
                 <Icon
@@ -474,69 +474,27 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
     }
 )
 
-const noop = (): void => {}
-const stopEventBubble = (event: { stopPropagation: () => void }): void => event.stopPropagation()
-
 const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; totalReposCount: number }> = React.memo(
     function EmbeddingsStatusIndicatorContent({ reposWithoutEmbeddingsCount, totalReposCount }) {
-        const [isEmbeddingsStatusOpen, setIsEmbeddingsStatusOpen] = useState(false)
-
-        const onEmbeddingsStatusOpenChange = useCallback(
-            (event: { isOpen: boolean }) => {
-                setIsEmbeddingsStatusOpen(event.isOpen)
-            },
-            [setIsEmbeddingsStatusOpen]
-        )
-
         return totalReposCount ? (
-            <div onClick={stopEventBubble} role="button" tabIndex={0} onKeyDown={noop}>
-                <Popover isOpen={isEmbeddingsStatusOpen} onOpenChange={onEmbeddingsStatusOpenChange}>
-                    <PopoverTrigger as={Button} outline={false} className="p-0 mr-2 d-flex align-items-center">
-                        {reposWithoutEmbeddingsCount ? (
-                            <Icon aria-hidden={true} className="text-warning" svgPath={mdiDatabaseRemoveOutline} />
-                        ) : (
-                            <CodyHighQualityIcon />
-                        )}
-                    </PopoverTrigger>
-                    <PopoverContent position={Position.topStart}>
-                        <Card className={classNames('d-flex flex-column', styles.embeddingsStatusContent)}>
-                            <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                <Text className={classNames('m-0 text-uppercase', styles.header)}>
-                                    Cody's Response Quality is{' '}
-                                    {reposWithoutEmbeddingsCount ? (
-                                        <span className="text-warning">Medium</span>
-                                    ) : (
-                                        <span className="text-success">High</span>
-                                    )}
-                                </Text>
-                            </div>
-                            <div className="d-flex align-items-start p-2">
-                                <Text className="m-0 pr-2">
-                                    <strong>Embeddings:</strong>
-                                </Text>
-                                {reposWithoutEmbeddingsCount ? (
-                                    <Text className="m-0">
-                                        <strong>
-                                            Not enabled for{' '}
-                                            {reposWithoutEmbeddingsCount === totalReposCount
-                                                ? 'any of the repositories'
-                                                : totalReposCount > 1
-                                                ? `${reposWithoutEmbeddingsCount} of ${totalReposCount} repositories`
-                                                : 'the repository'}{' '}
-                                            you selected.
-                                        </strong>{' '}
-                                        You can still use Cody, but the quality of Cody’s responses may be low.
-                                    </Text>
-                                ) : (
-                                    <Text className="m-0">
-                                        <strong>All selected repositories are indexed.</strong> When embeddings are
-                                        running, you’ll see how amazing the results are!
-                                    </Text>
-                                )}
-                            </div>
-                        </Card>
-                    </PopoverContent>
-                </Popover>
+            <div className="mr-1">
+                <Tooltip
+                    content={
+                        reposWithoutEmbeddingsCount
+                            ? `Embeddings are missing for ${
+                                  totalReposCount === 1 ? 'this repository' : 'some repositories'
+                              }. Enable embeddings to increase the quality of Cody’s responses.`
+                            : totalReposCount === 1
+                            ? 'Embeddings are enabled for this repository'
+                            : 'Embeddings are enabled' // Doesn't use 'all repos' otherwise it might sound system-wide
+                    }
+                >
+                    {reposWithoutEmbeddingsCount ? (
+                        <Icon aria-hidden={true} className="text-warning" svgPath={mdiDatabaseRemoveOutline} />
+                    ) : (
+                        <CodyHighQualityIcon />
+                    )}
+                </Tooltip>
             </div>
         ) : null
     }

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -3,9 +3,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import {
     mdiChevronUp,
     mdiMinusCircleOutline,
-    mdiClose,
     mdiCheck,
-    mdiCloseCircle,
     mdiDatabaseCheckOutline,
     mdiDatabaseRemoveOutline,
 } from '@mdi/js'
@@ -93,8 +91,6 @@ export const RepositoriesSelectorPopover: React.FC<{
             /* eslint-enable no-console */
         }
     }, [searchTextDebounced, searchRepositories])
-
-    const clearSearchText = useCallback(() => setSearchText(''), [setSearchText])
 
     const onOpenChange = useCallback(
         (event: { isOpen: boolean }) => {
@@ -314,7 +310,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                             </>
                         )}
                     </div>
-                    <div className={classNames('relative p-2 border-top mt-auto', styles.inputContainer)}>
+                    <div className="p-2 border-top mt-auto">
                         <Input
                             role="combobox"
                             autoFocus={true}
@@ -329,20 +325,8 @@ export const RepositoriesSelectorPopover: React.FC<{
                             disabled={!searchText && !additionalRepositoriesLeft}
                             value={searchText}
                             onChange={onSearch}
+                            type="search"
                         />
-                        {!!searchText && (
-                            <Button
-                                className={classNames(
-                                    'd-flex p-1 align-items-center justify-content-center',
-                                    styles.clearButton
-                                )}
-                                variant="icon"
-                                onClick={clearSearchText}
-                                aria-label="Clear"
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiCloseCircle} />
-                            </Button>
-                        )}
                     </div>
                 </Card>
             </PopoverContent>

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -4,6 +4,7 @@ import {
     mdiChevronUp,
     mdiMinusCircleOutline,
     mdiCheck,
+    mdiDatabaseOutline,
     mdiDatabaseCheckOutline,
     mdiDatabaseRemoveOutline,
 } from '@mdi/js'
@@ -150,7 +151,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                     ) : netRepositories.length ? (
                         getFileName(netRepositories[0].name)
                     ) : (
-                        'Add repositories to the scope...'
+                        'Add repositories...'
                     )}
                 </div>
                 <Icon aria-hidden={true} svgPath={mdiChevronUp} />
@@ -481,7 +482,14 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
 
 const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; totalReposCount: number }> = React.memo(
     function EmbeddingsStatusIndicatorContent({ reposWithoutEmbeddingsCount, totalReposCount }) {
-        return totalReposCount ? (
+        if (!totalReposCount) {
+            return (
+                <div className="mr-1">
+                    <Icon aria-hidden={true} className="text-muted" svgPath={mdiDatabaseOutline} />
+                </div>
+            )
+        }
+        return (
             <div className="mr-1">
                 <Tooltip
                     content={
@@ -501,6 +509,6 @@ const EmbeddingStatusIndicator: React.FC<{ reposWithoutEmbeddingsCount: number; 
                     )}
                 </Tooltip>
             </div>
-        ) : null
+        )
     }
 )

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -25,10 +25,9 @@
     font-weight: 400;
 
     svg {
-        min-width: 1rem;
-        min-height: 1rem;
-        max-width: 1rem;
-        max-height: 1rem;
+        width: 1rem;
+        height: 1rem;
+        flex-shrink: 0;
     }
 }
 

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -9,7 +9,7 @@
 .separator {
     height: 100%;
     border-left: 1px solid var(--border-color-2);
-    margin-right: .675rem;
+    margin-right: 0.675rem;
 }
 
 .footer {

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -113,7 +113,8 @@
 }
 
 .not-included-in-context {
-    &, .repo-icon {
+    &,
+    .repo-icon {
         color: var(--text-disabled);
     }
     .embedding-icon-no-embeddings {

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -42,14 +42,6 @@
     background-color: var(--mark-bg);
 }
 
-.input-container {
-    position: relative;
-
-    input {
-        padding-right: 2rem;
-    }
-}
-
 .clear-button {
     position: absolute;
     top: 1.25rem;

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -7,10 +7,9 @@
 }
 
 .separator {
-    background-color: var(--border-color-2);
     height: 100%;
-    min-width: 0.0625rem;
-    width: 0.0625rem;
+    border-left: 1px solid var(--border-color-2);
+    margin-right: .675rem;
 }
 
 .footer {

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -99,6 +99,7 @@
     font-size: 0.625rem;
     line-height: 1rem;
     font-weight: 500;
+    text-transform: uppercase;
 }
 
 .repository-list-item {

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -103,8 +103,10 @@
 }
 
 .repository-list-item {
+    all: unset;
     font-size: 0.8rem;
     line-height: 1rem;
+    display: block;
 
     svg {
         min-width: 1rem;
@@ -115,6 +117,8 @@
         visibility: hidden;
     }
     &:hover {
+        background-color: var(--gray-01);
+
         .remove-repo-icon {
             visibility: visible;
         }

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -54,20 +54,6 @@
     color: var(--input-focus-border-color);
 }
 
-.embeddings-status-content {
-    width: 24rem;
-    height: 100%;
-    max-width: 24rem;
-    min-height: 7rem;
-    overflow: hidden;
-    font-size: 0.8rem;
-    line-height: 1rem;
-
-    strong {
-        font-weight: 500;
-    }
-}
-
 .repository-selector-content {
     width: 20rem;
     height: 100%;

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -131,9 +131,18 @@
 }
 
 .not-included-in-context {
-    opacity: 50%;
+    &, .repo-icon {
+        color: var(--text-disabled);
+    }
+    .embedding-icon-no-embeddings {
+        color: var(--gray-05);
+    }
 }
 
 .not-included-in-context:hover {
     opacity: 100%;
+}
+
+.embedding-icon-no-embeddings {
+    color: var(--warning);
 }

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -108,7 +108,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                 />
                 {scope.includeInferredFile && activeEditor?.filePath && (
                     <div className={classNames('d-flex align-items-center', styles.filepathText)}>
-                        <div className={classNames('mx-2', styles.separator)} />
+                        <div className={styles.separator} />
                         {getFileName(activeEditor.filePath)}
                     </div>
                 )}

--- a/client/web/src/site-admin/components/ExternalRepositoryIcon.tsx
+++ b/client/web/src/site-admin/components/ExternalRepositoryIcon.tsx
@@ -14,8 +14,8 @@ export const ExternalRepositoryIcon: React.FunctionComponent<
 > = ({ externalRepo, className }) => {
     const IconComponent = externalRepoIcon(externalRepo)
     return IconComponent ? (
-        <Icon as={IconComponent} aria-label="Code host logo" className={classNames('mr-2', className)} />
+        <Icon as={IconComponent} aria-label="Code host logo" className={classNames('mr-1', className)} />
     ) : (
-        <Icon svgPath={mdiCloudQuestion} aria-label="Unknown code host" className={classNames('mr-2', className)} />
+        <Icon svgPath={mdiCloudQuestion} aria-label="Unknown code host" className={classNames('mr-1', className)} />
     )
 }


### PR DESCRIPTION
This fixes a few layout bugs and cleans up some of the design details on the new repository selector popover.

* Better visibility for disabled inferred items
* Hover styles for clickable rows
* Improve the embeddings status text (as per https://github.com/sourcegraph/sourcegraph/pull/53165#issuecomment-1583677432 but without the link to docs, as I couldn't figure that out). It's now consistent in behaviour and text between both the popover and on the icon in the compose window. It did mean switching to a plain tooltip, but I think that's okay for now until we figure out how we want to talk about "quality" (if we want to do that at all)
* Doesn't show the Reset button unless there's something to reset
* Switches to a `type="search"` input for the search (escape key behaviour could still be improved to only bubble up to the popover only if the search is empty)
* Fixes position of button content if labels are long and truncated
* Adjusts the text more dependently for inferred-less pages (Cody top level) vs contextual pages
* Adds an icon to the empty state on the top-level Cody page
* Removes the (x) button when doing a search, as it can be confused with clearing the search
* Fixing the gradient "all embeddings are okay" version of the button so it's the same size and doesn't shift

### Before

https://github.com/sourcegraph/sourcegraph/assets/153/cff7dd95-ccbe-4bc7-8c91-138478c886f4 

https://github.com/sourcegraph/sourcegraph/assets/153/4d11b8c2-e2ca-4ec3-b5b9-8a3d290a8e44

<img width="454" alt="Screenshot 2023-06-09 at 5 15 36 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/9cacee3a-00ff-415c-90c2-1e215f2909cb">

### After

https://github.com/sourcegraph/sourcegraph/assets/153/064497ab-11a3-46c8-b5c7-a25e3bff735c

https://github.com/sourcegraph/sourcegraph/assets/153/552b017b-bd6a-4758-9cb2-a2e3c83f532a

<img width="427" alt="Screenshot 2023-06-09 at 5 15 50 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/c07aeec8-d705-46c2-b61d-7a920ca1fc9b">

## Test plan

* Navigate to Cody AI and repo pages
* Use the selector with as many states
* Very all states display as expected