### PR TITLE
cody: fix callback route for dotcom

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- `Continue with Sourcegraph.com` callback URL. []()
+
 ### Changed
 
 ## [0.2.3]

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -32,7 +32,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 }) => {
     const [token, setToken] = useState<string>('')
     const [endpoint, setEndpoint] = useState(serverEndpoint)
-    const authUri = new URL('https://sourcegraph/user/settings/tokens/new/callback')
+    const authUri = new URL('https://sourcegraph.com/user/settings/tokens/new/callback')
     authUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
 
     const onSubmit = useCallback<React.FormEventHandler>(


### PR DESCRIPTION
Update the callback route with the correct URL.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

cd client/cody && pnpm test:unit 