### PR TITLE
cody: add config properties for embeddings and completions cache

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -1,5 +1,6 @@
 export type ConfigurationUseContext = 'embeddings' | 'keyword' | 'none' | 'blended' | 'unified'
 
+// Should we share VS Code specific config via cody-shared?
 export interface Configuration {
     serverEndpoint: string
     codebase?: string
@@ -15,6 +16,8 @@ export interface Configuration {
     experimentalNonStop: boolean
     completionsAdvancedProvider: 'anthropic' | 'unstable-codegen'
     completionsAdvancedServerEndpoint: string | null
+    completionsAdvancedCache: boolean
+    completionsAdvancedEmbeddings: boolean
 }
 
 export interface ConfigurationWithAccessToken extends Configuration {

--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -55,6 +55,7 @@ ts_project(
         "src/completions/providers/unstable-codegen.ts",
         "src/completions/utils.ts",
         "src/configuration.ts",
+        "src/configuration-keys.ts",
         "src/editor/vscode-editor.ts",
         "src/event-logger.ts",
         "src/extension.ts",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -832,6 +832,18 @@
         "cody.completions.advanced.serverEndpoint": {
           "type": "string",
           "markdownDescription": "Overwrite the server endpoint used for generating code completions. This is only supported with the `unstable-codegen` provider right now."
+        },
+        "cody.completions.advanced.cache": {
+          "order": 99,
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enables caching of code completions."
+        },
+        "cody.completions.advanced.embeddings": {
+          "order": 99,
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enables the use of embeddings as code completions context."
         }
       }
     },

--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -7,7 +7,7 @@ import {
 
 import { mockVSCodeExports } from '../testutils/vscode'
 
-import { CodyCompletionItemProvider, inlineCompletionsCache } from '.'
+import { CodyCompletionItemProvider } from '.'
 import { createProviderConfig } from './providers/anthropic'
 
 jest.mock('vscode', () => ({
@@ -94,16 +94,13 @@ async function complete(
         completionsClient,
         contextWindowTokens: 2048,
     })
-    const completionProvider = new CodyCompletionItemProvider(
+    const completionProvider = new CodyCompletionItemProvider({
         providerConfig,
-        null as any,
-        noopStatusBar,
-        null as any,
-        undefined,
-        undefined,
-        undefined,
-        true // disable timeouts
-    )
+        statusBar: noopStatusBar,
+        history: null as any,
+        codebaseContext: null as any,
+        disableTimeouts: true,
+    })
 
     if (!code.includes(CURSOR_MARKER)) {
         throw new Error('The test code must include a | to denote the cursor position')
@@ -177,8 +174,6 @@ function truncateMultilineString(string: string): string {
 }
 
 describe('Cody completions', () => {
-    beforeEach(() => inlineCompletionsCache.clear())
-
     it('uses a simple prompt for small files', async () => {
         const { requests } = await complete(`foo ${CURSOR_MARKER}`)
 

--- a/client/cody/src/completions/context.ts
+++ b/client/cody/src/completions/context.ts
@@ -22,16 +22,17 @@ interface GetContextOptions {
     jaccardDistanceWindowSize: number
     maxChars: number
     codebaseContext: CodebaseContext
+    isEmbeddingsContextEnabled?: boolean
 }
 
 export async function getContext(options: GetContextOptions): Promise<ReferenceSnippet[]> {
-    const { maxChars } = options
+    const { maxChars, isEmbeddingsContextEnabled } = options
 
     /**
      * The embeddings context is sync to retrieve to keep the completions latency minumal.
      * If it's not available in cache yet, we'll retrieve it in the background and cache it for future use.
      */
-    const embeddingsMatches = getContextFromEmbeddings(options)
+    const embeddingsMatches = isEmbeddingsContextEnabled ? getContextFromEmbeddings(options) : []
     const editorMatches = await getContextFromCurrentEditor(options)
 
     const usedFilenames = new Set<string>()

--- a/client/cody/src/configuration-keys.ts
+++ b/client/cody/src/configuration-keys.ts
@@ -1,0 +1,50 @@
+import { camelCase } from 'lodash'
+
+import packageJson from '../package.json'
+
+const { properties } = packageJson.contributes.configuration
+
+type ConfigurationKeysMap = {
+    // Use key remapping to get a nice typescript interface with the correct keys.
+    // https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#key-remapping-via-as
+    [key in keyof typeof properties as RemoveCodyPrefixAndCamelCase<key>]: key
+}
+
+function getConfigFromPackageJson(): ConfigurationKeysMap {
+    return Object.keys(properties).reduce<ConfigurationKeysMap>((acc, key) => {
+        // Remove the `cody.` prefix and camelCase the rest of the key.
+        const keyProperty = camelCase(key.split('.').slice(1).join('.')) as keyof ConfigurationKeysMap
+
+        // This is just to hard to type correctly 😜 and it's doesn't make any difference.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        acc[keyProperty] = key as ConfigurationKeysMap[typeof keyProperty]
+
+        return acc
+    }, {} as ConfigurationKeysMap)
+}
+
+// Use template literal type for string manipulation. See examples here:
+// https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html
+type RemoveCodyPrefixAndCamelCase<T extends string> = T extends `cody.${infer A}`
+    ? A extends `${infer B}.${infer C}`
+        ? `${B}${CamelCaseDotSeparatedFragments<C>}`
+        : `${A}`
+    : never
+
+type CamelCaseDotSeparatedFragments<T extends string> = T extends `${infer A}.${infer B}`
+    ? `${Capitalize<A>}${CamelCaseDotSeparatedFragments<B>}`
+    : `${Capitalize<T>}`
+
+/**
+ * Automatically infer the configuration keys from the package.json in a type-safe way.
+ * All the keys are mapped into the `CONFIG_KEY` object by removing the `cody.` prefix and
+ * camelcasing the rest of the dot separated fragments.
+ *
+ * We should avoid specifiying config keys manually and instead rely on constant.
+ * No manual changes will be required in this file when changing configuration keys in package.json.
+ * Typescript will error for all outdated/missing keys.
+ */
+export const CONFIG_KEY = getConfigFromPackageJson()
+
+export type ConfigKeys = keyof typeof CONFIG_KEY

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -22,6 +22,8 @@ describe('getConfiguration', () => {
             debugFilter: null,
             completionsAdvancedProvider: 'anthropic',
             completionsAdvancedServerEndpoint: null,
+            completionsAdvancedCache: true,
+            completionsAdvancedEmbeddings: true,
         })
     })
 
@@ -60,6 +62,10 @@ describe('getConfiguration', () => {
                         return 'unstable-codegen'
                     case 'cody.completions.advanced.serverEndpoint':
                         return 'https://example.com/llm'
+                    case 'cody.completions.advanced.cache':
+                        return false
+                    case 'cody.completions.advanced.embeddings':
+                        return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -83,6 +89,8 @@ describe('getConfiguration', () => {
             debugFilter: /.*/,
             completionsAdvancedProvider: 'unstable-codegen',
             completionsAdvancedServerEndpoint: 'https://example.com/llm',
+            completionsAdvancedCache: false,
+            completionsAdvancedEmbeddings: false,
         })
     })
 })

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -101,6 +101,7 @@ const register = async (
     const controllers = { inline: commentController, fixups: fixup }
 
     const editor = new VSCodeEditor(controllers)
+    // Could we use the `initialConfig` instead?
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
 
@@ -427,7 +428,14 @@ function createCompletionsProvider(
                 contextWindowTokens: 2048,
             })
     }
-    const completionsProvider = new CodyCompletionItemProvider(providerConfig, history, statusBar, codebaseContext)
+    const completionsProvider = new CodyCompletionItemProvider({
+        providerConfig,
+        history,
+        statusBar,
+        codebaseContext,
+        isCompletionsCacheEnabled: config.completionsAdvancedCache,
+        isEmbeddingsContextEnabled: config.completionsAdvancedEmbeddings,
+    })
 
     disposables.push(
         vscode.commands.registerCommand('cody.manual-completions', async () => {

--- a/client/cody/src/testutils/cli/run-code-completions-on-dataset.ts
+++ b/client/cody/src/testutils/cli/run-code-completions-on-dataset.ts
@@ -44,16 +44,13 @@ async function initCompletionsProvider(): Promise<CodyCompletionItemProvider> {
         completionsClient,
         contextWindowTokens: 2048,
     })
-    const completionsProvider = new CodyCompletionItemProvider(
+    const completionsProvider = new CodyCompletionItemProvider({
         providerConfig,
+        statusBar: noopStatusBar,
         history,
-        noopStatusBar,
-        null as any,
-        undefined,
-        undefined,
-        undefined,
-        true // disable timeouts
-    )
+        codebaseContext: null as any,
+        disableTimeouts: true,
+    })
 
     return completionsProvider
 }


### PR DESCRIPTION
## Context 

- Adds a setting to turn off code completions cache: `cody.completions.advanced.cache`. Needed to verify if the completions cache size is the issue for our customer. More context in [the Slack thread](https://sourcegraph.slack.com/archives/C05A7PPR07Q/p1686930187417899?thread_ts=1686841844.511079&cid=C05A7PPR07Q).
- Adds a setting to turn off embeddings context for code completions.: `cody.completions.advanced.embeddings`. Since embeddings also employ a cache, it should help debug the abovementioned issue.
- Change the `CodyCompletionItemProvider` constructor to be an object instead of a long list of arguments. READABILITY FTW.
- Implements a type-safe way to automatically generate a mapping of the VS Code extensions settings defined in the `package.json`. No more typos and updating keys in multiple places! We need to migrate other places where we directly use `config.get('cody.my.config.name')` to `CONFIG_KEY.myConfigName`.

## Passing config values around vs direct access

To use config values, we have to pass them from the place where `getConfiguration` is called. Would it make sense to create standalone type-safe getters for config values? Is it "free" to read config values multiple times? 

## Test plan

CI
