### PR TITLE
sg: use os.WriteFile for help -output

### DIFF
--- a/dev/sg/sg_help.go
+++ b/dev/sg/sg_help.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/cliutil/docgen"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -51,6 +53,12 @@ var helpCommand = &cli.Command{
 		}
 
 		if output := cmd.String("output"); output != "" {
+			root, err := root.RepositoryRoot()
+			if err != nil {
+				return err
+			}
+			output = filepath.Join(root, output)
+
 			if err := os.WriteFile(output, []byte(generatedSgReferenceHeader+"\n\n"+doc), 0644); err != nil {
 				return errors.Wrapf(err, "failed to write reference to %q", output)
 			}

--- a/dev/sg/sg_help.go
+++ b/dev/sg/sg_help.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"strings"
+	"os"
 
 	"github.com/urfave/cli/v2"
 
-	"github.com/sourcegraph/run"
-
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
-	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/cliutil/docgen"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -54,9 +51,7 @@ var helpCommand = &cli.Command{
 		}
 
 		if output := cmd.String("output"); output != "" {
-			cmd := run.Cmd(cmd.Context, "cp /dev/stdin", output).
-				Input(strings.NewReader(generatedSgReferenceHeader + "\n\n" + doc))
-			if err := root.Run(cmd).Wait(); err != nil {
+			if err := os.WriteFile(output, []byte(generatedSgReferenceHeader+"\n\n"+doc), 0644); err != nil {
 				return errors.Wrapf(err, "failed to write reference to %q", output)
 			}
 			return nil


### PR DESCRIPTION
I don't really understand why we are using trickery like cp /dev/stdin to write a file, but it gave a very obtuse error when the directory for the output doesn't exist.

```
# Before
failed to write reference to "doesnotexist/foo.md": exit status 1: cp:
skipping file '/dev/stdin', as it was replaced while being copied

# After
failed to write reference to "doesnotexist/foo.md": open
doesnotexist/foo.md: no such file or directory
```

Test Plan: sensible output from running go generate ./dev/sg when it errors.
