### PR TITLE
Cody completions: Require an embeddings connection when using embeddings context

### DIFF
--- a/client/cody/src/completions/context-embeddings.ts
+++ b/client/cody/src/completions/context-embeddings.ts
@@ -65,6 +65,10 @@ const NUM_TEXT_RESULTS = 1
 async function fetchAndSaveEmbeddings(options: FetchEmbeddingsOptions): Promise<void> {
     const { currentFilePath, text, codebaseContext } = options
 
+    if (!codebaseContext.checkEmbeddingsConnection()) {
+        return
+    }
+
     logCompletionEvent('fetchEmbeddings')
 
     // TODO: add comment on how big are the embedding results


### PR DESCRIPTION
While playing around on other things, I noticed that embeddings are logged even when the repo has no embeddings:

<img width="1188" alt="Screenshot 2023-06-15 at 18 12 20" src="https://github.com/sourcegraph/sourcegraph/assets/458591/7e844c8f-956e-4a21-9351-1be9a3c5d57f">

As it turns out, in this case we automatically fall back to keyword search which I don't think are any better then the local context we have anyways so I suggest we bail out of it. We also call the event `embeddings` so we should only fire it when there are embeddings that are being used.

## Test plan

<img width="1041" alt="Screenshot 2023-06-15 at 18 18 23" src="https://github.com/sourcegraph/sourcegraph/assets/458591/4f6a6b6c-a523-4bc9-bc6b-d256d23dbd4a">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
