### PR TITLE
Reset include inferred state on repo change

### DIFF
--- a/client/cody-shared/src/chat/useClient.ts
+++ b/client/cody-shared/src/chat/useClient.ts
@@ -140,7 +140,22 @@ export const useClient = ({
     const setScope = useCallback((scope: CodyClientScope) => setScopeState(scope), [setScopeState])
 
     const setEditorScope = useCallback(
-        (editor: Editor) => setScopeState(scope => ({ ...scope, editor })),
+        (editor: Editor) => {
+            const newRepoName = editor.getActiveTextEditor()?.repoName
+
+            return setScopeState(scope => {
+                const oldRepoName = scope.editor.getActiveTextEditor()?.repoName
+
+                const resetInferredScope = newRepoName !== oldRepoName
+
+                return {
+                    ...scope,
+                    editor,
+                    includeInferredRepository: resetInferredScope ? true : scope.includeInferredRepository,
+                    includeInferredFile: resetInferredScope ? true : scope.includeInferredFile,
+                }
+            })
+        },
         [setScopeState]
     )
 

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -85,7 +85,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore }): JSX.Element =
                 submitButtonComponent={SubmitButton}
                 fileLinkComponent={FileLink}
                 className={styles.container}
-                afterTips={CODY_TERMS_MARKDOWN}
+                afterTips={transcriptHistory.length > 1 ? '' : CODY_TERMS_MARKDOWN}
                 transcriptItemClassName={styles.transcriptItem}
                 humanTranscriptItemClassName={styles.humanTranscriptItem}
                 transcriptItemParticipantClassName="text-muted"

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -115,7 +115,7 @@
 }
 
 .disabled-search-result {
-    opacity: 50%;
+    opacity: 0.5;
 }
 
 .not-included-in-context {
@@ -124,12 +124,12 @@
         color: var(--text-disabled);
     }
     .embedding-icon-no-embeddings {
-        color: var(--gray-05);
+        color: var(--gray-07);
     }
 }
 
 .not-included-in-context:hover {
-    opacity: 100%;
+    opacity: 1;
 }
 
 .embedding-icon-no-embeddings {


### PR DESCRIPTION
As per the [Slack](https://sourcegraph.slack.com/archives/C054KJEF8DQ/p1686230667410879) discussion, we have decided to reset the include inferred repo/file state when the user navigates to a different repo. 

## Test plan

- visit https://sourcegraph.test:3443/github.com/hashicorp/errwrap
- open Cody and disable inferred repo/file
- navigate to a different repo using the search
- the inferred repo & file should be enabled now.