### PR TITLE
Set embedding batch size header for Sourcegraph provider

### DIFF
--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -121,9 +120,6 @@ func (c *openaiEmbeddingsClient) getEmbeddings(ctx context.Context, texts []stri
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.accessToken)
-	if len(texts) > 1 {
-		req.Header.Set("X-Cody-Embed-Batch-Size", strconv.Itoa(len(texts)))
-	}
 
 	resp, err := httpcli.ExternalDoer.Do(req)
 	if err != nil {

--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,6 +121,9 @@ func (c *openaiEmbeddingsClient) getEmbeddings(ctx context.Context, texts []stri
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	if len(texts) > 1 {
+		req.Header.Set("X-Cody-Embed-Batch-Size", strconv.Itoa(len(texts)))
+	}
 
 	resp, err := httpcli.ExternalDoer.Do(req)
 	if err != nil {

--- a/enterprise/internal/embeddings/embed/client/sourcegraph/client.go
+++ b/enterprise/internal/embeddings/embed/client/sourcegraph/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-
 	"io"
 	"math"
 	"net/http"

--- a/enterprise/internal/embeddings/embed/client/sourcegraph/client.go
+++ b/enterprise/internal/embeddings/embed/client/sourcegraph/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+
 	"io"
 	"math"
 	"net/http"
@@ -137,7 +138,9 @@ func (c *sourcegraphEmbeddingsClient) getEmbeddings(ctx context.Context, texts [
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.accessToken)
-
+	if len(texts) > 1 {
+		req.Header.Set("X-Cody-Embed-Batch-Size", strconv.Itoa(len(texts)))
+	}
 	resp, err := httpcli.ExternalDoer.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For [go/embeddings-generation-api](https://go/embeddings-generation-api), we'd like to be able to distinguish between batch and interactive requests - this PR adds the logic to set a `X-Cody-Embed-Batch-Size` HTTP header when embedding more than a single input.
## Test plan

- tested locally with embeddings API running
- verified with outbound request log
