### PR TITLE
[sub-repo perms] Move check to CanReadAnyPath instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ All notable changes to Sourcegraph are documented in this file.
 - SAML assertions to get user display name are now compared case insensitively and we do not always return an error. [#52992](https://github.com/sourcegraph/sourcegraph/pull/52992)
 - The braindot menu on the blob view no longer fetches data eagerly to prevent performance issues for larger monorepo users. [#53039](https://github.com/sourcegraph/sourcegraph/pull/53039)
 - Fixed an issue where commenting out redacted site-config secrets would re-add the secrets. [#53152](https://github.com/sourcegraph/sourcegraph/pull/53152)
-- Fixed an issue where `type:diff` search would not work when sub-repo permissions are enabeld. [#53210](https://github.com/sourcegraph/sourcegraph/pull/53210)
+- Fixed an issue where `type:diff` search would not work when sub-repo permissions are enabled. [#53210](https://github.com/sourcegraph/sourcegraph/pull/53210)
 
 ### Removed
 

--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -164,6 +164,14 @@ func canReadPaths(ctx context.Context, checker SubRepoPermissionChecker, repo ap
 		return true, nil
 	}
 
+	enabled, err := SubRepoEnabledForRepo(ctx, checker, repo)
+	if err != nil {
+		return false, err
+	}
+	if !enabled {
+		return true, nil
+	}
+
 	start := time.Now()
 	var checkPathPermsCount int
 	defer func() {

--- a/internal/authz/sub_repo_perms_test.go
+++ b/internal/authz/sub_repo_perms_test.go
@@ -70,6 +70,12 @@ func TestCanReadAllPaths(t *testing.T) {
 			}
 		}, nil
 	})
+	checker.EnabledForRepoFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName) (bool, error) {
+		if rn == repo {
+			return true, nil
+		}
+		return false, nil
+	})
 
 	ok, err := CanReadAllPaths(ctx, checker, repo, testPaths)
 	if err != nil {

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -2,7 +2,6 @@ package jobutil
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/sourcegraph/log"
@@ -86,15 +85,6 @@ func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionC
 	filtered := matches[:0]
 
 	for _, m := range matches {
-		enabled, err := authz.SubRepoEnabledForRepo(ctx, checker, m.Key().Repo)
-		if err != nil {
-			logger.Warn(fmt.Sprintf("Could not determine if sub-repo permissions are enabled for repo %s. Skipping.", m.Key().Repo))
-			continue
-		}
-		if !enabled {
-			filtered = append(filtered, m)
-			continue
-		}
 		switch mm := m.(type) {
 		case *result.FileMatch:
 			repo := mm.Repo.Name


### PR DESCRIPTION
Addresses @keegancsmith 's comments from #53210

## Test plan

Tests still passing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
