### PR TITLE
JetBrains: snappier Cody autocomplete

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Changed
 
+- Parallelized completion API calls and reduced debounce down to 20ms [#53592](https://github.com/sourcegraph/sourcegraph/pull/53592)
+
 ### Deprecated
 
 ### Removed

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -85,7 +85,7 @@ public class CodyCompletionsManager {
       // debouncing the completion trigger
       cancelCurrentJob();
       this.currentJob.set(
-          Optional.of(this.scheduler.schedule(callable, 200, TimeUnit.MILLISECONDS)));
+          Optional.of(this.scheduler.schedule(callable, 20, TimeUnit.MILLISECONDS)));
     }
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
@@ -3,7 +3,8 @@ package com.sourcegraph.cody.completions.prompt_library;
 import com.sourcegraph.cody.api.Promises;
 import com.sourcegraph.cody.vscode.*;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -13,6 +14,10 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings({"unused", "FieldCanBeLocal", "CommentedOutCode"})
 public class CodyCompletionItemProvider extends InlineCompletionItemProvider {
+
+  // should we reuse the scheduler from CodyCompletionsManager here later on?
+  // nThreads = 3 to have up to 3 completion API calls to run in parallel
+  private final ExecutorService executor = Executors.newFixedThreadPool(3);
   private final int promptTokens;
   private final int maxPrefixTokens;
   private final int maxSuffixTokens;
@@ -166,7 +171,11 @@ public class CodyCompletionItemProvider extends InlineCompletionItemProvider {
     }
     List<CompletableFuture<List<Completion>>> promises =
         completers.stream()
-            .map(c -> c.generateCompletions(token, Optional.empty()))
+            .map(
+                c -> // ensure completions are called for asynchronously
+                CompletableFuture.supplyAsync(
+                        () -> c.generateCompletions(token, Optional.empty()), executor))
+            .map(cf -> cf.thenCompose(Function.identity())) // flatten the CompletableFutures
             .collect(Collectors.toList());
     CompletableFuture<List<InlineCompletionItem>> all =
         Promises.all(promises)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
@@ -14,10 +14,9 @@ import java.util.stream.Collectors;
  */
 @SuppressWarnings({"unused", "FieldCanBeLocal", "CommentedOutCode"})
 public class CodyCompletionItemProvider extends InlineCompletionItemProvider {
-
+  int nThreads = 3; // up to 3 completion API calls to run in parallel
   // should we reuse the scheduler from CodyCompletionsManager here later on?
-  // nThreads = 3 to have up to 3 completion API calls to run in parallel
-  private final ExecutorService executor = Executors.newFixedThreadPool(3);
+  private final ExecutorService executor = Executors.newFixedThreadPool(nThreads);
   private final int promptTokens;
   private final int maxPrefixTokens;
   private final int maxSuffixTokens;


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/assets/18601388/b37ef1c0-ab3d-4f4f-95c6-5aed00811551
Autocomplete calls to Sourcegraph API should now be running in parallel.
Additionally, I reduced the debounce down to 20ms.
This should make response times a lot more reasonable.

## Test plan
- just check if I didn't make things slower on your machine for whatever reason
