### PR TITLE
JetBrains: fix UI of the cody prompt input

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fixed font on the chat ui [#53540](https://github.com/sourcegraph/sourcegraph/pull/53540)
 - Fixed line breaks in the chat ui [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
 - Reset prompt input on message send [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
+- Fixed UI of the prompt input [#53548](https://github.com/sourcegraph/sourcegraph/pull/53548)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -17,6 +17,7 @@ import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatBubble;
 import com.sourcegraph.cody.chat.ChatMessage;
@@ -151,7 +152,13 @@ class CodyToolWindowContent implements UpdatableChat {
     promptInput = createPromptInput(this.project);
 
     JPanel messagePanel = new JPanel(new BorderLayout());
-    messagePanel.add(promptInput, BorderLayout.CENTER);
+
+    JBScrollPane promptInputWithScroll =
+        new JBScrollPane(
+            promptInput,
+            JBScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+            JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    messagePanel.add(promptInputWithScroll, BorderLayout.CENTER);
     messagePanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
 
     controlsPanel.add(messagePanel, BorderLayout.NORTH);
@@ -214,9 +221,11 @@ class CodyToolWindowContent implements UpdatableChat {
   @NotNull
   private JBTextArea createPromptInput(@NotNull Project project) {
     JBTextArea promptInput = new RoundedJBTextArea(4, 0, 10);
+    promptInput.setFont(UIUtil.getLabelFont());
     BasicTextAreaUI textUI = (BasicTextAreaUI) DarculaTextAreaUI.createUI(promptInput);
     promptInput.setUI(textUI);
     promptInput.setLineWrap(true);
+    promptInput.setWrapStyleWord(true);
     KeyboardShortcut CTRL_ENTER =
         new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
     KeyboardShortcut META_ENTER =


### PR DESCRIPTION
- limit prompt input height to 4 rows, for bigger input scroll appears
- break text by words instead of characters
- use standard label font

closes #53465 


## Test plan
- Height of the input should not grow
- text should break by words
- font should be the same as in the chat messages

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="808" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/66b6f118-84e8-4688-a85c-6d08607b7290">
