### PR TITLE
Cody: Skip flaky e2e tests

### DIFF
--- a/client/cody/test/e2e/history.test.ts
+++ b/client/cody/test/e2e/history.test.ts
@@ -4,7 +4,7 @@ import { SERVER_URL, VALID_TOKEN } from '../fixtures/mock-server'
 
 import { test } from './helpers'
 
-test('checks for the chat history and new session', async ({ page, sidebar }) => {
+test.skip('checks for the chat history and new session', async ({ page, sidebar }) => {
     await sidebar.getByRole('textbox', { name: 'Sourcegraph Instance URL' }).fill(SERVER_URL)
 
     await sidebar.getByRole('textbox', { name: 'Access Token (docs)' }).fill(VALID_TOKEN)

--- a/client/cody/test/e2e/inline-assist-file-touch.test.ts
+++ b/client/cody/test/e2e/inline-assist-file-touch.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
-test('start a fixup job from inline assist with valid auth', async ({ page, sidebar }) => {
+test.skip('start a fixup job from inline assist with valid auth', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1686755959771579

We need to look into it, especially the history one is very flaky. I don't have the time to investigate right now, though.

## Test plan

ci green again (like, always ideally)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
