### PR TITLE
cody: add `typescriptreact` languageID

### DIFF
--- a/client/cody/src/completions/multiline.ts
+++ b/client/cody/src/completions/multiline.ts
@@ -119,6 +119,7 @@ interface LanguageConfig {
 function getLanguageConfig(languageId: string): LanguageConfig | null {
     switch (languageId) {
         case 'typescript':
+        case 'typescriptreact':
         case 'javascript':
         case 'go':
             return {

--- a/client/cody/src/completions/multiline.ts
+++ b/client/cody/src/completions/multiline.ts
@@ -121,6 +121,7 @@ function getLanguageConfig(languageId: string): LanguageConfig | null {
         case 'typescript':
         case 'typescriptreact':
         case 'javascript':
+        case 'javascriptreact':
         case 'go':
             return {
                 blockStart: '{',


### PR DESCRIPTION
## Context

Adding a missing `languageID` value [after digging into this area more](https://github.com/sourcegraph/sourcegraph/pull/53073#discussion_r1224503599). 

## Test plan

CI
