### PR TITLE
cody: ensure backcompat with old transcript JSON

### DIFF
--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -28,8 +28,11 @@ export class Transcript {
     public static fromJSON(json: TranscriptJSON): Transcript {
         return new Transcript(
             json.interactions.map(
-                ({ humanMessage, assistantMessage, fullContext, usedContextFiles, timestamp }) =>
-                    new Interaction(
+                ({ humanMessage, assistantMessage, context, fullContext, usedContextFiles, timestamp }) => {
+                    if (!fullContext) {
+                        fullContext = context || []
+                    }
+                    return new Interaction(
                         humanMessage,
                         assistantMessage,
                         Promise.resolve(
@@ -46,9 +49,10 @@ export class Transcript {
                                 return message
                             })
                         ),
-                        usedContextFiles,
+                        usedContextFiles || [],
                         timestamp || new Date().toISOString()
                     )
+                }
             ),
             json.id
         )

--- a/client/cody-shared/src/chat/transcript/interaction.ts
+++ b/client/cody-shared/src/chat/transcript/interaction.ts
@@ -8,6 +8,9 @@ export interface InteractionJSON {
     fullContext: ContextMessage[]
     usedContextFiles: ContextFile[]
     timestamp: string
+
+    // DEPRECATED: Legacy field for backcompat, renamed to `fullContext`
+    context?: ContextMessage[]
 }
 
 export class Interaction {


### PR DESCRIPTION
This fixes the `Cannot read properties of undefined (reading 'map')` error

## Test plan

Tested locally