### PR TITLE
Cody-Gateway - Return known gql error when dotcom user not found

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_vektah_gqlparser_v2//gqlerror",
     ],
 )
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -139,6 +139,24 @@ func TestCodyGatewayDotcomUserResolver(t *testing.T) {
 	}
 }
 
+func TestCodyGatewayDotcomUserResolverUserNotFound(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+
+	// admin user to make request
+	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})
+	require.NoError(t, err)
+
+	// Create an admin context to use for the request
+	adminContext := actor.WithActor(context.Background(), actor.FromActualUser(adminUser))
+
+	r := productsubscription.CodyGatewayDotcomUserResolver{DB: db}
+	_, err = r.CodyGatewayDotcomUserByToken(adminContext, &graphqlbackend.CodyGatewayUsersByAccessTokenArgs{Token: "NOT_A_TOKEN"})
+
+	_, got := err.(productsubscription.ErrDotcomUserNotFound)
+	assert.True(t, got, "should have error type ErrDotcomUserNotFound")
+}
+
 func TestCodyGatewayDotcomUserResolverRequestAccess(t *testing.T) {
 	ctx := context.Background()
 	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))

--- a/enterprise/internal/codygateway/consts.go
+++ b/enterprise/internal/codygateway/consts.go
@@ -27,3 +27,7 @@ const FeatureHeaderName = "X-Sourcegraph-Feature"
 // GQLErrCodeProductSubscriptionNotFound is the GraphQL error code returned when
 // attempting to look up a product subscription failed by any means.
 const GQLErrCodeProductSubscriptionNotFound = "ErrProductSubscriptionNotFound"
+
+// GQLErrCodeDotcomUserNotFound is the GraphQL error code returned when
+// attempting to look up a product subscription failed by any means.
+const GQLErrCodeDotcomUserNotFound = "ErrDotcomUserNotFound"

--- a/enterprise/internal/codygateway/consts.go
+++ b/enterprise/internal/codygateway/consts.go
@@ -29,5 +29,5 @@ const FeatureHeaderName = "X-Sourcegraph-Feature"
 const GQLErrCodeProductSubscriptionNotFound = "ErrProductSubscriptionNotFound"
 
 // GQLErrCodeDotcomUserNotFound is the GraphQL error code returned when
-// attempting to look up a product subscription failed by any means.
+// attempting to look up a dotcom user failed.
 const GQLErrCodeDotcomUserNotFound = "ErrDotcomUserNotFound"


### PR DESCRIPTION
This updates the DotcomUser Actor to return a 401 instead of a 503 error when the user isn't found, which in turn stops the calling api client from retrying the request.

## Test plan
Made requests with valid dotcom user token - Successful
Validated requests with invalid user token returned 401

**Before**
```
[       frontend] ERROR completions.chat httpapi/stream.go:40 error while streaming completions 
{"trace.family": "session > completions.chat", "error": "Anthropic: unexpected status code 503:
 {\"error\":\"dotcom-user: failed to validate access token: input: dotcom.codyGatewayDotcomUserByToken
 no associated token\"}\n"}
```

**After**
```
[       frontend] ERROR completions.chat httpapi/stream.go:40 error while streaming completions 
{"trace.family": "session > completions.chat", "error": "Anthropic: unexpected status code 401: 
{\"error\":\"dotcom-user: failed to validate access token: access token denied: associated dotcom user not found\"}\n"}
```



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
