### PR TITLE
[license-checks] Collapsible license key items

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -984,6 +984,7 @@ ts_project(
         "src/enterprise/productSubscription/ExpirationDate.tsx",
         "src/enterprise/productSubscription/LicenseGenerationKeyWarning.tsx",
         "src/enterprise/productSubscription/ProductCertificate.tsx",
+        "src/enterprise/productSubscription/ProductLicenseInfoDescription.tsx",
         "src/enterprise/productSubscription/ProductLicenseTags.tsx",
         "src/enterprise/productSubscription/TrueUpStatusSummary.tsx",
         "src/enterprise/rbac/SiteAdminRolesPage.tsx",

--- a/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
+++ b/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
@@ -4,7 +4,7 @@ import { mdiCheckCircle, mdiCloseCircle, mdiShieldRemove } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
-import { Icon } from '@sourcegraph/wildcard'
+import { Icon, Label } from '@sourcegraph/wildcard'
 
 import { ProductLicenseFields } from '../../../graphql-operations'
 import { isProductLicenseExpired } from '../../../productSubscription/helpers'
@@ -25,8 +25,8 @@ const ValidityIcon: React.FC<{ isExpired: boolean; isRevoked: boolean }> = ({ is
         aria-hidden={true}
         className={classNames('mr-1', {
             ['text-success']: !isExpired && !isRevoked,
-            ['text-danger']: isExpired && !isRevoked,
-            ['text-warning']: !isExpired && isRevoked,
+            ['text-muted']: isExpired && !isRevoked,
+            ['text-danger']: isRevoked,
         })}
     />
 )
@@ -68,7 +68,11 @@ export const ProductLicenseValidity: React.FunctionComponent<
         <div className={className}>
             {variant !== 'no-icon' && <ValidityIcon isExpired={isExpired} isRevoked={isRevoked} />}
             {getText(isExpired, isRevoked)} <Timestamp date={timestamp} noAbout={true} noAgo={true} /> {timestampSuffix}
-            {!isExpired && isRevoked && revokeReason && <span> because of "{revokeReason}" reason</span>}
+            {!isExpired && isRevoked && revokeReason && (
+                <>
+                    <Label className="ml-2 mb-0 d-inline">Reason:</Label> {revokeReason}
+                </>
+            )}
         </div>
     )
 }

--- a/client/web/src/enterprise/productSubscription/ProductLicenseInfoDescription.tsx
+++ b/client/web/src/enterprise/productSubscription/ProductLicenseInfoDescription.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { H3 } from '@sourcegraph/wildcard'
+
+import { ProductLicenseInfoFields } from '../../graphql-operations'
+import { formatUserCount } from '../../productSubscription/helpers'
+
+export const ProductLicenseInfoDescription: React.FunctionComponent<
+    React.PropsWithChildren<{
+        licenseInfo: ProductLicenseInfoFields
+        className?: string
+    }>
+> = ({ licenseInfo, className = '' }) => (
+    <H3 className={className}>
+        {licenseInfo.productNameWithBrand} ({formatUserCount(licenseInfo.userCount)})
+    </H3>
+)

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -1,32 +1,35 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
-import { mdiChevronUp, mdiChevronDown } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation } from '@sourcegraph/http-client'
 import {
-    Text,
-    LinkOrSpan,
-    Label,
     Alert,
-    H3,
-    Grid,
     Button,
-    Icon,
     Collapse,
     CollapseHeader,
     CollapsePanel,
+    Grid,
+    H3,
+    Icon,
+    Label,
+    LinkOrSpan,
+    Text,
 } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../../../components/CopyableText'
 import { LoaderButton } from '../../../../components/LoaderButton'
 import { ProductLicenseFields, RevokeLicenseResult, RevokeLicenseVariables } from '../../../../graphql-operations'
