### PR TITLE
Completions: Fix issue where completion sometimes starts in a new line

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,7 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Open file paths from Cody's responses in a workspace with the correct protocol. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Open file paths from Cody's responses in a workspace with the correct protocol. [pull/53103](https://github.com/sourcegraph/sourcegraph/pull/53103)
+- Cody completions: Fixes an issue where completions would often start in the next line. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,7 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Fixed
 
 - Open file paths from Cody's responses in a workspace with the correct protocol. [pull/53103](https://github.com/sourcegraph/sourcegraph/pull/53103)
-- Cody completions: Fixes an issue where completions would often start in the next line. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Cody completions: Fixes an issue where completions would often start in the next line. [pull/53246](https://github.com/sourcegraph/sourcegraph/pull/53246)
 
 ### Changed
 

--- a/client/cody/src/completions/provider.ts
+++ b/client/cody/src/completions/provider.ts
@@ -308,17 +308,17 @@ export class InlineCompletionProvider extends CompletionProvider {
             hasOddIndentation = true
         }
 
+        // Insert the injected prefix back in
+        if (this.injectPrefix.length > 0) {
+            completion = this.injectPrefix + completion
+        }
+
         // Experimental: Trim start of the completion to remove all trailing whitespace nonsense
         completion = completion.trimStart()
 
         // Detect bad completion start
         if (BAD_COMPLETION_START.test(completion)) {
             completion = completion.replace(BAD_COMPLETION_START, '')
-        }
-
-        // Insert the injected prefix back in
-        if (this.injectPrefix.length > 0) {
-            completion = this.injectPrefix + completion
         }
 
         // Strip out trailing markdown block and trim trailing whitespace


### PR DESCRIPTION
I noticed a small issue when completions are triggered for non-empty lines.

We have one of the three requests that injects a `\n` at the end of the prefix. This was added back _after_ the trimming logic which of course means that it would include the `\n` in the result, not something that we want.

We have to evaluate and see if this logic really makes sense. For now it's just a way to "trigger" a response. 

## Test plan

- Tested this locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
