### PR TITLE
don't use `dbutil.NewNullString` when inserting into `gitserver_repos_sync_output`

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -510,7 +510,7 @@ WHERE
 }
 
 func (s *gitserverRepoStore) SetLastOutput(ctx context.Context, name api.RepoName, output string) error {
-	ns := dbutil.NewNullString(sanitizeToUTF8(output))
+	ns := sanitizeToUTF8(output)
 
 	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos_sync_output(repo_id, last_output)


### PR DESCRIPTION
Not sure why I was using `dbutil.NewNullString` when the column is non-nullable. Too much copy pasta.

Thanks for [the alert](https://github.com/sourcegraph/sourcegraph/pull/51598#issuecomment-1593866227), @camdencheek 

## Test plan

unit tests added

re-clone a repository and verify that the last output shows up in the `Mirroring and cloning` page (click on the kebab menu on the repository and choose `Last sync log`