### PR TITLE
Return single counts object from QueryAggregateCounts

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -415,10 +415,7 @@ func (r *ownStatsResolver) TotalCodeownedFiles(ctx context.Context) (int32, erro
 	if err != nil {
 		return 0, err
 	}
-	if len(counts) == 0 {
-		return 0, nil
-	}
-	return int32(counts[0].CodeownedFileCount), nil
+	return int32(counts.CodeownedFileCount), nil
 }
 
 type ownershipConnectionResolver struct {

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -2152,7 +2152,7 @@ func TestDisplayOwnershipStats(t *testing.T) {
 	db.RepoPathsFunc.SetDefaultReturn(fakeRepoPaths)
 	fakeOwnershipStats := database.NewMockOwnershipStatsStore()
 	fakeOwnershipStats.QueryAggregateCountsFunc.SetDefaultReturn(
-		[]database.PathAggregateCounts{{CodeownedFileCount: 150000}}, nil)
+		database.PathAggregateCounts{CodeownedFileCount: 150000}, nil)
 	db.OwnershipStatsFunc.SetDefaultReturn(fakeOwnershipStats)
 	ctx := context.Background()
 	schema, err := graphqlbackend.NewSchema(db, nil, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, nil, nil, logtest.NoOp(t))})

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -39241,7 +39241,7 @@ type MockOwnershipStatsStore struct {
 func NewMockOwnershipStatsStore() *MockOwnershipStatsStore {
 	return &MockOwnershipStatsStore{
 		QueryAggregateCountsFunc: &OwnershipStatsStoreQueryAggregateCountsFunc{
-			defaultHook: func(context.Context, TreeLocationOpts) (r0 []PathAggregateCounts, r1 error) {
+			defaultHook: func(context.Context, TreeLocationOpts) (r0 PathAggregateCounts, r1 error) {
 				return
 			},
 		},
@@ -39269,7 +39269,7 @@ func NewMockOwnershipStatsStore() *MockOwnershipStatsStore {
 func NewStrictMockOwnershipStatsStore() *MockOwnershipStatsStore {
 	return &MockOwnershipStatsStore{
 		QueryAggregateCountsFunc: &OwnershipStatsStoreQueryAggregateCountsFunc{
-			defaultHook: func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error) {
+			defaultHook: func(context.Context, TreeLocationOpts) (PathAggregateCounts, error) {
 				panic("unexpected invocation of MockOwnershipStatsStore.QueryAggregateCounts")
 			},
 		},
@@ -39315,15 +39315,15 @@ func NewMockOwnershipStatsStoreFrom(i OwnershipStatsStore) *MockOwnershipStatsSt
 // the QueryAggregateCounts method of the parent MockOwnershipStatsStore
 // instance is invoked.
 type OwnershipStatsStoreQueryAggregateCountsFunc struct {
-	defaultHook func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error)
-	hooks       []func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error)
+	defaultHook func(context.Context, TreeLocationOpts) (PathAggregateCounts, error)
+	hooks       []func(context.Context, TreeLocationOpts) (PathAggregateCounts, error)
 	history     []OwnershipStatsStoreQueryAggregateCountsFuncCall
 	mutex       sync.Mutex
 }
 
 // QueryAggregateCounts delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockOwnershipStatsStore) QueryAggregateCounts(v0 context.Context, v1 TreeLocationOpts) ([]PathAggregateCounts, error) {
+func (m *MockOwnershipStatsStore) QueryAggregateCounts(v0 context.Context, v1 TreeLocationOpts) (PathAggregateCounts, error) {
 	r0, r1 := m.QueryAggregateCountsFunc.nextHook()(v0, v1)
 	m.QueryAggregateCountsFunc.appendCall(OwnershipStatsStoreQueryAggregateCountsFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -39332,7 +39332,7 @@ func (m *MockOwnershipStatsStore) QueryAggregateCounts(v0 context.Context, v1 Tr
 // SetDefaultHook sets function that is called when the QueryAggregateCounts
 // method of the parent MockOwnershipStatsStore instance is invoked and the
 // hook queue is empty.
-func (f *OwnershipStatsStoreQueryAggregateCountsFunc) SetDefaultHook(hook func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error)) {
+func (f *OwnershipStatsStoreQueryAggregateCountsFunc) SetDefaultHook(hook func(context.Context, TreeLocationOpts) (PathAggregateCounts, error)) {
 	f.defaultHook = hook
 }
 
@@ -39341,7 +39341,7 @@ func (f *OwnershipStatsStoreQueryAggregateCountsFunc) SetDefaultHook(hook func(c
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *OwnershipStatsStoreQueryAggregateCountsFunc) PushHook(hook func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error)) {
+func (f *OwnershipStatsStoreQueryAggregateCountsFunc) PushHook(hook func(context.Context, TreeLocationOpts) (PathAggregateCounts, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -39349,20 +39349,20 @@ func (f *OwnershipStatsStoreQueryAggregateCountsFunc) PushHook(hook func(context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *OwnershipStatsStoreQueryAggregateCountsFunc) SetDefaultReturn(r0 []PathAggregateCounts, r1 error) {
-	f.SetDefaultHook(func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error) {
+func (f *OwnershipStatsStoreQueryAggregateCountsFunc) SetDefaultReturn(r0 PathAggregateCounts, r1 error) {
+	f.SetDefaultHook(func(context.Context, TreeLocationOpts) (PathAggregateCounts, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *OwnershipStatsStoreQueryAggregateCountsFunc) PushReturn(r0 []PathAggregateCounts, r1 error) {
-	f.PushHook(func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error) {
+func (f *OwnershipStatsStoreQueryAggregateCountsFunc) PushReturn(r0 PathAggregateCounts, r1 error) {
+	f.PushHook(func(context.Context, TreeLocationOpts) (PathAggregateCounts, error) {
 		return r0, r1
 	})
 }
 
-func (f *OwnershipStatsStoreQueryAggregateCountsFunc) nextHook() func(context.Context, TreeLocationOpts) ([]PathAggregateCounts, error) {
+func (f *OwnershipStatsStoreQueryAggregateCountsFunc) nextHook() func(context.Context, TreeLocationOpts) (PathAggregateCounts, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -39405,7 +39405,7 @@ type OwnershipStatsStoreQueryAggregateCountsFuncCall struct {
 	Arg1 TreeLocationOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []PathAggregateCounts
+	Result0 PathAggregateCounts
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -197,9 +197,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 0},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 0}
 		assert.DeepEqual(t, want, got)
 	})
 
@@ -207,9 +205,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		opts := TreeLocationOpts{}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 0},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 0}
 		assert.DeepEqual(t, want, got)
 	})
 
@@ -236,9 +232,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 1},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 1}
 		assert.DeepEqual(t, want, got)
 	})
 
@@ -249,9 +243,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 2},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 2}
 		assert.DeepEqual(t, want, got)
 	})
 
@@ -261,9 +253,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 3},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 3}
 		assert.DeepEqual(t, want, got)
 	})
 
@@ -271,9 +261,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		opts := TreeLocationOpts{}
 		got, err := d.OwnershipStats().QueryAggregateCounts(ctx, opts)
 		require.NoError(t, err)
-		want := []PathAggregateCounts{
-			{CodeownedFileCount: 13},
-		}
+		want := PathAggregateCounts{CodeownedFileCount: 13}
 		assert.DeepEqual(t, want, got)
 	})
 }


### PR DESCRIPTION
This is just an API change. The `QueryAggregateCounts` always would return singleton slice. It should have returned an object in the first place.

## Test plan

Existing tests updated.
