### PR TITLE
ui: Use experimental flag for changelist or commit URL

### DIFF
--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -33,11 +33,16 @@ export const GitCommitNodeTableRow: React.FC<
         setShowCommitMessageBody(!showCommitMessageBody)
     }, [showCommitMessageBody])
 
+    const canonicalURL =
+        window.context.experimentalFeatures.perforceChangelistMapping && node.perforceChangelist?.canonicalURL
+            ? node.perforceChangelist.canonicalURL
+            : node.canonicalURL
+
     const messageElement = (
         <div className={classNames(styles.message, styles.messageSmall)} data-testid="git-commit-node-message">
             <span className={classNames('mr-2', styles.messageSubject)}>
                 <CommitMessageWithLinks
-                    to={node.canonicalURL}
+                    to={canonicalURL}
                     className={classNames(messageSubjectClassName, styles.messageLink)}
                     message={node.subject}
                     externalURLs={node.externalURLs}
@@ -89,7 +94,7 @@ export const GitCommitNodeTableRow: React.FC<
                 />
                 <td className="flex-1 overflow-hidden">{messageElement}</td>
                 <td className="text-right">
-                    <Link to={node.perforceChangelist?.canonicalURL ?? node.canonicalURL}>
+                    <Link to={canonicalURL}>
                         <Code data-testid="git-commit-node-oid">
                             {node.perforceChangelist?.cid ?? node.abbreviatedOID}
                         </Code>


### PR DESCRIPTION
Spotted the bug while testing in dogfood.

## Test plan

Tested manually.

And see:

https://github.com/sourcegraph/sourcegraph/assets/2682729/3fa4aaf9-f7cc-41e8-af90-ac4d214acddf



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
