### PR TITLE
Fix sveltekit prototype

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -5,8 +5,8 @@
     import { EditorView, lineNumbers } from '@codemirror/view'
 
     import { browser } from '$app/environment'
-    import { syntaxHighlight } from '$lib/web'
     import type { BlobFileFields } from '$lib/graphql-operations'
+    import { syntaxHighlight } from '$lib/web'
 
     export let blob: BlobFileFields
     export let highlights: string

--- a/client/web-sveltekit/src/lib/Commit.svelte
+++ b/client/web-sveltekit/src/lib/Commit.svelte
@@ -2,10 +2,10 @@
     import { mdiDotsHorizontal } from '@mdi/js'
 
     import type { GitCommitFields } from '$lib/graphql-operations'
-    import { currentDate as now } from '$lib/stores'
-    import { getRelativeTime } from '$lib/relativeTime'
-    import UserAvatar from '$lib/UserAvatar.svelte'
     import Icon from '$lib/Icon.svelte'
+    import { getRelativeTime } from '$lib/relativeTime'
+    import { currentDate as now } from '$lib/stores'
+    import UserAvatar from '$lib/UserAvatar.svelte'
 
     export let commit: GitCommitFields
     export let alwaysExpanded: boolean = false

--- a/client/web-sveltekit/src/lib/Icon.svelte
+++ b/client/web-sveltekit/src/lib/Icon.svelte
@@ -9,6 +9,7 @@
 -->
 <script lang="ts">
     import type { SVGAttributes } from 'svelte/elements'
