### PR TITLE
sg.config.yaml: add symbols back to enterprise runset

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1233,6 +1233,7 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
+      - symbols
 
   enterprise-e2e:
     <<: *enterprise_set


### PR DESCRIPTION
It seems this was accidentally removed as a part of https://github.com/sourcegraph/sourcegraph/pull/53052


## Test plan

CI