### PR TITLE
scip-tags: Add ts/js support

### DIFF
--- a/docker-images/syntax-highlighter/README.md
+++ b/docker-images/syntax-highlighter/README.md
@@ -8,6 +8,10 @@ Crates:
 - `crates/scip-syntax/`: local navigation calculation (and some other utilities) live here.
 - `crates/sg-syntax/`: Sourcegraph code to glue together whatever from the above crates to be used for our purposes.
 
+# scip-ctags
+
+See [queries](./docs/queries.md)
+
 # Syntect Server
 
 This is an HTTP server that exposes the Rust [Syntect](https://github.com/trishume/syntect) syntax highlighting library for use by other services. Send it some code, and it'll send you syntax-highlighted code in response. This service is horizontally scalable, but please give [#21942](https://github.com/sourcegraph/sourcegraph/issues/21942) and [#32359](https://github.com/sourcegraph/sourcegraph/pull/32359#issuecomment-1063310638) a read before scaling it up.

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/java/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/java/scip-tags.scm
@@ -1,7 +1,9 @@
 (program
     (package_declaration
         (_)
-        @descriptor.namespace)) @scope
+        @descriptor.namespace @scope
+        (scoped_identifier)
+        @descriptor.namespace @scope))
 
 (class_declaration name: (_) @descriptor.type) @scope
 (interface_declaration name: (_) @descriptor.type) @scope

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
@@ -1,10 +1,7 @@
 (namespace_import (identifier) @descriptor.term)
 (named_imports
-    [
-        (import_specifier alias: (_) @descriptor.term)
-        (import_specifier name: (_) @descriptor.term !alias)])
-
-
+ [(import_specifier alias: (_) @descriptor.term)
+  (import_specifier name: (_) @descriptor.term !alias)])
 
 ;; Function / Generator declaration.
 ;;   Don't think there is any reason to expose anything from within the body of the functions

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
@@ -2,21 +2,47 @@
 (named_imports
     [
         (import_specifier alias: (_) @descriptor.term)
-        (import_specifier name: (_) @descriptor.term !alias)
-    ]
-)
+        (import_specifier name: (_) @descriptor.term !alias)])
 
+
+
+;; Function / Generator declaration.
+;;   Don't think there is any reason to expose anything from within the body of the functions
 (function_declaration (identifier) @descriptor.method body: (_) @local)
-(lexical_declaration (variable_declarator name: (identifier) @descriptor.term))
-(variable_declaration (variable_declarator name: (identifier) @descriptor.term))
+(generator_function_declaration  (identifier) @descriptor.method body: (_) @local)
 
-(class_declaration name: (_) @descriptor.type body: (_) @scope)
+(lexical_declaration (variable_declarator name: (identifier) @descriptor.term)) @scope
+(variable_declaration (variable_declarator name: (identifier) @descriptor.term)) @scope
+
+;; {{{ Handle multiple scenarios of literal objects at top level
+;; var X = { key: value }
+;;           ^^^ X.key
+;;
+;;   First query makes sure to make a method
+;;   Second query collects the rest of the options as a term
+;;     (best effort method detection)
+;;
+(object
+  (pair
+    key: (property_identifier) @descriptor.method
+    value: [(function) (arrow_function)]))
+
+((object
+   (pair
+     key: (property_identifier) @descriptor.term
+     value: (_) @_value_type))
+ (#filter! @_value_type "function" "arrow_function"))
+;; }}}
+
+;; class X { ... }
 (class_declaration
-    (class_body
-        [
-            (method_definition name: (_) @descriptor.method body: (_) @local)
-        ]
-    )
-)
+  name: (_) @descriptor.type
+  body: (_) @scope)
 
-[(if_statement) (while_statement) (for_statement) (do_statement)] @local
+(class_declaration
+ (class_body
+  [(method_definition
+     name: (_) @descriptor.method
+     body: (_) @local)]))
+
+[(if_statement) (while_statement) (for_statement) (do_statement) (call_expression)] @local

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/typescript/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/typescript/scip-tags.scm
@@ -1,42 +1,20 @@
-(namespace_import (identifier) @descriptor.term)
-(named_imports
-    [
-        (import_specifier alias: (_) @descriptor.term)
-        (import_specifier name: (_) @descriptor.term !alias)
-    ]
-)
+;;include javascript
 
-(function_declaration (identifier) @descriptor.method body: (_) @local)
-(lexical_declaration (variable_declarator name: (identifier) @descriptor.term))
-(variable_declaration (variable_declarator name: (identifier) @descriptor.term))
+(module name: (string (string_fragment) @descriptor.namespace) body: (_) @scope)
 
 (interface_declaration name: (_) @descriptor.type body: (_) @scope)
 (interface_declaration
     (object_type
         [
             (method_signature (property_identifier) @descriptor.method)
-            (property_signature (property_identifier) @descriptor.term)
-        ]
-    )
-)
+            (property_signature (property_identifier) @descriptor.term)]))
 
