### PR TITLE
cody: toggle config for inline and non-stop no reload required

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,10 +8,10 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
-- Add delete button for removing individual history [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
-- Load the recent ongoing chat on reload of window [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
-- Inline Assist: New Code Lens to undo `inline fix` performed by Cody [pull/]()
-- Inline Assist: New Code Lens to revert file back to last committed state [pull/]()
+- Add delete button for removing individual history. [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
+- Load the recent ongoing chat on reload of window. [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
+- Inline Assist: New Code Lens to undo `inline fix` performed by Cody. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
+- Inline Assist: New Code Lens to revert file back to last committed state. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
 
 ### Fixed
 
@@ -23,7 +23,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Save the current ongoing conversation to the chat history [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
 - Cody completions: Changed the feature flag from `cody.experimental.suggestions` to `cody.completions`. [pull/53240](https://github.com/sourcegraph/sourcegraph/pull/53240)
-- Inline Assist: Updating configuration no longer requires reloading the extension [pull/]()
+- Inline Assist: Updating configuration no longer requires reloading the extension. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
 
 ## [0.2.2]
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,7 +11,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Add delete button for removing individual history. [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
 - Load the recent ongoing chat on reload of window. [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
 - Inline Assist: New Code Lens to undo `inline fix` performed by Cody. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
-- Inline Assist: New Code Lens to revert file back to last committed state. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
 
 ### Fixed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Add delete button for removing individual history [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
 - Load the recent ongoing chat on reload of window [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
+- Inline Assist: New Code Lens to undo `inline fix` performed by Cody [pull/]()
+- Inline Assist: New Code Lens to revert file back to last committed state [pull/]()
 
 ### Fixed
 
@@ -21,6 +23,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Save the current ongoing conversation to the chat history [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
 - Cody completions: Changed the feature flag from `cody.experimental.suggestions` to `cody.completions`. [pull/53240](https://github.com/sourcegraph/sourcegraph/pull/53240)
+- Inline Assist: Updating configuration no longer requires reloading the extension [pull/]()
 
 ## [0.2.2]
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -343,12 +343,14 @@
         "command": "cody.comment.add",
         "title": "Ask Cody",
         "category": "Cody Inline Assist",
+        "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentIsEmpty"
       },
       {
         "command": "cody.comment.delete",
         "title": "Cody Inline Assist: Remove Comment",
         "category": "Cody Inline Assist",
+        "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentThreadIsEmpty",
         "icon": "$(trash)"
       },
@@ -356,6 +358,7 @@
         "command": "cody.comment.load",
         "title": "Cody Inline Assist: Loading",
         "category": "Cody Inline Assist",
+        "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentThreadIsEmpty",
         "icon": "$(sync~spin)"
       },
@@ -376,35 +379,41 @@
         "command": "cody.recipe.non-stop",
         "title": "Cody: Fixup (Experimental)",
         "icon": "resources/cody.png",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "cody.nonstop.fixups.enabled && editorHasSelection"
       },
       {
         "command": "cody.fixup.open",
         "title": "Cody: Go to Fixup",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "cody.nonstop.fixups.enabled",
         "icon": "$(file-code)"
       },
       {
         "command": "cody.fixup.apply",
         "title": "Cody: Apply fixup",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "!cody.fixup.view.isEmpty",
         "icon": "$(check)"
       },
       {
         "command": "cody.fixup.apply-all",
         "title": "Cody: Apply all fixups",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "!cody.fixup.view.isEmpty",
         "icon": "$(check-all)"
       },
       {
         "command": "cody.fixup.apply-by-file",
         "title": "Cody: Apply fixups to selected directory",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "!cody.fixup.view.isEmpty",
         "icon": "$(check-all)"
       },
       {
         "command": "cody.fixup.diff",
         "title": "Cody: Show diff for fixup",
+        "when": "cody.nonstop.fixups.enabled",
         "enablement": "!cody.fixup.view.isEmpty",
         "icon": "$(diff)"
       }
@@ -575,7 +584,7 @@
         },
         {
           "command": "cody.recipe.file-touch",
-          "when": "cody.activated"
+          "when": "cody.activated && cody.inline-assist.enabled"
         },
         {
           "command": "cody.recipe.generate-unit-test",
@@ -650,24 +659,24 @@
         {
           "command": "cody.comment.add",
           "group": "inline",
-          "when": "cody.activated && commentController =~ /^cody-inline/"
+          "when": "cody.activated && commentController =~ /^cody-inline/ && cody.inline-assist.enabled"
         },
         {
           "command": "cody.focus",
           "group": "inline",
-          "when": "!cody.activated && commentController =~ /^cody-inline/"
+          "when": "!cody.activated && commentController =~ /^cody-inline/ && cody.inline-assist.enabled"
         }
       ],
       "comments/commentThread/title": [
         {
           "command": "cody.comment.delete",
           "group": "inline@1",
-          "when": "cody.activated && commentController =~ /^cody-inline/ && cody.replied && !commentThreadIsEmpty"
+          "when": "cody.activated && commentController =~ /^cody-inline/ && cody.replied && !commentThreadIsEmpty && cody.inline-assist.enabled"
         },
         {
           "command": "cody.comment.load",
           "group": "inline@2",
-          "when": "cody.activated && commentController =~ /^cody-inline/ && cody.reply.pending"
+          "when": "cody.activated && commentController =~ /^cody-inline/ && cody.reply.pending && cody.inline-assist.enabled"
         }
       ],
       "view/item/context": [

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -22,9 +22,10 @@ export class VSCodeEditor implements Editor {
     ) {
         vscode.workspace.onDidChangeConfiguration(e => {
             const config = vscode.workspace.getConfiguration('cody')
+            const isTesting = process.env.CODY_TESTING === 'true'
             if (e.affectsConfiguration('cody')) {
                 // Non-Stop Cody
-                const enableNonStop = config.get('experimental.nonStop') as boolean
+                const enableNonStop = (config.get('experimental.nonStop') as boolean) || isTesting
                 const taskView = this.controllers.task.getTaskView()
                 void vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', enableNonStop)
                 if (enableNonStop) {
@@ -33,7 +34,7 @@ export class VSCodeEditor implements Editor {
                     taskView.dispose()
                 }
                 // Inline Assist
-                const enableInlineAssist = config.get('experimental.inline') as boolean
+                const enableInlineAssist = (config.get('experimental.inline') as boolean) || isTesting
                 const inlineController = this.controllers.inline
                 void vscode.commands.executeCommand('setContext', 'cody.inline-assist.enabled', enableInlineAssist)
                 inlineController.get().commentingRangeProvider = {

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -24,15 +24,6 @@ export class VSCodeEditor implements Editor {
             const config = vscode.workspace.getConfiguration('cody')
             const isTesting = process.env.CODY_TESTING === 'true'
             if (e.affectsConfiguration('cody')) {
-                // Non-Stop Cody
-                const enableNonStop = (config.get('experimental.nonStop') as boolean) || isTesting
-                const taskView = this.controllers.task.getTaskView()
-                void vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', enableNonStop)
-                if (enableNonStop) {
-                    vscode.window.registerTreeDataProvider('cody.fixup.tree.view', taskView)
-                } else {
-                    taskView.dispose()
-                }
                 // Inline Assist
                 const enableInlineAssist = (config.get('experimental.inline') as boolean) || isTesting
                 const inlineController = this.controllers.inline

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -166,6 +166,7 @@ const register = async (
         vscode.commands.registerCommand('cody.comment.delete', (thread: vscode.CommentThread) => {
             commentController.delete(thread)
         }),
+        vscode.commands.registerCommand('cody.recipe.file-touch', () => executeRecipe('file-touch', false)),
         // Access token - this is only used in configuration tests
         vscode.commands.registerCommand('cody.set-access-token', async (args: any[]) => {
             if (args?.length && (args[0] as string)) {
@@ -288,9 +289,7 @@ const register = async (
                 return [new vscode.Range(0, 0, lineCount - 1, 0)]
             },
         }
-        disposables.push(
-            vscode.commands.registerCommand('cody.recipe.file-touch', () => executeRecipe('file-touch', false))
-        )
+        void vscode.commands.executeCommand('setContext', 'cody.inline-assist.enabled', true)
     }
 
     if (initialConfig.experimentalGuardrails) {

--- a/client/cody/src/services/CodeLensProvider.ts
+++ b/client/cody/src/services/CodeLensProvider.ts
@@ -7,7 +7,6 @@ import { getSingleLineRange, updateRangeOnDocChange } from './InlineAssist'
 
 export class CodeLensProvider implements vscode.CodeLensProvider {
     private selectionRange: vscode.Range | null = null
-    private static lenses: CodeLensProvider
 
     private status = CodyTaskState.idle
     public decorator: DecorationProvider
@@ -16,10 +15,11 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event
 
-    constructor(public id = '', private extPath = '', private fileUri: vscode.Uri | null = null) {
+    constructor(public id: string, private extPath: string, private thread: vscode.CommentThread) {
+        this.provideCodeLenses = this.provideCodeLenses.bind(this)
         this.decorator = new DecorationProvider(this.id, this.extPath)
         vscode.workspace.onDidChangeTextDocument(e => {
-            if (e.document.uri.fsPath !== this.fileUri?.fsPath) {
+            if (e.document.uri.fsPath !== this.thread?.uri.fsPath) {
                 return
             }
             for (const change of e.contentChanges) {
@@ -41,12 +41,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
         vscode.workspace.onDidCloseTextDocument(e => this.removeOnFSPath(e.uri))
         vscode.workspace.onDidSaveTextDocument(e => this.removeOnFSPath(e.uri))
     }
-    /**
-     * Getter
-     */
-    public static get instance(): CodeLensProvider {
-        return (this.lenses ??= new this())
-    }
+
     /**
      * Define Current States
      */
@@ -64,6 +59,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
         this.decorator.remove()
         this.selectionRange = null
         this.status = CodyTaskState.idle
+        this.thread.dispose()
         this.dispose()
         this._onDidChangeCodeLenses.fire()
     }
@@ -75,10 +71,10 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
         token: vscode.CancellationToken
     ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
         // Only create Code lens in known filePath
-        if (!document || !token || document.uri.fsPath !== this.fileUri?.fsPath) {
+        if (!document || !token || document.uri.fsPath !== this.thread.uri.fsPath) {
             return []
         }
-        this.decorator.setFileUri(this.fileUri)
+        this.decorator.setFileUri(this.thread.uri)
         return this.createCodeLenses()
     }
     /**
@@ -91,14 +87,17 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
         }
         const codeLensRange = getSingleLineRange(range.start.line)
         return this.status === CodyTaskState.error
-            ? getErrorLenses(codeLensRange, this.id)
-            : getLenses(codeLensRange, this.isPending())
+            ? getErrorLenses(this.id, codeLensRange)
+            : getLenses(this.id, codeLensRange, this.isPending())
     }
     /**
      * Check if the file path is the same
      */
     private removeOnFSPath(uri: vscode.Uri): void {
-        if (uri.fsPath === this.fileUri?.fsPath) {
+        if (this.status === CodyTaskState.asking) {
+            return
+        }
+        if (uri.fsPath === this.thread.uri.fsPath) {
             this.remove()
         }
     }
@@ -119,37 +118,60 @@ export class CodeLensProvider implements vscode.CodeLensProvider {
     }
 }
 
-function getLenses(codeLensRange: vscode.Range, isPending: boolean): vscode.CodeLens[] {
-    const codeLensTitle = new vscode.CodeLens(codeLensRange)
+function getLenses(id: string, codeLensRange: vscode.Range, isPending: boolean): vscode.CodeLens[] {
+    const title = new vscode.CodeLens(codeLensRange)
     // Open Chat View
-    codeLensTitle.command = {
-        title: isPending ? '$(sync~spin) Processing by Cody' : '✨ Edited by Cody',
+    title.command = {
+        title: isPending ? '$(sync~spin) Asking Cody...' : '✨ Edited by Cody',
         tooltip: 'Open Cody chat view',
         command: 'cody.focus',
     }
-    const codeLensSave = new vscode.CodeLens(codeLensRange)
-    codeLensSave.command = {
-        title: 'Save',
-        tooltip: 'Accept and save all changes',
-        command: 'workbench.action.files.save',
-    }
-
-    return isPending ? [codeLensTitle] : [codeLensTitle, codeLensSave]
+    const undo = getInlineUndoLens(id, codeLensRange)
+    const revert = getInlineRevertLens(id, codeLensRange)
+    const close = getInlineCloseLens(id, codeLensRange)
+    return isPending ? [title, close] : [title, undo, close, revert]
 }
 
-function getErrorLenses(codeLensRange: vscode.Range, id: string): vscode.CodeLens[] {
-    const codeLensError = new vscode.CodeLens(codeLensRange)
-    codeLensError.command = {
+function getErrorLenses(id: string, codeLensRange: vscode.Range): vscode.CodeLens[] {
+    const title = new vscode.CodeLens(codeLensRange)
+    title.command = {
         title: '⛔️ Not Edited by Cody',
         tooltip: 'Open Cody chat view',
         command: 'cody.focus',
     }
-    const codeLensClose = new vscode.CodeLens(codeLensRange)
-    codeLensClose.command = {
+    const close = getInlineCloseLens(id, codeLensRange)
+    return [title, close]
+}
+
+function getInlineCloseLens(id: string, codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
         title: 'Close',
         tooltip: 'Click to remove decorations',
         command: 'cody.inline.decorations.remove',
         arguments: [id],
     }
-    return [codeLensError, codeLensClose]
+    return lens
+}
+
+function getInlineRevertLens(id: string, codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: 'Revert File',
+        tooltip: 'Revert file to last saved state',
+        command: 'cody.inline.file.revert',
+        arguments: [id],
+    }
+    return lens
+}
+
+function getInlineUndoLens(id: string, codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: '$(undo) Undo',
+        tooltip: 'Undo last change',
+        command: 'cody.inline.fix.undo',
+        arguments: [id],
+    }
+    return lens
 }

--- a/client/cody/src/services/CodeLensProvider.ts
+++ b/client/cody/src/services/CodeLensProvider.ts
@@ -143,9 +143,8 @@ function getLenses(id: string, codeLensRange: vscode.Range, isPending: boolean):
         command: 'cody.focus',
     }
     const undo = getInlineUndoLens(id, codeLensRange)
-    const revert = getInlineRevertLens(id, codeLensRange)
     const close = getInlineCloseLens(id, codeLensRange)
-    return isPending ? [title, close] : [title, undo, close, revert]
+    return isPending ? [title, close] : [title, undo, close]
 }
 
 function getErrorLenses(id: string, codeLensRange: vscode.Range): vscode.CodeLens[] {
@@ -165,17 +164,6 @@ function getInlineCloseLens(id: string, codeLensRange: vscode.Range): vscode.Cod
         title: 'Close',
         tooltip: 'Click to remove decorations',
         command: 'cody.inline.decorations.remove',
-        arguments: [id],
-    }
-    return lens
-}
-
-function getInlineRevertLens(id: string, codeLensRange: vscode.Range): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: 'Revert File',
-        tooltip: 'Revert file to last saved state',
-        command: 'cody.inline.file.revert',
         arguments: [id],
     }
     return lens

--- a/client/cody/src/services/DecorationProvider.ts
+++ b/client/cody/src/services/DecorationProvider.ts
@@ -62,7 +62,7 @@ export class DecorationProvider {
             await vscode.window.showTextDocument(this.fileUri, { selection: rangeStartLine })
             return
         }
-        if (this.status === CodyTaskState.ready) {
+        if (this.status === CodyTaskState.fixed) {
             this.decorationTypePending.dispose()
             this.decorations.push({ range, hoverMessage: 'Cody Assist #' + this.id })
             this.decorationsForIcon.push({ range: rangeStartLine })

--- a/client/cody/src/services/InlineController.ts
+++ b/client/cody/src/services/InlineController.ts
@@ -140,8 +140,7 @@ export class InlineController {
     }
 
     private undo(id: string): void {
-        void vscode.commands.executeCommand('undo')
-        this.codeLenses.get(id)?.remove()
+        void this.codeLenses.get(id)?.undo(id)
         this.codeLenses.delete(id)
     }
     /**
@@ -278,9 +277,12 @@ export class InlineController {
         this.isInProgress = false
         const chatSelection = this.getSelectionRange()
         const documentUri = vscode.Uri.joinPath(this.workspacePath, fileName)
-        // const documentUri = vscode.Uri.file(docFsPath)
         const range = new vscode.Selection(chatSelection.start, new vscode.Position(chatSelection.end.line + 1, 0))
         const newRange = await editDocByUri(documentUri, { start: range.start.line, end: range.end.line }, replacement)
+
+        const lens = this.codeLenses.get(this.currentTaskId)
+        lens?.storeContext(this.currentTaskId, documentUri, original, replacement, newRange)
+
         await this.stopFixMode(false, newRange)
         logEvent('CodyVSCodeExtension:inline-assist:replaced')
     }

--- a/client/cody/src/services/InlineController.ts
+++ b/client/cody/src/services/InlineController.ts
@@ -86,7 +86,6 @@ export class InlineController {
         })
         this._disposables.push(
             vscode.commands.registerCommand('cody.inline.decorations.remove', id => this.removeLens(id)),
-            vscode.commands.registerCommand('cody.inline.file.revert', id => this.revert(id)),
             vscode.commands.registerCommand('cody.inline.fix.undo', id => this.undo(id))
         )
     }
@@ -150,12 +149,6 @@ export class InlineController {
             this.threads.set(firstCommentId, this.thread)
         }
         void vscode.commands.executeCommand('setContext', 'cody.replied', true)
-    }
-
-    private revert(id: string): void {
-        void vscode.commands.executeCommand('workbench.action.files.revert')
-        this.codeLenses.get(id)?.remove()
-        this.codeLenses.delete(id)
     }
 
     private undo(id: string): void {


### PR DESCRIPTION
Requested by https://github.com/sourcegraph/sourcegraph/pull/53307
Close https://github.com/sourcegraph/sourcegraph/issues/53351 https://github.com/sourcegraph/sourcegraph/issues/53363

This PR includes:
- Updating the configuration for Inline Assist no longer requires users to reload the extension.
- Remove Code Lens to save Inline Fixup
- Add Undo Code Lens to Inline Fixup jobs that undo changes made by Cody
- Remove all comment threads from file when file is closed

For details: https://www.loom.com/share/540f4953b1ac4c9d81e90f4c37f86c2d?sid=41c65fd7-1be2-4225-92eb-3c7fa56766f8

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

All the existing tests should be passing. 


https://github.com/sourcegraph/sourcegraph/assets/68532117/ad229361-23ba-4653-91f5-b9dae98ee765

