### PR TITLE
Fix broken diff search if sub-repo perms are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to Sourcegraph are documented in this file.
 - SAML assertions to get user display name are now compared case insensitively and we do not always return an error. [#52992](https://github.com/sourcegraph/sourcegraph/pull/52992)
 - The braindot menu on the blob view no longer fetches data eagerly to prevent performance issues for larger monorepo users. [#53039](https://github.com/sourcegraph/sourcegraph/pull/53039)
 - Fixed an issue where commenting out redacted site-config secrets would re-add the secrets. [#53152](https://github.com/sourcegraph/sourcegraph/pull/53152)
+- Fixed an issue where `type:diff` search would not work when sub-repo permissions are enabeld. [#53210](https://github.com/sourcegraph/sourcegraph/pull/53210)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -633,6 +633,9 @@ func TestSubRepoFiltering(t *testing.T) {
 					}
 					return authz.Read, nil
 				})
+				checker.EnabledForRepoFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName) (bool, error) {
+					return true, nil
+				})
 				return checker
 			},
 		},


### PR DESCRIPTION
When sub-repo permissions are enabled, the sub-repo permissions filter would be applied to repositories where sub-repo permissions are relevant. This lead to `type:diff` search being broken when sub-repo permissions are enabled, since it would try to filter repositories for which sub-repo permissions do not apply.

This PR changes the check to confirm that sub-repo permissions are enabled for the repository being filtered before doing the sub-repo filter, and if the repository does not have sub-repo permissions enabled, the repository is skipped.

## Test plan

Verified with manual checks. Added unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
