### PR TITLE
Remove extra symbols service from starting

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1234,7 +1234,6 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
-      - symbols
 
   enterprise-e2e:
     <<: *enterprise_set


### PR DESCRIPTION
Removes the duplicate `symbols` service that causes a port conflict

## Test plan

`sg start` works again

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
