### PR TITLE
own: remove redundant feature flags.

### DIFF
--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -19,7 +19,7 @@ interface OwnCoverageDatum {
     fill: string
     tooltip: string
 }
-
+ˆ
 export const OwnAnalyticsPage: FC = () => {
     const { data, loading, error } = useQuery<GetOwnSignalConfigurationsResult>(GET_OWN_JOB_CONFIGURATIONS, {})
     const enabled =

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -19,7 +19,7 @@ interface OwnCoverageDatum {
     fill: string
     tooltip: string
 }
-ˆ
+
 export const OwnAnalyticsPage: FC = () => {
     const { data, loading, error } = useQuery<GetOwnSignalConfigurationsResult>(GET_OWN_JOB_CONFIGURATIONS, {})
     const enabled =

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -33,8 +33,6 @@ export type FeatureFlagName =
     | 'cody-web-sidebar'
     | 'cody-web-all'
     | 'cody-web-editor-recipes'
-    | 'own-promote'
-    | 'own-analytics'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -7,7 +7,6 @@ import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { FetchOwnershipResult, FetchOwnershipVariables } from '../../../graphql-operations'
 import { OwnershipAssignPermission } from '../../../rbac/constants'
 
@@ -47,18 +46,17 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     const canAssignOwners = (data?.currentUser?.permissions?.nodes || []).some(
         permission => permission.displayName === OwnershipAssignPermission
     )
-    const makeOwnerButton =
-        canAssignOwners
-            ? (userId: string | undefined) => (
-                  <MakeOwnerButton
-                      onSuccess={refetch}
-                      onError={setMakeOwnerError}
-                      repoId={repoID}
-                      path={filePath}
-                      userId={userId}
-                  />
-              )
-            : undefined
+    const makeOwnerButton = canAssignOwners
+        ? (userId: string | undefined) => (
+              <MakeOwnerButton
+                  onSuccess={refetch}
+                  onError={setMakeOwnerError}
+                  repoId={repoID}
+                  path={filePath}
+                  userId={userId}
+              />
+          )
+        : undefined
 
     if (error) {
         logger.log(error)

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -36,7 +36,6 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         },
     })
     const [makeOwnerError, setMakeOwnerError] = React.useState<Error | undefined>(undefined)
