### PR TITLE
Cody-Gateway - gateway dotcom user lookup should not require writer access

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -21,7 +21,7 @@ type CodyGatewayDotcomUserResolver struct {
 
 func (r CodyGatewayDotcomUserResolver) CodyGatewayDotcomUserByToken(ctx context.Context, args *graphqlbackend.CodyGatewayUsersByAccessTokenArgs) (graphqlbackend.CodyGatewayUser, error) {
 	// 🚨 SECURITY: Only site admins or the service accounts may check users.
-	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
+	if err := serviceAccountOrSiteAdmin(ctx, r.DB, false); err != nil {
 		return nil, err
 	}
 	dbTokens := newDBTokens(r.DB)


### PR DESCRIPTION
Looking up the dotcom user from the cody gateway was incorrectly requiring the service account to have the writer access.

## Test plan
unit test added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
