### PR TITLE
github app: add note that only org owners can view org installations

### DIFF
--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -179,6 +179,17 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                                 Learn more about public vs. private GitHub Apps.
                             </Link>
                         </Text>
+                        <Text>
+                            Only{' '}
+                            <Link
+                                to="https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                organization owners
+                            </Link>{' '}
+                            can view and manage installations for an organization.
+                        </Text>
                         <div className="list-group mb-3" aria-label="GitHub App Installations">
                             {app.installations?.length === 0 ? (
                                 <Text>


### PR DESCRIPTION
@st0nebraker [pointed out](https://github.com/sourcegraph/sourcegraph/pull/53212#pullrequestreview-1475310777) in a previous PR that the "View on GitHub" link for GitHub App installations only works if you are able to administer that installation, e.g. that you are an org owner for the org where it's installed, if it's on an org, or that you are the user. If we had this information, we could just hide the button for installations the user can't actually view, but since we don't, we thought it could help to add a note instead.

## Test plan

Just an in-product docs change. Verified the text appears on the GitHub App page.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