+
     interface $$Props extends SVGAttributes<SVGElement> {
         svgPath: string
         inline?: boolean

--- a/client/web-sveltekit/src/lib/Paginator.svelte
+++ b/client/web-sveltekit/src/lib/Paginator.svelte
@@ -24,9 +24,11 @@
 </script>
 
 <script lang="ts">
-    import Icon from './Icon.svelte'
     import { mdiPageFirst, mdiPageLast, mdiChevronRight, mdiChevronLeft } from '@mdi/js'
+
     import { page } from '$app/stores'
+
+    import Icon from './Icon.svelte'
     import { Button } from './wildcard'
 
     export let pageInfo: {

--- a/client/web-sveltekit/src/lib/Popover.svelte
+++ b/client/web-sveltekit/src/lib/Popover.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { createPopper, type Placement } from '@popperjs/core'
+
     import { onClickOutside } from './dom'
 
     export let placement: Placement = 'bottom'

--- a/client/web-sveltekit/src/lib/ReactComponent.svelte
+++ b/client/web-sveltekit/src/lib/ReactComponent.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
     import React from 'react'
+
     import { createRoot, type Root } from 'react-dom/client'
     import { onDestroy, onMount } from 'svelte'
+
     import { ReactAdapter } from './react-interop'
 
     type ComponentProps = $$Generic<{}>

--- a/client/web-sveltekit/src/lib/TabPanel.svelte
+++ b/client/web-sveltekit/src/lib/TabPanel.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import { getContext } from 'svelte'
-    import { type TabsContext, KEY } from './Tabs.svelte'
     import * as uuid from 'uuid'
+
+    import { type TabsContext, KEY } from './Tabs.svelte'
 
     export let title: string
 

--- a/client/web-sveltekit/src/lib/Tabs.svelte
+++ b/client/web-sveltekit/src/lib/Tabs.svelte
@@ -14,9 +14,9 @@
 </script>
 
 <script lang="ts">
-    import * as uuid from 'uuid'
     import { setContext } from 'svelte'
     import { derived, writable, type Readable, type Writable } from 'svelte/store'
+    import * as uuid from 'uuid'
 
     /**
      * The index of the tab that should be selected by default.

--- a/client/web-sveltekit/src/lib/Tooltip.svelte
+++ b/client/web-sveltekit/src/lib/Tooltip.svelte
@@ -91,25 +91,25 @@
         min-width: 0;
         display: none;
 
-        &:global([data-popper-placement^='top']) > .arrow {
-            bottom: -4px;
-        }
-
-        &:global([data-popper-placement^='bottom']) > .arrow {
-            top: -4px;
-        }
-
-        &:global([data-popper-placement^='left']) > .arrow {
-            right: -4px;
-        }
-
-        &:global([data-popper-placement^='right']) > .arrow {
-            left: -4px;
-        }
-
         &.visible {
             display: block;
         }
+    }
+
+    :global([data-popper-placement^='top']) > .arrow {
+        bottom: -4px;
+    }
+
+    :global([data-popper-placement^='bottom']) > .arrow {
+        top: -4px;
+    }
+
+    :global([data-popper-placement^='left']) > .arrow {
+        right: -4px;
+    }
+
+    :global([data-popper-placement^='right']) > .arrow {
+        left: -4px;
     }
 
     .arrow,

--- a/client/web-sveltekit/src/lib/repo/FileTree.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileTree.svelte
@@ -3,7 +3,6 @@
 
     import { isErrorLike, type ErrorLike } from '$lib/common'
     import type { TreeFields } from '$lib/graphql/shared'
-
     import Icon from '$lib/Icon.svelte'
 
     export let treeOrError: TreeFields | ErrorLike | null

--- a/client/web-sveltekit/src/lib/repo/GitReference.svelte
+++ b/client/web-sveltekit/src/lib/repo/GitReference.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-    import { getRelativeTime } from '$lib/relativeTime'
-    import { currentDate as now } from '$lib/stores'
     import { numberWithCommas } from '$lib/common'
     import type { GitRefFields } from '$lib/graphql-operations'
+    import { getRelativeTime } from '$lib/relativeTime'
+    import { currentDate as now } from '$lib/stores'
 
     export let ref: GitRefFields
 

--- a/client/web-sveltekit/src/lib/repo/HeaderAction.svelte
+++ b/client/web-sveltekit/src/lib/repo/HeaderAction.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { getContext, type ComponentType } from 'svelte'
+
     import type { ActionStore } from './actions'
 
     export let key: string

--- a/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+    import { closeCompletion } from '@codemirror/autocomplete'
     import { defaultKeymap, history, historyKeymap } from '@codemirror/commands'
     import { Compartment, EditorState, Prec } from '@codemirror/state'
     import { EditorView, keymap, placeholder as placeholderExtension } from '@codemirror/view'
-    import { closeCompletion } from '@codemirror/autocomplete'
     import { createEventDispatcher } from 'svelte'
 
     import { browser } from '$app/environment'
     import { goto } from '$app/navigation'
-    import type { SearchPatternType } from '$lib/graphql-operations'
     import { createDefaultSuggestions, singleLine, parseInputAsQuery, querySyntaxHighlighting } from '$lib/branded'
+    import type { SearchPatternType } from '$lib/graphql-operations'
     import { fetchStreamSuggestions, QueryChangeSource, type QueryState } from '$lib/shared'
 
     import { defaultTheme } from './codemirror/theme'

--- a/client/web-sveltekit/src/lib/search/QueryExampleChip.svelte
+++ b/client/web-sveltekit/src/lib/search/QueryExampleChip.svelte
@@ -9,8 +9,10 @@
 
 <script lang="ts">
     import { getContext } from 'svelte'
-    import type { SearchPageContext } from './utils'
+
     import SyntaxHighlightedQuery from '$lib/search/SyntaxHighlightedQuery.svelte'
+
+    import type { SearchPageContext } from './utils'
 
     export let queryExample: QueryExample
 

--- a/client/web-sveltekit/src/lib/search/SearchBox.svelte
+++ b/client/web-sveltekit/src/lib/search/SearchBox.svelte
@@ -2,10 +2,10 @@
     import { mdiClose, mdiCodeBrackets, mdiFormatLetterCase, mdiLightningBolt, mdiMagnify, mdiRegex } from '@mdi/js'
 
     import { invalidate } from '$app/navigation'
+    import { SearchPatternType } from '$lib/graphql-operations'
     import Icon from '$lib/Icon.svelte'
     import Popover from '$lib/Popover.svelte'
     import Tooltip from '$lib/Tooltip.svelte'
-    import { SearchPatternType } from '$lib/graphql-operations'
 
     import CodeMirrorQueryInput from './CodeMirrorQueryInput.svelte'
     import { SearchMode, submitSearch, type QueryStateStore } from './state'

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -16,7 +16,6 @@ export { replaceRevisionInURL } from '@sourcegraph/web/src/util/url'
 export type { ResolvedRevision } from '@sourcegraph/web/src/repo/backend'
 export { syntaxHighlight } from '@sourcegraph/web/src/repo/blob/codemirror/highlight'
 export { defaultSearchModeFromSettings } from '@sourcegraph/web/src/util/settings'
-export { setExperimentalFeaturesFromSettings } from '@sourcegraph/web/src/stores/experimentalFeatures'
 export { GlobalNotebooksArea, type GlobalNotebooksAreaProps } from '@sourcegraph/web/src/notebooks/GlobalNotebooksArea'
 export {
     CodeInsightsRouter,

--- a/client/web-sveltekit/src/lib/wildcard/Button.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Button.svelte
@@ -3,14 +3,15 @@
     // accepts any HTMLButton attributes. Note that those will only be used when
     // the default implementation is used.
     import type { HTMLButtonAttributes } from 'svelte/elements'
-    interface $$Props extends HTMLButtonAttributes {
-        variant?: (typeof BUTTON_VARIANTS)[number]
-        size?: (typeof BUTTON_SIZES)[number]
-        display?: (typeof BUTTON_DISPLAY)[number]
-        outline?: boolean
-    }
 
     import { type BUTTON_DISPLAY, type BUTTON_SIZES, type BUTTON_VARIANTS, getButtonClassName } from './Button'
+
+    interface $$Props extends HTMLButtonAttributes {
+        variant?: typeof BUTTON_VARIANTS[number]
+        size?: typeof BUTTON_SIZES[number]
+        display?: typeof BUTTON_DISPLAY[number]
+        outline?: boolean
+    }
 
     export let variant: $$Props['variant'] = 'primary'
     export let size: $$Props['size'] = undefined

--- a/client/web-sveltekit/src/lib/wildcard/ButtonGroup.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/ButtonGroup.svelte
@@ -3,7 +3,7 @@
 
     import { type BUTTON_GROUP_DIRECTION, styles } from './Button'
 
-    export let direction: (typeof BUTTON_GROUP_DIRECTION)[number] = 'horizontal'
+    export let direction: typeof BUTTON_GROUP_DIRECTION[number] = 'horizontal'
 
     $: className = classNames(styles.btnGroup, direction === 'vertical' && styles.btnGroupVertical)
 </script>

--- a/client/web-sveltekit/src/routes/(enterprise)/insights/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/(enterprise)/insights/[...path]/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import { CodeInsightsRouter, type CodeInsightsRouterProps } from '$lib/web'
     import { PUBLIC_DOTCOM } from '$env/static/public'
-    import type { PageData } from './$types'
-    import ReactComponent from '$lib/ReactComponent.svelte'
     import { eventLogger } from '$lib/logger'
+    import ReactComponent from '$lib/ReactComponent.svelte'
+    import { CodeInsightsRouter, type CodeInsightsRouterProps } from '$lib/web'
+
+    import type { PageData } from './$types'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/(enterprise)/notebooks/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/(enterprise)/notebooks/[...path]/+page.svelte
@@ -8,17 +8,19 @@
     the default browser behavior to take place.
 -->
 <script lang="ts">
+    import type { Observable } from 'rxjs'
+
     import { PUBLIC_DOTCOM } from '$env/static/public'
-    import { GlobalNotebooksArea, type GlobalNotebooksAreaProps } from '$lib/web'
-    import type { PageData } from './$types'
+    import { eventLogger } from '$lib/logger'
+    import ReactComponent from '$lib/ReactComponent.svelte'
     import {
         aggregateStreamingSearch,
         fetchHighlightedFileLineRanges as _fetchHighlightedFileLineRanges,
         type FetchFileParameters,
     } from '$lib/shared'
-    import type { Observable } from 'rxjs'
-    import ReactComponent from '$lib/ReactComponent.svelte'
-    import { eventLogger } from '$lib/logger'
+    import { GlobalNotebooksArea, type GlobalNotebooksAreaProps } from '$lib/web'
+
+    import type { PageData } from './$types'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -3,15 +3,18 @@
     import { readable, writable, type Readable } from 'svelte/store'
 
     import { browser } from '$app/environment'
-    import { KEY, type SourcegraphContext } from '$lib/stores'
     import { isErrorLike } from '$lib/common'
     import { TemporarySettingsStorage } from '$lib/shared'
+    import { KEY, type SourcegraphContext } from '$lib/stores'
     import { createTemporarySettingsStorage } from '$lib/temporarySettings'
 
     import Header from './Header.svelte'
+
     import './styles.scss'
-    import type { LayoutData, Snapshot } from './$types'
+
     import { beforeNavigate } from '$app/navigation'
+
+    import type { LayoutData, Snapshot } from './$types'
 
     export let data: LayoutData
 

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -11,7 +11,6 @@
     import Header from './Header.svelte'
     import './styles.scss'
     import type { LayoutData, Snapshot } from './$types'
-    import { setExperimentalFeaturesFromSettings } from '$lib/web'
     import { beforeNavigate } from '$app/navigation'
 
     export let data: LayoutData
@@ -60,8 +59,6 @@
     $: $user = data.user ?? null
     $: $settings = isErrorLike(data.settings) ? null : data.settings.final
     $: $platformContext = data.platformContext
-    // Sync React stores
-    $: setExperimentalFeaturesFromSettings(data.settings)
 
     $: if (browser) {
         document.documentElement.classList.toggle('theme-light', $isLightTheme)

--- a/client/web-sveltekit/src/routes/Header.svelte
+++ b/client/web-sveltekit/src/routes/Header.svelte
@@ -2,8 +2,8 @@
     import { mdiBookOutline, mdiChartBar, mdiMagnify } from '@mdi/js'
 
     import { mark } from '$lib/images'
-    import UserAvatar from '$lib/UserAvatar.svelte'
     import type { AuthenticatedUser } from '$lib/shared'
+    import UserAvatar from '$lib/UserAvatar.svelte'
 
     import HeaderNavLink from './HeaderNavLink.svelte'
 

--- a/client/web-sveltekit/src/routes/HeaderNavLink.svelte
+++ b/client/web-sveltekit/src/routes/HeaderNavLink.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { page } from '$app/stores'
-
     import Icon from '$lib/Icon.svelte'
 
     export let href: string

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import { page } from '$app/stores'
-
-    import FileTree from '$lib/repo/FileTree.svelte'
-    import Icon from '$lib/Icon.svelte'
     import { mdiChevronDoubleLeft, mdiChevronDoubleRight } from '@mdi/js'
+
+    import { page } from '$app/stores'
+    import Icon from '$lib/Icon.svelte'
+    import FileTree from '$lib/repo/FileTree.svelte'
+
     import type { PageData } from './$types'
 
     export let data: PageData

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import { mdiFolderOutline, mdiFileDocumentOutline } from '@mdi/js'
 
-    import { isErrorLike } from '$lib/common'
     import Commit from '$lib/Commit.svelte'
+    import { isErrorLike } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
+    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
 
     import type { PageData } from './$types'
-    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-    import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
-    import type { PageData } from './$types'
     import { page } from '$app/stores'
-    import WrapLinesAction, { lineWrap } from './WrapLinesAction.svelte'
-    import FormatAction from './FormatAction.svelte'
+    import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
     import type { BlobFileFields } from '$lib/graphql-operations'
     import HeaderAction from '$lib/repo/HeaderAction.svelte'
+
+    import type { PageData } from './$types'
+    import FormatAction from './FormatAction.svelte'
+    import WrapLinesAction, { lineWrap } from './WrapLinesAction.svelte'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/FormatAction.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/FormatAction.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-    import Icon from '$lib/Icon.svelte'
     import { mdiEye } from '@mdi/js'
-    import { page } from '$app/stores'
+
     import { goto } from '$app/navigation'
+    import { page } from '$app/stores'
+    import Icon from '$lib/Icon.svelte'
 
     $: formatted = $page.url.searchParams.get('view') !== 'raw'
     let url: string

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/WrapLinesAction.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/WrapLinesAction.svelte
@@ -1,11 +1,13 @@
 <script lang="ts" context="module">
     import { writable } from 'svelte/store'
+
     export const lineWrap = writable<boolean>(false)
 </script>
 
 <script lang="ts">
-    import Icon from '$lib/Icon.svelte'
     import { mdiWrap, mdiWrapDisabled } from '@mdi/js'
+
+    import Icon from '$lib/Icon.svelte'
 </script>
 
 <button on:click={() => lineWrap.update(wrap => !wrap)}

--- a/client/web-sveltekit/src/routes/[...repo]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/+layout.svelte
@@ -4,14 +4,14 @@
 
     import { page } from '$app/stores'
     import { isErrorLike } from '$lib/common'
-    import { displayRepoName, isRepoNotFoundErrorLike } from '$lib/shared'
+    import Icon from '$lib/Icon.svelte'
     import { createActionStore, type ActionStore } from '$lib/repo/actions'
     import { getRevisionLabel, navFromPath } from '$lib/repo/utils'
-    import Icon from '$lib/Icon.svelte'
+    import { displayRepoName, isRepoNotFoundErrorLike } from '$lib/shared'
 
-    import RepoNotFoundError from './RepoNotFoundError.svelte'
-    import Permalink from './Permalink.svelte'
     import type { LayoutData } from './$types'
+    import Permalink from './Permalink.svelte'
+    import RepoNotFoundError from './RepoNotFoundError.svelte'
 
     export let data: LayoutData
 

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { page } from '$app/stores'
+
     import type { LayoutData } from './$types'
 
     export let data: LayoutData

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+
     import type { PageData } from './$types'
 
     export let data: PageData

--- a/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-    import type { PageData } from './$types'
     import Commit from '$lib/Commit.svelte'
-    import FileDiff from './FileDiff.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+
+    import type { PageData } from './$types'
+    import FileDiff from './FileDiff.svelte'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/FileDiff.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/FileDiff.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import { mdiChevronRight, mdiChevronDown } from '@mdi/js'
     import { dirname } from 'path'
+
+    import { mdiChevronRight, mdiChevronDown } from '@mdi/js'
 
     import { numberWithCommas } from '$lib/common'
     import type { FileDiffFields } from '$lib/graphql-operations'

--- a/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import type { PageData } from './$types'
     import Commit from '$lib/Commit.svelte'
+
+    import type { PageData } from './$types'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/[...repo]/-/stats/contributors/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/stats/contributors/+page.svelte
@@ -2,13 +2,13 @@
     import { goto } from '$app/navigation'
     import { page } from '$app/stores'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import Paginator from '$lib/Paginator.svelte'
     import { getRelativeTime } from '$lib/relativeTime'
-    import UserAvatar from '$lib/UserAvatar.svelte'
     import { currentDate } from '$lib/stores'
+    import UserAvatar from '$lib/UserAvatar.svelte'
+    import { Button, ButtonGroup } from '$lib/wildcard'
 
     import type { PageData } from './$types'
-    import Paginator from '$lib/Paginator.svelte'
-    import { Button, ButtonGroup } from '$lib/wildcard'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/[...repo]/Permalink.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/Permalink.svelte
@@ -2,9 +2,9 @@
     import { mdiLink } from '@mdi/js'
 
     import { page } from '$app/stores'
-    import { replaceRevisionInURL } from '$lib/web'
     import { isErrorLike } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
+    import { replaceRevisionInURL } from '$lib/web'
 
     $: resolvedRevision = isErrorLike($page.data.resolvedRevision) ? null : $page.data.resolvedRevision
 

--- a/client/web-sveltekit/src/routes/[...repo]/RepoNotFoundError.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/RepoNotFoundError.svelte
@@ -2,10 +2,10 @@
     import { mdiMapSearch } from '@mdi/js'
     import { map, catchError } from 'rxjs/operators'
 
-    import { logViewEvent } from '$lib/logger'
     import { asError, isErrorLike, type ErrorLike } from '$lib/common'
-    import { checkMirrorRepositoryConnection } from '$lib/web'
     import HeroPage from '$lib/HeroPage.svelte'
+    import { logViewEvent } from '$lib/logger'
+    import { checkMirrorRepositoryConnection } from '$lib/web'
 
     export let repoName: string
     export let viewerCanAdminister: boolean

--- a/client/web-sveltekit/src/routes/search/+page.svelte
+++ b/client/web-sveltekit/src/routes/search/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-    import QueryExamples from './QueryExamples.svelte'
     import { getQueryExamples } from '$lib/search/queryExamples'
-
-    import type { PageData } from './$types'
-    import SearchHome from './SearchHome.svelte'
-    import SearchResults from './SearchResults.svelte'
     import { queryStateStore } from '$lib/search/state'
     import { settings } from '$lib/stores'
+
+    import type { PageData } from './$types'
+    import QueryExamples from './QueryExamples.svelte'
+    import SearchHome from './SearchHome.svelte'
+    import SearchResults from './SearchResults.svelte'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/search/CodeExcerpt.svelte
+++ b/client/web-sveltekit/src/routes/search/CodeExcerpt.svelte
@@ -6,8 +6,8 @@
     import { catchError } from 'rxjs/operators'
 
     import { asError, isErrorLike, highlightNodeMultiline } from '$lib/common'
-    import type { MatchGroupMatch } from '$lib/shared'
     import { observeIntersection } from '$lib/intersection-observer'
+    import type { MatchGroupMatch } from '$lib/shared'
 
     export let startLine: number
     export let endLine: number

--- a/client/web-sveltekit/src/routes/search/FileMatchChildren.svelte
+++ b/client/web-sveltekit/src/routes/search/FileMatchChildren.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import { map } from 'rxjs/operators'
 
-    import { platformContext } from '$lib/stores'
-    import type { MatchGroup, ContentMatch } from '$lib/shared'
     import { HighlightResponseFormat, type HighlightLineRange } from '$lib/graphql-operations'
     import { fetchFileRangeMatches } from '$lib/search/results'
+    import type { MatchGroup, ContentMatch } from '$lib/shared'
+    import { platformContext } from '$lib/stores'
 
     import CodeExcerpt from './CodeExcerpt.svelte'
 

--- a/client/web-sveltekit/src/routes/search/FileSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResult.svelte
@@ -1,9 +1,12 @@
 <svelte:options immutable />
 
 <script lang="ts">
-    import { getContext } from 'svelte'
     import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
+    import { getContext } from 'svelte'
 
+    import { pluralize } from '$lib/common'
+    import Icon from '$lib/Icon.svelte'
+    import { resultToMatchItems } from '$lib/search/utils'
     import {
         displayRepoName,
         splitPath,
@@ -13,13 +16,10 @@
         type MatchItem,
         ZoektRanking,
     } from '$lib/shared'
-    import Icon from '$lib/Icon.svelte'
-    import { pluralize } from '$lib/common'
-    import { resultToMatchItems } from '$lib/search/utils'
 
     import FileMatchChildren from './FileMatchChildren.svelte'
-    import type { Context } from './SearchResults.svelte'
     import SearchResult from './SearchResult.svelte'
+    import type { Context } from './SearchResults.svelte'
 
     export let result: ContentMatch
 

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { mdiBitbucket, mdiGithub, mdiGitlab, mdiStar } from '@mdi/js'
 
-    import type { SearchMatch } from '$lib/shared'
-    import Icon from '$lib/Icon.svelte'
     import { formatRepositoryStarCount } from '$lib/branded'
+    import Icon from '$lib/Icon.svelte'
+    import type { SearchMatch } from '$lib/shared'
     import Tooltip from '$lib/Tooltip.svelte'
 
     function codeHostIcon(repoName: string): { hostName: string; svgPath?: string } {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -19,20 +19,20 @@
     import { setContext, tick } from 'svelte'
 
     import { beforeNavigate } from '$app/navigation'
-    import { SearchSidebarSectionID, type AggregateStreamingSearchResults, type SearchMatch } from '$lib/shared'
     import { preserveScrollPosition } from '$lib/app'
     import { observeIntersection } from '$lib/intersection-observer'
-    import SearchBox from '$lib/search/SearchBox.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
-    import { submitSearch, type QueryStateStore } from '$lib/search/state'
+    import SearchBox from '$lib/search/SearchBox.svelte'
     import { searchTypes } from '$lib/search/sidebar'
+    import { submitSearch, type QueryStateStore } from '$lib/search/state'
     import type { SidebarFilter } from '$lib/search/utils'
+    import { SearchSidebarSectionID, type AggregateStreamingSearchResults, type SearchMatch } from '$lib/shared'
 
-    import Section from './SidebarSection.svelte'
-    import SymbolSearchResult from './SymbolSearchResult.svelte'
-    import StreamingProgress from './StreamingProgress.svelte'
     import FileSearchResult from './FileSearchResult.svelte'
     import RepoSearchResult from './RepoSearchResult.svelte'
+    import Section from './SidebarSection.svelte'
+    import StreamingProgress from './StreamingProgress.svelte'
+    import SymbolSearchResult from './SymbolSearchResult.svelte'
 
     export let stream: Observable<AggregateStreamingSearchResults | undefined>
     export let queryFromURL: string

--- a/client/web-sveltekit/src/routes/search/SidebarSection.svelte
+++ b/client/web-sveltekit/src/routes/search/SidebarSection.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+    import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
+
     import Icon from '$lib/Icon.svelte'
     import type { SidebarFilter } from '$lib/search/utils'
+    import type { SearchSidebarSectionID } from '$lib/shared'
     import { temporarySetting } from '$lib/temporarySettings'
     import Tooltip from '$lib/Tooltip.svelte'
     import Button from '$lib/wildcard/Button.svelte'
-    import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
-    import type { SearchSidebarSectionID } from '$lib/shared'
 
     export let id: SearchSidebarSectionID
     export let items: SidebarFilter[]

--- a/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
+++ b/client/web-sveltekit/src/routes/search/StreamingProgress.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import { mdiAlertCircle, mdiChevronDown, mdiChevronLeft, mdiInformationOutline, mdiMagnify } from '@mdi/js'
 
+    import { limitHit, sortBySeverity } from '$lib/branded'
     import { renderMarkdown, pluralize } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
     import Popover from '$lib/Popover.svelte'
     import SyntaxHighlightedQuery from '$lib/search/SyntaxHighlightedQuery.svelte'
-    import { limitHit, sortBySeverity } from '$lib/branded'
     import type { Progress, Skipped } from '$lib/shared'
     import { Button } from '$lib/wildcard'
 

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -3,12 +3,12 @@
 <script lang="ts">
     import { map } from 'rxjs/operators'
 
-    import { displayRepoName, splitPath, getFileMatchUrl, getRepositoryUrl, type SymbolMatch } from '$lib/shared'
     import { HighlightResponseFormat } from '$lib/graphql-operations'
-    import { platformContext } from '$lib/stores'
+    import Icon from '$lib/Icon.svelte'
     import { fetchFileRangeMatches } from '$lib/search/results'
     import { getSymbolIconPath } from '$lib/search/symbolIcons'
-    import Icon from '$lib/Icon.svelte'
+    import { displayRepoName, splitPath, getFileMatchUrl, getRepositoryUrl, type SymbolMatch } from '$lib/shared'
+    import { platformContext } from '$lib/stores'
 
     import CodeExcerpt from './CodeExcerpt.svelte'
     import SearchResult from './SearchResult.svelte'


### PR DESCRIPTION
Two issues prevented the prototype from running in dev mode:

- A module imported from web didn't exist anymore (experimental settings stuff)
- There are new restrictions about how `:global` can be used.

All the rest are just formatting changes.

## Test plan

Started the app locally with `pnpm dev`.
