### PR TITLE
Add cody setup docs like for site-admins

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -149,7 +149,13 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     }
 
     if (!authenticatedUser || !isCodyEnabled()) {
-        return <CodyMarketingPage isSourcegraphDotCom={isSourcegraphDotCom} context={context} />
+        return (
+            <CodyMarketingPage
+                isSourcegraphDotCom={isSourcegraphDotCom}
+                authenticatedUser={authenticatedUser}
+                context={context}
+            />
+        )
     }
 
     return (

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
@@ -1,5 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 
+import { AuthenticatedUser } from '../../../auth'
 import { WebStory } from '../../../components/WebStory'
 import { SourcegraphContext } from '../../../jscontext'
 
@@ -31,8 +32,24 @@ const context: Pick<SourcegraphContext, 'authProviders'> = {
 }
 
 export const SourcegraphDotCom: Story = () => (
-    <WebStory>{() => <CodyMarketingPage context={context} isSourcegraphDotCom={true} />}</WebStory>
+    <WebStory>
+        {() => <CodyMarketingPage context={context} isSourcegraphDotCom={true} authenticatedUser={null} />}
+    </WebStory>
 )
 export const Enterprise: Story = () => (
-    <WebStory>{() => <CodyMarketingPage context={context} isSourcegraphDotCom={false} />}</WebStory>
+    <WebStory>
+        {() => <CodyMarketingPage context={context} isSourcegraphDotCom={false} authenticatedUser={null} />}
+    </WebStory>
+)
+
+export const EnterpriseSiteAdmin: Story = () => (
+    <WebStory>
+        {() => (
+            <CodyMarketingPage
+                context={context}
+                isSourcegraphDotCom={false}
+                authenticatedUser={{ siteAdmin: true } as AuthenticatedUser}
+            />
+        )}
+    </WebStory>
 )

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { Theme, useTheme } from '@sourcegraph/shared/src/theme'
 import { H1, H2, H3, H4, Icon, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
+import { AuthenticatedUser } from '../../../auth'
 import { ExternalsAuth } from '../../../auth/components/ExternalsAuth'
 import { MarketingBlock } from '../../../components/MarketingBlock'
 import { Page } from '../../../components/Page'
@@ -99,11 +100,13 @@ const codyPlatformCardItems = (
 export interface CodyMarketingPageProps {
     isSourcegraphDotCom: boolean
     context: Pick<SourcegraphContext, 'authProviders'>
+    authenticatedUser: AuthenticatedUser | null
 }
 
 export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> = ({
     context,
     isSourcegraphDotCom,
+    authenticatedUser,
 }) => {
     const { theme } = useTheme()
     const isDarkTheme = theme === Theme.Dark
@@ -203,6 +206,12 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                         </ul>
                         <Text className="mb-0">
                             <Link to="https://about.sourcegraph.com/cody">Learn more about Cody &rarr;</Link>
+                            {authenticatedUser?.siteAdmin && (
+                                <>
+                                    {' '}
+                                    or <Link to="/help/cody/explanations/enabling_cody_enterprise">enable it now</Link>.
+                                </>
+                            )}
                         </Text>
                     </MarketingBlock>
                 )}


### PR DESCRIPTION
This PR adds a small additional link to the CTA that links to cody setup docs to reduce friction of setup.


![image](https://github.com/sourcegraph/sourcegraph/assets/19534377/d342ea0d-6f62-4f9d-8a02-df5a8c1ae6ad)

## Test plan

Manually verified and added a storybook story. 