### PR TITLE
Search: solidify Zoekt options for keyword search

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -164,7 +164,7 @@ func zoektSearchIgnorePaths(ctx context.Context, logger log.Logger, client zoekt
 
 	opts := (&search.ZoektParameters{
 		FileMatchLimit: int32(p.Limit),
-	}).ToSearchOptions(ctx, logger)
+	}).ToSearchOptions(ctx)
 	if deadline, ok := ctx.Deadline(); ok {
 		opts.MaxWallTime = time.Until(deadline) - 100*time.Millisecond
 	}

--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -127,7 +127,7 @@ func (s *Service) hybrid(ctx context.Context, rootLogger log.Logger, p *protocol
 
 		logger.Debug("starting zoekt search")
 
-		retryReason, err := zoektSearchIgnorePaths(ctx, logger, client, p, sender, indexed, indexedIgnore)
+		retryReason, err := zoektSearchIgnorePaths(ctx, client, p, sender, indexed, indexedIgnore)
 		if err != nil {
 			recordHybridFinalState("zoekt-search-error")
 			return nil, false, err
@@ -151,7 +151,7 @@ func (s *Service) hybrid(ctx context.Context, rootLogger log.Logger, p *protocol
 //
 // If we did not search the correct commit or we don't know if we did, a
 // non-empty retryReason is returned.
-func zoektSearchIgnorePaths(ctx context.Context, logger log.Logger, client zoekt.Streamer, p *protocol.Request, sender matchSender, indexed api.CommitID, ignoredPaths []string) (retryReason string, err error) {
+func zoektSearchIgnorePaths(ctx context.Context, client zoekt.Streamer, p *protocol.Request, sender matchSender, indexed api.CommitID, ignoredPaths []string) (retryReason string, err error) {
 	qText, err := zoektCompile(&p.PatternInfo)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to compile query for zoekt")

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -203,7 +203,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	if p.IsStructuralPat && p.Indexed {
 		// Execute the new structural search path that directly calls Zoekt.
 		// TODO use limit in indexed structural search
-		return structuralSearchWithZoekt(ctx, s.Log, s.Indexed, p, sender)
+		return structuralSearchWithZoekt(ctx, s.Indexed, p, sender)
 	}
 
 	// Compile pattern before fetching from store incase it is bad.

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/conc/pool"
-	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 	"go.opentelemetry.io/otel/attribute"
@@ -293,7 +292,7 @@ func lookupMatcher(language string) string {
 	return ".generic"
 }
 
-func structuralSearchWithZoekt(ctx context.Context, logger log.Logger, indexed zoekt.Streamer, p *protocol.Request, sender matchSender) (err error) {
+func structuralSearchWithZoekt(ctx context.Context, indexed zoekt.Streamer, p *protocol.Request, sender matchSender) (err error) {
 	patternInfo := &search.TextPatternInfo{
 		Pattern:                      p.Pattern,
 		IsNegated:                    p.IsNegated,

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -315,7 +315,7 @@ func structuralSearchWithZoekt(ctx context.Context, logger log.Logger, indexed z
 		p.Branch = "HEAD"
 	}
 	branchRepos := []zoektquery.BranchRepos{{Branch: p.Branch, Repos: roaring.BitmapOf(uint32(p.RepoID))}}
-	err = zoektSearch(ctx, logger, indexed, patternInfo, branchRepos, time.Since, p.Repo, sender)
+	err = zoektSearch(ctx, indexed, patternInfo, branchRepos, time.Since, p.Repo, sender)
 	if err != nil {
 		return err
 	}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/conc/pool"
-	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 
@@ -70,7 +69,7 @@ func buildQuery(args *search.TextPatternInfo, branchRepos []zoektquery.BranchRep
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, logger log.Logger, client zoekt.Streamer, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, repo api.RepoName, sender matchSender) (err error) {
+func zoektSearch(ctx context.Context, client zoekt.Streamer, args *search.TextPatternInfo, branchRepos []zoektquery.BranchRepos, since func(t time.Time) time.Duration, repo api.RepoName, sender matchSender) (err error) {
 	if len(branchRepos) == 0 {
 		return nil
 	}

--- a/cmd/searcher/internal/search/zoekt_search.go
+++ b/cmd/searcher/internal/search/zoekt_search.go
@@ -77,7 +77,7 @@ func zoektSearch(ctx context.Context, logger log.Logger, client zoekt.Streamer, 
 
 	searchOpts := (&search.ZoektParameters{
 		FileMatchLimit: args.FileMatchLimit,
-	}).ToSearchOptions(ctx, logger)
+	}).ToSearchOptions(ctx)
 	searchOpts.Whole = true
 
 	filePathPatterns, err := handleFilePathPatterns(args)

--- a/cmd/searcher/internal/search/zoekt_search_test.go
+++ b/cmd/searcher/internal/search/zoekt_search_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
-	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/stretchr/testify/require"
@@ -28,7 +27,6 @@ func (mc *mockClient) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.S
 
 func Test_zoektSearch(t *testing.T) {
 	ctx := context.Background()
-	logger := logtest.Scoped(t)
 
 	// Create a mock client that will send a few files worth of matches
 	client := &mockClient{
@@ -52,7 +50,6 @@ func Test_zoektSearch(t *testing.T) {
 	// indefinitely because the reader returns early.
 	err := zoektSearch(
 		ctx,
-		logger,
 		client,
 		&search.TextPatternInfo{},
 		[]query.BranchRepos{{Branch: "test", Repos: roaring.BitmapOf(1, 2, 3)}},

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -436,12 +436,18 @@ func SearchDocumentRanksWeight() float64 {
 
 // SearchFlushWallTime controls the amount of time that Zoekt shards collect and rank results. For
 // larger codebases, it can be helpful to increase this to improve the ranking stability and quality.
-func SearchFlushWallTime() time.Duration {
+func SearchFlushWallTime(keywordScoring bool) time.Duration {
 	ranking := ExperimentalFeatures().Ranking
 	if ranking != nil && ranking.FlushWallTimeMS > 0 {
 		return time.Duration(ranking.FlushWallTimeMS) * time.Millisecond
 	} else {
-		return 500 * time.Millisecond
+		if keywordScoring {
+			// Keyword scoring takes longer than standard searches, so use a higher FlushWallTime
+			// to help ensure ranking is stable
+			return 2 * time.Second
+		} else {
+			return 500 * time.Millisecond
+		}
 	}
 }
 

--- a/internal/search/BUILD.bazel
+++ b/internal/search/BUILD.bazel
@@ -57,7 +57,6 @@ go_test(
         "//schema",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
-        "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/search/keyword/query_transformer.go
+++ b/internal/search/keyword/query_transformer.go
@@ -32,8 +32,6 @@ func nodeToPatternsAndParameters(rootNode query.Node) ([]string, []query.Paramet
 
 	patterns := []string{}
 	parameters := []query.Parameter{
-		// Force search backend to return all results
-		{Field: query.FieldCount, Value: "all"},
 		// Only search file content
 		{Field: query.FieldType, Value: "file"},
 	}
@@ -50,7 +48,7 @@ func nodeToPatternsAndParameters(rootNode query.Node) ([]string, []query.Paramet
 				if op.Field == query.FieldContent {
 					// Split any content field on white space into a set of patterns
 					patterns = append(patterns, strings.Fields(op.Value)...)
-				} else if op.Field != query.FieldCount && op.Field != query.FieldCase && op.Field != query.FieldType {
+				} else if op.Field != query.FieldCase && op.Field != query.FieldType {
 					parameters = append(parameters, op)
 				}
 			case query.Pattern:

--- a/internal/search/keyword/query_transformer_test.go
+++ b/internal/search/keyword/query_transformer_test.go
@@ -48,27 +48,27 @@ func TestQueryStringToKeywordQuery(t *testing.T) {
 	}{
 		{
 			query:        "context:global abc",
-			wantQuery:    autogold.Expect("count:99999999 type:file context:global abc"),
+			wantQuery:    autogold.Expect("type:file context:global abc"),
 			wantPatterns: autogold.Expect([]string{"abc"}),
 		},
 		{
 			query:        "abc def",
-			wantQuery:    autogold.Expect("count:99999999 type:file (abc OR def)"),
+			wantQuery:    autogold.Expect("type:file (abc OR def)"),
 			wantPatterns: autogold.Expect([]string{"abc", "def"}),
 		},
 		{
 			query:        "context:global lang:Go how to unzip file",
-			wantQuery:    autogold.Expect("count:99999999 type:file context:global lang:Go (unzip OR file)"),
+			wantQuery:    autogold.Expect("type:file context:global lang:Go (unzip OR file)"),
 			wantPatterns: autogold.Expect([]string{"unzip", "file"}),
 		},
 		{
 			query:        "K MEANS CLUSTERING in python",
-			wantQuery:    autogold.Expect("count:99999999 type:file (cluster OR python)"),
+			wantQuery:    autogold.Expect("type:file (cluster OR python)"),
 			wantPatterns: autogold.Expect([]string{"cluster", "python"}),
 		},
 		{
 			query:     `outer content:"inner {with} (special) ^characters$ and keywords like file or repo"`,
-			wantQuery: autogold.Expect("count:99999999 type:file (special OR ^characters$ OR keyword OR file OR repo OR outer)"),
+			wantQuery: autogold.Expect("type:file (special OR ^characters$ OR keyword OR file OR repo OR outer)"),
 			wantPatterns: autogold.Expect([]string{
 				"special", "^characters$", "keyword", "file",
 				"repo",

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 	"go.opentelemetry.io/otel/attribute"
@@ -185,7 +184,7 @@ type ZoektParameters struct {
 }
 
 // ToSearchOptions converts the parameters to options for the Zoekt search API.
-func (o *ZoektParameters) ToSearchOptions(ctx context.Context, logger log.Logger) *zoekt.SearchOptions {
+func (o *ZoektParameters) ToSearchOptions(ctx context.Context) *zoekt.SearchOptions {
 	defaultTimeout := 20 * time.Second
 	searchOpts := &zoekt.SearchOptions{
 		Trace:             policy.ShouldTrace(ctx),

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -197,6 +197,12 @@ func (o *ZoektParameters) ToSearchOptions(ctx context.Context) *zoekt.SearchOpti
 	// replica respectively.
 	searchOpts.ShardMaxMatchCount = 10_000
 	searchOpts.TotalMaxMatchCount = 100_000
+	if o.KeywordScoring {
+		// Keyword searches tends to match much more broadly than code searches, so we need to
+		// consider more candidates to ensure we don't miss highly-ranked documents
+		searchOpts.ShardMaxMatchCount *= 10
+		searchOpts.TotalMaxMatchCount *= 10
+	}
 
 	// Tell each zoekt replica to not send back more than limit results.
 	limit := int(o.FileMatchLimit)
@@ -224,7 +230,7 @@ func (o *ZoektParameters) ToSearchOptions(ctx context.Context) *zoekt.SearchOpti
 	if o.Features.Ranking {
 		// This enables our stream based ranking, where we wait a certain amount
 		// of time to collect results before ranking.
-		searchOpts.FlushWallTime = conf.SearchFlushWallTime()
+		searchOpts.FlushWallTime = conf.SearchFlushWallTime(o.KeywordScoring)
 
 		// This enables the use of document ranks in scoring, if they are available.
 		searchOpts.UseDocumentRanks = true

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -190,7 +189,7 @@ func TestZoektParameters(t *testing.T) {
 				}()
 			}
 
-			got := tt.params.ToSearchOptions(tt.context, logtest.Scoped(t))
+			got := tt.params.ToSearchOptions(tt.context)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Fatalf("search params mismatch (-want +got):\n%s", diff)
 			}

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -165,15 +165,21 @@ func TestZoektParameters(t *testing.T) {
 			context: context.Background(),
 			params: &ZoektParameters{
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
+				Features: Features{
+					Ranking: true,
+				},
 				KeywordScoring: true,
 			},
 			want: &zoekt.SearchOptions{
-				ShardMaxMatchCount: 10000,
-				TotalMaxMatchCount: 100000,
-				MaxWallTime:        20000000000,
-				MaxDocDisplayCount: 500,
-				ChunkMatches:       true,
-				UseKeywordScoring:  true},
+				ShardMaxMatchCount:  100000,
+				TotalMaxMatchCount:  1000000,
+				MaxWallTime:         20000000000,
+				FlushWallTime:       2000000000, // for keyword search, default is 2 sec
+				MaxDocDisplayCount:  500,
+				ChunkMatches:        true,
+				UseDocumentRanks:    true,
+				DocumentRanksWeight: 4500,
+				UseKeywordScoring:   true},
 		},
 	}
 	for _, tt := range cases {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -272,8 +272,8 @@ func PartitionRepos(
 	return indexed, unindexed, nil
 }
 
-func DoZoektSearchGlobal(ctx context.Context, logger log.Logger, client zoekt.Streamer, params *search.ZoektParameters, pathRegexps []*regexp.Regexp, c streaming.Sender) error {
-	searchOpts := params.ToSearchOptions(ctx, logger)
+func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, params *search.ZoektParameters, pathRegexps []*regexp.Regexp, c streaming.Sender) error {
+	searchOpts := params.ToSearchOptions(ctx)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
@@ -312,7 +312,7 @@ func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs,
 	brs := repos.BranchRepos()
 
 	finalQuery := zoektquery.NewAnd(&zoektquery.BranchesRepos{List: brs}, q)
-	searchOpts := zoektParams.ToSearchOptions(ctx, logger)
+	searchOpts := zoektParams.ToSearchOptions(ctx)
 
 	// Start event stream.
 	t0 := time.Now()
@@ -720,7 +720,7 @@ func (t *GlobalTextSearchJob) Run(ctx context.Context, clients job.RuntimeClient
 	t.GlobalZoektQuery.ApplyPrivateFilter(userPrivateRepos)
 	t.ZoektParams.Query = t.GlobalZoektQuery.Generate()
 
-	return nil, DoZoektSearchGlobal(ctx, clients.Logger, clients.Zoekt, t.ZoektParams, t.GlobalZoektQueryRegexps, stream)
+	return nil, DoZoektSearchGlobal(ctx, clients.Zoekt, t.ZoektParams, t.GlobalZoektQueryRegexps, stream)
 }
 
 func (*GlobalTextSearchJob) Name() string {

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -304,7 +304,7 @@ func DoZoektSearchGlobal(ctx context.Context, client zoekt.Streamer, params *sea
 }
 
 // zoektSearch searches repositories using zoekt.
-func zoektSearch(ctx context.Context, logger log.Logger, repos *IndexedRepoRevs, q zoektquery.Q, pathRegexps []*regexp.Regexp, typ search.IndexedRequestType, client zoekt.Streamer, zoektParams *search.ZoektParameters, since func(t time.Time) time.Duration, c streaming.Sender) error {
+func zoektSearch(ctx context.Context, repos *IndexedRepoRevs, q zoektquery.Q, pathRegexps []*regexp.Regexp, typ search.IndexedRequestType, client zoekt.Streamer, zoektParams *search.ZoektParameters, since func(t time.Time) time.Duration, c streaming.Sender) error {
 	if len(repos.RepoRevs) == 0 {
 		return nil
 	}
@@ -670,7 +670,7 @@ func (z *RepoSubsetTextSearchJob) Run(ctx context.Context, clients job.RuntimeCl
 		since = z.Since
 	}
 
-	return nil, zoektSearch(ctx, clients.Logger, z.Repos, z.Query, z.ZoektQueryRegexps, z.Typ, clients.Zoekt, z.ZoektParams, since, stream)
+	return nil, zoektSearch(ctx, z.Repos, z.Query, z.ZoektQueryRegexps, z.Typ, clients.Zoekt, z.ZoektParams, since, stream)
 }
 
 func (*RepoSubsetTextSearchJob) Name() string {

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -97,7 +97,7 @@ func (s *GlobalSymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClie
 	s.ZoektParams.Query = s.GlobalZoektQuery.Generate()
 
 	// always search for symbols in indexed repositories when searching the repo universe.
-	err = DoZoektSearchGlobal(ctx, clients.Logger, clients.Zoekt, s.ZoektParams, nil, stream)
+	err = DoZoektSearchGlobal(ctx, clients.Zoekt, s.ZoektParams, nil, stream)
 	if err != nil {
 		tr.SetAttributes(trace.Error(err))
 		// Only record error if we haven't timed out.

--- a/internal/search/zoekt/symbol_search.go
+++ b/internal/search/zoekt/symbol_search.go
@@ -40,7 +40,7 @@ func (z *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = zoektSearch(ctx, clients.Logger, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.ZoektParams, since, stream)
+	err = zoektSearch(ctx, z.Repos, z.Query, nil, search.SymbolRequest, clients.Zoekt, z.ZoektParams, since, stream)
 	if err != nil {
 		tr.SetAttributes(trace.Error(err))
 		// Only record error if we haven't timed out.


### PR DESCRIPTION
This PR fixes two issues with Zoekt options for keyword search uses:
* Before, we always set `count: all`. This was left over from when keyword search used to rerank results. Now all ranking happens in Zoekt, so we use the default `count`. To make sure we still consider enough matches to get a good ranking, we increase `ShardMaxMatchCount` and `TotalMaxMatchCount`.
* Keyword search matches more broadly than many code searches, and therefore takes a bit longer. So we were often hitting Zoekt's `FlushWallTimeMS` limit. This meant cross-repo searches could return poor or non-deterministic results. To address this, we bump the default `FlushWallTimeMS` for keyword search.

## Test plan

Adapted unit test. Manual tests:
* Tested the example searches here before and after to make sure they return the same results: [#52233](https://github.com/sourcegraph/sourcegraph/pull/52233). Checked timing was similar or better.
* Tested several searches spanning the `sg/sourcegraph` and `sg/zoekt` repos. Checked results were ranked as expected, and searches are deterministic.