### PR TITLE
Improve the Cody for VS Code login messages

### DIFF
--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -259,7 +259,12 @@ const register = async (
                     })
                     await chatProvider.sendLogin(authStatus)
                     if (isLoggedIn(authStatus)) {
-                        void vscode.window.showInformationMessage(successMessage)
+                        const actionButtonLabel = 'Get Started'
+                        void vscode.window.showInformationMessage(successMessage, actionButtonLabel).then(action => {
+                            if (action === actionButtonLabel) {
+                                void vscode.commands.executeCommand('cody.chat.focus')
+                            }
+                        })
                     } else {
                         void vscode.window.showInformationMessage('Error logging into Cody')
                     }


### PR DESCRIPTION
* A nicer login success message
* Focuses the Cody extension on auth (in case they're elsewhere in VS Code)
* Support for param-less URLs for just focusing the Cody Extension (e.g. from App): `vscode://sourcegraph.cody-ai`

| Before | After |
| - | - |
| <img width="514" alt="Screenshot 2023-06-13 at 5 48 55 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/a0d8a2b4-f127-4f5c-8920-53068e458728"> |  <img width="501" alt="Screenshot 2023-06-13 at 5 52 41 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/0d5cd45f-f10f-4393-9744-ad1a78b8d911"> |

## Test plan

* Open extension
* Log out
* Trigger conditions w/ URL conditions