### PR TITLE
graphqlbackend: remove unused NewSchemaWith*Resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -386,40 +386,8 @@ func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
 	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{})
 }
 
-func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{NotebooksResolver: notebooks})
-}
-
-func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{AuthzResolver: authz})
-}
-
-func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{BatchChangesResolver: batchChanges})
-}
-
-func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{CodeMonitorsResolver: codeMonitors})
-}
-
-func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{LicenseResolver: license})
-}
-
-func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{WebhooksResolver: webhooksResolver})
-}
-
-func NewSchemaWithRBACResolver(db database.DB, rbacResolver RBACResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{RBACResolver: rbacResolver})
-}
-
-func NewSchemaWithOwnResolver(db database.DB, own OwnResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{OwnResolver: own})
-}
-
-func NewSchemaWithCompletionsResolver(db database.DB, completionsResolver CompletionsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, OptionalResolver{CompletionsResolver: completionsResolver})
+func NewSchemaWithResolver(db database.DB, optional OptionalResolver) (*graphql.Schema, error) {
+	return NewSchema(db, gitserver.NewClient(), nil, optional)
 }
 
 func NewSchema(

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -376,7 +376,9 @@ func TestQueryMonitor(t *testing.T) {
 	_, err = r.insertTestMonitorWithOpts(ctx, t, actionOpt, postHookOpt)
 	require.NoError(t, err)
 
-	gqlSchema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
+	gqlSchema, err := graphqlbackend.NewSchemaWithResolver(db, graphqlbackend.OptionalResolver{
+		CodeMonitorsResolver: r,
+	})
 	require.NoError(t, err)
 
 	t.Run("query by user", func(t *testing.T) {
@@ -703,7 +705,9 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	gqlSchema, err := graphqlbackend.NewSchemaWithCodeMonitorsResolver(db, r)
+	gqlSchema, err := graphqlbackend.NewSchemaWithResolver(db, graphqlbackend.OptionalResolver{
+		CodeMonitorsResolver: r,
+	})
 	require.NoError(t, err)
 	updateInput := map[string]any{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),


### PR DESCRIPTION
These mostly stopped being used since we introduced the OptionalResolver struct, but keep getting added to because it looks like the right copy paste to do when introducing a new resolver.

This commit removes all of them since they aren't used, except 2 uses by code monitors. In that case we use a new function called NewSchemaWithResolver.

Test Plan: CI