### PR TITLE
rcache: isolate further global prefix in test helper 

### DIFF
--- a/internal/goroutine/recorder/common_test.go
+++ b/internal/goroutine/recorder/common_test.go
@@ -15,7 +15,7 @@ func TestLoggerAndReaderHappyPaths(t *testing.T) {
 	rcache.SetupForTest(t)
 
 	// Create logger
-	c := rcache.NewWithTTL(keyPrefix, 1)
+	c := rcache.NewWithTTL(keyPrefix, 1) // Suffix key with uuid to prevent clashing.
 	recorder := New(log.NoOp(), "test", c)
 
 	// Create routines

--- a/internal/rcache/BUILD.bazel
+++ b/internal/rcache/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//internal/redispool",
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",
+        "@com_github_google_uuid//:uuid",
         "@com_github_inconshreveable_log15//:log15",
     ],
 )

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -7,6 +7,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
@@ -184,7 +185,8 @@ func SetupForTest(t TB) {
 	}
 	kvMock = redispool.RedisKeyValue(pool)
 
-	globalPrefix = "__test__" + t.Name()
+	id, _ := uuid.NewRandom()
+	globalPrefix = fmt.Sprintf("__test__%s_%s", t.Name(), id)
 	c := pool.Get()
 	defer c.Close()
 


### PR DESCRIPTION
Triggered a flake while running `bazel test //internal/...`, on `//internal/goroutine/recorder:recorder_test`. I'm unsure how it happened exactly, as we're setting a global prefix which includes the test name, so this should not have happened in the first place. 

Nevertheless, this PR further prevents this from happening by adding a uuid to the global prefix. 

On the long term, we probably want to avoid running those unit tests against the same redis database, which would remove the need to have such measures. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

```
bazel test //internal/goroutine/recorder:recorder_test --runs_per_test=30
``` 

+ CI 