### PR TITLE
fix API to filter on assigned owner reason

### DIFF
--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -162,7 +162,7 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
                 sourceType
                 commit(rev: $revision) {
                     blob(path: $currentPath) {
-                        ownership(first: 2, reasons: [CODEOWNERS_FILE_ENTRY]) {
+                        ownership(first: 2, reasons: [CODEOWNERS_FILE_ENTRY, ASSIGNED_OWNER]) {
                             nodes {
                                 owner {
                                     ...OwnerFields

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -159,19 +159,21 @@ func (r *ownResolver) GitBlobOwnership(
 		rrs = append(rrs, viewerResolvers...)
 	}
 
-	// Retrieve assigned owners.
-	assignedOwners, err := r.computeAssignedOwners(ctx, blob, repoID)
-	if err != nil {
-		return nil, err
-	}
-	rrs = append(rrs, assignedOwners...)
+	if args.IncludeReason(graphqlbackend.AssignedOwner) {
+		// Retrieve assigned owners.
+		assignedOwners, err := r.computeAssignedOwners(ctx, blob, repoID)
+		if err != nil {
+			return nil, err
+		}
+		rrs = append(rrs, assignedOwners...)
 
-	// Retrieve assigned teams.
-	assignedTeams, err := r.computeAssignedTeams(ctx, blob, repoID)
-	if err != nil {
-		return nil, err
+		// Retrieve assigned teams.
+		assignedTeams, err := r.computeAssignedTeams(ctx, blob, repoID)
+		if err != nil {
+			return nil, err
+		}
+		rrs = append(rrs, assignedTeams...)
 	}
-	rrs = append(rrs, assignedTeams...)
 
 	return r.ownershipConnection(ctx, args, rrs, blob.Repository(), blob.Path())
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1224,6 +1224,7 @@ commandsets:
       - gitserver-1
       - searcher
       - caddy
+      - symbols
       - docsite
       - syntax-highlighter
       - github-proxy

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1224,7 +1224,6 @@ commandsets:
       - gitserver-1
       - searcher
       - caddy
-      - symbols
       - docsite
       - syntax-highlighter
       - github-proxy


### PR DESCRIPTION
Fixes the own API to filter on assigned owners.

## Test plan

History and ownership panel loads with the correct information still, and the API filters down.
<img width="1497" alt="CleanShot 2023-06-15 at 08 58 56@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5090588/6ca72c73-1d00-460b-801d-f28cc175ba6c">

