### PR TITLE
Fix visual bug that would not display Teams properly in search results

### DIFF
--- a/enterprise/internal/own/codeowners/file.go
+++ b/enterprise/internal/own/codeowners/file.go
@@ -32,9 +32,10 @@ type IngestedRulesetSource struct {
 func (IngestedRulesetSource) rulesetSource() {}
 
 type Ruleset struct {
-	proto  *codeownerspb.File
-	rules  []*CompiledRule
-	source RulesetSource
+	proto        *codeownerspb.File
+	rules        []*CompiledRule
+	source       RulesetSource
+	codeHostType string
 }
 
 func NewRuleset(source RulesetSource, proto *codeownerspb.File) *Ruleset {
@@ -54,6 +55,14 @@ func (r *Ruleset) GetFile() *codeownerspb.File {
 
 func (r *Ruleset) GetSource() RulesetSource {
 	return r.source
+}
+
+func (r *Ruleset) GetCodeHostType() string {
+	return r.codeHostType
+}
+
+func (r *Ruleset) SetCodeHostType(cht string) {
+	r.codeHostType = cht
 }
 
 // Match returns the rule matching the given path as per this CODEOWNERS ruleset.

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -402,6 +402,9 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 			userExternalAccountsStore.ListFunc.SetDefaultReturn(nil, nil)
 			db.UserExternalAccountsFunc.SetDefaultReturn(userExternalAccountsStore)
 			db.TeamsFunc.SetDefaultReturn(database.NewMockTeamStore())
+			repoStore := database.NewMockRepoStore()
+			repoStore.GetFunc.SetDefaultReturn(&types.Repo{ExternalRepo: api.ExternalRepoSpec{ServiceType: "github"}}, nil)
+			db.ReposFunc.SetDefaultReturn(repoStore)
 			if tt.setup != nil {
 				tt.setup(db)
 			}

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -160,7 +160,7 @@ func getCodeOwnersFromMatches(
 			continue
 		}
 		refs := rule.References()
-		for i, _ := range refs {
+		for i := range refs {
 			refs[i].RepoContext = &own.RepoContext{
 				Name:         mm.Repo.Name,
 				CodeHostKind: rs.codeowners.GetCodeHostType(),

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -159,9 +159,17 @@ func getCodeOwnersFromMatches(
 			hasResultWithNoOwners = true
 			continue
 		}
+		refs := rule.References()
+		for i, _ := range refs {
+			refs[i].RepoContext = &own.RepoContext{
+				Name:         mm.Repo.Name,
+				CodeHostKind: rs.codeowners.GetCodeHostType(),
+			}
+		}
+
 		ownerMatches = append(ownerMatches, ownerFileMatch{
 			fileMatch:  mm,
-			references: rule.References(),
+			references: refs,
 		})
 	}
 	return ownerMatches, hasResultWithNoOwners, errs

--- a/enterprise/internal/own/search/select_job_test.go
+++ b/enterprise/internal/own/search/select_job_test.go
@@ -46,10 +46,13 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 	setupDB := func() *edb.MockEnterpriseDB {
 		codeownersStore := edb.NewMockCodeownersStore()
 		codeownersStore.GetCodeownersForRepoFunc.SetDefaultReturn(nil, nil)
+		repoStore := database.NewMockRepoStore()
+		repoStore.GetFunc.SetDefaultReturn(&types.Repo{ExternalRepo: api.ExternalRepoSpec{ServiceType: "github"}}, nil)
 		db := edb.NewMockEnterpriseDB()
 		db.CodeownersFunc.SetDefaultReturn(codeownersStore)
 		db.AssignedOwnersFunc.SetDefaultReturn(database.NewMockAssignedOwnersStore())
 		db.AssignedTeamsFunc.SetDefaultReturn(database.NewMockAssignedTeamsStore())
+		db.ReposFunc.SetDefaultReturn(repoStore)
 		return db
 	}
 

--- a/enterprise/internal/own/service.go
+++ b/enterprise/internal/own/service.go
@@ -111,35 +111,42 @@ func (s *service) RulesetForRepo(ctx context.Context, repoName api.RepoName, rep
 	if err != nil && !errcode.IsNotFound(err) {
 		return nil, err
 	}
+	var rs *codeowners.Ruleset
 	if ingestedCodeowners != nil {
-		return codeowners.NewRuleset(codeowners.IngestedRulesetSource{ID: int32(ingestedCodeowners.RepoID)}, ingestedCodeowners.Proto), nil
-	}
-	for _, path := range codeownersLocations {
-		content, err := s.gitserverClient.ReadFile(
-			ctx,
-			authz.DefaultSubRepoPermsChecker,
-			repoName,
-			commitID,
-			path,
-		)
-		if content != nil && err == nil {
-			pbfile, err := codeowners.Parse(bytes.NewReader(content))
-			if err != nil {
-				return nil, err
+		rs = codeowners.NewRuleset(codeowners.IngestedRulesetSource{ID: int32(ingestedCodeowners.RepoID)}, ingestedCodeowners.Proto)
+	} else {
+		for _, path := range codeownersLocations {
+			content, err := s.gitserverClient.ReadFile(
+				ctx,
+				authz.DefaultSubRepoPermsChecker,
+				repoName,
+				commitID,
+				path,
+			)
+			if content != nil && err == nil {
+				pbfile, err := codeowners.Parse(bytes.NewReader(content))
+				if err != nil {
+					return nil, err
+				}
+				rs = codeowners.NewRuleset(codeowners.GitRulesetSource{Repo: repoID, Commit: commitID, Path: path}, pbfile)
+				break
+			} else if os.IsNotExist(err) {
+				continue
 			}
-			repo, err := s.db.Repos().Get(ctx, repoID)
-			if err != nil && !errcode.IsNotFound(err) {
-				return nil, err
-			}
-			rs := codeowners.NewRuleset(codeowners.GitRulesetSource{Repo: repoID, Commit: commitID, Path: path}, pbfile)
-			rs.SetCodeHostType(repo.ExternalRepo.ServiceType)
-			return rs, nil
-		} else if os.IsNotExist(err) {
-			continue
+			return nil, err
 		}
-		return nil, err
 	}
-	return nil, nil
+	if rs == nil {
+		return nil, nil
+	}
+	repo, err := s.db.Repos().Get(ctx, repoID)
+	if err != nil && !errcode.IsNotFound(err) {
+		return nil, err
+	} else if errcode.IsNotFound(err) {
+		return nil, nil
+	}
+	rs.SetCodeHostType(repo.ExternalRepo.ServiceType)
+	return rs, nil
 }
 
 func (s *service) AssignedOwnership(ctx context.Context, repoID api.RepoID, _ api.CommitID) (AssignedOwners, error) {

--- a/enterprise/internal/own/service.go
+++ b/enterprise/internal/own/service.go
@@ -127,7 +127,13 @@ func (s *service) RulesetForRepo(ctx context.Context, repoName api.RepoName, rep
 			if err != nil {
 				return nil, err
 			}
-			return codeowners.NewRuleset(codeowners.GitRulesetSource{Repo: repoID, Commit: commitID, Path: path}, pbfile), nil
+			repo, err := s.db.Repos().Get(ctx, repoID)
+			if err != nil && !errcode.IsNotFound(err) {
+				return nil, err
+			}
+			rs := codeowners.NewRuleset(codeowners.GitRulesetSource{Repo: repoID, Commit: commitID, Path: path}, pbfile)
+			rs.SetCodeHostType(repo.ExternalRepo.ServiceType)
+			return rs, nil
 		} else if os.IsNotExist(err) {
 			continue
 		}


### PR DESCRIPTION
Addresses: https://github.com/sourcegraph/sourcegraph/issues/52719

After change the search result is properly categorized as a team:
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/a147320b-48c4-4a7d-a428-6263d60db4dd)


## Test plan

Manual, updated unit tests