### PR TITLE
own: separate History and Own so that turning off Own is not turning off History as well.

### DIFF
--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -448,8 +448,13 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                     />
                 )}
             </RepoHeaderContributionPortal>
-            {enableOwnershipPanel && repoID && (
-                <HistoryAndOwnBar repoID={repoID} revision={revision} filePath={filePath} />
+            {repoID && (
+                <HistoryAndOwnBar
+                    repoID={repoID}
+                    revision={revision}
+                    filePath={filePath}
+                    enableOwnershipPanel={enableOwnershipPanel}
+                />
             )}
         </>
     )

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.module.scss
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.module.scss
@@ -9,16 +9,28 @@
     margin-bottom: 0.25rem;
 }
 
-.history {
-    min-width: 0;
+.history-panel {
     padding: 0;
+    display: flex;
+    align-items: stretch;
+    vertical-align: middle;
+    font-weight: normal;
+    letter-spacing: normal;
+    line-height: normal;
     font-size: 0.75rem;
-    flex-shrink: 1000000; // Very high value to shink this before shrinking the ownership side.
+    overflow: hidden;
 
     // Hide on small screen sizes
     @media (--sm-breakpoint-down) {
         display: none;
     }
+}
+
+.history {
+    min-width: 0;
+    padding: 0;
+    font-size: 0.75rem;
+    flex-shrink: 1000000; // Very high value to shrink this before shrinking the ownership side.
 }
 
 .own {

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -153,5 +153,5 @@ const config: Meta = {
 export default config
 
 export const Default: Story = () => (
-    <WebStory mocks={[mockLoaded]}>{() => <HistoryAndOwnBar {...variables} />}</WebStory>
+    <WebStory mocks={[mockLoaded]}>{() => <HistoryAndOwnBar enableOwnershipPanel={true} {...variables} />}</WebStory>
 )

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
@@ -22,11 +22,16 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
     repoID: string
     revision?: string
     filePath: string
-}> = ({ repoID, revision, filePath }) => {
+    enableOwnershipPanel: boolean
+}> = ({ repoID, revision, filePath, enableOwnershipPanel }) => {
     const navigate = useNavigate()
 
     const openOwnershipPanel = useCallback(() => {
         navigate({ hash: '#tab=ownership' })
+    }, [navigate])
+
+    const openHistoryPanel = useCallback(() => {
+        navigate({ hash: '#tab=history' })
     }, [navigate])
 
     const { data, error, loading } = useQuery<FetchOwnersAndHistoryResult, FetchOwnersAndHistoryVariables>(
@@ -36,6 +41,7 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
                 repo: repoID,
                 revision: revision ?? '',
                 currentPath: filePath,
+                includeOwn: enableOwnershipPanel,
             },
         }
     )
@@ -71,12 +77,23 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
     return (
         <div className={styles.wrapper}>
             {history && (
-                <GitCommitNode
-                    node={history}
-                    extraCompact={true}
-                    hideExpandCommitMessageBody={true}
-                    className={styles.history}
-                />
+                <div className={styles.historyPanel}>
+                    <GitCommitNode
+                        node={history}
+                        extraCompact={true}
+                        hideExpandCommitMessageBody={true}
+                        className={styles.history}
+                    />
+                    <Button
+                        variant="link"
+                        size="sm"
+                        display="inline"
+                        className="pt-0 pb-0 border-0"
+                        onClick={openHistoryPanel}
+                    >
+                        Show history
+                    </Button>
+                </div>
             )}
             {ownership && (
                 <Tooltip content="Show ownership details" placement="left">

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -156,12 +156,12 @@ export const FETCH_OWNERS_AND_HISTORY = gql`
     ${OWNER_FIELDS}
     ${gitCommitFragment}
 
-    query FetchOwnersAndHistory($repo: ID!, $revision: String!, $currentPath: String!) {
+    query FetchOwnersAndHistory($repo: ID!, $revision: String!, $currentPath: String!, $includeOwn: Boolean!) {
         node(id: $repo) {
             ... on Repository {
                 sourceType
                 commit(rev: $revision) {
-                    blob(path: $currentPath) {
+                    blob(path: $currentPath) @include(if: $includeOwn) {
                         ownership(first: 2, reasons: [CODEOWNERS_FILE_ENTRY, ASSIGNED_OWNER]) {
                             nodes {
                                 owner {


### PR DESCRIPTION
Main points:
- History can now live without own
- If own is off, one little GQL `@include(if: $includeOwn)` spares us the whole ownership query, leaving only the request for history

Test plan:
Local sg run and tests.

Closes https://github.com/sourcegraph/sourcegraph/issues/53556.
~Merge after https://github.com/sourcegraph/sourcegraph/pull/53558.~

## Le quicc demo

https://github.com/sourcegraph/sourcegraph/assets/94846361/19070721-3253-4e21-945a-15e6695996fe

