### PR TITLE
trace: add SRC_ENABLE_NET_TRACE to disable net/trace

### DIFF
--- a/internal/debugserver/BUILD.bazel
+++ b/internal/debugserver/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/goroutine",
         "//internal/grpc/defaults",
         "//internal/httpserver",
+        "//internal/trace",
         "//internal/version",
         "//lib/errors",
         "@com_github_felixge_fgprof//:fgprof",

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -13,11 +13,12 @@ import (
 	"github.com/felixge/fgprof"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/net/trace"
+	nettrace "golang.org/x/net/trace"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
 var addr = env.Get("SRC_PROF_HTTP", ":6060", "net/http/pprof http bind address.")
@@ -89,7 +90,7 @@ func NewServerRoutine(ready <-chan struct{}, extra ...Endpoint) goroutine.Backgr
 	}
 
 	// we're protected by adminOnly on the front of this
-	trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
+	nettrace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
 		return true, true
 	}
 
@@ -126,8 +127,17 @@ func NewServerRoutine(ready <-chan struct{}, extra ...Endpoint) goroutine.Backgr
 		router.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 		router.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 		router.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
-		router.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
-		router.Handle("/debug/events", http.HandlerFunc(trace.Events))
+		if trace.EnableNetTrace {
+			router.Handle("/debug/requests", http.HandlerFunc(nettrace.Traces))
+			router.Handle("/debug/events", http.HandlerFunc(nettrace.Events))
+		} else {
+			netTraceDisabled := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("golang.org/x/net/trace is not available, SRC_ENABLE_NET_TRACE=false"))
+			})
+			router.Handle("/debug/requests", netTraceDisabled)
+			router.Handle("/debug/events", netTraceDisabled)
+		}
 		router.Handle("/metrics", promhttp.Handler())
 
 		// This path acts as a wildcard and should appear after more specific entries.


### PR DESCRIPTION
This change adds `SRC_ENABLE_NET_TRACE`, which if set to `false` will disable `net/trace` support in `internal/trace` and our debug routers. The plan is to just set this to `false` in Sourcegraph.com (https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17937) until we can absolutely confirm that `net/trace` is an issue - it's also possible this is only problematic for Sourcegraph.com levels of traffic. Follow-ups will be in [INC-214](https://sourcegraph.slack.com/archives/C05CGC5UL3E).

Context: today we noticed unreliability in Sourcegraph.com, [INC-214](https://sourcegraph.slack.com/archives/C05CGC5UL3E), where a lot of requests would get no responses. We diagnosed the issue to be a frontend pod that had a huge goroutine leak, causing unreliability in sourcegraph.com for requests routed to the affected pod. Removing the affected pod immediately resolved the stability issues.

<img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/b158305c-8724-463c-b5e5-0c20a3ea9d72">
<img width="500" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/8780f3ca-9f0d-496e-9daf-f7e46d2c969a">

It appears this may be caused by increased usage of `internal/trace`, which [creates a trace with `golang.org/x/net/trace`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f3b0276dfe24018db5f76d5d8d430db98e59f2dd/-/blob/internal/trace/tracer.go?L32-33), which then [acquires a global mutex](https://sourcegraph.com/go/golang.org/x/net/-/blob/trace/trace.go?L369-380). Cloud Profile indicates this trend started ~June 5, which _somewhat_ correlates with a series of changes that removed OpenTracing usages and replaced them with OpenTelemetry/`internal/trace`, the latter of which ends up in this code path.

<img width="979" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/304c6de7-6d0c-4a29-936f-b56405f8cae8">
<img width="1001" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/48a281db-df81-4e3e-8455-90844ee008a4">

See incident discussion thread for more details: https://sourcegraph.slack.com/archives/C05CGC5UL3E/p1686712614273539?thread_ts=1686710733.750869&cid=C05CGC5UL3E

## Test plan

`sg start`, code review, CI