### PR TITLE
rfc/oauth: Implement new Google OAuth flow.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,14 @@
       }
     },
     {
+      "name": "Launch sg rfc list",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/dev/sg",
+      "args": ["rfc", "list"]
+    },
+    {
       "name": "Launch VS Code Extension",
       "type": "extensionHost",
       "request": "launch",

--- a/dev/sg/internal/rfc/BUILD.bazel
+++ b/dev/sg/internal/rfc/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
 
 go_library(
     name = "rfc",
@@ -16,5 +17,16 @@ go_library(
         "@org_golang_google_api//option",
         "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_oauth2//google",
+    ],
+)
+
+go_test(
+    name = "rfc_test",
+    timeout = "short",
+    srcs = ["rfc_test.go"],
+    embed = [":rfc"],
+    deps = [
+        "//dev/sg/internal/std",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/dev/sg/internal/rfc/BUILD.bazel
+++ b/dev/sg/internal/rfc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//lib/errors",
         "//lib/output",
         "@com_github_grafana_regexp//:regexp",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_google_api//drive/v3:drive",
         "@org_golang_google_api//option",
         "@org_golang_x_oauth2//:oauth2",

--- a/dev/sg/internal/rfc/BUILD.bazel
+++ b/dev/sg/internal/rfc/BUILD.bazel
@@ -25,6 +25,10 @@ go_test(
     timeout = "short",
     srcs = ["rfc_test.go"],
     embed = [":rfc"],
+    tags = [
+        # Test requires localhost database
+        "requires-network",
+    ],
     deps = [
         "//dev/sg/internal/std",
         "@org_golang_x_oauth2//:oauth2",

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -130,7 +130,7 @@ func startAuthHandlerServer(socket net.Listener, authEndpoint string,
 		defer socket.Close()
 		if err := server.Serve(socket); err != nil {
 			if !gracefulShutdown {
-				log.Fatal("failure to handle", err)
+				log.Print("failure to handle", err)
 			}
 		}
 	}()
@@ -214,7 +214,8 @@ func getTokenFromWeb(responseFactory authResponseHandlerFactory, ctx context.Con
 	if redirectUrl, waitForCode, waitForError, err = responseFactory(); err == nil {
 		config.SetRedirectURL(redirectUrl)
 	} else {
-		log.Fatal("Cannot create a response handler for Google authorization: ", err)
+		// TODO
+		return nil, err
 	}
 
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -3,7 +3,11 @@ package rfc
 import (
 	"context"
 	"fmt"
+	"log"
+	"net"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,6 +45,8 @@ type DriveSpec struct {
 	OrderBy     string
 }
 
+const AuthEndpoint = "/oauth2/callback"
+
 func (d *DriveSpec) Query(q string) string {
 	return fmt.Sprintf("%s and parents in '%s'", q, d.FolderID)
 }
@@ -55,7 +61,7 @@ func getClient(ctx context.Context, config *oauth2.Config, out *std.Output) (*ht
 	if err := sec.Get("rfc", tok); err != nil {
 		// ...if it doesn't exist, open browser and ask user to give us
 		// permissions
-		tok, err = getTokenFromWeb(ctx, config, out)
+		tok, err = getTokenFromWeb(handleAuthResponse, ctx, NewTokenHandler(config), out)
 		if err != nil {
 			return nil, err
 		}
@@ -68,9 +74,142 @@ func getClient(ctx context.Context, config *oauth2.Config, out *std.Output) (*ht
 	return config.Client(ctx, tok), nil
 }
 
+// allocateRandomPort ... allocates a random port
+func allocateRandomPort() (net.Listener, error) {
+	socket, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot allocate port for Google Authentication handler")
+	}
+	return socket, nil
+}
+
+// authResponseHandler returns a handler for the OAuth redirect response from Google.
+// It sends the authentication code received from the redirect to the sendCode channel.
+//
+// sendCode: A channel to send the authentication code received from the redirect to.
+// gracefulShutdown: Whether the server should shutdown gracefully after handling the request.
+func authResponseHandler(sendCode chan string, gracefulShutdown *bool) func(
+	rw http.ResponseWriter, r *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		authCode := r.URL.Query().Get("code")
+		if authCode == "" {
+			log.Fatal("Did not get authentication code from Google")
+		}
+		rw.Header().Add("Content-Type", "text/plain")
+		_, _ = rw.Write([]byte(`'sg' authentication complete. You may close this window.`))
+		sendCode <- authCode
+		*gracefulShutdown = true
+	}
+}
+
+// startAuthHandlerServer starts a local HTTP server to handle the OAuth redirect
+// response from Google.
+//
+// socket: The listener for the server.
+// authEndpoint: The endpoint which will handle the OAuth redirect response.
+// sendCode: A channel to send the authentication code received from the redirect to.
+// server: The HTTP server.
+// gracefulShutdown: Whether the server shutdown gracefully after handling a request.
+// handler: The request handler for the server, containing the authEndpoint.
+func startAuthHandlerServer(socket net.Listener, authEndpoint string,
+	sendCode chan string) {
+	var server http.Server
+	var gracefulShutdown bool = false
+
+	// Creates a handler to handle response
+	handler := http.NewServeMux()
+	handler.Handle(authEndpoint,
+		http.HandlerFunc(authResponseHandler(sendCode, &gracefulShutdown)))
+
+	server.Handler = handler
+
+	go func() {
+		defer socket.Close()
+		if err := server.Serve(socket); err != nil {
+			if !gracefulShutdown {
+				log.Fatal("failure to handle", err)
+			}
+		}
+	}()
+}
+
+// handleAuthResponse sets up a local HTTP server to handle the OAuth redirect
+// response from Google. It returns the redirect URL to provide to Google, and a
+// channel which will receive the authentication code from the redirect.
+//
+// sendCode: A channel which will receive the authentication code from the redirect.
+// socket: A listener for the local HTTP server.
+// redirectUrl: The URL to provide to Google for the OAuth redirect.
+// err: Any error encountered setting up the server.
+func handleAuthResponse() (*url.URL, chan string, error) {
+	sendCode := make(chan string, 1)
+
+	socket, err := allocateRandomPort()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	startAuthHandlerServer(socket, AuthEndpoint, sendCode)
+
+	redirectUrl := url.URL{
+		Host:   net.JoinHostPort("localhost", strconv.Itoa(socket.Addr().(*net.TCPAddr).Port)),
+		Path:   AuthEndpoint,
+		Scheme: "http",
+	}
+	return &redirectUrl, sendCode, nil
+}
+
+type authResponseHandlerFactory func() (*url.URL, chan string, error)
+
+// tokenHandler implements a minimal surface required to retrieve a token.
+//
+// It wraps the OAuth2 token acquisition, so we can mock it and
+// test it without hitting Google servers.
+type tokenHandler interface {
+	AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
+	Exchange(ctx context.Context, code string,
+		opts ...oauth2.AuthCodeOption) (*oauth2.Token, error)
+	SetRedirectURL(*url.URL)
+}
+
+type tokenHandlerImpl struct {
+	config *oauth2.Config
+}
+
+func (th *tokenHandlerImpl) SetRedirectURL(url *url.URL) {
+	th.config.RedirectURL = url.String()
+}
+
+func (th *tokenHandlerImpl) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	return th.config.AuthCodeURL(state, opts...)
+}
+
+func (th *tokenHandlerImpl) Exchange(ctx context.Context, code string,
+	opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	return th.config.Exchange(ctx, code, opts...)
+}
+
+func NewTokenHandler(config *oauth2.Config) *tokenHandlerImpl {
+	return &tokenHandlerImpl{
+		config: config,
+	}
+}
+
 // Request a token from the web, then returns the retrieved token.
-func getTokenFromWeb(ctx context.Context, config *oauth2.Config, out *std.Output) (*oauth2.Token, error) {
+func getTokenFromWeb(responseFactory authResponseHandlerFactory, ctx context.Context,
+	config tokenHandler, out *std.Output) (*oauth2.Token, error) {
 	out.WriteNoticef("Setting up Google token via oAuth - follow the prompts to get set up!")
+
+	var err error
+
+	var redirectUrl *url.URL
+	var waitForCode chan string
+
+	if redirectUrl, waitForCode, err = responseFactory(); err == nil {
+		config.SetRedirectURL(redirectUrl)
+	} else {
+		log.Fatal("Cannot create a response handler for Google authorization: ", err)
+	}
 
 	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 
@@ -79,11 +218,15 @@ func getTokenFromWeb(ctx context.Context, config *oauth2.Config, out *std.Output
 		return nil, err
 	}
 
-	fmt.Printf("Paste the OAuth token here: ")
-	var authCode string
-	if _, err := fmt.Scan(&authCode); err != nil {
-		return nil, err
-	}
+	out.WriteWarningf(
+		" Your action is required:\n" +
+			"   1. Your computer may ask to receive incoming connections.\n" +
+			"      Please allow so the browser and sg can communicate.\n" +
+			"   2. Please accept the browser access request.\n\n" +
+			"   This process will resume automatically.")
+
+	authCode := <-waitForCode
+	out.WriteSuccessf("Received confirmation. Continuing.")
 
 	return config.Exchange(ctx, authCode)
 }
@@ -149,7 +292,9 @@ func Search(ctx context.Context, query string, driveSpec DriveSpec, out *std.Out
 func Open(ctx context.Context, number string, driveSpec DriveSpec, out *std.Output) error {
 	return queryRFCs(ctx, fmt.Sprintf("name contains 'RFC %s'", number), driveSpec, func(r *drive.FileList) error {
 		for _, f := range r.Files {
-			open.URL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id))
+			if err := open.URL(fmt.Sprintf("https://docs.google.com/document/d/%s/edit", f.Id)); err != nil {
+				out.WriteFailuref("failed to open browser ", err)
+			}
 		}
 		return nil
 	}, out)

--- a/dev/sg/internal/rfc/rfc_test.go
+++ b/dev/sg/internal/rfc/rfc_test.go
@@ -29,12 +29,12 @@ func TestAllocateRandomPort(t *testing.T) {
 		t.Errorf("Expected non-zero port, got %d", port)
 	}
 
-	// Check that we can listen on the port
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	// Test the port is open and we can listen on it
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal(err) // Port is closed or an error occurred
 	}
-	listener.Close()
+	defer conn.Close()
 }
 
 func TestAuthResponseHandler(t *testing.T) {

--- a/dev/sg/internal/rfc/rfc_test.go
+++ b/dev/sg/internal/rfc/rfc_test.go
@@ -181,7 +181,7 @@ func TestGetTokenFromWeb(t *testing.T) {
 		sendError <- nil
 	}()
 
-	token, err := getTokenFromWeb(responseFactory, ctx, config, out)
+	token, err := getTokenFromWeb(ctx, responseFactory, config, out)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dev/sg/internal/rfc/rfc_test.go
+++ b/dev/sg/internal/rfc/rfc_test.go
@@ -1,0 +1,180 @@
+package rfc
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+)
+
+func TestAllocateRandomPort(t *testing.T) {
+	socket, err := allocateRandomPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer socket.Close()
+
+	// Check that a port was allocated
+	port := socket.Addr().(*net.TCPAddr).Port
+	if port == 0 {
+		t.Errorf("Expected non-zero port, got %d", port)
+	}
+
+	// Check that we can listen on the port
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener.Close()
+}
+
+func TestAuthResponseHandler(t *testing.T) {
+	sendCode := make(chan string, 1)
+	gracefulShutdown := false
+
+	handler := authResponseHandler(sendCode, &gracefulShutdown)
+	req, _ := http.NewRequest("GET", "/?code=abc123", nil)
+	w := httptest.NewRecorder()
+
+	handler(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("Expected status code 200, got %d", w.Code)
+	}
+	if w.Body.String() != "'sg' authentication complete. You may close this window." {
+		t.Errorf("Expected response body to match, got %s", w.Body.String())
+	}
+	if gracefulShutdown != true {
+		t.Error("Expected gracefulShutdown to be true")
+	}
+	code := <-sendCode
+	if code != "abc123" {
+		t.Errorf("Expected auth code abc123, got %s", code)
+	}
+}
+
+func TestStartAuthHandlerServer(t *testing.T) {
+	sendCode := make(chan string, 1)
+	socket, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer socket.Close()
+
+	startAuthHandlerServer(socket, "/auth", sendCode)
+
+	const fakeAuthCode = "AAABBB"
+
+	// Make request to auth endpoint
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/auth?code=%s",
+		socket.Addr().(*net.TCPAddr).Port, fakeAuthCode))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+
+	// Check auth code is sent on channel
+	authCode := <-sendCode
+	if authCode != fakeAuthCode {
+		t.Error("Expected non-empty auth code")
+	}
+}
+
+func TestHandleAuthResponse(t *testing.T) {
+	redirectUrl, sendCode, err := handleAuthResponse()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check redirect URL is properly formed
+	host, port, _ := net.SplitHostPort(redirectUrl.Host)
+	if redirectUrl.Scheme != "http" || host != "localhost" || port == "0" {
+		t.Errorf("Expected redirect URL to be http://localhost, got %s", redirectUrl.String())
+	}
+
+	const fakeAuthCode = "XXXYYYZZZ"
+
+	query := redirectUrl.Query()
+	query.Add("code", fakeAuthCode)
+	redirectUrl.RawQuery = query.Encode()
+
+	// Make request to auth endpoint
+	resp, err := http.Get(redirectUrl.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+
+	// Check auth code is sent on channel
+	authCode := <-sendCode
+	if authCode != fakeAuthCode {
+		t.Error("Expected non-empty auth code")
+	}
+}
+
+type mockConfig struct {
+	code  string
+	url   *url.URL
+	token *oauth2.Token
+}
+
+func (th *mockConfig) SetRedirectURL(url *url.URL) {}
+
+func (th *mockConfig) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
+	return th.url.String()
+}
+
+func (th *mockConfig) Exchange(ctx context.Context, code string,
+	opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	if code != th.code {
+		return nil, fmt.Errorf("Code mismatch. Wanted '%s' but got '%s", th.code, code)
+	}
+	return th.token, nil
+}
+
+func TestGetTokenFromWeb(t *testing.T) {
+	sendCode := make(chan string, 1)
+
+	responseFactory := func() (*url.URL, chan string, error) {
+		return &url.URL{Scheme: "http", Host: "localhost"}, sendCode, nil
+	}
+	ctx := context.Background()
+	config := &mockConfig{
+		code: "QQQAAAZZZ",
+		token: &oauth2.Token{
+			AccessToken:  "foo-foo-giggly-pufs",
+			RefreshToken: "mary-had-a-little-lamb",
+		},
+		url: &url.URL{
+			Host: "somewhere-far-away:11111",
+		},
+	}
+	buf := bytes.Buffer{}
+	out := std.NewOutput(bufio.NewWriter(&buf), false)
+
+	go func() {
+		sendCode <- config.code
+	}()
+
+	token, err := getTokenFromWeb(responseFactory, ctx, config, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if token != config.token {
+		t.Error("Expected non-nil token")
+	}
+}


### PR DESCRIPTION
Implements the new Google OAuth flow following [Obtaining OAuth 2.0 access tokens](https://developers.google.com/identity/protocols/oauth2/native-app?hl=en#step-2:-send-a-request-to-googles-oauth-2.0-server).

Closes #53522.

## Test plan

Added tests for the OAuth flow:

    bazel test //dev/sg/internal/rfc:all

- All new code has a corresponding unit test
- Added unit test to existing code that was changed