### PR TITLE
JetBrains: cut same line suffix when providing inline completions

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -76,9 +76,12 @@ public class CodyCompletionsManager {
             0.6,
             0.1);
     TextDocument textDocument = new IntelliJTextDocument(editor);
-    if (textDocument.getCompletionContext(offset).isCompletionTriggerValid()) {
+    CompletionDocumentContext documentCompletionContext = textDocument.getCompletionContext(offset);
+    if (documentCompletionContext.isCompletionTriggerValid()) {
       Callable<CompletableFuture<Void>> callable =
-          () -> triggerCompletionAsync(editor, offset, token, provider, textDocument);
+          () ->
+              triggerCompletionAsync(
+                  editor, offset, token, provider, textDocument, documentCompletionContext);
       // debouncing the completion trigger
       cancelCurrentJob();
       this.currentJob.set(
@@ -86,12 +89,40 @@ public class CodyCompletionsManager {
     }
   }
 
+  public static InlineCompletionItem postProcessInlineCompletionBasedOnDocumentContext(
+      InlineCompletionItem resultItem, CompletionDocumentContext documentCompletionContext) {
+    String sameLineSuffix = documentCompletionContext.getSameLineSuffix();
+    if (resultItem.insertText.endsWith(sameLineSuffix)) {
+      // if the completion already has the same line suffix, we strip it
+      String newInsertText = StringUtils.stripEnd(resultItem.insertText, sameLineSuffix);
+      // adjusting the range to account for the shorter completion
+      Range newRange =
+          resultItem.range.withEnd(
+              resultItem.range.end.withCharacter(
+                  resultItem.range.end.character - sameLineSuffix.length()));
+      return resultItem.withRange(newRange).withInsertText(newInsertText);
+    } else if (resultItem.insertText.contains(sameLineSuffix)) {
+      // if the completion already contains the same line suffix
+      // but it doesn't strictly end with it
+      // we cut the end of the completion starting with the suffix
+      int index = resultItem.insertText.lastIndexOf(sameLineSuffix);
+      String newInsertText = resultItem.insertText.substring(0, index);
+      // adjusting the range to account for the shorter completion
+      int rangeDiff = resultItem.insertText.length() - newInsertText.length();
+      Range newRange =
+          resultItem.range.withEnd(
+              resultItem.range.end.withCharacter(resultItem.range.end.character - rangeDiff));
+      return resultItem.withRange(newRange).withInsertText(newInsertText);
+    } else return resultItem;
+  }
+
   private CompletableFuture<Void> triggerCompletionAsync(
       Editor editor,
       int offset,
       CancellationToken token,
       CodyCompletionItemProvider provider,
-      TextDocument textDocument) {
+      TextDocument textDocument,
+      CompletionDocumentContext documentCompletionContext) {
     return provider
         .provideInlineCompletions(
             textDocument,
@@ -110,6 +141,10 @@ public class CodyCompletionsManager {
               // TODO: smarter logic around selecting the best completion item.
               Optional<InlineCompletionItem> maybeItem =
                   result.items.stream()
+                      .map(
+                          resultItem ->
+                              postProcessInlineCompletionBasedOnDocumentContext(
+                                  resultItem, documentCompletionContext))
                       .filter(resultItem -> !resultItem.insertText.isEmpty())
                       .findFirst();
               if (maybeItem.isEmpty()) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineCompletionItem.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineCompletionItem.java
@@ -13,6 +13,22 @@ public class InlineCompletionItem {
     this.command = command;
   }
 
+  public InlineCompletionItem withInsertText(String newInsertText) {
+    return new InlineCompletionItem(newInsertText, this.filterText, this.range, this.command);
+  }
+
+  public InlineCompletionItem withFilterText(String newFilterText) {
+    return new InlineCompletionItem(this.insertText, newFilterText, this.range, this.command);
+  }
+
+  public InlineCompletionItem withRange(Range newRange) {
+    return new InlineCompletionItem(this.insertText, this.filterText, newRange, this.command);
+  }
+
+  public InlineCompletionItem withCommand(Command newCommand) {
+    return new InlineCompletionItem(this.insertText, this.filterText, this.range, newCommand);
+  }
+
   public static InlineCompletionItem fromCompletion(Completion completion) {
     return new InlineCompletionItem(
         completion.content,

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/Position.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/Position.java
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.vscode;
 
+import java.util.Objects;
+
 public class Position {
   public final int line;
   public final int character;
@@ -9,8 +11,29 @@ public class Position {
     this.character = character;
   }
 
+  public Position withLine(int newLine) {
+    return new Position(newLine, this.character);
+  }
+
+  public Position withCharacter(int newCharacter) {
+    return new Position(this.line, newCharacter);
+  }
+
   @Override
   public String toString() {
     return "Position{" + "line=" + line + ", character=" + character + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Position)) return false;
+    Position position = (Position) o;
+    return line == position.line && character == position.character;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(line, character);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/Range.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/Range.java
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.vscode;
 
+import java.util.Objects;
+
 public class Range {
   public final Position start;
   public final Position end;
@@ -9,8 +11,29 @@ public class Range {
     this.end = end;
   }
 
+  public Range withStart(Position newStart) {
+    return new Range(newStart, this.end);
+  }
+
+  public Range withEnd(Position newEnd) {
+    return new Range(this.start, newEnd);
+  }
+
   @Override
   public String toString() {
     return "Range{" + "start=" + start + ", end=" + end + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Range)) return false;
+    Range range = (Range) o;
+    return Objects.equals(start, range.start) && Objects.equals(end, range.end);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(start, end);
   }
 }

--- a/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
+++ b/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
@@ -1,0 +1,61 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sourcegraph.cody.completions.CodyCompletionsManager;
+import com.sourcegraph.cody.completions.CompletionDocumentContext;
+import com.sourcegraph.cody.vscode.InlineCompletionItem;
+import com.sourcegraph.cody.vscode.Position;
+import com.sourcegraph.cody.vscode.Range;
+import org.junit.jupiter.api.Test;
+
+public class InlineCompletionsPostProcessingTest {
+
+  private final String sameLinePrefix = "System.out.println(\"Hello ";
+  private final String sameLineSuffix = "\");";
+  private final CompletionDocumentContext testDocumentContext =
+      new CompletionDocumentContext(sameLinePrefix, sameLineSuffix);
+
+  @Test
+  public void lineSuffixSeparateFromCompletion() {
+    String suggestionText = "world!";
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 6));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.postProcessInlineCompletionBasedOnDocumentContext(
+            inputCompletion, testDocumentContext);
+    assertEquals(outputCompletion.insertText, inputCompletion.insertText);
+    assertEquals(outputCompletion.range, inputCompletion.range);
+  }
+
+  @Test
+  public void completionEndsInLineSuffix() {
+    String suggestionTextWithoutSuffix = "world!";
+    String suggestionText = suggestionTextWithoutSuffix + sameLineSuffix;
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 9));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.postProcessInlineCompletionBasedOnDocumentContext(
+            inputCompletion, testDocumentContext);
+    assertEquals(outputCompletion.insertText, suggestionTextWithoutSuffix);
+    assertEquals(
+        outputCompletion.range,
+        inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(6)));
+  }
+
+  @Test
+  public void completionContainsLineSuffix() {
+    String suggestionTextWithoutSuffix = "world!";
+    String suggestionText = suggestionTextWithoutSuffix + sameLineSuffix + " // prints hello world";
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 31));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.postProcessInlineCompletionBasedOnDocumentContext(
+            inputCompletion, testDocumentContext);
+    assertEquals(outputCompletion.insertText, suggestionTextWithoutSuffix);
+    assertEquals(
+        outputCompletion.range,
+        inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(6)));
+  }
+}


### PR DESCRIPTION
Fixes #53239  (a follow up for #53476)

A rough-cut solution adjusting inline completion to not clash with the editor current line suffix.
- if the completion matches the suffix, the suffix is simply stripped.
- if the completion contains the suffix, its last occurence is cut.

![image](https://github.com/sourcegraph/sourcegraph/assets/18601388/8afaac5e-666c-49e8-81e1-679c0f152fdd)

## Test plan
- see: unit tests
- inline completions should not include the line suffix
