### PR TITLE
licensing: change access token format to 'slk_$hex($sha256($sha256(licenseKey)))'

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
@@ -56,8 +56,8 @@ WHERE
 	access_token_enabled=true
 	AND ( digest(digest(license_key, 'sha256'), 'sha256')=%s OR digest(license_key, 'sha256')=%s )`,
 		decoded,
-		// retain backcompat for now, see 'legacy token format' test case
-		// needs migration: sourcegraph.com, k8s.sgdev.org, cody-dev, S2
+		// TODO(@bobheadxi): retain backcompat for now, see 'legacy token format' test case
+		// needs migration: sourcegraph.com, k8s.sgdev.org, cody-dev, S2, dev-private
 		decoded,
 	)
 	subID, found, err := basestore.ScanFirstString(t.store.Query(ctx, query))

--- a/enterprise/internal/completions/client/client_test.go
+++ b/enterprise/internal/completions/client/client_test.go
@@ -64,7 +64,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 				LicenseKey: "foobar",
 			},
 			want: autogold.Expect(&schema.Completions{
-				AccessToken:     "slk_c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2",
+				AccessToken:     "slk_3f2c7ccae98af81e44c0ec419659f50d8b7d48c681e5d57fc747d0461e42dda1",
 				ChatModel:       "anthropic/claude-v1",
 				CompletionModel: "anthropic/claude-instant-v1",
 				Enabled:         true,

--- a/enterprise/internal/licensing/access_token.go
+++ b/enterprise/internal/licensing/access_token.go
@@ -13,8 +13,16 @@ const LicenseKeyBasedAccessTokenPrefix = "slk_" // "(S)ourcegraph (L)icense (K)e
 
 // GenerateLicenseKeyBasedAccessToken creates a prefixed, encoded token based on a
 // Sourcegraph license key.
+//
+// More specifically, the format goes:
+//
+//	slk_$hex($sha256($sha256(licenseKey)))
+//	└─┬┘
+//	  └──> licensing.LicenseKeyBasedAccessTokenPrefix
 func GenerateLicenseKeyBasedAccessToken(licenseKey string) string {
-	return LicenseKeyBasedAccessTokenPrefix + hex.EncodeToString(hashutil.ToSHA256Bytes([]byte(licenseKey)))
+	return LicenseKeyBasedAccessTokenPrefix + hex.EncodeToString(
+		hashutil.ToSHA256Bytes(hashutil.ToSHA256Bytes([]byte(licenseKey))),
+	)
 }
 
 func GenerateHashedLicenseKeyAccessToken(licenseKey string) []byte {


### PR DESCRIPTION
Changes the license-based access token to take the sha256 of the license key twice:

```diff
- slk_$hex($sha256(licenseKey))
+ slk_$hex($sha256($sha256(licenseKey)))
```

This aligns with other hashing of sensitive things (license check, dotcom user tokens) and some Stackoverflow answers indicate this prevents [certain vulnerabilities](https://crypto.stackexchange.com/questions/50017/why-hashing-twice).

Until we migrate our existing instances over, our check retains back-compat with previous tokens - see the back-compat test.

Latency on token checks is not currently an issue, since we run full syncs periodically. We're [exploring pre-computing it](https://sourcegraph.slack.com/archives/C05B23Y3VRP/p1686595502071599).

## Test plan

Tests
