### PR TITLE
JetBrains: Chat: Fix font in the prompt

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -221,9 +221,9 @@ class CodyToolWindowContent implements UpdatableChat {
   @NotNull
   private JBTextArea createPromptInput(@NotNull Project project) {
     JBTextArea promptInput = new RoundedJBTextArea(4, 0, 10);
-    promptInput.setFont(UIUtil.getLabelFont());
     BasicTextAreaUI textUI = (BasicTextAreaUI) DarculaTextAreaUI.createUI(promptInput);
     promptInput.setUI(textUI);
+    promptInput.setFont(UIUtil.getLabelFont());
     promptInput.setLineWrap(true);
     promptInput.setWrapStyleWord(true);
     KeyboardShortcut CTRL_ENTER =


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/53465

Had to flip two lines because `promptInput.setUI(textUI);` apparently overwrites the font.

## Test plan

It uses the correct font now:

<img width="497" alt="CleanShot 2023-06-16 at 11 43 01@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2552265/ec7ffefa-7118-4fd5-a28a-0c927e980180">
