### PR TITLE
Completions: Rename config option

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -8,7 +8,7 @@ export interface Configuration {
     debugVerbose: boolean
     useContext: ConfigurationUseContext
     customHeaders: Record<string, string>
-    experimentalSuggest: boolean
+    completions: boolean
     experimentalChatPredictions: boolean
     experimentalInline: boolean
     experimentalGuardrails: boolean

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -515,7 +515,7 @@
         },
         {
           "command": "cody.manual-completions",
-          "when": "config.cody.experimental.suggestions"
+          "when": "config.cody.completions"
         },
         {
           "command": "cody.guardrails.debug",
@@ -730,6 +730,10 @@
           ]
         },
         "cody.experimental.suggestions": {
+          "markdownDeprecationMessage": "This setting was renamed to `cody.completions`.",
+          "default":false
+        },
+        "cody.completions": {
           "order": 5,
           "type": "boolean",
           "markdownDescription": "Enables experimental Cody completions in your editor.",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -731,7 +731,7 @@
         },
         "cody.experimental.suggestions": {
           "markdownDeprecationMessage": "This setting was renamed to `cody.completions`.",
-          "default":false
+          "default": false
         },
         "cody.completions": {
           "order": 5,

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -11,7 +11,7 @@ describe('getConfiguration', () => {
             serverEndpoint: '',
             codebase: '',
             useContext: 'embeddings',
-            experimentalSuggest: false,
+            completions: false,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             experimentalInline: false,
@@ -38,6 +38,7 @@ describe('getConfiguration', () => {
                             'Cache-Control': 'no-cache',
                             'Proxy-Authenticate': 'Basic',
                         }
+                    case 'cody.completions':
                     case 'cody.experimental.suggestions':
                         return true
                     case 'cody.experimental.chatPredictions':
@@ -67,7 +68,7 @@ describe('getConfiguration', () => {
                 'Cache-Control': 'no-cache',
                 'Proxy-Authenticate': 'Basic',
             },
-            experimentalSuggest: true,
+            completions: true,
             experimentalChatPredictions: true,
             experimentalGuardrails: true,
             experimentalInline: true,

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -29,6 +29,9 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         debugRegex = new RegExp('.*')
     }
 
+    const completions = config.get('cody.completions', isTesting)
+    const deprecatedExperimentalSuggestions = config.get('cody.experimental.suggestions', isTesting)
+
     return {
         serverEndpoint: sanitizeServerEndpoint(config.get('cody.serverEndpoint', '')),
         codebase: sanitizeCodebase(config.get('cody.codebase')),
@@ -37,7 +40,7 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         debugEnable: config.get<boolean>('cody.debug.enable', false),
         debugVerbose: config.get<boolean>('cody.debug.verbose', false),
         debugFilter: debugRegex,
-        experimentalSuggest: config.get('cody.experimental.suggestions', isTesting),
+        completions: completions || deprecatedExperimentalSuggestions,
         experimentalChatPredictions: config.get('cody.experimental.chatPredictions', isTesting),
         experimentalInline: config.get('cody.experimental.inline', isTesting),
         experimentalGuardrails: config.get('cody.experimental.guardrails', isTesting),

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -200,10 +200,10 @@ const register = async (
             })
         }),
         vscode.commands.registerCommand('cody.walkthrough.enableCodeCompletions', async () => {
-            await workspaceConfig.update('cody.experimental.suggestions', true, vscode.ConfigurationTarget.Global)
+            await workspaceConfig.update('cody.completions', true, vscode.ConfigurationTarget.Global)
             // Open VSCode setting view. Provides visual confirmation that the setting is enabled.
             return vscode.commands.executeCommand('workbench.action.openSettings', {
-                query: 'cody.experimental.suggestions',
+                query: 'cody.completions',
                 openToSide: true,
             })
         }),
@@ -254,7 +254,7 @@ const register = async (
         })
     )
 
-    if (initialConfig.experimentalSuggest) {
+    if (initialConfig.completions) {
         // TODO(sqs): make this listen to config and not just use initialConfig
         const docprovider = new CompletionsDocumentProvider()
         disposables.push(vscode.workspace.registerTextDocumentContentProvider('cody', docprovider))


### PR DESCRIPTION
This renames the completions flag from `cody.experimental.suggest` to `cody.completions`. Old values are still read so if someone has it enabled right now, it still works (verified this locally)

## Test plan

<img width="1366" alt="Screenshot 2023-06-09 at 15 57 21" src="https://github.com/sourcegraph/sourcegraph/assets/458591/bf6ee0d7-0d1a-414f-babc-7150de27440e">
<img width="744" alt="Screenshot 2023-06-09 at 15 42 31" src="https://github.com/sourcegraph/sourcegraph/assets/458591/a868512e-a17c-4648-854a-b863c2752223">
<img width="614" alt="Screenshot 2023-06-09 at 16 01 54" src="https://github.com/sourcegraph/sourcegraph/assets/458591/a9ac07e1-ae1d-4ff0-9f32-9f99cfebc0af">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
