### PR TITLE
Fix GitLab project name with new navigation enabled

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -49,7 +49,7 @@ export const getPageKindFromPathName = (owner: string, projectName: string, path
  * Gets information about the page.
  */
 export function getPageInfo(): GitLabInfo {
-    const projectLink = document.querySelector<HTMLAnchorElement>('.context-header a')
+    const projectLink = document.querySelector<HTMLAnchorElement>('.context-header a, .shortcuts-project')
     if (!projectLink) {
         throw new Error('Unable to determine project name')
     }


### PR DESCRIPTION
Fixes the `getPageInfo` throwing a `Unable to determine project name` error when the new navigation is enabled.



## Test plan

- Enable new navigation in GitLab
- Have sourcegraph enabled in user preferences
- Visit a file
- Without this change sourcegraph will throw an error
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
