### PR TITLE
[licensing] Add dev license check for license verification skip

### DIFF
--- a/enterprise/internal/licensing/check.go
+++ b/enterprise/internal/licensing/check.go
@@ -50,6 +50,16 @@ func (l *licenseChecker) Handle(ctx context.Context) error {
 		return nil
 	}
 
+	info, err := GetConfiguredProductLicenseInfo()
+	if err != nil {
+		return err
+	}
+	if info.HasTag("dev") {
+		l.logger.Debug("dev license, skipping license verification check")
+		store.Set(licenseValidityStoreKey, true)
+		return nil
+	}
+
 	payload, err := json.Marshal(struct {
 		ClientSiteID string `json:"siteID"`
 	}{ClientSiteID: l.siteID})


### PR DESCRIPTION
This PR adds an exception to the license verification check to skip licenses with the "dev" tag. This prevents unnecessary calls to sourcegraph.com.

## Test plan

Added unit test for license with dev tag

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
