### PR TITLE
Bump token cost for OpenAI embeddings

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -135,7 +135,7 @@ func (r codyUserGatewayAccessResolver) CodeCompletionsRateLimit(ctx context.Cont
 	}, nil
 }
 
-const tokensPerDollar = int(1 / (0.0004 / 1_000))
+const tokensPerDollar = int(1 / (0.0001 / 1_000))
 
 func (r codyUserGatewayAccessResolver) EmbeddingsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
 	// If the user isn't enabled return no rate limit

--- a/enterprise/internal/licensing/codygateway.go
+++ b/enterprise/internal/licensing/codygateway.go
@@ -84,7 +84,7 @@ func NewCodyGatewayCodeRateLimit(plan Plan, userCount *int, licenseTags []string
 
 // tokensPerDollar is the number of tokens that will cost us roughly $1. It's used
 // below for some better illustration of math.
-const tokensPerDollar = int(1 / (0.0004 / 1_000))
+const tokensPerDollar = int(1 / (0.0001 / 1_000))
 
 // NewCodyGatewayEmbeddingsRateLimit applies default Cody Gateway access based on the plan.
 func NewCodyGatewayEmbeddingsRateLimit(plan Plan, userCount *int, licenseTags []string) CodyGatewayRateLimit {

--- a/enterprise/internal/licensing/codygateway_test.go
+++ b/enterprise/internal/licensing/codygateway_test.go
@@ -138,7 +138,7 @@ func TestCodyGatewayEmbeddingsRateLimit(t *testing.T) {
 			userCount: pointers.Ptr(50),
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"openai/text-embedding-ada-002"},
-				Limit:           20 * 50 * 2_500_000 / 30,
+				Limit:           20 * 50 * 10_000_000 / 30,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},
@@ -147,7 +147,7 @@ func TestCodyGatewayEmbeddingsRateLimit(t *testing.T) {
 			plan: PlanEnterprise1,
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"openai/text-embedding-ada-002"},
-				Limit:           1 * 20 * 2_500_000 / 30,
+				Limit:           1 * 20 * 10_000_000 / 30,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},
@@ -156,7 +156,7 @@ func TestCodyGatewayEmbeddingsRateLimit(t *testing.T) {
 			plan: "unknown",
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"openai/text-embedding-ada-002"},
-				Limit:           1 * 10 * 2_500_000 / 30,
+				Limit:           1 * 10 * 10_000_000 / 30,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},


### PR DESCRIPTION
After recent pricing changes, we can now allow more tokens by default for both app and enterprise :)

## Test plan

Adjusted test.