### PR TITLE
bzl: increase timeout for database tests

### DIFF
--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -154,8 +154,8 @@ go_library(
 
 go_test(
     name = "database_test",
-    size = "large",
-    timeout = "moderate",
+    size = "enormous",
+    timeout = "long",
     srcs = [
         "access_requests_test.go",
         "access_tokens_test.go",


### PR DESCRIPTION
Depending on the scheduling on the database tests, they may go over 300s and timeout which this PR fixes.

Test Plan: CI



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
