### PR TITLE
percy: disable flaky code mirror blob view test

### DIFF
--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -117,7 +117,8 @@ describe('CodeMirror blob view', () => {
             )
         })
 
-        it('truncates long file paths properly', async () => {
+        // TODO 53389: This test is disabled because it is flaky.
+        it.skip('truncates long file paths properly', async () => {
             await driver.page.goto(
                 `${driver.sourcegraphBaseUrl}${filePaths['this_is_a_long_file_path/apps/rest-showcase/src/main/java/org/demo/rest/example/OrdersController.java']}`
             )


### PR DESCRIPTION
This test has been flaky for a while. I filed https://github.com/sourcegraph/sourcegraph/issues/53389 to re-enable it.


## Test plan

Percy tests should pass.