### PR TITLE
App - fix bad version handling on updater handler

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -230,6 +231,11 @@ func readClientAppVersion(reqURL *url.URL) *AppVersion {
 			*attr = v[0]
 		}
 	}
+
+	// The app versions contain + and Tauri is not encoding the updater url
+	// so this is being interpreted as a blank space and breaking the semver check.  '
+	// Replacing all blank spaces with '+' as a patch to enable auto updates.
+	appClientVersion.Version = strings.ReplaceAll(appClientVersion.Version, " ", "+")
 
 	return &appClientVersion
 }

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -235,7 +235,7 @@ func readClientAppVersion(reqURL *url.URL) *AppVersion {
 	// The app versions contain + and Tauri is not encoding the updater url
 	// so this is being interpreted as a blank space and breaking the semver check.  '
 	// Replacing all blank spaces with '+' as a patch to enable auto updates.
-	appClientVersion.Version = strings.ReplaceAll(appClientVersion.Version, " ", "+")
+	appClientVersion.Version = strings.ReplaceAll(strings.TrimSpace(appClientVersion.Version), " ", "+")
 
 	return &appClientVersion
 }

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -232,9 +232,9 @@ func readClientAppVersion(reqURL *url.URL) *AppVersion {
 		}
 	}
 
-	// The app versions contain + and Tauri is not encoding the updater url
-	// so this is being interpreted as a blank space and breaking the semver check.  '
-	// Replacing all blank spaces with '+' as a patch to enable auto updates.
+	// The app versions contain '+' and Tauri is not encoding the updater url
+	// this is being interpreted as a blank space and breaking the semver check.
+	// Trimming all leading/trailing spaces then replacing spaces with '+' to get auto updates working.
 	appClientVersion.Version = strings.ReplaceAll(strings.TrimSpace(appClientVersion.Version), " ", "+")
 
 	return &appClientVersion


### PR DESCRIPTION
The App does not encode the url to the updater and because the App version numbers have a + sign it's being interpreted as a blank space.  This fails the semver comparison and is why app users are not prompted for auto updates. This will now replace any blank spaces within the version with a '+'.
## Test plan
`sg start dotcom` 

Before
```
POST https://sourcegraph.test:3443/.api/app/check/update?target=darwin&current_version=2023.6.6+1309&arch=aarch64
400 Bad Request
```

After
```
POST https://sourcegraph.test:3443/.api/app/check/update?target=darwin&current_version=2023.6.6+1309&arch=aarch64
204 No Content
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
