### PR TITLE
cody-gateway/actor: remove attempted SyncAll locking

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -104,6 +104,7 @@ func (s *Sources) SyncAll(ctx context.Context, logger log.Logger) error {
 	if !s.syncRunning.CompareAndSwap(s.syncRunning.Load(), true) {
 		return errors.New("sources.SyncAll already running")
 	}
+	defer s.syncRunning.Store(false)
 
 	p := pool.New().WithErrors().WithContext(ctx)
 	for _, src := range s.sources {

--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -3,7 +3,6 @@ package actor
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-redsync/redsync/v4"
@@ -61,13 +60,11 @@ type SourceSyncer interface {
 	Sync(ctx context.Context) (int, error)
 }
 
-type Sources struct {
-	sources []Source
+type Sources struct{ sources []Source }
 
-	syncRunning atomic.Bool
+func NewSources(sources ...Source) *Sources {
+	return &Sources{sources: sources}
 }
-
-func NewSources(sources ...Source) *Sources { return &Sources{sources: sources} }
 
 func (s *Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 	var span trace.Span
@@ -101,11 +98,6 @@ func (s *Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 // By default, this is only used by (Sources).Worker(), which ensures only
 // a primary worker instance is running these in the background.
 func (s *Sources) SyncAll(ctx context.Context, logger log.Logger) error {
-	if !s.syncRunning.CompareAndSwap(s.syncRunning.Load(), true) {
-		return errors.New("sources.SyncAll already running")
-	}
-	defer s.syncRunning.Store(false)
-
 	p := pool.New().WithErrors().WithContext(ctx)
 	for _, src := range s.sources {
 		if src, ok := src.(SourceSyncer); ok {

--- a/enterprise/cmd/cody-gateway/internal/actor/source_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source_test.go
@@ -117,6 +117,22 @@ func TestSourcesWorkers(t *testing.T) {
 	g.Wait()
 }
 
+func TestSourcesSyncAll(t *testing.T) {
+	t.Parallel()
+
+	var s1, s2 mockSourceSyncer
+	sources := NewSources(&s1, &s2)
+	err := sources.SyncAll(context.Background(), logtest.Scoped(t))
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), s1.syncCount.Load())
+	assert.Equal(t, int32(1), s2.syncCount.Load())
+
+	err = sources.SyncAll(context.Background(), logtest.Scoped(t))
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), s1.syncCount.Load())
+	assert.Equal(t, int32(2), s2.syncCount.Load())
+}
+
 func TestIsErrNotFromSource(t *testing.T) {
 	var err error
 	err = ErrNotFromSource{Reason: "foo"}


### PR DESCRIPTION
This "locking" didn't work before because I misunderstood what `CompareAndSwap` does so this would just always run anyway, and it shouldn't matter anyway because `SyncAll` is an "eventually consistent" type of thing so it shouldn't matter if an operator forces a sync while a worker sync is happening.

## Test plan

Unit tests
