### PR TITLE
update zoekt in bazel and go.mod

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6351,8 +6351,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:4YaX+murRcqCv60eoESOrBwkftm7ufrq6Slx8uUzzqs=",
-        version = "v0.0.0-20230614145612-a4e18dd297ab",
+        sum = "h1:hm6nFFwZohk97lIG3Z5NRJghrYjj50HYKicXqI4b2qY=",
+        version = "v0.0.0-20230614202706-0148e0248f66",
     )
 
     go_repository(

--- a/deps.bzl
+++ b/deps.bzl
@@ -6351,8 +6351,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:BF1WS0akdRzj/2nYEzqcVhnBDbgucO6sqgDmKgbQDU8=",
-        version = "v0.0.0-20230613154029-b8b672211c40",
+        sum = "h1:4YaX+murRcqCv60eoESOrBwkftm7ufrq6Slx8uUzzqs=",
+        version = "v0.0.0-20230614145612-a4e18dd297ab",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -508,7 +508,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230614145612-a4e18dd297ab
+	github.com/sourcegraph/zoekt v0.0.0-20230614202706-0148e0248f66
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2067,8 +2067,8 @@ github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3 h1:6PgJPdhDHRGs
 github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230614145612-a4e18dd297ab h1:4YaX+murRcqCv60eoESOrBwkftm7ufrq6Slx8uUzzqs=
-github.com/sourcegraph/zoekt v0.0.0-20230614145612-a4e18dd297ab/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
+github.com/sourcegraph/zoekt v0.0.0-20230614202706-0148e0248f66 h1:hm6nFFwZohk97lIG3Z5NRJghrYjj50HYKicXqI4b2qY=
+github.com/sourcegraph/zoekt v0.0.0-20230614202706-0148e0248f66/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Just because our go.mod says we are using a newer version of zoekt doesn't mean we are since CI uses bazel. Still debugging the issue but this might be the root cause.

Test Plan: CI