### PR TITLE
search: move settings and dotcommode from Plan to client

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,12 +5,10 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -28,11 +26,6 @@ type SearchImplementer interface {
 
 // NewBatchSearchImplementer returns a SearchImplementer that provides search results and suggestions.
 func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, args *SearchArgs) (_ SearchImplementer, err error) {
-	settings, err := settings.CurrentUserFinal(ctx, db)
-	if err != nil {
-		return nil, err
-	}
-
 	cli := client.New(logger, db, enterpriseJobs)
 	inputs, err := cli.Plan(
 		ctx,
@@ -41,8 +34,6 @@ func NewBatchSearchImplementer(ctx context.Context, logger log.Logger, db databa
 		args.Query,
 		search.Precise,
 		search.Batch,
-		settings,
-		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		var queryErr *client.QueryError

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -330,8 +330,6 @@ func TestSearchResultsHydration(t *testing.T) {
 		query,
 		search.Precise,
 		search.Batch,
-		&schema.Settings{},
-		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -568,8 +566,6 @@ func TestEvaluateAnd(t *testing.T) {
 				tt.query,
 				search.Precise,
 				search.Batch,
-				&schema.Settings{},
-				false,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -676,8 +672,6 @@ func TestSubRepoFiltering(t *testing.T) {
 				tt.searchQuery,
 				search.Precise,
 				search.Batch,
-				&schema.Settings{},
-				false,
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/frontend/internal/search/BUILD.bazel
+++ b/cmd/frontend/internal/search/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/internal/highlight",
         "//cmd/frontend/internal/search/logs",
@@ -32,7 +31,6 @@ go_library(
         "//internal/search/streaming/api",
         "//internal/search/streaming/client",
         "//internal/search/streaming/http",
-        "//internal/settings",
         "//internal/trace",
         "//internal/types",
         "//lib/errors",

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -34,7 +33,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	streamclient "github.com/sourcegraph/sourcegraph/internal/search/streaming/client"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -100,11 +98,6 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 		attribute.Int("search_mode", args.SearchMode),
 	)
 
-	settings, err := settings.CurrentUserFinal(ctx, h.db)
-	if err != nil {
-		return err
-	}
-
 	inputs, err := h.searchClient.Plan(
 		ctx,
 		args.Version,
@@ -112,8 +105,6 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 		args.Query,
 		search.Mode(args.SearchMode),
 		search.Streaming,
-		settings,
-		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		var queryErr *client.QueryError

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -186,7 +186,7 @@ func TestDisplayLimit(t *testing.T) {
 
 			mockInput := make(chan streaming.SearchEvent)
 			mock := client.NewMockSearchClient()
-			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, queryString string, _ search.Mode, _ search.Protocol, _ *schema.Settings, _ bool) (*search.Inputs, error) {
+			mock.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, queryString string, _ search.Mode, _ search.Protocol) (*search.Inputs, error) {
 				q, err := query.Parse(queryString, query.SearchTypeLiteral)
 				require.NoError(t, err)
 				return &search.Inputs{

--- a/dev/internal/cmd/search-plan/BUILD.bazel
+++ b/dev/internal/cmd/search-plan/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/internal/cmd/search-plan",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/conf",
         "//internal/search",
         "//internal/search/client",
@@ -14,7 +15,6 @@ go_library(
         "//internal/search/job/jobutil",
         "//internal/search/job/printer",
         "//lib/errors",
-        "//schema",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
@@ -17,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/printer"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func run(w io.Writer, args []string) error {
@@ -39,10 +39,10 @@ func run(w io.Writer, args []string) error {
 	if *smartSearch {
 		mode = search.SmartSearch
 	}
-	settings := &schema.Settings{}
 
 	// Sourcegraph infra we need
 	conf.Mock(&conf.Unified{})
+	envvar.MockSourcegraphDotComMode(*dotCom)
 	logger := log.Scoped("search-plan", "")
 
 	cli := client.MockedZoekt(logger, nil, nil)
@@ -54,8 +54,6 @@ func run(w io.Writer, args []string) error {
 		query,
 		mode,
 		search.Streaming,
-		settings,
-		*dotCom,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to plan")

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//internal/gqlutil",
         "//internal/httpcli",
         "//internal/search/job/jobutil",
-        "//internal/settings",
         "//lib/errors",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_graph_gophers_graphql_go//relay",

--- a/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -151,14 +150,9 @@ func (r *Resolver) CreateCodeMonitor(ctx context.Context, args *graphqlbackend.C
 		}
 
 		if featureflag.FromContext(ctx).GetBoolOr("cc-repo-aware-monitors", true) {
-			settings, err := settings.CurrentUserFinal(ctx, tx.db)
-			if err != nil {
-				return err
-			}
-
 			// Snapshot the state of the searched repos when the monitor is created so that
 			// we can distinguish new repos.
-			err = codemonitors.Snapshot(ctx, r.logger, tx.db, r.enterpriseJobs, args.Trigger.Query, m.ID, settings)
+			err = codemonitors.Snapshot(ctx, r.logger, tx.db, r.enterpriseJobs, args.Trigger.Query, m.ID)
 			if err != nil {
 				return err
 			}
@@ -551,14 +545,9 @@ func (r *Resolver) updateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 		// When the query is changed, take a new snapshot of the commits that currently
 		// exist so we know where to start.
 		if currentTrigger.QueryString != args.Trigger.Update.Query {
-			settings, err := settings.CurrentUserFinal(ctx, r.db)
-			if err != nil {
-				return nil, err
-			}
-
 			// Snapshot the state of the searched repos when the monitor is created so that
 			// we can distinguish new repos.
-			err = codemonitors.Snapshot(ctx, r.logger, r.db, r.enterpriseJobs, args.Trigger.Update.Query, monitorID, settings)
+			err = codemonitors.Snapshot(ctx, r.logger, r.db, r.enterpriseJobs, args.Trigger.Update.Query, monitorID)
 			if err != nil {
 				return nil, err
 			}

--- a/enterprise/cmd/frontend/internal/compute/streaming/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/compute/streaming/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/compute/streaming",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//enterprise/internal/compute",
         "//internal/conf",
         "//internal/database",
@@ -21,7 +20,6 @@ go_library(
         "//internal/search/streaming",
         "//internal/search/streaming/client",
         "//internal/search/streaming/http",
-        "//internal/settings",
         "//internal/trace",
         "//lib/errors",
         "@com_github_sourcegraph_conc//stream",

--- a/enterprise/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/enterprise/cmd/frontend/internal/context/resolvers/context_test.go
@@ -91,7 +91,7 @@ func TestContextResolver(t *testing.T) {
 	}
 
 	mockSearchClient := client.NewMockSearchClient()
-	mockSearchClient.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, query string, _ search.Mode, _ search.Protocol, _ *schema.Settings, _ bool) (*search.Inputs, error) {
+	mockSearchClient.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, query string, _ search.Mode, _ search.Protocol) (*search.Inputs, error) {
 		return &search.Inputs{OriginalQuery: query}, nil
 	})
 	mockSearchClient.ExecuteFunc.SetDefaultHook(func(_ context.Context, stream streaming.Sender, inputs *search.Inputs) (*search.Alert, error) {

--- a/enterprise/cmd/frontend/internal/guardrails/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/guardrails/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/enterprise",
-        "//cmd/frontend/envvar",
         "//enterprise/cmd/frontend/internal/guardrails/attribution",
         "//enterprise/cmd/frontend/internal/guardrails/resolvers",
         "//enterprise/internal/codeintel",
@@ -15,7 +14,5 @@ go_library(
         "//internal/database",
         "//internal/observation",
         "//internal/search/client",
-        "//internal/settings",
-        "//schema",
     ],
 )

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
         "//internal/search/client",
         "//internal/search/streaming",
         "//lib/errors",
-        "//schema",
     ],
 )

--- a/enterprise/cmd/frontend/internal/guardrails/init.go
+++ b/enterprise/cmd/frontend/internal/guardrails/init.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/attribution"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel"
@@ -12,8 +11,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func Init(
@@ -25,9 +22,7 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	attributionService := &attribution.Service{
-		CurrentUserFinal:      settingsService(db),
-		SearchClient:          client.New(observationCtx.Logger, db, enterpriseServices.EnterpriseSearchJobs),
-		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
+		SearchClient: client.New(observationCtx.Logger, db, enterpriseServices.EnterpriseSearchJobs),
 	}
 
 	enterpriseServices.GuardrailsResolver = &resolvers.GuardrailsResolver{
@@ -35,11 +30,4 @@ func Init(
 	}
 
 	return nil
-}
-
-// settingsService is a temporary helper until we introduce a settings service.
-func settingsService(db database.DB) func(context.Context) (*schema.Settings, error) {
-	return func(ctx context.Context) (*schema.Settings, error) {
-		return settings.CurrentUserFinal(ctx, db)
-	}
 }

--- a/enterprise/internal/codemonitors/BUILD.bazel
+++ b/enterprise/internal/codemonitors/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//enterprise/internal/database",
         "//internal/api",
         "//internal/api/internalapi",
@@ -23,7 +22,6 @@ go_library(
         "//internal/search/result",
         "//internal/search/streaming",
         "//lib/errors",
-        "//schema",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/enterprise/internal/codemonitors/background/BUILD.bazel
+++ b/enterprise/internal/codemonitors/background/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//internal/observation",
         "//internal/search/job/jobutil",
         "//internal/search/result",
-        "//internal/settings",
         "//internal/txemail",
         "//internal/txemail/txtypes",
         "//internal/types",

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -183,12 +182,7 @@ func (r *queryRunner) Handle(ctx context.Context, logger log.Logger, triggerJob 
 	ctx = actor.WithActor(ctx, actor.FromUser(m.UserID))
 	ctx = featureflag.WithFlags(ctx, r.db.FeatureFlags())
 
-	settings, err := settings.CurrentUserFinal(ctx, r.db)
-	if err != nil {
-		return errors.Wrap(err, "query settings")
-	}
-
-	results, searchErr := codemonitors.Search(ctx, logger, r.db, r.enterpriseJobs, q.QueryString, m.ID, settings)
+	results, searchErr := codemonitors.Search(ctx, logger, r.db, r.enterpriseJobs, q.QueryString, m.ID)
 
 	// Log next_run and latest_result to table cm_queries.
 	newLatestResult := latestResultTime(q.LatestResult, results, searchErr)

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
@@ -23,10 +22,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64, settings *schema.Settings) (_ []*result.CommitMatch, err error) {
+func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64) (_ []*result.CommitMatch, err error) {
 	searchClient := client.New(logger, db, enterpriseJobs)
 	inputs, err := searchClient.Plan(
 		ctx,
@@ -35,8 +33,6 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 		query,
 		search.Precise,
 		search.Streaming,
-		settings,
-		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		return nil, errcode.MakeNonRetryable(err)
@@ -79,7 +75,7 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 // Snapshot runs a dummy search that just saves the current state of the searched repos in the database.
 // On subsequent runs, this allows us to treat all new repos or sets of args as something new that should
 // be searched from the beginning.
-func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64, settings *schema.Settings) error {
+func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterpriseJobs jobutil.EnterpriseJobs, query string, monitorID int64) error {
 	searchClient := client.New(logger, db, enterpriseJobs)
 	inputs, err := searchClient.Plan(
 		ctx,
@@ -88,8 +84,6 @@ func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterprise
 		query,
 		search.Precise,
 		search.Streaming,
-		settings,
-		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		return err

--- a/enterprise/internal/codycontext/BUILD.bazel
+++ b/enterprise/internal/codycontext/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codycontext",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//enterprise/internal/database",
         "//enterprise/internal/embeddings",
         "//enterprise/internal/embeddings/embed",
@@ -16,7 +15,6 @@ go_library(
         "//internal/search/query",
         "//internal/search/result",
         "//internal/search/streaming",
-        "//internal/settings",
         "//internal/types",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",

--- a/enterprise/internal/codycontext/context.go
+++ b/enterprise/internal/codycontext/context.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed"
@@ -22,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -179,11 +177,6 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 		return nil, nil
 	}
 
-	settings, err := settings.CurrentUserFinal(ctx, c.db)
-	if err != nil {
-		return nil, err
-	}
-
 	// mini-HACK: pass in the scope using repo: filters. In an ideal world, we
 	// would not be using query text manipulation for this and would be using
 	// the job structs directly.
@@ -212,8 +205,6 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 			query,
 			search.Precise,
 			search.Streaming,
-			settings,
-			envvar.SourcegraphDotComMode(),
 		)
 		if err != nil {
 			return nil, err

--- a/enterprise/internal/insights/query/streaming/BUILD.bazel
+++ b/enterprise/internal/insights/query/streaming/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/query/streaming",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//enterprise/internal/compute",
         "//enterprise/internal/compute/client",
         "//internal/api",
@@ -23,7 +22,6 @@ go_library(
         "//internal/search/streaming",
         "//internal/search/streaming/api",
         "//internal/search/streaming/http",
-        "//internal/settings",
         "//internal/trace",
         "//internal/types",
         "@com_github_sourcegraph_log//:log",

--- a/enterprise/internal/insights/query/streaming/search_client.go
+++ b/enterprise/internal/insights/query/streaming/search_client.go
@@ -5,13 +5,11 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/settings"
 )
 
 type SearchClient interface {
@@ -32,10 +30,6 @@ type insightsSearchClient struct {
 }
 
 func (r *insightsSearchClient) Search(ctx context.Context, query string, patternType *string, sender streaming.Sender) (*search.Alert, error) {
-	settings, err := settings.CurrentUserFinal(ctx, r.db)
-	if err != nil {
-		return nil, err
-	}
 	inputs, err := r.searchClient.Plan(
 		ctx,
 		"",
@@ -43,8 +37,6 @@ func (r *insightsSearchClient) Search(ctx context.Context, query string, pattern
 		query,
 		search.Precise,
 		search.Streaming,
-		settings,
-		envvar.SourcegraphDotComMode(),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/search/client/BUILD.bazel
+++ b/internal/search/client/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/client",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/actor",
         "//internal/conf",
         "//internal/database",
@@ -23,6 +24,7 @@ go_library(
         "//internal/search/query",
         "//internal/search/searchcontexts",
         "//internal/search/streaming",
+        "//internal/settings",
         "//internal/trace",
         "//lib/errors",
         "//schema",

--- a/internal/search/client/mocks_temp.go
+++ b/internal/search/client/mocks_temp.go
@@ -13,7 +13,6 @@ import (
 	search "github.com/sourcegraph/sourcegraph/internal/search"
 	job "github.com/sourcegraph/sourcegraph/internal/search/job"
 	streaming "github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	schema "github.com/sourcegraph/sourcegraph/schema"
 )
 
 // MockSearchClient is a mock implementation of the SearchClient interface
@@ -47,7 +46,7 @@ func NewMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (r0 *search.Inputs, r1 error) {
+			defaultHook: func(context.Context, string, *string, string, search.Mode, search.Protocol) (r0 *search.Inputs, r1 error) {
 				return
 			},
 		},
@@ -69,7 +68,7 @@ func NewStrictMockSearchClient() *MockSearchClient {
 			},
 		},
 		PlanFunc: &SearchClientPlanFunc{
-			defaultHook: func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error) {
+			defaultHook: func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error) {
 				panic("unexpected invocation of MockSearchClient.Plan")
 			},
 		},
@@ -306,23 +305,23 @@ func (c SearchClientJobClientsFuncCall) Results() []interface{} {
 // SearchClientPlanFunc describes the behavior when the Plan method of the
 // parent MockSearchClient instance is invoked.
 type SearchClientPlanFunc struct {
-	defaultHook func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error)
-	hooks       []func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error)
+	defaultHook func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error)
+	hooks       []func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error)
 	history     []SearchClientPlanFuncCall
 	mutex       sync.Mutex
 }
 
 // Plan delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockSearchClient) Plan(v0 context.Context, v1 string, v2 *string, v3 string, v4 search.Mode, v5 search.Protocol, v6 *schema.Settings, v7 bool) (*search.Inputs, error) {
-	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6, v7)
-	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, v6, v7, r0, r1})
+func (m *MockSearchClient) Plan(v0 context.Context, v1 string, v2 *string, v3 string, v4 search.Mode, v5 search.Protocol) (*search.Inputs, error) {
+	r0, r1 := m.PlanFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.PlanFunc.appendCall(SearchClientPlanFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Plan method of the
 // parent MockSearchClient instance is invoked and the hook queue is empty.
-func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error)) {
+func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error)) {
 	f.defaultHook = hook
 }
 
@@ -330,7 +329,7 @@ func (f *SearchClientPlanFunc) SetDefaultHook(hook func(context.Context, string,
 // Plan method of the parent MockSearchClient instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error)) {
+func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -339,19 +338,19 @@ func (f *SearchClientPlanFunc) PushHook(hook func(context.Context, string, *stri
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *SearchClientPlanFunc) SetDefaultReturn(r0 *search.Inputs, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error) {
+	f.SetDefaultHook(func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *SearchClientPlanFunc) PushReturn(r0 *search.Inputs, r1 error) {
-	f.PushHook(func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error) {
+	f.PushHook(func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error) {
 		return r0, r1
 	})
 }
 
-func (f *SearchClientPlanFunc) nextHook() func(context.Context, string, *string, string, search.Mode, search.Protocol, *schema.Settings, bool) (*search.Inputs, error) {
+func (f *SearchClientPlanFunc) nextHook() func(context.Context, string, *string, string, search.Mode, search.Protocol) (*search.Inputs, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -402,12 +401,6 @@ type SearchClientPlanFuncCall struct {
 	// Arg5 is the value of the 6th argument passed to this method
 	// invocation.
 	Arg5 search.Protocol
-	// Arg6 is the value of the 7th argument passed to this method
-	// invocation.
-	Arg6 *schema.Settings
-	// Arg7 is the value of the 8th argument passed to this method
-	// invocation.
-	Arg7 bool
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 *search.Inputs
@@ -419,7 +412,7 @@ type SearchClientPlanFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c SearchClientPlanFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this


### PR DESCRIPTION
We always passed in envvar.SourcegraphDotComMode() for dot com mode. Additionally this variable doesn't change per request, so makes more request to be set in the client at construction time.

We always called settings.CurrentUserFinal before calling Plan. Now that settings can be a service, we make it part of the client struct as well. This also makes sense from the perspective that plan should only be taking in the per request information, then the client does actions based on that.

Both these changes simplify much of the call sites which is a nice side effect.

Test Plan: CI