### PR TITLE
Bring back Cody unit and integration tests

### DIFF
--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -266,7 +266,6 @@ func addCodyUnitIntegrationTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(
 		":vscode::robot_face: Unit and integration tests for the Cody VS Code extension",
 		withPnpmCache(),
-		bk.Skip("2023-06-08 Cody e2e tests failing"),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter cody-ai run test:unit"),


### PR DESCRIPTION
Only the E2E tests based on playwright are causing issues. Let's continue with the rest of cody CI.

## Test plan

- CI green 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
