### PR TITLE
own: make Team resolver robust when resolving external teams.

### DIFF
--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -416,10 +416,11 @@ func (r *schemaResolver) CreateTeam(ctx context.Context, args *CreateTeamArgs) (
 		}
 	}
 	t.CreatorID = actor.FromContext(ctx).UID
-	if err := teams.CreateTeam(ctx, &t); err != nil {
+	team, err := teams.CreateTeam(ctx, &t)
+	if err != nil {
 		return nil, err
 	}
-	return NewTeamResolver(r.db, &t), nil
+	return NewTeamResolver(r.db, team), nil
 }
 
 type UpdateTeamArgs struct {

--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -166,6 +166,9 @@ func (r *TeamResolver) Name() string {
 }
 
 func (r *TeamResolver) URL() string {
+	if r.External() {
+		return ""
+	}
 	absolutePath := fmt.Sprintf("/teams/%s", r.team.Name)
 	u := &url.URL{Path: absolutePath}
 	return u.String()
@@ -191,7 +194,7 @@ func (r *TeamResolver) DisplayName() *string {
 }
 
 func (r *TeamResolver) Readonly() bool {
-	return r.team.ReadOnly
+	return r.team.ReadOnly || r.External()
 }
 
 func (r *TeamResolver) ParentTeam(ctx context.Context) (*TeamResolver, error) {
@@ -210,6 +213,9 @@ func (r *TeamResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 }
 
 func (r *TeamResolver) Members(_ context.Context, args *ListTeamMembersArgs) (*teamMemberConnection, error) {
+	if r.External() {
+		return nil, errors.New("cannot get members of external team")
+	}
 	c := &teamMemberConnection{
 		db:     r.db,
 		teamID: r.team.ID,
@@ -221,6 +227,9 @@ func (r *TeamResolver) Members(_ context.Context, args *ListTeamMembersArgs) (*t
 }
 
 func (r *TeamResolver) ChildTeams(_ context.Context, args *ListTeamsArgs) (*teamConnectionResolver, error) {
+	if r.External() {
+		return nil, errors.New("cannot get child teams of external team")
+	}
 	c := &teamConnectionResolver{
 		db:       r.db,
 		parentID: r.team.ID,
@@ -998,6 +1007,9 @@ func areTeamEndpointsAvailable(ctx context.Context) error {
 }
 
 func canModifyTeam(ctx context.Context, db database.DB, team *types.Team) (bool, error) {
+	if team.ID == 0 {
+		return false, nil
+	}
 	if isSiteAdmin(ctx, db) {
 		return true, nil
 	}

--- a/cmd/frontend/graphqlbackend/teams_test.go
+++ b/cmd/frontend/graphqlbackend/teams_test.go
@@ -32,7 +32,7 @@ func TestTeamNode(t *testing.T) {
 	userID := fs.AddUser(types.User{Username: "bob", SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
 		t.Fatalf("failed to create fake team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -78,7 +78,7 @@ func TestTeamNodeURL(t *testing.T) {
 	team := &types.Team{
 		Name: "team-刺身", // team-sashimi
 	}
-	if err := fs.TeamStore.CreateTeam(ctx, team); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, team); err != nil {
 		t.Fatalf("failed to create fake team: %s", err)
 	}
 	RunTest(t, &Test{
@@ -107,7 +107,7 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 			fs.Wire(db)
 			ctx := userCtx(fs.AddUser(types.User{SiteAdmin: isAdmin}))
 			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-			if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+			if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 				t.Fatalf("failed to create fake team: %s", err)
 			}
 			team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -145,7 +145,7 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 			userID := fs.AddUser(types.User{SiteAdmin: false})
 			ctx := userCtx(userID)
 			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-			if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+			if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 				t.Fatalf("failed to create fake team: %s", err)
 			}
 			team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -188,7 +188,7 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
 		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
 			t.Fatalf("failed to create fake team: %s", err)
 		}
 		team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -370,7 +370,7 @@ func TestCreateTeamParentByID(t *testing.T) {
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
 		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-		err := fs.TeamStore.CreateTeam(ctx, &types.Team{
+		_, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 			Name: "team-name-parent",
 		})
 		if err != nil {
@@ -411,7 +411,7 @@ func TestCreateTeamParentByID(t *testing.T) {
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
 		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-		err := fs.TeamStore.CreateTeam(ctx, &types.Team{
+		_, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 			Name:     "team-name-parent",
 			ReadOnly: true,
 		})
@@ -451,7 +451,7 @@ func TestCreateTeamParentByName(t *testing.T) {
 	fs := fakedb.New()
 	db := database.NewMockDB()
 	fs.Wire(db)
-	if err := fs.TeamStore.CreateTeam(context.Background(), &types.Team{Name: "team-name-parent"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(context.Background(), &types.Team{Name: "team-name-parent"}); err != nil {
 		t.Fatal(err)
 	}
 	userID := fs.AddUser(types.User{SiteAdmin: false})
@@ -495,7 +495,7 @@ func TestUpdateTeamByID(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
 	}); err != nil {
@@ -545,7 +545,7 @@ func TestUpdateTeamByName(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
 	}); err != nil {
@@ -595,7 +595,7 @@ func TestUpdateTeamErrorBothNameAndID(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
 	}); err != nil {
@@ -638,14 +638,14 @@ func TestUpdateParentByID(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
 	parentTeam, err := fs.TeamStore.GetTeamByName(ctx, "parent")
 	if err != nil {
 		t.Fatalf("failed to fetch fake parent team: %s", err)
 	}
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -686,14 +686,14 @@ func TestUpdateParentByName(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
 	parentTeam, err := fs.TeamStore.GetTeamByName(ctx, "parent")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -734,14 +734,14 @@ func TestUpdateParentErrorBothNameAndID(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
 	parentTeam, err := fs.TeamStore.GetTeamByName(ctx, "parent")
 	if err != nil {
 		t.Fatalf("failed to fetch fake parent team: %s", err)
 	}
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	RunTest(t, &Test{
@@ -839,7 +839,7 @@ func TestDeleteTeamByID(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -878,7 +878,7 @@ func TestDeleteTeamByName(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -917,7 +917,7 @@ func TestDeleteTeamErrorBothIDAndNameGiven(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -1013,7 +1013,7 @@ func TestDeleteTeamUnauthorized(t *testing.T) {
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	t.Run("non-member", func(t *testing.T) {
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
 		}
 		RunTest(t, &Test{
@@ -1039,7 +1039,7 @@ func TestDeleteTeamUnauthorized(t *testing.T) {
 		})
 	})
 	t.Run("readonly", func(t *testing.T) {
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team-readonly", ReadOnly: true}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team-readonly", ReadOnly: true}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
 		}
 		team, err := fs.TeamStore.GetTeamByName(ctx, "team-readonly")
@@ -1080,7 +1080,7 @@ func TestTeamByName(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
 	RunTest(t, &Test{
@@ -1135,7 +1135,7 @@ func TestTeamsPaginated(t *testing.T) {
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for i := 1; i <= 25; i++ {
 		name := fmt.Sprintf("team-%d", i)
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
 		}
 	}
@@ -1201,7 +1201,7 @@ func TestTeamsNameSearch(t *testing.T) {
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for _, name := range []string{"hit-1", "Hit-2", "HIT-3", "miss-4", "mIss-5", "MISS-6"} {
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
 		}
 	}
@@ -1328,7 +1328,7 @@ func TestTeamsCount(t *testing.T) {
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for i := 1; i <= 25; i++ {
 		name := fmt.Sprintf("team-%d", i)
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
 		}
 	}
@@ -1365,7 +1365,7 @@ func TestChildTeams(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
 	parent, err := fs.TeamStore.GetTeamByName(ctx, "parent")
@@ -1374,13 +1374,13 @@ func TestChildTeams(t *testing.T) {
 	}
 	for i := 1; i <= 5; i++ {
 		name := fmt.Sprintf("child-%d", i)
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name, ParentTeamID: parent.ID}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name, ParentTeamID: parent.ID}); err != nil {
 			t.Fatalf("cannot create child team: %s", err)
 		}
 	}
 	for i := 6; i <= 10; i++ {
 		name := fmt.Sprintf("not-child-%d", i)
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
 			t.Fatalf("cannot create a team: %s", err)
 		}
 	}
@@ -1419,14 +1419,14 @@ func TestMembersPaginated(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team-with-members"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team-with-members"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
 	teamWithMembers, err := fs.TeamStore.GetTeamByName(ctx, "team-with-members")
 	if err != nil {
 		t.Fatalf("failed to featch fake team: %s", err)
 	}
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "different-team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "different-team"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
 	differentTeam, err := fs.TeamStore.GetTeamByName(ctx, "different-team")
@@ -1516,7 +1516,7 @@ func TestMembersSearch(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -1577,7 +1577,7 @@ func TestMembersAdd(t *testing.T) {
 		userID := fs.AddUser(types.User{SiteAdmin: true})
 		ctx := userCtx(userID)
 		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create team: %s", err)
 		}
 		team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -1632,7 +1632,7 @@ func TestMembersAdd(t *testing.T) {
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
 		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-		if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create team: %s", err)
 		}
 		RunTest(t, &Test{
@@ -1667,7 +1667,7 @@ func TestMembersRemove(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")
@@ -1727,7 +1727,7 @@ func TestMembersSet(t *testing.T) {
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
-	if err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
+	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
 	team, err := fs.TeamStore.GetTeamByName(ctx, "team")

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -398,7 +398,7 @@ func TestBlobOwnershipPanelQueryTeamResolved(t *testing.T) {
 		}
 		return resolvedRevision, nil
 	}
-	if err := fakeDB.TeamStore.CreateTeam(ctx, team); err != nil {
+	if _, err := fakeDB.TeamStore.CreateTeam(ctx, team); err != nil {
 		t.Fatalf("failed to create fake team: %s", err)
 	}
 	schema, err := graphqlbackend.NewSchema(db, git, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, git, own, logger)})
@@ -2281,9 +2281,7 @@ func TestDisplayOwnershipStats(t *testing.T) {
 
 func createTeam(t *testing.T, ctx context.Context, db database.DB, teamName string) *types.Team {
 	t.Helper()
-	err := db.Teams().CreateTeam(ctx, &types.Team{Name: teamName})
-	require.NoError(t, err)
-	team, err := db.Teams().GetTeamByName(ctx, teamName)
+	team, err := db.Teams().CreateTeam(ctx, &types.Team{Name: teamName})
 	require.NoError(t, err)
 	return team
 }

--- a/enterprise/internal/own/ownref_test.go
+++ b/enterprise/internal/own/ownref_test.go
@@ -308,9 +308,7 @@ func TestBagRetrievesTeamsByName(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := edb.NewEnterpriseDB(database.NewDB(logger, dbtest.NewDB(logger, t)))
 	ctx := context.Background()
-	err := db.Teams().CreateTeam(ctx, &types.Team{Name: "team-name"})
-	require.NoError(t, err)
-	team, err := db.Teams().GetTeamByName(ctx, "team-name")
+	team, err := db.Teams().CreateTeam(ctx, &types.Team{Name: "team-name"})
 	require.NoError(t, err)
 	bag := ByTextReference(ctx, db, "team-name")
 	ref := Reference{TeamID: team.ID}

--- a/enterprise/internal/own/service_test.go
+++ b/enterprise/internal/own/service_test.go
@@ -507,9 +507,7 @@ func TestAssignedTeamsMatch(t *testing.T) {
 
 func createTeam(t *testing.T, ctx context.Context, db database.DB, teamName string) *itypes.Team {
 	t.Helper()
-	err := db.Teams().CreateTeam(ctx, &itypes.Team{Name: teamName})
-	require.NoError(t, err)
-	team, err := db.Teams().GetTeamByName(ctx, teamName)
+	team, err := db.Teams().CreateTeam(ctx, &itypes.Team{Name: teamName})
 	require.NoError(t, err)
 	return team
 }

--- a/internal/database/assigned_teams_test.go
+++ b/internal/database/assigned_teams_test.go
@@ -170,9 +170,7 @@ func TestAssignedTeamsStore_Delete(t *testing.T) {
 
 func createTeam(t *testing.T, ctx context.Context, db DB, teamName string) *types.Team {
 	t.Helper()
-	err := db.Teams().CreateTeam(ctx, &types.Team{Name: teamName})
-	require.NoError(t, err)
-	team, err := db.Teams().GetTeamByName(ctx, teamName)
+	team, err := db.Teams().CreateTeam(ctx, &types.Team{Name: teamName})
 	require.NoError(t, err)
 	return team
 }

--- a/internal/database/fakedb/teams.go
+++ b/internal/database/fakedb/teams.go
@@ -39,10 +39,10 @@ func (fs Fakes) AddTeam(t *types.Team) int32 {
 	return u.ID
 }
 
-func (teams *Teams) CreateTeam(_ context.Context, t *types.Team) error {
+func (teams *Teams) CreateTeam(_ context.Context, t *types.Team) (*types.Team, error) {
 	u := *t
 	teams.addTeam(&u)
-	return nil
+	return &u, nil
 }
 
 func (teams *Teams) addTeam(t *types.Team) {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -57755,7 +57755,7 @@ func NewMockTeamStore() *MockTeamStore {
 			},
 		},
 		CreateTeamFunc: &TeamStoreCreateTeamFunc{
-			defaultHook: func(context.Context, *types.Team) (r0 error) {
+			defaultHook: func(context.Context, *types.Team) (r0 *types.Team, r1 error) {
 				return
 			},
 		},
@@ -57837,7 +57837,7 @@ func NewStrictMockTeamStore() *MockTeamStore {
 			},
 		},
 		CreateTeamFunc: &TeamStoreCreateTeamFunc{
-			defaultHook: func(context.Context, *types.Team) error {
+			defaultHook: func(context.Context, *types.Team) (*types.Team, error) {
 				panic("unexpected invocation of MockTeamStore.CreateTeam")
 			},
 		},
@@ -58280,23 +58280,23 @@ func (c TeamStoreCountTeamsFuncCall) Results() []interface{} {
 // TeamStoreCreateTeamFunc describes the behavior when the CreateTeam method
 // of the parent MockTeamStore instance is invoked.
 type TeamStoreCreateTeamFunc struct {
-	defaultHook func(context.Context, *types.Team) error
-	hooks       []func(context.Context, *types.Team) error
+	defaultHook func(context.Context, *types.Team) (*types.Team, error)
+	hooks       []func(context.Context, *types.Team) (*types.Team, error)
 	history     []TeamStoreCreateTeamFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateTeam delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockTeamStore) CreateTeam(v0 context.Context, v1 *types.Team) error {
-	r0 := m.CreateTeamFunc.nextHook()(v0, v1)
-	m.CreateTeamFunc.appendCall(TeamStoreCreateTeamFuncCall{v0, v1, r0})
-	return r0
+func (m *MockTeamStore) CreateTeam(v0 context.Context, v1 *types.Team) (*types.Team, error) {
+	r0, r1 := m.CreateTeamFunc.nextHook()(v0, v1)
+	m.CreateTeamFunc.appendCall(TeamStoreCreateTeamFuncCall{v0, v1, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the CreateTeam method of
 // the parent MockTeamStore instance is invoked and the hook queue is empty.
-func (f *TeamStoreCreateTeamFunc) SetDefaultHook(hook func(context.Context, *types.Team) error) {
+func (f *TeamStoreCreateTeamFunc) SetDefaultHook(hook func(context.Context, *types.Team) (*types.Team, error)) {
 	f.defaultHook = hook
 }
 
@@ -58304,7 +58304,7 @@ func (f *TeamStoreCreateTeamFunc) SetDefaultHook(hook func(context.Context, *typ
 // CreateTeam method of the parent MockTeamStore instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *TeamStoreCreateTeamFunc) PushHook(hook func(context.Context, *types.Team) error) {
+func (f *TeamStoreCreateTeamFunc) PushHook(hook func(context.Context, *types.Team) (*types.Team, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -58312,20 +58312,20 @@ func (f *TeamStoreCreateTeamFunc) PushHook(hook func(context.Context, *types.Tea
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *TeamStoreCreateTeamFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, *types.Team) error {
-		return r0
+func (f *TeamStoreCreateTeamFunc) SetDefaultReturn(r0 *types.Team, r1 error) {
+	f.SetDefaultHook(func(context.Context, *types.Team) (*types.Team, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *TeamStoreCreateTeamFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, *types.Team) error {
-		return r0
+func (f *TeamStoreCreateTeamFunc) PushReturn(r0 *types.Team, r1 error) {
+	f.PushHook(func(context.Context, *types.Team) (*types.Team, error) {
+		return r0, r1
 	})
 }
 
-func (f *TeamStoreCreateTeamFunc) nextHook() func(context.Context, *types.Team) error {
+func (f *TeamStoreCreateTeamFunc) nextHook() func(context.Context, *types.Team) (*types.Team, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -58366,7 +58366,10 @@ type TeamStoreCreateTeamFuncCall struct {
 	Arg1 *types.Team
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *types.Team
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -58378,7 +58381,7 @@ func (c TeamStoreCreateTeamFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c TeamStoreCreateTeamFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // TeamStoreCreateTeamMemberFunc describes the behavior when the

--- a/internal/database/teams_test.go
+++ b/internal/database/teams_test.go
@@ -34,7 +34,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 		ReadOnly:    true,
 		CreatorID:   user.ID,
 	}
-	if err := store.CreateTeam(ctx, team); err != nil {
+	if _, err := store.CreateTeam(ctx, team); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +61,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 	})
 
 	t.Run("duplicate team names are forbidden", func(t *testing.T) {
-		err := store.CreateTeam(ctx, team)
+		_, err := store.CreateTeam(ctx, team)
 		if err == nil {
 			t.Fatal("got no error")
 		}
@@ -75,7 +75,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 			Name:      user.Username,
 			CreatorID: user.ID,
 		}
-		err := store.CreateTeam(ctx, tm)
+		_, err := store.CreateTeam(ctx, tm)
 		if err == nil {
 			t.Fatal("got no error")
 		}
@@ -95,7 +95,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 			Name:      name,
 			CreatorID: user.ID,
 		}
-		err = store.CreateTeam(ctx, tm)
+		_, err = store.CreateTeam(ctx, tm)
 		if err == nil {
 			t.Fatal("got no error")
 		}
@@ -106,7 +106,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 
 	t.Run("update", func(t *testing.T) {
 		otherTeam := &types.Team{Name: "own2", CreatorID: user.ID}
-		err := store.CreateTeam(ctx, otherTeam)
+		_, err := store.CreateTeam(ctx, otherTeam)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 		}
 
 		// Check that we can create a new team with the same name now.
-		err := store.CreateTeam(ctx, team)
+		_, err := store.CreateTeam(ctx, team)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestTeams_GetListCount(t *testing.T) {
 
 	createTeam := func(team *types.Team, members ...int32) *types.Team {
 		team.CreatorID = johndoe.ID
-		if err := store.CreateTeam(internalCtx, team); err != nil {
+		if _, err := store.CreateTeam(internalCtx, team); err != nil {
 			t.Fatal(err)
 		}
 		for _, m := range members {


### PR DESCRIPTION
Test plan:
GraphQL tests updated.

Closes https://github.com/sourcegraph/sourcegraph/issues/53444