### PR TITLE
Create language specification for VbNet

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/comments.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/comments.ts
@@ -18,6 +18,9 @@ export const leadingAtSymbolPattern = /^\s*@/
 /** Matches whitespace followed by a hash symbol at beginning of a line. */
 export const leadingHashPattern = /^\s*#/
 
+/** Matches one or more apostrophes followed by one optional space. */
+export const apostrophePattern = /\'+\s?/
+
 export const cStyleBlockComment: BlockCommentStyle = {
     startRegex: /\/\*\*?/,
     endRegex: /\*\//,

--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -1,4 +1,5 @@
 import {
+    apostrophePattern,
     cStyleComment,
     dashPattern,
     javaStyleComment,
@@ -337,6 +338,13 @@ const thriftSpec: LanguageSpec = {
     commentStyles: [cStyleComment],
 }
 
+const vbnetSpec: LanguageSpec = {
+    languageID: 'vbnet',
+    stylized: 'VB.Net',
+    fileExts: ['vb'],
+    commentStyles: [{ lineRegex: apostrophePattern }],
+}
+
 const verilogSpec: LanguageSpec = {
     languageID: 'verilog',
     stylized: 'Verilog',
@@ -416,6 +424,7 @@ export const languageSpecs: LanguageSpec[] = [
     swiftSpec,
     thriftSpec,
     typescriptSpec,
+    vbnetSpec,
     verilogSpec,
     vhdlSpec,
     zigSpec,


### PR DESCRIPTION
Following the steps from https://docs.sourcegraph.com/dev/how-to/add_support_for_a_language#code-navigation-support

The SCIP indexer for VbNet was added in PR https://github.com/sourcegraph/scip-dotnet/pull/26.