### PR TITLE
app: disable fuzzy finder

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -81,8 +81,8 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     const [wasAppSetupFinished] = useLocalStorage('app.setup.finished', false)
 
     const { fuzzyFinder } = useExperimentalFeatures(features => ({
-        // enable fuzzy finder by default unless it's explicitly disabled in settings
-        fuzzyFinder: features.fuzzyFinder ?? true,
+        // enable fuzzy finder by default unless it's explicitly disabled in settings, or it's the Cody app
+        fuzzyFinder: features.fuzzyFinder ?? !props.isSourcegraphApp,
     }))
     const isSetupWizardPage = location.pathname.startsWith(PageRoutes.SetupWizard)
 


### PR DESCRIPTION
Cmd+P to open the fuzzy finder was still working in App. This disables it.

## Test plan

Cmd+P should not open the fuzzy finder in App.