### PR TITLE
JetBrains: add a setting to enable/disable Cody completions

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -27,6 +27,7 @@
   - Improve variable names
   - Smell code
   - Optimize code
+- A separate setting for enabling/disabling Cody completions. [pull/53302](https://github.com/sourcegraph/sourcegraph/pull/53302)
 
 ### Changed
 

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -87,7 +87,6 @@ The plugin works with all JetBrains IDEs, including:
 - **Globbing**: Determines whether you can specify sets of filenames with wildcard characters.
 - **Cody completions**: Enables/disables Cody completions in the editor.
   - The completions are disabled by default.
-  - It is possible to override this setting with the `CODY_COMPLETIONS_ENABLED` environment variable.
 
 ### Git remote setting
 

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -85,6 +85,10 @@ The plugin works with all JetBrains IDEs, including:
       pair for _each repo_ or _each depot_ you may have. If none of these solutions work for you, please raise this
       at [support@sourcegraph.com](mailto:support@sourcegraph.com), and we'll prioritize making this more convenient.
 - **Globbing**: Determines whether you can specify sets of filenames with wildcard characters.
+- **Cody completions**: Enables/disables Cody completions in the editor.
+  - The completions are disabled by default.
+  - It is possible to override this setting with the `CODY_COMPLETIONS_ENABLED` environment variable.
+  - If initially unset, it defaults to the `cody.completions.enabled` property value.
 
 ### Git remote setting
 

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -88,7 +88,6 @@ The plugin works with all JetBrains IDEs, including:
 - **Cody completions**: Enables/disables Cody completions in the editor.
   - The completions are disabled by default.
   - It is possible to override this setting with the `CODY_COMPLETIONS_ENABLED` environment variable.
-  - If initially unset, it defaults to the `cody.completions.enabled` property value.
 
 ### Git remote setting
 

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -97,7 +97,7 @@ tasks {
 
     runIde {
         jvmArgs("-Djdk.module.illegalAccess.silent=true")
-        systemProperty("cody.completions.enabled", "true")
+        // systemProperty("cody.completions.enabled", "true")
     }
 
     // Configure UI tests plugin

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -97,7 +97,6 @@ tasks {
 
     runIde {
         jvmArgs("-Djdk.module.illegalAccess.silent=true")
-        // systemProperty("cody.completions.enabled", "true")
     }
 
     // Configure UI tests plugin

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -32,13 +32,6 @@ public class CodyCompletionsManager {
   private final ConcurrentLinkedQueue<Future<CompletableFuture<Void>>> jobs =
       new ConcurrentLinkedQueue<>();
 
-  // We don't want casual users to turn on completions by discovering a setting in the UI so
-  // we only allow enabling completions via a system property. This property is automatically
-  // configured when running `./gradle :runIde`, and we'll need to document internally for
-  // Sourcegraph team members how to use "Edit Custom VM Options..." to enable completions.
-  private static final boolean IS_COMPLETIONS_ENABLED =
-      "true".equals(System.getProperty("cody.completions.enabled"));
-
   public static @NotNull CodyCompletionsManager getInstance() {
     return ApplicationManager.getApplication().getService(CodyCompletionsManager.class);
   }
@@ -57,14 +50,14 @@ public class CodyCompletionsManager {
 
   @RequiresEdt
   public boolean isEnabledForEditor(Editor editor) {
-    return IS_COMPLETIONS_ENABLED
+    return ConfigUtil.areCodyCompletionsEnabled()
         && editor != null
         && isProjectAvailable(editor.getProject())
         && isEditorSupported(editor);
   }
 
   public void triggerCompletion(Editor editor, int offset) {
-    if (!IS_COMPLETIONS_ENABLED) {
+    if (!ConfigUtil.areCodyCompletionsEnabled()) {
       return;
     }
     CancellationToken token = new CancellationToken();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -193,6 +193,10 @@ public class ConfigUtil {
     return getApplicationLevelConfig().isUrlNotificationDismissed();
   }
 
+  public static boolean areCodyCompletionsEnabled() {
+    return getApplicationLevelConfig().areCodyCompletionsEnabled();
+  }
+
   public static boolean isAccessTokenNotificationDismissed() {
     return getApplicationLevelConfig().isAccessTokenNotificationDismissed();
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -37,6 +37,7 @@ public class SettingsComponent {
   private JBTextField defaultBranchNameTextField;
   private JBTextField remoteUrlReplacementsTextField;
   private JBCheckBox isUrlNotificationDismissedCheckBox;
+  private JBCheckBox areCompletionsEnabledCheckBox;
 
   public JComponent getPreferredFocusedComponent() {
     return defaultBranchNameTextField;
@@ -46,11 +47,13 @@ public class SettingsComponent {
     this.project = project;
     JPanel userAuthenticationPanel = createAuthenticationPanel();
     JPanel navigationSettingsPanel = createNavigationSettingsPanel();
+    JPanel codySettingsPanel = createCodySettingsPanel();
 
     panel =
         FormBuilder.createFormBuilder()
             .addComponent(userAuthenticationPanel)
             .addComponent(navigationSettingsPanel)
+            .addComponent(codySettingsPanel)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
   }
@@ -296,6 +299,14 @@ public class SettingsComponent {
     isUrlNotificationDismissedCheckBox.setSelected(value);
   }
 
+  public boolean areCodyCompletionsEnabled() {
+    return areCompletionsEnabledCheckBox.isSelected();
+  }
+
+  public void setCodyCompletionsEnabled(boolean value) {
+    areCompletionsEnabledCheckBox.setSelected(value);
+  }
+
   private void setEnterpriseSettingsEnabled(boolean enable) {
     urlTextField.setEnabled(enable);
     enterpriseAccessTokenTextField.setEnabled(enable);
@@ -409,5 +420,15 @@ public class SettingsComponent {
     navigationSettingsPanel.setBorder(
         IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
     return navigationSettingsPanel;
+  }
+
+  @NotNull
+  private JPanel createCodySettingsPanel() {
+    areCompletionsEnabledCheckBox = new JBCheckBox("Enable Cody completions");
+    JPanel codySettingsPanel =
+        FormBuilder.createFormBuilder().addComponent(areCompletionsEnabledCheckBox, 10).getPanel();
+    codySettingsPanel.setBorder(
+        IdeBorderFactory.createTitledBorder("Cody Settings", true, JBUI.insetsTop(8)));
+    return codySettingsPanel;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -58,7 +58,9 @@ public class SettingsConfigurable implements Configurable {
             .getRemoteUrlReplacements()
             .equals(ConfigUtil.getRemoteUrlReplacements(project))
         || mySettingsComponent.isUrlNotificationDismissed()
-            != ConfigUtil.isUrlNotificationDismissed();
+            != ConfigUtil.isUrlNotificationDismissed()
+        || mySettingsComponent.areCodyCompletionsEnabled()
+            != ConfigUtil.areCodyCompletionsEnabled();
   }
 
   @Override
@@ -125,6 +127,7 @@ public class SettingsConfigurable implements Configurable {
       aSettings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
     }
     aSettings.isUrlNotificationDismissed = mySettingsComponent.isUrlNotificationDismissed();
+    aSettings.areCodyCompletionsEnabled = mySettingsComponent.areCodyCompletionsEnabled();
 
     publisher.afterAction(context);
   }
@@ -144,6 +147,7 @@ public class SettingsConfigurable implements Configurable {
     String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);
     mySettingsComponent.setRemoteUrlReplacements(remoteUrlReplacements);
     mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());
+    mySettingsComponent.setCodyCompletionsEnabled(ConfigUtil.areCodyCompletionsEnabled());
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.sourcegraph.find.Search;
+import java.util.Optional;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -121,9 +122,7 @@ public class SourcegraphApplicationService
 
   public boolean areCodyCompletionsEnabled() {
     boolean enabledViaEnv = "true".equals(System.getenv("CODY_COMPLETIONS_ENABLED"));
-    boolean enabledViaProperty = "true".equals(System.getProperty("cody.completions.enabled"));
-    return enabledViaEnv
-        || (areCodyCompletionsEnabled == null ? enabledViaProperty : areCodyCompletionsEnabled);
+    return enabledViaEnv || Optional.ofNullable(areCodyCompletionsEnabled).orElse(false);
   }
 
   public boolean isAccessTokenNotificationDismissed() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -121,8 +121,7 @@ public class SourcegraphApplicationService
   }
 
   public boolean areCodyCompletionsEnabled() {
-    boolean enabledViaEnv = "true".equals(System.getenv("CODY_COMPLETIONS_ENABLED"));
-    return enabledViaEnv || Optional.ofNullable(areCodyCompletionsEnabled).orElse(false);
+    return Optional.ofNullable(areCodyCompletionsEnabled).orElse(false);
   }
 
   public boolean isAccessTokenNotificationDismissed() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphApplicationService.java
@@ -29,6 +29,7 @@ public class SourcegraphApplicationService
   @Nullable public String anonymousUserId;
   public boolean isInstallEventLogged;
   public boolean isUrlNotificationDismissed;
+  @Nullable public Boolean areCodyCompletionsEnabled;
   public boolean isAccessTokenNotificationDismissed;
   @Nullable public Boolean authenticationFailedLastTime;
 
@@ -118,6 +119,13 @@ public class SourcegraphApplicationService
     return isUrlNotificationDismissed;
   }
 
+  public boolean areCodyCompletionsEnabled() {
+    boolean enabledViaEnv = "true".equals(System.getenv("CODY_COMPLETIONS_ENABLED"));
+    boolean enabledViaProperty = "true".equals(System.getProperty("cody.completions.enabled"));
+    return enabledViaEnv
+        || (areCodyCompletionsEnabled == null ? enabledViaProperty : areCodyCompletionsEnabled);
+  }
+
   public boolean isAccessTokenNotificationDismissed() {
     return isAccessTokenNotificationDismissed;
   }
@@ -149,6 +157,7 @@ public class SourcegraphApplicationService
     this.remoteUrlReplacements = settings.remoteUrlReplacements;
     this.anonymousUserId = settings.anonymousUserId;
     this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;
+    this.areCodyCompletionsEnabled = settings.areCodyCompletionsEnabled;
     this.isAccessTokenNotificationDismissed = settings.isAccessTokenNotificationDismissed;
     this.authenticationFailedLastTime = settings.authenticationFailedLastTime;
     this.lastUpdateNotificationPluginVersion = settings.lastUpdateNotificationPluginVersion;


### PR DESCRIPTION
Fixes #53244

<img width="280" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/18601388/bf354785-9a0e-421b-aad5-264119fbf747">

Added a simple setting for enabling/disabling Cody completions.

<img width="716" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/18601388/299722e9-01ca-4887-917d-c3285fc3de0e">


## Test plan
(I've tested these things locally, but it is generally advised to double check on another machine, since we don't have UI tests set-up)
- ~When the setting is initially unset, the `cody.completions.enabled` property should be respected (as before)~
- Otherwise, completions should only appear when the setting is enabled
- The setting should be overridable with the `CODY_COMPLETIONS_ENABLED` env variable
