### PR TITLE
Cody: Re-spin tasks which have conflicts with local edits

### DIFF
--- a/client/cody-shared/src/chat/recipes/non-stop.ts
+++ b/client/cody-shared/src/chat/recipes/non-stop.ts
@@ -10,57 +10,45 @@ import { Recipe, RecipeContext, RecipeID } from './recipe'
 export class NonStop implements Recipe {
     public id: RecipeID = 'non-stop'
 
-    public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
-        // TODO: Invoke this recipe with a task from the fixup queue.
+    public async getInteraction(taskId: string, context: RecipeContext): Promise<Interaction | null> {
         const controllers = context.editor.controllers
-        const selection = context.editor.getActiveTextEditorSelection()
-
-        // TODO: Make this work with unsaved documents
-        // TODO: Do not require any text to be selected
-        if (!controllers || !selection) {
-            await context.editor.showWarningMessage('Cody Fixups: Failed to start.')
+        if (!controllers) {
             return null
         }
-
-        // TODO: Remove dependency on human input and use input box only
-        const humanInput =
-            humanChatInput ||
-            (await context.editor.showInputBox('Ask Cody to edit your code, or use /chat to ask a question.')) ||
-            ''
-
-        if (!humanInput && !selection.selectedText.trim()) {
-            await context.editor.showWarningMessage(
-                'Cody Fixups: Failed to start due to missing instruction with empty selection.'
-            )
+        const taskParameters = controllers.fixups.getTaskRecipeData(taskId)
+        if (!taskParameters) {
+            // Nothing to do.
             return null
         }
+        const { instruction, fileName, precedingText, selectedText, followingText } = taskParameters
 
         const quarterFileContext = Math.floor(MAX_CURRENT_FILE_TOKENS / 4)
-        if (truncateText(selection.selectedText, quarterFileContext * 2) !== selection.selectedText) {
+        if (truncateText(selectedText, quarterFileContext * 2) !== selectedText) {
             const msg = "The amount of text selected exceeds Cody's current capacity."
             await context.editor.showWarningMessage(msg)
+            // TODO: Communicate this error back to the FixupController
             return null
         }
 
         // Reconstruct Cody's prompt using user's context
         // Replace placeholders in reverse order to avoid collisions if a placeholder occurs in the input
         const promptText = NonStop.prompt
-            .replace('{humanInput}', truncateText(humanInput, MAX_HUMAN_INPUT_TOKENS))
+            .replace('{humanInput}', truncateText(instruction, MAX_HUMAN_INPUT_TOKENS))
             .replace('{responseMultiplexerPrompt}', context.responseMultiplexer.prompt())
-            .replace('{truncateFollowingText}', truncateText(selection.followingText, quarterFileContext))
-            .replace('{selectedText}', selection.selectedText)
-            .replace('{truncateTextStart}', truncateTextStart(selection.precedingText, quarterFileContext))
-            .replace('{fileName}', selection.fileName)
+            .replace('{truncateFollowingText}', truncateText(followingText, quarterFileContext))
+            .replace('{selectedText}', selectedText)
+            .replace('{truncateTextStart}', truncateTextStart(precedingText, quarterFileContext))
+            .replace('{fileName}', fileName)
 
         let text = ''
 
         context.responseMultiplexer.sub('selection', {
             onResponse: async (content: string) => {
                 text += content
-                await context.editor.didReceiveFixupText('', text, 'streaming')
+                await context.editor.didReceiveFixupText(taskId, text, 'streaming')
             },
             onTurnComplete: async () => {
-                await context.editor.didReceiveFixupText('', text, 'complete')
+                await context.editor.didReceiveFixupText(taskId, text, 'complete')
             },
         })
 
@@ -69,13 +57,13 @@ export class NonStop implements Recipe {
                 {
                     speaker: 'human',
                     text: promptText,
-                    displayText: 'Cody Fixups: ' + humanInput,
+                    displayText: 'Cody Fixups: ' + instruction,
                 },
                 {
                     speaker: 'assistant',
                     prefix: 'Check your document for updates from Cody.',
                 },
-                this.getContextMessages(selection.selectedText, context.codebaseContext),
+                this.getContextMessages(selectedText, context.codebaseContext),
                 []
             )
         )

--- a/client/cody-shared/src/chat/recipes/non-stop.ts
+++ b/client/cody-shared/src/chat/recipes/non-stop.ts
@@ -61,7 +61,6 @@ export class NonStop implements Recipe {
             },
             onTurnComplete: async () => {
                 await context.editor.didReceiveFixupText(taskID, text, 'complete')
-                controllers.task.stop(taskID)
             },
         })
 

--- a/client/cody-shared/src/chat/recipes/non-stop.ts
+++ b/client/cody-shared/src/chat/recipes/non-stop.ts
@@ -15,7 +15,7 @@ export class NonStop implements Recipe {
         if (!controllers) {
             return null
         }
-        const taskParameters = controllers.fixups.getTaskRecipeData(taskId)
+        const taskParameters = await controllers.fixups.getTaskRecipeData(taskId)
         if (!taskParameters) {
             // Nothing to do.
             return null

--- a/client/cody-shared/src/chat/recipes/non-stop.ts
+++ b/client/cody-shared/src/chat/recipes/non-stop.ts
@@ -11,6 +11,7 @@ export class NonStop implements Recipe {
     public id: RecipeID = 'non-stop'
 
     public async getInteraction(humanChatInput: string, context: RecipeContext): Promise<Interaction | null> {
+        // TODO: Invoke this recipe with a task from the fixup queue.
         const controllers = context.editor.controllers
         const selection = context.editor.getActiveTextEditorSelection()
 
@@ -27,8 +28,7 @@ export class NonStop implements Recipe {
             (await context.editor.showInputBox('Ask Cody to edit your code, or use /chat to ask a question.')) ||
             ''
 
-        const taskID = controllers.task.add(humanInput, selection)
-        if ((!humanInput && !selection.selectedText.trim()) || !taskID) {
+        if (!humanInput && !selection.selectedText.trim()) {
             await context.editor.showWarningMessage(
                 'Cody Fixups: Failed to start due to missing instruction with empty selection.'
             )
@@ -57,10 +57,10 @@ export class NonStop implements Recipe {
         context.responseMultiplexer.sub('selection', {
             onResponse: async (content: string) => {
                 text += content
-                await context.editor.didReceiveFixupText(taskID, text, 'streaming')
+                await context.editor.didReceiveFixupText('', text, 'streaming')
             },
             onTurnComplete: async () => {
-                await context.editor.didReceiveFixupText(taskID, text, 'complete')
+                await context.editor.didReceiveFixupText('', text, 'complete')
             },
         })
 

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -27,7 +27,7 @@ interface VsCodeInlineController {
 }
 
 interface VsCodeFixupController {
-    getTaskRecipeData(taskId: string):
+    getTaskRecipeData(taskId: string): Promise<
         | {
               instruction: string
               fileName: string
@@ -36,6 +36,7 @@ interface VsCodeFixupController {
               followingText: string
           }
         | undefined
+    >
 }
 
 export interface ActiveTextEditorViewControllers {

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -26,8 +26,21 @@ interface VsCodeInlineController {
     error(): Promise<void>
 }
 
+interface VsCodeFixupController {
+    getTaskRecipeData(taskId: string):
+        | {
+              instruction: string
+              fileName: string
+              precedingText: string
+              selectedText: string
+              followingText: string
+          }
+        | undefined
+}
+
 export interface ActiveTextEditorViewControllers {
     inline: VsCodeInlineController
+    fixups: VsCodeFixupController
 }
 
 export interface Editor {

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -29,7 +29,6 @@ interface VsCodeInlineController {
 // TODO: Move this interface to client/cody
 interface VsCodeTaskController {
     add(input: string, selection: ActiveTextEditorSelection): string | null
-    stop(taskID: string): void
 }
 
 export interface ActiveTextEditorViewControllers {

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -26,15 +26,8 @@ interface VsCodeInlineController {
     error(): Promise<void>
 }
 
-// TODO: Move this interface to client/cody
-interface VsCodeTaskController {
-    add(input: string, selection: ActiveTextEditorSelection): string | null
-}
-
 export interface ActiveTextEditorViewControllers {
     inline: VsCodeInlineController
-    // TODO: Remove this field once the fixup task view moves to client/cody
-    task: VsCodeTaskController
 }
 
 export interface Editor {

--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -68,6 +68,7 @@ ts_project(
         "src/non-stop/FixupFileObserver.ts",
         "src/non-stop/FixupScheduler.ts",
         "src/non-stop/FixupTask.ts",
+        "src/non-stop/FixupTypingUI.ts",
         "src/non-stop/TaskViewProvider.ts",
         "src/non-stop/codelenses.ts",
         "src/non-stop/diff.ts",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -406,7 +406,7 @@
         "title": "Insert text at the current cursor position"
       },
       {
-        "command": "cody.recipe.non-stop",
+        "command": "cody.non-stop.fixup",
         "category": "Cody",
         "title": "Fixup (Experimental)",
         "icon": "resources/cody.png",
@@ -465,7 +465,7 @@
         "when": "cody.activated && editorTextFocus && !editorReadonly"
       },
       {
-        "command": "cody.recipe.non-stop",
+        "command": "cody.non-stop.fixup",
         "key": "ctrl+shift+v",
         "mac": "shift+cmd+v",
         "when": "cody.activated && editorHasSelection && !editorReadonly"

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -685,7 +685,7 @@
       ],
       "editor/title": [
         {
-          "command": "cody.recipe.non-stop",
+          "command": "cody.non-stop.fixup",
           "when": "cody.nonstop.fixups.enabled && cody.activated",
           "group": "navigation",
           "visibility": "visible"

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -870,7 +870,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             console.error('used ForTesting method without test support object')
             return []
         }
-        return this.editor.controllers.task.getTasks()
+        return this.editor.controllers.fixups.getTasks()
     }
 
     public dispose(): void {

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -31,6 +31,7 @@ import { LocalKeywordContextFetcher } from '../local-context/local-keyword-conte
 import { debug } from '../log'
 import { getRerankWithLog } from '../logged-rerank'
 import { FixupTask } from '../non-stop/FixupTask'
+import { IdleRecipeRunner } from '../non-stop/roles'
 import { LocalStorage } from '../services/LocalStorageProvider'
 import { CODY_ACCESS_TOKEN_SECRET, SecretStorage } from '../services/SecretStorageProvider'
 import { TestSupport } from '../test-support'
@@ -63,7 +64,7 @@ export type Config = Pick<
     | 'experimentalGuardrails'
 >
 
-export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
+export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disposable, IdleRecipeRunner {
     private isMessageInProgress = false
     private cancelCompletionCallback: (() => void) | null = null
     private webview?: Omit<vscode.Webview, 'postMessage'> & {
@@ -135,6 +136,50 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             },
         })
         this.disposables.push(this.localAppDetector)
+    }
+
+    private idleCallbacks_: (() => void)[] = []
+
+    private get isIdle(): boolean {
+        // TODO: Use a cooldown timer for typing and interaction
+        return !this.isMessageInProgress
+    }
+
+    private scheduleIdleRecipes(): void {
+        setTimeout(() => {
+            if (!this.isIdle) {
+                // We rely on the recipe ending re-scheduling idle recipes
+                return
+            }
+            const notifyIdle = this.idleCallbacks_.shift()
+            if (!notifyIdle) {
+                return
+            }
+            try {
+                notifyIdle()
+            } catch (error) {
+                console.error(error)
+            }
+            if (this.idleCallbacks_.length) {
+                this.scheduleIdleRecipes()
+            }
+        }, 1000)
+    }
+
+    public onIdle(callback: () => void): void {
+        if (this.isIdle) {
+            // Run "now", but not synchronously on this callstack.
+            void Promise.resolve().then(callback)
+        } else {
+            this.idleCallbacks_.push(callback)
+        }
+    }
+
+    public runIdleRecipe(recipeId: RecipeID, humanChatInput?: string): Promise<void> {
+        if (!this.isIdle) {
+            throw new Error('not idle')
+        }
+        return this.executeRecipe(recipeId, humanChatInput, false)
     }
 
     public onConfigurationChange(newConfig: Config): void {
@@ -347,6 +392,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.sendChatHistory()
         void vscode.commands.executeCommand('setContext', 'cody.reply.pending', false)
         this.logEmbeddingsSearchErrors()
+        this.scheduleIdleRecipes()
     }
 
     private async onHumanMessageSubmitted(text: string, submitType: 'user' | 'suggestion'): Promise<void> {

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -15,8 +15,6 @@ export class VSCodeEditor implements Editor {
     constructor(
         public controllers: {
             inline: InlineController
-            // TODO: Rename this from "task" to "fixup" when the fixup data
-            // model moves from client/cody-shared to client/cody
             task: FixupController
         }
     ) {

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -15,7 +15,7 @@ export class VSCodeEditor implements Editor {
     constructor(
         public controllers: {
             inline: InlineController
-            task: FixupController
+            fixups: FixupController
         }
     ) {
         vscode.workspace.onDidChangeConfiguration(e => {
@@ -190,6 +190,6 @@ export class VSCodeEditor implements Editor {
     // TODO: When Non-Stop Fixup doesn't depend directly on the chat view,
     // move the recipe to client/cody and remove this entrypoint.
     public async didReceiveFixupText(id: string, text: string, state: 'streaming' | 'complete'): Promise<void> {
-        await this.controllers.task.didReceiveFixupText(id, text, state)
+        await this.controllers.fixups.didReceiveFixupText(id, text, state)
     }
 }

--- a/client/cody/src/extension.ts
+++ b/client/cody/src/extension.ts
@@ -6,6 +6,7 @@ import { ExtensionApi } from './extension-api'
 import { start } from './main'
 
 export function activate(context: vscode.ExtensionContext): ExtensionApi {
+    const api = new ExtensionApi()
     PromptMixin.add(languagePromptMixin(vscode.env.language))
 
     if (process.env.CODY_FOCUS_ON_STARTUP) {
@@ -23,5 +24,5 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
         })
         .catch(error => console.error(error))
 
-    return new ExtensionApi()
+    return api
 }

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -27,6 +27,7 @@ import {
     VSCodeSecretStorage,
 } from './services/SecretStorageProvider'
 import { createStatusBar } from './services/StatusBar'
+import { TestSupport } from './test-support'
 
 const CODY_FEEDBACK_URL =
     'https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&labels=cody,cody/vscode'
@@ -88,6 +89,9 @@ const register = async (
 
     const fixup = new FixupController()
     disposables.push(fixup)
+    if (TestSupport.instance) {
+        TestSupport.instance.fixupController.set(fixup)
+    }
     const controllers = { inline: commentController, fixups: fixup }
 
     const editor = new VSCodeEditor(controllers)

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -153,6 +153,7 @@ const register = async (
     const statusBar = createStatusBar()
 
     disposables.push(
+        fixup,
         vscode.commands.registerCommand('cody.inline.insert', async (copiedText: string) => {
             // Insert copiedText to the current cursor position
             await vscode.commands.executeCommand('editor.action.insertSnippet', {
@@ -328,12 +329,7 @@ const register = async (
     }
     // Register task view and non-stop cody command when feature flag is on
     if (initialConfig.experimentalNonStop || process.env.CODY_TESTING === 'true') {
-        disposables.push(vscode.window.registerTreeDataProvider('cody.fixup.tree.view', fixup.getTaskView()))
-        disposables.push(
-            vscode.commands.registerCommand('cody.recipe.non-stop', async () => {
-                await chatProvider.executeRecipe('non-stop', '', false)
-            })
-        )
+        fixup.register()
         await vscode.commands.executeCommand('setContext', 'cody.nonstop.fixups.enabled', true)
     }
 

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -88,7 +88,7 @@ const register = async (
 
     const fixup = new FixupController()
     disposables.push(fixup)
-    const controllers = { inline: commentController, task: fixup }
+    const controllers = { inline: commentController, fixups: fixup }
 
     const editor = new VSCodeEditor(controllers)
     const workspaceConfig = vscode.workspace.getConfiguration()

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -87,7 +87,8 @@ const register = async (
     disposables.push(commentController.get())
 
     const fixup = new FixupController()
-    const controllers = { inline: commentController, task: fixup, fixup }
+    disposables.push(fixup)
+    const controllers = { inline: commentController, task: fixup }
 
     const editor = new VSCodeEditor(controllers)
     const workspaceConfig = vscode.workspace.getConfiguration()
@@ -116,6 +117,7 @@ const register = async (
         rgPath
     )
     disposables.push(chatProvider)
+    fixup.recipeRunner = chatProvider
 
     disposables.push(
         vscode.window.registerWebviewViewProvider('cody.chat', chatProvider, {
@@ -153,7 +155,6 @@ const register = async (
     const statusBar = createStatusBar()
 
     disposables.push(
-        fixup,
         vscode.commands.registerCommand('cody.inline.insert', async (copiedText: string) => {
             // Insert copiedText to the current cursor position
             await vscode.commands.executeCommand('editor.action.insertSnippet', {

--- a/client/cody/src/non-stop/FixupCodeLenses.ts
+++ b/client/cody/src/non-stop/FixupCodeLenses.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { getLensesByState } from './codelenses'
+import { getLensesForTask } from './codelenses'
 import { FixupTask } from './FixupTask'
 import { FixupFileCollection } from './roles'
 import { CodyTaskState } from './utils'
@@ -44,7 +44,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider {
             this.removeLensesFor(task)
             return
         }
-        this.taskLenses.set(task, getLensesByState(task.id, task.state, task.selectionRange))
+        this.taskLenses.set(task, getLensesForTask(task))
         this.notifyCodeLensesChanged()
     }
 

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -96,6 +96,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
 
     // Replaces content of the file before mark the task as done
     // Then update the tree view with the new task state
+    // TODO: Move this to the state transition to "ready"
     public stop(taskID: taskID): void {
         const task = this.tasks.get(taskID)
         if (!task) {
@@ -262,7 +263,7 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         if (!task) {
             return Promise.resolve()
         }
-        if (task.state !== CodyTaskState.asking && task.state !== CodyTaskState.marking) {
+        if (task.state !== CodyTaskState.asking) {
             // TODO: Update this when we re-spin tasks with conflicts so that
             // we store the new text but can also display something reasonably
             // stable in the editor
@@ -272,7 +273,6 @@ export class FixupController implements FixupFileCollection, FixupIdleTaskRunner
         switch (state) {
             case 'streaming':
                 task.inProgressReplacement = text
-                await this.setTaskState(task, CodyTaskState.marking)
                 break
             case 'complete':
                 task.inProgressReplacement = undefined

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -10,7 +10,7 @@ import { FixupFileObserver } from './FixupFileObserver'
 import { FixupScheduler } from './FixupScheduler'
 import { FixupTask, taskID } from './FixupTask'
 import { FixupTypingUI } from './FixupTypingUI'
-import { FixupFileCollection, FixupIdleTaskRunner, FixupTaskFactory, FixupTextChanged } from './roles'
+import { FixupFileCollection, FixupIdleTaskRunner, FixupTaskFactory, FixupTextChanged, IdleRecipeRunner } from './roles'
 import { TaskViewProvider, FixupTaskTreeItem } from './TaskViewProvider'
 import { CodyTaskState } from './utils'
 
@@ -28,6 +28,7 @@ export class FixupController
     private readonly codelenses = new FixupCodeLenses(this)
     private readonly contentStore = new ContentProvider()
     private readonly typingUI = new FixupTypingUI(this)
+    public recipeRunner: IdleRecipeRunner | undefined
 
     private _disposables: vscode.Disposable[] = []
 

--- a/client/cody/src/non-stop/FixupController.ts
+++ b/client/cody/src/non-stop/FixupController.ts
@@ -130,7 +130,7 @@ export class FixupController
     // will return undefined. This may update the task with the newly computed
     // diff.
     private applicableDiffOrRespin(task: FixupTask, document: vscode.TextDocument): Diff | undefined {
-        if (!(task.state == CodyTaskState.ready || task.state == CodyTaskState.applying)) {
+        if (!(task.state === CodyTaskState.ready || task.state === CodyTaskState.applying)) {
             // We haven't received a response from the LLM yet, so there is
             // no diff.
             console.warn('no response cached from LLM so no applicable diff')

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -9,7 +9,7 @@ export type taskID = string
 export class FixupTask {
     public id: taskID
     public selectionRange: vscode.Range
-    public state_: CodyTaskState = CodyTaskState.idle
+    public state_: CodyTaskState = CodyTaskState.waiting
     // The original text that we're working on updating
     public readonly original: string
     // The text of the streaming turn of the LLM, if any

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -9,6 +9,9 @@ export type taskID = string
 export class FixupTask {
     public id: taskID
     public state_: CodyTaskState = CodyTaskState.idle
+    // The original text that we're working on updating. Set when we start an
+    // LLM spin.
+    public original = ''
     // The text of the streaming turn of the LLM, if any
     public inProgressReplacement: string | undefined
     // The text of the last completed turn of the LLM, if any
@@ -16,12 +19,12 @@ export class FixupTask {
     // If text has been received from the LLM and a diff has been computed, it
     // is cached here. Diffs are recomputed lazily and may be stale.
     public diff: Diff | undefined
+    // The number of times we've submitted this to the LLM.
+    public spinCount = 0
 
     constructor(
         public readonly fixupFile: FixupFile,
         public readonly instruction: string,
-        // The original text that we're working on updating
-        public readonly original: string,
         public selectionRange: vscode.Range
     ) {
         this.id = Date.now().toString(36).replace(/\d+/g, '')

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -8,7 +8,7 @@ export type taskID = string
 
 export class FixupTask {
     public id: taskID
-    public state_: CodyTaskState = CodyTaskState.waiting
+    public state_: CodyTaskState = CodyTaskState.idle
     // The text of the streaming turn of the LLM, if any
     public inProgressReplacement: string | undefined
     // The text of the last completed turn of the LLM, if any

--- a/client/cody/src/non-stop/FixupTask.ts
+++ b/client/cody/src/non-stop/FixupTask.ts
@@ -8,10 +8,7 @@ export type taskID = string
 
 export class FixupTask {
     public id: taskID
-    public selectionRange: vscode.Range
     public state_: CodyTaskState = CodyTaskState.waiting
-    // The original text that we're working on updating
-    public readonly original: string
     // The text of the streaming turn of the LLM, if any
     public inProgressReplacement: string | undefined
     // The text of the last completed turn of the LLM, if any
@@ -20,10 +17,14 @@ export class FixupTask {
     // is cached here. Diffs are recomputed lazily and may be stale.
     public diff: Diff | undefined
 
-    constructor(public readonly fixupFile: FixupFile, public readonly instruction: string, editor: vscode.TextEditor) {
+    constructor(
+        public readonly fixupFile: FixupFile,
+        public readonly instruction: string,
+        // The original text that we're working on updating
+        public readonly original: string,
+        public selectionRange: vscode.Range
+    ) {
         this.id = Date.now().toString(36).replace(/\d+/g, '')
-        this.selectionRange = editor.selection
-        this.original = editor.document.getText(this.selectionRange)
     }
 
     /**

--- a/client/cody/src/non-stop/FixupTypingUI.ts
+++ b/client/cody/src/non-stop/FixupTypingUI.ts
@@ -41,5 +41,8 @@ export class FixupTypingUI {
         }
 
         this.taskFactory.createTask(editor.document.uri, instruction, text, range)
+
+        // Return focus to the editor
+        void vscode.window.showTextDocument(editor.document)
     }
 }

--- a/client/cody/src/non-stop/FixupTypingUI.ts
+++ b/client/cody/src/non-stop/FixupTypingUI.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode'
+
+import { FixupTaskFactory } from './roles'
+
+/**
+ * The UI for creating non-stop fixup tasks by typing instructions.
+ */
+export class FixupTypingUI {
+    constructor(private readonly taskFactory: FixupTaskFactory) {}
+
+    public async show(): Promise<void> {
+        const editor = vscode.window.activeTextEditor
+        if (!editor) {
+            return
+        }
+        const range = editor.selection
+        const text = editor.document.getText(editor.selection)
+
+        // TODO: Do not require any text to be selected
+        if (range.isEmpty) {
+            await vscode.window.showWarningMessage('Select some text to fix up')
+            return
+        }
+
+        const CHAT_COMMAND = '/chat'
+        const CHAT_RE = /\/chat(|\s.*)^/
+        const instruction = (
+            await vscode.window.showInputBox({
+                title: `Ask Cody to edit your code, or use ${CHAT_COMMAND} to ask a question`,
+            })
+        )?.trim()
+        if (!instruction) {
+            return
+        }
+        const match = instruction.match(CHAT_RE)
+        if (match) {
+            void vscode.commands.executeCommand('cody.focus', match[1].trim())
+            return
+        }
+
+        this.taskFactory.createTask(editor.document.uri, instruction, text, range)
+    }
+}

--- a/client/cody/src/non-stop/FixupTypingUI.ts
+++ b/client/cody/src/non-stop/FixupTypingUI.ts
@@ -23,7 +23,7 @@ export class FixupTypingUI {
         }
 
         const CHAT_COMMAND = '/chat'
-        const CHAT_RE = /\/chat(|\s.*)^/
+        const CHAT_RE = /^\/chat(|\s.*)$/
         const instruction = (
             await vscode.window.showInputBox({
                 title: `Ask Cody to edit your code, or use ${CHAT_COMMAND} to ask a question`,
@@ -34,7 +34,9 @@ export class FixupTypingUI {
         }
         const match = instruction.match(CHAT_RE)
         if (match) {
-            void vscode.commands.executeCommand('cody.focus', match[1].trim())
+            // TODO: If we got here, we have a selection; start an inline chat
+            // with match[1].
+            void vscode.commands.executeCommand('cody.focus')
             return
         }
 

--- a/client/cody/src/non-stop/FixupTypingUI.ts
+++ b/client/cody/src/non-stop/FixupTypingUI.ts
@@ -14,7 +14,6 @@ export class FixupTypingUI {
             return
         }
         const range = editor.selection
-        const text = editor.document.getText(editor.selection)
 
         // TODO: Do not require any text to be selected
         if (range.isEmpty) {
@@ -40,7 +39,7 @@ export class FixupTypingUI {
             return
         }
 
-        this.taskFactory.createTask(editor.document.uri, instruction, text, range)
+        this.taskFactory.createTask(editor.document.uri, instruction, range)
 
         // Return focus to the editor
         void vscode.window.showTextDocument(editor.document)

--- a/client/cody/src/non-stop/TaskViewProvider.ts
+++ b/client/cody/src/non-stop/TaskViewProvider.ts
@@ -116,7 +116,8 @@ export class TaskViewProvider implements vscode.TreeDataProvider<FixupTaskTreeIt
 }
 
 export class FixupTaskTreeItem extends vscode.TreeItem {
-    private state: CodyTaskState = CodyTaskState.idle
+    // TODO: Don't duplicate the task state here; use the FixupTask directly.
+    private state: CodyTaskState = CodyTaskState.waiting
     public fsPath: string
 
     // state for parent node

--- a/client/cody/src/non-stop/codelenses.ts
+++ b/client/cody/src/non-stop/codelenses.ts
@@ -2,43 +2,45 @@ import * as vscode from 'vscode'
 
 import { getSingleLineRange } from '../services/InlineAssist'
 
+import { FixupTask } from './FixupTask'
 import { CodyTaskState } from './utils'
 
 // Create Lenses based on state
-export function getLensesByState(id: string, state: CodyTaskState, range: vscode.Range): vscode.CodeLens[] {
-    const codeLensRange = getSingleLineRange(range.start.line)
-    switch (state) {
-        case CodyTaskState.error: {
-            const title = getErrorLens(codeLensRange)
-            const diff = getDiffLens(codeLensRange, id)
-            const discard = getDiscardLens(codeLensRange, id)
-            return [title, diff, discard]
-        }
-        case CodyTaskState.applying: {
-            const title = getApplyingLens(codeLensRange)
-            const cancel = getCancelLens(codeLensRange, id)
+export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
+    const codeLensRange = getSingleLineRange(task.selectionRange.start.line)
+    switch (task.state) {
+        case CodyTaskState.waiting: {
+            const title = getWaitingLens(codeLensRange)
+            const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
         case CodyTaskState.asking: {
             const title = getAskingLens(codeLensRange)
-            const cancel = getCancelLens(codeLensRange, id)
+            const cancel = getCancelLens(codeLensRange, task.id)
             return [title, cancel]
         }
         case CodyTaskState.ready: {
-            const title = getReadyLens(codeLensRange, id)
-            const apply = getApplyLens(codeLensRange, id)
-            const diff = getDiffLens(codeLensRange, id)
-            const edit = getEditLens(codeLensRange, id)
-            return [title, apply, edit, diff]
+            const title = getReadyLens(codeLensRange, task.id)
+            const apply = getApplyLens(codeLensRange, task.id)
+            const diff = getDiffLens(codeLensRange, task.id)
+            return [title, apply, diff]
         }
-        // TODO: Add lenses for waiting tasks, so they can be cancelled
+        case CodyTaskState.applying: {
+            const title = getApplyingLens(codeLensRange)
+            return [title]
+        }
+        case CodyTaskState.error: {
+            const title = getErrorLens(codeLensRange)
+            const discard = getDiscardLens(codeLensRange, task.id)
+            return [title, discard]
+        }
         default:
             return []
     }
 }
 
 // List of lenses
-// NOTE: code lens requires a command so we will use 'cody.focus' as a placeholder
+// TODO: Replace cody.focus with appropriate tasks
 // TODO (bea) send error messages to the chat UI so that they can see the task progress in the chat and chat history
 function getErrorLens(codeLensRange: vscode.Range): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
@@ -53,6 +55,15 @@ function getAskingLens(codeLensRange: vscode.Range): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: '$(sync~spin) Asking Cody...',
+        command: 'cody.focus',
+    }
+    return lens
+}
+
+function getWaitingLens(codeLensRange: vscode.Range): vscode.CodeLens {
+    const lens = new vscode.CodeLens(codeLensRange)
+    lens.command = {
+        title: '$(sync) Asking Cody...',
         command: 'cody.focus',
     }
     return lens
@@ -81,7 +92,7 @@ function getDiscardLens(codeLensRange: vscode.Range, id: string): vscode.CodeLen
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
         title: 'Discard',
-        command: 'cody.fixup.codelens.discard',
+        command: 'cody.fixup.codelens.cancel',
         arguments: [id],
     }
     return lens
@@ -100,18 +111,8 @@ function getDiffLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
 function getReadyLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
     lens.command = {
-        title: '✨ Fixup ready',
-        command: 'cody.focus',
-        arguments: [id],
-    }
-    return lens
-}
-
-function getEditLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: 'Edit',
-        command: 'cody.fixup.codelens.edit',
+        title: '$(pencil) Fixup ready',
+        command: 'cody.fixup.codelens.apply',
         arguments: [id],
     }
     return lens

--- a/client/cody/src/non-stop/codelenses.ts
+++ b/client/cody/src/non-stop/codelenses.ts
@@ -31,11 +31,7 @@ export function getLensesByState(id: string, state: CodyTaskState, range: vscode
             const edit = getEditLens(codeLensRange, id)
             return [title, apply, edit, diff]
         }
-        case CodyTaskState.marking: {
-            const title = getMakingFixupsLens(codeLensRange)
-            const follow = getFollowLens(codeLensRange, id)
-            return [title, follow]
-        }
+        // TODO: Add lenses for waiting tasks, so they can be cancelled
         default:
             return []
     }
@@ -126,24 +122,6 @@ function getApplyLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens 
     lens.command = {
         title: 'Apply',
         command: 'cody.fixup.codelens.apply',
-        arguments: [id],
-    }
-    return lens
-}
-
-function getMakingFixupsLens(codeLensRange: vscode.Range): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: '$(edit) Cody is making fixups...',
-        command: 'cody.focus',
-    }
-    return lens
-}
-function getFollowLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
-    const lens = new vscode.CodeLens(codeLensRange)
-    lens.command = {
-        title: 'Follow',
-        command: 'cody.fixup.open',
         arguments: [id],
     }
     return lens

--- a/client/cody/src/non-stop/diff.ts
+++ b/client/cody/src/non-stop/diff.ts
@@ -222,6 +222,7 @@ export interface Edit {
 }
 
 export interface Diff {
+    originalText: string
     bufferText: string
     mergedText: string | undefined
     // TODO: We can use the presence of mergedText to indicate clean
@@ -298,6 +299,7 @@ export function computeDiff(original: string, a: string, b: string, bStart: Posi
         originalPos = originalEnd
     }
     return {
+        originalText: original,
         bufferText: b,
         mergedText: clean ? mergedText.join('') : undefined,
         clean,

--- a/client/cody/src/non-stop/roles.ts
+++ b/client/cody/src/non-stop/roles.ts
@@ -29,6 +29,13 @@ export interface FixupIdleTaskRunner {
 }
 
 /**
+ * Creates and starts processing a task.
+ */
+export interface FixupTaskFactory {
+    createTask(documentUri: vscode.Uri, instruction: string, originalText: string, selectionRange: vscode.Range): void
+}
+
+/**
  * Sink for notifications that text related to the fixup task--either the text
  * in the file, or the text provided by Cody--has changed.
  */

--- a/client/cody/src/non-stop/roles.ts
+++ b/client/cody/src/non-stop/roles.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
 
+import { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
+
 import { FixupFile } from './FixupFile'
 import { FixupTask } from './FixupTask'
 
@@ -42,4 +44,19 @@ export interface FixupTaskFactory {
 export interface FixupTextChanged {
     textDidChange(task: FixupTask): void
     rangeDidChange(task: FixupTask): void
+}
+
+/**
+ * Runs recipes. Can call you back when no recipes are running.
+ */
+export interface IdleRecipeRunner {
+    /**
+     * Calls callback once when the recipe run loop is idle.
+     */
+    onIdle(callback: () => void): void
+
+    /**
+     * Runs the specified recipe. Rejects if the recipe runner is busy.
+     */
+    runIdleRecipe(recipeId: RecipeID, humanChatInput?: string): Promise<void>
 }

--- a/client/cody/src/non-stop/roles.ts
+++ b/client/cody/src/non-stop/roles.ts
@@ -34,7 +34,7 @@ export interface FixupIdleTaskRunner {
  * Creates and starts processing a task.
  */
 export interface FixupTaskFactory {
-    createTask(documentUri: vscode.Uri, instruction: string, originalText: string, selectionRange: vscode.Range): void
+    createTask(documentUri: vscode.Uri, instruction: string, selectionRange: vscode.Range): void
 }
 
 /**

--- a/client/cody/src/non-stop/utils.ts
+++ b/client/cody/src/non-stop/utils.ts
@@ -20,8 +20,6 @@ export type CodyTaskList = {
  * Icon for each task state
  */
 export const fixupTaskList: CodyTaskList = {
-    // TODO: Remove this state when the code lens and decoration provider
-    // no longer maintain their own copy of state.
     [CodyTaskState.idle]: {
         id: 'idle',
         icon: 'clock',

--- a/client/cody/src/non-stop/utils.ts
+++ b/client/cody/src/non-stop/utils.ts
@@ -1,12 +1,11 @@
 export enum CodyTaskState {
     'idle' = 0,
-    'queued' = 1,
+    'waiting' = 1,
     'asking' = 2,
-    'marking' = 3,
-    'ready' = 4,
-    'applying' = 5,
-    'fixed' = 6,
-    'error' = 7,
+    'ready' = 3,
+    'applying' = 4,
+    'fixed' = 5,
+    'error' = 6,
 }
 
 export type CodyTaskList = {
@@ -16,51 +15,51 @@ export type CodyTaskList = {
         description: string
     }
 }
+
 /**
  * Icon for each task state
  */
 export const fixupTaskList: CodyTaskList = {
+    // TODO: Remove this state when the code lens and decoration provider
+    // no longer maintain their own copy of state.
     [CodyTaskState.idle]: {
         id: 'idle',
         icon: 'clock',
-        description: 'Initial state - all task starts from here',
+        description: 'Initial state',
+    },
+    [CodyTaskState.waiting]: {
+        id: 'waiting',
+        // TODO: Per Figma, this should be a Cody wink
+        icon: 'debug-pause',
+        description: 'The task is waiting to be processed by Cody',
     },
     [CodyTaskState.asking]: {
         id: 'asking',
         icon: 'sync~spin',
-        description: 'In the process of pending for Cody response',
+        description: 'Cody is preparing a response',
     },
     [CodyTaskState.ready]: {
         id: 'ready',
-        icon: 'smiley',
+        icon: 'pencil',
         description: 'Cody has responsed with suggestions and is ready to apply them',
-    },
-    [CodyTaskState.error]: {
-        id: 'error',
-        icon: 'stop',
-        description: 'The task has been completed and returned error',
-    },
-    [CodyTaskState.queued]: {
-        id: 'queue',
-        icon: 'debug-pause',
-        description: 'The task is in the queue to be processed by Cody',
     },
     [CodyTaskState.applying]: {
         id: 'applying',
-        icon: 'sync~spin',
-        description: 'In the process of applying the fixups to the docs',
-    },
-    [CodyTaskState.marking]: {
-        id: 'marking',
-        icon: 'edit',
-        description: 'Marking the fixups as Cody responses',
+        icon: 'pencil',
+        description: 'The fixup is being applied to the document',
     },
     [CodyTaskState.fixed]: {
         id: 'fixed',
         icon: 'pass-filled',
-        description: 'Suggestions from Cody have been applied to the docs successfully',
+        description: 'Suggestions from Cody have been applied or discarded',
+    },
+    [CodyTaskState.error]: {
+        id: 'error',
+        icon: 'stop',
+        description: 'The task failed',
     },
 }
+
 /**
  * Get the last part of the file path after the last slash
  */

--- a/client/cody/src/test-support.ts
+++ b/client/cody/src/test-support.ts
@@ -3,6 +3,7 @@ import { MockReranker, Reranker } from '@sourcegraph/cody-shared/src/codebase-co
 import { ContextResult } from '@sourcegraph/cody-shared/src/local-context'
 
 import { ChatViewProvider } from './chat/ChatViewProvider'
+import { FixupController } from './non-stop/FixupController'
 import { FixupTask } from './non-stop/FixupTask'
 
 // A one-slot channel which lets readers block on a value being
@@ -40,6 +41,7 @@ export class TestSupport {
     public static instance: TestSupport | undefined
 
     public chatViewProvider = new Rendezvous<ChatViewProvider>()
+    public fixupController = new Rendezvous<FixupController>()
 
     public reranker: Reranker | undefined
 

--- a/client/cody/test/e2e/fixup-decorator.test.ts
+++ b/client/cody/test/e2e/fixup-decorator.test.ts
@@ -33,7 +33,7 @@ test('decorations from un-applied Cody changes appear', async ({ page, sidebar }
     await page.getByRole('button', { name: 'Fixup (Experimental)' }).click()
 
     // Wait for the input box to appear
-    await page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.').click()
+    await page.getByText('Ask Cody to edit your code, or use /chat to ask a question').click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')
     // Press enter to submit the fixup

--- a/client/cody/test/e2e/task-controller.test.ts
+++ b/client/cody/test/e2e/task-controller.test.ts
@@ -33,7 +33,7 @@ test('task tree view for non-stop cody', async ({ page, sidebar }) => {
     await page.getByRole('button', { name: 'Fixup (Experimental)' }).click()
 
     // Wait for the input box to appear
-    await page.getByPlaceholder('Ask Cody to edit your code, or use /chat to ask a question.').click()
+    await page.getByText('Ask Cody to edit your code, or use /chat to ask a question').click()
     // Type in the instruction for fixup
     await page.keyboard.type('replace hello with goodbye')
     // Press enter to submit the fixup

--- a/client/cody/test/integration/task-controller.test.ts
+++ b/client/cody/test/integration/task-controller.test.ts
@@ -33,12 +33,7 @@ suite('Cody Fixup Task Controller', function () {
 
         // Brings up the vscode input box
         const fixups = await getFixupController()
-        fixups.createTask(
-            textEditor.document.uri,
-            'Replace hello with goodbye',
-            textEditor.document.getText(textEditor.selection),
-            textEditor.selection
-        )
+        fixups.createTask(textEditor.document.uri, 'Replace hello with goodbye', textEditor.selection)
 
         // Check the chat transcript contains markdown
         const humanMessage = await getTranscript(0)

--- a/client/cody/test/integration/task-controller.test.ts
+++ b/client/cody/test/integration/task-controller.test.ts
@@ -2,14 +2,14 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import { ChatViewProvider } from '../../src/chat/ChatViewProvider'
+import { FixupController } from '../../src/non-stop/FixupController'
 
 import { afterIntegrationTest, beforeIntegrationTest, getExtensionAPI, getFixupTasks, getTranscript } from './helpers'
 
-async function getChatViewProvider(): Promise<ChatViewProvider> {
-    const chatViewProvider = await getExtensionAPI().exports.testing?.chatViewProvider.get()
-    assert.ok(chatViewProvider)
-    return chatViewProvider
+async function getFixupController(): Promise<FixupController> {
+    const fixups = await getExtensionAPI().exports.testing?.fixupController.get()
+    assert.ok(fixups)
+    return fixups
 }
 
 suite('Cody Fixup Task Controller', function () {
@@ -21,7 +21,6 @@ suite('Cody Fixup Task Controller', function () {
     // Run the non-stop recipe to create a new task before every test
     this.beforeEach(async () => {
         await vscode.commands.executeCommand('cody.chat.focus')
-        const chatView = await getChatViewProvider()
 
         // Open index.html
         assert.ok(vscode.workspace.workspaceFolders)
@@ -33,7 +32,13 @@ suite('Cody Fixup Task Controller', function () {
         textEditor.selection = new vscode.Selection(6, 0, 7, 0)
 
         // Brings up the vscode input box
-        await chatView.executeRecipe('non-stop', 'Replace hello with goodbye', false)
+        const fixups = await getFixupController()
+        fixups.createTask(
+            textEditor.document.uri,
+            'Replace hello with goodbye',
+            textEditor.document.getText(textEditor.selection),
+            textEditor.selection
+        )
 
         // Check the chat transcript contains markdown
         const humanMessage = await getTranscript(0)


### PR DESCRIPTION
This does not *automatically* re-spin tasks, but the respin mechanism is working.

## Test plan

```
pnpm test:unit && pnpm test:integration && pnpm test:e2e
```

Manual test:

1. Create and save a file. Write a bunch of code in it.
2. Ask Cody to do something time consuming in chat, like list US states and their capitals.
3. While chat is busy, Cmd-Shift-P, Fixup (Experimental) and ask Cody to fix something. Note that the fixup task is paused while chat is busy, and gets picked up automatically when chat is not busy.
4. Edit in a blue rectangle to create a conflict with what Cody wants to write. Click Apply. Note that the task re-spins and Cody redoes its work including your changes.
5. Edit "in the zone" but outside blue rectangles so there's no conflict. Apply the change. Note that all the changes are applied, merged.