-    const [ownPromotionEnabled] = useFeatureFlag('own-promote')
 
     if (loading) {
         return (
@@ -49,7 +48,7 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         permission => permission.displayName === OwnershipAssignPermission
     )
     const makeOwnerButton =
-        canAssignOwners && ownPromotionEnabled
+        canAssignOwners
             ? (userId: string | undefined) => (
                   <MakeOwnerButton
                       onSuccess={refetch}

--- a/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
@@ -8,7 +8,6 @@ import { useQuery } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { FetchTreeOwnershipResult, FetchTreeOwnershipVariables } from '../../../graphql-operations'
 import { OwnershipAssignPermission } from '../../../rbac/constants'
 
@@ -56,18 +55,17 @@ export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     const canAssignOwners = (data?.currentUser?.permissions?.nodes || []).some(
         permission => permission.displayName === OwnershipAssignPermission
     )
-    const makeOwnerButton =
-        canAssignOwners
-            ? (userId: string | undefined) => (
-                  <MakeOwnerButton
-                      onSuccess={refetch}
-                      onError={setMakeOwnerError}
-                      repoId={repoID}
-                      path={filePath}
-                      userId={userId}
-                  />
-              )
-            : undefined
+    const makeOwnerButton = canAssignOwners
+        ? (userId: string | undefined) => (
+              <MakeOwnerButton
+                  onSuccess={refetch}
+                  onError={setMakeOwnerError}
+                  repoId={repoID}
+                  path={filePath}
+                  userId={userId}
+              />
+          )
+        : undefined
 
     if (error) {
         logger.log(error)

--- a/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
@@ -45,7 +45,6 @@ export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         }
     )
     const [makeOwnerError, setMakeOwnerError] = React.useState<Error | undefined>(undefined)
-    const [ownPromotionEnabled] = useFeatureFlag('own-promote')
 
     if (loading) {
         return (
@@ -58,7 +57,7 @@ export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         permission => permission.displayName === OwnershipAssignPermission
     )
     const makeOwnerButton =
-        canAssignOwners && ownPromotionEnabled
+        canAssignOwners
             ? (userId: string | undefined) => (
                   <MakeOwnerButton
                       onSuccess={refetch}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -346,6 +346,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
                 {!isPackage && (
                     <div className={styles.contributors}>
+                        {/*TODO(#53160): use settings instead of feature flags to show Ownership*/}
                         {ownSignalsEnabled && (
                             <Card>
                                 <CardHeader className={panelStyles.cardColHeaderWrapper}>Own</CardHeader>

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -346,7 +346,7 @@ export const TreePageContent: React.FunctionComponent<React.PropsWithChildren<Tr
 
                 {!isPackage && (
                     <div className={styles.contributors}>
-                        {/*TODO(#53160): use settings instead of feature flags to show Ownership*/}
+                        {/* TODO(#53160): use settings instead of feature flags to show Ownership */}
                         {ownSignalsEnabled && (
                             <Card>
                                 <CardHeader className={panelStyles.cardColHeaderWrapper}>Own</CardHeader>
@@ -421,6 +421,7 @@ const CONTRIBUTORS_QUERY = gql`
 `
 
 interface ContributorsProps extends TreePageContentProps {}
+
 const Contributors: React.FC<ContributorsProps> = ({ repo, filePath }) => {
     const spec: QuerySpec = {
         revisionRange: '',
@@ -542,6 +543,7 @@ const OWNERS_QUERY = gql`
 `
 
 interface OwnershipProps extends TreePageContentProps {}
+
 const Ownership: React.FC<OwnershipProps> = ({ repo, filePath }) => {
     const { data, error, loading } = useQuery<TreePageOwnershipResult, TreePageOwnershipVariables>(OWNERS_QUERY, {
         variables: {
@@ -617,6 +619,7 @@ const Ownership: React.FC<OwnershipProps> = ({ repo, filePath }) => {
 interface OwnerNodeProps {
     node: TreePageOwnershipNodeFields
 }
+
 const OwnerNode: React.FC<OwnerNodeProps> = ({ node }) => {
     const owner = node?.owner
     const primaryReason =
@@ -681,6 +684,7 @@ interface RepositoryContributorNodeProps extends QuerySpec {
     repoName: string
     sourceType: string
 }
+
 const RepositoryContributorNode: React.FC<RepositoryContributorNodeProps> = ({
     node,
     repoName,
@@ -752,6 +756,7 @@ const COMMITS_QUERY = gql`
 `
 
 interface CommitsProps extends TreePageContentProps {}
+
 const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => {
     const after: string = useMemo(() => formatISO(subYears(Date.now(), 1)), [])
     const { data, error, loading } = useQuery<TreeCommitsResult, TreeCommitsVariables>(COMMITS_QUERY, {

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -86,8 +86,6 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
     const [isSourcegraphOperatorSiteAdminHideMaintenance] = useFeatureFlag(
         'sourcegraph-operator-site-admin-hide-maintenance'
     )
-    const [ownAnalyticsEnabled] = useFeatureFlag('own-analytics', false)
-
     const adminSideBarGroups = useMemo(
         () =>
             props.sideBarGroups.map(group => {
@@ -147,7 +145,6 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                 <SiteAdminSidebar
                     className={classNames('flex-0 mr-3 mb-4', styles.sidebar)}
                     groups={adminSideBarGroups}
-                    ownAnalyticsEnabled={ownAnalyticsEnabled}
                     isSourcegraphDotCom={props.isSourcegraphDotCom}
                     isSourcegraphApp={props.isSourcegraphApp}
                     batchChangesEnabled={props.batchChangesEnabled}

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -14,7 +14,6 @@ import styles from './SiteAdminSidebar.module.scss'
 export interface SiteAdminSideBarGroupContext extends BatchChangesProps {
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
-    ownAnalyticsEnabled: boolean
 }
 
 export interface SiteAdminSideBarGroup extends NavGroupDescriptor<SiteAdminSideBarGroupContext> {}
@@ -27,7 +26,6 @@ export interface SiteAdminSidebarProps extends BatchChangesProps {
     /** The items for the side bar, by group */
     groups: SiteAdminSideBarGroups
     className?: string
-    ownAnalyticsEnabled: boolean
 }
 
 /**

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -53,7 +53,6 @@ export const analyticsGroup: SiteAdminSideBarGroup = {
         {
             label: 'Own',
             to: '/site-admin/analytics/own',
-            condition: context => context.ownAnalyticsEnabled,
         },
         {
             label: 'Feedback survey',


### PR DESCRIPTION
Test plan:
Local sg run and tests that Own views ˆstill show up.

Part of https://github.com/sourcegraph/sourcegraph/issues/53160