### PR TITLE
Add wolfi initcontainer

### DIFF
--- a/docker-images/initcontainer/BUILD.bazel
+++ b/docker-images/initcontainer/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("//dev:oci_defs.bzl", "image_repository")
+
+oci_image(
+    name = "image",
+    base = "@wolfi_base",
+    entrypoint = ["/bin/sh"],
+    user = "root",
+)
+
+oci_tarball(
+    name = "image_tarball",
+    image = ":image",
+    repo_tags = ["initcontainer:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = ["requires-network"],
+)
+
+oci_push(
+    name = "candidate_push",
+    image = ":image",
+    repository = image_repository("initcontainer"),
+)

--- a/docker-images/initcontainer/README.md
+++ b/docker-images/initcontainer/README.md
@@ -1,0 +1,1 @@
+Simple container used as an initContainer in several places, to replace the use of sourcegraph/alpine-3.14.

--- a/docker-images/initcontainer/image_test.yaml
+++ b/docker-images/initcontainer/image_test.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    expectedOutput: ["^0"]
+    exitCode: 0


### PR DESCRIPTION
Add a simple wolfi-based container that runs as root, which can be used as an initcontainer in our manifests

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- container structure tests
- testing container manually
