### PR TITLE
cody-gateway: ignore cancelled requests

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/trace",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_exp//slices",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -226,6 +226,7 @@ func makeUpstreamHandler[ReqT any](
 				var headers bytes.Buffer
 				_ = resp.Header.Write(&headers)
 				logger.Error("upstream returned 429, rewriting to 503",
+					log.Error(errors.New(resp.Status)), // real error needed for Sentry reporting
 					log.String("resp.headers", headers.String()))
 				resolvedStatusCode = http.StatusServiceUnavailable
 			}

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -197,6 +197,7 @@ func makeUpstreamHandler[ReqT any](
 				// Ignore reporting errors where client disconnected
 				if req.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
 					oteltrace.SpanFromContext(req.Context()).RecordError(err)
+					logger.Info("request canceled", log.Error(err))
 					return
 				}
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
@@ -195,6 +196,7 @@ func makeUpstreamHandler[ReqT any](
 			if err != nil {
 				// Ignore reporting errors where client disconnected
 				if req.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
+					oteltrace.SpanFromContext(req.Context()).RecordError(err)
 					return
 				}
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -192,6 +193,11 @@ func makeUpstreamHandler[ReqT any](
 
 			resp, err := httpcli.ExternalDoer.Do(req)
 			if err != nil {
+				// Ignore reporting errors where client disconnected
+				if req.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
+					return
+				}
+
 				response.JSONError(logger, w, http.StatusInternalServerError,
 					errors.Wrapf(err, "failed to make request to upstream provider %s", upstreamName))
 				return


### PR DESCRIPTION
This handling mimics the handling we have in a few other places in Sourcegraph.

If we have excessive requests hitting external timeouts e.g. Cloud Run or Cloudflare timeouts, we have alerting that will catch the long requests instead.

## Test plan

n/a