### PR TITLE
Add an alert banner to check for revoked licenses

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -79,6 +79,17 @@ func Init(
 		return errors.Wrap(err, "Failed to createe sub-repo client")
 	}
 
+	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
+		if licensing.IsLicenseValid() {
+			return nil
+		}
+
+		return []*graphqlbackend.Alert{{
+			TypeValue:    graphqlbackend.AlertTypeError,
+			MessageValue: "To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration).",
+		}}
+	})
+
 	// Warn about usage of authz providers that are not enabled by the license.
 	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
 		// Only site admins can act on this alert, so only show it to site admins.

--- a/enterprise/internal/licensing/features.go
+++ b/enterprise/internal/licensing/features.go
@@ -141,6 +141,11 @@ func Check(feature Feature) error {
 	if err != nil {
 		return errors.WithMessage(err, fmt.Sprintf("checking feature %q activation", feature))
 	}
+
+	if !IsLicenseValid() {
+		return errors.New("Sourcegraph license is no longer valid")
+	}
+
 	return feature.Check(info)
 }
 

--- a/enterprise/internal/licensing/licensing.go
+++ b/enterprise/internal/licensing/licensing.go
@@ -98,7 +98,7 @@ func GetConfiguredProductLicenseInfo() (*Info, error) {
 	return info, err
 }
 
-func isLicenseValid() bool {
+func IsLicenseValid() bool {
 	val := store.Get(licenseValidityStoreKey)
 	if val.IsNil() {
 		return true
@@ -139,10 +139,6 @@ func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {
 
 			if err = info.hasUnknownPlan(); err != nil {
 				return nil, "", err
-			}
-
-			if !isLicenseValid() {
-				return nil, "", errors.New("license is not valid")
 			}
 
 			lastKeyText = keyText

--- a/enterprise/internal/licensing/licensing_test.go
+++ b/enterprise/internal/licensing/licensing_test.go
@@ -24,18 +24,18 @@ func TestIsLicenseValid(t *testing.T) {
 
 	t.Run("unset key returns true", func(t *testing.T) {
 		cleanupStore(t, store)
-		require.True(t, isLicenseValid())
+		require.True(t, IsLicenseValid())
 	})
 
 	t.Run("set false key returns false", func(t *testing.T) {
 		cleanupStore(t, store)
 		require.NoError(t, store.Set(licenseValidityStoreKey, false))
-		require.False(t, isLicenseValid())
+		require.False(t, IsLicenseValid())
 	})
 
 	t.Run("set true key returns true", func(t *testing.T) {
 		cleanupStore(t, store)
 		require.NoError(t, store.Set(licenseValidityStoreKey, true))
-		require.True(t, isLicenseValid())
+		require.True(t, IsLicenseValid())
 	})
 }


### PR DESCRIPTION
Adds an alert banner that communicates when the Sourcegraph license is no longer valid.

This PR also moves the check to the `licensing.Check` function instead of the main GetLicenseInfo functions, which prevents a bunch of false-positive alerts from popping up.

![Screenshot 2023-06-12 at 11 44 43](https://github.com/sourcegraph/sourcegraph/assets/6427795/fe985fa6-97cc-4849-8315-e5d010c34933)

## Test plan

Tested locally by editing `enterprise/internal/licensing/licensing.go` and making `IsLicenseValid` always return `false`.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
