### PR TITLE
guardrails: use attribution backend

### DIFF
--- a/client/cody-shared/src/guardrails/client.ts
+++ b/client/cody-shared/src/guardrails/client.ts
@@ -4,87 +4,18 @@ import { isError } from '../utils'
 import { Guardrails, Attribution } from '.'
 
 export class SourcegraphGuardrailsClient implements Guardrails {
-    private clients: SourcegraphGraphQLAPIClient[]
-
-    constructor(client: SourcegraphGraphQLAPIClient) {
-        this.clients = [client]
-        // We want to use dotcom since that has a much larger corpus.
-        if (!client.isDotCom()) {
-            // Note: this is an anonymous request. We intend on adding a
-            // guardrails specific API to sourcegraph which will do
-            // authenticated federation to dotcom.
-            this.clients.push(
-                new SourcegraphGraphQLAPIClient({
-                    serverEndpoint: 'https://sourcegraph.com',
-                    accessToken: null,
-                    customHeaders: {},
-                })
-            )
-        }
-    }
+    constructor(private client: SourcegraphGraphQLAPIClient) {}
 
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
-        // TODO(keegancsmith) adjust implementation to respect line count thresholds
-        const query = `type:file select:repo content:${goEscapeString(snippet)}`
-        const results = await Promise.all(this.clients.map(client => client.searchTypeRepo(query)))
+        const result = await this.client.searchAttribution(snippet)
 
-        // aggregate unique repos by name
-        const seen = new Set<string>()
-        const aggregate: Attribution = {
-            limitHit: false,
-            repositories: [],
+        if (isError(result)) {
+            return result
         }
 
-        for (const result of results) {
-            if (isError(result)) {
-                return result
-            }
-            aggregate.limitHit = aggregate.limitHit || result.limitHit
-            for (const repo of result.repositories) {
-                if (seen.has(repo.name)) {
-                    continue
-                }
-                seen.add(repo.name)
-                aggregate.repositories.push(repo)
-            }
-        }
-
-        return aggregate
-    }
-}
-
-function goEscapeString(str: string): string {
-    // TODO(keegancsmith) verify correct, this is blind copy pasta from cody
-    let escaped = ''
-    for (const c of str) {
-        switch (c) {
-            case '\n':
-                escaped += '\\n'
-                break
-            case '\t':
-                escaped += '\\t'
-                break
-            case '\r':
-                escaped += '\\r'
-                break
-            case '\v':
-                escaped += '\\v'
-                break
-            case '\b':
-                escaped += '\\b'
-                break
-            case '\f':
-                escaped += '\\f'
-                break
-            case '\\':
-                escaped += '\\\\'
-                break
-            case '"':
-                escaped += '\\"'
-                break
-            default:
-                escaped += c
+        return {
+            limitHit: result.limitHit,
+            repositories: result.nodes.map(repo => ({ name: repo.repositoryName })),
         }
     }
-    return `"${escaped}"`
 }

--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -10,11 +10,11 @@ import {
     IS_CONTEXT_REQUIRED_QUERY,
     REPOSITORY_ID_QUERY,
     REPOSITORY_IDS_QUERY,
+    SEARCH_ATTRIBUTION_QUERY,
     SEARCH_EMBEDDINGS_QUERY,
     LEGACY_SEARCH_EMBEDDINGS_QUERY,
     LOG_EVENT_MUTATION,
     REPOSITORY_EMBEDDING_EXISTS_QUERY,
-    SEARCH_TYPE_REPO_QUERY,
     CURRENT_USER_ID_AND_VERIFIED_EMAIL_QUERY,
     CURRENT_SITE_VERSION_QUERY,
     CURRENT_SITE_HAS_CODY_ENABLED_QUERY,
@@ -91,12 +91,10 @@ interface GetCodyContextResponse {
     getCodyContext: GetCodyContextResult[]
 }
 
-interface SearchTypeRepoResponse {
-    search: {
-        results: {
-            limitHit: boolean
-            results: { name: string }[]
-        }
+interface SearchAttributionResponse {
+    snippetAttribution: {
+        limitHit: boolean
+        nodes: { repositoryName: string }[]
     }
 }
 
@@ -116,9 +114,9 @@ export interface EmbeddingsSearchResults {
     textResults: EmbeddingsSearchResult[]
 }
 
-export interface SearchTypeRepoResults {
+export interface SearchAttributionResults {
     limitHit: boolean
-    repositories: { name: string }[]
+    nodes: { repositoryName: string }[]
 }
 
 interface IsContextRequiredForChatQueryResponse {
@@ -348,15 +346,10 @@ export class SourcegraphGraphQLAPIClient {
         }).then(response => extractDataOrError(response, data => data.embeddingsSearch))
     }
 
-    public async searchTypeRepo(query: string): Promise<SearchTypeRepoResults | Error> {
-        return this.fetchSourcegraphAPI<APIResponse<SearchTypeRepoResponse>>(SEARCH_TYPE_REPO_QUERY, {
-            query,
-        }).then(response =>
-            extractDataOrError(response, data => ({
-                limitHit: data.search.results.limitHit,
-                repositories: data.search.results.results,
-            }))
-        )
+    public async searchAttribution(snippet: string): Promise<SearchAttributionResults | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<SearchAttributionResponse>>(SEARCH_ATTRIBUTION_QUERY, {
+            snippet,
+        }).then(response => extractDataOrError(response, data => data.snippetAttribution))
     }
 
     public async isContextRequiredForQuery(query: string): Promise<boolean | Error> {

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -123,18 +123,14 @@ query LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int
 	}
 }`
 
-export const SEARCH_TYPE_REPO_QUERY = `
-query SearchTypeRepo($query: String!) {
-	search(query: $query, version: V3) {
-        results {
-            limitHit
-            results {
-                ... on Repository {
-                    name
-                }
-            }
+export const SEARCH_ATTRIBUTION_QUERY = `
+query SnippetAttribution($snippet: String!) {
+    snippetAttribution(snippet: $snippet) {
+        limitHit
+        nodes {
+            repositoryName
         }
-	}
+    }
 }`
 
 export const IS_CONTEXT_REQUIRED_QUERY = `

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -365,7 +365,7 @@
       {
         "command": "cody.guardrails.debug",
         "title": "Cody: Guardrails Debug Attribution",
-        "enablement": "config.cody.debug && config.cody.experimental.guardrails && editorHasSelection"
+        "enablement": "config.cody.experimental.guardrails && editorHasSelection"
       },
       {
         "command": "cody.recipe.file-touch",
@@ -532,7 +532,7 @@
         },
         {
           "command": "cody.guardrails.debug",
-          "when": "false"
+          "when": "config.cody.experimental.guardrails && editorHasSelection"
         },
         {
           "command": "cody.inline.insert",
@@ -612,7 +612,7 @@
         },
         {
           "command": "cody.guardrails.debug",
-          "when": "cody.activated && config.cody.debug && config.cody.experimental.guardrails && editorHasSelection"
+          "when": "config.cody.experimental.guardrails && editorHasSelection"
         }
       ],
       "view/title": [


### PR DESCRIPTION
We switch from directly using the search API to using the newly introduced attribution API. This API will take care of federating to sourcegraph.com and is under the site-admins control.

Note: the guardrails debug commands don't need cody to be activated to work. This fixes them to work again.

Test Plan: run cody with experimental.guardrails turned on. Then select some code and run the guardrails debug command. Observe hits. Then create some unique looking text and run attribution against that. Get no hits.