### PR TITLE
JetBrains: fix line breaks in the chat and reset prompt input

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -42,6 +42,8 @@
 ### Fixed
 
 - Fixed font on the chat ui [#53540](https://github.com/sourcegraph/sourcegraph/pull/53540)
+- Fixed line breaks in the chat ui [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
+- Reset prompt input on message send [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -309,6 +309,7 @@ class CodyToolWindowContent implements UpdatableChat {
 
   private void sendMessage(@NotNull Project project) {
     String messageText = promptInput.getText();
+    promptInput.setText("");
     sendMessage(
         project,
         ChatMessage.createHumanMessage(messageText, messageText, Collections.emptyList()),

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -44,7 +44,8 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
 
   @NotNull
   private JEditorPane createNewEmptyTextPane() {
-    JEditorPane jEditorPane = SwingHelper.createHtmlLabel("", null, null);
+    JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
+    jEditorPane.setFocusable(true);
     jEditorPane.setMargin(
         JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
     textPane = jEditorPane;
@@ -53,9 +54,13 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   }
 
   @Override
+  public void visit(Paragraph paragraph) {
+    addContentOfNodeAsHtml(htmlRenderer.render(paragraph));
+  }
+
+  @Override
   public void visit(Code code) {
     addContentOfNodeAsHtml(htmlRenderer.render(code));
-
     super.visit(code);
   }
 


### PR DESCRIPTION

## Test plan
- Line breaks should be preserved in the chat messages
- Prompt input should be emptied after we click Send button

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
