### PR TITLE
Cody: Simplify non-stop fixup states, transitions and actions

### DIFF
--- a/client/cody-shared/src/chat/recipes/non-stop.ts
+++ b/client/cody-shared/src/chat/recipes/non-stop.ts
@@ -61,7 +61,6 @@ export class NonStop implements Recipe {
             },
             onTurnComplete: async () => {
                 await context.editor.didReceiveFixupText(taskID, text, 'complete')
-                controllers.task.stop(taskID)
             },
         })
 

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -29,7 +29,6 @@ interface VsCodeInlineController {
 // TODO: Move this interface to client/cody
 interface VsCodeTaskController {
     add(input: string, selection: ActiveTextEditorSelection): string | null
-    stop(taskID: string): void
 }
 
 export interface ActiveTextEditorViewControllers {

--- a/client/cody/src/non-stop/FixupCodeLenses.ts
+++ b/client/cody/src/non-stop/FixupCodeLenses.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { getLensesByState } from './codelenses'
+import { getLensesForTask } from './codelenses'
 import { FixupTask } from './FixupTask'
 import { FixupFileCollection } from './roles'
 import { CodyTaskState } from './utils'
@@ -44,7 +44,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
             this.removeLensesFor(task)
             return
         }
-        this.taskLenses.set(task, getLensesByState(task.id, task.state, task.selectionRange))
+        this.taskLenses.set(task, getLensesForTask(task))
         this.notifyCodeLensesChanged()
     }
 

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -96,6 +96,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
 
     // Replaces content of the file before mark the task as done
     // Then update the tree view with the new task state
+    // TODO: Move this to the state transition to "ready"
     public stop(taskID: taskID): void {
         const task = this.tasks.get(taskID)
         if (!task) {
@@ -262,7 +263,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         if (!task) {
             return Promise.resolve()
         }
-        if (task.state !== CodyTaskState.asking && task.state !== CodyTaskState.marking) {
+        if (task.state !== CodyTaskState.asking) {
             // TODO: Update this when we re-spin tasks with conflicts so that
             // we store the new text but can also display something reasonably
             // stable in the editor
@@ -272,7 +273,6 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         switch (state) {
             case 'streaming':
                 task.inProgressReplacement = text
-                await this.setTaskState(task, CodyTaskState.marking)
                 break
             case 'complete':
                 task.inProgressReplacement = undefined

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -9,7 +9,7 @@ export type taskID = string
 export class FixupTask {
     public id: taskID
     public selectionRange: vscode.Range
-    public state_: CodyTaskState = CodyTaskState.idle
+    public state_: CodyTaskState = CodyTaskState.waiting
     // The original text that we're working on updating
     public readonly original: string
     // The text of the streaming turn of the LLM, if any

--- a/client/cody/src/non-stop/TaskViewProvider.ts
+++ b/client/cody/src/non-stop/TaskViewProvider.ts
@@ -116,7 +116,8 @@ export class TaskViewProvider implements vscode.TreeDataProvider<FixupTaskTreeIt
 }
 
 export class FixupTaskTreeItem extends vscode.TreeItem {
-    private state: CodyTaskState = CodyTaskState.idle
+    // TODO: Don't duplicate the task state here; use the FixupTask directly.
+    private state: CodyTaskState = CodyTaskState.waiting
     public fsPath: string
 
     // state for parent node

--- a/client/cody/src/non-stop/codelenses.ts
+++ b/client/cody/src/non-stop/codelenses.ts
@@ -2,43 +2,45 @@ import * as vscode from 'vscode'
 
 import { getSingleLineRange } from '../services/InlineAssist'
 
+import { FixupTask } from './FixupTask'
 import { CodyTaskState } from './utils'
 
 // Create Lenses based on state
-export function getLensesByState(id: string, state: CodyTaskState, range: vscode.Range): vscode.CodeLens[] {
-    const codeLensRange = getSingleLineRange(range.start.line)
-    switch (state) {
-        case CodyTaskState.error: {
-            const title = getErrorLens(codeLensRange)
-            const diff = getDiffLens(codeLensRange, id)
-            const discard = getDiscardLens(codeLensRange, id)
-            return [title, diff, discard]
-        }
-        case CodyTaskState.applying: {
-            const title = getApplyingLens(codeLensRange)
-            const cancel = getCancelLens(codeLensRange, id)
+export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
+    const codeLensRange = getSingleLineRange(task.selectionRange.start.line)
+    switch (task.state) {
+        case CodyTaskState.waiting: {
+            const title = getWaitingLens(codeLensRange)
+            const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
         case CodyTaskState.asking: {
             const title = getAskingLens(codeLensRange)
-            const cancel = getCancelLens(codeLensRange, id)
+            const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
         case CodyTaskState.ready: {
-            const title = getReadyLens(codeLensRange, id)
-            const apply = getApplyLens(codeLensRange, id)
-            const diff = getDiffLens(codeLensRange, id)
-            const edit = getEditLens(codeLensRange, id)
-            return [title, apply, edit, diff]
+            const title = getReadyLens(codeLensRange, task.id)
+            const apply = getApplyLens(codeLensRange, task.id)
+            const diff = getDiffLens(codeLensRange, task.id)
+            return [title, apply, diff]
         }
-        // TODO: Add lenses for waiting tasks, so they can be cancelled
+        case CodyTaskState.applying: {
+            const title = getApplyingLens(codeLensRange)
+            return [title]
+        }
+        case CodyTaskState.error: {
+            const title = getErrorLens(codeLensRange)
+            const discard = getDiscardLens(codeLensRange, task.id)
+            return [title, discard]
+        }
         default:
             return []
     }
 }
 
 // List of lenses
-// NOTE: code lens requires a command so we will use 'cody.focus' as a placeholder
+// TODO: Replace cody.focus with appropriate tasks
 // TODO (bea) send error messages to the chat UI so that they can see the task progress in the chat and chat history
 function getErrorLens(codeLensRange: vscode.Range): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
@@ -53,6 +55,15 @@ function getAskingLens(codeLensRange: vscode.Range): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Asking Cody...',
+        command: 'cody.focus',
+    }
+    return lens
+}
+
+function getWaitingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: '$(sync) Asking Cody...',
         command: 'cody.focus',
     }
     return lens
@@ -81,7 +92,7 @@ function getDiscardLens(codeLensRange: vscode.Range, id: string): vscode.CodeLen
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: 'Discard',
-        command: 'cody.fixup.codelens.discard',
+        command: 'cody.fixup.codelens.cancel',
         arguments: [id],
     }
     return lens
@@ -100,18 +111,8 @@ function getDiffLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
 function getReadyLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
-        title: '✨ Fixup ready',
-        command: 'cody.focus',
-        arguments: [id],
-    }
-    return lens
-}
-
-function getEditLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: 'Edit',
-        command: 'cody.fixup.codelens.edit',
+        title: '$(pencil) Fixup ready',
+        command: 'cody.fixup.codelens.apply',
         arguments: [id],
     }
     return lens

--- a/client/cody/src/non-stop/codelenses.ts
+++ b/client/cody/src/non-stop/codelenses.ts
@@ -31,11 +31,7 @@ export function getLensesByState(id: string, state: CodyTaskState, range: vscode
             const edit = getEditLens(codeLensRange, id)
             return [title, apply, edit, diff]
         }
-        case CodyTaskState.marking: {
-            const title = getMakingFixupsLens(codeLensRange)
-            const follow = getFollowLens(codeLensRange, id)
-            return [title, follow]
-        }
+        // TODO: Add lenses for waiting tasks, so they can be cancelled
         default:
             return []
     }
@@ -126,24 +122,6 @@ function getApplyLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens 
     lens.command = {
         title: 'Apply',
         command: 'cody.fixup.codelens.apply',
-        arguments: [id],
-    }
-    return lens
-}
-
-function getMakingFixupsLens(codeLensRange: vscode.Range): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: '$(edit) Cody is making fixups...',
-        command: 'cody.focus',
-    }
-    return lens
-}
-function getFollowLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: 'Follow',
-        command: 'cody.fixup.open',
         arguments: [id],
     }
     return lens

