### PR TITLE
executors: Be able to unmarshall heartbeat response IDs as strings or ints

### DIFF
--- a/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
@@ -464,7 +464,8 @@ func TestMultiQueueHeartbeat(t *testing.T) {
 			"igniteVersion": "test-ignite-version",
 			"srcCliVersion": "test-src-cli-version",
 
-			"prometheusMetrics": ""
+			"prometheusMetrics": "",
+			"version": ""
 		}`,
 		responseStatus:  http.StatusOK,
 		responsePayload: `{"knownIDs": ["1-test_queue_one"], "cancelIDs": ["2-test_queue_two"]}`,
@@ -514,7 +515,8 @@ func TestMultiQueueHeartbeatBadResponse(t *testing.T) {
 			"igniteVersion": "test-ignite-version",
 			"srcCliVersion": "test-src-cli-version",
 
-			"prometheusMetrics": ""
+			"prometheusMetrics": "",
+			"version": ""
 		}`,
 		responseStatus:  http.StatusInternalServerError,
 		responsePayload: ``,

--- a/enterprise/internal/executor/types/http_test.go
+++ b/enterprise/internal/executor/types/http_test.go
@@ -148,3 +148,59 @@ func TestHeartbeatRequest_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestHeartbeatResponse_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name             string
+		payload          string
+		expectedResponse types.HeartbeatResponse
+		expectedError    error
+	}{
+		{
+			name: "String IDs",
+			payload: `{
+  "knownIds": ["42", "72"],
+  "cancelIds": ["11", "22"]
+}`,
+			expectedResponse: types.HeartbeatResponse{
+				KnownIDs:  []string{"42", "72"},
+				CancelIDs: []string{"11", "22"},
+			},
+		},
+		{
+			name: "Number IDs",
+			payload: `{
+  "knownIds": [42, 72],
+  "cancelIds": [11, 22]
+}`,
+			expectedResponse: types.HeartbeatResponse{
+				KnownIDs:  []string{"42", "72"},
+				CancelIDs: []string{"11", "22"},
+			},
+		},
+		{
+			name: "Mix of IDs",
+			payload: `{
+  "knownIds": ["42", 72],
+  "cancelIds": [11, "22"]
+}`,
+			expectedResponse: types.HeartbeatResponse{
+				KnownIDs:  []string{"42", "72"},
+				CancelIDs: []string{"11", "22"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actual types.HeartbeatResponse
+			err := json.Unmarshal([]byte(test.payload), &actual)
+			if test.expectedError != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, test.expectedError.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedResponse, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue found with backwards compatibility.

In SG 5.0.x the Heartbeat Response is

```golang
type HeartbeatResponse struct {
	KnownIDs  []int `json:"knownIds"`
	CancelIDs []int `json:"cancelIds"`
}
```

And in 5.1.x it is now

```golang
type HeartbeatResponse struct {
	KnownIDs  []string `json:"knownIds"`
	CancelIDs []string `json:"cancelIds"`
}
```

So we need to add a custom unmarshaller for this.

## Test plan

Added new Go Tests.