### PR TITLE
executor/apiclient: make output of job ID parsing deterministic

### DIFF
--- a/enterprise/cmd/executor/internal/apiclient/queue/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -298,6 +299,9 @@ func ParseJobIDs(jobIDs []string) ([]types.QueueJobIDs, error) {
 	for q, ids := range queueIds {
 		queueJobIDs = append(queueJobIDs, types.QueueJobIDs{QueueName: q, JobIDs: ids})
 	}
+	sort.Slice(queueJobIDs, func(i, j int) bool {
+		return queueJobIDs[i].QueueName < queueJobIDs[j].QueueName
+	})
 	return queueJobIDs, nil
 }
 

--- a/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/queue/client_test.go
@@ -542,12 +542,12 @@ func Test_parseJobIDs(t *testing.T) {
 			jobIDs: []string{"1-foo", "2-foo", "3-bar", "44-foo"},
 			expected: []types.QueueJobIDs{
 				{
-					QueueName: "foo",
-					JobIDs:    []string{"1", "2", "44"},
-				},
-				{
 					QueueName: "bar",
 					JobIDs:    []string{"3"},
+				},
+				{
+					QueueName: "foo",
+					JobIDs:    []string{"1", "2", "44"},
 				},
 			},
 		},


### PR DESCRIPTION
This was causing some tests to be flaky as the list of queue/job ID pairs would sometimes flip.

## Test plan
Ran the affected test suite 500 times:

```shell
$ bazel test --cache_test_results=no //enterprise/cmd/executor/internal/apiclient/queue:queue_test --runs_per_test=500 
INFO: Analyzed target //enterprise/cmd/executor/internal/apiclient/queue:queue_test (0 packages loaded, 2 targets configured).
INFO: Found 1 test target...
Target //enterprise/cmd/executor/internal/apiclient/queue:queue_test up-to-date:
  bazel-bin/enterprise/cmd/executor/internal/apiclient/queue/queue_test_/queue_test
INFO: Elapsed time: 14.700s, Critical Path: 0.39s
INFO: 501 processes: 1 internal, 500 darwin-sandbox.
//enterprise/cmd/executor/internal/apiclient/queue:queue_test            PASSED in 0.4s
  Stats over 500 runs: max = 0.4s, min = 0.2s, avg = 0.3s, dev = 0.0s

Executed 1 out of 1 test: 1 test passes.
INFO: Build completed successfully, 501 total actions
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
