### PR TITLE
Revert "App - default app to use incremental embeddings (#53161)"

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -93,9 +93,6 @@ var App = conftypes.RawUnified{
 	"experimentalFeatures": {		
 		"structuralSearch": "disabled"
 	},
-	"embeddings": {	
-		"incremental": true
-	},
 }`,
 }
 


### PR DESCRIPTION
This reverts commit d99f0509e6cca727d86cac5fbf0a20c0e0be8bab.

This is a default setting for App, when the embeddings section is present enabled is required.  

Setting enabled to false is problematic because it isn't currently updated when the user connects app to dotcom
Setting enabled to true is problematic because of the "zero config cody" which will provide defaults that don't work with app.

## Test plan
revert app default setting
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
