### PR TITLE
App: Rename to Cody

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -21,7 +21,7 @@ fn create_system_tray_menu() -> SystemTrayMenu {
     );
 
     SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new("open".to_string(), "Open Sourcegraph"))
+        .add_item(CustomMenuItem::new("open".to_string(), "Open chat"))
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(
             CustomMenuItem::new("settings".to_string(), "Settings").accelerator("CmdOrCtrl+,"),
@@ -51,7 +51,9 @@ pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
             }
             "settings" => {
                 let window = app.get_window("main").unwrap();
-                window.eval("window.location.href = '/user/app-settings'").unwrap();
+                window
+                    .eval("window.location.href = '/user/app-settings'")
+                    .unwrap();
                 show_window(app, "main");
             }
             "view_logs" => show_logs(app),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -21,7 +21,7 @@ fn create_system_tray_menu() -> SystemTrayMenu {
     );
 
     SystemTrayMenu::new()
-        .add_item(CustomMenuItem::new("open".to_string(), "Open chat"))
+        .add_item(CustomMenuItem::new("open".to_string(), "Open Cody"))
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(
             CustomMenuItem::new("settings".to_string(), "Settings").accelerator("CmdOrCtrl+,"),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "Sourcegraph",
+    "productName": "Cody",
     "version": "2023.0.0+dev"
   },
   "tauri": {
@@ -82,7 +82,7 @@
         "fullscreen": false,
         "height": 768,
         "resizable": true,
-        "title": "Sourcegraph",
+        "title": "Cody",
         "width": 1024
       }
     ]


### PR DESCRIPTION
Rename to Cody in:

- Application name when running (top left menu name)
- Title bar of the window
- In the system tray menu, "Open Sourcegraph" becomes "Open Cody"

<img width="222" alt="Screenshot 2023-06-15 at 1 09 12 PM" src="https://github.com/sourcegraph/sourcegraph/assets/602886/92d43710-4fe4-457d-96bc-1eb87d3d7ebc">

Part of:

- #53120

The other part of the rename is the filenames of the releases. That's handled in a separate PR because it touches the build scripts:

- #53552 

## Test plan

- Check all updated places in App
