### PR TITLE
Refresh page when making/removing owners

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { mdiEmail } from '@mdi/js'
+import { useNavigate } from 'react-router-dom'
 
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
@@ -27,7 +28,6 @@ interface Props {
     repoID: string
     filePath: string
     setRemoveOwnerError: any
-    refetch: any
 }
 
 type OwnershipReason =
@@ -42,7 +42,6 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({
     makeOwnerButton,
     repoID,
     filePath,
-    refetch,
     setRemoveOwnerError,
 }) => {
     const findEmail = (): string | undefined => {
@@ -68,6 +67,11 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({
 
     const sortReasons = () => (reason1: OwnershipReason, reason2: OwnershipReason) =>
         getOwnershipReasonPriority(reason2) - getOwnershipReasonPriority(reason1)
+
+    const navigate = useNavigate()
+    const refreshPage = () => {
+        return Promise.resolve(navigate(0))
+    }
 
     return (
         <tr>
@@ -108,7 +112,7 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({
                         {makeOwnerButton ||
                             (hasAssigned && (
                                 <RemoveOwnerButton
-                                    onSuccess={refetch}
+                                    onSuccess={refreshPage}
                                     onError={setRemoveOwnerError}
                                     repoId={repoID}
                                     path={filePath}

--- a/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipEntry.tsx
@@ -69,9 +69,7 @@ export const FileOwnershipEntry: React.FunctionComponent<Props> = ({
         getOwnershipReasonPriority(reason2) - getOwnershipReasonPriority(reason1)
 
     const navigate = useNavigate()
-    const refreshPage = () => {
-        return Promise.resolve(navigate(0))
-    }
+    const refreshPage = (): Promise<any> => Promise.resolve(navigate(0))
 
     return (
         <tr>

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import classNames from 'classnames'
+import { useNavigate } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
@@ -27,7 +28,7 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         telemetryService.log('OwnershipPanelOpened')
     }, [telemetryService])
 
-    const { data, loading, error, refetch } = useQuery<FetchOwnershipResult, FetchOwnershipVariables>(FETCH_OWNERS, {
+    const { data, loading, error } = useQuery<FetchOwnershipResult, FetchOwnershipVariables>(FETCH_OWNERS, {
         variables: {
             repo: repoID,
             revision: revision ?? '',
@@ -35,6 +36,10 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
         },
     })
     const [makeOwnerError, setMakeOwnerError] = React.useState<Error | undefined>(undefined)
+    const navigate = useNavigate()
+    const refreshPage = () => {
+        return Promise.resolve(navigate(0))
+    }
 
     if (loading) {
         return (
@@ -49,7 +54,7 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     const makeOwnerButton = canAssignOwners
         ? (userId: string | undefined) => (
               <MakeOwnerButton
-                  onSuccess={refetch}
+                  onSuccess={refreshPage}
                   onError={setMakeOwnerError}
                   repoId={repoID}
                   path={filePath}
@@ -76,9 +81,8 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
                 makeOwnerError={makeOwnerError}
                 repoID={repoID}
                 filePath={filePath}
-                refetch={refetch}
             />
         )
     }
-    return <OwnerList refetch={refetch} filePath={filePath} repoID={repoID} />
+    return <OwnerList filePath={filePath} repoID={repoID} />
 }

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -37,9 +37,7 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     })
     const [makeOwnerError, setMakeOwnerError] = React.useState<Error | undefined>(undefined)
     const navigate = useNavigate()
-    const refreshPage = () => {
-        return Promise.resolve(navigate(0))
-    }
+    const refreshPage = (): Promise<any> => Promise.resolve(navigate(0))
 
     if (loading) {
         return (

--- a/client/web/src/repo/blob/own/OwnerList.tsx
+++ b/client/web/src/repo/blob/own/OwnerList.tsx
@@ -91,7 +91,6 @@ interface OwnerListProps {
     makeOwnerError?: Error
     repoID: string
     filePath: string
-    refetch: any
 }
 
 export const OwnerList: React.FunctionComponent<OwnerListProps> = ({
@@ -101,7 +100,6 @@ export const OwnerList: React.FunctionComponent<OwnerListProps> = ({
     makeOwnerError,
     repoID,
     filePath,
-    refetch,
 }) => {
     const [removeOwnerError, setRemoveOwnerError] = React.useState<Error | undefined>(undefined)
 
@@ -153,7 +151,6 @@ export const OwnerList: React.FunctionComponent<OwnerListProps> = ({
                                 <React.Fragment key={index}>
                                     {index > 0 && <tr className={styles.bordered} />}
                                     <FileOwnershipEntry
-                                        refetch={refetch}
                                         owner={ownership.owner}
                                         repoID={repoID}
                                         filePath={filePath}
@@ -204,7 +201,6 @@ export const OwnerList: React.FunctionComponent<OwnerListProps> = ({
                                             makeOwnerButton={makeOwnerButton?.(userId)}
                                             repoID={repoID}
                                             filePath={filePath}
-                                            refetch={refetch}
                                             setRemoveOwnerError={setRemoveOwnerError}
                                         />
                                     </React.Fragment>

--- a/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
@@ -84,10 +84,9 @@ export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
                 makeOwnerButton={makeOwnerButton}
                 repoID={repoID}
                 filePath={filePath}
-                refetch={refetch}
                 makeOwnerError={makeOwnerError}
             />
         )
     }
-    return <OwnerList repoID={repoID} filePath={filePath} refetch={refetch} />
+    return <OwnerList repoID={repoID} filePath={filePath} />
 }


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/53162

Ended up just refreshing the page instead of trying to link the OwnersList and HistoryAndOwnBar components, which would be a bit of a mess.

## Test plan

Manual