### PR TITLE
ci: fix flaky Percy snapshot

### DIFF
--- a/client/web/src/integration/org.test.ts
+++ b/client/web/src/integration/org.test.ts
@@ -165,6 +165,9 @@ describe('Organizations', () => {
                 await driver.page.goto(driver.sourcegraphBaseUrl + `/organizations/${testOrg.name}/settings`)
                 const updatedSettings = '// updated'
                 const editor = await createEditorAPI(driver, '.test-settings-file .test-editor')
+
+                // Take snapshot before updating text in the editor to avoid flakiness.
+                await percySnapshotWithVariants(driver.page, 'Organization settings page')
                 await editor.replace(updatedSettings, 'paste')
 
                 const variables = await testContext.waitForGraphQLRequest(async () => {
@@ -177,7 +180,6 @@ describe('Organizations', () => {
                     contents: updatedSettings,
                 })
 
-                await percySnapshotWithVariants(driver.page, 'Organization settings page')
                 await accessibilityAudit(driver.page)
             })
         })


### PR DESCRIPTION
## Context

Make Percy snapshot before updating the editor text to avoid flakes. [The flaky build example](https://percy.io/Sourcegraph/Sourcegraph/builds/28240133/changed/1569967000?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=1920). 

## Test plan

CI
