### PR TITLE
bzl: fix timeout warnings + add short as default for Go tests

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -2166,6 +2166,7 @@ build_test(
 
 bundlesize_bin.bundlesize_test(
     name = "bundlesize-report",
+    timeout = "short",
     args = [
         "--config",
         "$(location bundlesize.config.js)",

--- a/client/wildcard/BUILD.bazel
+++ b/client/wildcard/BUILD.bazel
@@ -563,7 +563,7 @@ npm_package(
 
 jest_test(
     name = "test",
-    timeout = "moderate",
+    timeout = "short",
     data = [
         ":wildcard_tests",
     ],

--- a/cmd/frontend/backend/BUILD.bazel
+++ b/cmd/frontend/backend/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
 
 go_test(
     name = "backend_test",
+    timeout = "moderate",
     srcs = [
         "external_services_test.go",
         "repos_test.go",

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -365,6 +365,7 @@ go_library(
 
 go_test(
     name = "graphqlbackend_test",
+    timeout = "moderate",
     srcs = [
         "access_requests_test.go",
         "access_tokens_test.go",

--- a/cmd/frontend/internal/bg/BUILD.bazel
+++ b/cmd/frontend/internal/bg/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
 
 go_test(
     name = "bg_test",
+    timeout = "moderate",
     srcs = ["update_permissions_test.go"],
     embed = [":bg"],
     tags = [

--- a/cmd/frontend/webhooks/BUILD.bazel
+++ b/cmd/frontend/webhooks/BUILD.bazel
@@ -40,7 +40,7 @@ go_library(
 
 go_test(
     name = "webhooks_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "github_webhooks_test.go",
         "middleware_test.go",

--- a/cmd/gitserver/server/BUILD.bazel
+++ b/cmd/gitserver/server/BUILD.bazel
@@ -105,6 +105,7 @@ go_library(
 
 go_test(
     name = "server_test",
+    timeout = "moderate",
     srcs = [
         "cleanup_test.go",
         "customfetch_test.go",

--- a/cmd/repo-updater/repoupdater/BUILD.bazel
+++ b/cmd/repo-updater/repoupdater/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
 
 go_test(
     name = "repoupdater_test",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "server_test.go",

--- a/cmd/worker/BUILD.bazel
+++ b/cmd/worker/BUILD.bazel
@@ -50,6 +50,7 @@ oci_tarball(
 
 container_structure_test(
     name = "image_test",
+    timeout = "short",
     configs = ["image_test.yaml"],
     driver = "docker",
     image = ":image",

--- a/dev/go_defs.bzl
+++ b/dev/go_defs.bzl
@@ -1,4 +1,8 @@
 load("@io_bazel_rules_go//go:def.bzl", _go_test="go_test")
 
 def go_test(**kwargs):
-  _go_test(race="on", **kwargs)
+    # All go tests have their timeout set to short by default, unless specified otherwise.
+    if "timeout" not in kwargs:
+        kwargs["timeout"] = "short"
+
+    _go_test(race="on", **kwargs)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/BUILD.bazel
@@ -87,6 +87,7 @@ go_library(
 
 go_test(
     name = "resolvers_test",
+    timeout = "moderate",
     srcs = [
         "batch_change_connection_test.go",
         "batch_change_test.go",

--- a/enterprise/cmd/frontend/internal/batches/webhooks/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/batches/webhooks/BUILD.bazel
@@ -42,7 +42,7 @@ go_library(
 
 go_test(
     name = "webhooks_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "bitbucketcloud_test.go",
         "bitbucketserver_test.go",

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
 
 go_test(
     name = "productsubscription_test",
+    timeout = "moderate",
     srcs = [
         "codygateway_dotcom_user_test.go",
         "codygateway_graphql_test.go",

--- a/enterprise/cmd/frontend/internal/insights/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/insights/resolvers/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
 
 go_test(
     name = "resolvers_test",
+    timeout = "moderate",
     srcs = [
         "aggregates_resolvers_test.go",
         "dashboard_resolvers_test.go",

--- a/enterprise/cmd/worker/internal/auth/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/auth/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 
 go_test(
     name = "auth_test",
+    timeout = "moderate",
     srcs = ["sourcegraph_operator_cleaner_test.go"],
     embed = [":auth"],
     tags = [

--- a/enterprise/cmd/worker/internal/telemetry/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/telemetry/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 
 go_test(
     name = "telemetry_test",
+    timeout = "moderate",
     srcs = [
         "mocks_test.go",
         "telemetry_job_test.go",

--- a/enterprise/internal/batches/service/BUILD.bazel
+++ b/enterprise/internal/batches/service/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
 
 go_test(
     name = "service_test",
+    timeout = "moderate",
     srcs = [
         "service_apply_batch_change_test.go",
         "service_test.go",

--- a/enterprise/internal/codeintel/autoindexing/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/autoindexing/internal/store/BUILD.bazel
@@ -36,7 +36,7 @@ go_library(
 
 go_test(
     name = "store_test",
-    size = "large",
+    timeout = "moderate",
     srcs = [
         "config_inference_test.go",
         "config_repo_test.go",

--- a/enterprise/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
+++ b/enterprise/internal/codeintel/codenav/internal/lsifstore/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
 
 go_test(
     name = "lsifstore_test",
+    timeout = "moderate",
     srcs = [
         "document_metadata_test.go",
         "locations_by_position_test.go",

--- a/enterprise/internal/codeintel/ranking/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/ranking/internal/store/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = [
         "coordinator_test.go",
         "definitions_test.go",

--- a/enterprise/internal/codeintel/sentinel/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/sentinel/internal/store/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = [
         "matches_test.go",
         "vulnerabilities_test.go",

--- a/enterprise/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
 
 go_test(
     name = "lsifstore_test",
+    timeout = "moderate",
     srcs = [
         "cleanup_test.go",
         "insert_test.go",

--- a/enterprise/internal/codeintel/uploads/internal/store/BUILD.bazel
+++ b/enterprise/internal/codeintel/uploads/internal/store/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
 go_test(
     name = "store_test",
     size = "large",
+    timeout = "moderate",
     srcs = [
         "cleanup_test.go",
         "commitdate_test.go",

--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -54,7 +54,7 @@ go_library(
 
 go_test(
     name = "embeddings_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = [
         "dot_test.go",
         "index_storage_test.go",

--- a/enterprise/internal/github_apps/store/BUILD.bazel
+++ b/enterprise/internal/github_apps/store/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = ["store_test.go"],
     embed = [":store"],
     tags = [

--- a/enterprise/internal/insights/background/queryrunner/BUILD.bazel
+++ b/enterprise/internal/insights/background/queryrunner/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
 
 go_test(
     name = "queryrunner_test",
+    timeout = "moderate",
     srcs = [
         "main_test.go",
         "search_test.go",

--- a/enterprise/internal/insights/scheduler/BUILD.bazel
+++ b/enterprise/internal/insights/scheduler/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
 
 go_test(
     name = "scheduler_test",
+    timeout = "moderate",
     srcs = [
         "backfill_state_inprogress_handler_test.go",
         "backfill_state_new_handler_test.go",

--- a/enterprise/internal/insights/store/BUILD.bazel
+++ b/enterprise/internal/insights/store/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = [
         "dashboard_store_test.go",
         "insight_store_test.go",

--- a/enterprise/internal/oobmigration/migrations/codeintel/lsif/BUILD.bazel
+++ b/enterprise/internal/oobmigration/migrations/codeintel/lsif/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
 
 go_test(
     name = "lsif_test",
+    timeout = "moderate",
     srcs = [
         "diagnostics_count_test.go",
         "document_column_split_test.go",

--- a/internal/codeintel/dependencies/internal/store/BUILD.bazel
+++ b/internal/codeintel/dependencies/internal/store/BUILD.bazel
@@ -30,7 +30,7 @@ go_library(
 
 go_test(
     name = "store_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["store_test.go"],
     embed = [":store"],
     tags = [

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -155,6 +155,7 @@ go_library(
 go_test(
     name = "database_test",
     size = "large",
+    timeout = "moderate",
     srcs = [
         "access_requests_test.go",
         "access_tokens_test.go",

--- a/internal/database/batch/BUILD.bazel
+++ b/internal/database/batch/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
 
 go_test(
     name = "batch_test",
+    timeout = "moderate",
     srcs = ["batch_test.go"],
     embed = [":batch"],
     tags = [

--- a/internal/database/connections/live/BUILD.bazel
+++ b/internal/database/connections/live/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 
 go_test(
     name = "live_test",
+    timeout = "moderate",
     srcs = ["migration_test.go"],
     embed = [":live"],
     tags = [

--- a/internal/database/locker/BUILD.bazel
+++ b/internal/database/locker/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
 
 go_test(
     name = "locker_test",
-    timeout = "short",
+    timeout = "moderate",
     srcs = ["locker_test.go"],
     embed = [":locker"],
     tags = [

--- a/internal/database/migration/store/BUILD.bazel
+++ b/internal/database/migration/store/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = [
         "describe_test.go",
         "store_test.go",

--- a/internal/usagestats/BUILD.bazel
+++ b/internal/usagestats/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
 
 go_test(
     name = "usagestats_test",
+    timeout = "moderate",
     srcs = [
         "aggregated_codeintel_test.go",
         "aggregated_repo_metadata_test.go",

--- a/internal/workerutil/dbworker/store/BUILD.bazel
+++ b/internal/workerutil/dbworker/store/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 
 go_test(
     name = "store_test",
+    timeout = "moderate",
     srcs = [
         "helpers_test.go",
         "store_test.go",


### PR DESCRIPTION
Rather than tagging all `go_test` rules with `timeout = "short"`, we leverage the wrapped `go_test` macro we already have to set the timeout to `"short"` unless specified otherwise. 

And I've added explicitly the `timeout = "moderate"` on the slower tests. Only a few warnings remains, but they're unrelated to Go and will be taken on in another PR. 

@keegancsmith before you ask, yes, that's where I'll put an additional tag for the go unit test as we discussed earlier :) I'll cover the doc part of this PR then, as I'll extract some Go stuff into its own page. 

This PR fixes about 30 warnings.

 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI, observing that we don't see the warnings anymore.
