### PR TITLE
Add concurrency limit for dotcomuser actor

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     embed = [":dotcomuser"],
     deps = [
         "//enterprise/cmd/cody-gateway/internal/dotcom",
+        "//enterprise/internal/codygateway",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -83,10 +83,10 @@ func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor,
 	resp, checkErr := dotcom.CheckDotcomUserAccessToken(ctx, s.dotcom, token)
 	if checkErr != nil {
 		// Generate a stateless actor so that we aren't constantly hitting the dotcom API
-		act = newActor(s, token, dotcom.DotcomUserState{})
+		act = newActor(s, token, dotcom.DotcomUserState{}, s.concurrencyConfig)
 	} else {
 		act = newActor(s, token,
-			resp.Dotcom.CodyGatewayDotcomUserByToken.DotcomUserState)
+			resp.Dotcom.CodyGatewayDotcomUserByToken.DotcomUserState, s.concurrencyConfig)
 	}
 
 	if data, err := json.Marshal(act); err != nil {
@@ -103,7 +103,7 @@ func (s *Source) fetchAndCache(ctx context.Context, token string) (*actor.Actor,
 }
 
 // newActor creates an actor from Sourcegraph.com user.
-func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *actor.Actor {
+func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState, concurrencyConfig codygateway.ActorConcurrencyLimitConfig) *actor.Actor {
 	now := time.Now()
 	a := &actor.Actor{
 		Key:           cacheKey,
@@ -119,7 +119,7 @@ func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 			rl.Limit,
 			time.Duration(rl.IntervalSeconds)*time.Second,
 			rl.AllowedModels,
-			source.concurrencyConfig,
+			concurrencyConfig,
 		)
 	}
 
@@ -128,7 +128,7 @@ func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 			rl.Limit,
 			time.Duration(rl.IntervalSeconds)*time.Second,
 			rl.AllowedModels,
-			source.concurrencyConfig,
+			concurrencyConfig,
 		)
 	}
 
@@ -137,7 +137,7 @@ func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 			rl.Limit,
 			time.Duration(rl.IntervalSeconds)*time.Second,
 			rl.AllowedModels,
-			source.concurrencyConfig,
+			concurrencyConfig,
 		)
 	}
 

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -3,7 +3,6 @@ package dotcomuser
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -115,7 +115,6 @@ func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 		Source:        source,
 	}
 
-
 	if rl := user.CodyGatewayAccess.ChatCompletionsRateLimit; rl != nil {
 		a.RateLimits[codygateway.FeatureChatCompletions] = actor.NewRateLimitWithPercentageConcurrency(
 			rl.Limit,

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -115,9 +115,6 @@ func newActor(source *Source, cacheKey string, user dotcom.DotcomUserState) *act
 		Source:        source,
 	}
 
-	fmt.Printf("newActor for dotcomuser: %+#v\n", user.CodyGatewayAccess.ChatCompletionsRateLimit)
-	fmt.Printf("newActor for dotcomuser: %+#v\n", user.CodyGatewayAccess.CodeCompletionsRateLimit)
-	fmt.Printf("newActor for dotcomuser: %+#v\n", user.CodyGatewayAccess.EmbeddingsRateLimit)
 
 	if rl := user.CodyGatewayAccess.ChatCompletionsRateLimit; rl != nil {
 		a.RateLimits[codygateway.FeatureChatCompletions] = actor.NewRateLimitWithPercentageConcurrency(

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
@@ -2,13 +2,19 @@ package dotcomuser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
 )
 
 func TestNewActor(t *testing.T) {
+	concurrencyConfig := codygateway.ActorConcurrencyLimitConfig{
+		Percentage: 50,
+		Interval:   10 * time.Second,
+	}
 	type args struct {
 		s dotcom.DotcomUserState
 	}
@@ -94,7 +100,7 @@ func TestNewActor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			act := newActor(nil, "", tt.args.s)
+			act := newActor(nil, "", tt.args.s, concurrencyConfig)
 			assert.Equal(t, act.AccessEnabled, tt.wantEnabled)
 		})
 	}


### PR DESCRIPTION
Forgot to add this for the dotcomuser actor in the previous PR, so it would always be 0 at the moment.

## Test plan

Works E2E now locally.