### PR TITLE
productsubscriptions: move access token to bottom of page

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
@@ -96,19 +96,6 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
                 Cody services <ProductStatusBadge status="beta" />
             </H3>
             <Container className="mb-3">
-                <H4>Access token</H4>
-                <Text className="mb-2">Access tokens can be used for Cody Gateway access</Text>
-                {currentSourcegraphAccessToken && (
-                    <CopyableText
-                        label="Access token"
-                        secret={true}
-                        flex={true}
-                        text={currentSourcegraphAccessToken}
-                        className="mb-2"
-                    />
-                )}
-                {accessTokenError && <ErrorAlert error={accessTokenError} className="mb-0" />}
-
                 {currentSourcegraphAccessToken && (
                     <>
                         <div className="form-group mb-2">
@@ -199,8 +186,26 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
                                 />
                             </>
                         )}
+
+                        <hr className="my-3" />
                     </>
                 )}
+
+                <H4>Access token</H4>
+                <Text className="mb-2">
+                    Access tokens can be used for Cody Gateway access. In most cases this is not needed, since access
+                    tokens are automatically generated from each instance's configured license key.
+                </Text>
+                {currentSourcegraphAccessToken && (
+                    <CopyableText
+                        label="Access token"
+                        secret={true}
+                        flex={true}
+                        text={currentSourcegraphAccessToken}
+                        className="mb-2"
+                    />
+                )}
+                {accessTokenError && <ErrorAlert error={accessTokenError} className="mb-0" />}
             </Container>
         </>
     )


### PR DESCRIPTION
With zero-config, the access token will now very rarely be explicitly needed. We retain the section just in case, but move it to the bottom of the Cody Services section so that it's less prominent.

## Test plan

<img width="950" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/500ede0e-c1b2-488a-80d4-cf31de2ac83c">