### PR TITLE
Extend Own GraphQL schema with assigned ownership stats

### DIFF
--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -84,6 +84,8 @@ type OwnershipConnectionResolver interface {
 type OwnershipStatsResolver interface {
 	TotalFiles(context.Context) (int32, error)
 	TotalCodeownedFiles(context.Context) (int32, error)
+	TotalOwnedFiles(context.Context) (int32, error)
+	TotalAssignedOwnershipFiles(context.Context) (int32, error)
 }
 
 type Ownable interface {

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -88,9 +88,19 @@ type OwnershipStats {
     totalFiles: Int!
 
     """
-    Total files with ownership assigned by CODEOWNERS.
+    Total files with ownership stemming from CODEOWNERS files.
     """
     totalCodeownedFiles: Int!
+
+    """
+    Total files with any ownership defined (both CODEOWNERS and assigned).
+    """
+    totalOwnedFiles: Int!
+
+    """
+    Total files with assigned ownership.
+    """
+    totalAssignedOwnershipFiles: Int!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -418,6 +418,14 @@ func (r *ownStatsResolver) TotalCodeownedFiles(ctx context.Context) (int32, erro
 	return int32(counts.CodeownedFileCount), nil
 }
 
+func (r *ownStatsResolver) TotalOwnedFiles(context.Context) (int32, error) {
+	return 0, nil
+}
+
+func (r *ownStatsResolver) TotalAssignedOwnershipFiles(context.Context) (int32, error) {
+	return 0, nil
+}
+
 type ownershipConnectionResolver struct {
 	db         edb.EnterpriseDB
 	total      int

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -2182,13 +2182,17 @@ func TestDisplayOwnershipStats(t *testing.T) {
 				instanceOwnershipStats {
 					totalFiles
 					totalCodeownedFiles
+					totalOwnedFiles
+					totalAssignedOwnershipFiles
 				}
 			}`,
 		ExpectedResult: `
 			{
 				"instanceOwnershipStats": {
 					"totalFiles": 350000,
-					"totalCodeownedFiles" : 150000
+					"totalCodeownedFiles" : 150000,
+					"totalOwnedFiles" : 0,
+					"totalAssignedOwnershipFiles" : 0
 				}
 			}`,
 	})


### PR DESCRIPTION
Part of #53438

Extend Own graphQL schema with two stats:

- `totalOwnedFiles` - returning total number of files that are owned for given tree through any means (CODEOWNERS or assigned ownership)
- `totalAssignedOwnershipFiles` - returning total number of files that are owned for given tree through assigned ownership

## Test plan

Extend existing unit tests to check schema compiles and evaluates.
