### PR TITLE
Clearly surface errors in keyword search

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -43,17 +43,23 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan, enterpriseJobs Enterpris
 	newJob := func(b query.Basic) (job.Job, error) {
 		return NewBasicJob(inputs, b, enterpriseJobs)
 	}
-	if inputs.SearchMode == search.SmartSearch || inputs.PatternType == query.SearchTypeLucky {
-		jobTree = smartsearch.NewSmartSearchJob(jobTree, newJob, plan)
-	} else if inputs.PatternType == query.SearchTypeKeyword && len(plan) == 1 {
-		// TODO(camdencheek): we should almost definitely not be doing plan[0] here
-		newJobTree, err := keyword.NewKeywordSearchJob(plan[0], newJob)
+
+	if inputs.PatternType == query.SearchTypeKeyword {
+		if inputs.SearchMode == search.SmartSearch {
+			return nil, errors.New("The 'keyword' patterntype is not compatible with Smart Search")
+		}
+
+		newJobTree, err := keyword.NewKeywordSearchJob(plan, newJob)
 		if err != nil {
 			return nil, err
 		}
 		if newJobTree != nil {
 			jobTree = newJobTree
 		}
+	}
+
+	if inputs.SearchMode == search.SmartSearch || inputs.PatternType == query.SearchTypeLucky {
+		jobTree = smartsearch.NewSmartSearchJob(jobTree, newJob, plan)
 	}
 
 	alertJob := NewAlertJob(inputs, jobTree)

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -53,9 +53,8 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan, enterpriseJobs Enterpris
 		if err != nil {
 			return nil, err
 		}
-		if newJobTree != nil {
-			jobTree = newJobTree
-		}
+
+		jobTree = newJobTree
 	}
 
 	if inputs.SearchMode == search.SmartSearch || inputs.PatternType == query.SearchTypeLucky {

--- a/internal/search/keyword/BUILD.bazel
+++ b/internal/search/keyword/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/search/job",
         "//internal/search/query",
         "//internal/search/streaming",
+        "//lib/errors",
         "@com_github_kljensen_snowball//:snowball",
         "@io_opentelemetry_go_otel//attribute",
     ],

--- a/internal/search/keyword/keyword_search_job.go
+++ b/internal/search/keyword/keyword_search_job.go
@@ -9,10 +9,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func NewKeywordSearchJob(b query.Basic, newJob func(query.Basic) (job.Job, error)) (job.Job, error) {
-	keywordQuery, err := basicQueryToKeywordQuery(b)
+func NewKeywordSearchJob(plan query.Plan, newJob func(query.Basic) (job.Job, error)) (job.Job, error) {
+	if len(plan) > 1 {
+		return nil, errors.New("The 'keyword' patterntype does not support multiple clauses")
+	}
+
+	keywordQuery, err := basicQueryToKeywordQuery(plan[0])
 	if err != nil || keywordQuery == nil {
 		return nil, err
 	}


### PR DESCRIPTION
A small PR to make debugging `patterntype:keyword` searches easier in the search UI. Before, we silently disabled keyword search if smart search was enabled, or if the search had multiple clauses.

## Test plan

All my manual tests still work, and things that don't make sense show a clear error in UI:
* Using `patterntype:keyword` with smart search enabled
* Specifying multiple clauses