### PR TITLE
cody: document embeddings policies

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -155,3 +155,21 @@ Embeddings can currently be disabled, even with Cody enabled, using the followin
   "embeddings": { "enabled": false }
 }
 ```
+
+### Configuring global policy match limit
+
+By default, a global policy, that means an embeddings policy without a pattern, is applied to up to 5000 repositories. 
+The repositories matching the policy are first sorted by star count (descending) and id (descending) and then the first 5000 repositories are selected.
+You can configure the limit by setting the `policyRepositoryMatchLimit` property in the embeddings configuration.
+
+A negative value disables the limit and all repositories are selected.
+
+```json
+{
+  // [...]
+  "embeddings": {
+    // [...]
+    "policyRepositoryMatchLimit": 5000
+  }
+}
+```

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -156,7 +156,7 @@ Embeddings can currently be disabled, even with Cody enabled, using the followin
 }
 ```
 
-### Configuring global policy match limit
+### Configuring the global policy match limit
 
 By default, a global policy, that means an embeddings policy without a pattern, is applied to up to 5000 repositories. 
 The repositories matching the policy are first sorted by star count (descending) and id (descending) and then the first 5000 repositories are selected.

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -5,4 +5,4 @@
 - [Installing the Cody VS Code Extension](installing_vs_code.md)
 - [Configuring code graph context](code_graph_context.md)
 - [Generating Index to Enable Codebase-Aware Answers](indexing.md)
-- [Auto-indexing](policy.md)
+- [Auto-indexing](policies.md)

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -5,3 +5,4 @@
 - [Installing the Cody VS Code Extension](installing_vs_code.md)
 - [Configuring code graph context](code_graph_context.md)
 - [Generating Index to Enable Codebase-Aware Answers](indexing.md)
+- [Auto-indexing](policy.md)

--- a/doc/cody/explanations/policies.md
+++ b/doc/cody/explanations/policies.md
@@ -13,10 +13,10 @@ Open the _Site Admin_ page and select **Cody > Embedding Policies** from the lef
 
 The page shows a list of all existing embedding policies.
 Click the **Create new global policy** button to create a new policy.
+Provide a descriptive name for the policy and click on **Add repository pattern** to define a pattern.
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/new-policy-create.png" class="screenshot" alt="Create new global policy">
 
