### PR TITLE
Revert "Completions: Rename config option (#53240)"

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -8,7 +8,7 @@ export interface Configuration {
     debugVerbose: boolean
     useContext: ConfigurationUseContext
     customHeaders: Record<string, string>
-    completions: boolean
+    experimentalSuggest: boolean
     experimentalChatPredictions: boolean
     experimentalInline: boolean
     experimentalGuardrails: boolean

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -21,7 +21,6 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Changed
 
 - Save the current ongoing conversation to the chat history [pull/52904](https://github.com/sourcegraph/sourcegraph/pull/52904)
-- Cody completions: Changed the feature flag from `cody.experimental.suggestions` to `cody.completions`. [pull/53240](https://github.com/sourcegraph/sourcegraph/pull/53240)
 - Inline Assist: Updating configuration no longer requires reloading the extension. [pull/53348](https://github.com/sourcegraph/sourcegraph/pull/53348)
 
 ## [0.2.2]

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -528,7 +528,7 @@
         },
         {
           "command": "cody.manual-completions",
-          "when": "config.cody.completions"
+          "when": "config.cody.experimental.suggestions"
         },
         {
           "command": "cody.guardrails.debug",
@@ -743,10 +743,6 @@
           ]
         },
         "cody.experimental.suggestions": {
-          "markdownDeprecationMessage": "This setting was renamed to `cody.completions`.",
-          "default": false
-        },
-        "cody.completions": {
           "order": 5,
           "type": "boolean",
           "markdownDescription": "Enables experimental Cody completions in your editor.",

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -11,7 +11,7 @@ describe('getConfiguration', () => {
             serverEndpoint: '',
             codebase: '',
             useContext: 'embeddings',
-            completions: false,
+            experimentalSuggest: false,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             experimentalInline: false,
@@ -38,7 +38,6 @@ describe('getConfiguration', () => {
                             'Cache-Control': 'no-cache',
                             'Proxy-Authenticate': 'Basic',
                         }
-                    case 'cody.completions':
                     case 'cody.experimental.suggestions':
                         return true
                     case 'cody.experimental.chatPredictions':
@@ -68,7 +67,7 @@ describe('getConfiguration', () => {
                 'Cache-Control': 'no-cache',
                 'Proxy-Authenticate': 'Basic',
             },
-            completions: true,
+            experimentalSuggest: true,
             experimentalChatPredictions: true,
             experimentalGuardrails: true,
             experimentalInline: true,

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -29,9 +29,6 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         debugRegex = new RegExp('.*')
     }
 
-    const completions = config.get('cody.completions', isTesting)
-    const deprecatedExperimentalSuggestions = config.get('cody.experimental.suggestions', isTesting)
-
     return {
         serverEndpoint: sanitizeServerEndpoint(config.get('cody.serverEndpoint', '')),
         codebase: sanitizeCodebase(config.get('cody.codebase')),
@@ -40,7 +37,7 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         debugEnable: config.get<boolean>('cody.debug.enable', false),
         debugVerbose: config.get<boolean>('cody.debug.verbose', false),
         debugFilter: debugRegex,
-        completions: completions || deprecatedExperimentalSuggestions,
+        experimentalSuggest: config.get('cody.experimental.suggestions', isTesting),
         experimentalChatPredictions: config.get('cody.experimental.chatPredictions', isTesting),
         experimentalInline: config.get('cody.experimental.inline', isTesting),
         experimentalGuardrails: config.get('cody.experimental.guardrails', isTesting),

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -204,10 +204,10 @@ const register = async (
             })
         }),
         vscode.commands.registerCommand('cody.walkthrough.enableCodeCompletions', async () => {
-            await workspaceConfig.update('cody.completions', true, vscode.ConfigurationTarget.Global)
+            await workspaceConfig.update('cody.experimental.suggestions', true, vscode.ConfigurationTarget.Global)
             // Open VSCode setting view. Provides visual confirmation that the setting is enabled.
             return vscode.commands.executeCommand('workbench.action.openSettings', {
-                query: 'cody.completions',
+                query: 'cody.experimental.suggestions',
                 openToSide: true,
             })
         }),
@@ -258,7 +258,7 @@ const register = async (
         })
     )
 
-    if (initialConfig.completions) {
+    if (initialConfig.experimentalSuggest) {
         // TODO(sqs): make this listen to config and not just use initialConfig
         const docprovider = new CompletionsDocumentProvider()
         disposables.push(vscode.workspace.registerTextDocumentContentProvider('cody', docprovider))


### PR DESCRIPTION
This reverts commit d007c1c.

Two reasons:

- We found some bugs with the migration in https://github.com/sourcegraph/sourcegraph/pull/53307
- We want to make a bug fix release now and aren't settled on the name 100% yet (so I want to reduce churn)

## Test plan

- 👀 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
