### PR TITLE
cody-gateway: use trace logger when handling event

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/events/buffered.go
+++ b/enterprise/cmd/cody-gateway/internal/events/buffered.go
@@ -83,7 +83,8 @@ func (l *BufferedLogger) LogEvent(spanCtx context.Context, event Event) error {
 func (l *BufferedLogger) Start() {
 	for event := range l.bufferC {
 		if err := l.handler.LogEvent(event.spanCtx, event.Event); err != nil {
-			l.log.Error("failed to log buffered event", log.Error(err))
+			trace.Logger(event.spanCtx, l.log).
+				Error("failed to log buffered event", log.Error(err))
 		}
 	}
 


### PR DESCRIPTION
Will help us find what request's events logs - noticed trace span was missing.

## Test plan

n/a