-Provide a descriptive name for the policy and click on **Add repository pattern** to define a pattern.
 The pattern matches exactly, unless you use an asterisk _*_ to match any sequence of characters.
 The policy will be applied to all repositories that match the pattern.
 If you choose not to define a pattern, the policy will be applied to up to [embeddings.policyRepositoryMatchLimit](./code_graph_context.md#configuring-global-policy-match-limit) repositories.
@@ -35,7 +35,7 @@ A repository cannot be queued for indexing if
 
 - it is already queued or being processed
 - a job for the same repository and the same revision already completed successfully
-- if another job has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window
+- if another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window
 
 All embeddings jobs are listed under **Cody > Embeddings Jobs**
 

--- a/doc/cody/explanations/policies.md
+++ b/doc/cody/explanations/policies.md
@@ -19,7 +19,7 @@ Provide a descriptive name for the policy and click on **Add repository pattern*
 
 The pattern matches exactly, unless you use an asterisk _*_ to match any sequence of characters.
 The policy will be applied to all repositories that match the pattern.
-If you choose not to define a pattern, the policy will be applied to up to [embeddings.policyRepositoryMatchLimit](./code_graph_context.md#configuring-global-policy-match-limit) repositories.
+If you choose not to define a pattern, the policy will be applied to up to [embeddings.policyRepositoryMatchLimit](./code_graph_context.md#configuring-the-global-policy-match-limit) repositories.
 Finally, click on **Create policy**.
 The new policy will be shown in the list of policies.
 

--- a/doc/cody/explanations/policies.md
+++ b/doc/cody/explanations/policies.md
@@ -31,7 +31,7 @@ Once a policy has been created, it is active.
 To deactivate a policy, simply delete it.
 A worker process periodically checks the embeddings policies and resolves them into a list of repositories to index.
 Another worker then creates a new index job for each repository and queues it for processing.
-A repository cannot be queued for indexing if
+A repository cannot be queued for processing if
 
 - it is already queued or being processed
 - a job for the same repository and the same revision already completed successfully

--- a/doc/cody/explanations/policy.md
+++ b/doc/cody/explanations/policy.md
@@ -9,12 +9,12 @@ Embedding policies define which repositories are automatically scheduled for emb
 Policies are created by administrators from the _Site Admin_ page.
 Open the _Site Admin_ page and select **Cody > Embedding Policies** from the left-hand navigation menu.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/embeddings-policies.png" class="screenshot" alt="Embedding policies page">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/embedding-policies.png" class="screenshot" alt="Embedding policies page">
 
 The page shows a list of all existing embedding policies.
 Click the **Create new global policy** button to create a new policy.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/new-policy-create.png" class="screenshot" alt="Create new global policy">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/new-policy-create.png" class="screenshot" alt="Create new global policy">
 
 Provide a descriptive name for the policy and click on **Add repository pattern** to define a pattern.
 The pattern matches exactly, unless you use an asterisk _*_ to match any sequence of characters.
@@ -23,7 +23,7 @@ If you choose not to define a pattern, the policy will be applied to up to [embe
 Finally, click on **Create policy**.
 The new policy will be shown in the list of policies.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/new-policy-saved.png" class="screenshot" alt="policy-saved">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/new-policy-saved.png" class="screenshot" alt="policy-saved">
 
 ## Lifecycle of an embeddings policy
 
@@ -39,4 +39,4 @@ A repository cannot be queued for indexing if
 
 All embeddings jobs are listed under **Cody > Embeddings Jobs**
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/embeddings-jobs.png" class="screenshot" alt="policy-saved">
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/embeddings-jobs.png" class="screenshot" alt="policy-saved">

--- a/doc/cody/explanations/policy.md
+++ b/doc/cody/explanations/policy.md
@@ -1,0 +1,42 @@
+# Auto-indexing
+
+## Embeddings Policies
+
+Embedding policies define which repositories are automatically scheduled for embedding.
+
+## How to create an embeddings policy
+
+Policies are created by administrators from the _Site Admin_ page.
+Open the _Site Admin_ page and select **Cody > Embedding Policies** from the left-hand navigation menu.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/embeddings-policies.png" class="screenshot" alt="Embedding policies page">
+
+The page shows a list of all existing embedding policies.
+Click the **Create new global policy** button to create a new policy.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/new-policy-create.png" class="screenshot" alt="Create new global policy">
+
+Provide a descriptive name for the policy and click on **Add repository pattern** to define a pattern.
+The pattern matches exactly, unless you use an asterisk _*_ to match any sequence of characters.
+The policy will be applied to all repositories that match the pattern.
+If you choose not to define a pattern, the policy will be applied to up to [embeddings.policyRepositoryMatchLimit](./code_graph_context.md#configuring-global-policy-match-limit) repositories.
+Finally, click on **Create policy**.
+The new policy will be shown in the list of policies.
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/new-policy-saved.png" class="screenshot" alt="policy-saved">
+
+## Lifecycle of an auto-indexing policy
+
+Once a policy has been created, it is active.
+To deactivate a policy, simply delete it.
+A worker process periodically checks the embeddings policies and resolves them into a list of repositories to index.
+Another worker then creates a new index job for each repository and queues it for processing.
+A repository cannot be queued for indexing if
+
+- it is already queued or being processed
+- a job for the same repository and the same revision already completed successfully
+- if another job has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window
+
+All embeddings jobs are listed under **Cody > Embeddings Jobs**
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/embeddings-jobs.png" class="screenshot" alt="policy-saved">

--- a/doc/cody/explanations/policy.md
+++ b/doc/cody/explanations/policy.md
@@ -25,7 +25,7 @@ The new policy will be shown in the list of policies.
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/context/new-policy-saved.png" class="screenshot" alt="policy-saved">
 
-## Lifecycle of an auto-indexing policy
+## Lifecycle of an embeddings policy
 
 Once a policy has been created, it is active.
 To deactivate a policy, simply delete it.


### PR DESCRIPTION
This adds a doc page for embeddings policies to Sourcegraph docs > Cody > Explanations

## Test plan
I ran a local instance and verified that the screenshots are displayed correctly.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
