### PR TITLE
Fix grafana config generation

### DIFF
--- a/docker-images/grafana/BUILD.bazel
+++ b/docker-images/grafana/BUILD.bazel
@@ -13,11 +13,9 @@ pkg_tar(
     srcs = [
         ":config_files",
         "//docker-images/grafana/config",
-        "//monitoring:generate_config_zip",
     ],
     remap_paths = {
         "docker-images/grafana/config": "/sg_config_grafana",
-        "monitoring/outputs/grafana": "/sg_config_grafana/provisioning/dashboards/sourcegraph",
         "/entry-bazel.sh": "/entry.sh",
     },
 )
@@ -26,7 +24,10 @@ oci_image(
     name = "image",
     base = "@wolfi_grafana_base",
     entrypoint = ["/entry.sh"],
-    tars = [":config_tar"],
+    tars = [
+        ":config_tar",
+        "//monitoring:generate_grafana_config_tar",
+    ],
     user = "grafana",
 )
 

--- a/monitoring/BUILD.bazel
+++ b/monitoring/BUILD.bazel
@@ -31,6 +31,26 @@ genrule(
     visibility = ["//docker-images/grafana:__pkg__"],
 )
 
+genrule(
+    name = "generate_grafana_config_tar",
+    srcs = [],
+    outs = ["monitoring.tar"],
+    cmd = """
+        $(location //monitoring:monitoring) generate \
+                --all.dir monitoring && \
+
+        mkdir -p usr/share/grafana/public/dashboards/ && \
+        mv monitoring/grafana/home.json usr/share/grafana/public/dashboards/ && \
+
+        mkdir -p sg_config_grafana/provisioning/dashboards/sourcegraph/ && \
+        mv monitoring/grafana/* sg_config_grafana/provisioning/dashboards/sourcegraph/ &&\
+
+        tar -cf $@ usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
+        """,
+    tools = ["//monitoring"],
+    visibility = ["//docker-images/grafana:__pkg__"],
+)
+
 # Bazel expects all outputs to be explicitly defined. Therefore we have
 # to manually list them here. This so we can use this target as inputs to a
 # pkg_tar rule. Using the zip variant from above would not work, as we


### PR DESCRIPTION
The previous bazel config generated a zip file which was added but not unpacked.

This fixes the issue by creating a tar file containing just Grafana config with correct paths - we can't use Bazel's file path rules here



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Manually inspecting created image
- Checking dashboards have been updated on S2 + DotCom
