### PR TITLE
ranking: Improve export query performance

### DIFF
--- a/enterprise/internal/codeintel/ranking/internal/store/uploads.go
+++ b/enterprise/internal/codeintel/ranking/internal/store/uploads.go
@@ -37,18 +37,19 @@ WITH candidates AS (
 	FROM lsif_uploads u
 	JOIN repo r ON r.id = u.repository_id
 	WHERE
-		u.id IN (
-			SELECT uvt.upload_id
+		EXISTS (
+			SELECT 1
 			FROM lsif_uploads_visible_at_tip uvt
 			WHERE
 				uvt.is_default_branch AND
-				NOT EXISTS (
-					SELECT 1
-					FROM codeintel_ranking_exports re
-					WHERE
-						re.graph_key = %s AND
-						re.upload_id = uvt.upload_id
-				)
+				uvt.upload_id = u.id
+		) AND
+		NOT EXISTS (
+			SELECT 1
+			FROM codeintel_ranking_exports re
+			WHERE
+				re.graph_key = %s AND
+				re.upload_id = u.id
 		) AND
 		r.deleted_at IS NULL AND
 		r.blocked IS NULL


### PR DESCRIPTION
**Before**:

```
                                                                                                      QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CTE Scan on candidates  (cost=83057.94..83057.96 rows=1 width=4) (actual time=10343.762..10344.180 rows=100 loops=1)
   CTE candidates
     ->  Limit  (cost=83057.93..83057.94 rows=1 width=117) (actual time=10343.759..10344.145 rows=100 loops=1)
           ->  LockRows  (cost=83057.93..83057.94 rows=1 width=117) (actual time=10343.759..10344.137 rows=100 loops=1)
                 ->  Sort  (cost=83057.93..83057.93 rows=1 width=117) (actual time=10343.731..10343.793 rows=101 loops=1)
                       Sort Key: u.id DESC
                       Sort Method: quicksort  Memory: 154005kB
                       ->  Nested Loop  (cost=83056.15..83057.92 rows=1 width=117) (actual time=1555.181..9859.372 rows=721276 loops=1)
                             ->  Nested Loop  (cost=83055.71..83057.25 rows=1 width=49) (actual time=1555.161..5788.043 rows=725472 loops=1)
                                   ->  HashAggregate  (cost=83055.15..83055.16 rows=1 width=16) (actual time=1555.131..1971.508 rows=793319 loops=1)
                                         Group Key: uvt.upload_id
                                         ->  Hash Anti Join  (cost=7668.50..83055.15 rows=1 width=16) (actual time=81.480..1065.255 rows=793319 loops=1)
                                               Hash Cond: (uvt.upload_id = re.upload_id)
                                               ->  Index Scan Backward using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..71872.68 rows=937172 width=10) (actual time=0.011..634.657 rows=963863 loops=1)
                                                     Filter: is_default_branch
                                               ->  Hash  (cost=5494.54..5494.54 rows=173883 width=10) (actual time=81.154..81.155 rows=173738 loops=1)
                                                     Buckets: 262144  Batches: 1  Memory Usage: 9514kB
                                                     ->  Seq Scan on codeintel_ranking_exports re  (cost=0.00..5494.54 rows=173883 width=10) (actual time=0.020..43.711 rows=173738 loops=1)
                                                           Filter: (graph_key = 'dotcom_2023_06_13_A'::text)
                                   ->  Index Scan using lsif_uploads_pkey on lsif_uploads u  (cost=0.56..2.09 rows=1 width=37) (actual time=0.004..0.004 rows=1 loops=793319)
                                         Index Cond: (id = uvt.upload_id)
                             ->  Index Scan using repo_pkey on repo r  (cost=0.43..0.65 rows=1 width=53) (actual time=0.005..0.005 rows=1 loops=725472)
                                   Index Cond: (id = u.repository_id)
                                   Filter: ((deleted_at IS NULL) AND (blocked IS NULL))
                                   Rows Removed by Filter: 0
 Planning Time: 0.868 ms
 Execution Time: 10369.357 ms
(27 rows)
```

**After**:

```
                                                                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CTE Scan on candidates  (cost=3622.12..3624.12 rows=100 width=4) (actual time=0.722..3.037 rows=100 loops=1)
   CTE candidates
     ->  Limit  (cost=1.84..3622.12 rows=100 width=117) (actual time=0.717..2.950 rows=100 loops=1)
           ->  LockRows  (cost=1.84..3814841.04 rows=105374 width=117) (actual time=0.716..2.939 rows=100 loops=1)
                 ->  Nested Loop Anti Join  (cost=1.84..3813787.30 rows=105374 width=117) (actual time=0.094..2.038 rows=101 loops=1)
                       ->  Nested Loop  (cost=1.42..3763820.64 rows=108959 width=92) (actual time=0.065..1.658 rows=101 loops=1)
                             ->  Nested Loop Semi Join  (cost=0.98..3662926.80 rows=156102 width=43) (actual time=0.054..1.237 rows=101 loops=1)
                                   ->  Index Scan Backward using lsif_uploads_pkey on lsif_uploads u  (cost=0.56..1307751.38 rows=5284975 width=37) (actual time=0.005..0.838 rows=169 loops=1)
                                   ->  Index Scan using lsif_uploads_visible_at_tip_is_default_branch on lsif_uploads_visible_at_tip uvt  (cost=0.42..0.54 rows=6 width=10) (actual time=0.002..0.002 rows=1 loops=169)
                                         Index Cond: (upload_id = u.id)
                                         Filter: is_default_branch
                             ->  Index Scan using repo_pkey on repo r  (cost=0.43..0.65 rows=1 width=53) (actual time=0.004..0.004 rows=1 loops=101)
                                   Index Cond: (id = u.repository_id)
                                   Filter: ((deleted_at IS NULL) AND (blocked IS NULL))
                       ->  Index Scan using codeintel_ranking_exports_graph_key_upload_id on codeintel_ranking_exports re  (cost=0.42..0.44 rows=1 width=10) (actual time=0.003..0.003 rows=0 loops=101)
                             Index Cond: ((graph_key = 'dotcom_2023_06_13_A'::text) AND (upload_id = u.id))
 Planning Time: 3.592 ms
 Execution Time: 3.121 ms
(18 rows)
```

## Test plan

Existing unit tests, tested on dotcom.