### PR TITLE
Rename cody recipe executed event logs

### DIFF
--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -264,7 +264,7 @@ export const useCodyChat = ({
 
     const executeRecipe = useCallback<typeof executeRecipeInternal>(
         async (recipeId, options): Promise<Transcript | null> => {
-            eventLogger.log(EventName.CODY_CHAT_RECIPE_EXECUTED, { recipeId })
+            eventLogger.log(`web:codyChat:recipe:${recipeId}:executed`, { recipeId })
 
             const transcript = await executeRecipeInternal(recipeId, options)
 

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -18,11 +18,7 @@ import { GlowingCodySVG, MeetCodySVG } from './WidgetIcons'
 
 import styles from './TryCodyWidget.module.scss'
 
-const AUTO_DISMISS_ON_EVENTS = new Set([
-    EventName.CODY_SIDEBAR_CHAT_OPENED,
-    EventName.CODY_CHAT_SUBMIT,
-    EventName.CODY_CHAT_RECIPE_EXECUTED,
-])
+const AUTO_DISMISS_ON_EVENTS = new Set([EventName.CODY_SIDEBAR_CHAT_OPENED, EventName.CODY_CHAT_SUBMIT])
 
 interface WidgetContentProps extends TelemetryProps {
     type: 'blob' | 'repo'

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -4,9 +4,9 @@ export const enum EventName {
     CODY_CHAT_EDIT = 'web:codyChat:edit',
     CODY_CHAT_INITIALIZED = 'web:codyChat:initialized',
     CODY_CHAT_EDITOR_WIDGET_VIEWED = 'web:codyChat:editorWidgetViewed',
-    CODY_CHAT_RECIPE_EXECUTED = 'web:codyChat:recipeExecuted',
     CODY_CHAT_HISTORY_CLEARED = 'web:codyChat:historyCleared',
     CODY_CHAT_HISTORY_ITEM_DELETED = 'web:codyChat:historyItemDeleted',
+
     CODY_CHAT_SCOPE_REPO_ADDED = 'web:codyChat:scopeRepoAdded',
     CODY_CHAT_SCOPE_REPO_REMOVED = 'web:codyChat:scopeRepoRemoved',
     CODY_CHAT_SCOPE_RESET = 'web:codyChat:scopeReset',


### PR DESCRIPTION
Rename event logs for recipe executed on web. 

## Test plan

- visit any file view page
- select code from the editor
- execute recipe
- check for event log request
