### PR TITLE
cody-gateway: improve shutdown handling, fix rate limit trace attribute

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
 go_test(
     name = "actor_test",
     srcs = [
+        "actor_test.go",
         "limits_test.go",
         "source_test.go",
     ],

--- a/enterprise/cmd/cody-gateway/internal/actor/actor.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/actor.go
@@ -2,10 +2,12 @@ package actor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/notify"
@@ -89,6 +91,29 @@ func (a *Actor) Update(ctx context.Context) {
 	if su, ok := a.Source.(SourceUpdater); ok && su != nil {
 		su.Update(ctx, a)
 	}
+}
+
+func (a *Actor) TraceAttributes() []attribute.KeyValue {
+	if a == nil {
+		return []attribute.KeyValue{attribute.String("actor", "<nil>")}
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String("actor.id", a.ID),
+		attribute.Bool("actor.accessEnabled", a.AccessEnabled),
+	}
+	if a.LastUpdated != nil {
+		attrs = append(attrs, attribute.String("actor.lastUpdated", a.LastUpdated.String()))
+	}
+	for f, rl := range a.RateLimits {
+		key := fmt.Sprintf("actor.rateLimits.%s", f)
+		if rlJSON, err := json.Marshal(rl); err != nil {
+			attrs = append(attrs, attribute.String(key, err.Error()))
+		} else {
+			attrs = append(attrs, attribute.String(key, string(rlJSON)))
+		}
+	}
+	return attrs
 }
 
 // WithActor returns a new context with the given Actor instance.

--- a/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/actor_test.go
@@ -1,0 +1,61 @@
+package actor
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codygateway"
+)
+
+func TestActor_TraceAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		actor    *Actor
+		wantAttr autogold.Value
+	}{
+		{
+			name:     "nil actor",
+			actor:    nil,
+			wantAttr: autogold.Expect(`[{"Key":"actor","Value":{"Type":"STRING","Value":"\u003cnil\u003e"}}]`),
+		},
+		{
+			name: "with ID and access enabled",
+			actor: &Actor{
+				ID:            "abc123",
+				AccessEnabled: true,
+			},
+			wantAttr: autogold.Expect(`[{"Key":"actor.id","Value":{"Type":"STRING","Value":"abc123"}},{"Key":"actor.accessEnabled","Value":{"Type":"BOOL","Value":true}}]`),
+		},
+		{
+			name: "with rate limits",
+			actor: &Actor{
+				ID: "abc123",
+				RateLimits: map[codygateway.Feature]RateLimit{
+					codygateway.FeatureCodeCompletions: {
+						Limit: 50,
+					},
+					codygateway.FeatureEmbeddings: {
+						Limit: 50,
+					},
+				},
+			},
+			wantAttr: autogold.Expect(`[{"Key":"actor.rateLimits.embeddings","Value":{"Type":"STRING","Value":"{\"allowedModels\":null,\"limit\":50,\"interval\":0,\"concurrentRequests\":0,\"concurrentRequestsInterval\":0}"}},{"Key":"actor.rateLimits.code_completions","Value":{"Type":"STRING","Value":"{\"allowedModels\":null,\"limit\":50,\"interval\":0,\"concurrentRequests\":0,\"concurrentRequestsInterval\":0}"}},{"Key":"actor.id","Value":{"Type":"STRING","Value":"abc123"}},{"Key":"actor.accessEnabled","Value":{"Type":"BOOL","Value":false}}]`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAttr := tt.actor.TraceAttributes()
+			sort.Slice(gotAttr, func(i, j int) bool {
+				return string(gotAttr[i].Key) > string(gotAttr[j].Key)
+			})
+			// Just a sanity check, keep in one line for test stability
+			b, err := json.Marshal(gotAttr)
+			require.NoError(t, err)
+			tt.wantAttr.Equal(t, string(b))
+		})
+	}
+}

--- a/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -140,6 +140,12 @@ func (s *Source) Sync(ctx context.Context) (seen int, errs error) {
 
 	for _, sub := range resp.Dotcom.ProductSubscriptions.Nodes {
 		for _, token := range sub.SourcegraphAccessTokens {
+			select {
+			case <-ctx.Done():
+				return seen, ctx.Err()
+			default:
+			}
+
 			act := newActor(s, token, sub.ProductSubscriptionState, s.internalMode, s.concurrencyConfig)
 			data, err := json.Marshal(act)
 			if err != nil {


### PR DESCRIPTION
Traces indicate that for whatever reason multiple revisions can linger around for a while attempting to do worker work - this change adds more aggressive shutdown deadlines in various places that may hold up shutdown, and also adds more logging around shutdown of various components.

Also added a fix for the rate limit trace attribute which seems to get cut off due to character limits.

Related: https://github.com/sourcegraph/sourcegraph/issues/53398

## Test plan

n/a no real functional changes
