### PR TITLE
Auto upgrades add additional check to fresh instance detection

### DIFF
--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "@com_github_gorilla_mux//:mux",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_inconshreveable_log15//:log15",
+        "@com_github_jackc_pgerrcode//:pgerrcode",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_keegancsmith_tmpfriend//:tmpfriend",
         "@com_github_kr_text//:text",

--- a/cmd/frontend/internal/cli/autoupgrade.go
+++ b/cmd/frontend/internal/cli/autoupgrade.go
@@ -10,6 +10,7 @@ import (
 
 	gcontext "github.com/gorilla/context"
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgerrcode"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
@@ -63,7 +64,7 @@ func tryAutoUpgrade(ctx context.Context, obsvCtx *observation.Context, ready ser
 
 	currentVersionStr, dbShouldAutoUpgrade, err := upgradestore.GetAutoUpgrade(ctx)
 	// fresh instance
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, sql.ErrNoRows) || errors.HasPostgresCode(err, pgerrcode.UndefinedTable) {
 		return nil
 	} else if err != nil {
 		return errors.Wrap(err, "autoupgradestore.GetAutoUpgrade")


### PR DESCRIPTION
Fresh instances with no tables were incorrectly erroring, blocking the initial startup of App
## Test plan
clear all app data
```
rm -rf ~/.sourcegraph-psql ~/Library/Application\ Support/sourcegraph-dev ~/Library/Caches/sourcegraph-dev ~/Library/WebKit/sourcegraph-dev
```
`sg start app` ensured app starts successfully 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
