### PR TITLE
add ./monitoring and ./enterprise/dev/ci/images to scip-go GH actions

### DIFF
--- a/.github/workflows/scip-go.yml
+++ b/.github/workflows/scip-go.yml
@@ -16,6 +16,8 @@ jobs:
         root:
           - ''
           - lib
+          - monitoring
+          - enterprise/dev/ci/images
     steps:
       # Setup
       - name: Checkout


### PR DESCRIPTION
These two appear to get more traffic than other uncovered go modules in this repo

## Test plan

N/A, scip-go GH action
