### PR TITLE
cody-gateway: simplify error messages for error grouping

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
@@ -167,7 +167,7 @@ func TestConcurrencyLimiter_TryAcquire(t *testing.T) {
 				featureLimiter: featureLimiter,
 				nowFunc:        nowFunc,
 			},
-			wantErr: autogold.Expect(`you exceeded the concurrency limit of 2 requests for "code_completions". Retry after 2000-01-01 00:00:10 +0000 UTC`),
+			wantErr: autogold.Expect(`"code_completions": concurrency limit exceeded`),
 			wantStore: autogold.Expect(limiter.MockRedisStore{
 				"foobar": limiter.MockRedisEntry{Value: 2, TTL: 10},
 			}),

--- a/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestNewRateLimitWithPercentageConcurrency(t *testing.T) {
@@ -186,4 +187,12 @@ func TestConcurrencyLimiter_TryAcquire(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAsErrConcurrencyLimitExceeded(t *testing.T) {
+	var concurrencyLimitExceeded ErrConcurrencyLimitExceeded
+	var err error
+	err = ErrConcurrencyLimitExceeded{}
+	assert.True(t, errors.As(err, &concurrencyLimitExceeded))
+	assert.True(t, errors.As(errors.Wrap(err, "foo"), &concurrencyLimitExceeded))
 }

--- a/enterprise/cmd/cody-gateway/internal/limiter/limiter_test.go
+++ b/enterprise/cmd/cody-gateway/internal/limiter/limiter_test.go
@@ -134,7 +134,7 @@ func TestStaticLimiterTryAcquire(t *testing.T) {
 				Interval: 24 * time.Hour,
 			},
 			noCommit: true, // error scenario
-			wantErr:  autogold.Expect("you exceeded the rate limit for completions. Current usage: 10 out of 10 requests. Retry after 2000-01-01 00:01:00 +0000 UTC"),
+			wantErr:  autogold.Expect("rate limit exceeded"),
 			wantStore: autogold.Expect(MockRedisStore{"foobar": MockRedisEntry{
 				Value: 10,
 				TTL:   60,


### PR DESCRIPTION
Including too many details in the error messages prevents Sentry from grouping our errors nicely, causing a lot of spam.

## Test plan

n/a