### PR TITLE
own: delete `search-ownership` feature flag, making Own enabled by default 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Ping data now reflects whether `cody.enabled` and `completions` are set.
 - If a Sourcegraph request is traced, its trace ID and span ID are now set to the `X-Trace` and `X-Trace-Span` response headers respectively. The trace URL (if a template is configured in `observability.tracing.urlTemplate`) is now set to `X-Trace-URL` - previously, the URL was set to `X-Trace`. [#53259](https://github.com/sourcegraph/sourcegraph/pull/53259)
 - For users using the single-container server image with the default built-in database, the database must be reindexed. This process can take up to a few hours on systems with large datasets. See [Migrating to Sourcegraph 5.1.x](https://docs.sourcegraph.com/admin/migration/5_1) for full details. [#53256](https://github.com/sourcegraph/sourcegraph/pull/53256)
+- [Sourcegraph Own](https://docs.sourcegraph.com/own) is now available as a beta enterprise feature. `search-ownership` feature flag is removed and doesn't need to be used.
 
 ### Fixed
 

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -58,18 +58,13 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     queryState = { query: '' },
     setQueryState,
     isSourcegraphDotCom = false,
-    enableOwnershipSearch = false,
 }) => {
     const [selectedTip, setSelectedTip] = useState<Tip | null>(null)
     const [selectTipTimeout, setSelectTipTimeout] = useState<NodeJS.Timeout>()
     const [queryExampleTabActive, setQueryExampleTabActive] = useState<boolean>(false)
     const navigate = useNavigate()
 
-    const exampleSyntaxColumns = useQueryExamples(
-        selectedSearchContextSpec ?? 'global',
-        isSourcegraphDotCom,
-        enableOwnershipSearch
-    )
+    const exampleSyntaxColumns = useQueryExamples(selectedSearchContextSpec ?? 'global', isSourcegraphDotCom)
 
     const handleTabChange = (selectedTab: number): void => {
         setQueryExampleTabActive(!!selectedTab)

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -70,8 +70,7 @@ function getRepoFilterExamples(repositoryName: string): { singleRepoExample: str
 
 export function useQueryExamples(
     selectedSearchContextSpec: string,
-    isSourcegraphDotCom: boolean = false,
-    enableOwnershipSearch: boolean = false
+    isSourcegraphDotCom: boolean = false
 ): QueryExamplesSection[][] {
     const [queryExamplesContent, setQueryExamplesContent] = useState<QueryExamplesContent>()
     const [cachedQueryExamplesContent, setCachedQueryExamplesContent, cachedQueryExamplesContentLoadStatus] =
@@ -197,26 +196,19 @@ export function useQueryExamples(
                         { id: 'not-operator', query: 'lang:go NOT file:main.go' },
                     ],
                 },
-                ...(enableOwnershipSearch
-                    ? [
-                          {
-                              title: 'Explore code ownership',
-                              productStatus: 'experimental' as const,
-                              queryExamples: [
-                                  { id: 'type-has-owner', query: 'file:^some_path file:has.owner(johndoe)' },
-                                  { id: 'type-select-file-owners', query: 'file:^some_path select:file.owners' },
-                              ],
-                          },
-                      ]
-                    : [
-                          {
-                              title: 'Get advanced',
-                              queryExamples: [
-                                  { id: 'repo-has-description', query: 'repo:has.description(hello world)' },
-                              ],
-                          },
-                      ]),
+                {
+                    title: 'Explore code ownership',
+                    productStatus: 'experimental' as const,
+                    queryExamples: [
+                        { id: 'type-has-owner', query: 'file:^some_path file:has.owner(johndoe)' },
+                        { id: 'type-select-file-owners', query: 'file:^some_path select:file.owners' },
+                    ],
+                },
+                {
+                    title: 'Get advanced',
+                    queryExamples: [{ id: 'repo-has-description', query: 'repo:has.description(hello world)' }],
+                },
             ],
         ]
-    }, [queryExamplesContent, isSourcegraphDotCom, enableOwnershipSearch])
+    }, [queryExamplesContent, isSourcegraphDotCom])
 }

