### PR TITLE
ci: fix flaky Percy snapshot

### DIFF
--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -139,7 +139,12 @@ export class SettingsFile extends React.PureComponent<Props, State> {
             this.state.contents === undefined ? this.getPropsSettingsContentsOrEmpty() : this.state.contents
 
         return (
-            <div className={classNames('test-settings-file d-flex flex-grow-1 flex-column', styles.settingsFile)}>
+            <div
+                className={classNames(
+                    'test-settings-file percy-hide d-flex flex-grow-1 flex-column',
+                    styles.settingsFile
+                )}
+            >
                 <BeforeUnloadPrompt when={this.state.saving || this.dirty} message="Discard settings changes?" />
                 <React.Suspense fallback={<LoadingSpinner className="mt-2" />}>
                     <MonacoSettingsEditor


### PR DESCRIPTION
## Context

Follow-up on https://github.com/sourcegraph/sourcegraph/pull/53525
Hide Monaco editor from Percy to avoid flakes. [The flake example](https://percy.io/Sourcegraph/Sourcegraph/builds/28244433/changed/1570186388?browser=chrome&browser_ids=38&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=1920).

## Test plan

CI
