### PR TITLE
bzl: improve stability of //enterprise/cmd/server:image_test 

### DIFF
--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -131,6 +131,12 @@ pkg_tar(
     package_dir = "/usr/local/bin",
 )
 
+pkg_tar(
+    name = "tar_image_test_scripts",
+    srcs = ["//enterprise/cmd/server/image_tests:scripts"],
+    package_dir = "/opt/image_tests",
+)
+
 # Tip: to view exactly what gets built here, you can run:
 #   bazel cquery '//cmd/server:image' --output build
 oci_image(
@@ -157,6 +163,7 @@ oci_image(
         ":tar_postgres_optimize",
         ":tar_prom-wrapper",
         "//enterprise/cmd/gitserver:tar_p4_fusion_wrappers",
+        "tar_image_test_scripts",
     ] + dependencies_tars(DEPS) + dependencies_tars(ZOEKT_DEPS),
     workdir = "/",
 )

--- a/enterprise/cmd/server/image_test.yaml
+++ b/enterprise/cmd/server/image_test.yaml
@@ -7,22 +7,16 @@ commandTests:
       - key: "SANITY_CHECK"
         value: "true"
 
-  # Sourcegraph binaries
+  # Sourcegraph binaries, run as a single test case to keep test case count short.
   - name: "sourcegraph binaries are runnable"
     command: "/opt/image_tests/test_services.sh"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
+
+
+  # Base packages
+  - name: "packages binaries are runnable"
+    command: "/opt/image_tests/test_packages.sh"
 
   # Git
-  - name: "git is runnable"
-    command: "git"
-    args:
-      - version
-  - name: "git-lfs is runnable"
-    command: "git-lfs"
-    args:
-      - version
   - name: "git p4 is runnable"
     command: "git"
     args:
@@ -31,110 +25,14 @@ commandTests:
     exitCode: 2
 
   # Zoekt binaries
-  - name: "zoekt-webserver is runnable"
-    command: "zoekt-webserver"
-    args:
-      - --version
-  - name: "zoekt-archive-index is runnable"
-    command: "zoekt-archive-index"
-    args:
-      - --help
-  - name: "zoekt-git-index is runnable"
-    command: "zoekt-git-index"
-    args:
-      - --version
-  - name: "zoekt-sourcegraph-indexserver is runnable"
-    command: "zoekt-sourcegraph-indexserver"
-    args:
-      - --help
+  - name: "zoket binaries are runnable"
+    command: "/opt/image_tests/test_zoekt.sh"
 
-  # Postgresql
-  - name: "postgres is runnable"
-    command: "postgres"
-    args:
-      - --version
-  # Bash
-  - name: "bash is runnable"
-    command: "bash"
-    args:
-      - --version
-  # P4 tools
-  - name: "p4 is runnable"
-    command: "p4"
-    args:
-      - -h
-  - name: "p4-fusion binary is runnable"
-    command: "p4-fusion-binary"
-  # Coursier
-  - name: "coursier is runnable"
-    command: "coursier"
-  # Redis
-  - name: "redis-server is runnable"
-    command: "redis-server"
-    args:
-      - --version
-  # Python3
-  - name: "python3 is runnable"
-    command: "python3"
-    args:
-      - --version
   # SSH
   - name: "ssh is runnable"
     command: "ssh"
     exitCode: 255
-  # PCRE
-  - name: "pcre is runnable"
-    command: "pcregrep"
-    args:
-      - --help
-  # Comby
-  - name: "comby is runnable"
-    command: "comby"
-    args:
-      - -h
-  # s3proxy
-  - name: "s3proxy is runnable"
-    command: "/opt/s3proxy/s3proxy"
-    args:
-      - --version
-  # Ctags
-  - name: "ctags is runnable"
-    command: "universal-ctags"
-    args:
-      - --version
-  # su-exec
-  - name: "su-exec is runnable"
-    command: "su-exec"
-    args:
-      - --help
-  # nginx
-  - name: "nginx is runnable"
-    command: "nginx"
-    args:
-      - -version
-  # postgres_exporter
-  - name: "postgres_exporter is runnable"
-    command: "postgres_exporter"
-    args:
-      - --version
-  # Prometheus + Alertmanager
-  - name: "prometheus is runnable"
-    command: "prometheus"
-    args:
-      - --version
-  - name: "promtool is runnable"
-    command: "promtool"
-    args:
-      - --version
-  - name: "alertmanager is runnable"
-    command: "alertmanager"
-    args:
-      - --version
-  # Grafana
-  - name: "grafana-server is runnable"
-    command: "/usr/share/grafana/bin/grafana-server"
-    args:
-      - -v
+
   # Correct users and groups
   - name: "correct users exist"
     command: "cat"

--- a/enterprise/cmd/server/image_test.yaml
+++ b/enterprise/cmd/server/image_test.yaml
@@ -8,63 +8,8 @@ commandTests:
         value: "true"
 
   # Sourcegraph binaries
