### PR TITLE
Fix Cody tests by hardcoding VS Code version

### DIFF
--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -15,7 +15,7 @@ export const test = base
 
             const codyRoot = path.resolve(__dirname, '..', '..')
 
-            const vscodeExecutablePath = await downloadAndUnzipVSCode()
+            const vscodeExecutablePath = await downloadAndUnzipVSCode('1.78.2')
             const extensionDevelopmentPath = codyRoot
 
             const userDataDirectory = mkdtempSync(path.join(tmpdir(), 'cody-vsce'))

--- a/client/cody/test/integration/main.ts
+++ b/client/cody/test/integration/main.ts
@@ -30,6 +30,7 @@ async function main(): Promise<void> {
         // Download VS Code, unzip it, and run the integration test.
         await mockServer.run(() =>
             runTests({
+                version: '1.78.2',
                 extensionDevelopmentPath,
                 extensionTestsPath,
                 launchArgs: [

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -279,7 +279,6 @@ func addCodyE2ETests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(
 		":vscode::robot_face: E2E tests for the Cody VS Code extension",
 		withPnpmCache(),
-		bk.Skip("2023-06-08 Cody e2e tests failing"),
 		bk.Cmd("pnpm install --frozen-lockfile --fetch-timeout 60000"),
 		bk.Cmd("client/cody/scripts/download-rg.sh x86_64-unknown-linux"),
 		bk.Cmd("pnpm --filter cody-ai run test:e2e"),


### PR DESCRIPTION
As of the latest VS Code update, we see our extension test not working properly across both the integration and E2E setups. This seems to be an upstream problem and was also reported here: https://github.com/microsoft/vscode-test/issues/221

This PR hardcodes these setups to use the previous version.
 
## Test plan

- CI passes again

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
