### PR TITLE
doc/cody: customer-facing Cody Gateway docs

### DIFF
--- a/doc/cody/completions.md
+++ b/doc/cody/completions.md
@@ -26,7 +26,7 @@ While in experimental state, Cody completions need to be enabled manually. To do
 
 Please follow the steps in [Enabling Cody on Sourcegraph Enterprise](explanations/enabling_cody_enterprise.md) to enable Cody on Sourcegraph Enterprise.
 
-Custom models can be used for Cody completions via the `completionModel` option inside the `completions` site config.
+By default, a fully configured Sourcegraph instance picks a default LLM to generate code completions. Custom models can be used for Cody completions via the `completionModel` option inside the `completions` site config.
 
 > NOTE: Self-hosted customers need to update to a minimum of version 5.0.4 to use completions.
 

--- a/doc/cody/completions.md
+++ b/doc/cody/completions.md
@@ -24,24 +24,12 @@ While in experimental state, Cody completions need to be enabled manually. To do
 
 ### Configuring on Sourcegraph Enterprise
 
-Please follow the steps in [Enabling Cody on Sourcegraph Enterprise](explanations/enabling_cody_enterprise.md#enabling-cody-on-sourcegraph-enterprise) to enable Cody on Sourcegraph Enterprise.
+Please follow the steps in [Enabling Cody on Sourcegraph Enterprise](explanations/enabling_cody_enterprise.md) to enable Cody on Sourcegraph Enterprise.
 
-You have to configure the model used for Cody completions via the `completionModel` option inside the `completions` site config.
-
-```json
-{
-  // [...]
-  "cody.enabled": true,
-  "completions": {
-    "provider": "anthropic",
-    "completionModel": "claude-instant-v1.0",
-    "accessToken": "<key>"
-  }
-}
-```
+Custom models can be used for Cody completions via the `completionModel` option inside the `completions` site config.
 
 > NOTE: Self-hosted customers need to update to a minimum of version 5.0.4 to use completions.
 
 <br />
 
-> NOTE: Cody completions currently only work with Claude Instant or our Cody Gateway configured with Claude Instant. Support for other models will be coming later.
+> NOTE: Cody completions currently only work with Anthropic's Claude Instant model. Support for other models will be coming later.

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -147,10 +147,7 @@ You must create your own key with OpenAI [here](https://beta.openai.com/account/
   "cody.enabled": true,
   "embeddings": {
     "provider": "openai",
-    "url": "https://api.openai.com/v1/embeddings",
     "accessToken": "<token>",
-    "model": "text-embedding-ada-002",
-    "dimensions": 1536,
     "excludedFilePathPatterns": []
   }
 }

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -14,24 +14,17 @@ Embeddings for relevant code files must be enabled for each repository that you'
 
 ### Configuring embeddings
 
-> NOTE: Enterprise Cloud customers should reach out to their Sourcegraph representative to enable embeddings. 
-> See [Enabling Cody Enterprise](./enabling_cody_enterprise.md#cody-on-sourcegraph-cloud)
+> NOTE: Enterprise Cloud customers should reach out to their Sourcegraph representative to enable embeddings.
+> See [Enabling Cody Enterprise: Cody on Sourcegraph Cloud](./enabling_cody_enterprise.md#cody-on-sourcegraph-cloud)
 
-1. Go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance
-2. Add the following to configure [Cody Gateway](./cody_gateway.md) embeddings:
-    ```json
-    {
-      // [...]
-      "embeddings": { "enabled": true }
-    }
-    ```
-3. Navigate to **Site admin > Cody** (`/site-admin/cody`) and schedule repositories for embedding.
+Embeddings are automatically enabled and configured once [Cody is enabled](../quickstart.md).
+After enabling Cody, navigate to **Site admin > Cody** (`/site-admin/cody`) and schedule repositories for embedding.
 
 > NOTE: By enabling Cody, you agree to the [Cody Notice and Usage Policy](https://about.sourcegraph.com/terms/cody-notice).
 
 <span class="virtual-br"></span>
 
-> NOTE: You can also [use third-party LLM directly](#using-a-third-party-llm-directly) for embeddings.
+> NOTE: You can also [use third-party embeddings provider directly](#using-a-third-party-embeddings-provider-directly) for embeddings.
 
 ### Excluding files from embeddings
 
@@ -150,5 +143,15 @@ You must create your own key with OpenAI [here](https://beta.openai.com/account/
     "accessToken": "<token>",
     "excludedFilePathPatterns": []
   }
+}
+```
+
+### Disabling embeddings
+
+Embeddings can currently be disabled, even with Cody enabled, using the following site configuration:
+
+```jsonc
+{
+  "embeddings": { "enabled": false }
 }
 ```

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -136,7 +136,7 @@ Supported time units are h (hours), m ( minutes), and s (seconds).
 }
 ```
 
-### Using a third-party LLM directly
+### Using a third-party embeddings provider directly
 
 Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly for embeddings. Currently, this can only be OpenAI embeddings.
 

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -18,23 +18,20 @@ Embeddings for relevant code files must be enabled for each repository that you'
 > See [Enabling Cody Enterprise](./enabling_cody_enterprise.md#cody-on-sourcegraph-cloud)
 
 1. Go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance
-1. Add the following to configure OpenAI embeddings:
+2. Add the following to configure [Cody Gateway](./cody_gateway.md) embeddings:
     ```json
     {
       // [...]
-      "embeddings": {
-        "enabled": true,
-        "url": "https://api.openai.com/v1/embeddings",
-        "accessToken": "<token>",
-        "model": "text-embedding-ada-002",
-        "dimensions": 1536,
-        "excludedFilePathPatterns": []
-      }
+      "embeddings": { "enabled": true }
     }
     ```
-1. Navigate to **Site admin > Cody** (`/site-admin/cody`) and schedule repositories for embedding.
+3. Navigate to **Site admin > Cody** (`/site-admin/cody`) and schedule repositories for embedding.
 
-> NOTE: By enabling Cody, you agree to the [Cody Notice and Usage Policy](https://about.sourcegraph.com/terms/cody-notice). 
+> NOTE: By enabling Cody, you agree to the [Cody Notice and Usage Policy](https://about.sourcegraph.com/terms/cody-notice).
+
+<span class="virtual-br"></span>
+
+> NOTE: You can also [use third-party LLM directly](#using-a-third-party-llm-directly) for embeddings.
 
 ### Excluding files from embeddings
 
@@ -79,8 +76,7 @@ To target an S3 bucket you've already provisioned, set the following environment
 
 > NOTE: You don't need to set the `EMBEDDINGS_UPLOAD_AWS_ACCESS_KEY_ID` environment variable when using `EMBEDDINGS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` because role credentials will be automatically resolved. 
 
-
-### Using GCS
+#### Using GCS
 
 To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
 
@@ -136,6 +132,26 @@ Supported time units are h (hours), m ( minutes), and s (seconds).
   "embeddings": {
     // [...]
     "minimumInterval": "24h"
+  }
+}
+```
+
+### Using a third-party LLM directly
+
+Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly for embeddings. Currently, this can only be OpenAI embeddings.
+
+You must create your own key with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+```jsonc
+{
+  "cody.enabled": true,
+  "embeddings": {
+    "provider": "openai",
+    "url": "https://api.openai.com/v1/embeddings",
+    "accessToken": "<token>",
+    "model": "text-embedding-ada-002",
+    "dimensions": 1536,
+    "excludedFilePathPatterns": []
   }
 }
 ```

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -70,7 +70,7 @@ In addition to the above, we may throttle concurrent requests to Cody Gateway pe
 
 Sourcegraph Cody Gateway does not retain any sensitive data (prompt test and source code included in requests, etc) from any traffic we receive.
 We only tracks rate limit consumption per Sourcegraph Enterprise subscription, and some high-level diagnostic data (errors codes from upstream, numeric/enum request parameters, etc).
-The cody that powers Cody Gateway is also [source-available](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph$+f:cmd/cody-gateway+lang:go&patternType=lucky&sm=1&groupBy=path) for audit.
+The code that powers Cody Gateway is also [source-available](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph$+f:cmd/cody-gateway+lang:go&patternType=lucky&sm=1&groupBy=path) for audit.
 
 For more details about Cody Gateway security practices, please reach out to your account manager.
 Also refer to the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice) for more privacy details about Cody in general.

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -64,7 +64,7 @@ Rate limits, quotas, and model availability is tied to one of:
 All successful requests to Cody Gateway will count towards your rate limits.
 Unsuccesful requests are not counted as usage.
 
-In addition to the above, we also throttle concurrent requests to Cody Gateway per Sourcegraph Enterprise instance or Sourcegraph App user.
+In addition to the above, we may throttle concurrent requests to Cody Gateway per Sourcegraph Enterprise instance or Sourcegraph App user, to prevent excessive burst consumption.
 
 ## Privacy and security
 

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -1,0 +1,76 @@
+# Sourcegraph Cody Gateway
+
+<span class="badge badge-note">Sourcegraph 5.1+</span>
+
+Sourcegraph Cody Gateway powers the default `"provider": "sourcegraph"` Cody completions and embeddings for Sourcegraph Enterprise customers.
+It supports a variety of upstream LLM providers, such as [Anthropic](https://www.anthropic.com/) and [OpenAI](https://openai.com/), with rate limits, quotas, and model availability tied to your Sourcegraph Enterprise product subscription.
+[Sourcegraph App users](../../app/index.md) with Sourcegraph.com accounts will also be able to use Sourcegraph Cody Gateway.
+
+Reach out your account manager for more details about Sourcegraph Cody Gateway access available to you and how you can gain access to higher rate limits, quotas, and/or model options.
+
+## Using Cody Gateway in Sourcegraph Enterprise
+
+> WARNING: Sourcegraph Cody Gateway access must be included in your Sourcegraph Enterprise subscription plan first - reach out to your account manager for more details.
+>
+> If you are a [Sourcegraph Cloud](../../cloud/index.md) customer, please reach out to your account manager to enable Cody.
+
+<span class="virtual-br"></span>
+
+> NOTE: Sourcegraph Cody Gateway uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension or when embeddings are enabled.
+
+To enable completions and embeddings provided by Cody Gateway on your Sourcegraph Enterprise instance, simply ensure your license key is set and Cody is enabled in [site configuration](../../admin/config/site_config.md):
+
+```json
+{
+  "licenseKey": "<...>",
+  "cody.enabled": true,
+  "embeddings": { "enabled": true } // if desired, for Code Graph Context embeddings
+}
+```
+
+That's it! Reasonable defaults will automatically be applied, and authentication will happen automatically based on the configured license key.
+
+For more details about configuring Cody, refer to the following guides:
+
+- [Enabling Cody for Sourcegraph Enterprise](./enabling_cody_enterprise.md)
+- [Code Graph Context: Embeddings](./code_graph_context.md#embeddings)
+
+## Configuring custom models
+
+To configure custom models for various Cody configurations (e.g. `"completions"` and `"embeddings"`), specify the desired model with the upstream provider as a prefix to the name of the model. For example, to use the `claude-v1` model from Anthropic, you would configure:
+
+```json
+{
+  "completions": { "chatModel": "anthropic/claude-v1" },
+}
+```
+
+The currently supported upstream providers for models are:
+
+- [`anthropic/`](https://www.anthropic.com/)
+- [`openai/`](https://openai.com/)
+
+For Sourcegraph Enterprise customers, model availability depends on your Sourcegraph Enterprise subscription - reach out your account manager for more details.
+
+Refer to [Cody documentation](../index.md) to learn more about Cody configuration.
+
+## Rate limits and quotas
+
+Rate limits, quotas, and model availability is tied to one of:
+
+- your Sourcegraph Enterprise product subscription, for Sourcegraph Enterprise instances
+- your Sourcegraph.com account, for [Sourcegraph App users](../../app/index.md)
+
+All successful requests to Cody Gateway will count towards your rate limits.
+Unsuccesful requests are not counted as usage.
+
+In addition to the above, we also throttle concurrent requests to Cody Gateway per Sourcegraph Enterprise instance or Sourcegraph App user.
+
+## Privacy and security
+
+Sourcegraph Cody Gateway does not retain any sensitive data (prompt test and source code included in requests, etc) from any traffic we receive.
+We only tracks rate limit consumption per Sourcegraph Enterprise subscription, and some high-level diagnostic data (errors codes from upstream, numeric/enum request parameters, etc).
+The cody that powers Cody Gateway is also [source-available](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph$+f:cmd/cody-gateway+lang:go&patternType=lucky&sm=1&groupBy=path) for audit.
+
+For more details about Cody Gateway security practices, please reach out to your account manager.
+Also refer to the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice) for more privacy details about Cody in general.

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -20,7 +20,7 @@ Reach out your account manager for more details about Sourcegraph Cody Gateway a
 
 To enable completions and embeddings provided by Cody Gateway on your Sourcegraph Enterprise instance, simply ensure your license key is set and Cody is enabled in [site configuration](../../admin/config/site_config.md):
 
-```json
+```jsonc
 {
   "licenseKey": "<...>",
   "cody.enabled": true,

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -24,7 +24,6 @@ To enable completions and embeddings provided by Cody Gateway on your Sourcegrap
 {
   "licenseKey": "<...>",
   "cody.enabled": true,
-  "embeddings": { "enabled": true } // if desired, for Code Graph Context embeddings
 }
 ```
 
@@ -63,6 +62,7 @@ Rate limits, quotas, and model availability is tied to one of:
 
 All successful requests to Cody Gateway will count towards your rate limits.
 Unsuccesful requests are not counted as usage.
+Rate limits, quotas, and model availability are also configured per Cody feature - for example, you will have a separate rate limits for Cody chat, Cody completions, and Cody embeddings.
 
 In addition to the above, we may throttle concurrent requests to Cody Gateway per Sourcegraph Enterprise instance or Sourcegraph App user, to prevent excessive burst consumption.
 

--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -9,36 +9,32 @@
 
 ### Prerequisites
 
-- Sourcegraph 5.0.1 or above
-- An Anthropic or OpenAI API key (we can help you get one, see below)
-- Optionally: An OpenAI API key for embeddings to power code graph context
+- Sourcegraph 5.1.0 or above
+- A Sourcegraph Enterprise subscription with [Cody Gateway access](./cody_gateway.md), or [an account with a third-party LLM provider](#using-a-third-party-llm-provider-directly).
 
 There are two steps required to enable Cody on your enterprise instance:
 
-1. Enable your Sourcegraph instance
+1. Enable Cody on your Sourcegraph instance
 2. Configure the VS Code extension
 
 ### Step 1: Enable Cody on your Sourcegraph instance
 
-Note that this requires site-admin privileges.
+> NOTE: Cody uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension or when embeddings are enabled.
 
-1. Cody uses one or more third-party LLM (Large Language Model) providers. Make sure you review the [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice). In particular, code snippets will be sent to a third-party language model provider when you use the Cody extension.
-2. To turn Cody on, you will need to set an access token for Sourcegraph to authenticate with the third-party large language model provider. Currently, this can be Anthropic or OpenAI. Reach out to your Sourcegraph Technical Advisor or Customer Engineer to get an Anthropic key through Sourcegraph with our zero-retention policy. Alternatively, you can create your own key with Anthropic [here](https://console.anthropic.com/account/keys) or with OpenAI [here](https://beta.openai.com/account/api-keys).
-3. Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+Note that this requires site-admin privileges. First, configure your desired LLM provider:
 
-    ```json
-    {
-      // [...]
-      "cody.enabled": true,
-      "completions": {
-        "provider": "anthropic", // or "openai" if you use OpenAI
-        "model": "claude-v1", // or one of the models listed [here](https://platform.openai.com/docs/models) if you use OpenAI
-        "accessToken": "<key>"
-      }
-    }
-    ```
-4. You're done! 
-5. Cody can be configured to use embeddings for code graph context to significantly improve the quality of its responses. This involves sending your entire codebase to a third-party service to generate a low-dimensional semantic representation, that is used for improved context fetching. See the [codebase-aware answers](#enabling-codebase-aware-answers) section for more.
+- [Using Sourcegraph Cody Gateway](./cody_gateway.md#using-cody-gateway-in-sourcegraph-enterprise)
+- [Using a third-party LLM provider directly](#using-a-third-party-llm-provider-directly)
+
+Once your provider is set up, make sure Cody is enabled in your site configuration:
+
+```json
+{
+  "cody.enabled": true,
+}
+```
+
+Cody can also be configured to use embeddings for code graph context to significantly improve the quality of its responses. This involves sending your entire codebase to a third-party service to generate a low-dimensional semantic representation, that is used for improved context fetching. See the [codebase-aware answers](#enabling-codebase-aware-answers) section for more.
 
 ### Step 2: Configure the VS Code extension
 
@@ -78,7 +74,7 @@ These are a few things you can ask Cody:
 
 ## Cody on Sourcegraph Cloud
 
-On Sourcegraph Cloud, Cody is a managed service and you do not need to follow the step 1 of the self-hosted guide above. 
+On [Sourcegraph Cloud](../../cloud/index.md), Cody is a managed service and you do not need to follow step 1 of the self-hosted guide above.
 
 ### Step 1: Enable Cody for your instance
 
@@ -94,7 +90,7 @@ Cody can be enabled on demand on your Sourcegraph instance by contacting your ac
 
 ## Enabling codebase-aware answers
 
-**Pre-requisite: In order to enable codebase-aware answers for Cody, you must first [configure code graph context](code_graph_context.md).**
+> NOTE: In order to enable codebase-aware answers for Cody, you must first [configure code graph context](code_graph_context.md).
 
 The `Cody: Codebase` setting in VS Code enables codebase-aware answers for the Cody extension. By setting this configuration option to the repository name on your Sourcegraph instance, Cody will be able to provide more accurate and relevant answers to your coding questions, based on the context of the codebase you are currently working in.
 
@@ -137,5 +133,22 @@ To do so:
 
 <img width="979" alt="Add overides" src="https://user-images.githubusercontent.com/25070988/235454594-9f1a6b27-6882-44d9-be32-258d6c244880.png">
 
+## Using a third-party LLM provider directly
 
+Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly. Currently, this can only be Anthropic or OpenAI.
 
+You must create your own key with Anthropic [here](https://console.anthropic.com/account/keys) or with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+```jsonc
+{
+  // [...]
+  "cody.enabled": true,
+  "completions": {
+    "provider": "anthropic", // or "openai" if you use OpenAI
+    "model": "claude-v1", // or one of the models listed [here](https://platform.openai.com/docs/models) if you use OpenAI
+    "accessToken": "<key>"
+  }
+}
+```
+
+Similarly, you can also [use a third-party LLM provider directly for embeddings](./code_graph_context.md#using-a-third-party-llm-directly).

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -48,7 +48,7 @@ In the future, here are the steps that Sourcegraph will follow:
 
 #### What is the default `sourcegraph` provider for completions and embeddings?
 
-The default `"provider": "sourcegraph"` for completions and embeddings is the [Sourcegraph Cody Gateway](./explanations/cody_gateway.md). Cody Gateway forwards completions and embeddings requests to third-party services.
+The default `"provider": "sourcegraph"` for completions and embeddings is the [Sourcegraph Cody Gateway](./explanations/cody_gateway.md). Cody Gateway provides Sourcegraph enterprise instances access to completions and embeddings using third-party services like Anthropic and OpenAI.
 
 #### What third-party cloud services does Cody depend on today?
 

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -46,10 +46,16 @@ In the future, here are the steps that Sourcegraph will follow:
 
 ### Third party dependencies
 
+#### What is the default `sourcegraph` provider for completions and embeddings?
+
+The default `"provider": "sourcegraph"` for completions and embeddings is the [Sourcegraph Cody Gateway](./explanations/cody_gateway.md). Cody Gateway forwards completions and embeddings requests to third-party services.
+
 #### What third-party cloud services does Cody depend on today?
 
 - Cody has one third-party dependency, which is Anthropic's Claude API. In the config, this can be replaced with OpenAI API.
 - Cody can optionally use OpenAI to generate embeddings, that are then used to improve the quality of its context snippets, but this is not required.
+
+The above is also the case even when using [the default `sourcegraph` provider, Cody Gateway](./explanations/cody_gateway.md), which forwards requests to third-party providers.
 
 #### What's the retention policy for Anthropic/OpenAI?
 

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -55,7 +55,7 @@ The default `"provider": "sourcegraph"` for completions and embeddings is the [S
 - Cody has one third-party dependency, which is Anthropic's Claude API. In the config, this can be replaced with OpenAI API.
 - Cody can optionally use OpenAI to generate embeddings, that are then used to improve the quality of its context snippets, but this is not required.
 
-The above is also the case even when using [the default `sourcegraph` provider, Cody Gateway](./explanations/cody_gateway.md), which forwards requests to third-party providers.
+The above is also the case even when using [the default `sourcegraph` provider, Cody Gateway](./explanations/cody_gateway.md), which uses the same third-party providers.
 
 #### What's the retention policy for Anthropic/OpenAI?
 

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -87,3 +87,4 @@ See [Cody troubleshooting guide](troubleshooting.md).
 - [Enabling Cody for open source Sourcegraph.com users](explanations/enabling_cody.md)
 - [Installing the Cody VS Code extension](explanations/installing_vs_code.md)
 - [Configuring code graph context](explanations/code_graph_context.md)
+- [Sourcegraph Cody Gateway](explanations/cody_gateway.md)


### PR DESCRIPTION
Adds customer/user-facing Cody Gateway docs, noting how access works, changing setup to use it as a default, and separating direct third-party LLM configuration into various sections. The docs focus primarily on Sourcegraph Enterprise since the story for that is a lot clearer, but I've included mentions of App to so that this page can be extended to accommodate App, which will talk to Cody Gateway directly.

The changes assume that customers are on 5.1, but given things are experimental and there are already a lot of 5.1-specific things in here I think that's fine?

There are also a few lightweight details about security/privacy here. Note that we do not yet have an SLA commitment for Cody Gateway due to a [lack of SLA from OpenAI](https://github.com/sourcegraph/sourcegraph/issues/52409#issuecomment-1570702299), which we depend on.

This is intentionally separate from the internal-facing docs at [go/cody-gateway](https://www.golinks.io/cody-gateway?trackSource=github), which focuses on support enablement and engineering guidance.

I've tried to fit it in to the existing docs structure to avoid changing too much, though it's a bit confusing to navigate.

Closes https://github.com/sourcegraph/sourcegraph/issues/53354

## Test plan

CI, `sg run docsite`
