### PR TITLE
cody: configurable match limit for global policies

### DIFF
--- a/enterprise/internal/embeddings/background/repo/BUILD.bazel
+++ b/enterprise/internal/embeddings/background/repo/BUILD.bazel
@@ -38,9 +38,11 @@ go_test(
     deps = [
         "//enterprise/internal/codeintel/policies/shared",
         "//internal/api",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/types",
+        "//schema",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",

--- a/enterprise/internal/embeddings/background/repo/store.go
+++ b/enterprise/internal/embeddings/background/repo/store.go
@@ -239,7 +239,9 @@ func GetEmbeddableRepoOpts() EmbeddableRepoOpts {
 		opts.MinimumInterval = d
 	}
 
-	opts.PolicyRepositoryMatchLimit = embeddingsConf.PolicyRepositoryMatchLimit
+	if embeddingsConf.PolicyRepositoryMatchLimit != nil {
+		opts.PolicyRepositoryMatchLimit = embeddingsConf.PolicyRepositoryMatchLimit
+	}
 
 	return opts
 }

--- a/enterprise/internal/embeddings/background/repo/store.go
+++ b/enterprise/internal/embeddings/background/repo/store.go
@@ -217,11 +217,13 @@ func embeddingConfigValidator(q conftypes.SiteConfigQuerier) conf.Problems {
 	return nil
 }
 
+var defaultOpts = EmbeddableRepoOpts{
+	MinimumInterval:            24 * time.Hour,
+	PolicyRepositoryMatchLimit: 5000,
+}
+
 func GetEmbeddableRepoOpts() EmbeddableRepoOpts {
-	var opts = EmbeddableRepoOpts{
-		MinimumInterval:            24 * time.Hour,
-		PolicyRepositoryMatchLimit: 5000,
-	}
+	opts := defaultOpts
 
 	embeddingsConf := conf.Get().Embeddings
 	if embeddingsConf == nil {

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -265,7 +265,7 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(fmt.Sprintf("policyRepositoryMatchLimit=%d", tt.policyRepositoryMatchLimit), func(t *testing.T) {
-			repos, err := store.GetEmbeddableRepos(ctx, EmbeddableRepoOpts{MinimumInterval: 1 * time.Hour, PolicyRepositoryMatchLimit: tt.policyRepositoryMatchLimit})
+			repos, err := store.GetEmbeddableRepos(ctx, EmbeddableRepoOpts{MinimumInterval: 1 * time.Hour, PolicyRepositoryMatchLimit: &tt.policyRepositoryMatchLimit})
 			require.NoError(t, err)
 			require.Equal(t, tt.wantMatches, len(repos))
 		})
@@ -278,14 +278,14 @@ func TestGetEmbeddableRepoOpts(t *testing.T) {
 
 	opts := GetEmbeddableRepoOpts()
 	require.Equal(t, defaultOpts.MinimumInterval, opts.MinimumInterval)
-	require.Equal(t, defaultOpts.PolicyRepositoryMatchLimit, opts.PolicyRepositoryMatchLimit)
+	require.Equal(t, *defaultOpts.PolicyRepositoryMatchLimit, *opts.PolicyRepositoryMatchLimit)
 
 	limit := 5
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{Embeddings: &schema.Embeddings{MinimumInterval: "1h", PolicyRepositoryMatchLimit: &limit}}})
 
 	opts = GetEmbeddableRepoOpts()
 	require.Equal(t, 1*time.Hour, opts.MinimumInterval)
-	require.Equal(t, 5, opts.PolicyRepositoryMatchLimit)
+	require.Equal(t, 5, *opts.PolicyRepositoryMatchLimit)
 }
 
 func setJobState(t *testing.T, ctx context.Context, store RepoEmbeddingJobsStore, jobID int, state string) {

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -238,34 +238,34 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	cases := []struct {
-		globalPolicyMatchLimit int
-		wantMatches            int
+		policyRepositoryMatchLimit int
+		wantMatches                int
 	}{
 		{
-			globalPolicyMatchLimit: -1, // unlimited
-			wantMatches:            2,
+			policyRepositoryMatchLimit: -1, // unlimited
+			wantMatches:                2,
 		},
 		{
-			globalPolicyMatchLimit: 0,
-			wantMatches:            0,
+			policyRepositoryMatchLimit: 0,
+			wantMatches:                0,
 		},
 		{
-			globalPolicyMatchLimit: 1,
-			wantMatches:            1,
+			policyRepositoryMatchLimit: 1,
+			wantMatches:                1,
 		},
 		{
-			globalPolicyMatchLimit: 2,
-			wantMatches:            2,
+			policyRepositoryMatchLimit: 2,
+			wantMatches:                2,
 		},
 		{
-			globalPolicyMatchLimit: 3,
-			wantMatches:            2,
+			policyRepositoryMatchLimit: 3,
+			wantMatches:                2,
 		},
 	}
 
 	for _, tt := range cases {
-		t.Run(fmt.Sprintf("globalPolicyMatchLimit=%d", tt.globalPolicyMatchLimit), func(t *testing.T) {
-			repos, err := store.GetEmbeddableRepos(ctx, EmbeddableRepoOpts{MinimumInterval: 1 * time.Hour, PolicyRepositoryMatchLimit: tt.globalPolicyMatchLimit})
+		t.Run(fmt.Sprintf("policyRepositoryMatchLimit=%d", tt.policyRepositoryMatchLimit), func(t *testing.T) {
+			repos, err := store.GetEmbeddableRepos(ctx, EmbeddableRepoOpts{MinimumInterval: 1 * time.Hour, PolicyRepositoryMatchLimit: tt.policyRepositoryMatchLimit})
 			require.NoError(t, err)
 			require.Equal(t, tt.wantMatches, len(repos))
 		})

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -277,8 +277,8 @@ func TestGetEmbeddableRepoOpts(t *testing.T) {
 	defer conf.Mock(nil)
 
 	opts := GetEmbeddableRepoOpts()
-	require.Equal(t, 24*time.Hour, opts.MinimumInterval)
-	require.Equal(t, 5000, opts.PolicyRepositoryMatchLimit)
+	require.Equal(t, defaultOpts.MinimumInterval, opts.MinimumInterval)
+	require.Equal(t, defaultOpts.PolicyRepositoryMatchLimit, opts.PolicyRepositoryMatchLimit)
 
 	limit := 5
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{Embeddings: &schema.Embeddings{MinimumInterval: "1h", PolicyRepositoryMatchLimit: &limit}}})

--- a/enterprise/internal/embeddings/background/repo/store_test.go
+++ b/enterprise/internal/embeddings/background/repo/store_test.go
@@ -280,6 +280,11 @@ func TestGetEmbeddableRepoOpts(t *testing.T) {
 	require.Equal(t, defaultOpts.MinimumInterval, opts.MinimumInterval)
 	require.Equal(t, *defaultOpts.PolicyRepositoryMatchLimit, *opts.PolicyRepositoryMatchLimit)
 
+	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{Embeddings: &schema.Embeddings{}}})
+	opts = GetEmbeddableRepoOpts()
+	require.Equal(t, defaultOpts.MinimumInterval, opts.MinimumInterval)
+	require.Equal(t, *defaultOpts.PolicyRepositoryMatchLimit, *opts.PolicyRepositoryMatchLimit)
+
 	limit := 5
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{Embeddings: &schema.Embeddings{MinimumInterval: "1h", PolicyRepositoryMatchLimit: &limit}}})
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -628,6 +628,8 @@ type Embeddings struct {
 	Endpoint string `json:"endpoint,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
+	// GlobalPolicyMatchLimit description: The maximum number of repositories that can be matched by a global embeddings policy
+	GlobalPolicyMatchLimit int `json:"globalPolicyMatchLimit,omitempty"`
 	// Incremental description: Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
 	Incremental bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -628,8 +628,6 @@ type Embeddings struct {
 	Endpoint string `json:"endpoint,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
-	// GlobalPolicyMatchLimit description: The maximum number of repositories that can be matched by a global embeddings policy
-	GlobalPolicyMatchLimit int `json:"globalPolicyMatchLimit,omitempty"`
 	// Incremental description: Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
 	Incremental bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
@@ -640,6 +638,8 @@ type Embeddings struct {
 	MinimumInterval string `json:"minimumInterval,omitempty"`
 	// Model description: The model used for embedding. A default model will be used for each provider, if not set.
 	Model string `json:"model,omitempty"`
+	// PolicyRepositoryMatchLimit description: The maximum number of repositories that can be matched by a global embeddings policy
+	PolicyRepositoryMatchLimit *int `json:"policyRepositoryMatchLimit,omitempty"`
 	// Provider description: The provider to use for generating embeddings. Defaults to sourcegraph.
 	Provider string `json:"provider,omitempty"`
 	// Url description: The url to the external embedding API service. Deprecated, use endpoint instead.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2395,6 +2395,11 @@
           "description": "The time to wait between runs. Valid time units are \"s\", \"m\", \"h\". Example values: \"30s\", \"5m\", \"1h\".",
           "type": "string",
           "default": "24h"
+        },
+        "globalPolicyMatchLimit": {
+          "description": "The maximum number of repositories that can be matched by a global embeddings policy",
+          "type": "integer",
+          "default": "5000"
         }
       },
       "examples": [

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2396,9 +2396,12 @@
           "type": "string",
           "default": "24h"
         },
-        "globalPolicyMatchLimit": {
+        "policyRepositoryMatchLimit": {
           "description": "The maximum number of repositories that can be matched by a global embeddings policy",
           "type": "integer",
+          "!go": {
+            "pointer": true
+          },
           "default": "5000"
         }
       },


### PR DESCRIPTION
If a user creates a global policy (a policy without a repo pattern), the policy matches up to embeddings.policyRepositoryMatchLimit repos (default=5000).

Previously the limit was hard coded to 5000.

I chose the name to match Code intel's "codeIntelAutoIndexing.policyRepositoryMatchLimit".

## Test plan:
- new unit tests
- Set various values for embeddings.PolicyRepositoryMatchLimit in site-config, create a global policy, and verify that jobs created in site-admin > embeddings jobs matches the expectation.
