### PR TITLE
completions/client/codygateway: record gateway trace ID, span ID in request span

### DIFF
--- a/enterprise/internal/completions/client/codygateway/BUILD.bazel
+++ b/enterprise/internal/completions/client/codygateway/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//enterprise/internal/completions/types",
         "//internal/httpcli",
         "//lib/errors",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )
 


### PR DESCRIPTION
Records the trace and span IDs received from Cody Gateway (see #53259) on the request span in Sourcegraph. This can be useful if we can't get GCP linking on the traces from Sourcegraph to the standalone Cody Gateway.

Part of #53025 
Stacked on #53259

## Test plan

<img width="1703" alt="Screenshot 2023-06-09 at 10 25 31 AM" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/263776d9-29cf-4ec3-bd54-2521fcd97dc3">
