### PR TITLE
guardrails: add unit test for attribution

### DIFF
--- a/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -11,5 +12,20 @@ go_library(
         "//internal/search/client",
         "//internal/search/streaming",
         "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "attribution_test",
+    srcs = ["attribution_test.go"],
+    embed = [":attribution"],
+    deps = [
+        "//internal/database",
+        "//internal/search/backend",
+        "//internal/search/client",
+        "//internal/types",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_sourcegraph_zoekt//:zoekt",
     ],
 )

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/attribution.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/attribution.go
@@ -79,7 +79,7 @@ func (c *Service) SnippetAttribution(ctx context.Context, snippet string, limit 
 	// something like sorting by name from the map.
 	var (
 		mu        sync.Mutex
-		seen      map[api.RepoID]struct{}
+		seen      = map[api.RepoID]struct{}{}
 		repoNames []string
 		limitHit  bool
 	)

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -1,0 +1,81 @@
+package attribution
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/zoekt"
+)
+
+func TestAttribution(t *testing.T) {
+	ctx := context.Background()
+
+	// inputs
+	count := 5
+	limit := count + 1
+	localNames := genRepoNames("localrepo-", count)
+
+	// we want the localNames back
+	wantNames := genRepoNames("localrepo-", count)
+
+	svc := &Service{
+		SearchClient: mockSearchClient(t, localNames),
+	}
+
+	result, err := svc.SnippetAttribution(ctx, "test", limit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &SnippetAttributions{
+		TotalCount:      count,
+		LimitHit:        false,
+		RepositoryNames: wantNames,
+	}
+	if d := cmp.Diff(want, result); d != "" {
+		t.Fatalf("unexpected (-want, +got):\n%s", d)
+	}
+}
+
+func genRepoNames(prefix string, count int) []string {
+	var names []string
+	for i := 1; i <= count; i++ {
+		names = append(names, fmt.Sprintf("%s-%d", prefix, i))
+	}
+	return names
+}
+
+// mockSearchClient returns a client which will return matches. This exercises
+// more of the search code path to give a bit more confidence we are correctly
+// calling Plan and Execute vs a dumb SearchClient mock.
+func mockSearchClient(t testing.TB, repoNames []string) client.SearchClient {
+	repos := database.NewMockRepoStore()
+	repos.ListMinimalReposFunc.SetDefaultReturn([]types.MinimalRepo{}, nil)
+	repos.CountFunc.SetDefaultReturn(0, nil)
+
+	db := database.NewMockDB()
+	db.ReposFunc.SetDefaultReturn(repos)
+
+	var matches []zoekt.FileMatch
+	for i, name := range repoNames {
+		matches = append(matches, zoekt.FileMatch{
+			RepositoryID: uint32(i),
+			Repository:   name,
+		})
+	}
+	mockZoekt := &searchbackend.FakeStreamer{
+		Repos: []*zoekt.RepoListEntry{},
+		Results: []*zoekt.SearchResult{{
+			Files: matches,
+		}},
+	}
+
+	return client.MockedZoekt(logtest.Scoped(t), db, mockZoekt)
+}


### PR DESCRIPTION
This adds a simple unit test which exercises the core logic of the attribution backend.

Test Plan: go test

Part of #52366 