### PR TITLE
codeintel: Add "prioritize index" button

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -666,6 +666,7 @@ ts_project(
         "src/enterprise/codeintel/indexes/hooks/useDeletePreciseIndex.tsx",
         "src/enterprise/codeintel/indexes/hooks/useDeletePreciseIndexes.tsx",
         "src/enterprise/codeintel/indexes/hooks/useEnqueueIndexJob.tsx",
+        "src/enterprise/codeintel/indexes/hooks/usePrioritizePreciseIndex.tsx",
         "src/enterprise/codeintel/indexes/hooks/useReindexPreciseIndex.tsx",
         "src/enterprise/codeintel/indexes/hooks/useReindexPreciseIndexes.tsx",
         "src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx",

--- a/client/web/src/enterprise/codeintel/indexes/hooks/usePrioritizePreciseIndex.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/hooks/usePrioritizePreciseIndex.tsx
@@ -1,0 +1,43 @@
+import { ApolloError, MutationFunctionOptions, FetchResult, useMutation } from '@apollo/client'
+
+import { gql, getDocumentNode } from '@sourcegraph/http-client'
+
+import { PrioritizePreciseIndexResult, PrioritizePreciseIndexVariables, Exact } from '../../../../graphql-operations'
+
+type PrioritizePreciseIndexResults = Promise<
+    FetchResult<PrioritizePreciseIndexResult, Record<string, any>, Record<string, any>>
+>
+
+interface UsePrioritizePreciseIndexResult {
+    handlePrioritizePreciseIndex: (
+        options?:
+            | MutationFunctionOptions<
+                  PrioritizePreciseIndexResult,
+                  Exact<{
+                      id: string
+                  }>
+              >
+            | undefined
+    ) => PrioritizePreciseIndexResults
+    prioritizeError: ApolloError | undefined
+}
+
+const PRIORITIZE_PRECISE_INDEX = gql`
+    mutation PrioritizePreciseIndex($id: ID!) {
+        prioritizePreciseIndex(id: $id) {
+            alwaysNil
+        }
+    }
+`
+
+export const usePrioritizePreciseIndex = (): UsePrioritizePreciseIndexResult => {
+    const [handlePrioritizePreciseIndex, { error }] = useMutation<
+        PrioritizePreciseIndexResult,
+        PrioritizePreciseIndexVariables
+    >(getDocumentNode(PRIORITIZE_PRECISE_INDEX))
+
+    return {
+        handlePrioritizePreciseIndex,
+        prioritizeError: error,
+    }
+}

--- a/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
@@ -91,6 +91,11 @@ extend type Mutation {
     deletePreciseIndex(id: ID!): EmptyResponse
 
     """
+    Jumps this precise index to the front of its current queue.
+    """
+    prioritizePreciseIndex(id: ID!): EmptyResponse
+
+    """
     Deletes precise indexes by filter criteria.
     """
     deletePreciseIndexes(

--- a/enterprise/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -167,6 +167,12 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
 	NumRepositoriesWithCodeIntelligenceFunc *StoreNumRepositoriesWithCodeIntelligenceFunc
+	// PrioritizeIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeIndexByID.
+	PrioritizeIndexByIDFunc *StorePrioritizeIndexByIDFunc
+	// PrioritizeUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeUploadByID.
+	PrioritizeUploadByIDFunc *StorePrioritizeUploadByIDFunc
 	// ProcessSourcedCommitsFunc is an instance of a mock function object
 	// controlling the behavior of the method ProcessSourcedCommits.
 	ProcessSourcedCommitsFunc *StoreProcessSourcedCommitsFunc
@@ -453,6 +459,16 @@ func NewMockStore() *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+				return
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -783,6 +799,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.NumRepositoriesWithCodeIntelligence")
 			},
 		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeIndexByID")
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeUploadByID")
+			},
+		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: func(context.Context, time.Duration, time.Duration, int, func(ctx context.Context, repositoryID int, repositoryName string, commit string) (bool, error), time.Time) (int, int, error) {
 				panic("unexpected invocation of MockStore.ProcessSourcedCommits")
@@ -1023,6 +1049,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: i.PrioritizeIndexByID,
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: i.PrioritizeUploadByID,
 		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: i.ProcessSourcedCommits,
@@ -5893,6 +5925,222 @@ func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeIndexByIDFunc describes the behavior when the
+// PrioritizeIndexByID method of the parent MockStore instance is invoked.
+type StorePrioritizeIndexByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeIndexByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeIndexByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeIndexByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeIndexByIDFunc.appendCall(StorePrioritizeIndexByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeIndexByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeIndexByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeIndexByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeIndexByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeIndexByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeIndexByIDFunc) appendCall(r0 StorePrioritizeIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeIndexByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeIndexByIDFunc) History() []StorePrioritizeIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeIndexByIDFuncCall is an object that describes an
+// invocation of method PrioritizeIndexByID on an instance of MockStore.
+type StorePrioritizeIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeUploadByIDFunc describes the behavior when the
+// PrioritizeUploadByID method of the parent MockStore instance is invoked.
+type StorePrioritizeUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeUploadByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeUploadByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeUploadByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeUploadByIDFunc.appendCall(StorePrioritizeUploadByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeUploadByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeUploadByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeUploadByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeUploadByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeUploadByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeUploadByIDFunc) appendCall(r0 StorePrioritizeUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeUploadByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeUploadByIDFunc) History() []StorePrioritizeUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeUploadByIDFuncCall is an object that describes an
+// invocation of method PrioritizeUploadByID on an instance of MockStore.
+type StorePrioritizeUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -511,6 +511,12 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
 	NumRepositoriesWithCodeIntelligenceFunc *StoreNumRepositoriesWithCodeIntelligenceFunc
+	// PrioritizeIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeIndexByID.
+	PrioritizeIndexByIDFunc *StorePrioritizeIndexByIDFunc
+	// PrioritizeUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeUploadByID.
+	PrioritizeUploadByIDFunc *StorePrioritizeUploadByIDFunc
 	// ProcessSourcedCommitsFunc is an instance of a mock function object
 	// controlling the behavior of the method ProcessSourcedCommits.
 	ProcessSourcedCommitsFunc *StoreProcessSourcedCommitsFunc
@@ -797,6 +803,16 @@ func NewMockStore() *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+				return
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -1127,6 +1143,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.NumRepositoriesWithCodeIntelligence")
 			},
 		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeIndexByID")
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeUploadByID")
+			},
+		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: func(context.Context, time.Duration, time.Duration, int, func(ctx context.Context, repositoryID int, repositoryName string, commit string) (bool, error), time.Time) (int, int, error) {
 				panic("unexpected invocation of MockStore.ProcessSourcedCommits")
@@ -1367,6 +1393,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: i.PrioritizeIndexByID,
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: i.PrioritizeUploadByID,
 		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: i.ProcessSourcedCommits,
@@ -6237,6 +6269,222 @@ func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeIndexByIDFunc describes the behavior when the
+// PrioritizeIndexByID method of the parent MockStore instance is invoked.
+type StorePrioritizeIndexByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeIndexByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeIndexByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeIndexByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeIndexByIDFunc.appendCall(StorePrioritizeIndexByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeIndexByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeIndexByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeIndexByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeIndexByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeIndexByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeIndexByIDFunc) appendCall(r0 StorePrioritizeIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeIndexByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeIndexByIDFunc) History() []StorePrioritizeIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeIndexByIDFuncCall is an object that describes an
+// invocation of method PrioritizeIndexByID on an instance of MockStore.
+type StorePrioritizeIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeUploadByIDFunc describes the behavior when the
+// PrioritizeUploadByID method of the parent MockStore instance is invoked.
+type StorePrioritizeUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeUploadByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeUploadByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeUploadByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeUploadByIDFunc.appendCall(StorePrioritizeUploadByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeUploadByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeUploadByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeUploadByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeUploadByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeUploadByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeUploadByIDFunc) appendCall(r0 StorePrioritizeUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeUploadByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeUploadByIDFunc) History() []StorePrioritizeUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeUploadByIDFuncCall is an object that describes an
+// invocation of method PrioritizeUploadByID on an instance of MockStore.
+type StorePrioritizeUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -325,6 +325,12 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
 	NumRepositoriesWithCodeIntelligenceFunc *StoreNumRepositoriesWithCodeIntelligenceFunc
+	// PrioritizeIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeIndexByID.
+	PrioritizeIndexByIDFunc *StorePrioritizeIndexByIDFunc
+	// PrioritizeUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeUploadByID.
+	PrioritizeUploadByIDFunc *StorePrioritizeUploadByIDFunc
 	// ProcessSourcedCommitsFunc is an instance of a mock function object
 	// controlling the behavior of the method ProcessSourcedCommits.
 	ProcessSourcedCommitsFunc *StoreProcessSourcedCommitsFunc
@@ -611,6 +617,16 @@ func NewMockStore() *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+				return
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -941,6 +957,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.NumRepositoriesWithCodeIntelligence")
 			},
 		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeIndexByID")
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeUploadByID")
+			},
+		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: func(context.Context, time.Duration, time.Duration, int, func(ctx context.Context, repositoryID int, repositoryName string, commit string) (bool, error), time.Time) (int, int, error) {
 				panic("unexpected invocation of MockStore.ProcessSourcedCommits")
@@ -1181,6 +1207,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: i.PrioritizeIndexByID,
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: i.PrioritizeUploadByID,
 		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: i.ProcessSourcedCommits,
@@ -6051,6 +6083,222 @@ func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeIndexByIDFunc describes the behavior when the
+// PrioritizeIndexByID method of the parent MockStore instance is invoked.
+type StorePrioritizeIndexByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeIndexByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeIndexByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeIndexByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeIndexByIDFunc.appendCall(StorePrioritizeIndexByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeIndexByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeIndexByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeIndexByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeIndexByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeIndexByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeIndexByIDFunc) appendCall(r0 StorePrioritizeIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeIndexByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeIndexByIDFunc) History() []StorePrioritizeIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeIndexByIDFuncCall is an object that describes an
+// invocation of method PrioritizeIndexByID on an instance of MockStore.
+type StorePrioritizeIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeUploadByIDFunc describes the behavior when the
+// PrioritizeUploadByID method of the parent MockStore instance is invoked.
+type StorePrioritizeUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeUploadByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeUploadByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeUploadByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeUploadByIDFunc.appendCall(StorePrioritizeUploadByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeUploadByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeUploadByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeUploadByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeUploadByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeUploadByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeUploadByIDFunc) appendCall(r0 StorePrioritizeUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeUploadByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeUploadByIDFunc) History() []StorePrioritizeUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeUploadByIDFuncCall is an object that describes an
+// invocation of method PrioritizeUploadByID on an instance of MockStore.
+type StorePrioritizeUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/internal/store/observability.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/observability.go
@@ -55,6 +55,7 @@ type operations struct {
 	softDeleteExpiredUploads             *observation.Operation
 	hardDeleteUploadsByIDs               *observation.Operation
 	deleteUploadByID                     *observation.Operation
+	prioritizeUploadByID                 *observation.Operation
 	insertUpload                         *observation.Operation
 	addUploadPart                        *observation.Operation
 	markQueued                           *observation.Operation
@@ -89,6 +90,7 @@ type operations struct {
 	getIndexByID               *observation.Operation
 	getIndexesByIDs            *observation.Operation
 	deleteIndexByID            *observation.Operation
+	prioritizeIndexByID        *observation.Operation
 	deleteIndexes              *observation.Operation
 	reindexIndexByID           *observation.Operation
 	reindexIndexes             *observation.Operation
@@ -157,6 +159,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		softDeleteExpiredUploads:             op("SoftDeleteExpiredUploads"),
 		hardDeleteUploadsByIDs:               op("HardDeleteUploadsByIDs"),
 		deleteUploadByID:                     op("DeleteUploadByID"),
+		prioritizeUploadByID:                 op("PrioritizeUploadByID"),
 		insertUpload:                         op("InsertUpload"),
 		addUploadPart:                        op("AddUploadPart"),
 		markQueued:                           op("MarkQueued"),
@@ -196,6 +199,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getIndexByID:                        op("GetIndexByID"),
 		getIndexesByIDs:                     op("GetIndexesByIDs"),
 		deleteIndexByID:                     op("DeleteIndexByID"),
+		prioritizeIndexByID:                 op("PrioritizeIndexByID"),
 		deleteIndexes:                       op("DeleteIndexes"),
 		reindexIndexByID:                    op("ReindexIndexByID"),
 		reindexIndexes:                      op("ReindexIndexes"),

--- a/enterprise/internal/codeintel/uploads/internal/store/store.go
+++ b/enterprise/internal/codeintel/uploads/internal/store/store.go
@@ -32,6 +32,7 @@ type Store interface {
 	GetAuditLogsForUpload(ctx context.Context, uploadID int) ([]shared.UploadLog, error)
 	DeleteUploads(ctx context.Context, opts shared.DeleteUploadsOptions) error
 	DeleteUploadByID(ctx context.Context, id int) (bool, error)
+	PrioritizeUploadByID(ctx context.Context, id int) (bool, error)
 	ReindexUploads(ctx context.Context, opts shared.ReindexUploadsOptions) error
 	ReindexUploadByID(ctx context.Context, id int) error
 
@@ -40,6 +41,7 @@ type Store interface {
 	GetIndexByID(ctx context.Context, id int) (uploadsshared.Index, bool, error)
 	GetIndexesByIDs(ctx context.Context, ids ...int) ([]uploadsshared.Index, error)
 	DeleteIndexByID(ctx context.Context, id int) (bool, error)
+	PrioritizeIndexByID(ctx context.Context, id int) (bool, error)
 	DeleteIndexes(ctx context.Context, opts shared.DeleteIndexesOptions) error
 	ReindexIndexByID(ctx context.Context, id int) error
 	ReindexIndexes(ctx context.Context, opts shared.ReindexIndexesOptions) error

--- a/enterprise/internal/codeintel/uploads/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/mocks_test.go
@@ -175,6 +175,12 @@ type MockStore struct {
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
 	NumRepositoriesWithCodeIntelligenceFunc *StoreNumRepositoriesWithCodeIntelligenceFunc
+	// PrioritizeIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeIndexByID.
+	PrioritizeIndexByIDFunc *StorePrioritizeIndexByIDFunc
+	// PrioritizeUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeUploadByID.
+	PrioritizeUploadByIDFunc *StorePrioritizeUploadByIDFunc
 	// ProcessSourcedCommitsFunc is an instance of a mock function object
 	// controlling the behavior of the method ProcessSourcedCommits.
 	ProcessSourcedCommitsFunc *StoreProcessSourcedCommitsFunc
@@ -461,6 +467,16 @@ func NewMockStore() *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+				return
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -791,6 +807,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.NumRepositoriesWithCodeIntelligence")
 			},
 		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeIndexByID")
+			},
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockStore.PrioritizeUploadByID")
+			},
+		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: func(context.Context, time.Duration, time.Duration, int, func(ctx context.Context, repositoryID int, repositoryName string, commit string) (bool, error), time.Time) (int, int, error) {
 				panic("unexpected invocation of MockStore.ProcessSourcedCommits")
@@ -1031,6 +1057,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &StoreNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
+		},
+		PrioritizeIndexByIDFunc: &StorePrioritizeIndexByIDFunc{
+			defaultHook: i.PrioritizeIndexByID,
+		},
+		PrioritizeUploadByIDFunc: &StorePrioritizeUploadByIDFunc{
+			defaultHook: i.PrioritizeUploadByID,
 		},
 		ProcessSourcedCommitsFunc: &StoreProcessSourcedCommitsFunc{
 			defaultHook: i.ProcessSourcedCommits,
@@ -5901,6 +5933,222 @@ func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreNumRepositoriesWithCodeIntelligenceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeIndexByIDFunc describes the behavior when the
+// PrioritizeIndexByID method of the parent MockStore instance is invoked.
+type StorePrioritizeIndexByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeIndexByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeIndexByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeIndexByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeIndexByIDFunc.appendCall(StorePrioritizeIndexByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeIndexByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeIndexByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeIndexByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeIndexByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeIndexByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeIndexByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeIndexByIDFunc) appendCall(r0 StorePrioritizeIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeIndexByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeIndexByIDFunc) History() []StorePrioritizeIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeIndexByIDFuncCall is an object that describes an
+// invocation of method PrioritizeIndexByID on an instance of MockStore.
+type StorePrioritizeIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeIndexByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StorePrioritizeUploadByIDFunc describes the behavior when the
+// PrioritizeUploadByID method of the parent MockStore instance is invoked.
+type StorePrioritizeUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []StorePrioritizeUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeUploadByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockStore) PrioritizeUploadByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeUploadByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeUploadByIDFunc.appendCall(StorePrioritizeUploadByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeUploadByID
+// method of the parent MockStore instance is invoked and the hook queue is
+// empty.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeUploadByID method of the parent MockStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *StorePrioritizeUploadByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StorePrioritizeUploadByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StorePrioritizeUploadByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *StorePrioritizeUploadByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StorePrioritizeUploadByIDFunc) appendCall(r0 StorePrioritizeUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StorePrioritizeUploadByIDFuncCall objects
+// describing the invocations of this function.
+func (f *StorePrioritizeUploadByIDFunc) History() []StorePrioritizeUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]StorePrioritizeUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StorePrioritizeUploadByIDFuncCall is an object that describes an
+// invocation of method PrioritizeUploadByID on an instance of MockStore.
+type StorePrioritizeUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StorePrioritizeUploadByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/service.go
+++ b/enterprise/internal/codeintel/uploads/service.go
@@ -77,6 +77,10 @@ func (s *Service) DeleteUploadByID(ctx context.Context, id int) (bool, error) {
 	return s.store.DeleteUploadByID(ctx, id)
 }
 
+func (s *Service) PrioritizeUploadByID(ctx context.Context, id int) (bool, error) {
+	return s.store.PrioritizeUploadByID(ctx, id)
+}
+
 func (s *Service) DeleteUploads(ctx context.Context, opts shared.DeleteUploadsOptions) error {
 	return s.store.DeleteUploads(ctx, opts)
 }
@@ -220,6 +224,10 @@ func (s *Service) DeleteIndexByID(ctx context.Context, id int) (bool, error) {
 	return s.store.DeleteIndexByID(ctx, id)
 }
 
+func (s *Service) PrioritizeIndexByID(ctx context.Context, id int) (bool, error) {
+	return s.store.PrioritizeIndexByID(ctx, id)
+}
+
 func (s *Service) DeleteIndexes(ctx context.Context, opts shared.DeleteIndexesOptions) error {
 	return s.store.DeleteIndexes(ctx, opts)
 }
@@ -242,12 +250,4 @@ func (s *Service) NumRepositoriesWithCodeIntelligence(ctx context.Context) (int,
 
 func (s *Service) RepositoryIDsWithErrors(ctx context.Context, offset, limit int) ([]uploadsshared.RepositoryWithCount, int, error) {
 	return s.store.RepositoryIDsWithErrors(ctx, offset, limit)
-}
-
-func (s *Service) PrioritizeUploadByID(ctx context.Context, id int) (bool, error) {
-	return s.store.PrioritizeUploadByID(ctx, id)
-}
-
-func (s *Service) PrioritizeIndexByID(ctx context.Context, id int) (bool, error) {
-	return s.store.PrioritizeIndexByID(ctx, id)
 }

--- a/enterprise/internal/codeintel/uploads/service.go
+++ b/enterprise/internal/codeintel/uploads/service.go
@@ -243,3 +243,11 @@ func (s *Service) NumRepositoriesWithCodeIntelligence(ctx context.Context) (int,
 func (s *Service) RepositoryIDsWithErrors(ctx context.Context, offset, limit int) ([]uploadsshared.RepositoryWithCount, int, error) {
 	return s.store.RepositoryIDsWithErrors(ctx, offset, limit)
 }
+
+func (s *Service) PrioritizeUploadByID(ctx context.Context, id int) (bool, error) {
+	return s.store.PrioritizeUploadByID(ctx, id)
+}
+
+func (s *Service) PrioritizeIndexByID(ctx context.Context, id int) (bool, error) {
+	return s.store.PrioritizeIndexByID(ctx, id)
+}

--- a/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
@@ -34,6 +34,8 @@ type UploadsService interface {
 	GetRecentIndexesSummary(ctx context.Context, repositoryID int) ([]uploadshared.IndexesWithRepositoryNamespace, error)
 	NumRepositoriesWithCodeIntelligence(ctx context.Context) (int, error)
 	RepositoryIDsWithErrors(ctx context.Context, offset, limit int) (_ []uploadshared.RepositoryWithCount, totalCount int, err error)
+	PrioritizeUploadByID(ctx context.Context, id int) (_ bool, err error)
+	PrioritizeIndexByID(ctx context.Context, id int) (_ bool, err error)
 }
 
 type AutoIndexingService interface {

--- a/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/iface.go
@@ -19,12 +19,14 @@ type UploadsService interface {
 	GetAuditLogsForUpload(ctx context.Context, uploadID int) (_ []shared.UploadLog, err error)
 	GetIndexByID(ctx context.Context, id int) (_ uploadsshared.Index, _ bool, err error)
 	DeleteIndexByID(ctx context.Context, id int) (_ bool, err error)
+	PrioritizeIndexByID(ctx context.Context, id int) (_ bool, err error)
 	DeleteIndexes(ctx context.Context, opts uploadshared.DeleteIndexesOptions) (err error)
 	ReindexIndexByID(ctx context.Context, id int) (err error)
 	ReindexIndexes(ctx context.Context, opts uploadshared.ReindexIndexesOptions) (err error)
 	GetIndexers(ctx context.Context, opts uploadshared.GetIndexersOptions) ([]string, error)
 	GetUploadByID(ctx context.Context, id int) (_ shared.Upload, _ bool, err error)
 	DeleteUploadByID(ctx context.Context, id int) (_ bool, err error)
+	PrioritizeUploadByID(ctx context.Context, id int) (_ bool, err error)
 	DeleteUploads(ctx context.Context, opts uploadshared.DeleteUploadsOptions) (err error)
 	ReindexUploads(ctx context.Context, opts uploadshared.ReindexUploadsOptions) error
 	ReindexUploadByID(ctx context.Context, id int) error
@@ -34,8 +36,6 @@ type UploadsService interface {
 	GetRecentIndexesSummary(ctx context.Context, repositoryID int) ([]uploadshared.IndexesWithRepositoryNamespace, error)
 	NumRepositoriesWithCodeIntelligence(ctx context.Context) (int, error)
 	RepositoryIDsWithErrors(ctx context.Context, offset, limit int) (_ []uploadshared.RepositoryWithCount, totalCount int, err error)
-	PrioritizeUploadByID(ctx context.Context, id int) (_ bool, err error)
-	PrioritizeIndexByID(ctx context.Context, id int) (_ bool, err error)
 }
 
 type AutoIndexingService interface {

--- a/enterprise/internal/codeintel/uploads/transport/graphql/mocks_test.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/mocks_test.go
@@ -72,6 +72,12 @@ type MockUploadsService struct {
 	// function object controlling the behavior of the method
 	// NumRepositoriesWithCodeIntelligence.
 	NumRepositoriesWithCodeIntelligenceFunc *UploadsServiceNumRepositoriesWithCodeIntelligenceFunc
+	// PrioritizeIndexByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeIndexByID.
+	PrioritizeIndexByIDFunc *UploadsServicePrioritizeIndexByIDFunc
+	// PrioritizeUploadByIDFunc is an instance of a mock function object
+	// controlling the behavior of the method PrioritizeUploadByID.
+	PrioritizeUploadByIDFunc *UploadsServicePrioritizeUploadByIDFunc
 	// ReindexIndexByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method ReindexIndexByID.
 	ReindexIndexByIDFunc *UploadsServiceReindexIndexByIDFunc
@@ -175,6 +181,16 @@ func NewMockUploadsService() *MockUploadsService {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &UploadsServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: func(context.Context) (r0 int, r1 error) {
+				return
+			},
+		},
+		PrioritizeIndexByIDFunc: &UploadsServicePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
+				return
+			},
+		},
+		PrioritizeUploadByIDFunc: &UploadsServicePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (r0 bool, r1 error) {
 				return
 			},
 		},
@@ -295,6 +311,16 @@ func NewStrictMockUploadsService() *MockUploadsService {
 				panic("unexpected invocation of MockUploadsService.NumRepositoriesWithCodeIntelligence")
 			},
 		},
+		PrioritizeIndexByIDFunc: &UploadsServicePrioritizeIndexByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockUploadsService.PrioritizeIndexByID")
+			},
+		},
+		PrioritizeUploadByIDFunc: &UploadsServicePrioritizeUploadByIDFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				panic("unexpected invocation of MockUploadsService.PrioritizeUploadByID")
+			},
+		},
 		ReindexIndexByIDFunc: &UploadsServiceReindexIndexByIDFunc{
 			defaultHook: func(context.Context, int) error {
 				panic("unexpected invocation of MockUploadsService.ReindexIndexByID")
@@ -378,6 +404,12 @@ func NewMockUploadsServiceFrom(i UploadsService) *MockUploadsService {
 		},
 		NumRepositoriesWithCodeIntelligenceFunc: &UploadsServiceNumRepositoriesWithCodeIntelligenceFunc{
 			defaultHook: i.NumRepositoriesWithCodeIntelligence,
+		},
+		PrioritizeIndexByIDFunc: &UploadsServicePrioritizeIndexByIDFunc{
+			defaultHook: i.PrioritizeIndexByID,
+		},
+		PrioritizeUploadByIDFunc: &UploadsServicePrioritizeUploadByIDFunc{
+			defaultHook: i.PrioritizeUploadByID,
 		},
 		ReindexIndexByIDFunc: &UploadsServiceReindexIndexByIDFunc{
 			defaultHook: i.ReindexIndexByID,
@@ -2287,6 +2319,228 @@ func (c UploadsServiceNumRepositoriesWithCodeIntelligenceFuncCall) Args() []inte
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UploadsServiceNumRepositoriesWithCodeIntelligenceFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// UploadsServicePrioritizeIndexByIDFunc describes the behavior when the
+// PrioritizeIndexByID method of the parent MockUploadsService instance is
+// invoked.
+type UploadsServicePrioritizeIndexByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []UploadsServicePrioritizeIndexByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeIndexByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUploadsService) PrioritizeIndexByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeIndexByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeIndexByIDFunc.appendCall(UploadsServicePrioritizeIndexByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeIndexByID
+// method of the parent MockUploadsService instance is invoked and the hook
+// queue is empty.
+func (f *UploadsServicePrioritizeIndexByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeIndexByID method of the parent MockUploadsService instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UploadsServicePrioritizeIndexByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UploadsServicePrioritizeIndexByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UploadsServicePrioritizeIndexByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *UploadsServicePrioritizeIndexByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UploadsServicePrioritizeIndexByIDFunc) appendCall(r0 UploadsServicePrioritizeIndexByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UploadsServicePrioritizeIndexByIDFuncCall
+// objects describing the invocations of this function.
+func (f *UploadsServicePrioritizeIndexByIDFunc) History() []UploadsServicePrioritizeIndexByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]UploadsServicePrioritizeIndexByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UploadsServicePrioritizeIndexByIDFuncCall is an object that describes an
+// invocation of method PrioritizeIndexByID on an instance of
+// MockUploadsService.
+type UploadsServicePrioritizeIndexByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UploadsServicePrioritizeIndexByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UploadsServicePrioritizeIndexByIDFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// UploadsServicePrioritizeUploadByIDFunc describes the behavior when the
+// PrioritizeUploadByID method of the parent MockUploadsService instance is
+// invoked.
+type UploadsServicePrioritizeUploadByIDFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []UploadsServicePrioritizeUploadByIDFuncCall
+	mutex       sync.Mutex
+}
+
+// PrioritizeUploadByID delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockUploadsService) PrioritizeUploadByID(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.PrioritizeUploadByIDFunc.nextHook()(v0, v1)
+	m.PrioritizeUploadByIDFunc.appendCall(UploadsServicePrioritizeUploadByIDFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the PrioritizeUploadByID
+// method of the parent MockUploadsService instance is invoked and the hook
+// queue is empty.
+func (f *UploadsServicePrioritizeUploadByIDFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// PrioritizeUploadByID method of the parent MockUploadsService instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UploadsServicePrioritizeUploadByIDFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *UploadsServicePrioritizeUploadByIDFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *UploadsServicePrioritizeUploadByIDFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *UploadsServicePrioritizeUploadByIDFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *UploadsServicePrioritizeUploadByIDFunc) appendCall(r0 UploadsServicePrioritizeUploadByIDFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of UploadsServicePrioritizeUploadByIDFuncCall
+// objects describing the invocations of this function.
+func (f *UploadsServicePrioritizeUploadByIDFunc) History() []UploadsServicePrioritizeUploadByIDFuncCall {
+	f.mutex.Lock()
+	history := make([]UploadsServicePrioritizeUploadByIDFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// UploadsServicePrioritizeUploadByIDFuncCall is an object that describes an
+// invocation of method PrioritizeUploadByID on an instance of
+// MockUploadsService.
+type UploadsServicePrioritizeUploadByIDFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c UploadsServicePrioritizeUploadByIDFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c UploadsServicePrioritizeUploadByIDFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/internal/codeintel/uploads/transport/graphql/observability.go
+++ b/enterprise/internal/codeintel/uploads/transport/graphql/observability.go
@@ -8,15 +8,16 @@ import (
 )
 
 type operations struct {
-	codeIntelSummary      *observation.Operation
-	commitGraph           *observation.Operation
-	deletePreciseIndex    *observation.Operation
-	deletePreciseIndexes  *observation.Operation
-	preciseIndexByID      *observation.Operation
-	preciseIndexes        *observation.Operation
-	reindexPreciseIndex   *observation.Operation
-	reindexPreciseIndexes *observation.Operation
-	repositorySummary     *observation.Operation
+	codeIntelSummary       *observation.Operation
+	commitGraph            *observation.Operation
+	deletePreciseIndex     *observation.Operation
+	prioritizePreciseIndex *observation.Operation
+	deletePreciseIndexes   *observation.Operation
+	preciseIndexByID       *observation.Operation
+	preciseIndexes         *observation.Operation
+	reindexPreciseIndex    *observation.Operation
+	reindexPreciseIndexes  *observation.Operation
+	repositorySummary      *observation.Operation
 }
 
 func newOperations(observationCtx *observation.Context) *operations {
@@ -36,14 +37,15 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		codeIntelSummary:      op("CodeIntelSummary"),
-		commitGraph:           op("CommitGraph"),
-		deletePreciseIndex:    op("DeletePreciseIndex"),
-		deletePreciseIndexes:  op("DeletePreciseIndexes"),
-		preciseIndexByID:      op("PreciseIndexByID"),
-		preciseIndexes:        op("PreciseIndexes"),
-		reindexPreciseIndex:   op("ReindexPreciseIndex"),
-		reindexPreciseIndexes: op("ReindexPreciseIndexes"),
-		repositorySummary:     op("RepositorySummary"),
+		codeIntelSummary:       op("CodeIntelSummary"),
+		commitGraph:            op("CommitGraph"),
+		deletePreciseIndex:     op("DeletePreciseIndex"),
+		prioritizePreciseIndex: op("PrioritizePreciseIndex"),
+		deletePreciseIndexes:   op("DeletePreciseIndexes"),
+		preciseIndexByID:       op("PreciseIndexByID"),
+		preciseIndexes:         op("PreciseIndexes"),
+		reindexPreciseIndex:    op("ReindexPreciseIndex"),
+		reindexPreciseIndexes:  op("ReindexPreciseIndexes"),
+		repositorySummary:      op("RepositorySummary"),
 	}
 }

--- a/internal/codeintel/resolvers/root_resolver.go
+++ b/internal/codeintel/resolvers/root_resolver.go
@@ -129,6 +129,10 @@ func (r *Resolver) DeletePreciseIndex(ctx context.Context, args *struct{ ID grap
 	return r.uploadsRootResolver.DeletePreciseIndex(ctx, args)
 }
 
+func (r *Resolver) PrioritizePreciseIndex(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error) {
+	return r.uploadsRootResolver.PrioritizePreciseIndex(ctx, args)
+}
+
 func (r *Resolver) DeletePreciseIndexes(ctx context.Context, args *DeletePreciseIndexesArgs) (*EmptyResponse, error) {
 	return r.uploadsRootResolver.DeletePreciseIndexes(ctx, args)
 }

--- a/internal/codeintel/resolvers/uploads.go
+++ b/internal/codeintel/resolvers/uploads.go
@@ -16,6 +16,7 @@ type UploadsServiceResolver interface {
 
 	// Modify precise indexes
 	DeletePreciseIndex(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
+	PrioritizePreciseIndex(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
 	DeletePreciseIndexes(ctx context.Context, args *DeletePreciseIndexesArgs) (*EmptyResponse, error)
 	ReindexPreciseIndex(ctx context.Context, args *struct{ ID graphql.ID }) (*EmptyResponse, error)
 	ReindexPreciseIndexes(ctx context.Context, args *ReindexPreciseIndexesArgs) (*EmptyResponse, error)


### PR DESCRIPTION
Add a button to send a precise index to the front of the queue. Right now this just works by modifying the uploaded_at/queued_at timestamp to be a year in the past. This might give a quick win for demoability on dotcom, and something easy to remove from the upcoming branch cut.

## Test plan

Tested locally, added unit tests to store.
