### PR TITLE
Lock light theme in the app wizard flow

### DIFF
--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -1,10 +1,11 @@
-import { FC, useCallback } from 'react'
+import { FC, useCallback, useLayoutEffect } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { Theme, ThemeContext, ThemeSetting, useTheme } from '@sourcegraph/shared/src/theme'
 
 import { PageTitle } from '../../../components/PageTitle'
-import { StepConfiguration, SetupStepsContent, SetupStepsRoot } from '../../../setup-wizard'
+import { SetupStepsContent, SetupStepsRoot, StepConfiguration } from '../../../setup-wizard'
 
 import { AppAllSetSetupStep } from './steps/AppAllSetSetupStep'
 import { AppInstallExtensionsSetupStep } from './steps/AppInstallExtensionsSetupStep'
@@ -56,6 +57,7 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
  * for any other deploy type setup flows.
  */
 export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
+    const { theme } = useTheme()
     const [activeStepId, setStepId, status] = useTemporarySetting('app-setup.activeStepId')
 
     const handleStepChange = useCallback(
@@ -70,12 +72,26 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
         [setStepId]
     )
 
+    // Force light theme when app setup wizard is rendered and return
+    // original theme-based theme value when app wizard redirects to the
+    // main app
+    useLayoutEffect(() => {
+        document.documentElement.classList.toggle('theme-light', true)
+
+        return () => {
+            const isLightTheme = theme === Theme.Light
+
+            document.documentElement.classList.toggle('theme-light', isLightTheme)
+            document.documentElement.classList.toggle('theme-dark', !isLightTheme)
+        }
+    }, [theme])
+
     if (status !== 'loaded') {
         return null
     }
 
     return (
-        <>
+        <ThemeContext.Provider value={{ themeSetting: ThemeSetting.Light }}>
             <PageTitle title="Sourcegraph App setup" />
 
             <SetupStepsRoot
@@ -86,6 +102,6 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
             >
                 <SetupStepsContent telemetryService={telemetryService} className={styles.content} />
             </SetupStepsRoot>
-        </>
+        </ThemeContext.Provider>
     )
 }

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -77,6 +77,7 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
     // main app
     useLayoutEffect(() => {
         document.documentElement.classList.toggle('theme-light', true)
+        document.documentElement.classList.toggle('theme-dark', false)
 
         return () => {
             const isLightTheme = theme === Theme.Light


### PR DESCRIPTION

| Before | After |
| --------- | ---------- |
| <img width="1136" alt="Screenshot 2023-06-12 at 16 20 01" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/49f992c7-a3d7-4d7e-aa18-9ed0557b53e1"> | <img width="1136" alt="Screenshot 2023-06-12 at 16 20 10" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/ceb520fe-37ff-4643-b6b2-0c2e92e50c6f"> |
## Test plan
- Check that even your system preferences have a dark theme as defealt, Cody app setup pages have light theme colours values (in components and background colours)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
