### PR TITLE
drift copy to clipboard - dark mode styling2

### DIFF
--- a/client/web/src/site-admin/SiteAdminUpdatesPage.module.scss
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.module.scss
@@ -9,15 +9,24 @@
 
 .container {
     padding: 2rem;
-    border-bottom: 1px solid #808080;
     border-bottom: 1px solid var(--gray-03);
 
     &:first-child {
         padding-top: 1rem;
     }
 
-    &:nth-child(even) {
-        background: #f5f6f6;
+    :global(.theme-light) & {
+        &:nth-child(even) {
+            background: #f5f6f6;
+        }
+        border-bottom: 1px solid #808080;
+    }
+
+    :global(.theme-dark) & {
+        &:nth-child(even) {
+            background: #14171f;
+        }
+        border: 1px solid #262b38;
     }
 }
 

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -280,16 +280,14 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                                                 <div className="d-flex flex-row justify-content-between">
                                                     <div className={styles.label}>Suggested statements to repair:</div>
                                                     <Button
-                                                        onClick={() => {
+                                                        onClick={async () => {
                                                             if (summary.statements) {
-                                                                navigator.clipboard.writeText(
+                                                                await navigator.clipboard.writeText(
                                                                     summary.statements.join('\n')
                                                                 )
-                                                            } else {
-                                                                // Handle null case
-                                                                console.log('summary.statements was null or undefined')
                                                             }
-                                                            return Promise.resolve(null)
+
+                                                            return null
                                                         }}
                                                         variant="primary"
                                                         size="sm"

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -209,13 +209,7 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                     <hr className="my-3" />
                     <div className="d-flex flex-row justify-content-between">
                         <H3>Schema drift</H3>
-                        <Button
-                            onClick={() => refetch()}
-                            variant="primary"
-                            size="sm"
-                            aria-label="refresh drift check"
-                            q
-                        >
+                        <Button onClick={() => refetch()} variant="primary" size="sm" aria-label="refresh drift check">
                             {' '}
                             Refresh{' '}
                         </Button>

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -295,6 +295,7 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                                                                 // Handle null case
                                                                 console.log('summary.statements was null or undefined')
                                                             }
+                                                            return Promise.resolve(null)
                                                         }}
                                                         variant="primary"
                                                         size="sm"

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react'
 
-import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown, mdiAlertOctagram } from '@mdi/js'
+import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown, mdiAlertOctagram, mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import { parseISO } from 'date-fns'
 import formatDistance from 'date-fns/formatDistance'
@@ -209,7 +209,13 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                     <hr className="my-3" />
                     <div className="d-flex flex-row justify-content-between">
                         <H3>Schema drift</H3>
-                        <Button onClick={() => refetch()} variant="primary" size="sm">
+                        <Button
+                            onClick={() => refetch()}
+                            variant="primary"
+                            size="sm"
+                            aria-label="refresh drift check"
+                            q
+                        >
                             {' '}
                             Refresh{' '}
                         </Button>
@@ -277,7 +283,27 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
                                             </div>
 
                                             <div className={styles.infoContainer}>
-                                                <div className={styles.label}>Suggested statements to repair:</div>
+                                                <div className="d-flex flex-row justify-content-between">
+                                                    <div className={styles.label}>Suggested statements to repair:</div>
+                                                    <Button
+                                                        onClick={() => {
+                                                            if (summary.statements) {
+                                                                navigator.clipboard.writeText(
+                                                                    summary.statements.join('\n')
+                                                                )
+                                                            } else {
+                                                                // Handle null case
+                                                                console.log('summary.statements was null or undefined')
+                                                            }
+                                                        }}
+                                                        variant="primary"
+                                                        size="sm"
+                                                        aria-label="copy sql statements to repair"
+                                                        className="mb-1"
+                                                    >
+                                                        <Icon aria-hidden={true} svgPath={mdiContentCopy} />
+                                                    </Button>
+                                                </div>
                                                 <div>
                                                     <LogOutput
                                                         text={


### PR DESCRIPTION
_Second branch opened to address weird git merge snafu_

This PR introduced a copy button for suggested fixes for each individual schema drift logOutput, it also adds styling for dark mode users

![Screenshot 2023-06-14 at 2 50 53 AM](https://github.com/sourcegraph/sourcegraph/assets/13024338/04d6e131-3f9e-4d18-a363-1f13122d04ac)
![Screenshot 2023-06-14 at 2 51 05 AM](https://github.com/sourcegraph/sourcegraph/assets/13024338/18bdde55-883c-46a8-a202-110e2da196bf)

## Test plan

Introduced drift to my local db `sg start`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
