### PR TITLE
graphqlbackend: Add changelistURL to GitBlob

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -705,6 +705,7 @@ type BatchWorkspaceFileResolver interface {
 	RichHTML(ctx context.Context, args *GitTreeContentPageArgs) (string, error)
 	URL(ctx context.Context) (string, error)
 	CanonicalURL() string
+	ChangelistURL(ctx context.Context) (*string, error)
 	ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error)
 	Highlight(ctx context.Context, args *HighlightArgs) (*HighlightedFileResolver, error)
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -3646,6 +3646,12 @@ type BatchSpecWorkspaceFile implements File2 & Node {
     The canonical URL to this file (using an immutable revision specifier).
     """
     canonicalURL: String!
+
+    """
+    Not implemented.
+    """
+    changelistURL: String
+
     """
     The URLs to this file on external services.
     """

--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -20,6 +20,7 @@ type FileResolver interface {
 	RichHTML(ctx context.Context, args *GitTreeContentPageArgs) (string, error)
 	URL(ctx context.Context) (string, error)
 	CanonicalURL() string
+	ChangelistURL(ctx context.Context) (*string, error)
 	ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error)
 	Highlight(ctx context.Context, args *HighlightArgs) (*HighlightedFileResolver, error)
 

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -74,6 +75,18 @@ func (r *PerforceChangelistResolver) CID() string {
 
 func (r *PerforceChangelistResolver) CanonicalURL() string {
 	return r.canonicalURL
+}
+
+func (r *PerforceChangelistResolver) cidURL() *url.URL {
+	// Do not mutate the URL on the RepoMatch object.
+	repoURL := *r.repositoryResolver.RepoMatch.URL()
+
+	// We don't expect cid to be empty, but guard against any potential bugs.
+	if r.cid != "" {
+		repoURL.Path += "@" + r.cid
+	}
+
+	return &repoURL
 }
 
 func (r *PerforceChangelistResolver) Commit(ctx context.Context) (_ *GitCommitResolver, err error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -273,7 +273,24 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 
 	cid, err := strconv.ParseInt(args.CID, 10, 64)
 	if err != nil {
-		return nil, &perforce.BadChangelistError{}
+		// NOTE: From the UI, the user may visit a URL like:
+		// https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e28429f899870db6f6cbf0fc2bf98de6e947b213/-/blob/README.md
+		//
+		// Or they may visit a URL like:
+		//
+		// https://sourcegraph.com/perforce.sgdev.test/test-depot@998765/-/blob/README.md
+		//
+		// To make things easier, we request both the `commit($revision)` and the `changelist($cid)`
+		// nodes on the `repository`.
+		//
+		// If the revision in the URL is a changelist ID then the commit node will be null (the
+		// commit will not resolve).
+		//
+		// But if the revision in the URL is a commit SHA, then the changelist node will be null.
+		// Which means we will be inadvertenly trying to parse a commit SHA into a int each time a
+		// commit is viewed. We don't want to return an error in these cases.
+		r.logger.Debug("failed to parse args.CID into int", log.String("args.CID", args.CID), log.Error(err))
+		return nil, nil
 	}
 
 	repo, err := r.repo(ctx)

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -998,9 +998,10 @@ func TestFileDiffHighlighter(t *testing.T) {
 type dummyFileResolver struct {
 	path, name string
 
-	richHTML     string
-	url          string
-	canonicalURL string
+	richHTML      string
+	url           string
+	canonicalURL  string
+	changelistURL string
 
 	content func(context.Context, *GitTreeContentPageArgs) (string, error)
 }
@@ -1041,6 +1042,10 @@ func (d *dummyFileResolver) URL(ctx context.Context) (string, error) {
 
 func (d *dummyFileResolver) CanonicalURL() string {
 	return d.canonicalURL
+}
+
+func (d *dummyFileResolver) ChangelistURL(ctx context.Context) (*string, error) {
+	return &d.changelistURL, nil
 }
 
 func (d *dummyFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5520,6 +5520,10 @@ interface File2 {
     """
     canonicalURL: String!
     """
+    The URL to this file using the changelist ID if this file is inside a perforce depot.
+    """
+    changelistURL: String
+    """
     The URLs to this file on external services.
     """
     externalURLs: [ExternalLink!]!
@@ -5618,6 +5622,10 @@ type VirtualFile implements File2 {
     Not implemented.
     """
     canonicalURL: String!
+    """
+    Not impleemented.
+    """
+    changelistURL: String
     """
     Not implemented.
     """
@@ -5751,6 +5759,12 @@ type GitBlob implements TreeEntry & File2 {
     The canonical URL to this blob (using an immutable revision specifier).
     """
     canonicalURL: String!
+
+    """
+    The URL to this file using the changelist ID if this file is inside a perforce depot.
+    """
+    changelistURL: String
+
     """
     The URLs to this blob on its repository's external services.
     """

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -59,6 +59,10 @@ func (r *VirtualFileResolver) CanonicalURL() string {
 	return r.opts.CanonicalURL
 }
 
+func (r *VirtualFileResolver) ChangelistURL(_ context.Context) (*string, error) {
+	return nil, nil
+}
+
 func (r *VirtualFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
 	return r.opts.ExternalURLs, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file.go
@@ -122,6 +122,10 @@ func (r *batchSpecWorkspaceFileResolver) CanonicalURL() string {
 	return ""
 }
 
+func (r *batchSpecWorkspaceFileResolver) ChangelistURL(_ context.Context) (*string, error) {
+	return nil, nil
+}
+
 func (r *batchSpecWorkspaceFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
 	return nil, errors.New("not implemented")
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_test.go
@@ -43,7 +43,13 @@ func (m *mockFileResolver) RichHTML(ctx context.Context, args *graphqlbackend.Gi
 func (m *mockFileResolver) URL(ctx context.Context) (string, error) {
 	return "", errors.New("not implemented")
 }
+
 func (m *mockFileResolver) CanonicalURL() string { return "" }
+
+func (r *mockFileResolver) ChangelistURL(_ context.Context) (*string, error) {
+	return nil, nil
+}
+
 func (m *mockFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
 	return nil, errors.New("not implemented")
 }

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -36,12 +36,3 @@ type ChangelistNotFoundError struct {
 func (e *ChangelistNotFoundError) Error() string {
 	return fmt.Sprintf("revision not found: %s@%s", e.Repo, e.ID)
 }
-
-type BadChangelistError struct {
-	CID  string
-	Repo api.RepoName
-}
-
-func (e *BadChangelistError) Error() string {
-	return fmt.Sprintf("invalid changelist ID %q for repo %q", e.Repo, e.CID)
-}


### PR DESCRIPTION
Part of #40330.

## Why

We want to be able to generate permalinks for files in a perforce depot

## What

- Add the `changelistURL` property to the `File2` interface
- Add the `changelistURL` property to all the types that implement the `File2` interface
- Implement the `ChangelistURL` API and return a changelist URL for the `GitBlob` type
- Return nil for all the other types that implement `File2` (existing behaviour for these types, for example `url` is also not implemented on them)

Following existing conventions. Ideally we should have a top level `urls` node that embeds all the different type of urls instead of having them on the top level definition in the `File2` interface, but that is a major API change that we're not ready for


## Test plan

- Added tests
- Tested with UI code (another PR coming soon)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
