### PR TITLE
cody: enable incremental embedding by default

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -102,21 +102,20 @@ If you would like to allow your Sourcegraph instance to control the creation and
 
 ### Incremental embeddings
 
-<span class="badge badge-experimental">Experimental</span>
-
 Incremental embeddings allow you to update the embeddings for a repository without having to re-embed the entire
 repository. With incremental embeddings, outdated embeddings of deleted and modified files are removed and new
 embeddings of the modified and added files are added to the repository's embeddings. This speeds up updates, reduces the
 data sent to the embedding provider and saves costs.
 
-Incremental embeddings are disabled by default.
+Incremental embeddings are enabled by default. You can disable incremental embeddings by setting
+the `disableIncremental` property in the embeddings configuration to `true`.
 
 ```json
 {
   // [...]
   "embeddings": {
     // [...]
-    "incremental": true
+    "disableIncremental": true
   }
 }
 ```

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -108,14 +108,14 @@ embeddings of the modified and added files are added to the repository's embeddi
 data sent to the embedding provider and saves costs.
 
 Incremental embeddings are enabled by default. You can disable incremental embeddings by setting
-the `disableIncremental` property in the embeddings configuration to `true`.
+the `incremental` property in the embeddings configuration to `false`.
 
 ```json
 {
   // [...]
   "embeddings": {
     // [...]
-    "disableIncremental": true
+    "incremental": false
   }
 }
 ```

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -66,7 +66,7 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	// we fall back to a full index.
 	var lastSuccessfulJobRevision api.CommitID
 	var previousEmbeddingsIndex *embeddings.RepoEmbeddingIndex
-	if incrementalEnabled := !conf.Get().Embeddings.DisableIncremental; incrementalEnabled {
+	if conf.Get().Embeddings.Incremental == nil || *conf.Get().Embeddings.Incremental {
 		lastSuccessfulJobRevision, previousEmbeddingsIndex = h.getPreviousEmbeddingIndex(ctx, logger, repo)
 	}
 

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -66,7 +66,6 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	// we fall back to a full index.
 	var lastSuccessfulJobRevision api.CommitID
 	var previousEmbeddingsIndex *embeddings.RepoEmbeddingIndex
-
 	if incrementalEnabled := !conf.Get().Embeddings.DisableIncremental; incrementalEnabled {
 		lastSuccessfulJobRevision, previousEmbeddingsIndex = h.getPreviousEmbeddingIndex(ctx, logger, repo)
 	}

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -66,7 +66,8 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *repoemb
 	// we fall back to a full index.
 	var lastSuccessfulJobRevision api.CommitID
 	var previousEmbeddingsIndex *embeddings.RepoEmbeddingIndex
-	if conf.Get().Embeddings.Incremental {
+
+	if incrementalEnabled := !conf.Get().Embeddings.DisableIncremental; incrementalEnabled {
 		lastSuccessfulJobRevision, previousEmbeddingsIndex = h.getPreviousEmbeddingIndex(ctx, logger, repo)
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -622,14 +622,14 @@ type Embeddings struct {
 	AccessToken string `json:"accessToken,omitempty"`
 	// Dimensions description: The dimensionality of the embedding vectors. Required field if not using the sourcegraph provider.
 	Dimensions int `json:"dimensions,omitempty"`
-	// DisableIncremental description: Disables incremental embedding generation. If set to true, all embeddings will be regenerated on each run.
-	DisableIncremental bool `json:"disableIncremental,omitempty"`
 	// Enabled description: Toggles whether embedding service is enabled.
 	Enabled bool `json:"enabled"`
 	// Endpoint description: The endpoint under which to reach the provider. Sensible default will be used for each provider.
 	Endpoint string `json:"endpoint,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
+	// Incremental description: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
+	Incremental *bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
 	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`
 	// MaxTextEmbeddingsPerRepo description: The maximum number of embeddings for text files to generate per repo

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -622,14 +622,14 @@ type Embeddings struct {
 	AccessToken string `json:"accessToken,omitempty"`
 	// Dimensions description: The dimensionality of the embedding vectors. Required field if not using the sourcegraph provider.
 	Dimensions int `json:"dimensions,omitempty"`
+	// DisableIncremental description: Disables incremental embedding generation. If set to true, all embeddings will be regenerated on each run.
+	DisableIncremental bool `json:"disableIncremental,omitempty"`
 	// Enabled description: Toggles whether embedding service is enabled.
 	Enabled bool `json:"enabled"`
 	// Endpoint description: The endpoint under which to reach the provider. Sensible default will be used for each provider.
 	Endpoint string `json:"endpoint,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
 	ExcludedFilePathPatterns []string `json:"excludedFilePathPatterns,omitempty"`
-	// Incremental description: Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.
-	Incremental bool `json:"incremental,omitempty"`
 	// MaxCodeEmbeddingsPerRepo description: The maximum number of embeddings for code files to generate per repo
 	MaxCodeEmbeddingsPerRepo int `json:"maxCodeEmbeddingsPerRepo,omitempty"`
 	// MaxTextEmbeddingsPerRepo description: The maximum number of embeddings for text files to generate per repo

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2386,10 +2386,13 @@
           "type": "integer",
           "minimum": 0
         },
-        "disableIncremental": {
-          "description": "Disables incremental embedding generation. If set to true, all embeddings will be regenerated on each run.",
+        "incremental": {
+          "description": "Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
           "type": "boolean",
-          "default": false
+          "!go": {
+            "pointer": true
+          },
+          "default": true
         },
         "minimumInterval": {
           "description": "The time to wait between runs. Valid time units are \"s\", \"m\", \"h\". Example values: \"30s\", \"5m\", \"1h\".",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2386,8 +2386,8 @@
           "type": "integer",
           "minimum": 0
         },
-        "incremental": {
-          "description": "Experimental: Whether to generate embeddings incrementally. If true, only files that have changed since the last run will be processed.",
+        "disableIncremental": {
+          "description": "Disables incremental embedding generation. If set to true, all embeddings will be regenerated on each run.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
Incremental embeddings have been enabled for 3 weeks on S2 and for 1 week on .com without issues. 
We want to enable incremental embeddings by default before the release.

## Test plan

manual testing

- `sg start`
- trigger embeddings job of mock repo
- update the repo
- trigger antoher job and verify in the logs that the job is marked as "incremental": true
- set "disableIncremental": true
- update the repo again
- trigger another job and verify in the logs that the job is marked as "incremental": false