### PR TITLE
docs: Fix wrong color in table

### DIFF
--- a/doc/code_navigation/references/indexers.md
+++ b/doc/code_navigation/references/indexers.md
@@ -62,7 +62,7 @@ This table is maintained as an authoritative resource for users, Sales, and Cust
         <td class="indexer-implemented-y">✓</td> <!-- Go to definition -->
         <td class="indexer-implemented-y">✓</td> <!-- Find references -->
         <td class="indexer-implemented-y">✓</td> <!-- Cross-file -->
-        <td class="indexer-implemented-n">✓</td> <!-- Cross-repository -->
+        <td class="indexer-implemented-y">✓</td> <!-- Cross-repository -->
         <td class="indexer-implemented-n">✗</td> <!-- Find implementations -->
         <td><a href="https://github.com/sourcegraph/scip-clang#supported-platforms">See notes</a></td> <!-- Build tooling -->
       </tr>


### PR DESCRIPTION
Checkmark should have a `y`, not `n`

## Test plan

n/a