### PR TITLE
featureflags: remove cody-gateway-management-ui, enable by default

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -19,7 +19,6 @@ import {
 } from '../../../../components/FilteredConnection/ui'
 import { PageTitle } from '../../../../components/PageTitle'
 import { useScrollToLocationHash } from '../../../../components/useScrollToLocationHash'
-import { useFeatureFlag } from '../../../../featureFlags/useFeatureFlag'
 import {
     DotComProductSubscriptionResult,
     DotComProductSubscriptionVariables,
@@ -104,9 +103,6 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
         setShowGenerate(false)
     }, [refetch, refetchRef])
 
-    // Feature flag only used as this is under development - will be enabled by default
-    const [codyGatewayMananagementUI] = useFeatureFlag('cody-gateway-management-ui')
-
     if (loading && !data) {
         return <LoadingSpinner />
     }
@@ -182,17 +178,15 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                     </table>
                 </Container>
 
-                {codyGatewayMananagementUI && (
-                    <CodyServicesSection
-                        viewerCanAdminister={true}
-                        currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
-                        accessTokenError={errorForPath(error, accessTokenPath)}
-                        codyGatewayAccess={productSubscription.codyGatewayAccess}
-                        productSubscriptionID={productSubscription.id}
-                        productSubscriptionUUID={subscriptionUUID}
-                        refetchSubscription={refetch}
-                    />
-                )}
+                <CodyServicesSection
+                    viewerCanAdminister={true}
+                    currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
+                    accessTokenError={errorForPath(error, accessTokenPath)}
+                    codyGatewayAccess={productSubscription.codyGatewayAccess}
+                    productSubscriptionID={productSubscription.id}
+                    productSubscriptionUUID={subscriptionUUID}
+                    refetchSubscription={refetch}
+                />
 
                 <H3 className="d-flex align-items-center mt-5">
                     Licenses

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -8,7 +8,6 @@ import { useQuery } from '@sourcegraph/http-client'
 import { LoadingSpinner, H4, Text, Link, ErrorAlert, PageHeader, Container } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import {
     UserAreaUserFields,
     UserProductSubscriptionResult,
@@ -46,9 +45,6 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
             errorPolicy: 'all',
         }
     )
-
-    // Feature flag only used as this is under development - will be enabled by default
-    const [codyGatewayManagementUI] = useFeatureFlag('cody-gateway-management-ui')
 
     if (loading) {
         return <LoadingSpinner />
@@ -108,17 +104,15 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
                 </Container>
             )}
 
-            {codyGatewayManagementUI && (
-                <CodyServicesSection
-                    viewerCanAdminister={false}
-                    currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
-                    accessTokenError={errorForPath(error, accessTokenPath)}
-                    codyGatewayAccess={productSubscription.codyGatewayAccess}
-                    productSubscriptionID={productSubscription.id}
-                    productSubscriptionUUID={subscriptionUUID}
-                    refetchSubscription={refetch}
-                />
-            )}
+            <CodyServicesSection
+                viewerCanAdminister={false}
+                currentSourcegraphAccessToken={productSubscription.currentSourcegraphAccessToken}
+                accessTokenError={errorForPath(error, accessTokenPath)}
+                codyGatewayAccess={productSubscription.codyGatewayAccess}
+                productSubscriptionID={productSubscription.id}
+                productSubscriptionUUID={subscriptionUUID}
+                refetchSubscription={refetch}
+            />
         </div>
     )
 }

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserSubscriptionsProductSubscriptionPage.test.tsx.snap
@@ -36,6 +36,37 @@ exports[`UserSubscriptionsProductSubscriptionPage renders 1`] = `
         </h2>
       </div>
     </div>
+    <h3
+      class="h3"
+    >
+      Cody services 
+      <span
+        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+      >
+        This feature is currently in beta
+      </span>
+      <span
+        aria-hidden="true"
+        class="badge info productStatusBadge"
+        status="beta"
+      >
+        beta
+      </span>
+    </h3>
+    <div
+      class="container mb-3"
+    >
+      <h4
+        class="h4"
+      >
+        Access token
+      </h4>
+      <p
+        class="mb-2"
+      >
+        Access tokens can be used for Cody Gateway access
+      </p>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -27,7 +27,6 @@ export type FeatureFlagName =
     | 'clone-progress-logging'
     | 'sourcegraph-operator-site-admin-hide-maintenance'
     | 'repository-metadata'
-    | 'cody-gateway-management-ui'
     | 'cody-web-search'
     | 'own-promote'
     | 'own-analytics'

--- a/doc/dev/how-to/cody_gateway.md
+++ b/doc/dev/how-to/cody_gateway.md
@@ -14,7 +14,6 @@ Then, set up some feature flags:
 - `product-subscriptions-service-account`: set to `true` globally for convenience.
   In production, this flag is used to denote service accounts, but in development it doesn't matter.
   - You can also create an additional user and set this flag to `true` only for that user for more robust testing.
-- `cody-gateway-management-ui` (TODO: this will no logner be required once Cody Gateway is GA)
 
 Configure Cody features to talk to your local Cody Gateway:
 


### PR DESCRIPTION
As we approach GA, this enables the Cody Gateway management UI by default for Sourcegraph.com so that teammates can begin to familiarize themselves with it before Enterprise GA (5.1 release). I'll be making an announcement tomorrow 😁 

Closes #52519

### Test plan

CI
