### PR TITLE
own: add a convenient link from "edit" to "view" ownership page.

### DIFF
--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -24,7 +24,7 @@ export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'use
     repo: RepositoryFields
     authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'> | null
 }
-const BREADCRUMB = { key: 'edit-own', element: 'Edit ownership' }
+const EDIT_PAGE_BREADCRUMB = { key: 'edit-own', element: 'Edit ownership' }
 
 export const RepositoryOwnEditPage: React.FunctionComponent<RepositoryOwnAreaPageProps> = ({
     useBreadcrumb,
@@ -32,7 +32,8 @@ export const RepositoryOwnEditPage: React.FunctionComponent<RepositoryOwnAreaPag
     authenticatedUser,
     telemetryService,
 }) => {
-    useBreadcrumb(BREADCRUMB)
+    const breadcrumbSetters = useBreadcrumb({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> })
+    breadcrumbSetters.useBreadcrumb(EDIT_PAGE_BREADCRUMB)
 
     const [ownEnabled, status] = useFeatureFlag('search-ownership')
 

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -25,8 +25,6 @@ import { RepositoryOwnAreaPageProps } from './RepositoryOwnEditPage'
 
 import styles from './RepositoryOwnPageContents.module.scss'
 
-const BREADCRUMB = { key: 'own', element: 'Ownership' }
-
 export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPageProps> = ({
     useBreadcrumb,
     repo,
@@ -35,7 +33,7 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
     const queryParameters = new URLSearchParams(location.search)
     const path = queryParameters.get('path') ?? ''
 
-    useBreadcrumb(BREADCRUMB)
+    useBreadcrumb({ key: 'own', element: 'Ownership' })
 
     const [ownEnabled, status] = useFeatureFlag('search-ownership')
     const [openAddOwnerModal, setOpenAddOwnerModal] = useState<boolean>(false)


### PR DESCRIPTION
Test plan:
Local sg run and check that the link points to the right page.

Closes https://github.com/sourcegraph/sourcegraph/issues/53151.

### Demo

https://github.com/sourcegraph/sourcegraph/assets/94846361/5db3a022-4ca0-4c42-a3c4-f796f90f2bb1

