### PR TITLE
Handle invalid license checks

### DIFF
--- a/enterprise/internal/licensing/BUILD.bazel
+++ b/enterprise/internal/licensing/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "check_test.go",
         "codygateway_test.go",
         "features_test.go",
+        "licensing_test.go",
         "plans_test.go",
         "tags_test.go",
     ],
@@ -53,6 +54,7 @@ go_test(
     ],
     deps = [
         "//enterprise/internal/license",
+        "//internal/rcache",
         "//internal/redispool",
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_cmp//cmp",

--- a/enterprise/internal/licensing/BUILD.bazel
+++ b/enterprise/internal/licensing/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
     ],
     deps = [
         "//enterprise/internal/license",
-        "//internal/rcache",
         "//internal/redispool",
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_cmp//cmp",

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -100,7 +99,7 @@ func GetConfiguredProductLicenseInfo() (*Info, error) {
 }
 
 func isLicenseValid() bool {
-	val := redispool.Store.Get(licenseValidityStoreKey)
+	val := store.Get(licenseValidityStoreKey)
 	if val.IsNil() {
 		return true
 	}

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -104,11 +104,12 @@ func isLicenseValid() bool {
 		return true
 	}
 
-	if val, err := val.Bool(); err != nil {
-		return val
+	v, err := val.Bool()
+	if err != nil {
+		return true
 	}
 
-	return true
+	return v
 }
 
 // GetConfiguredProductLicenseInfoWithSignature returns information about the current product license key

--- a/enterprise/internal/licensing/licensing_test.go
+++ b/enterprise/internal/licensing/licensing_test.go
@@ -2,14 +2,18 @@ package licensing
 
 import (
 	"testing"
+	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/gomodule/redigo/redis"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsLicenseValid(t *testing.T) {
-	rcache.SetupForTest(t)
+	store = redispool.NewKeyValue("127.0.0.1:6379", &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 5 * time.Second,
+	})
 
 	t.Run("unset key returns true", func(t *testing.T) {
 		require.True(t, isLicenseValid())

--- a/enterprise/internal/licensing/licensing_test.go
+++ b/enterprise/internal/licensing/licensing_test.go
@@ -1,0 +1,27 @@
+package licensing
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLicenseValid(t *testing.T) {
+	rcache.SetupForTest(t)
+
+	t.Run("unset key returns true", func(t *testing.T) {
+		require.True(t, isLicenseValid())
+	})
+
+	t.Run("set false key returns false", func(t *testing.T) {
+		require.NoError(t, redispool.Store.Set("is_license_valid", false))
+		require.False(t, isLicenseValid())
+	})
+
+	t.Run("set true key returns true", func(t *testing.T) {
+		require.NoError(t, redispool.Store.Set("is_license_valid", true))
+		require.True(t, isLicenseValid())
+	})
+}

--- a/enterprise/internal/licensing/licensing_test.go
+++ b/enterprise/internal/licensing/licensing_test.go
@@ -9,23 +9,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func cleanupStore(t *testing.T, store redispool.KeyValue) {
+	t.Cleanup(func() {
+		store.Del(licenseValidityStoreKey)
+	})
+}
+
 func TestIsLicenseValid(t *testing.T) {
 	store = redispool.NewKeyValue("127.0.0.1:6379", &redis.Pool{
 		MaxIdle:     3,
 		IdleTimeout: 5 * time.Second,
 	})
+	store.Del(licenseValidityStoreKey)
 
 	t.Run("unset key returns true", func(t *testing.T) {
+		cleanupStore(t, store)
 		require.True(t, isLicenseValid())
 	})
 
 	t.Run("set false key returns false", func(t *testing.T) {
-		require.NoError(t, redispool.Store.Set("is_license_valid", false))
+		cleanupStore(t, store)
+		require.NoError(t, store.Set(licenseValidityStoreKey, false))
 		require.False(t, isLicenseValid())
 	})
 
 	t.Run("set true key returns true", func(t *testing.T) {
-		require.NoError(t, redispool.Store.Set("is_license_valid", true))
+		cleanupStore(t, store)
+		require.NoError(t, store.Set(licenseValidityStoreKey, true))
 		require.True(t, isLicenseValid())
 	})
 }


### PR DESCRIPTION
If a remote license is marked as invalid, then all license checks for that license should fail.

## Test plan

Add unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
