### PR TITLE
storybook: fix typescript errors

### DIFF
--- a/client/web/src/enterprise/executors/instances/ExecutorsListPage.story.tsx
+++ b/client/web/src/enterprise/executors/instances/ExecutorsListPage.story.tsx
@@ -37,6 +37,7 @@ const listExecutorsQuery: () => Observable<ExecutorConnectionFields> = () =>
                 os: 'linux',
                 queueName: 'batches',
                 srcCliVersion: '4.1.0',
+                queueNames: [],
             },
             {
                 __typename: 'Executor',
@@ -54,6 +55,7 @@ const listExecutorsQuery: () => Observable<ExecutorConnectionFields> = () =>
                 os: 'linux',
                 queueName: 'batches',
                 srcCliVersion: '4.1.0',
+                queueNames: [],
             },
         ],
     })

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.story.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.story.tsx
@@ -11,6 +11,9 @@ import { FileOwnershipPanel } from './FileOwnershipPanel'
 import { FETCH_OWNERS } from './grapqlQueries'
 
 const response: FetchOwnershipResult = {
+    currentUser: {
+        permissions: { nodes: [] },
+    },
     node: {
         __typename: 'Repository',
         commit: {
@@ -48,6 +51,7 @@ const response: FetchOwnershipResult = {
                                 avatarURL: 'https://avatars.githubusercontent.com/u/5090588?v=4',
                                 displayName: 'Bob the Builder',
                                 user: {
+                                    id: 'user1',
                                     __typename: 'User',
                                     displayName: 'Bob the Builder',
                                     url: '/users/bob',

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -14,10 +14,14 @@ const barData: FetchOwnersAndHistoryResult = {
         sourceType: RepositoryType.GIT_REPOSITORY,
         commit: {
             blob: {
+                contributors: {
+                    totalCount: 0,
+                },
                 ownership: {
                     nodes: [
                         {
                             owner: {
+                                id: 'user1',
                                 avatarURL: null,
                                 teamDisplayName: 'Xclaesse',
                                 url: '/teams/xclaesse',
@@ -33,6 +37,7 @@ const barData: FetchOwnersAndHistoryResult = {
                                 avatarURL: 'https://avatars.githubusercontent.com/u/5090588?v=4',
                                 displayName: 'pwithnall',
                                 user: {
+                                    id: 'user2',
                                     displayName: 'Philip Withnall',
                                     url: '/users/pwithnall',
                                     username: 'pwithnall',

--- a/client/web/src/site-admin/SiteAdminSidebar.story.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.story.tsx
@@ -25,6 +25,7 @@ export const AdminSidebarItems: Story = () => (
                 batchChangesEnabled={false}
                 batchChangesExecutionEnabled={false}
                 batchChangesWebhookLogsEnabled={false}
+                ownAnalyticsEnabled={false}
             />
         )}
     </WebStory>


### PR DESCRIPTION
Storybook tests aren't being type-checked yet in our new Bazel CI. This PR fixes some issues with typings that have not been caught.

## Test plan

No type errors on storybook files when running `pnpn run build-ts`