### PR TITLE
cody-gateway: add escape hatch to force sync all sources

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -134,7 +134,12 @@ func (s *Sources) SyncAll(ctx context.Context, logger log.Logger) error {
 			})
 		}
 	}
-	return p.Wait()
+	if err := p.Wait(); err != nil {
+		return err
+	}
+
+	logger.Info("All sources synced")
+	return nil
 }
 
 // Worker is a goroutine.BackgroundRoutine that runs any SourceSyncer implementations

--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -3,6 +3,7 @@ package actor
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-redsync/redsync/v4"
@@ -60,9 +61,15 @@ type SourceSyncer interface {
 	Sync(ctx context.Context) (int, error)
 }
 
-type Sources []Source
+type Sources struct {
+	sources []Source
 
-func (s Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
+	syncRunning atomic.Bool
+}
+
+func NewSources(sources ...Source) *Sources { return &Sources{sources: sources} }
+
+func (s *Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "Sources.Get")
 	defer func() {
@@ -70,7 +77,7 @@ func (s Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 		span.End()
 	}()
 
-	for _, src := range s {
+	for _, src := range s.sources {
 		actor, err := src.Get(ctx, token)
 		// Only if the Source indicates it doesn't know about this token do
 		// we continue to the next Source.
@@ -93,9 +100,13 @@ func (s Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 //
 // By default, this is only used by (Sources).Worker(), which ensures only
 // a primary worker instance is running these in the background.
-func (s Sources) SyncAll(ctx context.Context, logger log.Logger) error {
+func (s *Sources) SyncAll(ctx context.Context, logger log.Logger) error {
+	if !s.syncRunning.CompareAndSwap(s.syncRunning.Load(), true) {
+		return errors.New("sources.SyncAll already running")
+	}
+
 	p := pool.New().WithErrors().WithContext(ctx)
-	for _, src := range s {
+	for _, src := range s.sources {
 		if src, ok := src.(SourceSyncer); ok {
 			p.Go(func(ctx context.Context) (err error) {
 				var span trace.Span
@@ -129,7 +140,7 @@ func (s Sources) SyncAll(ctx context.Context, logger log.Logger) error {
 // Worker is a goroutine.BackgroundRoutine that runs any SourceSyncer implementations
 // at a regular interval. It uses a redsync.Mutex to ensure only one worker is running
 // at a time.
-func (s Sources) Worker(obCtx *observation.Context, rmux *redsync.Mutex, rootInterval time.Duration) goroutine.BackgroundRoutine {
+func (s *Sources) Worker(obCtx *observation.Context, rmux *redsync.Mutex, rootInterval time.Duration) goroutine.BackgroundRoutine {
 	logger := obCtx.Logger.Scoped("sources.worker", "sources background routie")
 
 	return &redisLockedBackgroundRoutine{
@@ -195,7 +206,7 @@ func (s *redisLockedBackgroundRoutine) Stop() {
 type sourcesSyncHandler struct {
 	logger  log.Logger
 	rmux    *redsync.Mutex
-	sources Sources
+	sources *Sources
 }
 
 var _ goroutine.Handler = &sourcesSyncHandler{}

--- a/enterprise/cmd/cody-gateway/internal/actor/source_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source_test.go
@@ -63,7 +63,7 @@ func TestSourcesWorkers(t *testing.T) {
 	s1 := &mockSourceSyncer{}
 	stop1 := make(chan struct{})
 	g.Go(func() {
-		w := (Sources{s1}).Worker(observation.NewContext(logger), sourceWorkerMutex1, time.Millisecond)
+		w := (NewSources(s1)).Worker(observation.NewContext(logger), sourceWorkerMutex1, time.Millisecond)
 		go func() {
 			<-stop1
 			w.Stop()
@@ -78,7 +78,7 @@ func TestSourcesWorkers(t *testing.T) {
 		sourceWorkerMutex := rs.NewMutex(lockName,
 			// Competing worker should only try once to avoid getting stuck
 			redsync.WithTries(1))
-		w := (Sources{s2}).Worker(observation.NewContext(logger), sourceWorkerMutex, time.Millisecond)
+		w := (NewSources(s2)).Worker(observation.NewContext(logger), sourceWorkerMutex, time.Millisecond)
 		go func() {
 			<-stop2
 			w.Stop()

--- a/enterprise/cmd/cody-gateway/internal/auth/auth.go
+++ b/enterprise/cmd/cody-gateway/internal/auth/auth.go
@@ -16,7 +16,7 @@ import (
 type Authenticator struct {
 	Logger      log.Logger
 	EventLogger events.Logger
-	Sources     actor.Sources
+	Sources     *actor.Sources
 }
 
 func (a *Authenticator) Middleware(next http.Handler) http.Handler {

--- a/enterprise/cmd/cody-gateway/internal/auth/auth_test.go
+++ b/enterprise/cmd/cody-gateway/internal/auth/auth_test.go
@@ -38,7 +38,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{anonymous.NewSource(true, concurrencyConfig)},
+			Sources:     actor.NewSources(anonymous.NewSource(true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
@@ -49,7 +49,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{anonymous.NewSource(false, concurrencyConfig)},
+			Sources:     actor.NewSources(anonymous.NewSource(false, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusForbidden, w.Code)
 	})
@@ -97,7 +97,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 		mockrequire.Called(t, client.MakeRequestFunc)
@@ -121,7 +121,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 		mockrequire.NotCalled(t, client.MakeRequestFunc)
@@ -141,7 +141,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, false, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusForbidden, w.Code)
 	})
@@ -164,7 +164,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
@@ -182,7 +182,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 	})
@@ -231,7 +231,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusForbidden, w.Code)
 	})
@@ -280,7 +280,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
@@ -329,7 +329,7 @@ func TestAuthenticatorMiddleware(t *testing.T) {
 		(&Authenticator{
 			Logger:      logger,
 			EventLogger: events.NewStdoutLogger(logger),
-			Sources:     actor.Sources{productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)},
+			Sources:     actor.NewSources(productsubscription.NewSource(logger, cache, client, true, concurrencyConfig)),
 		}).Middleware(next).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})

--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi",
     visibility = ["//enterprise/cmd/cody-gateway:__subpackages__"],
     deps = [
+        "//enterprise/cmd/cody-gateway/internal/actor",
         "//enterprise/cmd/cody-gateway/internal/auth",
         "//enterprise/cmd/cody-gateway/internal/events",
         "//enterprise/cmd/cody-gateway/internal/httpapi/completions",
@@ -23,5 +24,7 @@ go_library(
         "//lib/errors",
         "@com_github_gorilla_mux//:mux",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_log//hook",
+        "@com_github_sourcegraph_log//output",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/httpapi/diagnostics.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/diagnostics.go
@@ -25,18 +25,15 @@ func NewDiagnosticsHandler(baseLogger log.Logger, next http.Handler, secret stri
 	baseLogger = baseLogger.Scoped("diagnostics", "healthz checks")
 
 	mustHaveSecret := func(l log.Logger, w http.ResponseWriter, r *http.Request) {
-		if secret != "" {
-			token, err := auth.ExtractBearer(r.Header)
-			if err != nil {
-				response.JSONError(l, w, http.StatusBadRequest, err)
-				return
-			}
+		token, err := auth.ExtractBearer(r.Header)
+		if err != nil {
+			response.JSONError(l, w, http.StatusBadRequest, err)
+			return
+		}
 
-			if token != secret {
-				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte("healthz: unauthorized"))
-				return
-			}
+		if token != secret {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
 		}
 	}
 

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -68,7 +68,7 @@ type TraceConfig struct {
 func (c *Config) Load() {
 	c.InsecureDev = env.InsecureDev
 	c.Address = c.Get("CODY_GATEWAY_ADDR", ":9992", "Address to serve Cody Gateway on.")
-	c.DiagnosticsSecret = c.GetOptional("CODY_GATEWAY_DIAGNOSTICS_SECRET", "Secret for accessing diagnostics - "+
+	c.DiagnosticsSecret = c.Get("CODY_GATEWAY_DIAGNOSTICS_SECRET", "", "Secret for accessing diagnostics - "+
 		"should be used as 'Authorization: Bearer $secret' header when accessing diagnostics endpoints.")
 
 	c.Dotcom.AccessToken = c.Get("CODY_GATEWAY_DOTCOM_ACCESS_TOKEN", "", "The Sourcegraph.com access token to be used.")

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -122,7 +122,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	})
 
 	// Diagnostic layers
-	handler = httpapi.NewDiagnosticsHandler(obctx.Logger, handler, config.DiagnosticsSecret)
+	handler = httpapi.NewDiagnosticsHandler(obctx.Logger, handler, config.DiagnosticsSecret, sources)
 
 	// Basic instrumentation. Note that tracing should be added on individual
 	// handlers rather than here at a high level so that we don't collect traces

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -73,7 +73,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	dotcomClient := dotcom.NewClient(config.Dotcom.URL, config.Dotcom.AccessToken)
 
 	// Supported actor/auth sources
-	sources := actor.Sources{
+	sources := actor.NewSources(
 		anonymous.NewSource(config.AllowAnonymous, config.ActorConcurrencyLimit),
 		productsubscription.NewSource(
 			obctx.Logger,
@@ -87,7 +87,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			dotcomClient,
 			config.ActorConcurrencyLimit,
 		),
-	}
+	)
 
 	authr := &auth.Authenticator{
 		Logger:      obctx.Logger.Scoped("auth", "authentication middleware"),

--- a/internal/grpc/messagesize/BUILD.bazel
+++ b/internal/grpc/messagesize/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("//dev:go_defs.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "messagesize",


### PR DESCRIPTION
Notably, some cache migration efforts need this, until we have https://github.com/sourcegraph/sourcegraph/pull/53263

This new endpoint also tees the logs back to the caller for convenience. This is safe because `SourceSyncer` implementations do not accept loggers, so they cannot emit logs that contain PII - this will only include progress logs from `actor.Sources`, see example.

## Test plan

```
sg start dotcom
```

```
curl -H "Authorization: Bearer sekret" localhost:9992/-/actor/sync-all-sources | jq --slurp '.[].Body'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   820  100   820    0     0  49296      0 --:--:-- --:--:-- --:--:-- 63076
"Starting a new sync"
"Completed sync"
```