### PR TITLE
Filter out error logging from Gitserver client observability

### DIFF
--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -55,6 +55,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Name:              fmt.Sprintf("gitserver.client.%s", name),
 			MetricLabelValues: []string{name},
 			Metrics:           redMetrics,
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForAllExceptLogs
+			},
 		})
 	}
 
@@ -64,6 +67,9 @@ func newOperations(observationCtx *observation.Context) *operations {
 	subOp := func(name string) *observation.Operation {
 		return observationCtx.Operation(observation.Op{
 			Name: fmt.Sprintf("gitserver.client.%s", name),
+			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
+				return observation.EmitForAllExceptLogs
+			},
 		})
 	}
 

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -33,6 +33,7 @@ const (
 	EmitForTraces
 	EmitForHoney
 	EmitForSentry
+	EmitForAllExceptLogs = EmitForMetrics | EmitForSentry | EmitForTraces | EmitForHoney
 
 	EmitForDefault = EmitForMetrics | EmitForLogs | EmitForTraces | EmitForHoney
 )


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/53455

Followup to https://github.com/sourcegraph/sourcegraph/pull/53565, @Strum355 made the great suggestion to use ErrorFilters directly.

This changes the gitserver client behavior, it will now **no longer log errors** as part of the end of observation.

## Test plan
Manual