--- a/client/branded/src/search-ui/results/NoResultsPage.tsx
+++ b/client/branded/src/search-ui/results/NoResultsPage.tsx
@@ -46,7 +46,6 @@ const Container: React.FunctionComponent<React.PropsWithChildren<ContainerProps>
 
 interface NoResultsPageProps extends TelemetryProps, Pick<SearchContextProps, 'searchContextsEnabled'> {
     isSourcegraphDotCom: boolean
-    enableOwnershipSearch: boolean
     showSearchContext: boolean
     showQueryExamples?: boolean
     setQueryState?: (query: QueryState) => void
@@ -62,7 +61,6 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
     searchContextsEnabled,
     telemetryService,
     isSourcegraphDotCom,
-    enableOwnershipSearch,
     showSearchContext,
     showQueryExamples,
     setQueryState,
@@ -113,7 +111,6 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                             telemetryService={telemetryService}
                             setQueryState={setQueryState}
                             isSourcegraphDotCom={isSourcegraphDotCom}
-                            enableOwnershipSearch={enableOwnershipSearch}
                         />
                     </div>
                 </>

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -47,7 +47,6 @@ export interface StreamingSearchResultsListProps
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         PlatformContextProps<'requestGraphQL'> {
     isSourcegraphDotCom: boolean
-    enableOwnershipSearch: boolean
     results?: AggregateStreamingSearchResults
     allExpanded: boolean
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
@@ -107,7 +106,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     settingsCascade,
     telemetryService,
     isSourcegraphDotCom,
-    enableOwnershipSearch,
     searchContextsEnabled,
     platformContext,
     openMatchesInNewTab,
@@ -301,7 +299,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                             <NoResultsPage
                                 searchContextsEnabled={searchContextsEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
-                                enableOwnershipSearch={enableOwnershipSearch}
                                 telemetryService={telemetryService}
                                 showSearchContext={searchContextsEnabled}
                                 showQueryExamples={showQueryExamplesOnNoResultsPage}

--- a/client/vscode/src/webview/search-panel/SearchResultsView.tsx
+++ b/client/vscode/src/webview/search-panel/SearchResultsView.tsx
@@ -389,8 +389,6 @@ export const SearchResultsView: React.FunctionComponent<React.PropsWithChildren<
                             showQueryExamplesOnNoResultsPage={true}
                             setQueryState={setUserQueryState}
                             selectedSearchContextSpec={context.selectedSearchContextSpec}
-                            // TODO: No access to feature flags in vscode.
-                            enableOwnershipSearch={false}
                         />
                     </MatchHandlersContext.Provider>
                 </div>

--- a/client/web/src/enterprise/own/OwnPage.tsx
+++ b/client/web/src/enterprise/own/OwnPage.tsx
@@ -18,8 +18,6 @@ import { PageTitle } from '../../components/PageTitle'
 
 /**
  * A page explaining how to use Sourcegraph Own.
- * Note that this page is visible regardless of whether the `search-ownership`
- * feature flag has been enabled.
  */
 export const OwnPage: React.FunctionComponent<{}> = () => {
     const allowAutoplay = !useReducedMotion()

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
@@ -3,10 +3,8 @@ import { Meta, Story } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../components/WebStory'
-import { createFlagMock } from '../../featureFlags/createFlagMock'
 import {
     ExternalServiceKind,
     GetIngestedCodeownersResult,
@@ -52,7 +50,7 @@ const repo: RepositoryFields = {
     sourceType: RepositoryType.GIT_REPOSITORY,
 }
 
-const empyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCodeownersVariables> = {
+const emptyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCodeownersVariables> = {
     request: {
         query: getDocumentNode(GET_INGESTED_CODEOWNERS_QUERY),
         variables: {
@@ -64,31 +62,19 @@ const empyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCodeo
     },
 }
 
-const searchOwnershipFlagMock = createFlagMock('search-ownership', true)
-
 export const EmptyNonAdmin: Story = () => (
-    <WebStory mocks={[empyResponse, searchOwnershipFlagMock]}>
+    <WebStory mocks={[emptyResponse]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnEditPage
-                repo={repo}
-                authenticatedUser={{ siteAdmin: false }}
-                useBreadcrumb={useBreadcrumb}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
         )}
     </WebStory>
 )
 EmptyNonAdmin.storyName = 'Empty (non-admin)'
 
 export const EmptyAdmin: Story = () => (
-    <WebStory mocks={[empyResponse, searchOwnershipFlagMock]}>
+    <WebStory mocks={[emptyResponse]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnEditPage
-                repo={repo}
-                authenticatedUser={{ siteAdmin: true }}
-                useBreadcrumb={useBreadcrumb}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />
         )}
     </WebStory>
 )
@@ -117,28 +103,18 @@ const populatedResponse: MockedResponse<GetIngestedCodeownersResult, GetIngested
 }
 
 export const PopulatedNonAdmin: Story = () => (
-    <WebStory mocks={[populatedResponse, searchOwnershipFlagMock]}>
+    <WebStory mocks={[populatedResponse]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnEditPage
-                repo={repo}
-                authenticatedUser={{ siteAdmin: false }}
-                useBreadcrumb={useBreadcrumb}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
         )}
     </WebStory>
 )
 PopulatedNonAdmin.storyName = 'Populated (non-admin)'
 
 export const PopulatedAdmin: Story = () => (
-    <WebStory mocks={[populatedResponse, searchOwnershipFlagMock]}>
+    <WebStory mocks={[populatedResponse]}>
         {({ useBreadcrumb }) => (
-            <RepositoryOwnEditPage
-                repo={repo}
-                authenticatedUser={{ siteAdmin: true }}
-                useBreadcrumb={useBreadcrumb}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-            />
+            <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />
         )}
     </WebStory>
 )

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mdiAccount } from '@mdi/js'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H1, Icon, Link, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
@@ -16,7 +17,7 @@ import { RepositoryOwnPageContents } from './RepositoryOwnPageContents'
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'> {
+export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'> | null

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -1,17 +1,14 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { mdiAccount } from '@mdi/js'
-import { Navigate } from 'react-router-dom'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { H1, Icon, Link, LoadingSpinner, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
+import { H1, Icon, Link, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { RepositoryFields } from '../../graphql-operations'
 
 import { RepositoryOwnPageContents } from './RepositoryOwnPageContents'
@@ -19,7 +16,7 @@ import { RepositoryOwnPageContents } from './RepositoryOwnPageContents'
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
+export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'> {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'> | null
@@ -30,30 +27,9 @@ export const RepositoryOwnEditPage: React.FunctionComponent<RepositoryOwnAreaPag
     useBreadcrumb,
     repo,
     authenticatedUser,
-    telemetryService,
 }) => {
     const breadcrumbSetters = useBreadcrumb({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> })
     breadcrumbSetters.useBreadcrumb(EDIT_PAGE_BREADCRUMB)
-
-    const [ownEnabled, status] = useFeatureFlag('search-ownership')
-
-    useEffect(() => {
-        if (status !== 'initial' && ownEnabled) {
-            telemetryService.log('repoPage:ownershipPage:viewed')
-        }
-    }, [status, ownEnabled, telemetryService])
-
-    if (status === 'initial') {
-        return (
-            <div className="container d-flex justify-content-center mt-3">
-                <LoadingSpinner /> Loading...
-            </div>
-        )
-    }
-
-    if (!ownEnabled) {
-        return <Navigate to={repo.url} replace={true} />
-    }
 
     return (
         <Page>

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -1,23 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
 import { mdiAccount, mdiPencil, mdiPlus } from '@mdi/js'
-import { Navigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
-import {
-    Button,
-    H1,
-    Icon,
-    Link,
-    LoadingSpinner,
-    PageHeader,
-    ProductStatusBadge,
-    ButtonLink,
-} from '@sourcegraph/wildcard'
+import { Button, H1, Icon, Link, PageHeader, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
 
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { TreeOwnershipPanel } from '../../repo/blob/own/TreeOwnershipPanel'
 import { FilePathBreadcrumbs } from '../../repo/FilePathBreadcrumbs'
 
@@ -58,7 +48,6 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
 
     useBreadcrumb({ key: 'own', element: 'Ownership' })
 
-    const [ownEnabled, status] = useFeatureFlag('search-ownership')
     const [openAddOwnerModal, setOpenAddOwnerModal] = useState<boolean>(false)
     const onClickAdd = useCallback<React.MouseEventHandler>(event => {
         event.preventDefault()
@@ -67,24 +56,6 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
     const closeModal = useCallback(() => {
         setOpenAddOwnerModal(false)
     }, [])
-
-    useEffect(() => {
-        if (status !== 'initial' && ownEnabled) {
-            telemetryService.log('repoPage:ownershipPage:viewed')
-        }
-    }, [status, ownEnabled, telemetryService])
-
-    if (status === 'initial') {
-        return (
-            <div className="container d-flex justify-content-center mt-3">
-                <LoadingSpinner /> Loading...
-            </div>
-        )
-    }
-
-    if (!ownEnabled) {
-        return <Navigate to={repo.url} replace={true} />
-    }
 
     return (
         <>

--- a/client/web/src/enterprise/own/RepositoryOwnPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { mdiAccount, mdiPencil, mdiPlus } from '@mdi/js'
 import { useSearchParams } from 'react-router-dom'
@@ -57,6 +57,9 @@ export const RepositoryOwnPage: React.FunctionComponent<RepositoryOwnAreaPagePro
         setOpenAddOwnerModal(false)
     }, [])
 
+    useEffect(() => {
+        telemetryService.log('repoPage:ownershipPage:viewed')
+    }, [telemetryService])
     return (
         <>
             <Page>

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -18,7 +18,6 @@ export type FeatureFlagName =
     | 'accessible-file-tree'
     | 'accessible-symbol-tree'
     | 'accessible-file-tree-always-load-ancestors'
-    | 'search-ownership'
     | 'enable-ownership-panels'
     | 'search-ranking'
     | 'blob-page-switch-areas-shortcuts'

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -27,7 +27,6 @@ import {
 } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { useExperimentalQueryInput } from '../search/useExperimentalSearchInput'
 
 import { AppUserConnectDotComAccount } from './AppUserConnectDotComAccount'
@@ -67,7 +66,6 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
 
     const { themeSetting, setThemeSetting } = useTheme()
     const keyboardShortcutSwitchTheme = useKeyboardShortcut('switchTheme')
-    const [enableTeams] = useFeatureFlag('search-ownership')
 
     const supportsSystemTheme = useMemo(
         () => Boolean(window.matchMedia?.('not all and (prefers-color-scheme), (prefers-color-scheme)').matches),
@@ -151,7 +149,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 </MenuLink>
                             )}
                             {isSourcegraphApp && <AppUserConnectDotComAccount />}
-                            {enableTeams && !isSourcegraphDotCom && (
+                            {!isSourcegraphDotCom && (
                                 <MenuLink as={Link} to="/teams">
                                     Teams
                                 </MenuLink>

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -23,7 +23,6 @@ import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
 
 import { BlockProps, QueryBlock } from '../..'
 import { AuthenticatedUser } from '../../../auth'
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { SearchPatternType } from '../../../graphql-operations'
 import { OwnConfigProps } from '../../../own/OwnConfigProps'
 import { submitSearch } from '../../../search/helpers'
@@ -80,8 +79,6 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         const [executedQuery, setExecutedQuery] = useState<string>(input.query)
         const applySuggestionsOnEnter =
             useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-        const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership', false)
-        const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
 
         const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
         const searchMode = useNavbarQueryState(state => state.searchMode)
@@ -200,7 +197,6 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                         <div className={styles.results}>
                             <StreamingSearchResultsList
                                 isSourcegraphDotCom={isSourcegraphDotCom}
-                                enableOwnershipSearch={enableOwnershipSearch}
                                 searchContextsEnabled={searchContextsEnabled}
                                 allExpanded={false}
                                 results={searchResults}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -49,7 +49,6 @@ import { CodeIntelligenceProps } from '../../codeintel'
 import { isCodyEnabled } from '../../cody/isCodyEnabled'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { PageTitle } from '../../components/PageTitle'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import { RepositoryFields } from '../../graphql-operations'
 import { SourcegraphContext } from '../../jscontext'
 import { OwnConfigProps } from '../../own/OwnConfigProps'
@@ -172,8 +171,7 @@ export const TreePage: FC<Props> = ({
         !!settingsCascade.final?.experimentalFeatures?.codeInsights &&
         settingsCascade.final['insights.displayLocation.directory'] === true
 
-    const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership')
-    const showOwnership = ownEnabled && ownFeatureFlagEnabled && !isSourcegraphDotCom
+    const showOwnership = ownEnabled && !isSourcegraphDotCom
 
     // Add DirectoryViewer
     const uri = toURIWithPath({ repoName, commitID, filePath })

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -20,7 +20,6 @@ import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settin
 import { LoadingSpinner, Button, useObservable } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { SearchPatternType } from '../graphql-operations'
 import { OwnConfigProps } from '../own/OwnConfigProps'
 import { setSearchMode, useNavbarQueryState } from '../stores'
@@ -32,10 +31,7 @@ import styles from './SearchConsolePage.module.scss'
 
 interface SearchConsolePageProps
     extends SearchStreamingProps,
-        Omit<
-            StreamingSearchResultsListProps,
-            'allExpanded' | 'executedQuery' | 'showSearchContext' | 'enableOwnershipSearch'
-        >,
+        Omit<StreamingSearchResultsListProps, 'allExpanded' | 'executedQuery' | 'showSearchContext'>,
         OwnConfigProps {
     isMacPlatform: boolean
 }
@@ -43,13 +39,10 @@ interface SearchConsolePageProps
 export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<SearchConsolePageProps>> = props => {
     const location = useLocation()
     const navigate = useNavigate()
-    const { streamSearch, isSourcegraphDotCom, ownEnabled } = props
+    const { streamSearch, isSourcegraphDotCom } = props
     const { applySuggestionsOnEnter } = useExperimentalFeatures(features => ({
         applySuggestionsOnEnter: features.applySearchQuerySuggestionOnEnter ?? true,
     }))
-    const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership', false)
-    const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
-
     const searchQuery = useMemo(
         () => new BehaviorSubject<string>(parseSearchURLQuery(location.search) ?? ''),
         [location.search]
@@ -133,7 +126,6 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
                         ) : (
                             <StreamingSearchResultsList
                                 {...props}
-                                enableOwnershipSearch={enableOwnershipSearch}
                                 allExpanded={false}
                                 results={results}
                                 executedQuery={location.search}

--- a/client/web/src/search/input/ExperimentalSearchInput.tsx
+++ b/client/web/src/search/input/ExperimentalSearchInput.tsx
@@ -21,8 +21,6 @@ import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/util
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
-
 import { createSuggestionsSource, type SuggestionsSourceConfig } from './suggestions'
 import { useRecentSearches } from './useRecentSearches'
 
@@ -68,25 +66,6 @@ const examples: Example[] = [
         valid: tokens => !tokens.some(token => token.type === 'filter' && token.value?.value.startsWith('commit.diff')),
     },
 ]
-
-const ownershipExamples: Example[] = [
-    {
-        label: 'file:has.owner()',
-        snippet: 'file:has.owner(${}) ${}',
-        description: 'Search code ownership',
-        valid: tokens => !tokens.some(token => token.type === 'filter' && token.value?.value.startsWith('has.owner(')),
-    },
-]
-
-function buildExamples(config: { enableOwnershipSearch: boolean }): Example[] {
-    let final = examples
-
-    if (config.enableOwnershipSearch) {
-        final = final.concat(ownershipExamples)
-    }
-
-    return final
-}
 
 function useUsedExamples(): [Set<string>, (value: string) => void] {
     const [usedExamples = [], setUsedExamples] = useTemporarySetting('search.input.usedExamples', [])
@@ -153,8 +132,6 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
         getSearchContextRef.current = () => selectedSearchContextSpec
     }, [selectedSearchContextSpec])
 
-    const [enableOwnershipSearch] = useFeatureFlag('search-ownership')
-
     const editorRef = useRef<Editor | null>(null)
 
     const suggestionSource = useMemo(
@@ -197,11 +174,11 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
                 exampleSuggestions({
                     getUsedExamples: () => usedExamplesRef.current,
                     markExampleUsed: addExample,
-                    examples: buildExamples({ enableOwnershipSearch }),
+                    examples,
                 })
             ),
         ],
-        [telemetryService, addExample, enableOwnershipSearch]
+        [telemetryService, addExample]
     )
 
     return (

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -73,7 +73,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         isSourcegraphDotCom,
         searchAggregationEnabled,
         codeMonitoringEnabled,
-        ownEnabled,
         platformContext,
     } = props
 
@@ -83,8 +82,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
     // Feature flags
     const prefetchFileEnabled = useExperimentalFeatures(features => features.enableSearchFilePrefetch ?? false)
     const [enableSearchResultsKeyboardNavigation] = useFeatureFlag('search-results-keyboard-navigation', true)
-    const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership', false)
-    const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
     const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
     const [sidebarCollapsed, setSidebarCollapsed] = useTemporarySetting('search.sidebar.collapsed', false)
@@ -512,7 +509,6 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
 
                         <StreamingSearchResultsList
                             {...props}
-                            enableOwnershipSearch={enableOwnershipSearch}
                             enableRepositoryMetadata={enableRepositoryMetadata}
                             results={results}
                             allExpanded={allExpanded}

--- a/client/web/src/site-admin/SiteAdminPingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPingsPage.tsx
@@ -393,7 +393,6 @@ export const SiteAdminPingsPage: React.FunctionComponent<React.PropsWithChildren
                     <li>
                         Sourcegraph Own usage data
                         <ul>
-                            <li>Whether the search-ownership feature flag is turned on.</li>
                             <li>
                                 Number and ratio of repositories for which ownership data is available via CODEOWNERS
                                 file or the API.

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.loader.ts
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.loader.ts
@@ -43,8 +43,7 @@ const LAYOUT_PAGE_QUERY = gql`
         # Preload feature flags
         flag1: evaluateFeatureFlag(flagName: "contrast-compliant-syntax-highlighting")
         flag2: evaluateFeatureFlag(flagName: "cody")
-        flag3: evaluateFeatureFlag(flagName: "search-ownership")
-        flag4: evaluateFeatureFlag(flagName: "blob-page-switch-areas-shortcuts")
+        flag3: evaluateFeatureFlag(flagName: "blob-page-switch-areas-shortcuts")
     }
 
     ${siteFlagFieldsFragment}

--- a/client/web/src/storm/pages/SearchPage/SearchPage.loader.ts
+++ b/client/web/src/storm/pages/SearchPage/SearchPage.loader.ts
@@ -20,7 +20,6 @@ const SEARCH_PAGE_QUERY = gql`
             totalCount
         }
         codehostWidgetFlag: evaluateFeatureFlag(flagName: "plg-enable-add-codehost-widget")
-        searchOwnershipFlag: evaluateFeatureFlag(flagName: "search-ownership")
     }
 `
 

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -10,7 +10,6 @@ import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Tooltip } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../../../components/branding/BrandLogo'
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { useLegacyContext_onlyInStormRoutes } from '../../../LegacyRouteContext'
 import { useExperimentalQueryInput } from '../../../search/useExperimentalSearchInput'
 
@@ -29,13 +28,11 @@ interface SearchPageContentProps {
 export const SearchPageContent: FC<SearchPageContentProps> = props => {
     const { shouldShowAddCodeHostWidget } = props
 
-    const { telemetryService, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser, ownEnabled } =
+    const { telemetryService, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser } =
         useLegacyContext_onlyInStormRoutes()
 
     const isLightTheme = useIsLightTheme()
     const [experimentalQueryInput] = useExperimentalQueryInput()
-    const [ownFeatureFlagEnabled] = useFeatureFlag('search-ownership')
-    const enableOwnershipSearch = ownEnabled && ownFeatureFlagEnabled
 
     /** The value entered by the user in the query input */
     const [queryState, setQueryState] = useState<QueryState>({
@@ -106,7 +103,6 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                         queryState={queryState}
                         setQueryState={setQueryState}
                         isSourcegraphDotCom={isSourcegraphDotCom}
-                        enableOwnershipSearch={enableOwnershipSearch}
                     />
                 )}
             </div>

--- a/client/web/src/team/TeamsArea.tsx
+++ b/client/web/src/team/TeamsArea.tsx
@@ -3,13 +3,12 @@ import * as React from 'react'
 import { Routes, Route } from 'react-router-dom'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
-import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
+import { LoadingSpinner } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { withAuthenticatedUser } from '../auth/withAuthenticatedUser'
 import { RouteError } from '../components/ErrorBoundary'
 import { NotFoundPage } from '../components/HeroPage'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
 import type { TeamAreaProps } from './area/TeamArea'
 import type { TeamListPageProps } from './list/TeamListPage'
@@ -31,17 +30,8 @@ export interface Props {
  * Renders a layout of a sidebar and a content area to display team-related pages.
  */
 const AuthenticatedTeamsArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    const [enableTeams, fetchStatus, fetchError] = useFeatureFlag('search-ownership')
-
-    switch (fetchStatus) {
-        case 'initial':
-            return <LoadingSpinner className="m-2" />
-        case 'error':
-            return <ErrorAlert prefix="Failed to load teams feature flag" error={fetchError} />
-    }
-
     // No teams on sourcegraph.com
-    if (!enableTeams || props.isSourcegraphDotCom) {
+    if (props.isSourcegraphDotCom) {
         return <NotFoundPage pageType="team" />
     }
     return (

--- a/cmd/frontend/graphqlbackend/teams.go
+++ b/cmd/frontend/graphqlbackend/teams.go
@@ -17,13 +17,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func teamByID(ctx context.Context, db database.DB, id graphql.ID) (Node, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -383,7 +382,7 @@ type CreateTeamArgs struct {
 }
 
 func (r *schemaResolver) CreateTeam(ctx context.Context, args *CreateTeamArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -433,7 +432,7 @@ type UpdateTeamArgs struct {
 }
 
 func (r *schemaResolver) UpdateTeam(ctx context.Context, args *UpdateTeamArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -541,7 +540,7 @@ type DeleteTeamArgs struct {
 }
 
 func (r *schemaResolver) DeleteTeam(ctx context.Context, args *DeleteTeamArgs) (*EmptyResponse, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -617,7 +616,7 @@ func (t TeamMemberInput) String() string {
 }
 
 func (r *schemaResolver) AddTeamMembers(ctx context.Context, args *TeamMembersArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -670,7 +669,7 @@ func (r *schemaResolver) AddTeamMembers(ctx context.Context, args *TeamMembersAr
 }
 
 func (r *schemaResolver) SetTeamMembers(ctx context.Context, args *TeamMembersArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -758,7 +757,7 @@ func (r *schemaResolver) SetTeamMembers(ctx context.Context, args *TeamMembersAr
 }
 
 func (r *schemaResolver) RemoveTeamMembers(ctx context.Context, args *TeamMembersArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -812,7 +811,7 @@ type QueryTeamsArgs struct {
 }
 
 func (r *schemaResolver) Teams(ctx context.Context, args *QueryTeamsArgs) (*teamConnectionResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 	c := &teamConnectionResolver{db: r.db}
@@ -838,7 +837,7 @@ type TeamArgs struct {
 }
 
 func (r *schemaResolver) Team(ctx context.Context, args *TeamArgs) (*TeamResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -854,7 +853,7 @@ func (r *schemaResolver) Team(ctx context.Context, args *TeamArgs) (*TeamResolve
 }
 
 func (r *UserResolver) Teams(ctx context.Context, args *ListTeamsArgs) (*teamConnectionResolver, error) {
-	if err := areTeamEndpointsAvailable(ctx); err != nil {
+	if err := areTeamEndpointsAvailable(); err != nil {
 		return nil, err
 	}
 
@@ -997,12 +996,9 @@ func extractMembers(members []TeamMemberInput, pred func(member TeamMemberInput)
 
 var ErrNoAccessToTeam = errors.New("user cannot modify team")
 
-func areTeamEndpointsAvailable(ctx context.Context) error {
+func areTeamEndpointsAvailable() error {
 	if envvar.SourcegraphDotComMode() {
 		return errors.New("teams are not available on sourcegraph.com")
-	}
-	if !featureflag.FromContext(ctx).GetBoolOr("search-ownership", false) {
-		return errors.New("teams are not available yet")
 	}
 	return nil
 }

--- a/cmd/frontend/graphqlbackend/teams_test.go
+++ b/cmd/frontend/graphqlbackend/teams_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/fakedb"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -31,7 +30,6 @@ func TestTeamNode(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{Username: "bob", SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
 		t.Fatalf("failed to create fake team: %s", err)
 	}
@@ -74,7 +72,6 @@ func TestTeamNodeURL(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	team := &types.Team{
 		Name: "team-刺身", // team-sashimi
 	}
@@ -106,7 +103,6 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 			db := database.NewMockDB()
 			fs.Wire(db)
 			ctx := userCtx(fs.AddUser(types.User{SiteAdmin: isAdmin}))
-			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 			if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 				t.Fatalf("failed to create fake team: %s", err)
 			}
@@ -144,7 +140,6 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 			fs.Wire(db)
 			userID := fs.AddUser(types.User{SiteAdmin: false})
 			ctx := userCtx(userID)
-			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 			if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 				t.Fatalf("failed to create fake team: %s", err)
 			}
@@ -187,7 +182,6 @@ func TestTeamNodeViewerCanAdminister(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team", CreatorID: userID}); err != nil {
 			t.Fatalf("failed to create fake team: %s", err)
 		}
@@ -225,7 +219,6 @@ func TestCreateTeamBare(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -259,7 +252,6 @@ func TestCreateTeamDisplayName(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -286,7 +278,6 @@ func TestCreateTeamReadOnlyDefault(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -312,7 +303,6 @@ func TestCreateTeamReadOnlyTrue(t *testing.T) {
 		db := database.NewMockDB()
 		fs.Wire(db)
 		ctx := userCtx(fs.AddUser(types.User{SiteAdmin: true}))
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		RunTest(t, &Test{
 			Schema:  mustParseGraphQLSchema(t, db),
 			Context: ctx,
@@ -338,7 +328,6 @@ func TestCreateTeamReadOnlyTrue(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		RunTest(t, &Test{
 			Schema:  mustParseGraphQLSchema(t, db),
 			Context: ctx,
@@ -369,7 +358,6 @@ func TestCreateTeamParentByID(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		_, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 			Name: "team-name-parent",
 		})
@@ -410,7 +398,6 @@ func TestCreateTeamParentByID(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		_, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 			Name:     "team-name-parent",
 			ReadOnly: true,
@@ -456,7 +443,6 @@ func TestCreateTeamParentByName(t *testing.T) {
 	}
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	parentTeam, err := fs.TeamStore.GetTeamByName(ctx, "team-name-parent")
 	if err != nil {
 		t.Fatal(err)
@@ -494,7 +480,6 @@ func TestUpdateTeamByID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
@@ -544,7 +529,6 @@ func TestUpdateTeamByName(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
@@ -594,7 +578,6 @@ func TestUpdateTeamErrorBothNameAndID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{
 		Name:        "team-name-testing",
 		DisplayName: "Display Name",
@@ -637,7 +620,6 @@ func TestUpdateParentByID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
@@ -685,7 +667,6 @@ func TestUpdateParentByName(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
@@ -733,7 +714,6 @@ func TestUpdateParentErrorBothNameAndID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
@@ -775,7 +755,6 @@ func TestUpdateParentCircular(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	parentTeamID := fs.AddTeam(&types.Team{Name: "parent"})
 	fs.AddTeam(&types.Team{Name: "child", ParentTeamID: parentTeamID})
 	RunTest(t, &Test{
@@ -808,7 +787,6 @@ func TestTeamMakeRoot(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	parentTeamID := fs.AddTeam(&types.Team{Name: "parent"})
 	fs.AddTeam(&types.Team{Name: "child", ParentTeamID: parentTeamID})
 	RunTest(t, &Test{
@@ -838,7 +816,6 @@ func TestDeleteTeamByID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
@@ -877,7 +854,6 @@ func TestDeleteTeamByName(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
@@ -916,7 +892,6 @@ func TestDeleteTeamErrorBothIDAndNameGiven(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
@@ -954,7 +929,6 @@ func TestDeleteTeamNoIdentifierGiven(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -981,7 +955,6 @@ func TestDeleteTeamNotFound(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -1011,7 +984,6 @@ func TestDeleteTeamUnauthorized(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	t.Run("non-member", func(t *testing.T) {
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
@@ -1079,7 +1051,6 @@ func TestTeamByName(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create a team: %s", err)
 	}
@@ -1108,7 +1079,6 @@ func TestTeamByNameNotFound(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	RunTest(t, &Test{
 		Schema:  mustParseGraphQLSchema(t, db),
 		Context: ctx,
@@ -1132,7 +1102,6 @@ func TestTeamsPaginated(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for i := 1; i <= 25; i++ {
 		name := fmt.Sprintf("team-%d", i)
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
@@ -1199,7 +1168,6 @@ func TestTeamsNameSearch(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for _, name := range []string{"hit-1", "Hit-2", "HIT-3", "miss-4", "mIss-5", "MISS-6"} {
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
 			t.Fatalf("failed to create a team: %s", err)
@@ -1233,7 +1201,6 @@ func TestTeamsExceptAncestorID(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	parentTeamID := fs.AddTeam(&types.Team{Name: "parent-include"})
 	fs.AddTeam(&types.Team{Name: "child-include", ParentTeamID: parentTeamID})
 	topLevelNotExcluded := fs.AddTeam(&types.Team{Name: "top-level-not-excluded"})
@@ -1325,7 +1292,6 @@ func TestTeamsCount(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	for i := 1; i <= 25; i++ {
 		name := fmt.Sprintf("team-%d", i)
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: name}); err != nil {
@@ -1364,7 +1330,6 @@ func TestChildTeams(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "parent"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
@@ -1418,7 +1383,6 @@ func TestMembersPaginated(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team-with-members"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
@@ -1515,7 +1479,6 @@ func TestMembersSearch(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: false})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create parent team: %s", err)
 	}
@@ -1576,7 +1539,6 @@ func TestMembersAdd(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: true})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create team: %s", err)
 		}
@@ -1631,7 +1593,6 @@ func TestMembersAdd(t *testing.T) {
 		fs.Wire(db)
 		userID := fs.AddUser(types.User{SiteAdmin: false})
 		ctx := userCtx(userID)
-		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 		if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 			t.Fatalf("failed to create team: %s", err)
 		}
@@ -1666,7 +1627,6 @@ func TestMembersRemove(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
@@ -1726,7 +1686,6 @@ func TestMembersSet(t *testing.T) {
 	fs.Wire(db)
 	userID := fs.AddUser(types.User{SiteAdmin: true})
 	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	if _, err := fs.TeamStore.CreateTeam(ctx, &types.Team{Name: "team"}); err != nil {
 		t.Fatalf("failed to create team: %s", err)
 	}
@@ -1779,32 +1738,6 @@ func TestMembersSet(t *testing.T) {
 			"r2": string(relay.MarshalID("User", setIDs[1])),
 			"r3": string(relay.MarshalID("User", setIDs[2])),
 			"r4": string(relay.MarshalID("User", setIDs[3])),
-		},
-	})
-}
-
-func TestTeamsDisabled(t *testing.T) {
-	fs := fakedb.New()
-	db := database.NewMockDB()
-	fs.Wire(db)
-	userID := fs.AddUser(types.User{SiteAdmin: false})
-	ctx := userCtx(userID)
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": false}, nil, nil))
-	RunTest(t, &Test{
-		Schema:  mustParseGraphQLSchema(t, db),
-		Context: ctx,
-		Query: `query TeamByID($id: ID!){
-			node(id: $id) {
-				__typename
-				... on Team {
-				  name
-				}
-			}
-		}`,
-		ExpectedResult: `{"node": null}`,
-		ExpectedErrors: []*gqlerrors.QueryError{{Message: "teams are not available yet", Path: []any{"node"}}},
-		Variables: map[string]any{
-			"id": "VGVhbTox",
 		},
 	})
 }

--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -191,7 +191,6 @@ Sourcegraph aggregates usage and performance metrics for some product features i
     - Count interactions with the go imports search query transformation feature
     - Count of unique users who interacted with the go imports search query transformation feature
 - Sourcegraph Own usage data
-  - Whether the `search-ownership` feature flag is turned on.
   - Number and ratio of repositories for which ownership data is available via CODEOWNERS file or the API.
   - Number of owners assigned through Own.
   <!-- - Aggregate monthly weekly and daily active users for the following activities: -->

--- a/doc/own/codeowners_ingestion.md
+++ b/doc/own/codeowners_ingestion.md
@@ -1,8 +1,8 @@
 ## Codeowners ingestion
 
-<aside class="experimental">
+<aside class="beta">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change in the future.
+<span class="badge badge-beta">Beta</span> This feature is currently in beta.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>

--- a/doc/own/index.md
+++ b/doc/own/index.md
@@ -1,24 +1,24 @@
 # Sourcegraph Own
 
-<aside class="experimental">
+<aside class="beta">
 <p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change in the future.
+<span class="badge badge-beta">Beta</span> This feature is currently in beta.
 </p>
 
 <p><b>We're very much looking for input and feedback on this feature.</b> You can either <a href="https://about.sourcegraph.com/contact">contact us directly</a>, <a href="https://github.com/sourcegraph/sourcegraph">file an issue</a>, or <a href="https://twitter.com/sourcegraph">tweet at us</a>.</p>
 </aside>
 
-Sourcegraph Own is a new, experimental product aimed at helping find the right person and team to contact, for any question, at any time. We are starting out with code ownership, and are exploring ways to help you find someone to answer _every_ question.
+Sourcegraph Own is a new product aimed at helping find the right person and team to contact, for any question, at any time. We are starting out with code ownership, ownership inference and assignments and are exploring ways to help you find someone to answer _every_ question.
 
 ## Enabling Sourcegraph Own
 
-As an experimental feature, Sourcegraph Own is disabled by default. If you like to try it, a site-admin can enable the feature flag `search-ownership`:
+Sourcegraph Own is enabled by default. If you like to disable it from being shown in the UI, you can create the feature flag `enable-ownership-panels` and set it to `false`:
 
 - Go to **Site-admin > Feature flags**
-- If the feature flag `search-ownership` doesn't yet exist, click **Create feature flag**
-- Under **Name**, put `search-ownership`
+- If the feature flag `enable-ownership-panels` doesn't yet exist, click **Create feature flag**
+- Under **Name**, put `enable-ownership-panels`
 - For **Type** select **Boolean**
-- And set **Value** to **True**
+- And set **Value** to **False**
 - Click **Create flag**
 
 ## Concepts

--- a/enterprise/cmd/frontend/internal/own/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/own/resolvers/BUILD.bazel
@@ -69,7 +69,6 @@ go_test(
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/database/fakedb",
-        "//internal/featureflag",
         "//internal/gitserver",
         "//internal/rbac/types",
         "//internal/types",

--- a/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/codeowners_resolvers.go
@@ -35,7 +35,7 @@ var (
 )
 
 func (r *ownResolver) AddCodeownersFile(ctx context.Context, args *graphqlbackend.CodeownersFileArgs) (graphqlbackend.CodeownersIngestedFileResolver, error) {
-	if err := isIngestionAvailable(ctx); err != nil {
+	if err := isIngestionAvailable(); err != nil {
 		return nil, err
 	}
 	if err := r.viewerCanAdminister(ctx); err != nil {
@@ -68,7 +68,7 @@ func (r *ownResolver) AddCodeownersFile(ctx context.Context, args *graphqlbacken
 }
 
 func (r *ownResolver) UpdateCodeownersFile(ctx context.Context, args *graphqlbackend.CodeownersFileArgs) (graphqlbackend.CodeownersIngestedFileResolver, error) {
-	if err := isIngestionAvailable(ctx); err != nil {
+	if err := isIngestionAvailable(); err != nil {
 		return nil, err
 	}
 	if err := r.viewerCanAdminister(ctx); err != nil {
@@ -130,7 +130,7 @@ func (r *ownResolver) getRepo(ctx context.Context, input graphqlbackend.Codeowne
 }
 
 func (r *ownResolver) DeleteCodeownersFiles(ctx context.Context, args *graphqlbackend.DeleteCodeownersFileArgs) (*graphqlbackend.EmptyResponse, error) {
-	if err := isIngestionAvailable(ctx); err != nil {
+	if err := isIngestionAvailable(); err != nil {
 		return nil, err
 	}
 	if err := r.viewerCanAdminister(ctx); err != nil {
@@ -175,7 +175,7 @@ func (r *ownResolver) logBackendEvent(ctx context.Context, eventName string) {
 }
 
 func (r *ownResolver) CodeownersIngestedFiles(ctx context.Context, args *graphqlbackend.CodeownersIngestedFilesArgs) (graphqlbackend.CodeownersIngestedFileConnectionResolver, error) {
-	if err := isIngestionAvailable(ctx); err != nil {
+	if err := isIngestionAvailable(); err != nil {
 		return nil, err
 	}
 	if err := r.viewerCanAdminister(ctx); err != nil {
@@ -203,7 +203,7 @@ func (r *ownResolver) CodeownersIngestedFiles(ctx context.Context, args *graphql
 func (r *ownResolver) RepoIngestedCodeowners(ctx context.Context, repoID api.RepoID) (graphqlbackend.CodeownersIngestedFileResolver, error) {
 	// This endpoint is open to anyone.
 	// The repository store makes sure the viewer has access to the repository.
-	if err := isIngestionAvailable(ctx); err != nil {
+	if err := isIngestionAvailable(); err != nil {
 		return nil, err
 	}
 	repo, err := r.db.Repos().Get(ctx, repoID)
@@ -311,11 +311,11 @@ func (r *codeownersIngestedFileConnectionResolver) PageInfo(ctx context.Context)
 	return r.pageInfo, r.err
 }
 
-func isIngestionAvailable(ctx context.Context) error {
+func isIngestionAvailable() error {
 	if envvar.SourcegraphDotComMode() {
 		return errors.New("codeownership ingestion is not available on sourcegraph.com")
 	}
-	return areOwnEndpointsAvailable(ctx)
+	return nil
 }
 
 func (r *ownResolver) viewerCanAdminister(ctx context.Context) error {

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/fakedb"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -171,7 +170,6 @@ func TestBlobOwnershipPanelQueryPersonUnresolved(t *testing.T) {
 			}),
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
@@ -289,7 +287,6 @@ func TestBlobOwnershipPanelQueryIngested(t *testing.T) {
 			}),
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
@@ -388,7 +385,6 @@ func TestBlobOwnershipPanelQueryTeamResolved(t *testing.T) {
 	db.OwnSignalConfigurationsFunc.SetDefaultReturn(database.NewMockSignalConfigurationStore())
 	own := own.NewService(git, db)
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(repo, nil)
@@ -476,7 +472,6 @@ func TestBlobOwnershipPanelQueryExternalTeamResolved(t *testing.T) {
 	db.OwnSignalConfigurationsFunc.SetDefaultReturn(database.NewMockSignalConfigurationStore())
 	own := own.NewService(git, db)
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(repo, nil)
@@ -700,7 +695,6 @@ func TestOwnershipPagination(t *testing.T) {
 			}),
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
@@ -818,7 +812,6 @@ func TestOwnership_WithSignals(t *testing.T) {
 			}),
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{Username: santaName, DisplayName: santaName, SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
@@ -992,7 +985,6 @@ func TestTreeOwnershipSignals(t *testing.T) {
 			}),
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{Username: santaName, DisplayName: santaName, SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
@@ -1188,7 +1180,6 @@ func TestCommitOwnershipSignals(t *testing.T) {
 	repoID := api.RepoID(1)
 
 	ctx := userCtx(fakeDB.AddUser(types.User{SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)
@@ -1467,7 +1458,6 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 		},
 	}
 	ctx := userCtx(fakeDB.AddUser(types.User{Username: santaName, DisplayName: santaName, SiteAdmin: true}))
-	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"search-ownership": true}, nil, nil))
 	repos := database.NewMockRepoStore()
 	db.ReposFunc.SetDefaultReturn(repos)
 	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: repoID, Name: "github.com/sourcegraph/own"}, nil)

--- a/enterprise/internal/own/search/BUILD.bazel
+++ b/enterprise/internal/own/search/BUILD.bazel
@@ -51,6 +51,5 @@ go_test(
         "//internal/types",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/enterprise/internal/own/search/filter_job.go
+++ b/enterprise/internal/own/search/filter_job.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -17,35 +16,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type featureFlagError struct {
-	predicate string
-}
-
-func (e *featureFlagError) Error() string {
-	return fmt.Sprintf("`%s` searches are not enabled on this instance. <a href=\"/help/own\">Learn more about Own.</a>", e.predicate)
-}
-
-func NewFileHasOwnersJob(child job.Job, features *search.Features, includeOwners, excludeOwners []string) job.Job {
+func NewFileHasOwnersJob(child job.Job, includeOwners, excludeOwners []string) job.Job {
 	return &fileHasOwnersJob{
 		child:         child,
-		features:      features,
 		includeOwners: includeOwners,
 		excludeOwners: excludeOwners,
 	}
 }
 
 type fileHasOwnersJob struct {
-	child    job.Job
-	features *search.Features
+	child job.Job
 
 	includeOwners []string
 	excludeOwners []string
 }
 
 func (s *fileHasOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	if s.features == nil || !s.features.CodeOwnershipSearch {
-		return nil, &featureFlagError{predicate: "file:has.owner()"}
-	}
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer finish(alert, err)
 

--- a/enterprise/internal/own/search/filter_job_test.go
+++ b/enterprise/internal/own/search/filter_job_test.go
@@ -7,38 +7,15 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/own"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func TestFeatureFlaggedFileHasOwnerJob(t *testing.T) {
-	// We can run a quick exit check on the job runner since we don't need to use any clients or sender.
-	t.Run("does not run if no features attached to job", func(t *testing.T) {
-		selectJob := NewFileHasOwnersJob(nil, nil, nil, nil)
-		alert, err := selectJob.Run(context.Background(), job.RuntimeClients{}, nil)
-		require.Nil(t, alert)
-		var expectedErr *featureFlagError
-		assert.ErrorAs(t, err, &expectedErr)
-	})
-	t.Run("does not run if own feature is false", func(t *testing.T) {
-		selectJob := NewFileHasOwnersJob(nil, &search.Features{CodeOwnershipSearch: false}, nil, nil)
-		alert, err := selectJob.Run(context.Background(), job.RuntimeClients{}, nil)
-		require.Nil(t, alert)
-		var expectedErr *featureFlagError
-		assert.ErrorAs(t, err, &expectedErr)
-	})
-}
 
 func TestApplyCodeOwnershipFiltering(t *testing.T) {
 	type args struct {

--- a/enterprise/internal/own/search/select_job.go
+++ b/enterprise/internal/own/search/select_job.go
@@ -16,24 +16,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func NewSelectOwnersJob(child job.Job, features *search.Features) job.Job {
+func NewSelectOwnersJob(child job.Job) job.Job {
 	return &selectOwnersJob{
-		child:    child,
-		features: features,
+		child: child,
 	}
 }
 
 type selectOwnersJob struct {
 	child job.Job
-
-	features *search.Features
 }
 
 func (s *selectOwnersJob) Run(ctx context.Context, clients job.RuntimeClients, stream streaming.Sender) (alert *search.Alert, err error) {
-	if s.features == nil || !s.features.CodeOwnershipSearch {
-		return nil, &featureFlagError{predicate: "select:file.owners"}
-	}
-
 	_, ctx, stream, finish := job.StartSpan(ctx, stream, s)
 	defer finish(alert, err)
 

--- a/enterprise/internal/own/search/select_job_test.go
+++ b/enterprise/internal/own/search/select_job_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	edb "github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -22,25 +19,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/assert"
 )
-
-func TestFeatureFlaggedSelectOwnerJob(t *testing.T) {
-	// We can run a quick exit check on the job runner since we don't need to use any clients or sender.
-	t.Run("does not run if no features attached to job", func(t *testing.T) {
-		selectJob := NewSelectOwnersJob(nil, nil)
-		alert, err := selectJob.Run(context.Background(), job.RuntimeClients{}, nil)
-		require.Nil(t, alert)
-		var expectedErr *featureFlagError
-		assert.ErrorAs(t, err, &expectedErr)
-	})
-	t.Run("does not run if own feature is false", func(t *testing.T) {
-		selectJob := NewSelectOwnersJob(nil, &search.Features{CodeOwnershipSearch: false})
-		alert, err := selectJob.Run(context.Background(), job.RuntimeClients{}, nil)
-		require.Nil(t, alert)
-		var expectedErr *featureFlagError
-		assert.ErrorAs(t, err, &expectedErr)
-	})
-}
 
 func TestGetCodeOwnersFromMatches(t *testing.T) {
 	setupDB := func() *edb.MockEnterpriseDB {
@@ -178,8 +158,7 @@ func TestGetCodeOwnersFromMatches(t *testing.T) {
 			return nil, nil
 		})
 		j := &selectOwnersJob{
-			child:    mockJob,
-			features: &search.Features{CodeOwnershipSearch: true},
+			child: mockJob,
 		}
 		clients := job.RuntimeClients{
 			Gitserver: gitserverClient,

--- a/enterprise/internal/search/BUILD.bazel
+++ b/enterprise/internal/search/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/own/search",
-        "//internal/search",
         "//internal/search/job",
         "//internal/search/job/jobutil",
     ],

--- a/enterprise/internal/search/jobs.go
+++ b/enterprise/internal/search/jobs.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	ownsearch "github.com/sourcegraph/sourcegraph/enterprise/internal/own/search"
-	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 )
@@ -13,10 +12,10 @@ func NewEnterpriseSearchJobs() jobutil.EnterpriseJobs {
 
 type enterpriseJobs struct{}
 
-func (e *enterpriseJobs) FileHasOwnerJob(child job.Job, features *search.Features, includeOwners, excludeOwners []string) job.Job {
-	return ownsearch.NewFileHasOwnersJob(child, features, includeOwners, excludeOwners)
+func (e *enterpriseJobs) FileHasOwnerJob(child job.Job, includeOwners, excludeOwners []string) job.Job {
+	return ownsearch.NewFileHasOwnersJob(child, includeOwners, excludeOwners)
 }
 
-func (e *enterpriseJobs) SelectFileOwnerJob(child job.Job, features *search.Features) job.Job {
-	return ownsearch.NewSelectOwnersJob(child, features)
+func (e *enterpriseJobs) SelectFileOwnerJob(child job.Job) job.Job {
+	return ownsearch.NewSelectOwnersJob(child)
 }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -311,7 +311,6 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
-		CodeOwnershipSearch:     flagSet.GetBoolOr("search-ownership", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", true), // can remove flag in 4.5
 		Ranking:                 flagSet.GetBoolOr("search-ranking", true),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),

--- a/internal/search/job/jobutil/enterprise.go
+++ b/internal/search/job/jobutil/enterprise.go
@@ -12,8 +12,8 @@ import (
 )
 
 type EnterpriseJobs interface {
-	FileHasOwnerJob(child job.Job, features *search.Features, includeOwners, excludeOwners []string) job.Job
-	SelectFileOwnerJob(child job.Job, features *search.Features) job.Job
+	FileHasOwnerJob(child job.Job, includeOwners, excludeOwners []string) job.Job
+	SelectFileOwnerJob(child job.Job) job.Job
 }
 
 func NewUnimplementedEnterpriseJobs() EnterpriseJobs {
@@ -22,11 +22,11 @@ func NewUnimplementedEnterpriseJobs() EnterpriseJobs {
 
 type enterpriseJobs struct{}
 
-func (e *enterpriseJobs) FileHasOwnerJob(child job.Job, features *search.Features, includeOwners, excludeOwners []string) job.Job {
+func (e *enterpriseJobs) FileHasOwnerJob(_ job.Job, includeOwners, excludeOwners []string) job.Job {
 	return NewUnimplementedJob("`file:has.owner` searches are not available on this instance")
 }
 
-func (e *enterpriseJobs) SelectFileOwnerJob(child job.Job, features *search.Features) job.Job {
+func (e *enterpriseJobs) SelectFileOwnerJob(_ job.Job) job.Job {
 	return NewUnimplementedJob("`select:file.owners` searches are not available on this instance")
 }
 

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -198,7 +198,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 
 	{ // Apply code ownership post-search filter
 		if includeOwners, excludeOwners, ok := isOwnershipSearch(b); ok {
-			basicJob = enterpriseJobs.FileHasOwnerJob(basicJob, inputs.Features, includeOwners, excludeOwners)
+			basicJob = enterpriseJobs.FileHasOwnerJob(basicJob, includeOwners, excludeOwners)
 		}
 	}
 
@@ -222,7 +222,7 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic, enterpriseJobs Enterprise
 			sp, _ := filter.SelectPathFromString(v) // Invariant: select already validated
 			if isSelectOwnersSearch(sp) {
 				// the select owners job is ran separately as it requires state and can return multiple owners from one match.
-				basicJob = enterpriseJobs.SelectFileOwnerJob(basicJob, inputs.Features)
+				basicJob = enterpriseJobs.SelectFileOwnerJob(basicJob)
 			} else {
 				basicJob = NewSelectJob(sp, basicJob)
 			}

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -145,7 +145,7 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 				clients.Logger.Warn("Could not log search latency", log.Error(err))
 			}
 
-			if _, _, ok := isOwnershipSearch(q); ok && l.inputs.Features.CodeOwnershipSearch {
+			if _, _, ok := isOwnershipSearch(q); ok {
 				err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "FileHasOwnerSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
 				if err != nil {
 					clients.Logger.Warn("Could not log use of file:has.owners", log.Error(err))
@@ -153,7 +153,7 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 			}
 
 			if v, _ := q.ToParseTree().StringValue(query.FieldSelect); v != "" {
-				if sp, err := filter.SelectPathFromString(v); err == nil && isSelectOwnersSearch(sp) && l.inputs.Features.CodeOwnershipSearch {
+				if sp, err := filter.SelectPathFromString(v); err == nil && isSelectOwnersSearch(sp) {
 					err := usagestats.LogBackendEvent(clients.DB, a.UID, deviceid.FromContext(ctx), "SelectFileOwnersSearch", nil, nil, featureflag.GetEvaluatedFlagSet(ctx), nil)
 					if err != nil {
 						clients.Logger.Warn("Could not log use of select:file.owners", log.Error(err))

--- a/internal/search/job/jobutil/log_job_test.go
+++ b/internal/search/job/jobutil/log_job_test.go
@@ -58,10 +58,7 @@ func TestOwnSearchEventNames(t *testing.T) {
 				PatternType:         query.SearchTypeLiteral,
 				Protocol:            search.Streaming,
 				OnSourcegraphDotCom: true,
-				Features: &search.Features{
-					CodeOwnershipSearch: true,
-				},
-				Query: q,
+				Query:               q,
 			}
 			db := database.NewMockDB()
 			eventStore := &fakeEventLogStore{}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -412,10 +412,6 @@ type Features struct {
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.
 	Debug bool `json:"debug"`
-
-	// CodeOwnershipSearch when true will enable searching through code ownership
-	// using `file:has.owner({owner})` and `select:file.owners` filters.
-	CodeOwnershipSearch bool `json:"codeownership"`
 }
 
 func (f *Features) String() string {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1832,9 +1832,6 @@ type NotebooksUsageStatistics struct {
 }
 
 type OwnershipUsageStatistics struct {
-	// Whether the `search-ownership` feature flag is on anywhere on the instance.
-	FeatureFlagOn *bool `json:"feature_flag_on,omitempty"`
-
 	// Statistics about ownership data in repositories
 	ReposCount *OwnershipUsageReposCounts `json:"repos_count,omitempty"`
 

--- a/internal/usagestats/own.go
+++ b/internal/usagestats/own.go
@@ -2,7 +2,6 @@ package usagestats
 
 import (
 	"context"
-	"database/sql"
 	_ "embed"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -33,15 +32,6 @@ func GetOwnershipUsageStats(ctx context.Context, db database.DB) (*types.Ownersh
 		// computationally intensive (get all repos and query gitserver for each).
 		// This will become very easy once we have versioned CODEOWNERS in the database.
 	}
-	featureFlagOn := false
-	ff, err := db.FeatureFlags().GetFeatureFlag(ctx, "search-ownership")
-	if err != nil && err != sql.ErrNoRows {
-		return nil, err
-	}
-	if err != sql.ErrNoRows {
-		featureFlagOn = ff.Bool.Value
-	}
-	stats.FeatureFlagOn = &featureFlagOn
 	activity, err := db.EventLogs().OwnershipFeatureActivity(ctx, timeNow(),
 		selectFileOwnersEventName,
 		fileHasOwnerEventName,

--- a/internal/usagestats/own_test.go
+++ b/internal/usagestats/own_test.go
@@ -138,57 +138,6 @@ func TestGetOwnershipUsageStatsReposCountStatsNotCompacted(t *testing.T) {
 	}
 }
 
-func TestGetOwnershipUsageStatsFeatureFlagOn(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
-	if _, err := db.FeatureFlags().CreateBool(ctx, "search-ownership", true); err != nil {
-		t.Fatal(err)
-	}
-	stats, err := GetOwnershipUsageStats(ctx, db)
-	if err != nil {
-		t.Fatalf("GetOwnershipUsageStats err: %s", err)
-	}
-	want := true
-	if diff := cmp.Diff(&want, stats.FeatureFlagOn); diff != "" {
-		t.Errorf("GetOwnershipFeatureFlagOn, -want+got: %s", diff)
-	}
-}
-
-func TestGetOwnershipUsageStatsFeatureFlagOff(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
-	if _, err := db.FeatureFlags().CreateBool(ctx, "search-ownership", false); err != nil {
-		t.Fatal(err)
-	}
-	stats, err := GetOwnershipUsageStats(ctx, db)
-	if err != nil {
-		t.Fatalf("GetOwnershipUsageStats err: %s", err)
-	}
-	want := false
-	if diff := cmp.Diff(&want, stats.FeatureFlagOn); diff != "" {
-		t.Errorf("GetOwnershipFeatureFlagOn, -want+got: %s", diff)
-	}
-}
-
-func TestGetOwnershipUsageStatsFeatureFlagAbsent(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
-	ctx := context.Background()
-	stats, err := GetOwnershipUsageStats(ctx, db)
-	if err != nil {
-		t.Fatalf("GetOwnershipUsageStats err: %s", err)
-	}
-	want := false
-	if diff := cmp.Diff(&want, stats.FeatureFlagOn); diff != "" {
-		t.Errorf("GetOwnershipFeatureFlagOn, -want+got: %s", diff)
-	}
-}
-
 func TestGetOwnershipUsageStatsAggregatedStats(t *testing.T) {
 	// Not parallel as we're replacing timeNow.
 	now := time.Date(2020, 10, 13, 12, 0, 0, 0, time.UTC) // Tuesday


### PR DESCRIPTION
### Own is enabled by default!
### Run sg locally from this branch if you can, just in case.

Test plan:
Local sg run and tests that Own still works.

Closes https://github.com/sourcegraph/sourcegraph/issues/53554