--- a/client/cody/src/non-stop/utils.ts
+++ b/client/cody/src/non-stop/utils.ts
@@ -1,12 +1,11 @@
 export enum CodyTaskState {
     'idle' = 0,
-    'queued' = 1,
+    'waiting' = 1,
     'asking' = 2,
-    'marking' = 3,
-    'ready' = 4,
-    'applying' = 5,
-    'fixed' = 6,
-    'error' = 7,
+    'ready' = 3,
+    'applying' = 4,
+    'fixed' = 5,
+    'error' = 6,
 }
 
 export type CodyTaskList = {
@@ -16,51 +15,51 @@ export type CodyTaskList = {
         description: string
     }
 }
+
 /**
  * Icon for each task state
  */
 export const fixupTaskList: CodyTaskList = {
+    // TODO: Remove this state when the code lens and decoration provider
+    // no longer maintain their own copy of state.
     [CodyTaskState.idle]: {
         id: 'idle',
         icon: 'clock',
-        description: 'Initial state - all task starts from here',
+        description: 'Initial state',
+    },
+    [CodyTaskState.waiting]: {
+        id: 'waiting',
+        // TODO: Per Figma, this should be a Cody wink
+        icon: 'debug-pause',
+        description: 'The task is waiting to be processed by Cody',
     },
     [CodyTaskState.asking]: {
         id: 'asking',
         icon: 'sync~spin',
-        description: 'In the process of pending for Cody response',
+        description: 'Cody is preparing a response',
     },
     [CodyTaskState.ready]: {
         id: 'ready',
-        icon: 'smiley',
+        icon: 'pencil',
         description: 'Cody has responsed with suggestions and is ready to apply them',
-    },
-    [CodyTaskState.error]: {
-        id: 'error',
-        icon: 'stop',
-        description: 'The task has been completed and returned error',
-    },
-    [CodyTaskState.queued]: {
-        id: 'queue',
-        icon: 'debug-pause',
-        description: 'The task is in the queue to be processed by Cody',
     },
     [CodyTaskState.applying]: {
         id: 'applying',
-        icon: 'sync~spin',
-        description: 'In the process of applying the fixups to the docs',
-    },
-    [CodyTaskState.marking]: {
-        id: 'marking',
-        icon: 'edit',
-        description: 'Marking the fixups as Cody responses',
+        icon: 'pencil',
+        description: 'The fixup is being applied to the document',
     },
     [CodyTaskState.fixed]: {
         id: 'fixed',
         icon: 'pass-filled',
-        description: 'Suggestions from Cody have been applied to the docs successfully',
+        description: 'Suggestions from Cody have been applied or discarded',
+    },
+    [CodyTaskState.error]: {
+        id: 'error',
+        icon: 'stop',
+        description: 'The task failed',
     },
 }
+
 /**
  * Get the last part of the file path after the last slash
  */


### PR DESCRIPTION
## Test plan

```
pnpm test:unit && pnpm test:integration && pnpm test:e2e
```

1. Open a file
2. Cmd-Shift-P Cody: Fixup (Experimental)
3. Tell Cody to do some work
4. Note the "Edit" code lens button is gone; diffs still work; the Cancel/Discard buttons work