-  - name: "embeddings binary is runnable"
-    command: "embeddings"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "frontend binary is runnable"
-    command: "frontend"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "github-proxy binary is runnable"
-    command: "github-proxy"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "gitserver binary is runnable"
-    command: "gitserver"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "migrator binary is runnable"
-    command: "migrator"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "precise-code-intel-worker binary is runnable"
-    command: "precise-code-intel-worker"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "repo-updater binary is runnable"
-    command: "repo-updater"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "searcher binary is runnable"
-    command: "searcher"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "symbols binary is runnable"
-    command: "symbols"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "syntax_highlighter binary is runnable"
-    command: "syntax_highlighter"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "scip-ctags is runnable"
-    command: "/usr/local/bin/scip-ctags"
-    envVars:
-      - key: "SANITY_CHECK"
-        value: "true"
-  - name: "worker binary is runnable"
-    command: "worker"
+  - name: "sourcegraph binaries are runnable"
+    command: "/opt/image_tests/test_services.sh"
     envVars:
       - key: "SANITY_CHECK"
         value: "true"

--- a/enterprise/cmd/server/image_tests/BUILD.bazel
+++ b/enterprise/cmd/server/image_tests/BUILD.bazel
@@ -1,5 +1,5 @@
 filegroup(
     name = "scripts",
     srcs = glob(["*.sh"]),
-    visibility = ["//enterprise/cmd/server/__pkg__"],
+    visibility = ["//enterprise/cmd/server:__pkg__"],
 )

--- a/enterprise/cmd/server/image_tests/BUILD.bazel
+++ b/enterprise/cmd/server/image_tests/BUILD.bazel
@@ -1,4 +1,5 @@
 filegroup(
     name = "scripts",
     srcs = glob(["*.sh"]),
+    visibility = ["//enterprise/cmd/server/__pkg__"],
 )

--- a/enterprise/cmd/server/image_tests/BUILD.bazel
+++ b/enterprise/cmd/server/image_tests/BUILD.bazel
@@ -1,0 +1,4 @@
+filegroup(
+    name = "scripts",
+    srcs = glob(["*.sh"]),
+)

--- a/enterprise/cmd/server/image_tests/test_packages.sh
+++ b/enterprise/cmd/server/image_tests/test_packages.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -ex
+
+git version
+
+git-lfs version
+
+postgres --version
+
+bash --version
+
+p4 -h
+
+p4-fusion-binary
+
+coursier
+
+redis-server --version
+
+python3 --version
+
+pcregrep --help
+
+comby -h
+
+/opt/s3proxy/s3proxy --version
+
+universal-ctags --version
+
+su-exec --help
+
+nginx -version
+
+postgres_exporter --version
+
+prometheus --version
+
+promtool --version
+
+alertmanager --version
+
+/usr/share/grafana/bin/grafana-server -v

--- a/enterprise/cmd/server/image_tests/test_services.sh
+++ b/enterprise/cmd/server/image_tests/test_services.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+services=(
+  embededings
+  frontend
+  github-proxy
+  gitserver
+  migrator
+  precise-code-intel-worker
+  repo-updater
+  scip-ctags
+  searcher
+  symbols
+  syntax_highlighter
+  worker
+)
+
+for cmd in "${services[@]}"; do
+  if "$cmd"; then
+    echo "OK: $cmd"
+  else
+    echo "FAIL: $cmd"
+    exit 1
+  fi
+done

--- a/enterprise/cmd/server/image_tests/test_services.sh
+++ b/enterprise/cmd/server/image_tests/test_services.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export SANITY_CHECK=true
+
 services=(
   embededings
   frontend

--- a/enterprise/cmd/server/image_tests/test_services.sh
+++ b/enterprise/cmd/server/image_tests/test_services.sh
@@ -3,7 +3,7 @@
 export SANITY_CHECK=true
 
 services=(
-  embededings
+  embeddings
   frontend
   github-proxy
   gitserver

--- a/enterprise/cmd/server/image_tests/test_zoekt.sh
+++ b/enterprise/cmd/server/image_tests/test_zoekt.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+zoekt-webserver --version
+
+zoekt-archive-index --help
+
+zoekt-git-index --version
+
+zoekt-sourcegraph-indexserver --help
+


### PR DESCRIPTION
The previous iteration was perform every binary check in a single test case, which resulted a lot of containers being created. When running tests locally, with `bazel test  //enterprise/cmd/server:image_test --runs_per_test=10` you can see the timings increasing real fast, up to the point where we're timing out. 

This PR merges test cases with similar purpose into shell scripts, which are run as a single test case for each group, meaning we're down from 30 tests cases to something like 5 for the command tests. 

And running the above command again shows that the timing stays stable even when running 10 of them concurrently. 

This should fix the flakiness of those tests in CI.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested + CI 