### PR TITLE
Wire graphQL resolvers for assigned owners in Own analytics

### DIFF
--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -2185,7 +2185,11 @@ func TestDisplayOwnershipStats(t *testing.T) {
 	db.RepoPathsFunc.SetDefaultReturn(fakeRepoPaths)
 	fakeOwnershipStats := database.NewMockOwnershipStatsStore()
 	fakeOwnershipStats.QueryAggregateCountsFunc.SetDefaultReturn(
-		database.PathAggregateCounts{CodeownedFileCount: 150000}, nil)
+		database.PathAggregateCounts{
+			CodeownedFileCount:         150000,
+			AssignedOwnershipFileCount: 20000,
+			TotalOwnedFileCount:        165000,
+		}, nil)
 	db.OwnershipStatsFunc.SetDefaultReturn(fakeOwnershipStats)
 	ctx := context.Background()
 	schema, err := graphqlbackend.NewSchema(db, nil, nil, graphqlbackend.OptionalResolver{OwnResolver: resolvers.NewWithService(db, nil, nil, logtest.NoOp(t))})
@@ -2207,8 +2211,8 @@ func TestDisplayOwnershipStats(t *testing.T) {
 				"instanceOwnershipStats": {
 					"totalFiles": 350000,
 					"totalCodeownedFiles" : 150000,
-					"totalOwnedFiles" : 0,
-					"totalAssignedOwnershipFiles" : 0
+					"totalOwnedFiles" : 165000,
+					"totalAssignedOwnershipFiles" : 20000
 				}
 			}`,
 	})


### PR DESCRIPTION
Part of #53438

## Test plan

Extend existing graphQL unit tests with mocked stores.
