### PR TITLE
cmd/gitserver/server/perforce: Use log.Duration instead of log.Float64

### DIFF
--- a/cmd/gitserver/server/perforce/perforce.go
+++ b/cmd/gitserver/server/perforce/perforce.go
@@ -146,7 +146,7 @@ func (s *Service) changelistMappingConsumer(ctx context.Context, tasks <-chan *c
 		// NOTE: Hardcoded to log for tasks that run longer than 1 minute. Will revisit this if it
 		// becomes noisy under production loads.
 		if timeTaken > time.Duration(time.Second*60) {
-			s.Logger.Warn("mapping job took long to complete", log.Float64("seconds", timeTaken.Seconds()))
+			s.Logger.Warn("mapping job took long to complete", log.Duration("duration", timeTaken))
 		}
 	}
 }


### PR DESCRIPTION
Follow up to: https://github.com/sourcegraph/sourcegraph/pull/53325#discussion_r1229089328
## Test plan

Logger change only

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
