### PR TITLE
Cache results of sub-repo perms enabled checks

### DIFF
--- a/internal/authz/sub_repo_perms.go
+++ b/internal/authz/sub_repo_perms.go
@@ -164,14 +164,6 @@ func canReadPaths(ctx context.Context, checker SubRepoPermissionChecker, repo ap
 		return true, nil
 	}
 
-	enabled, err := SubRepoEnabledForRepo(ctx, checker, repo)
-	if err != nil {
-		return false, err
-	}
-	if !enabled {
-		return true, nil
-	}
-
 	start := time.Now()
 	var checkPathPermsCount int
 	defer func() {

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -103,7 +103,7 @@ func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionC
 			enabled, err := authz.SubRepoEnabledForRepo(ctx, checker, m.RepoName().Name)
 			if err != nil {
 				// If an error occurs while checking sub-repo perms, we omit it from the results
-				logger.Warn("Could not determine if sub-repo permissions are enabled for repo, skipping", log.String("repoName", string(m.RepoName().Name)))
+				logger.Error("Could not determine if sub-repo permissions are enabled for repo, skipping", log.String("repoName", string(m.RepoName().Name)))
 				errCache[m.RepoName().Name] = struct{}{}
 				continue
 			}


### PR DESCRIPTION
Moves the SubRepoPermsEnabledForRepo checks back to the top level function so that we can cache the results on a repo level.

## Test plan

Tests should still pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
