### PR TITLE
github app: toggle app default visibility

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -3,7 +3,7 @@ import React, { FC, useState, useCallback, useRef, useEffect } from 'react'
 import { noop } from 'lodash'
 import { Link } from 'react-router-dom'
 
-import { Alert, Container, Button, Input, Label, Text, PageHeader, ButtonLink } from '@sourcegraph/wildcard'
+import { Alert, Container, Button, Input, Label, Text, PageHeader, ButtonLink, Checkbox } from '@sourcegraph/wildcard'
 
 import { GitHubAppDomain } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -72,6 +72,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     const [url, setUrl] = useState<string>(baseURL || 'https://github.com')
     const [urlError, setUrlError] = useState<string>()
     const [org, setOrg] = useState<string>('')
+    const [isPublic, setIsPublic] = useState<boolean>(false)
     const [error, setError] = useState<string>()
 
     useEffect(() => eventLogger.logPageView('SiteAdminCreateGiHubApp'), [])
@@ -87,11 +88,11 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                 setup_url: new URL('/.auth/githubapp/setup', originURL).href,
                 callback_urls: [new URL('/.auth/github/callback', originURL).href],
                 setup_on_update: true,
-                public: false,
+                public: isPublic,
                 default_permissions: defaultPermissions,
                 default_events: defaultEvents,
             }),
-        [originURL, defaultEvents, defaultPermissions]
+        [originURL, defaultEvents, defaultPermissions, isPublic]
     )
 
     const createActionUrl = useCallback(
@@ -187,6 +188,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     )
 
     const handleOrgChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => setOrg(event.target.value), [])
+    const toggleIsPublic = useCallback(() => setIsPublic(isPublic => !isPublic), [])
 
     return (
         <>
@@ -210,9 +212,8 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                     Provide the details for a new GitHub App with the form below. Once you click "Create GitHub App",
                     you will be routed to {baseURL || 'GitHub'} to create the App and choose which repositories to grant
                     it access to. Once created on {baseURL || 'GitHub'}, you'll be redirected back here to finish
-                    installing it on Sourcegraph.
+                    connecting it to Sourcegraph.
                 </Text>
-
                 <Label className="w-100">
                     <Text alignment="left" className="mb-2">
                         GitHub App Name
@@ -258,7 +259,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                                 <Link
                                     to="https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners"
                                     target="_blank"
-                                    rel="noopener"
+                                    rel="noopener noreferrer"
                                 >
                                     organization owners
                                 </Link>{' '}
@@ -267,7 +268,31 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                         }
                     />
                 </Label>
-                <div className="mt-3">
+                <Checkbox
+                    wrapperClassName="mt-2"
+                    id="app-is-public"
+                    onChange={toggleIsPublic}
+                    checked={isPublic}
+                    label={
+                        <>
+                            Make App public <span className="text-muted">(optional)</span>
+                        </>
+                    }
+                    message={
+                        <>
+                            Your GitHub App must be public if you want to install it on multiple organizations or user
+                            accounts.{' '}
+                            <Link
+                                to="/help/admin/external_service/github#mutliple-installations"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Learn more about public vs. private GitHub Apps.
+                            </Link>
+                        </>
+                    }
+                />
+                <div className="mt-4">
                     <Button variant="primary" onClick={createState} disabled={!!nameError || !!urlError}>
                         Create Github App
                     </Button>

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -153,12 +153,31 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService }) => {
                     <hr className="mt-4 mb-4" />
 
                     <div>
-                        <H2 className="d-flex align-items-center">
+                        <H2 className="d-flex align-items-center mb-3">
                             Installations
                             <Button className="ml-auto" onClick={() => onAddInstallation(app)} variant="primary">
                                 <Icon svgPath={mdiPlus} aria-hidden={true} /> Add installation
                             </Button>
                         </H2>
+                        <Text>
+                            An installation is a connection between a GitHub App and a user or organization on GitHub.
+                            An installation allows the GitHub App to access resources owned by that account and perform
+                            actions on behalf of it.
+                        </Text>
+                        <Text>
+                            A GitHub App can only be installed in multiple accounts if it is{' '}
+                            <AnchorLink to="https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/making-a-github-app-public-or-private">
+                                public
+                            </AnchorLink>
+                            . A private GitHub App can only be installed on the account that originally created it.{' '}
+                            <Link
+                                to="/help/admin/external_service/github#mutliple-installations"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Learn more about public vs. private GitHub Apps.
+                            </Link>
+                        </Text>
                         <div className="list-group mb-3" aria-label="GitHub App Installations">
                             {app.installations?.length === 0 ? (
                                 <Text>


### PR DESCRIPTION
Adds a `<Checkbox />` to the Create GitHub App form for toggling the default visibility of the App from private to public. This will populate the value in the App manifest.

I also added a short explanation about GitHub App installations and the ability to install them in multiple places if the app is public vs. private to the main GitHub App page, with a link the part of our docs that describes it in more detail. 

### Demo

https://github.com/sourcegraph/sourcegraph/assets/8942601/9e8c17af-dc0d-4e3e-9a7c-cf9d170a4812

And a screenshot from the normal Repos create flow:

![image](https://github.com/sourcegraph/sourcegraph/assets/8942601/56b5e4b8-35dc-45f4-bc76-e124dfe7344a)

## Test plan

Manual testing.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
