### PR TITLE
Own s/experimental/beta/ in blob view

### DIFF
--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -129,7 +129,7 @@ function useBlobPanelViews({
                     ? {
                           id: 'ownership',
                           title: 'Ownership',
-                          productStatus: 'experimental' as const,
+                          productStatus: 'beta' as const,
                           element: (
                               <PanelContent>
                                   <FileOwnershipPanel


### PR DESCRIPTION
Ownership tab in blob view has Beta, not Experimental label.

## Test plan

Visual assessment

<img width="655" alt="Screenshot 2023-06-15 at 11 40 09 AM" src="https://github.com/sourcegraph/sourcegraph/assets/153410/7f949a5c-6df0-4557-a1c6-035d1b8c1c90">
