### PR TITLE
sg: correct generate path for reference.md

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -79,7 +79,7 @@ const sgBugReportTemplate = "https://github.com/sourcegraph/sourcegraph/issues/n
 
 // sg is the main sg CLI application.
 //
-//go:generate go run . -disable-overwrite help -full -output ./doc/dev/background-information/sg/reference.md
+//go:generate go run . -disable-overwrite help -full -output ../../doc/dev/background-information/sg/reference.md
 var sg = &cli.App{
 	Usage:       "The Sourcegraph developer tool!",
 	Description: "Learn more: https://docs.sourcegraph.com/dev/background-information/sg",


### PR DESCRIPTION
go generate is run from the directory the package is in. I am unsure how this ever worked, but on my computer sg generate was failing due to this and now works.

Test Plan: sg generate and go generate ./dev/sg
