### PR TITLE
Add a bunch of logging to licensing checks

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -20,9 +21,8 @@ var (
 	ReasonLicenseRevokedMsg        = "license revoked"
 )
 
-func NewLicenseCheckHandler(db database.DB) http.Handler {
+func NewLicenseCheckHandler(logger log.Logger, db database.DB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// todo: add logging & rate limiting
 		tokenHexEncoded, err := authz.ParseBearerHeader(r.Header.Get("Authorization"))
 		if err != nil {
 			replyWithJSON(w, http.StatusUnauthorized, licensing.LicenseCheckResponse{
@@ -31,9 +31,20 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 			return
 		}
 
+		var args licensing.LicenseCheckRequestParams
+		if err := json.NewDecoder(r.Body).Decode(&args); err != nil {
+			replyWithJSON(w, http.StatusBadRequest, licensing.LicenseCheckResponse{
+				Error: ErrInvalidRequestBodyMsg,
+			})
+			return
+		}
+
+		logger.Debug("starting license validity check", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
+
 		lStore := dbLicenses{db: db}
 		license, err := lStore.GetByToken(r.Context(), tokenHexEncoded)
 		if err != nil || license == nil {
+			logger.Warn("could not find license for provided token", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 			replyWithJSON(w, http.StatusUnauthorized, licensing.LicenseCheckResponse{
 				Error: ErrInvalidAccessTokenMsg,
 			})
@@ -41,6 +52,7 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 		}
 		now := time.Now()
 		if license.LicenseExpiresAt != nil && license.LicenseExpiresAt.Before(now) {
+			logger.Warn("license is expired", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 			replyWithJSON(w, http.StatusForbidden, licensing.LicenseCheckResponse{
 				Error: ErrExpiredLicenseMsg,
 			})
@@ -48,6 +60,7 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 		}
 
 		if license.RevokedAt != nil && license.RevokedAt.Before(now) {
+			logger.Warn("license is revoked", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 			replyWithJSON(w, http.StatusForbidden, licensing.LicenseCheckResponse{
 				Data: &licensing.LicenseCheckResponseData{
 					IsValid: false,
@@ -57,16 +70,8 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 			return
 		}
 
-		var args licensing.LicenseCheckRequestParams
-		err = json.NewDecoder(r.Body).Decode(&args)
-		if err != nil {
-			replyWithJSON(w, http.StatusBadRequest, licensing.LicenseCheckResponse{
-				Error: ErrInvalidRequestBodyMsg,
-			})
-			return
-		}
-
 		if license.SiteID != nil && *license.SiteID != args.ClientSiteID {
+			logger.Warn("license being used with multiple site IDs", log.String("token", tokenHexEncoded), log.String("previousSiteID", *license.SiteID), log.String("newSiteID", args.ClientSiteID))
 			replyWithJSON(w, http.StatusOK, licensing.LicenseCheckResponse{
 				Data: &licensing.LicenseCheckResponseData{
 					IsValid: false,
@@ -78,12 +83,15 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 
 		if license.SiteID == nil {
 			if err := lStore.AssignSiteID(r.Context(), license.ID, args.ClientSiteID); err != nil {
+				logger.Warn("failed to apply site ID to license", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 				replyWithJSON(w, http.StatusInternalServerError, licensing.LicenseCheckResponse{
 					Error: ErrFailedToAssignSiteIDMsg,
 				})
 				return
 			}
 		}
+
+		logger.Debug("finished license validity check", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 		replyWithJSON(w, http.StatusOK, licensing.LicenseCheckResponse{
 			Data: &licensing.LicenseCheckResponseData{
 				IsValid: true,

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -84,7 +84,7 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 
 		if license.SiteID == nil {
 			if err := lStore.AssignSiteID(r.Context(), license.ID, args.ClientSiteID); err != nil {
-				logger.Warn("failed to apply site ID to license", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
+				logger.Warn("failed to assign site ID to license", log.String("token", tokenHexEncoded), log.String("siteID", args.ClientSiteID))
 				replyWithJSON(w, http.StatusInternalServerError, licensing.LicenseCheckResponse{
 					Error: ErrFailedToAssignSiteIDMsg,
 				})

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -21,7 +21,8 @@ var (
 	ReasonLicenseRevokedMsg        = "license revoked"
 )
 
-func NewLicenseCheckHandler(logger log.Logger, db database.DB) http.Handler {
+func NewLicenseCheckHandler(db database.DB) http.Handler {
+	logger := log.Scoped("LicenseCheckHandler", "Handles license validity checks")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tokenHexEncoded, err := authz.ParseBearerHeader(r.Header.Get("Authorization"))
 		if err != nil {

--- a/enterprise/internal/licensing/BUILD.bazel
+++ b/enterprise/internal/licensing/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//internal/redispool",
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/internal/licensing/check_test.go
+++ b/enterprise/internal/licensing/check_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
@@ -48,6 +49,7 @@ func Test_licenseChecker(t *testing.T) {
 			siteID: siteID,
 			token:  token,
 			doer:   doer,
+			logger: logtest.NoOp(t),
 		}
 
 		err := handler.Handle(context.Background())
@@ -111,6 +113,7 @@ func Test_licenseChecker(t *testing.T) {
 				siteID: siteID,
 				token:  token,
 				doer:   doer,
+				logger: logtest.NoOp(t),
 			}
 
 			err := checker.Handle(context.Background())


### PR DESCRIPTION
Adds a lot of logging to client and server side licensing checks.

## Test plan

Just adds logging.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