-import { formatUserCount, isProductLicenseExpired } from '../../../../productSubscription/helpers'
+import { isProductLicenseExpired } from '../../../../productSubscription/helpers'
 import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 import { ProductLicenseValidity } from '../../../dotcom/productSubscriptions/ProductLicenseValidity'
-import { hasUnknownTags, ProductLicenseTags, UnknownTagWarning } from '../../../productSubscription/ProductLicenseTags'
+import { ProductLicenseInfoDescription } from '../../../productSubscription/ProductLicenseInfoDescription'
+import { ProductLicenseTags, UnknownTagWarning, hasUnknownTags } from '../../../productSubscription/ProductLicenseTags'
 
 import { REVOKE_LICENSE } from './backend'
+
+const getLicenseUUID = (id: string): string => atob(id).slice('ProductLicense:"'.length, -1)
 
 export interface SiteAdminProductLicenseNodeProps {
     node: ProductLicenseFields
@@ -41,7 +44,6 @@ export interface SiteAdminProductLicenseNodeProps {
 export const SiteAdminProductLicenseNode: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminProductLicenseNodeProps>
 > = ({ node, showSubscription, onRevokeCompleted, defaultExpanded = false }) => {
-    const [isOpen, setIsOpen] = useState<boolean>(defaultExpanded)
     const [revoke, { loading, error }] = useMutation<RevokeLicenseResult, RevokeLicenseVariables>(REVOKE_LICENSE)
 
     const onRevoke = useCallback(() => {
@@ -62,96 +64,115 @@ export const SiteAdminProductLicenseNode: React.FunctionComponent<
         }
     }, [revoke, node, onRevokeCompleted])
 
+    const [open, setOpen] = useState(defaultExpanded)
+    const toggleOpen = useCallback(() => {
+        setOpen(!open)
+    }, [open, setOpen])
+
+    const uuid = useMemo(() => getLicenseUUID(node.id), [node])
+
     return (
-        <li className="list-group-item py-3" id={encodeURIComponent(node?.id)}>
-            {showSubscription && (
-                <div className="text-truncate d-flex mb-1">
-                    <H3>
-                        License in{' '}
-                        <LinkOrSpan to={node.subscription.urlForSiteAdmin} className="mr-3">
-                            {node.subscription.name}
-                        </LinkOrSpan>
-                    </H3>
-                    <span className="mr-3">
-                        <AccountName account={node.subscription.account} />
-                    </span>
-                </div>
-            )}
-            {!loading && error && <Alert variant="danger">Error revoking license: {error.message}</Alert>}
-            <Collapse isOpen={isOpen} onOpenChange={setIsOpen}>
-                <CollapseHeader as={Button} className="w-100 m-0 p-0">
-                    <Grid columnCount={3} templateColumns="5fr 1fr 1fr" className="mb-0 align-items-center">
-                        {node.info && (
-                            <H3 className="mb-1 text-left">
-                                <ProductLicenseValidity
-                                    license={node}
-                                    className="mb-0 mr-1 d-inline"
-                                    variant="icon-only"
-                                />
-                                {node.info.productNameWithBrand}
-                                <Icon
-                                    className="ml-1"
-                                    aria-label={isOpen ? 'Less info' : 'More info'}
-                                    svgPath={isOpen ? mdiChevronUp : mdiChevronDown}
-                                />
-                            </H3>
-                        )}
-                        {node.info && formatUserCount(node.info.userCount)}
+        <li className="list-group-item p-3 mb-3 border">
+            <Collapse isOpen={open} onOpenChange={setOpen}>
+                <Grid columnCount={2} templateColumns="auto 1fr" spacing={0}>
+                    <Button variant="icon" onClick={toggleOpen} className="pr-3">
+                        <Icon
+                            aria-label={`collapse ${open ? 'opened' : 'closed'}`}
+                            svgPath={open ? mdiChevronUp : mdiChevronDown}
+                        />
+                    </Button>
+                    <CollapseHeader as="div" className="d-flex align-items-start">
+                        <div>
+                            {showSubscription && (
+                                <div className="text-truncate d-flex">
+                                    <H3>
+                                        License in{' '}
+                                        <LinkOrSpan to={node.subscription.urlForSiteAdmin} className="mr-3">
+                                            {node.subscription.name}
+                                        </LinkOrSpan>
+                                    </H3>
+                                    <span className="mr-3">
+                                        <AccountName account={node.subscription.account} />
+                                    </span>
+                                </div>
+                            )}
+                            {!loading && error && (
+                                <Alert variant="danger">Error revoking license: {error.message}</Alert>
+                            )}
+                            <div className="d-flex align-items-baseline mb-2">
+                                {node.info && (
+                                    <ProductLicenseInfoDescription licenseInfo={node.info} className="mb-0" />
+                                )}
+                                <Text className="ml-3 mb-0">
+                                    <small className="text-muted">
+                                        Created <Timestamp date={node.createdAt} />
+                                    </small>
+                                </Text>
+                                <Text className="ml-3 mb-0 text-muted">
+                                    <small>v{node.version}</small>
+                                </Text>
+                            </div>
+                            <ProductLicenseValidity license={node} />
+                        </div>
                         {!node?.revokedAt && !isProductLicenseExpired(node?.info?.expiresAt ?? 0) && (
                             <LoaderButton
-                                size="sm"
-                                variant="danger"
                                 className="ml-auto"
+                                variant="danger"
                                 label="Revoke"
                                 onClick={onRevoke}
                                 loading={loading}
                             />
                         )}
-                    </Grid>
-                    <div className="d-flex justify-content-between align-items-center outline-none border-none">
-                        <Text className="mb-0 text-muted" as="small" weight="regular">
-                            v{node.version}. Created <Timestamp date={node.createdAt} />.{' '}
-                            <ProductLicenseValidity license={node} className="mb-0 d-inline" variant="no-icon" />.
-                        </Text>
-                    </div>
-                </CollapseHeader>
-                <CollapsePanel>
-                    {node.version > 1 && (
-                        <>
-                            <div className="d-flex mt-1">
-                                <Label>Site ID</Label>
-                                <Text className="ml-3 mb-0">
-                                    {node.siteID ?? <span className="text-muted">Unused</span>}
-                                </Text>
-                            </div>
-                            <div className="d-flex mt-1">
-                                <Label>Salesforce Subscription ID</Label>
-                                <Text className="ml-3 mb-0">
-                                    {node.info?.salesforceSubscriptionID ?? <span className="text-muted">Unused</span>}
-                                </Text>
-                            </div>
-                            <div className="d-flex mt-1">
-                                <Label>Salesforce Opportunity ID</Label>
-                                <Text className="ml-3 mb-0">
-                                    {node.info?.salesforceOpportunityID ?? <span className="text-muted">Unused</span>}
-                                </Text>
-                            </div>
-                        </>
-                    )}
-                    {node.info && node.info.tags.length > 0 && (
-                        <div className="d-flex align-items-baseline mt-1">
-                            <Label className="mr-3">Tags</Label>
-                            <div className="d-flex justify-content-baseline">
-                                {hasUnknownTags(node.info.tags) && <UnknownTagWarning className="mb-2" />}
-                                <ProductLicenseTags tags={node.info.tags} />
-                            </div>
+                    </CollapseHeader>
+                    <div />
+                    <CollapsePanel className="mt-4">
+                        <div className="d-flex">
+                            <Label>License Key ID</Label>
+                            <Text className="ml-3">{uuid}</Text>
                         </div>
-                    )}
-                    <Label className="d-flex align-items-center mb-0">
-                        <Text className="mr-3 mb-0">License Key</Text>
-                        <CopyableText flex={true} text={node.licenseKey} className="flex-grow-1" />
-                    </Label>
-                </CollapsePanel>
+                        {node.version > 1 && (
+                            <>
+                                <div className="d-flex">
+                                    <Label>Site ID</Label>
+                                    <Text className="ml-3">
+                                        {node.siteID ?? <span className="text-muted">Unused</span>}
+                                    </Text>
+                                </div>
+                                <div className="d-flex">
+                                    <Label>Salesforce Subscription ID</Label>
+                                    <Text className="ml-3">
+                                        {node.info?.salesforceSubscriptionID ?? (
+                                            <span className="text-muted">Unused</span>
+                                        )}
+                                    </Text>
+                                </div>
+                                <div className="d-flex">
+                                    <Label>Salesforce Opportunity ID</Label>
+                                    <Text className="ml-3">
+                                        {node.info?.salesforceOpportunityID ?? (
+                                            <span className="text-muted">Unused</span>
+                                        )}
+                                    </Text>
+                                </div>
+                            </>
+                        )}
+                        {node.info && node.info.tags.length > 0 && (
+                            <>
+                                {hasUnknownTags(node.info.tags) && <UnknownTagWarning className="mb-2" />}
+                                <Label className="w-100">
+                                    <Text className="mb-2">Tags</Text>
+                                    <Text className="mb-2">
+                                        <ProductLicenseTags tags={node.info.tags} />
+                                    </Text>
+                                </Label>
+                            </>
+                        )}
+                        <Label className="w-100">
+                            <Text className="mb-2">License Key</Text>
+                            <CopyableText flex={true} text={node.licenseKey} />
+                        </Label>
+                    </CollapsePanel>
+                </Grid>
             </Collapse>
         </li>
     )

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
       </button>
       <div
         aria-expanded="false"
-        class="d-flex align-items-baseline"
+        class="d-flex align-items-start"
         role="button"
       >
         <div>
@@ -53,7 +53,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
             </span>
           </div>
           <div
-            class="d-flex justify-content-baseline mb-2"
+            class="d-flex align-items-baseline mb-2"
           >
             <h3
               class="h3 mb-0"
@@ -61,7 +61,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
               NB (123 users)
             </h3>
             <p
-              class="ml-2 mb-0"
+              class="ml-3 mb-0"
             >
               <small
                 class="text-muted"
@@ -74,12 +74,11 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
                 </span>
               </small>
             </p>
-            123 users
             <p
               class="ml-3 mb-0 text-muted"
             >
               <small>
-                Version 1
+                v1
               </small>
             </p>
           </div>
@@ -109,7 +108,7 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
           </div>
         </div>
         <button
-          class="btn btnDanger ml-auto align-self-baseline d-flex justify-content-center align-items-center"
+          class="btn btnDanger ml-auto d-flex justify-content-center align-items-center"
           type="button"
         >
           Revoke
@@ -242,7 +241,7 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
       </button>
       <div
         aria-expanded="false"
-        class="d-flex align-items-baseline"
+        class="d-flex align-items-start"
         role="button"
       >
         <div>
@@ -267,7 +266,7 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
             </span>
           </div>
           <div
-            class="d-flex justify-content-baseline mb-2"
+            class="d-flex align-items-baseline mb-2"
           >
             <h3
               class="h3 mb-0"
@@ -275,7 +274,7 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
               NB (123 users)
             </h3>
             <p
-              class="ml-2 mb-0"
+              class="ml-3 mb-0"
             >
               <small
                 class="text-muted"
@@ -288,12 +287,11 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
                 </span>
               </small>
             </p>
-            123 users
             <p
               class="ml-3 mb-0 text-muted"
             >
               <small>
-                Version 1
+                v1
               </small>
             </p>
           </div>
@@ -323,7 +321,7 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
           </div>
         </div>
         <button
-          class="btn btnDanger ml-auto align-self-baseline d-flex justify-content-center align-items-center"
+          class="btn btnDanger ml-auto d-flex justify-content-center align-items-center"
           type="button"
         >
           Revoke

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductLicenseNode.test.tsx.snap
@@ -3,44 +3,88 @@
 exports[`SiteAdminProductLicenseNode active 1`] = `
 <DocumentFragment>
   <li
-    class="list-group-item py-3"
-    id="l1"
+    class="list-group-item p-3 mb-3 border"
   >
     <div
-      class="text-truncate d-flex mb-1"
+      style="display: grid; gap: 0rem; grid-template-columns: auto 1fr; margin-bottom: 0rem;"
     >
-      <h3
-        class="h3"
+      <button
+        class="btn btnIcon pr-3"
+        type="button"
       >
-        License in 
-        <a
-          class="anchorLink mr-3"
-          href="/s"
+        <svg
+          aria-label="collapse closed"
+          class="mdi-icon iconInline"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
         >
-          s
-        </a>
-      </h3>
-      <span
-        class="mr-3"
-      >
-        <accountname />
-      </span>
-    </div>
-    <button
-      aria-expanded="false"
-      class="btn w-100 m-0 p-0"
-      role="button"
-      type="button"
-    >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </button>
       <div
-        class="mb-0 align-items-center"
-        style="display: grid; gap: 1rem; grid-template-columns: 5fr 1fr 1fr; margin-bottom: 1rem;"
+        aria-expanded="false"
+        class="d-flex align-items-baseline"
+        role="button"
       >
-        <h3
-          class="h3 mb-1 text-left"
-        >
+        <div>
           <div
-            class="mb-0 mr-1 d-inline"
+            class="text-truncate d-flex"
+          >
+            <h3
+              class="h3"
+            >
+              License in 
+              <a
+                class="anchorLink mr-3"
+                href="/s"
+              >
+                s
+              </a>
+            </h3>
+            <span
+              class="mr-3"
+            >
+              <accountname />
+            </span>
+          </div>
+          <div
+            class="d-flex justify-content-baseline mb-2"
+          >
+            <h3
+              class="h3 mb-0"
+            >
+              NB (123 users)
+            </h3>
+            <p
+              class="ml-2 mb-0"
+            >
+              <small
+                class="text-muted"
+              >
+                Created 
+                <span
+                  class="timestamp"
+                >
+                  in almost 14 years
+                </span>
+              </small>
+            </p>
+            123 users
+            <p
+              class="ml-3 mb-0 text-muted"
+            >
+              <small>
+                Version 1
+              </small>
+            </p>
+          </div>
+          <div
+            class=""
           >
             <svg
               aria-hidden="true"
@@ -55,138 +99,116 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
                 d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
               />
             </svg>
+            Valid 
+            <span
+              class="timestamp"
+            >
+              almost 15 years
+            </span>
+             remaining
           </div>
-          NB
-          <svg
-            aria-label="More info"
-            class="mdi-icon iconInline ml-1"
-            fill="currentColor"
-            height="24"
-            role="img"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-            />
-          </svg>
-        </h3>
-        123 users
-      </div>
-    </button>
-    <button
-      class="btn btnDanger btnSm ml-auto d-flex justify-content-center align-items-center"
-      type="button"
-    >
-      Revoke
-    </button>
-    <div
-      class="d-flex justify-content-between align-items-center outline-none border-none"
-    >
-      <small
-        class="fontWeightRegular mb-0 text-muted"
-      >
-        v1. Created 
-        <span
-          class="timestamp"
-        >
-          in almost 14 years
-        </span>
-        . 
-        <div
-          class="mb-0 d-inline"
-        >
-          Valid 
-          <span
-            class="timestamp"
-          >
-            almost 15 years
-          </span>
-           remaining
         </div>
-        .
-      </small>
-    </div>
-    <div
-      class="collapse"
-    >
+        <button
+          class="btn btnDanger ml-auto align-self-baseline d-flex justify-content-center align-items-center"
+          type="button"
+        >
+          Revoke
+        </button>
+      </div>
+      <div />
       <div
-        class="d-flex align-items-baseline mt-1"
+        class="collapse mt-4"
       >
+        <div
+          class="d-flex"
+        >
+          <label
+            class="label"
+          >
+            License Key ID
+          </label>
+          <p
+            class="ml-3"
+          />
+        </div>
+        <div
+          aria-live="assertive"
+          class="alert alertDanger mb-2"
+          role="alert"
+        >
+          License tags contain unknown values (marked red), please check if the tags are correct.
+        </div>
         <label
-          class="label mr-3"
+          class="label w-100"
         >
-          Tags
+          <p
+            class="mb-2"
+          >
+            Tags
+          </p>
+          <p
+            class="mb-2"
+          >
+            <span
+              class="badge danger mr-1"
+            >
+              a
+            </span>
+          </p>
         </label>
-        <div
-          class="d-flex justify-content-baseline"
+        <label
+          class="label w-100"
         >
-          <div
-            aria-live="assertive"
-            class="alert alertDanger mb-2"
-            role="alert"
+          <p
+            class="mb-2"
           >
-            License tags contain unknown values (marked red), please check if the tags are correct.
-          </div>
-          <span
-            class="badge danger mr-1"
-          >
-            a
-          </span>
-        </div>
-      </div>
-      <label
-        class="label d-flex align-items-center mb-0"
-      >
-        <p
-          class="mr-3 mb-0"
-        >
-          License Key
-        </p>
-        <div
-          class="form-inline flex-grow-1"
-        >
+            License Key
+          </p>
           <div
-            class="input-group flex-1"
+            class="form-inline"
           >
             <div
-              class="container loader-input loaderInput"
+              class="input-group flex-1"
             >
-              <input
-                class="input form-control with-invalid-icon"
-                readonly=""
-                type="text"
-                value="lk1"
-              />
-            </div>
-            <div
-              class="input-group-append flex-shrink-0"
-            >
-              <button
-                aria-disabled="false"
-                aria-label="Copy"
-                class="btn btnSecondary"
-                type="button"
+              <div
+                class="container loader-input loaderInput"
               >
-                <svg
-                  aria-hidden="true"
-                  class="mdi-icon iconInline"
-                  fill="currentColor"
-                  height="24"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="24"
+                <input
+                  class="input form-control with-invalid-icon"
+                  readonly=""
+                  type="text"
+                  value="lk1"
+                />
+              </div>
+              <div
+                class="input-group-append flex-shrink-0"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Copy"
+                  class="btn btnSecondary"
+                  type="button"
                 >
-                  <path
-                    d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
-                  />
-                </svg>
-                 Copy
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="mdi-icon iconInline"
+                    fill="currentColor"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+                    />
+                  </svg>
+                   Copy
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      </label>
+        </label>
+      </div>
     </div>
   </li>
 </DocumentFragment>
@@ -195,44 +217,88 @@ exports[`SiteAdminProductLicenseNode active 1`] = `
 exports[`SiteAdminProductLicenseNode inactive 1`] = `
 <DocumentFragment>
   <li
-    class="list-group-item py-3"
-    id="l1"
+    class="list-group-item p-3 mb-3 border"
   >
     <div
-      class="text-truncate d-flex mb-1"
+      style="display: grid; gap: 0rem; grid-template-columns: auto 1fr; margin-bottom: 0rem;"
     >
-      <h3
-        class="h3"
+      <button
+        class="btn btnIcon pr-3"
+        type="button"
       >
-        License in 
-        <a
-          class="anchorLink mr-3"
-          href="/s"
+        <svg
+          aria-label="collapse closed"
+          class="mdi-icon iconInline"
+          fill="currentColor"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
         >
-          s
-        </a>
-      </h3>
-      <span
-        class="mr-3"
-      >
-        <accountname />
-      </span>
-    </div>
-    <button
-      aria-expanded="false"
-      class="btn w-100 m-0 p-0"
-      role="button"
-      type="button"
-    >
+          <path
+            d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+          />
+        </svg>
+      </button>
       <div
-        class="mb-0 align-items-center"
-        style="display: grid; gap: 1rem; grid-template-columns: 5fr 1fr 1fr; margin-bottom: 1rem;"
+        aria-expanded="false"
+        class="d-flex align-items-baseline"
+        role="button"
       >
-        <h3
-          class="h3 mb-1 text-left"
-        >
+        <div>
           <div
-            class="mb-0 mr-1 d-inline"
+            class="text-truncate d-flex"
+          >
+            <h3
+              class="h3"
+            >
+              License in 
+              <a
+                class="anchorLink mr-3"
+                href="/s"
+              >
+                s
+              </a>
+            </h3>
+            <span
+              class="mr-3"
+            >
+              <accountname />
+            </span>
+          </div>
+          <div
+            class="d-flex justify-content-baseline mb-2"
+          >
+            <h3
+              class="h3 mb-0"
+            >
+              NB (123 users)
+            </h3>
+            <p
+              class="ml-2 mb-0"
+            >
+              <small
+                class="text-muted"
+              >
+                Created 
+                <span
+                  class="timestamp"
+                >
+                  in almost 14 years
+                </span>
+              </small>
+            </p>
+            123 users
+            <p
+              class="ml-3 mb-0 text-muted"
+            >
+              <small>
+                Version 1
+              </small>
+            </p>
+          </div>
+          <div
+            class=""
           >
             <svg
               aria-hidden="true"
@@ -247,138 +313,116 @@ exports[`SiteAdminProductLicenseNode inactive 1`] = `
                 d="M12 2C6.5 2 2 6.5 2 12S6.5 22 12 22 22 17.5 22 12 17.5 2 12 2M10 17L5 12L6.41 10.59L10 14.17L17.59 6.58L19 8L10 17Z"
               />
             </svg>
+            Valid 
+            <span
+              class="timestamp"
+            >
+              almost 15 years
+            </span>
+             remaining
           </div>
-          NB
-          <svg
-            aria-label="More info"
-            class="mdi-icon iconInline ml-1"
-            fill="currentColor"
-            height="24"
-            role="img"
-            viewBox="0 0 24 24"
-            width="24"
-          >
-            <path
-              d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
-            />
-          </svg>
-        </h3>
-        123 users
-      </div>
-    </button>
-    <button
-      class="btn btnDanger btnSm ml-auto d-flex justify-content-center align-items-center"
-      type="button"
-    >
-      Revoke
-    </button>
-    <div
-      class="d-flex justify-content-between align-items-center outline-none border-none"
-    >
-      <small
-        class="fontWeightRegular mb-0 text-muted"
-      >
-        v1. Created 
-        <span
-          class="timestamp"
-        >
-          in almost 14 years
-        </span>
-        . 
-        <div
-          class="mb-0 d-inline"
-        >
-          Valid 
-          <span
-            class="timestamp"
-          >
-            almost 15 years
-          </span>
-           remaining
         </div>
-        .
-      </small>
-    </div>
-    <div
-      class="collapse"
-    >
+        <button
+          class="btn btnDanger ml-auto align-self-baseline d-flex justify-content-center align-items-center"
+          type="button"
+        >
+          Revoke
+        </button>
+      </div>
+      <div />
       <div
-        class="d-flex align-items-baseline mt-1"
+        class="collapse mt-4"
       >
+        <div
+          class="d-flex"
+        >
+          <label
+            class="label"
+          >
+            License Key ID
+          </label>
+          <p
+            class="ml-3"
+          />
+        </div>
+        <div
+          aria-live="assertive"
+          class="alert alertDanger mb-2"
+          role="alert"
+        >
+          License tags contain unknown values (marked red), please check if the tags are correct.
+        </div>
         <label
-          class="label mr-3"
+          class="label w-100"
         >
-          Tags
+          <p
+            class="mb-2"
+          >
+            Tags
+          </p>
+          <p
+            class="mb-2"
+          >
+            <span
+              class="badge danger mr-1"
+            >
+              a
+            </span>
+          </p>
         </label>
-        <div
-          class="d-flex justify-content-baseline"
+        <label
+          class="label w-100"
         >
-          <div
-            aria-live="assertive"
-            class="alert alertDanger mb-2"
-            role="alert"
+          <p
+            class="mb-2"
           >
-            License tags contain unknown values (marked red), please check if the tags are correct.
-          </div>
-          <span
-            class="badge danger mr-1"
-          >
-            a
-          </span>
-        </div>
-      </div>
-      <label
-        class="label d-flex align-items-center mb-0"
-      >
-        <p
-          class="mr-3 mb-0"
-        >
-          License Key
-        </p>
-        <div
-          class="form-inline flex-grow-1"
-        >
+            License Key
+          </p>
           <div
-            class="input-group flex-1"
+            class="form-inline"
           >
             <div
-              class="container loader-input loaderInput"
+              class="input-group flex-1"
             >
-              <input
-                class="input form-control with-invalid-icon"
-                readonly=""
-                type="text"
-                value="lk1"
-              />
-            </div>
-            <div
-              class="input-group-append flex-shrink-0"
-            >
-              <button
-                aria-disabled="false"
-                aria-label="Copy"
-                class="btn btnSecondary"
-                type="button"
+              <div
+                class="container loader-input loaderInput"
               >
-                <svg
-                  aria-hidden="true"
-                  class="mdi-icon iconInline"
-                  fill="currentColor"
-                  height="24"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width="24"
+                <input
+                  class="input form-control with-invalid-icon"
+                  readonly=""
+                  type="text"
+                  value="lk1"
+                />
+              </div>
+              <div
+                class="input-group-append flex-shrink-0"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Copy"
+                  class="btn btnSecondary"
+                  type="button"
                 >
-                  <path
-                    d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
-                  />
-                </svg>
-                 Copy
-              </button>
+                  <svg
+                    aria-hidden="true"
+                    class="mdi-icon iconInline"
+                    fill="currentColor"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                  >
+                    <path
+                      d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"
+                    />
+                  </svg>
+                   Copy
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      </label>
+        </label>
+      </div>
     </div>
   </li>
 </DocumentFragment>


### PR DESCRIPTION
Based on latest designs from @meglynst.

## Screenshots

<table>
  <thead>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td rowspan="2">
        <img
          width="925"
          alt="Screenshot 2023-06-14 at 14 51 53"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/a6c814a0-76b8-4f7f-bb87-e0b5f7a2d15e"
        />
      </td>
      <td>
        <img
          width="932"
          alt="Screenshot 2023-06-14 at 14 37 29"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/fc795f1c-89e1-47c1-b412-8979b2f11460"
        />
      </td>
    </tr>
    <tr>
      <td>
        <img
          width="879"
          alt="Screenshot 2023-06-14 at 14 37 39"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/5531dd55-108d-4db1-bf74-4a98e945ad82"
        />
      </td>
    </tr>
    <tr>
      <td rowspan="2">
        <img
          width="928"
          alt="Screenshot 2023-06-14 at 14 52 06"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/a824a8fe-59bc-4b31-bd4a-047d4c87724b"
        />
      </td>
      <td>
        <img
          width="931"
          alt="Screenshot 2023-06-14 at 14 40 31"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/98a5e7f5-66e2-4113-b287-42d402c93693"
        />
      </td>
    </tr>
    <tr>
      <td>
        <img
          width="930"
          alt="Screenshot 2023-06-14 at 14 40 48"
          src="https://github.com/sourcegraph/sourcegraph/assets/9974711/a5375270-ea6d-40f1-9052-9b3b699667fd"
        />
      </td>
    </tr>
  </tbody>
</table>

![7pbjf9](https://github.com/sourcegraph/sourcegraph/assets/9974711/d793efac-efff-4c1f-88c8-440e26691e9a)


## Test plan

Tested locally by running dotcom mode
