### PR TITLE
site-admin: add badge for repos with embeddings

### DIFF
--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -45,6 +45,6 @@
 }
 
 .embeddings {
-    background-color: var(--purple) !important;
+    background-color: var(--success) !important;
     color: var(--white) !important;
 }

--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -43,3 +43,8 @@
     min-height: 16px;
     min-width: 16px;
 }
+
+.embedded {
+    background-color: var(--purple) !important;
+    color: var(--white) !important;
+}

--- a/client/web/src/site-admin/RepositoryNode.module.scss
+++ b/client/web/src/site-admin/RepositoryNode.module.scss
@@ -44,7 +44,7 @@
     min-width: 16px;
 }
 
-.embedded {
+.embeddings {
     background-color: var(--purple) !important;
     color: var(--white) !important;
 }

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -131,6 +131,11 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
 
                     <div className="d-flex align-items-center col justify-content-start px-0 px-md-2 mt-2 mt-md-0">
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
+                        {node.embeddingExists && (
+                            <div className="ml-2">
+                                <RepositoryStatusBadge status="embedded" />
+                            </div>
+                        )}
                         {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}
                         {node.mirrorInfo.lastError && (
                             <Popover isOpen={isPopoverOpen} onOpenChange={event => setIsPopoverOpen(event.isOpen)}>

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -133,8 +133,11 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                     <div className="d-flex align-items-center col justify-content-start px-0 px-md-2 mt-2 mt-md-0">
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
                         {node.embeddingExists && (
-                            <Link className="d-flex ml-2" to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
-                                 <RepositoryStatusBadge status="embeddings" />
+                            <Link
+                                className="d-flex ml-2"
+                                to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}
+                            >
+                                <RepositoryStatusBadge status="embeddings" />
                             </Link>
                         )}
                         {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -21,7 +21,7 @@ import {
     Badge,
     Button,
     H4,
-    Icon,
+    Icon, Link,
     LinkOrSpan,
     LoadingSpinner,
     Menu,
@@ -133,7 +133,9 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
                         {node.embeddingExists && (
                             <div className="ml-2">
-                                <RepositoryStatusBadge status="embedded" />
+                                <Link to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
+                                    <RepositoryStatusBadge status="embeddings" />
+                                </Link>
                             </div>
                         )}
                         {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -133,8 +133,8 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                     <div className="d-flex align-items-center col justify-content-start px-0 px-md-2 mt-2 mt-md-0">
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
                         {node.embeddingExists && (
-                            <Link className="ml-2" to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
-                                <RepositoryStatusBadge status="embeddings" />
+                            <Link className="d-flex ml-2" to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
+                                 <RepositoryStatusBadge status="embeddings" />
                             </Link>
                         )}
                         {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -21,7 +21,8 @@ import {
     Badge,
     Button,
     H4,
-    Icon, Link,
+    Icon,
+    Link,
     LinkOrSpan,
     LoadingSpinner,
     Menu,
@@ -132,11 +133,9 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                     <div className="d-flex align-items-center col justify-content-start px-0 px-md-2 mt-2 mt-md-0">
                         <RepositoryStatusBadge status={parseRepositoryStatus(node)} />
                         {node.embeddingExists && (
-                            <div className="ml-2">
-                                <Link to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
-                                    <RepositoryStatusBadge status="embeddings" />
-                                </Link>
-                            </div>
+                            <Link className="ml-2" to={`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`}>
+                                <RepositoryStatusBadge status="embeddings" />
+                            </Link>
                         )}
                         {node.mirrorInfo.cloneInProgress && <LoadingSpinner className="ml-2" />}
                         {node.mirrorInfo.lastError && (

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -148,6 +148,7 @@ const siteAdminRepositoryFieldsFragment = gql`
         externalRepository {
             ...ExternalRepositoryFields
         }
+        embeddingExists
     }
 `
 export const REPOSITORIES_QUERY = gql`


### PR DESCRIPTION
Relates to #52983 

We show a badge in site-admin > Repositories if an embedding exists. The badge links to the repo's embeddings jobs.

<img width="1703" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/7f297085-2b3d-49ca-acf2-3e8c7c09bc4e">
<img width="1695" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/d5359fba-3919-44bb-8298-391ace1caab5">


## Test plan
Visually inspected the change.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
