### PR TITLE
ci: disable flaky Percy snapshot

### DIFF
--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -123,7 +123,8 @@ describe('CodeMirror blob view', () => {
             )
             await waitForView()
             await driver.page.waitForSelector('.test-breadcrumb')
-            await percySnapshot(driver.page, 'truncates long file paths properly')
+            // TODO: this screenshot is flaky in Percy. Re-enable when we have a fix.
+            // await percySnapshot(driver.page, 'truncates long file paths properly')
         })
     })
 


### PR DESCRIPTION
## Context

Disabling the flaky Percy snapshot. Based on [the Slack conversation](https://sourcegraph.slack.com/archives/C01C3NCGD40/p1686604026660069).

## Test plan

CI
