### PR TITLE
sg: mention file and directory for go generate failure

### DIFF
--- a/dev/sg/internal/generate/golang/golang.go
+++ b/dev/sg/internal/generate/golang/golang.go
@@ -232,7 +232,7 @@ func runGoGenerateOnPaths(ctx context.Context, pkgPaths []string, progressBar bo
 
 			start := time.Now()
 			if err := root.Run(run.Cmd(ctx, "go", "generate", file), directory).Wait(); err != nil {
-				return err
+				return errors.Wrapf(err, "%s in %s", file, directory)
 			}
 			duration := time.Since(start)
 


### PR DESCRIPTION
If go generate fails the error message does not mention which directory go generate was run from, so you can end up with very hard to understand error messages. For example before this commit this was the error I was getting:

```
go: go generate: exit status 1: exit status 1
main.go:82: running "go": exit status 1
```

After this commit it becomes:

```
go: go generate: main.go in dev/sg: exit status 1: exit status 1
main.go:82: running "go": exit status 1
```

I could then go and manually run generate to find out what was broken. There is another issue here were the go generate failure output was missing, but that can be fixed in another commit.

Test Plan: sg generate