### PR TITLE
Completions: add observability

### DIFF
--- a/enterprise/internal/completions/client/BUILD.bazel
+++ b/enterprise/internal/completions/client/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "client",
-    srcs = ["client.go"],
+    srcs = [
+        "client.go",
+        "observe.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/completions/client",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
@@ -13,6 +16,11 @@ go_library(
         "//internal/completions/types",
         "//internal/conf/conftypes",
         "//internal/httpcli",
+        "//internal/metrics",
+        "//internal/observation",
         "//lib/errors",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/enterprise/internal/completions/client/client.go
+++ b/enterprise/internal/completions/client/client.go
@@ -11,6 +11,14 @@ import (
 )
 
 func Get(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
+	client, err := getBasic(endpoint, provider, accessToken)
+	if err != nil {
+		return nil, err
+	}
+	return newObservedClient(client), nil
+}
+
+func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
 	switch provider {
 	case conftypes.CompletionsProviderNameAnthropic:
 		return anthropic.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil

--- a/enterprise/internal/completions/client/observe.go
+++ b/enterprise/internal/completions/client/observe.go
@@ -62,15 +62,18 @@ type operations struct {
 }
 
 var (
-	streamMetrics = metrics.NewREDMetrics(
+	durationBuckets = []float64{0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 25.0, 30.0, 40.0}
+	streamMetrics   = metrics.NewREDMetrics(
 		prometheus.DefaultRegisterer,
 		"completions_stream",
 		metrics.WithLabels("model"),
+		metrics.WithDurationBuckets(durationBuckets),
 	)
 	completeMetrics = metrics.NewREDMetrics(
 		prometheus.DefaultRegisterer,
 		"completions_complete",
 		metrics.WithLabels("model"),
+		metrics.WithDurationBuckets(durationBuckets),
 	)
 )
 

--- a/enterprise/internal/completions/client/observe.go
+++ b/enterprise/internal/completions/client/observe.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func newObservedClient(inner types.CompletionsClient) *observedClient {
+	observationCtx := observation.NewContext(log.Scoped("completions", "completions client"))
+	ops := newOperations(observationCtx)
+	return &observedClient{
+		inner: inner,
+		ops:   ops,
+	}
+}
+
+type observedClient struct {
+	inner types.CompletionsClient
+	ops   *operations
+}
+
+var _ types.CompletionsClient = (*observedClient)(nil)
+
+func (o *observedClient) Stream(ctx context.Context, feature types.CompletionsFeature, params types.CompletionRequestParameters, send types.SendCompletionEvent) (err error) {
+	ctx, tr, endObservation := o.ops.stream.With(ctx, &err, observation.Args{
+		Attrs:             append(params.Attrs(), attribute.String("feature", string(feature))),
+		MetricLabelValues: []string{params.Model},
+	})
+	defer endObservation(1, observation.Args{})
+
+	tracedSend := func(event types.CompletionResponse) error {
+		if event.StopReason != "" {
+			tr.AddEvent("stopped", attribute.String("reason", event.StopReason))
+		} else {
+			tr.AddEvent("completion", attribute.Int("len", len(event.Completion)))
+		}
+		return send(event)
+	}
+
+	return o.inner.Stream(ctx, feature, params, tracedSend)
+}
+
+func (o *observedClient) Complete(ctx context.Context, feature types.CompletionsFeature, params types.CompletionRequestParameters) (resp *types.CompletionResponse, err error) {
+	ctx, _, endObservation := o.ops.stream.With(ctx, &err, observation.Args{
+		Attrs:             append(params.Attrs(), attribute.String("feature", string(feature))),
+		MetricLabelValues: []string{params.Model},
+	})
+	defer endObservation(1, observation.Args{})
+
+	return o.inner.Complete(ctx, feature, params)
+}
+
+type operations struct {
+	stream   *observation.Operation
+	complete *observation.Operation
+}
+
+var (
+	streamMetrics = metrics.NewREDMetrics(
+		prometheus.DefaultRegisterer,
+		"completions_stream",
+		metrics.WithLabels("model"),
+	)
+	completeMetrics = metrics.NewREDMetrics(
+		prometheus.DefaultRegisterer,
+		"completions_complete",
+		metrics.WithLabels("model"),
+	)
+)
+
+func newOperations(observationCtx *observation.Context) *operations {
+	streamOp := observationCtx.Operation(observation.Op{
+		Metrics: streamMetrics,
+		Name:    "completions.stream",
+	})
+	completeOp := observationCtx.Operation(observation.Op{
+		Metrics: streamMetrics,
+		Name:    "completions.complete",
+	})
+	return &operations{
+		stream:   streamOp,
+		complete: completeOp,
+	}
+}

--- a/internal/completions/types/BUILD.bazel
+++ b/internal/completions/types/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/completions/types",
     visibility = ["//:__subpackages__"],
-    deps = ["//lib/errors"],
+    deps = [
+        "//lib/errors",
+        "@io_opentelemetry_go_otel//attribute",
+    ],
 )
 
 go_test(

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const HUMAN_MESSAGE_SPEAKER = "human"
@@ -57,6 +58,18 @@ type CompletionRequestParameters struct {
 	TopK              int       `json:"topK,omitempty"`
 	TopP              float32   `json:"topP,omitempty"`
 	Model             string    `json:"model,omitempty"`
+}
+
+func (p *CompletionRequestParameters) Attrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int("promptLength", len(p.Prompt)),
+		attribute.Int("numMessages", len(p.Messages)),
+		attribute.Int("maxTokensToSample", p.MaxTokensToSample),
+		attribute.Float64("temperature", float64(p.Temperature)),
+		attribute.Int("topK", p.TopK),
+		attribute.Float64("topP", float64(p.TopP)),
+		attribute.String("model", p.Model),
+	}
 }
 
 type CompletionResponse struct {


### PR DESCRIPTION
This wraps our completions clients in an observability layer. The observability layer tracks metrics for completions durations as well as adds spans that capture both streaming and batch completion calls.

## Test plan

<img width="1512" alt="Screenshot 2023-06-16 at 11 44 19" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/a337e4f7-5b8b-415f-b3c9-447d864c4eaf">
<img width="1437" alt="Screenshot 2023-06-16 at 12 05 51" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/74ff0157-0163-47e0-a5f2-a7305f018f86">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
