### PR TITLE
ranking: Change ranking data availability timestamp

### DIFF
--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -759,18 +759,18 @@ func TestRepos_List_LastChanged(t *testing.T) {
 	setGitserverRepoLastChanged(t, db, r3.Name, now.Add(-time.Hour))
 	{
 		if _, err := db.Handle().ExecContext(ctx, `
-			INSERT INTO codeintel_path_ranks (graph_key, repository_id, updated_at, payload)
-			VALUES ('test', $1, $2, '{}'::jsonb)
+			INSERT INTO codeintel_path_ranks(graph_key, repository_id, updated_at, payload)
+			VALUES ('test', $1, NOW() + '1 day'::interval, '{}'::jsonb)
 		`,
-			r3.ID, now,
+			r3.ID,
 		); err != nil {
 			t.Fatal(err)
 		}
 
 		if _, err := db.Handle().ExecContext(ctx, `
 			INSERT INTO codeintel_ranking_progress(graph_key, max_export_id, mappers_started_at, reducer_completed_at)
-			VALUES ('test', 1000, NOW(), NOW())
-		`,
+			VALUES ('test', 1000, NOW(), $1)
+		`, now,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
We've recently changed all `codeintel_path_ranks` to become available at the same time, which means we need Zoekt to reindex it if the *reducer* completed after the last reindex (not if the records existed but invisibly at that time).

## Test plan

Existing unit tests.