### PR TITLE
grpc: add server interceptors to catch "internal" utf-8 errors for streaming methods

### DIFF
--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -105,6 +105,7 @@ func ServerOptions(logger log.Logger, additionalOptions ...grpc.ServerOption) []
 	out := []grpc.ServerOption{
 		grpc.ChainStreamInterceptor(
 			internalgrpc.NewStreamPanicCatcher(logger),
+			internalerrs.LoggingStreamServerInterceptor(logger),
 			grpc_prometheus.StreamServerInterceptor(metrics),
 			propagator.StreamServerPropagator(requestclient.Propagator{}),
 			propagator.StreamServerPropagator(actor.ActorPropagator{}),
@@ -113,6 +114,7 @@ func ServerOptions(logger log.Logger, additionalOptions ...grpc.ServerOption) []
 		),
 		grpc.ChainUnaryInterceptor(
 			internalgrpc.NewUnaryPanicCatcher(logger),
+			internalerrs.LoggingUnaryServerInterceptor(logger),
 			grpc_prometheus.UnaryServerInterceptor(metrics),
 			propagator.UnaryServerPropagator(requestclient.Propagator{}),
 			propagator.UnaryServerPropagator(actor.ActorPropagator{}),

--- a/internal/grpc/internalerrs/common.go
+++ b/internal/grpc/internalerrs/common.go
@@ -2,12 +2,15 @@ package internalerrs
 
 import (
 	"strings"
+	"sync"
+	"sync/atomic"
 	"unicode/utf8"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protopath"
 	"google.golang.org/protobuf/reflect/protorange"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -24,19 +27,109 @@ type callBackClientStream struct {
 
 func (c *callBackClientStream) SendMsg(m any) error {
 	err := c.ClientStream.SendMsg(m)
-	c.postMessageSend(m, err)
+	if c.postMessageSend != nil {
+		c.postMessageSend(m, err)
+	}
 
 	return err
 }
 
 func (c *callBackClientStream) RecvMsg(m any) error {
 	err := c.ClientStream.RecvMsg(m)
-	c.postMessageReceive(m, err)
+	if c.postMessageReceive != nil {
+		c.postMessageReceive(m, err)
+	}
 
 	return err
 }
 
 var _ grpc.ClientStream = &callBackClientStream{}
+
+// requestSavingClientStream is a grpc.ClientStream that saves the initial request sent to the server.
+type requestSavingClientStream struct {
+	grpc.ClientStream
+
+	initialRequest  atomic.Pointer[proto.Message]
+	saveRequestOnce sync.Once
+}
+
+func (c *requestSavingClientStream) SendMsg(m any) error {
+	c.saveRequestOnce.Do(func() {
+		message, ok := m.(proto.Message)
+		if !ok {
+			return
+		}
+
+		c.initialRequest.Store(&message)
+	})
+
+	return c.ClientStream.SendMsg(m)
+}
+
+// InitialRequest returns the initial request sent by the client on the stream.
+func (c *requestSavingClientStream) InitialRequest() *proto.Message {
+	return c.initialRequest.Load()
+}
+
+var _ grpc.ClientStream = &requestSavingClientStream{}
+
+// requestSavingServerStream is a grpc.ServerStream that saves the initial request sent by the client.
+type requestSavingServerStream struct {
+	grpc.ServerStream
+
+	initialRequest  atomic.Pointer[proto.Message]
+	saveRequestOnce sync.Once
+}
+
+func (s *requestSavingServerStream) RecvMsg(m any) error {
+	s.saveRequestOnce.Do(func() {
+		message, ok := m.(proto.Message)
+		if !ok {
+			return
+		}
+
+		s.initialRequest.Store(&message)
+	})
+
+	return s.ServerStream.RecvMsg(m)
+}
+
+// InitialRequest returns the initial request sent by the client on the stream.
+func (s *requestSavingServerStream) InitialRequest() *proto.Message {
+	return s.initialRequest.Load()
+}
+
+var _ grpc.ServerStream = &requestSavingServerStream{}
+
+// callBackServerStream is a grpc.ServerStream that calls a function after SendMsg and RecvMsg.
+type callBackServerStream struct {
+	grpc.ServerStream
+
+	postMessageSend    func(message any, err error)
+	postMessageReceive func(message any, err error)
+}
+
+func (c *callBackServerStream) SendMsg(m any) error {
+	err := c.ServerStream.SendMsg(m)
+
+	if c.postMessageSend != nil {
+		c.postMessageSend(m, err)
+	}
+
+	return err
+}
+
+func (c *callBackServerStream) RecvMsg(m any) error {
+	err := c.ServerStream.RecvMsg(m)
+
+	if c.postMessageReceive != nil {
+		c.postMessageReceive(m, err)
+	}
+
+	return err
+}
+
+var _ grpc.ServerStream = &callBackServerStream{}
 
 // probablyInternalGRPCError checks if a gRPC status likely represents an error that comes from
 // the go-grpc library.

--- a/internal/grpc/internalerrs/logging.go
+++ b/internal/grpc/internalerrs/logging.go
@@ -7,9 +7,10 @@ import (
 	"io"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/log"
 	"google.golang.org/grpc"
@@ -40,11 +41,19 @@ func LoggingUnaryClientInterceptor(l log.Logger) grpc.UnaryClientInterceptor {
 	}
 
 	logger := l.Scoped(logScope, logDescription)
+	logger = logger.Scoped("unaryMethod", "errors that originated from a unary method")
+
 	return func(ctx context.Context, fullMethod string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		err := invoker(ctx, fullMethod, req, reply, cc, opts...)
 		if err != nil {
 			serviceName, methodName := splitMethodName(fullMethod)
-			doLog(logger, serviceName, methodName, req, err)
+
+			var initialRequest proto.Message
+			if m, ok := req.(proto.Message); ok {
+				initialRequest = m
+			}
+
+			doLog(logger, serviceName, methodName, &initialRequest, req, err)
 		}
 
 		return err
@@ -62,17 +71,19 @@ func LoggingStreamClientInterceptor(l log.Logger) grpc.StreamClientInterceptor {
 	}
 
 	logger := l.Scoped(logScope, logDescription)
+	logger = logger.Scoped("streamingMethod", "errors that originated from a streaming method")
 
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		serviceName, methodName := splitMethodName(fullMethod)
 
 		stream, err := streamer(ctx, desc, cc, fullMethod, opts...)
 		if err != nil {
-			// Note: This is a bit hacky, we provide a nil message here since the message isn't available
+			// Note: This is a bit hacky, we provide nil initial and payload messages here since they message isn't available
 			// until after the stream is created.
 			//
 			// This is fine since the error is already available, and the non-utf8 string check is robust against nil messages.
-			doLog(logger, serviceName, methodName, nil, err)
+			logger := logger.Scoped("postInit", "errors that occurred after stream initialization, but before the first message was sent")
+			doLog(logger, serviceName, methodName, nil, nil, err)
 			return nil, err
 		}
 
@@ -81,25 +92,104 @@ func LoggingStreamClientInterceptor(l log.Logger) grpc.StreamClientInterceptor {
 	}
 }
 
-func newLoggingClientStream(s grpc.ClientStream, logger log.Logger, serviceName, methodName string) *callBackClientStream {
-	return &callBackClientStream{
-		ClientStream: s,
+// LoggingUnaryServerInterceptor returns a grpc.UnaryServerInterceptor that logs
+// errors that appear to come from the go-grpc implementation.
+func LoggingUnaryServerInterceptor(l log.Logger) grpc.UnaryServerInterceptor {
+	if !envLoggingEnabled {
+		// Just return the default handler if logging is disabled.
+		return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+			return handler(ctx, req)
+		}
+	}
+
+	logger := l.Scoped(logScope, logDescription)
+	logger = logger.Scoped("unaryMethod", "errors that originated from a unary method")
+
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+		response, err := handler(ctx, req)
+		if err != nil {
+			serviceName, methodName := splitMethodName(info.FullMethod)
+
+			var initialRequest proto.Message
+			if m, ok := req.(proto.Message); ok {
+				initialRequest = m
+			}
+
+			doLog(logger, serviceName, methodName, &initialRequest, response, err)
+		}
+
+		return response, err
+	}
+}
+
+// LoggingStreamServerInterceptor returns a grpc.StreamServerInterceptor that logs
+// errors that appear to come from the go-grpc implementation.
+func LoggingStreamServerInterceptor(l log.Logger) grpc.StreamServerInterceptor {
+	if !envLoggingEnabled {
+		// Just return the default handler if logging is disabled.
+		return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+			return handler(srv, ss)
+		}
+	}
+
+	logger := l.Scoped(logScope, logDescription)
+	logger = logger.Scoped("streamingMethod", "errors that originated from a streaming method")
+
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		serviceName, methodName := splitMethodName(info.FullMethod)
+
+		stream := newLoggingServerStream(ss, logger, serviceName, methodName)
+		return handler(srv, stream)
+	}
+}
+
+func newLoggingServerStream(s grpc.ServerStream, logger log.Logger, serviceName, methodName string) grpc.ServerStream {
+	sendLogger := logger.Scoped("postMessageSend", "errors that occurred after sending a message")
+	receiveLogger := logger.Scoped("postMessageReceive", "errors that occurred after receiving a message")
+
+	requestSaver := requestSavingServerStream{ServerStream: s}
+
+	return &callBackServerStream{
+		ServerStream: &requestSaver,
 
 		postMessageSend: func(m any, err error) {
 			if err != nil {
-				doLog(logger, serviceName, methodName, m, err)
+				doLog(sendLogger, serviceName, methodName, requestSaver.InitialRequest(), m, err)
 			}
 		},
 
 		postMessageReceive: func(m any, err error) {
 			if err != nil && err != io.EOF { // EOF is expected at the end of a stream, so no need to log an error
-				doLog(logger, serviceName, methodName, m, err)
+				doLog(receiveLogger, serviceName, methodName, requestSaver.InitialRequest(), m, err)
 			}
 		},
 	}
 }
 
-func doLog(logger log.Logger, serviceName, methodName string, payload any, err error) {
+func newLoggingClientStream(s grpc.ClientStream, logger log.Logger, serviceName, methodName string) grpc.ClientStream {
+	sendLogger := logger.Scoped("postMessageSend", "errors that occurred after sending a message")
+	receiveLogger := logger.Scoped("postMessageReceive", "errors that occurred after receiving a message")
+
+	requestSaver := requestSavingClientStream{ClientStream: s}
+
+	return &callBackClientStream{
+		ClientStream: &requestSaver,
+
+		postMessageSend: func(m any, err error) {
+			if err != nil {
+				doLog(sendLogger, serviceName, methodName, requestSaver.InitialRequest(), m, err)
+			}
+		},
+
+		postMessageReceive: func(m any, err error) {
+			if err != nil && err != io.EOF { // EOF is expected at the end of a stream, so no need to log an error
+				doLog(receiveLogger, serviceName, methodName, requestSaver.InitialRequest(), m, err)
+			}
+		},
+	}
+}
+
+func doLog(logger log.Logger, serviceName, methodName string, initialRequest *proto.Message, payload any, err error) {
 	if err == nil {
 		return
 	}
@@ -124,10 +214,11 @@ func doLog(logger log.Logger, serviceName, methodName string, payload any, err e
 	}
 
 	if isNonUTF8StringError(s) {
-		if m, ok := payload.(proto.Message); ok {
+		m, ok := payload.(proto.Message)
+		if ok {
 			allFields = append(
 				allFields,
-				additionalNonUTF8StringDebugFields(m, envLogNonUTF8ProtobufMessages, envLogNonUTF8ProtobufMessagesMaxSize)...,
+				additionalNonUTF8StringDebugFields(initialRequest, m, envLogNonUTF8ProtobufMessages, envLogNonUTF8ProtobufMessagesMaxSize)...,
 			)
 		}
 	}
@@ -138,16 +229,16 @@ func doLog(logger log.Logger, serviceName, methodName string, payload any, err e
 // additionalNonUTF8StringDebugFields returns additional log fields that should be included when logging a non-UTF8 string error.
 //
 // By default, this includes the names of all fields that contain non-UTF8 strings.
-// If shouldLogMessageJSON is true, then the JSON representation of the message is also included.
-// The maxMessageSizeLogBytes parameter controls the maximum size of the message that will be logged, after which it will be truncated. Negative values disable truncation.
-func additionalNonUTF8StringDebugFields(message proto.Message, shouldLogMessageJSON bool, maxMessageLogSizeBytes int) []log.Field {
+// If shouldLogMessageJSON is true, then the JSON representation of the initial request message and latest message ares also included.
+// The maxMessageSizeLogBytes parameter controls the maximum size of the messages that will be logged, after which they will be truncated. Negative values disable truncation.
+func additionalNonUTF8StringDebugFields(firstMessage *proto.Message, latestMessage proto.Message, shouldLogMessageJSON bool, maxMessageLogSizeBytes int) []log.Field {
 	var allFields []log.Field
 
 	// Add the names of all protobuf fields that contain non-UTF-8 strings to the log.
 
-	badFields, err := findNonUTF8StringFields(message)
+	badFields, err := findNonUTF8StringFields(latestMessage)
 	if err != nil {
-		allFields = append(allFields, log.Error(errors.Wrapf(err, "failed to find non-UTF8 string allFields")))
+		allFields = append(allFields, log.Error(errors.Wrapf(err, "failed to find non-UTF8 string fields in protobuf message")))
 		return allFields
 	}
 
@@ -160,24 +251,50 @@ func additionalNonUTF8StringDebugFields(message proto.Message, shouldLogMessageJ
 	}
 
 	// Note: we can't use the protojson library here since it doesn't support messages with non-UTF8 strings.
-	jsonBytes, err := json.Marshal(message)
+	jsonBytes, err := json.Marshal(latestMessage)
 	if err != nil {
-		allFields = append(allFields, log.Error(errors.Wrapf(err, "failed to marshal protobuf message to bytes")))
+		allFields = append(allFields, log.Error(errors.Wrapf(err, "failed to marshal latest protobuf message to bytes")))
 		return allFields
 	}
 
-	if maxMessageLogSizeBytes < 0 { // If truncation is disabled, set the max size to the full message size.
-		maxMessageLogSizeBytes = len(jsonBytes)
+	s := truncate(string(jsonBytes), maxMessageLogSizeBytes)
+	allFields = append(allFields, log.String("messageJSON", s))
+
+	// Log the JSON representation of the initial request message, if available for debugging purposes.
+
+	if firstMessage == nil {
+		return allFields
 	}
 
-	bytesToTruncate := len(jsonBytes) - maxMessageLogSizeBytes
-	if bytesToTruncate > 0 {
-		jsonBytes = jsonBytes[:maxMessageLogSizeBytes]
-		jsonBytes = append(jsonBytes, []byte(fmt.Sprintf("...(truncated %d bytes)", bytesToTruncate))...)
+	jsonBytes, err = json.Marshal(*firstMessage)
+	if err != nil {
+		allFields = append(allFields, log.Error(errors.Wrapf(err, "failed to marshal initial request protobuf message to bytes")))
+		return allFields
 	}
 
-	allFields = append(allFields, log.String("messageJSON", string(jsonBytes)))
+	s = truncate(string(jsonBytes), maxMessageLogSizeBytes)
+	allFields = append(allFields, log.String("initialRequestJSON", s))
+
 	return allFields
+}
+
+// truncate shortens the string be to at most maxBytes bytes, appending a message indicating that the string was truncated if necessary.
+//
+// If maxBytes is negative, then the string is not truncated.
+func truncate(s string, maxBytes int) string {
+	if maxBytes < 0 {
+		return s
+	}
+
+	bs := []byte(s)
+
+	bytesToTruncate := len(bs) - maxBytes
+	if bytesToTruncate > 0 {
+		bs = bs[:maxBytes]
+		bs = append(bs, []byte(fmt.Sprintf("...(truncated %d bytes)", bytesToTruncate))...)
+	}
+
+	return string(bs)
 }
 
 func isNonUTF8StringError(s *status.Status) bool {

--- a/internal/grpc/internalerrs/logging.go
+++ b/internal/grpc/internalerrs/logging.go
@@ -78,7 +78,7 @@ func LoggingStreamClientInterceptor(l log.Logger) grpc.StreamClientInterceptor {
 
 		stream, err := streamer(ctx, desc, cc, fullMethod, opts...)
 		if err != nil {
-			// Note: This is a bit hacky, we provide nil initial and payload messages here since they message isn't available
+			// Note: This is a bit hacky, we provide nil initial and payload messages here since the message isn't available
 			// until after the stream is created.
 			//
 			// This is fine since the error is already available, and the non-utf8 string check is robust against nil messages.
@@ -229,7 +229,7 @@ func doLog(logger log.Logger, serviceName, methodName string, initialRequest *pr
 // additionalNonUTF8StringDebugFields returns additional log fields that should be included when logging a non-UTF8 string error.
 //
 // By default, this includes the names of all fields that contain non-UTF8 strings.
-// If shouldLogMessageJSON is true, then the JSON representation of the initial request message and latest message ares also included.
+// If shouldLogMessageJSON is true, then the JSON representations for the initial request message and latest message are also included.
 // The maxMessageSizeLogBytes parameter controls the maximum size of the messages that will be logged, after which they will be truncated. Negative values disable truncation.
 func additionalNonUTF8StringDebugFields(firstMessage *proto.Message, latestMessage proto.Message, shouldLogMessageJSON bool, maxMessageLogSizeBytes int) []log.Field {
 	var allFields []log.Field

--- a/internal/grpc/internalerrs/logging.go
+++ b/internal/grpc/internalerrs/logging.go
@@ -286,15 +286,13 @@ func truncate(s string, maxBytes int) string {
 		return s
 	}
 
-	bs := []byte(s)
-
-	bytesToTruncate := len(bs) - maxBytes
+	bytesToTruncate := len(s) - maxBytes
 	if bytesToTruncate > 0 {
-		bs = bs[:maxBytes]
-		bs = append(bs, []byte(fmt.Sprintf("...(truncated %d bytes)", bytesToTruncate))...)
+		s = s[:maxBytes]
+		s = fmt.Sprintf("%s...(truncated %d bytes)", s, bytesToTruncate)
 	}
 
-	return string(bs)
+	return s
 }
 
 func isNonUTF8StringError(s *status.Status) bool {


### PR DESCRIPTION
## overview 

This PR expands upon #52208 to also add _Server_-side interceptors that check for "internal" gRPC errors (which includes the [non utf-8 string issue](https://github.com/sourcegraph/sourcegraph/issues/52181)). 

## details

After deploying #52208 to sourcegraph.com, I saw many [grpc error logs](https://cloudlogging.app.goo.gl/zykd4dbAFaMeHdHs8) that look like:
```jsonc
{
  
  "jsonPayload": {
    "InstrumentationScope": "gitserver.client.gRPC.internal.error.reporter",
    "Body": "grpc: error while marshaling: string field contains invalid UTF-8",
    "Attributes": {
      "nonUTF8StringFields": [],
      "grpcService": "gitserver.v1.GitserverService",
      "messageJSON": "{\"Message\":null}", // ❗
      "grpcMethod": "Search",
      "grpcCode": "Internal"
    },
    "Resource": {
      "service.name": "worker"
    }
  },
}
```

After a while, I realized that the `{\"Message\":null}"` messageJSON was coming from the client-side streaming code [here](https://github.com/sourcegraph/sourcegraph/blob/436141cbe124a48f2e02b45c10009ead657b7d02/internal/gitserver/v1/gitserver_grpc.pb.go#L167-L173). The client saw the error communicated back by the server, but the actual protobuf message contents were never sent (because the couldn't be serialized) - resulting in the[ mostly `null` message JSON](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/gitserver/v1/gitserver.pb.go?L1857-1867). 

This PR fixes that monitoring issue by adding an interceptor on the server-side, which should still have access to the non-compliant protobuf message (with the non-utf8 fields).

---

This PR also:

- Includes the JSON for the "original request"  message in the utf-8 error logs, which is helpful for debugging. This is only emitted when `SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_NON_UTF8_PROTOBUF_MESSAGES_ENABLED=true` and is subject to the same truncation logic as the "latest" message.
   - A new helper "requestSaving" implementation of `grpc.ClientStream/grpc.ServerStream` that saves the initial request sent from the client was added to facilitate this.
- Adds additional scopes to the internal error logger that indicate whether or not the error comes from a unary method or a streaming method. In addition, the new scopes also indicate whether the message occurred after a message was _sent_ or _received_. 

## caveats

The server interceptors introduced in this PR are only able to report detailed utf-8 debugging information for [**streaming**](https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc) methods, not [**unary** methods](https://grpc.io/docs/what-is-grpc/core-concepts/#unary-rpc). 

- For **streaming** methods, errors encountered when encoding a message are reported via the [`grpc.ServerStream.SendMsg`](https://sourcegraph.com/github.com/grpc/grpc-go@642dd63a85275a96d172f446911fd04111e2c74c/-/blob/stream.go?L1642:29-1642:39) method. It's possible to wrap the `grpc.ServerStream` that's used via server interceptors, so our detailed utf-8 debugging logic has a hook to run here. 
- For **unary** methods, all the provided interceptors [run _before_](https://sourcegraph.com/github.com/grpc/grpc-go@642dd63a85275a96d172f446911fd04111e2c74c/-/blob/server.go?L1337) the reply is[ finally encoded and sent back to the client](https://sourcegraph.com/github.com/grpc/grpc-go@642dd63a85275a96d172f446911fd04111e2c74c/-/blob/server.go?L1384). At this point, the interceptors have already run and can't see any errors that occur during the encoding process.  There don't seem to be any hooks that a user of the [grpc/grpc-go](https://github.com/grpc/grpc-go/) can provide that would have access to any encoding errors.

I still think it's worth merging this PR as-is. Even if we can't get detailed debugging information for unary server methods, the client can still see that an error occurred and print the initial request message - so it's at least possible to continue debugging further. If we decide that we need the detailed debugging info for unary methods, the only way I can think of to do that is to _pre-emptively_ check every message to see if it's properly utf-8 encoded. This seems quite expensive.

## Test plan

### Unit tests

I added additional unit tests for the new custom grpc.ServerStreams and the request-saving grpc.Server/ClientStreams.

### Manual testing

I cloned this repository (with non-utf8 content) to my local instance: https://github.com/Eltecz/STM32G4_OSC


I then ran this diff search query: `context:global repo:^github\.com/Eltecz/STM32G4_OSC$@0727622 file:^MDK-ARM/usr/malloc/malloc\.c type:diff malloc`.

That produced the followng error message in the UI:

<img width="1486" alt="Screenshot 2023-06-14 at 1 07 08 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/ac15ae8a-6449-4e0c-a3df-48baf9d918f6">


It also produced the following logs in my terminal (my development environment has `SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_NON_UTF8_PROTOBUF_MESSAGES_ENABLED=true` set):



```
[    gitserver-1] ERROR gitserver.gRPC.internal.error.reporter.streamingMethod.postMessageSend internalerrs/logging.go:226 grpc: error while marshaling: string field contains invalid UTF-8 {"grpcService": "gitserver.v1.GitserverService", "grpcMethod": "Search", "grpcCode": "Internal", "nonUTF8StringFields": ["match.diff.content"], "messageJSON": "{\"Message\":{\"Match\":{\"oid\":\"5b473830a3158ab981fd562de8bf41365fa20868\",\"author\":{\"name\":\"Eltecz\",\"email\":\"Defenver@foxmail.com\",\"date\":{\"seconds\":1668933502}},\"committer\":{\"name\":\"Eltecz\",\"email\":\"Defenver@foxmail.com\",\"date\":{\"seconds\":1668933502}},\"parents\":[\"\"],\"refs\":[\"\"],\"source_refs\":[\"0727622\"],\"message\":{\"content\":\"first commit\"},\"diff\":{\"content\":\"/dev/null MDK-ARM/usr/malloc/malloc.c\\n@@ -0,0 +1,2 @@ \\n+#include \\\"malloc.h\\\"\\t   \\n+//////////////////////////////////////////////////////////////////////////////////\\t \\n@@ -0,0 +85,3 @@ \\n+//\\ufffd\\ufffd\\ufffd\\ufffdֵ:0XFFFFFFFF,\\ufffd\\ufffd\\ufffd\\ufffd\\ufffd\\ufffd\\ufffd\\ufffd;\\ufffd\\ufffd\\ufffd\\ufffd,\\ufffdڴ\\ufffdƫ\\ufffdƵ\\ufffdַ \\n+u32 my_mem_malloc(u8 memx,u32 size)  \\n+{  \\n@@ -0,0 +147,6 @@ \\n+//\\ufffd\\ufffd\\ufffd\\ufffdֵ:\\ufffd\\ufffd\\ufffd䵽\\ufffd\\ufffd\\ufffdڴ\\ufffd\\ufffd׵\\ufffdַ.\\n+void *mymalloc(u8 memx,u32 size)  \\n+{  \\n+    u32 offset;   \\n+\\toffset=my_mem_malloc(memx,size);  \\t   \\t \\t   \\n+    if(offset==0XFFFFFFFF)return NULL;  \\n\",...(truncated 19114 bytes)", "initialRequestJSON": "{\"repo\":\"github.com/Eltecz/STM32G4_OSC\",\"revisions\":[{\"rev_spec\":\"0727622\"}],\"limit\":50000,\"include_diff\":true,\"query\":{\"Value\":{\"Operator\":{\"kind\":1,\"operands\":[{\"Value\":{\"DiffModifiesFile\":{\"expr\":\"^MDK-ARM/usr/malloc/malloc\\\\.c\",\"ignore_case\":true}}},{\"Value\":{\"DiffMatches\":{\"expr\":\"malloc\",\"ignore_case\":true}}}]}}}}"}
[       frontend] ERROR gitserver.client.gRPC.internal.error.reporter.streamingMethod.postMessageReceive internalerrs/logging.go:226 grpc: error while marshaling: string field contains invalid UTF-8 {"grpcService": "gitserver.v1.GitserverService", "grpcMethod": "Search", "grpcCode": "Internal", "nonUTF8StringFields": [], "messageJSON": "{\"Message\":null}", "initialRequestJSON": "{\"repo\":\"github.com/Eltecz/STM32G4_OSC\",\"revisions\":[{\"rev_spec\":\"0727622\"}],\"limit\":50000,\"include_diff\":true,\"query\":{\"Value\":{\"Operator\":{\"kind\":1,\"operands\":[{\"Value\":{\"DiffModifiesFile\":{\"expr\":\"^MDK-ARM/usr/malloc/malloc\\\\.c\",\"ignore_case\":true}}},{\"Value\":{\"DiffMatches\":{\"expr\":\"malloc\",\"ignore_case\":true}}}]}}}}"}
```