### PR TITLE
Add feedback to the Cody for VS Code welcome guide

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -132,8 +132,8 @@
           },
           {
             "id": "learn-more",
-            "title": "Learn More",
-            "description": "📖 Dive deeper into Cody by reading our [full documentation](https://docs.sourcegraph.com/cody).\n🎨 Discover more features by searching for \"Cody\" in the [Command Palette](command:workbench.action.showCommands).\n🗒️ Find out how Cody is improving by taking a look at the [Changelog](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/cody/CHANGELOG.md).",
+            "title": "Learn More & Feedback",
+            "description": "📖 Dive deeper into Cody by reading our [full documentation](https://docs.sourcegraph.com/cody).\n🎨 Discover more features by searching for \"Cody\" in the [Command Palette](command:workbench.action.showCommands).\n🗒️ Find out how Cody is improving by taking a look at the [Changelog](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/cody/CHANGELOG.md).\n💬 Bugs, ideas or feedback? Post a message on our [GitHub Discussions](https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&labels=cody,cody/vscode).",
             "media": {
               "markdown": "walkthroughs/learn-more.md"
             }


### PR DESCRIPTION
Given we're really wanting to help direct and engage people that have ideas, or problems, I don't think we can go too hard adding CTAs for sending us feedback. So this updates the welcome guide to include "Feedback" in the last item too.

| Before | After |
| - | - |
| <img width="1129" alt="Screenshot 2023-06-09 at 10 14 29 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/69c89f45-f397-4505-a21f-fd0e1b19a6cd"> | <img width="1089" alt="Screenshot 2023-06-09 at 10 12 21 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/257c86f9-e3f9-42ca-9919-9682f139073d"> |

## Test plan

* Open up the welcome guide
* Click around

