### PR TITLE
Completions: Add multi-line heuristics for C, C++, C#, and Java

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,6 +14,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Completions: Updating configuration no longer requires reloading the extension. [pull/53401](https://github.com/sourcegraph/sourcegraph/pull/53401)
 - Completions: Completions can now be used on unsaved files. [pull/53495](https://github.com/sourcegraph/sourcegraph/pull/53495)
+- Completions: Add multi-line heuristics for C, C++, C#, and Java. [pull/]()
 
 ## [0.2.4]
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -14,7 +14,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 - Completions: Updating configuration no longer requires reloading the extension. [pull/53401](https://github.com/sourcegraph/sourcegraph/pull/53401)
 - Completions: Completions can now be used on unsaved files. [pull/53495](https://github.com/sourcegraph/sourcegraph/pull/53495)
-- Completions: Add multi-line heuristics for C, C++, C#, and Java. [pull/]()
+- Completions: Add multi-line heuristics for C, C++, C#, and Java. [pull/53631](https://github.com/sourcegraph/sourcegraph/pull/53631)
 
 ## [0.2.4]
 

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -487,6 +487,150 @@ describe('Cody completions', () => {
             `)
         })
 
+        it('works with java', async () => {
+            const { completions, requests } = await complete(
+                `
+                for (int i = 0; i < 11; i++) {
+                    if (i % 2 == 0) {
+                        ${CURSOR_MARKER}`,
+                [
+                    createCompletionResponse(`
+                    System.out.println(i);
+                        } else if (i % 3 == 0) {
+                            System.out.println("Multiple of 3: " + i);
+                        } else {
+                            System.out.println("ODD " + i);
+                        }
+                    }
+
+                    for (int i = 0; i < 12; i++) {
+                        System.out.println("unrelated");
+                    }`),
+                ],
+                'java'
+            )
+
+            expect(requests).toHaveLength(3)
+            expect(requests[0]!.stopSequences).not.toContain('\n')
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+                "System.out.println(i);
+                    } else if (i % 3 == 0) {
+                        System.out.println(\\"Multiple of 3: \\" + i);
+                    } else {
+                        System.out.println(\\"ODD \\" + i);
+                    }"
+            `)
+        })
+
+        // TODO: Detect `}\nelse\n{` pattern for else skip logic
+        it('works with csharp', async () => {
+            const { completions, requests } = await complete(
+                `
+                for (int i = 0; i < 11; i++) {
+                    if (i % 2 == 0)
+                    {
+                        ${CURSOR_MARKER}`,
+                [
+                    createCompletionResponse(`
+                    Console.WriteLine(i);
+                        }
+                        else if (i % 3 == 0)
+                        {
+                            Console.WriteLine("Multiple of 3: " + i);
+                        }
+                        else
+                        {
+                            Console.WriteLine("ODD " + i);
+                        }
+
+                    }
+
+                    for (int i = 0; i < 12; i++)
+                    {
+                        Console.WriteLine("unrelated");
+                    }`),
+                ],
+                'csharp'
+            )
+
+            expect(requests).toHaveLength(3)
+            expect(requests[0]!.stopSequences).not.toContain('\n')
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+                "Console.WriteLine(i);
+                    }"
+            `)
+        })
+
+        it('works with c++', async () => {
+            const { completions, requests } = await complete(
+                `
+                for (int i = 0; i < 11; i++) {
+                    if (i % 2 == 0) {
+                        ${CURSOR_MARKER}`,
+                [
+                    createCompletionResponse(`
+                    std::cout << i;
+                        } else if (i % 3 == 0) {
+                            std::cout << "Multiple of 3: " << i;
+                        } else  {
+                            std::cout << "ODD " << i;
+                        }
+                    }
+
+                    for (int i = 0; i < 12; i++) {
+                        std::cout << "unrelated";
+                    }`),
+                ],
+                'cpp'
+            )
+
+            expect(requests).toHaveLength(3)
+            expect(requests[0]!.stopSequences).not.toContain('\n')
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+                "std::cout << i;
+                    } else if (i % 3 == 0) {
+                        std::cout << \\"Multiple of 3: \\" << i;
+                    } else  {
+                        std::cout << \\"ODD \\" << i;
+                    }"
+            `)
+        })
+
+        it('works with c', async () => {
+            const { completions, requests } = await complete(
+                `
+                for (int i = 0; i < 11; i++) {
+                    if (i % 2 == 0) {
+                        ${CURSOR_MARKER}`,
+                [
+                    createCompletionResponse(`
+                    printf("%d", i);
+                        } else if (i % 3 == 0) {
+                            printf("Multiple of 3: %d", i);
+                        } else {
+                            printf("ODD %d", i);
+                        }
+                    }
+
+                    for (int i = 0; i < 12; i++) {
+                        printf("unrelated");
+                    }`),
+                ],
+                'c'
+            )
+
+            expect(requests).toHaveLength(3)
+            expect(requests[0]!.stopSequences).not.toContain('\n')
+            expect(completions[0].insertText).toMatchInlineSnapshot(`
+                "printf(\\"%d\\", i);
+                    } else if (i % 3 == 0) {
+                        printf(\\"Multiple of 3: %d\\", i);
+                    } else {
+                        printf(\\"ODD %d\\", i);
+                    }"
+            `)
+        })
+
         it('skips over empty lines', async () => {
             const { completions } = await complete(
                 `

--- a/client/cody/src/completions/multiline.ts
+++ b/client/cody/src/completions/multiline.ts
@@ -16,7 +16,8 @@ export function detectMultilineMode(
         sameLineSuffix.trim() === '' &&
         // Only trigger multiline suggestions for the beginning of blocks
         prefix.trim().at(prefix.trim().length - config.blockStart.length) === config.blockStart &&
-        // Only trigger multiline suggestions when the new current line is indented
+        // Only trigger multiline suggestions when the new current line is
+        // indented
         indentation(prevNonEmptyLine) < indentation(sameLinePrefix)
     ) {
         return 'block'
@@ -38,15 +39,16 @@ export function truncateMultilineCompletion(
 
     const lines = completion.split('\n')
 
-    // We use a whitespace counting approach to finding the end of the completion. To find
-    // an end, we look for the first line that is below the start scope of the completion (
-    // calculated by the number of leading spaces or tabs)
+    // We use a whitespace counting approach to finding the end of the
+    // completion. To find an end, we look for the first line that is below the
+    // start scope of the completion ( calculated by the number of leading
+    // spaces or tabs)
     const prefixLastNewline = prefix.lastIndexOf('\n')
     const prefixIndentationWithFirstCompletionLine = prefix.slice(prefixLastNewline + 1) + completion[0]
     const startIndent = indentation(prefixIndentationWithFirstCompletionLine)
 
-    // Normalize responses that start with a newline followed by the exact indentation of
-    // the first line.
+    // Normalize responses that start with a newline followed by the exact
+    // indentation of the first line.
     if (lines.length > 1 && lines[0] === '' && indentation(lines[1]) === startIndent) {
         lines.shift()
         lines[0] = lines[0].trimStart()
@@ -64,8 +66,8 @@ export function truncateMultilineCompletion(
         }
     }
 
-    // Only include a closing line (e.g. `}`) if the block is empty yet. We detect this by
-    // looking at the indentation of the next non-empty line.
+    // Only include a closing line (e.g. `}`) if the block is empty yet. We
+    // detect this by looking at the indentation of the next non-empty line.
     const includeClosingLine = indentation(nextNonEmptyLine) < startIndent
 
     let cutOffIndex = lines.length
@@ -77,8 +79,8 @@ export function truncateMultilineCompletion(
         }
 
         if (indentation(line) < startIndent) {
-            // When we find the first block below the start indentation, only include it if
-            // it is an end block
+            // When we find the first block below the start indentation, only
+            // include it if it is an end block
             if (includeClosingLine && config.blockEnd && line.trim().startsWith(config.blockEnd)) {
                 cutOffIndex = i + 1
             } else {
@@ -118,11 +120,15 @@ interface LanguageConfig {
 }
 function getLanguageConfig(languageId: string): LanguageConfig | null {
     switch (languageId) {
-        case 'typescript':
-        case 'typescriptreact':
+        case 'c':
+        case 'cpp':
+        case 'csharp':
+        case 'go':
+        case 'java':
         case 'javascript':
         case 'javascriptreact':
-        case 'go':
+        case 'typescript':
+        case 'typescriptreact':
             return {
                 blockStart: '{',
                 blockElseTest: /^[\t ]*} else/,


### PR DESCRIPTION
The title says it all. They're all c-like so the implementation doesn't need to change.

I also noticed that we currently do not support this style of syntax for else-block continuation. I don't think it's a big issue though since the single line `}` would end the selection so it's not as noticible as in the single line case. E.g. compare this cut-off behavior:


This:
```c
if ()
{
  // foo
} 
```

With this:
```c
if ()
{
  // foo
} else {
```

And it's clear as to why this is only an issue in the single line case

## Test plan

- Big test coverage this time

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
