### PR TITLE
Support ownership search in diffs

### DIFF
--- a/enterprise/internal/own/search/BUILD.bazel
+++ b/enterprise/internal/own/search/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/search/job",
         "//internal/search/result",
         "//internal/search/streaming",
+        "//internal/types",
         "//lib/errors",
         "@io_opentelemetry_go_otel//attribute",
     ],

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -76,7 +76,6 @@ func (s *fileHasOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, 
 	})
 
 	alert, err = s.child.Run(ctx, clients, filteredStream)
-	// Add is nil-safe, we can just add an alert even if its pointer is nil.
 	maxAlerter.Add(alert)
 	return maxAlerter.Alert, err
 }

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -145,14 +145,18 @@ matchesLoop:
 			errs = errors.Append(errs, err)
 			continue matchesLoop
 		}
+		var fileMatchesIncludeTerms bool
 		for _, path := range filePaths {
 			fileOwners := file.Match(path)
-			if len(includeTerms) > 0 && !ownersFilters(fileOwners, includeTerms, includeBags, false) {
-				continue matchesLoop
+			if len(includeTerms) > 0 && ownersFilters(fileOwners, includeTerms, includeBags, false) {
+				fileMatchesIncludeTerms = true
 			}
 			if len(excludeTerms) > 0 && !ownersFilters(fileOwners, excludeTerms, excludeBags, true) {
 				continue matchesLoop
 			}
+		}
+		if len(includeTerms) > 0 && !fileMatchesIncludeTerms {
+			continue matchesLoop
 		}
 
 		filtered = append(filtered, m)

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -145,6 +145,9 @@ matchesLoop:
 			errs = errors.Append(errs, err)
 			continue matchesLoop
 		}
+		// For multiple files considered for ownership in single result (CommitMatch case) we:
+		// * exclude a result if none of the files is owned by all included owners,
+		// * exclude a result if any of the files is owned by all excluded owners.
 		var fileMatchesIncludeTerms bool
 		for _, path := range filePaths {
 			fileOwners := file.Match(path)

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -128,18 +128,15 @@ matchesLoop:
 			commitID  api.CommitID
 			repo      types.MinimalRepo
 		)
-		fmt.Printf("MATCHES TYPEZ %T\n", m)
 		switch mm := m.(type) {
 		case *result.FileMatch:
 			filePaths = []string{mm.File.Path}
 			commitID = mm.CommitID
 			repo = mm.Repo
-			fmt.Println("FILE MATCH CASE", filePaths)
 		case *result.CommitMatch:
 			filePaths = mm.ModifiedFiles
 			commitID = mm.Commit.ID
 			repo = mm.Repo
-			fmt.Println("COMMIT MATCH CASE", filePaths)
 		}
 		if len(filePaths) == 0 {
 			continue matchesLoop

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -526,6 +526,35 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "discard commits through exclude owners despite having include owners",
+			args: args{
+				includeOwners: []string{"@includeOwner"},
+				excludeOwners: []string{"@excludeOwner"},
+				matches: []result.Match{
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file1.included", "file2"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file3.included", "file4.excluded"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file5.excluded", "file3"},
+					},
+				},
+				repoContent: map[string]string{
+					"CODEOWNERS": strings.Join([]string{
+						"*.included @includeOwner",
+						"*.excluded @excludeOwner",
+					}, "\n"),
+				},
+			},
+			want: autogold.Expect([]result.Match{
+				&result.CommitMatch{
+					ModifiedFiles: []string{"file1.included", "file2"},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -472,7 +472,7 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 			}),
 		},
 		{
-			name: "match commits where any file is owned by requested owner",
+			name: "match commits where any file is owned by included owner",
 			args: args{
 				includeOwners: []string{"@owner"},
 				excludeOwners: []string{},
@@ -497,6 +497,32 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				},
 				&result.CommitMatch{
 					ModifiedFiles: []string{"file5.owned"},
+				},
+			}),
+		},
+		{
+			name: "discard commits where any file is owned by excluded owner",
+			args: args{
+				includeOwners: []string{},
+				excludeOwners: []string{"@owner"},
+				matches: []result.Match{
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file1.notOwned", "file2.owned"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file3.notOwned", "file4.notOwned"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file5.owned"},
+					},
+				},
+				repoContent: map[string]string{
+					"CODEOWNERS": "*.owned @owner\n",
+				},
+			},
+			want: autogold.Expect([]result.Match{
+				&result.CommitMatch{
+					ModifiedFiles: []string{"file3.notOwned", "file4.notOwned"},
 				},
 			}),
 		},

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -471,6 +471,35 @@ func TestApplyCodeOwnershipFiltering(t *testing.T) {
 				},
 			}),
 		},
