### PR TITLE
cody-gateway/events: submit event instead of dropping if buffer is full

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/events/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/events/BUILD.bazel
@@ -30,8 +30,10 @@ go_test(
     srcs = ["buffered_test.go"],
     deps = [
         ":events",
+        "//lib/errors",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_conc//:conc",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
Currently, we drop events in the unlikely case the buffer fills up - instead we should attempt to send the event anyway, at the cost of some hot-path latency, since the buffered logger is only intended to be a minor optimization.

The test case asserts that when 1 submission blocks, every other submission just queues up, and then the next one after filling up will send the event directly.

Addresses https://github.com/sourcegraph/sourcegraph/pull/52747#discussion_r1224876533

## Test plan

Unit tests
