### PR TITLE
ranking: Fix reducer getting permanently stuck

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/reducer.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/reducer.go
@@ -91,7 +91,7 @@ input_ranks AS (
 processed AS (
 	UPDATE codeintel_ranking_path_counts_inputs
 	SET processed = true
-	WHERE id IN (SELECT ir.id FROM input_ranks ir)
+	WHERE id IN (SELECT ir.id FROM rank_ids ir)
 	RETURNING 1
 ),
 inserted AS (


### PR DESCRIPTION
#53171 fixes *premature* exit but introduces the ability to have the reducer get stuck as it's not marking records for deleted repos as processed, keeping them always in the in-pile.

## Test plan

Existing unit tests.