+		{
+			name: "match commits where any file is owned by requested owner",
+			args: args{
+				includeOwners: []string{"@owner"},
+				excludeOwners: []string{},
+				matches: []result.Match{
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file1.notOwned", "file2.owned"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file3.notOwned", "file4.notOwned"},
+					},
+					&result.CommitMatch{
+						ModifiedFiles: []string{"file5.owned"},
+					},
+				},
+				repoContent: map[string]string{
+					"CODEOWNERS": "*.owned @owner\n",
+				},
+			},
+			want: autogold.Expect([]result.Match{
+				&result.CommitMatch{
+					ModifiedFiles: []string{"file1.notOwned", "file2.owned"},
+				},
+				&result.CommitMatch{
+					ModifiedFiles: []string{"file5.owned"},
+				},
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -153,7 +153,9 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 			}
 		}
 
+		// TODO
 		if resultTypes.Has(result.TypeCommit) || resultTypes.Has(result.TypeDiff) {
+			_, _, own := isOwnershipSearch(b)
 			diff := resultTypes.Has(result.TypeDiff)
 			repoOptionsCopy := repoOptions
 			repoOptionsCopy.OnlyCloned = true
@@ -162,7 +164,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 				RepoOpts:             repoOptionsCopy,
 				Diff:                 diff,
 				Limit:                int(fileMatchLimit),
-				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker),
+				IncludeModifiedFiles: own,
 				Concurrency:          4,
 			})
 		}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -153,7 +153,6 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 			}
 		}
 
-		// TODO
 		if resultTypes.Has(result.TypeCommit) || resultTypes.Has(result.TypeDiff) {
 			_, _, own := isOwnershipSearch(b)
 			diff := resultTypes.Has(result.TypeDiff)
@@ -164,7 +163,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 				RepoOpts:             repoOptionsCopy,
 				Diff:                 diff,
 				Limit:                int(fileMatchLimit),
-				IncludeModifiedFiles: own,
+				IncludeModifiedFiles: authz.SubRepoEnabled(authz.DefaultSubRepoPermsChecker) || own,
 				Concurrency:          4,
 			})
 		}

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -39,7 +39,10 @@ type CommitMatch struct {
 	Diff []DiffFile
 
 	// ModifiedFiles will include the list of files modified in the commit when
-	// sub-repo permissions filtering has been enabled.
+	// explicitly requested via IncludeModifiedFiles. This is disabled by default for performance.
+	// Search requests to include modified files in the following cases:
+	// * when sub-repo permissions filtering has been enabled,
+	// * when ownership filtering clause is used, and search result is commits.
 	ModifiedFiles []string
 }
 


### PR DESCRIPTION
Part of #53537

This change adds support for ownership filtering for commit results. And it was a request from a major customer.

- We include `ModifiedFiles` in `CommitMatch` for own (alongside sub-repo permissions case) see [#ask-iam](https://sourcegraph.slack.com/archives/C04ML7GFK5Y/p1686827762022219).
- We modify filter job to consider `[]string` for file paths rather than single string.
  - This slice is a singleton for `FileMatch`.
  - For `CommitMatch` in contains all `ModifiedFiles`. Here the filter will discard the `CommitMatch` if:
    - Any of the files' owners match all excluded owners (if excluded owners are preset)
    - None of the files' owners match all included owners (if included owners are present)

https://www.loom.com/share/591f13945b854c349c31e61a8096a6d8?sid=a71be5c4-b022-43d1-b35c-5fe080bfcf63

## Test plan

Extend existing filter job unit tests with `CommitMatch` examples.
