### PR TITLE
doc/dev: link to customer-facing cody gateway docs from dev guide

### DIFF
--- a/doc/dev/how-to/cody_gateway.md
+++ b/doc/dev/how-to/cody_gateway.md
@@ -1,5 +1,7 @@
 # How to set up Cody Gateway locally
 
+> WARNING: This is a development guide - to use Cody Gateway for Sourcegraph, refer to [Sourcegraph Cody Gateway](../../cody/explanations/cody_gateway.md).
+
 This guide documents how to set up [Cody Gateway](https://handbook.sourcegraph.com/departments/engineering/teams/cody/cody-gateway/) locally for development.
 
 To get started, Cody Gateway is included in the standard `dotcom` run set.


### PR DESCRIPTION
The dev guide surfaces above the usage guide in docsite search 😅 This will help redirect anyone who accidentally lands on the wrong page

## Test plan

CI