### PR TITLE
JetBrains: debounce Cody completion triggers & limit completion jobs to 1 at a time

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -28,6 +28,7 @@
   - Smell code
   - Optimize code
 - A separate setting for enabling/disabling Cody completions. [pull/53302](https://github.com/sourcegraph/sourcegraph/pull/53302)
+- Debounce for inline Cody completions [pull/53447](https://github.com/sourcegraph/sourcegraph/pull/53447)
 
 ### Changed
 


### PR DESCRIPTION
This adds a 500ms debounce on inline completions being triggered, which prevents the completion API to be called repeatedly after every caret move in the editor.
Effectively, this speeds up the completions responsiveness by a fair bit (not to mention it prevents hitting the API limit too fast for a user).

## Notes
Please check locally if ~500ms~ 200ms feels fine, we can tweak the debounce time to get the right UX while keeping API calls sane.

## Test plan
- inline completions should trigger with a 500ms delay
  - subsequent code edits & caret moves should only trigger one API call if the interval is <500ms
