### PR TITLE
Fix linter issue on main and remove old linter from VS Code build

### DIFF
--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useLocation } from 'react-router-dom'
 
-import { Container, H3, Link, Text } from '@sourcegraph/wildcard'
+import { Container, H3, Text } from '@sourcegraph/wildcard'
 
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 import { UseShowMorePaginationResult } from '../../../components/FilteredConnection/hooks/useShowMorePagination'

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -104,12 +104,7 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                 )}
             </ConnectionContainer>
             <Text className="mb-0">
-                Code host not present? Batch Changes only supports commit signing on GitHub code hosts today.{' '}
-                {/* TODO: Fill in docs link */}
-                <Link to="/help/admin/commit_signing_intergrations" target="_blank" rel="noopener noreferrer">
-                    See the docs
-                </Link>{' '}
-                for more information.
+                Code host not present? Batch Changes only supports commit signing on GitHub code hosts today.
             </Text>
         </Container>
     )

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -150,9 +150,6 @@ The run type for environment including `{"BEXT_NIGHTLY":"true"}`.
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Test (client/browser)
 - Puppeteer tests for chrome extension
 - Test (all)
@@ -164,9 +161,6 @@ The run type for environment including `{"VSCE_NIGHTLY":"true"}`.
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Tests for VS Code extension
 
 ### Cody VS Code extension nightly release build
@@ -175,9 +169,6 @@ The run type for environment including `{"CODY_NIGHTLY":"true"}`.
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Unit and integration tests for the Cody VS Code extension
 - E2E tests for the Cody VS Code extension
 - Cody release
@@ -240,9 +231,6 @@ The run type for branches matching `bext/release` (exact match).
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Test (client/browser)
 - Puppeteer tests for chrome extension
 - Test (all)
@@ -257,9 +245,6 @@ The run type for branches matching `vsce/release` (exact match).
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Tests for VS Code extension
 - Extension release
 
@@ -269,9 +254,6 @@ The run type for branches matching `cody/release` (exact match).
 
 Base pipeline (more steps might be included based on branch changes):
 
-- Stylelint (all)
-- ESLint (all)
-- ESLint (web)
 - Unit and integration tests for the Cody VS Code extension
 - E2E tests for the Cody VS Code extension
 - Cody release

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -128,21 +128,6 @@ func addStylelint(pipeline *bk.Pipeline) {
 		bk.Cmd("dev/ci/pnpm-run.sh lint:css:all"))
 }
 
-func addESLint(pipeline *bk.Pipeline) {
-	pipeline.AddStep(":eslint: ESLint (all)",
-		withPnpmCache(),
-		bk.Cmd("dev/ci/pnpm-run.sh lint:js:all"))
-
-	pipeline.AddStep(":eslint: ESLint (web)",
-		withPnpmCache(),
-		bk.Cmd("dev/ci/pnpm-run.sh lint:js:web"))
-}
-
-func addClientLintersForAllFiles(pipeline *bk.Pipeline) {
-	addStylelint(pipeline)
-	addESLint(pipeline)
-}
-
 // Adds steps for the OSS and Enterprise web app builds. Runs the web app tests.
 func addWebAppOSSBuild(opts CoreTestOperationsOptions) operations.Operation {
 	return func(pipeline *bk.Pipeline) {

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -193,7 +193,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a browser extension release branch, run the browser-extension tests and
 		// builds.
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addBrowserExtensionUnitTests,
 			addBrowserExtensionIntegrationTests(0), // we pass 0 here as we don't have other pipeline steps to contribute to the resulting Percy build
 			frontendTests,
@@ -203,7 +202,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.VsceReleaseBranch:
 		// If this is a vs code extension release branch, run the vscode-extension tests and release
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addVsceTests,
 			wait,
 			addVsceReleaseSteps)
@@ -211,7 +209,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.CodyReleaseBranch:
 		// If this is the Cody VS Code extension release branch, run the Cody tests and release
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addCodyUnitIntegrationTests,
 			addCodyE2ETests,
 			wait,
@@ -220,7 +217,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.CodyNightly:
 		// If this is a Cody VS Code extension nightly build, run the Cody tests and release
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addCodyUnitIntegrationTests,
 			addCodyE2ETests,
 			wait,
@@ -230,7 +226,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// If this is a browser extension nightly build, run the browser-extension tests and
 		// e2e tests.
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addBrowserExtensionUnitTests,
 			recordBrowserExtensionIntegrationTests,
 			frontendTests,
@@ -240,7 +235,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	case runtype.VsceNightly:
 		// If this is a VS Code extension nightly build, run the vsce-extension integration tests
 		ops = operations.NewSet(
-			addClientLintersForAllFiles,
 			addVsceTests,
 		)
 


### PR DESCRIPTION
This caused a linter issue on main because the docs page doesn't exist. No idea why the local test run didn't fail though? cc @jhchabran 

```
> @sourcegraph/web@1.10.1 lint:js /root/buildkite/build/sourcegraph/client/web
  | > NODE_OPTIONS="--max_old_space_size=16192" eslint --cache '**/*.[tj]s?(x)' "--quiet"
  |  
  |  
  | /root/buildkite/build/sourcegraph/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
  | 109:17  error  Help link to non-existent page: admin/commit_signing_intergrations  @sourcegraph/sourcegraph/check-help-links
  |  
  | ✖ 1 problem (1 error, 0 warnings)
 

<br class="Apple-interchange-newline">
```

Edit: It seems like the VS Code release job still ran the old ESLint tests (outside of Bazel). So this PR also removes them to unblock the releases and nightlies. We should still investigate why there's a difference in behavior between the old jobs <> bazel. 

## Test plan

- Remove link

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
