### PR TITLE
JetBrains: Fixed: filter out zero-width spaces from inline autocomplete

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Fixed line breaks in the chat ui [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
 - Reset prompt input on message send [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
 - Fixed UI of the prompt input [#53548](https://github.com/sourcegraph/sourcegraph/pull/53548)
+- Fixed zero-width spaces popping up in inline autocomplete [#53599](https://github.com/sourcegraph/sourcegraph/pull/53599)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -141,6 +141,7 @@ public class CodyCompletionsManager {
               // TODO: smarter logic around selecting the best completion item.
               Optional<InlineCompletionItem> maybeItem =
                   result.items.stream()
+                      .map(CodyCompletionsManager::removeUndesiredCharacters)
                       .map(
                           resultItem ->
                               postProcessInlineCompletionBasedOnDocumentContext(
@@ -165,6 +166,14 @@ public class CodyCompletionsManager {
                 e.printStackTrace();
               }
             });
+  }
+
+  public static InlineCompletionItem removeUndesiredCharacters(InlineCompletionItem item) {
+    String newInsertText = item.insertText.replaceAll("\u200b", ""); // no zero-width spaces, pls
+    int rangeDiff = item.insertText.length() - newInsertText.length();
+    Range newRange =
+        item.range.withEnd(item.range.end.withCharacter(item.range.end.character - rangeDiff));
+    return item.withRange(newRange).withInsertText(newInsertText);
   }
 
   private boolean isProjectAvailable(Project project) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -169,7 +169,8 @@ public class CodyCompletionsManager {
   }
 
   public static InlineCompletionItem removeUndesiredCharacters(InlineCompletionItem item) {
-    String newInsertText = item.insertText.replaceAll("\u200b", ""); // no zero-width spaces, pls
+    // no zero-width spaces or line separator chars, pls
+    String newInsertText = item.insertText.replaceAll("[\u200b\u2028]", "");
     int rangeDiff = item.insertText.length() - newInsertText.length();
     Range newRange =
         item.range.withEnd(item.range.end.withCharacter(item.range.end.character - rangeDiff));

--- a/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
+++ b/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
@@ -72,4 +72,18 @@ public class InlineCompletionsPostProcessingTest {
         outputCompletion.range,
         inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(7)));
   }
+
+  @Test
+  public void completionContainsLineSeparatorChar() {
+    String suggestionText = "\u2028 \u2028world!\u2028";
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 10));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.removeUndesiredCharacters(inputCompletion);
+    assertEquals(outputCompletion.insertText, " world!");
+    assertEquals(
+        outputCompletion.range,
+        inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(7)));
+  }
 }

--- a/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
+++ b/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
@@ -58,4 +58,18 @@ public class InlineCompletionsPostProcessingTest {
         outputCompletion.range,
         inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(6)));
   }
+
+  @Test
+  public void completionContainsZeroWidthSpaces() {
+    String suggestionText = "\u200b \u200bworld!\u200b";
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 10));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.removeUndesiredCharacters(inputCompletion);
+    assertEquals(outputCompletion.insertText, " world!");
+    assertEquals(
+        outputCompletion.range,
+        inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(7)));
+  }
 }


### PR DESCRIPTION
Fixes #53595 

Cody was returning completions with zero-width spaces for whatever reason.
I just filter them out.

## Test plan
Included a unit test.
Can double check if the bug is still replicable.
