### PR TITLE
write git output with error in CommitLog

### DIFF
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -315,7 +315,7 @@ func (c *clientImplementor) CommitLog(ctx context.Context, repo api.RepoName, af
 	cmd := c.gitCommand(repo, args...)
 	out, err := cmd.CombinedOutput(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "gitCommand")
+		return nil, errors.Wrapf(err, "gitCommand %s", string(out))
 	}
 
 	var ls []CommitLog

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -3265,7 +3265,7 @@ func Test_CommitLog(t *testing.T) {
 			wantCommits:      2,
 		},
 		"no commits": {
-			wantErr: "gitCommand: exit status 128",
+			wantErr: "gitCommand fatal: your current branch 'master' does not have any commits yet: exit status 128",
 		},
 		"one file two commits": {
 			extraGitCommands: getGitCommandsWithFileLists([]string{"file1.txt"}, []string{"file1.txt"}),


### PR DESCRIPTION
We aren't writing the error message here, so the result in the DB is not useful (doesn't actually say the problem). This PR just adds the error message to the error string.

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
