### PR TITLE
Make executor secret a text area

### DIFF
--- a/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
+++ b/client/web/src/enterprise/executors/secrets/UpdateSecretModal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { logger } from '@sourcegraph/common'
-import { Button, Modal, Input, H3, Text, Alert, Link, ErrorAlert, Form } from '@sourcegraph/wildcard'
+import { Button, Modal, H3, Text, Alert, Link, ErrorAlert, Form, TextArea } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../../../components/LoaderButton'
 import { ExecutorSecretFields } from '../../../graphql-operations'
@@ -23,7 +23,7 @@ export const UpdateSecretModal: React.FunctionComponent<React.PropsWithChildren<
     const labelId = 'updateSecret'
 
     const [value, setValue] = useState<string>('')
-    const onChangeValue = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
+    const onChangeValue = useCallback<React.ChangeEventHandler<HTMLTextAreaElement>>(event => {
         setValue(event.target.value)
     }, [])
 
@@ -75,17 +75,14 @@ export const UpdateSecretModal: React.FunctionComponent<React.PropsWithChildren<
 
             <Form onSubmit={onSubmit}>
                 <div className="form-group">
-                    <Input
+                    <TextArea
                         id="value"
                         name="value"
-                        type="password"
                         autoComplete="off"
                         required={true}
                         spellCheck="false"
                         minLength={1}
                         label="Value"
-                        placeholder="******"
-                        value={value}
                         onChange={onChangeValue}
                     />
                 </div>


### PR DESCRIPTION
Secrets can be multiline strings as well

There is no built-in way to create text area with masked content, so instead we sort of act the same way as GH secrets - the value is plaintext when added, but after that you can only update with new value, the old one is not presented anywhere.

<img width="514" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/1052965/3efb2c6f-c17c-4bd6-88f7-6a3b64e1085d">


## Test plan

- Manual testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
