### PR TITLE
Use NPMRC_DATA to write .npmrc file in auto-indexing job for Typescript

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/inference/lang_typescript_test.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/lang_typescript_test.go
@@ -9,6 +9,15 @@ import (
 
 func TestTypeScriptGenerator(t *testing.T) {
 	expectedIndexerImage, _ := libs.DefaultIndexerForLang("typescript")
+	npmrcStep := `if [ "$NPMRC_DATA" ]; then
+  echo "Writing npmrc config to $HOME/.npmrc"
+  echo "$NPMRC_DATA" > ~/.npmrc
+else
+  echo "No npmrc config set, continuing"
+fi`
+	nodeMemoryStep := `if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`
+
+	expectedLocalSteps := []string{nodeMemoryStep, npmrcStep}
 
 	testGenerators(t,
 		generatorTestCase{
@@ -25,7 +34,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"npm install --ignore-scripts"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index", "--infer-tsconfig"},
@@ -49,7 +58,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"yarn --ignore-scripts"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index", "--infer-tsconfig"},
@@ -66,7 +75,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 			expected: []config.IndexJob{
 				{
 					Steps:            nil,
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -85,7 +94,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 			expected: []config.IndexJob{
 				{
 					Steps:            nil,
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "a",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -94,7 +103,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 				},
 				{
 					Steps:            nil,
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "b",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -103,7 +112,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 				},
 				{
 					Steps:            nil,
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "c",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -133,7 +142,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"npm install"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -153,7 +162,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"yarn"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "foo/bar/baz",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -178,7 +187,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"npm install"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "foo/bar/bonk",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -193,7 +202,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"npm install"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "foo/baz",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -218,7 +227,7 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"yarn"},
 						},
 					},
-					LocalSteps:       []string{`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`},
+					LocalSteps:       expectedLocalSteps,
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},
@@ -243,10 +252,10 @@ func TestTypeScriptGenerator(t *testing.T) {
 							Commands: []string{"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto", "npm install"},
 						},
 					},
-					LocalSteps: []string{
-						"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto",
-						`if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi`,
-					},
+					LocalSteps: append(
+						[]string{"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"},
+						expectedLocalSteps...,
+					),
 					Root:             "",
 					Indexer:          expectedIndexerImage,
 					IndexerArgs:      []string{"scip-typescript", "index"},

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -8,18 +8,27 @@ local util = require("sg.autoindex.util")
 
 local indexer = require("sg.autoindex.indexes").get "typescript"
 local typescript_nmusl_command =
-	"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"
+"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"
 
 local exclude_paths = pattern.new_path_combine(shared.exclude_paths, {
 	pattern.new_path_segment("node_modules"),
 })
 
-local safe_decode = function(encoded)
-  local _, payload = pcall(function()
-    return json.decode(encoded)
-  end)
+local npmrc_steps = [[if [ "$NPMRC_DATA" ]; then
+  echo "Writing npmrc config to $HOME/.npmrc"
+  echo "$NPMRC_DATA" > ~/.npmrc
+else
+  echo "No npmrc config set, continuing"
+fi]]
 
-  return payload
+
+
+local safe_decode = function(encoded)
+	local _, payload = pcall(function()
+		return json.decode(encoded)
+	end)
+
+	return payload
 end
 
 local check_lerna_file = function(root, contents_by_path)
@@ -124,6 +133,8 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
 				local_steps,
 				'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
 			)
+
+			table.insert(local_steps, npmrc_steps)
 
 			local args = { "scip-typescript", "index" }
 			if should_infer_config then

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -148,7 +148,7 @@ local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
 				indexer = indexer,
 				indexer_args = args,
 				outfile = "index.scip",
-				requested_envvars = { "NPM_TOKEN" },
+				requested_envvars = { "NPM_TOKEN", "NPMRC_DATA" },
 			}
 		end,
 	}))


### PR DESCRIPTION
This is to support a `.npmrc` location that can be populated from an executor secret, and we write it to a global location.

This seems to be the recommended way to authorise with JFrog artifactory hosting NPM packages.

https://jfrog.com/help/r/jfrog-artifactory-documentation/npm-registry

<img width="425" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/1052965/d8687205-6ae9-4f86-83de-a82fdc9074e6">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
