### PR TITLE
fix(licensing) add initial delay before running license check

### DIFF
--- a/enterprise/internal/licensing/BUILD.bazel
+++ b/enterprise/internal/licensing/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//internal/httpcli",
         "//internal/redispool",
         "//lib/errors",
+        "@com_github_derision_test_glock//:glock",
         "@com_github_gomodule_redigo//redis",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_x_crypto//ssh",
@@ -55,6 +56,7 @@ go_test(
     deps = [
         "//enterprise/internal/license",
         "//internal/redispool",
+        "@com_github_derision_test_glock//:glock",
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//logtest",

--- a/enterprise/internal/licensing/check.go
+++ b/enterprise/internal/licensing/check.go
@@ -151,7 +151,6 @@ func StartLicenseCheck(originalCtx context.Context, logger log.Logger, siteID st
 			initialWaitInterval, _ = calcDurationSinceLastCalled(glock.NewRealClock())
 		}
 
-		// todo: clarify shall we use sync.Mutex or something else?
 		// continue running with new license key
 		store.Set(prevLicenseTokenKey, licenseToken)
 

--- a/enterprise/internal/licensing/check.go
+++ b/enterprise/internal/licensing/check.go
@@ -148,8 +148,7 @@ func StartLicenseCheck(originalCtx context.Context, logger log.Logger, siteID st
 		licenseToken := hex.EncodeToString(GenerateHashedLicenseKeyAccessToken(conf.Get().LicenseKey))
 		var initialWaitInterval time.Duration = 0
 		if prevLicenseToken == licenseToken {
-			durationSinceLastCalled, _ := calcDurationSinceLastCalled(glock.NewRealClock())
-			initialWaitInterval = durationSinceLastCalled
+			initialWaitInterval, _ = calcDurationSinceLastCalled(glock.NewRealClock())
 		}
 
 		// todo: clarify shall we use sync.Mutex or something else?

--- a/enterprise/internal/licensing/check_test.go
+++ b/enterprise/internal/licensing/check_test.go
@@ -54,19 +54,19 @@ func Test_calcDurationToWaitForNextHandle(t *testing.T) {
 			want:         0,
 			wantErr:      true,
 		},
-		"returns 0 if last called at is before licenseCheckInterval": {
-			lastCalledAt: now.Add(-licenseCheckInterval - time.Minute).Format(time.RFC3339),
+		"returns 0 if last called at is before LicenseCheckInterval": {
+			lastCalledAt: now.Add(-LicenseCheckInterval - time.Minute).Format(time.RFC3339),
 			want:         0,
 			wantErr:      false,
 		},
-		"returns 0 if last called at is at licenseCheckInterval": {
-			lastCalledAt: now.Add(-licenseCheckInterval).Format(time.RFC3339),
+		"returns 0 if last called at is at LicenseCheckInterval": {
+			lastCalledAt: now.Add(-LicenseCheckInterval).Format(time.RFC3339),
 			want:         0,
 			wantErr:      false,
 		},
 		"returns diff between last called at and now": {
 			lastCalledAt: now.Add(-time.Hour).Format(time.RFC3339),
-			want:         licenseCheckInterval - time.Hour,
+			want:         LicenseCheckInterval - time.Hour,
 			wantErr:      false,
 		},
 	}

--- a/enterprise/internal/licensing/check_test.go
+++ b/enterprise/internal/licensing/check_test.go
@@ -9,12 +9,84 @@ import (
 	"testing"
 	"time"
 
+	"github.com/derision-test/glock"
 	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
+
+func Test_calcDurationToWaitForNextHandle(t *testing.T) {
+	// Connect to local redis for testing, this is the same URL used in rcache.SetupForTest
+	store = redispool.NewKeyValue("127.0.0.1:6379", &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 5 * time.Second,
+	})
+
+	cleanupStore := func() {
+		store.Del(licenseValidityStoreKey)
+		store.Del(lastCalledAtStoreKey)
+	}
+
+	now := time.Now().Round(time.Second)
+	clock := glock.NewMockClock()
+	clock.SetCurrent(now)
+
+	tests := map[string]struct {
+		lastCalledAt string
+		want         time.Duration
+		wantErr      bool
+	}{
+		"returns 0 if last called at is empty": {
+			lastCalledAt: "",
+			want:         0,
+			wantErr:      true,
+		},
+		"returns 0 if last called at is invalid": {
+			lastCalledAt: "invalid",
+			want:         0,
+			wantErr:      true,
+		},
+		"returns 0 if last called at is in the future": {
+			lastCalledAt: now.Add(time.Minute).Format(time.RFC3339),
+			want:         0,
+			wantErr:      true,
+		},
+		"returns 0 if last called at is before licenseCheckInterval": {
+			lastCalledAt: now.Add(-licenseCheckInterval - time.Minute).Format(time.RFC3339),
+			want:         0,
+			wantErr:      false,
+		},
+		"returns 0 if last called at is at licenseCheckInterval": {
+			lastCalledAt: now.Add(-licenseCheckInterval).Format(time.RFC3339),
+			want:         0,
+			wantErr:      false,
+		},
+		"returns diff between last called at and now": {
+			lastCalledAt: now.Add(-time.Hour).Format(time.RFC3339),
+			want:         licenseCheckInterval - time.Hour,
+			wantErr:      false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cleanupStore()
+			if test.lastCalledAt != "" {
+				store.Set(lastCalledAtStoreKey, test.lastCalledAt)
+			}
+
+			got, err := calcDurationSinceLastCalled(clock)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.want, got)
+		})
+	}
+}
 
 func Test_licenseChecker(t *testing.T) {
 	// Connect to local redis for testing, this is the same URL used in rcache.SetupForTest
@@ -23,10 +95,16 @@ func Test_licenseChecker(t *testing.T) {
 		IdleTimeout: 5 * time.Second,
 	})
 
+	cleanupStore := func() {
+		store.Del(licenseValidityStoreKey)
+		store.Del(lastCalledAtStoreKey)
+	}
+
 	siteID := "some-site-id"
 	token := "test-token"
 
 	t.Run("skips check if license is air-gapped", func(t *testing.T) {
+		cleanupStore()
 		var featureChecked Feature
 		defaultMock := MockCheckFeature
 		MockCheckFeature = func(feature Feature) error {
@@ -37,9 +115,6 @@ func Test_licenseChecker(t *testing.T) {
 		t.Cleanup(func() {
 			MockCheckFeature = defaultMock
 		})
-
-		store.Del(licenseValidityStoreKey)
-		store.Del(lastCalledAtStoreKey)
 
 		doer := &mockDoer{
 			status:   '1',
@@ -102,8 +177,7 @@ func Test_licenseChecker(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			store.Del(licenseValidityStoreKey)
-			store.Del(lastCalledAtStoreKey)
+			cleanupStore()
 
 			doer := &mockDoer{
 				status:   test.status,

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -296,7 +296,7 @@ func (r *PeriodicGoroutine) runHandlerPeriodically(monitorCtx context.Context) {
 	}()
 
 	select {
-	// Sleep - might be a zero-duration value if we're immediately reinvoking,
+	// Initial delay sleep - might be a zero-duration value if it wasn't set,
 	// but this gives us a nice chance to check the context to see if we should
 	// exit naturally.
 	case <-r.clock.After(r.initialDelay):

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -29,6 +29,7 @@ type PeriodicGoroutine struct {
 	jobName           string
 	recorder          *recorder.Recorder
 	getInterval       getIntervalFunc
+	initialDelay      time.Duration
 	getConcurrency    getConcurrencyFunc
 	handler           unifiedHandler
 	operation         *observation.Operation
@@ -128,6 +129,11 @@ func WithConcurrencyFunc(getConcurrency getConcurrencyFunc) Option {
 
 func WithOperation(operation *observation.Operation) Option {
 	return func(p *PeriodicGoroutine) { p.operation = operation }
+}
+
+// WithInitialDelay sets the initial delay before the first invocation of the handler.
+func WithInitialDelay(delay time.Duration) Option {
+	return func(p *PeriodicGoroutine) { p.initialDelay = delay }
 }
 
 func withClock(clock glock.Clock) Option {
@@ -288,6 +294,21 @@ func (r *PeriodicGoroutine) runHandlerPeriodically(monitorCtx context.Context) {
 		<-monitorCtx.Done()
 		cancel()
 	}()
+
+	select {
+	// Sleep - might be a zero-duration value if we're immediately reinvoking,
+	// but this gives us a nice chance to check the context to see if we should
+	// exit naturally.
+	case <-r.clock.After(r.initialDelay):
+
+	case <-r.ctx.Done():
+		// Goroutine is shutting down
+		return
+
+	case <-monitorCtx.Done():
+		// Caller is requesting we return to resize the pool
+		return
+	}
 
 	for {
 		interval, ok := r.runHandlerAndDetermineBackoff(handlerCtx)


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/52948.

This PR:
- Update instance license checks logic to respect previous call times, to keep a consistent period between dotcom API calls for the same license key
- Adds new `WithInitialDelay` option to `goroutine.PeriodicGoroutine`


## Test plan
- Check the diff

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