-(class_declaration name: (_) @descriptor.type body: (_) @scope)
 (class_declaration
     (class_body
-        [
-            (public_field_definition name: (_) @descriptor.term)
-            (method_definition name: (_) @descriptor.method body: (_) @local)
-        ]
-    )
-)
+        [(public_field_definition name: (_) @descriptor.term)]))
+
 
 (enum_declaration name: (_) @descriptor.type body: (_) @scope)
 (enum_declaration
     (enum_body
-        (property_identifier) @descriptor.term
-    )
-)
-
-(module name: (string (string_fragment) @descriptor.namespace) body: (_) @scope)
-
-[(if_statement) (while_statement) (for_statement) (do_statement)] @local
+        (property_identifier) @descriptor.term))

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/globals.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/globals.rs
@@ -132,6 +132,10 @@ pub fn parse_tree<'a>(
 
     let matches = cursor.matches(&config.query, root_node, source_bytes);
     for m in matches {
+        if config.is_filtered(&m) {
+            continue;
+        }
+
         let mut node = None;
         let mut enclosing_node = None;
         let mut scope = None;
@@ -302,6 +306,32 @@ pub mod test {
             },
         )?;
 
+        insta::assert_snapshot!(dumped);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_can_parse_javascript_tree() -> Result<()> {
+        let config = crate::languages::get_tag_configuration(&BundledParser::Javascript)
+            .expect("to have parser");
+        let source_code = include_str!("../testdata/globals.js");
+        let doc = parse_file_for_lang(config, source_code)?;
+
+        let dumped = dump_document(&doc, source_code)?;
+        insta::assert_snapshot!(dumped);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_can_parse_javascript_object() -> Result<()> {
+        let config = crate::languages::get_tag_configuration(&BundledParser::Javascript)
+            .expect("to have parser");
+        let source_code = include_str!("../testdata/javascript-object.js");
+        let doc = parse_file_for_lang(config, source_code)?;
+
+        let dumped = dump_document(&doc, source_code)?;
         insta::assert_snapshot!(dumped);
 
         Ok(())

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/globals.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/globals.rs
@@ -310,30 +310,4 @@ pub mod test {
 
         Ok(())
     }
-
-    #[test]
-    fn test_can_parse_javascript_tree() -> Result<()> {
-        let config = crate::languages::get_tag_configuration(&BundledParser::Javascript)
-            .expect("to have parser");
-        let source_code = include_str!("../testdata/globals.js");
-        let doc = parse_file_for_lang(config, source_code)?;
-
-        let dumped = dump_document(&doc, source_code)?;
-        insta::assert_snapshot!(dumped);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_can_parse_javascript_object() -> Result<()> {
-        let config = crate::languages::get_tag_configuration(&BundledParser::Javascript)
-            .expect("to have parser");
-        let source_code = include_str!("../testdata/javascript-object.js");
-        let doc = parse_file_for_lang(config, source_code)?;
-
-        let dumped = dump_document(&doc, source_code)?;
-        insta::assert_snapshot!(dumped);
-
-        Ok(())
-    }
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/languages.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/languages.rs
@@ -7,9 +7,16 @@ use scip_macros::include_scip_query;
 use scip_treesitter_languages::parsers::BundledParser;
 use tree_sitter::{Language, Parser, Query};
 
+#[derive(Debug)]
 pub struct Transform {
     pattern: Regex,
     replace: String,
+}
+
+#[derive(Debug)]
+pub struct NodeFilter {
+    capture: u32,
+    names: Vec<String>,
 }
 
 pub struct TagConfiguration {
@@ -18,47 +25,90 @@ pub struct TagConfiguration {
 
     // Handles #transform! predicates in queries
     transforms: HashMap<usize, Vec<Transform>>,
+
+    // Handles #filter! predicates in queries
+    filters: HashMap<usize, Vec<NodeFilter>>,
 }
 
 impl TagConfiguration {
     fn new(language: Language, query: Query) -> Self {
         let mut transforms = HashMap::new();
+        let mut filters = HashMap::new();
 
         for index in 0..query.pattern_count() {
             let predicate = query.general_predicates(index);
 
             if !predicate.is_empty() {
-                let pattern_transforms = predicate
-                    .iter()
-                    .filter_map(|pred| match pred.operator.as_ref() {
-                        "transform!" => {
-                            let args = &pred.args;
-                            if args.len() != 2 {
-                                panic!("bad transform!??!");
-                            }
+                // Collect #transform! predicates
+                transforms.insert(
+                    index,
+                    predicate
+                        .iter()
+                        .filter_map(|pred| match pred.operator.as_ref() {
+                            "transform!" => {
+                                let args = &pred.args;
+                                if args.len() != 2 {
+                                    panic!("bad transform!??!");
+                                }
 
-                            let pattern = {
-                                let replace_str = match &args[0] {
-                                    tree_sitter::QueryPredicateArg::String(str) => str,
-                                    _ => panic!("pattern for #transform! should be a string"),
+                                let pattern = {
+                                    let replace_str = match &args[0] {
+                                        tree_sitter::QueryPredicateArg::String(str) => str,
+                                        _ => panic!("pattern for #transform! should be a string"),
+                                    };
+
+                                    Regex::new(replace_str)
+                                        .expect("pattern for #transform! should be a valid regex")
                                 };
 
-                                Regex::new(replace_str)
-                                    .expect("pattern for #transform! should be a valid regex")
-                            };
+                                let replace = match &args[1] {
+                                    tree_sitter::QueryPredicateArg::String(str) => str.to_string(),
+                                    _ => panic!("replace to #transform! should be a string"),
+                                };
 
-                            let replace = match &args[1] {
-                                tree_sitter::QueryPredicateArg::String(str) => str.to_string(),
-                                _ => panic!("replace to #transform! should be a string"),
-                            };
+                                Some(Transform { pattern, replace })
+                            }
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>(),
+                );
 
-                            Some(Transform { pattern, replace })
-                        }
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>();
+                // Collect #filter! predicates
+                filters.insert(
+                    index,
+                    predicate
+                        .iter()
+                        .filter_map(|pred| match pred.operator.as_ref() {
+                            "filter!" => {
+                                let args = &pred.args;
 
-                transforms.insert(index, pattern_transforms);
+                                if args.len() < 2 {
+                                    panic!("should have at least two arguments for filter");
+                                }
+
+                                let capture = match &args[0] {
+                                    tree_sitter::QueryPredicateArg::Capture(capture) => *capture,
+                                    _ => panic!("filter! first arg should be a  capture"),
+                                };
+
+                                let names = args[1..]
+                                    .iter()
+                                    .map(|arg| {
+                                        let name = match arg {
+                                            tree_sitter::QueryPredicateArg::String(name) => name,
+                                            _ => panic!("filter! 1.. args should be string names"),
+                                        };
+
+                                        name.to_string()
+                                    })
+                                    .collect();
+
+                                Some(NodeFilter { capture, names })
+                            }
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>(),
+                );
             }
         }
 
@@ -66,6 +116,7 @@ impl TagConfiguration {
             language,
             query,
             transforms,
+            filters,
         }
     }
 
@@ -76,20 +127,33 @@ impl TagConfiguration {
     }
 
     pub fn transform(&self, index: usize, captured: &Descriptor) -> Option<Vec<Descriptor>> {
-        self.transforms.get(&index).map(|transforms| {
-            transforms
-                .iter()
-                .map(|t| Descriptor {
-                    name: t
-                        .pattern
-                        .replace_all(&captured.name, &t.replace)
-                        .to_string(),
-                    suffix: captured.suffix,
-                    disambiguator: captured.disambiguator.clone(),
-                    ..Default::default()
-                })
-                .collect::<Vec<_>>()
-        })
+        match self.transforms.get(&index) {
+            Some(transforms) if !transforms.is_empty() => Some(
+                transforms
+                    .iter()
+                    .map(|t| Descriptor {
+                        name: t
+                            .pattern
+                            .replace_all(&captured.name, &t.replace)
+                            .to_string(),
+                        suffix: captured.suffix,
+                        disambiguator: captured.disambiguator.clone(),
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        }
+    }
+
+    pub fn is_filtered(&self, m: &tree_sitter::QueryMatch) -> bool {
+        match self.filters.get(&m.pattern_index) {
+            Some(filters) if !filters.is_empty() => filters.iter().any(|filter| {
+                m.nodes_for_capture_index(filter.capture)
+                    .any(|node| filter.names.iter().any(|name| name == node.kind()))
+            }),
+            _ => false,
+        }
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/lib.rs
@@ -95,4 +95,7 @@ mod test {
     generate_tags_and_snapshot!(Scip, test_scip_go_example, "example.go");
 
     generate_tags_and_snapshot!(Scip, test_scip_rust_scopes, "scopes.rs");
+
+    generate_tags_and_snapshot!(Scip, test_scip_javascript, "globals.js");
+    generate_tags_and_snapshot!(Scip, test_scip_javascript_object, "javascript-object.js");
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__can_parse_javascript_object.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__can_parse_javascript_object.snap
@@ -1,0 +1,16 @@
+---
+source: crates/scip-syntax/src/globals.rs
+expression: dumped
+---
+  var myObject = {
+//    ^^^^^^^^ definition scip-ctags myObject.
+    myProperty: "value",
+//  ^^^^^^^^^^ definition scip-ctags myObject.myProperty.
+  
+    myMethod: function() {},
+//  ^^^^^^^^ definition scip-ctags myObject.myMethod().
+    myArrow: () => {},
+//  ^^^^^^^ definition scip-ctags myObject.myArrow().
+  };
+  
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__can_parse_javascript_tree.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__globals__test__can_parse_javascript_tree.snap
@@ -1,0 +1,162 @@
+---
+source: crates/scip-syntax/src/globals.rs
+expression: dumped
+---
+  // Traditional variable declaration
+  var traditionalVar = "Hello, I'm an old-style variable";
+//    ^^^^^^^^^^^^^^ definition scip-ctags traditionalVar.
+  
+  // Let variable declaration
+  let scopedLetVar = "Hello, I'm a block-scoped variable";
+//    ^^^^^^^^^^^^ definition scip-ctags scopedLetVar.
+  
+  // Constant variable declaration
+  const constantVar = "Hello, I'm a constant variable";
+//      ^^^^^^^^^^^ definition scip-ctags constantVar.
+  
+  // Function declaration
+  function functionDeclaration() {
+//         ^^^^^^^^^^^^^^^^^^^ definition scip-ctags functionDeclaration().
+    return "Hello, I'm a function declaration";
+  }
+  
+  // Anonymous function declaration
+  var anonymousFunction = function() {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags anonymousFunction.
+    return "Hello, I'm an anonymous function";
+  };
+  
+  // ES6 arrow function declaration
+  const arrowFunction = () => {
+//      ^^^^^^^^^^^^^ definition scip-ctags arrowFunction.
+    return "Hello, I'm an arrow function";
+  };
+  
+  // ES6 class declaration
+  class ClassDeclaration {
+//      ^^^^^^^^^^^^^^^^ definition scip-ctags ClassDeclaration#
+    constructor() {
+//  ^^^^^^^^^^^ definition scip-ctags ClassDeclaration#constructor().
+      this.message = "Hello, I'm a class declaration";
+    }
+  }
+  
+  // Object declaration
+  var objectDeclaration = {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectDeclaration.
+    message: "Hello, I'm an object declaration"
+//  ^^^^^^^ definition scip-ctags objectDeclaration.message.
+  };
+  
+  // Object constructor declaration
+  function ObjectConstructor() {
+//         ^^^^^^^^^^^^^^^^^ definition scip-ctags ObjectConstructor().
+    this.message = "Hello, I'm an object constructor";
+  }
+  var objectConstructed = new ObjectConstructor();
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectConstructed.
+  
+  // ES6 method shorthand in object declaration
+  var objectWithMethods = {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectWithMethods.
+    method() {
+      return "Hello, I'm a method in an object";
+    }
+  };
+  
+  // ES6 Generator Function declaration
+  function* generatorFunction(){
+//          ^^^^^^^^^^^^^^^^^ definition scip-ctags generatorFunction().
+    yield "Hello, I'm a generator function";
+  }
+  
+  // ES6 Async Function declaration
+  async function asyncFunction() {
+//               ^^^^^^^^^^^^^ definition scip-ctags asyncFunction().
+    return "Hello, I'm an async function";
+  }
+  
+  // Top level name through Object.defineProperty
+  Object.defineProperty(window, 'definedProp', {
+    value: "Hello, I'm a defined property",
+    writable: false,
+    enumerable: true,
+    configurable: true
+  });
+  
+  // ES6 class declaration
+  class ExampleClass {
+//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#
+  
+    // Private field declaration (ES2020)
+    #privateField = "Hello, I'm a private field";
+  
+    // Private method declaration (ES2020)
+    #privateMethod() {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#`#privateMethod`().
+      return "Hello, I'm a private method";
+    }
+  
+    // Class Constructor
+    constructor(publicField, publicMethodParameter) {
+//  ^^^^^^^^^^^ definition scip-ctags ExampleClass#constructor().
+      this.publicField = publicField; // Public Field
+      this.publicMethodParameter = publicMethodParameter;
+    }
+  
+    // Instance method
+    instanceMethod() {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#instanceMethod().
+      return "Hello, I'm an instance method";
+    }
+  
+    // Static method
+    static staticMethod() {
+//         ^^^^^^^^^^^^ definition scip-ctags ExampleClass#staticMethod().
+      return "Hello, I'm a static method";
+    }
+  
+    // Getter method
+    get retrievedField() {
+//      ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#retrievedField().
+      return this.publicField;
+    }
+  
+    // Setter method
+    set updatedField(value) {
+//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#updatedField().
+      this.publicField = value;
+    }
+  
+    // Public method using private field and private method
+    publicMethod() {
+//  ^^^^^^^^^^^^ definition scip-ctags ExampleClass#publicMethod().
+      return this.#privateMethod() + " " + this.#privateField;
+    }
+  
+    // Method using arguments
+    methodWithArgs(arg1, arg2) {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithArgs().
+      return "Hello, I received " + arg1 + " and " + arg2;
+    }
+  
+    // Method using rest parameters
+    methodWithRestArgs(...args) {
+//  ^^^^^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithRestArgs().
+      return "Hello, I received " + args.join(", ");
+    }
+  }
+  
+  // Prototype methods
+  function MyClass() {}
+//         ^^^^^^^ definition scip-ctags MyClass().
+  MyClass.prototype.myMethod = function() {};
+  
+  // Generator function
+  function* myGeneratorFunction() {}
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-ctags myGeneratorFunction().
+  
+  // Async function
+  async function myAsyncFunction() {}
+//               ^^^^^^^^^^^^^^^ definition scip-ctags myAsyncFunction().
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.java.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.java.snap
@@ -3,68 +3,67 @@ source: crates/scip-syntax/src/lib.rs
 expression: dumped
 ---
   package MyPackage;
-//        ^^^^^^^^^ definition scip-ctags MyPackage/
   
   public class globals {
-//             ^^^^^^^ definition scip-ctags MyPackage/globals#
+//             ^^^^^^^ definition scip-ctags globals#
       private static int field1;
-//                       ^^^^^^ definition scip-ctags MyPackage/globals#field1.
+//                       ^^^^^^ definition scip-ctags globals#field1.
       protected static int field2;
-//                         ^^^^^^ definition scip-ctags MyPackage/globals#field2.
+//                         ^^^^^^ definition scip-ctags globals#field2.
       public static int field3;
-//                      ^^^^^^ definition scip-ctags MyPackage/globals#field3.
+//                      ^^^^^^ definition scip-ctags globals#field3.
       private int field4;
-//                ^^^^^^ definition scip-ctags MyPackage/globals#field4.
+//                ^^^^^^ definition scip-ctags globals#field4.
       protected int field5;
-//                  ^^^^^^ definition scip-ctags MyPackage/globals#field5.
+//                  ^^^^^^ definition scip-ctags globals#field5.
       public int field6;
-//               ^^^^^^ definition scip-ctags MyPackage/globals#field6.
+//               ^^^^^^ definition scip-ctags globals#field6.
   
       private static void method1() {}
-//                        ^^^^^^^ definition scip-ctags MyPackage/globals#method1().
+//                        ^^^^^^^ definition scip-ctags globals#method1().
       protected static void method2() {}
-//                          ^^^^^^^ definition scip-ctags MyPackage/globals#method2().
+//                          ^^^^^^^ definition scip-ctags globals#method2().
       public static void method3() {}
-//                       ^^^^^^^ definition scip-ctags MyPackage/globals#method3().
+//                       ^^^^^^^ definition scip-ctags globals#method3().
       private void method4() {}
-//                 ^^^^^^^ definition scip-ctags MyPackage/globals#method4().
+//                 ^^^^^^^ definition scip-ctags globals#method4().
       protected void method5() {}
-//                   ^^^^^^^ definition scip-ctags MyPackage/globals#method5().
+//                   ^^^^^^^ definition scip-ctags globals#method5().
       public void method6() {}
-//                ^^^^^^^ definition scip-ctags MyPackage/globals#method6().
+//                ^^^^^^^ definition scip-ctags globals#method6().
   
       public static final String COOLEST_STRING = "probably this one";
-//                               ^^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#COOLEST_STRING.
+//                               ^^^^^^^^^^^^^^ definition scip-ctags globals#COOLEST_STRING.
   
       public class ClassInAClass {
-//                 ^^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#
+//                 ^^^^^^^^^^^^^ definition scip-ctags globals#ClassInAClass#
           boolean classy = true;
-//                ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#classy.
+//                ^^^^^^ definition scip-ctags globals#ClassInAClass#classy.
   
           public static enum Enum {
-//                           ^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#
+//                           ^^^^ definition scip-ctags globals#ClassInAClass#Enum#
               these,
-//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#these.
+//            ^^^^^ definition scip-ctags globals#ClassInAClass#Enum#these.
               should,
-//            ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#should.
+//            ^^^^^^ definition scip-ctags globals#ClassInAClass#Enum#should.
               be,
-//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#be.
+//            ^^ definition scip-ctags globals#ClassInAClass#Enum#be.
               recognized,
-//            ^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#recognized.
+//            ^^^^^^^^^^ definition scip-ctags globals#ClassInAClass#Enum#recognized.
               as,
-//            ^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#as.
+//            ^^ definition scip-ctags globals#ClassInAClass#Enum#as.
               terms
-//            ^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Enum#terms.
+//            ^^^^^ definition scip-ctags globals#ClassInAClass#Enum#terms.
           }
   
           public interface Goated {
-//                         ^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#
+//                         ^^^^^^ definition scip-ctags globals#ClassInAClass#Goated#
               boolean withTheSauce();
-//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#Goated#withTheSauce().
+//                    ^^^^^^^^^^^^ definition scip-ctags globals#ClassInAClass#Goated#withTheSauce().
           }
   
           public void myCoolMethod() {
-//                    ^^^^^^^^^^^^ definition scip-ctags MyPackage/globals#ClassInAClass#myCoolMethod().
+//                    ^^^^^^^^^^^^ definition scip-ctags globals#ClassInAClass#myCoolMethod().
               class WhatIsGoingOn {}
               boolean iThinkThisIsAllowedButWeDontReallyCare = true;
           }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.js.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.js.snap
@@ -1,0 +1,162 @@
+---
+source: crates/scip-syntax/src/lib.rs
+expression: dumped
+---
+  // Traditional variable declaration
+  var traditionalVar = "Hello, I'm an old-style variable";
+//    ^^^^^^^^^^^^^^ definition scip-ctags traditionalVar.
+  
+  // Let variable declaration
+  let scopedLetVar = "Hello, I'm a block-scoped variable";
+//    ^^^^^^^^^^^^ definition scip-ctags scopedLetVar.
+  
+  // Constant variable declaration
+  const constantVar = "Hello, I'm a constant variable";
+//      ^^^^^^^^^^^ definition scip-ctags constantVar.
+  
+  // Function declaration
+  function functionDeclaration() {
+//         ^^^^^^^^^^^^^^^^^^^ definition scip-ctags functionDeclaration().
+    return "Hello, I'm a function declaration";
+  }
+  
+  // Anonymous function declaration
+  var anonymousFunction = function() {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags anonymousFunction.
+    return "Hello, I'm an anonymous function";
+  };
+  
+  // ES6 arrow function declaration
+  const arrowFunction = () => {
+//      ^^^^^^^^^^^^^ definition scip-ctags arrowFunction.
+    return "Hello, I'm an arrow function";
+  };
+  
+  // ES6 class declaration
+  class ClassDeclaration {
+//      ^^^^^^^^^^^^^^^^ definition scip-ctags ClassDeclaration#
+    constructor() {
+//  ^^^^^^^^^^^ definition scip-ctags ClassDeclaration#constructor().
+      this.message = "Hello, I'm a class declaration";
+    }
+  }
+  
+  // Object declaration
+  var objectDeclaration = {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectDeclaration.
+    message: "Hello, I'm an object declaration"
+//  ^^^^^^^ definition scip-ctags objectDeclaration.message.
+  };
+  
+  // Object constructor declaration
+  function ObjectConstructor() {
+//         ^^^^^^^^^^^^^^^^^ definition scip-ctags ObjectConstructor().
+    this.message = "Hello, I'm an object constructor";
+  }
+  var objectConstructed = new ObjectConstructor();
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectConstructed.
+  
+  // ES6 method shorthand in object declaration
+  var objectWithMethods = {
+//    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectWithMethods.
+    method() {
+      return "Hello, I'm a method in an object";
+    }
+  };
+  
+  // ES6 Generator Function declaration
+  function* generatorFunction(){
+//          ^^^^^^^^^^^^^^^^^ definition scip-ctags generatorFunction().
+    yield "Hello, I'm a generator function";
+  }
+  
+  // ES6 Async Function declaration
+  async function asyncFunction() {
+//               ^^^^^^^^^^^^^ definition scip-ctags asyncFunction().
+    return "Hello, I'm an async function";
+  }
+  
+  // Top level name through Object.defineProperty
+  Object.defineProperty(window, 'definedProp', {
+    value: "Hello, I'm a defined property",
+    writable: false,
+    enumerable: true,
+    configurable: true
+  });
+  
+  // ES6 class declaration
+  class ExampleClass {
+//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#
+  
+    // Private field declaration (ES2020)
+    #privateField = "Hello, I'm a private field";
+  
+    // Private method declaration (ES2020)
+    #privateMethod() {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#`#privateMethod`().
+      return "Hello, I'm a private method";
+    }
+  
+    // Class Constructor
+    constructor(publicField, publicMethodParameter) {
+//  ^^^^^^^^^^^ definition scip-ctags ExampleClass#constructor().
+      this.publicField = publicField; // Public Field
+      this.publicMethodParameter = publicMethodParameter;
+    }
+  
+    // Instance method
+    instanceMethod() {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#instanceMethod().
+      return "Hello, I'm an instance method";
+    }
+  
+    // Static method
+    static staticMethod() {
+//         ^^^^^^^^^^^^ definition scip-ctags ExampleClass#staticMethod().
+      return "Hello, I'm a static method";
+    }
+  
+    // Getter method
+    get retrievedField() {
+//      ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#retrievedField().
+      return this.publicField;
+    }
+  
+    // Setter method
+    set updatedField(value) {
+//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#updatedField().
+      this.publicField = value;
+    }
+  
+    // Public method using private field and private method
+    publicMethod() {
+//  ^^^^^^^^^^^^ definition scip-ctags ExampleClass#publicMethod().
+      return this.#privateMethod() + " " + this.#privateField;
+    }
+  
+    // Method using arguments
+    methodWithArgs(arg1, arg2) {
+//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithArgs().
+      return "Hello, I received " + arg1 + " and " + arg2;
+    }
+  
+    // Method using rest parameters
+    methodWithRestArgs(...args) {
+//  ^^^^^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithRestArgs().
+      return "Hello, I received " + args.join(", ");
+    }
+  }
+  
+  // Prototype methods
+  function MyClass() {}
+//         ^^^^^^^ definition scip-ctags MyClass().
+  MyClass.prototype.myMethod = function() {};
+  
+  // Generator function
+  function* myGeneratorFunction() {}
+//          ^^^^^^^^^^^^^^^^^^^ definition scip-ctags myGeneratorFunction().
+  
+  // Async function
+  async function myAsyncFunction() {}
+//               ^^^^^^^^^^^^^^^ definition scip-ctags myAsyncFunction().
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.ts.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.ts.snap
@@ -52,4 +52,16 @@ expression: dumped
           }
       }
   }
+  
+  var myObject = {
+//    ^^^^^^^^ definition scip-ctags myObject.
+    myProperty: "value",
+//  ^^^^^^^^^^ definition scip-ctags myObject.myProperty.
+  
+    myMethod: function() {},
+//  ^^^^^^^^ definition scip-ctags myObject.myMethod().
+    myArrow: () => {},
+//  ^^^^^^^ definition scip-ctags myObject.myArrow().
+  };
+  
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_javascript-object.js.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_javascript-object.js.snap
@@ -1,0 +1,16 @@
+---
+source: crates/scip-syntax/src/lib.rs
+expression: dumped
+---
+  var myObject = {
+//    ^^^^^^^^ definition scip-ctags myObject.
+    myProperty: "value",
+//  ^^^^^^^^^^ definition scip-ctags myObject.myProperty.
+  
+    myMethod: function() {},
+//  ^^^^^^^^ definition scip-ctags myObject.myMethod().
+    myArrow: () => {},
+//  ^^^^^^^ definition scip-ctags myObject.myArrow().
+  };
+  
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/globals.js
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/globals.js
@@ -1,0 +1,129 @@
+// Traditional variable declaration
+var traditionalVar = "Hello, I'm an old-style variable";
+
+// Let variable declaration
+let scopedLetVar = "Hello, I'm a block-scoped variable";
+
+// Constant variable declaration
+const constantVar = "Hello, I'm a constant variable";
+
+// Function declaration
+function functionDeclaration() {
+  return "Hello, I'm a function declaration";
+}
+
+// Anonymous function declaration
+var anonymousFunction = function() {
+  return "Hello, I'm an anonymous function";
+};
+
+// ES6 arrow function declaration
+const arrowFunction = () => {
+  return "Hello, I'm an arrow function";
+};
+
+// ES6 class declaration
+class ClassDeclaration {
+  constructor() {
+    this.message = "Hello, I'm a class declaration";
+  }
+}
+
+// Object declaration
+var objectDeclaration = {
+  message: "Hello, I'm an object declaration"
+};
+
+// Object constructor declaration
+function ObjectConstructor() {
+  this.message = "Hello, I'm an object constructor";
+}
+var objectConstructed = new ObjectConstructor();
+
+// ES6 method shorthand in object declaration
+var objectWithMethods = {
+  method() {
+    return "Hello, I'm a method in an object";
+  }
+};
+
+// ES6 Generator Function declaration
+function* generatorFunction(){
+  yield "Hello, I'm a generator function";
+}
+
+// ES6 Async Function declaration
+async function asyncFunction() {
+  return "Hello, I'm an async function";
+}
+
+// Top level name through Object.defineProperty
+Object.defineProperty(window, 'definedProp', {
+  value: "Hello, I'm a defined property",
+  writable: false,
+  enumerable: true,
+  configurable: true
+});
+
+// ES6 class declaration
+class ExampleClass {
+
+  // Private field declaration (ES2020)
+  #privateField = "Hello, I'm a private field";
+
+  // Private method declaration (ES2020)
+  #privateMethod() {
+    return "Hello, I'm a private method";
+  }
+
+  // Class Constructor
+  constructor(publicField, publicMethodParameter) {
+    this.publicField = publicField; // Public Field
+    this.publicMethodParameter = publicMethodParameter;
+  }
+
+  // Instance method
+  instanceMethod() {
+    return "Hello, I'm an instance method";
+  }
+
+  // Static method
+  static staticMethod() {
+    return "Hello, I'm a static method";
+  }
+
+  // Getter method
+  get retrievedField() {
+    return this.publicField;
+  }
+
+  // Setter method
+  set updatedField(value) {
+    this.publicField = value;
+  }
+
+  // Public method using private field and private method
+  publicMethod() {
+    return this.#privateMethod() + " " + this.#privateField;
+  }
+
+  // Method using arguments
+  methodWithArgs(arg1, arg2) {
+    return "Hello, I received " + arg1 + " and " + arg2;
+  }
+
+  // Method using rest parameters
+  methodWithRestArgs(...args) {
+    return "Hello, I received " + args.join(", ");
+  }
+}
+
+// Prototype methods
+function MyClass() {}
+MyClass.prototype.myMethod = function() {};
+
+// Generator function
+function* myGeneratorFunction() {}
+
+// Async function
+async function myAsyncFunction() {}

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/globals.ts
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/globals.ts
@@ -31,3 +31,11 @@ function func() {
         }
     }
 }
+
+var myObject = {
+  myProperty: "value",
+
+  myMethod: function() {},
+  myArrow: () => {},
+};
+

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/javascript-object.js
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/javascript-object.js
@@ -1,0 +1,7 @@
+var myObject = {
+  myProperty: "value",
+
+  myMethod: function() {},
+  myArrow: () => {},
+};
+

--- a/docker-images/syntax-highlighter/docs/queries.md
+++ b/docker-images/syntax-highlighter/docs/queries.md
@@ -1,0 +1,75 @@
+# scip-tags.scm
+
+## Captures:
+
+- `@descriptor.SUFFIX`
+  - Used to create a new descriptor for the query match.
+  - For example, `@descriptor.term` will create a new term descriptor with the string contents of whatever node is captured
+  - Can use more than one of these per match.
+    - For example, in Go, when you declare a method, you would do `func (thing *MyThing) ThisFunc() {}`. In this case, you want to associate
+    `ThisFunc` with the struct `MyThing. You can do that via the following query:
+
+```
+(method_declaration
+  receiver: (parameter_list
+               (parameter_declaration type: (type_identifier) @descriptor.type))
+  name: (field_identifier) @descriptor.method)
+```
+
+- `@scope`
+  - Used to create a new scope, with whatever descriptors are defined by this query.
+  - This allows namespacing nested elements
+
+- `@enclosing`
+  - Used primarily for the `/symbols` endpoint, but gives the enclosing range for a particular symbol.
+  - Does not need to be used with `@scope` because `@scope` already gives us the range already.
+    - TODO: In the future, it may be possible we come up with some scenarios for this,
+    but I haven't found any use cases for it at the moment
+
+- `@local`
+  - Use this to ignore any new symbols that might be generated within this block.
+  - Future improvement would hope that we just skip parsing / matching on this block, but I don't think that's
+  feasible at the moment. For now it just notices the match and skips doing anymore work on it.
+
+## Predicates
+
+- `(#filter! @node "node-kind-1" "node-kind-2" ...)`
+  - `#filter!` can be used to make certain cases NOT match. This is useful for if you want anything EXCEPT some case to match.
+
+For example:
+
+```scheme
+;; {{{ Handle multiple scenarios of literal objects at top level
+;; var X = { key: value }
+;;           ^^^ X.key
+;;
+;;   First query makes sure to make a method
+;;   Second query collects the rest of the options as a term
+;;     (best effort method detection)
+;;
+(object
+  (pair
+    key: (property_identifier) @descriptor.method
+    value: [(function) (arrow_function)]))
+
+((object
+   (pair
+     key: (property_identifier) @descriptor.term
+     value: (_) @_value_type))
+ (#filter! @_value_type "function" "arrow_function"))
+;; }}}
+```
+
+- `(#transform! "regex-string" "regex-replacement")`
+  - `#transform!` can be used to take the last descriptor of a match and generat new identifiers from it. This is useful when
+  a language feature mangles a name in some new way, but it's predicatble in text.
+
+```scheme
+;; attr_accessor :bar -> bar, bar=
+((call
+   method: (identifier) @_attr_accessor
+   arguments: (argument_list (simple_symbol) @descriptor.method))
+ (#eq? @_attr_accessor "attr_accessor")
+ (#transform! ":(.*)" "$1")
+ (#transform! ":(.*)" "$1="))
+```

--- a/docker-images/syntax-highlighter/docs/queries.md
+++ b/docker-images/syntax-highlighter/docs/queries.md
@@ -7,7 +7,7 @@
   - For example, `@descriptor.term` will create a new term descriptor with the string contents of whatever node is captured
   - Can use more than one of these per match.
     - For example, in Go, when you declare a method, you would do `func (thing *MyThing) ThisFunc() {}`. In this case, you want to associate
-    `ThisFunc` with the struct `MyThing. You can do that via the following query:
+      `ThisFunc` with the struct `MyThing. You can do that via the following query:
 
 ```
 (method_declaration
@@ -17,19 +17,21 @@
 ```
 
 - `@scope`
+
   - Used to create a new scope, with whatever descriptors are defined by this query.
   - This allows namespacing nested elements
 
 - `@enclosing`
+
   - Used primarily for the `/symbols` endpoint, but gives the enclosing range for a particular symbol.
   - Does not need to be used with `@scope` because `@scope` already gives us the range already.
     - TODO: In the future, it may be possible we come up with some scenarios for this,
-    but I haven't found any use cases for it at the moment
+      but I haven't found any use cases for it at the moment
 
 - `@local`
   - Use this to ignore any new symbols that might be generated within this block.
   - Future improvement would hope that we just skip parsing / matching on this block, but I don't think that's
-  feasible at the moment. For now it just notices the match and skips doing anymore work on it.
+    feasible at the moment. For now it just notices the match and skips doing anymore work on it.
 
 ## Predicates
 
@@ -62,7 +64,7 @@ For example:
 
 - `(#transform! "regex-string" "regex-replacement")`
   - `#transform!` can be used to take the last descriptor of a match and generat new identifiers from it. This is useful when
-  a language feature mangles a name in some new way, but it's predicatble in text.
+    a language feature mangles a name in some new way, but it's predicatble in text.
 
 ```scheme
 ;; attr_accessor :bar -> bar, bar=

--- a/internal/ctags_config/ctags_config.go
+++ b/internal/ctags_config/ctags_config.go
@@ -56,9 +56,11 @@ func LanguageSupportsParserType(language string, parserType ParserType) bool {
 }
 
 var supportedLanguages = map[string]struct{}{
-	"c_sharp": {},
-	"java":    {},
-	"python":  {},
-	"zig":     {},
-	"scala":   {},
+	"c_sharp":    {},
+	"java":       {},
+	"javascript": {},
+	"python":     {},
+	"scala":      {},
+	"typescript": {},
+	"zig":        {},
 }


### PR DESCRIPTION
This one we can probably enable by default. I think JS/TS support is not that good for symbols often.

## Test plan

- [ ] Snapshots
- [ ] Green tests
