### PR TITLE
Add prometheus-gcp to list of legacy images

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -24,6 +24,7 @@ var legacyDockerImages = []string{
 	"codeinsights-db",
 	"codeintel-db",
 	"postgres-12-alpine",
+	"prometheus-gcp",
 }
 
 // GeneratePipeline is the main pipeline generation function. It defines the build pipeline for each of the


### PR DESCRIPTION
We don't have a wolfi/bazel version of the prometheus-gcp container. This is an interim measure to keep publishing the old container while we work on a hardened image.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Manually test image
- Confirm successful deployment on S2
