### PR TITLE
JetBrains: display message in the chat on invalid access token

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Enabled "Translate to different language" recipe [#53393](https://github.com/sourcegraph/sourcegraph/pull/53393)
 - Skip Cody completions if there is code in line suffix or in the middle of a word in prefix [#53476](https://github.com/sourcegraph/sourcegraph/pull/53476)
 - Enabled "Summarize recent code changes" recipe [#53534](https://github.com/sourcegraph/sourcegraph/pull/53534)
-
+- Chat message when access token is invalid or not configured [#53659](https://github.com/sourcegraph/sourcegraph/pull/53659)
 ### Changed
 
 - Parallelized completion API calls and reduced debounce down to 20ms [#53592](https://github.com/sourcegraph/sourcegraph/pull/53592)

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Skip Cody completions if there is code in line suffix or in the middle of a word in prefix [#53476](https://github.com/sourcegraph/sourcegraph/pull/53476)
 - Enabled "Summarize recent code changes" recipe [#53534](https://github.com/sourcegraph/sourcegraph/pull/53534)
 - Chat message when access token is invalid or not configured [#53659](https://github.com/sourcegraph/sourcegraph/pull/53659)
+
 ### Changed
 
 - Parallelized completion API calls and reduced debounce down to 20ms [#53592](https://github.com/sourcegraph/sourcegraph/pull/53592)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -16,18 +16,14 @@ import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.ui.components.JBTextArea;
-import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.UIUtil;
-import com.sourcegraph.cody.chat.Chat;
-import com.sourcegraph.cody.chat.ChatBubble;
-import com.sourcegraph.cody.chat.ChatMessage;
+import com.intellij.util.ui.*;
+import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.editor.EditorContext;
 import com.sourcegraph.cody.editor.EditorContextGetter;
 import com.sourcegraph.cody.prompts.SupportedLanguages;
 import com.sourcegraph.cody.recipes.*;
 import com.sourcegraph.cody.ui.RoundedJBTextArea;
 import com.sourcegraph.cody.ui.SelectOptionManager;
-import com.sourcegraph.cody.vcs.*;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
 import java.awt.*;
@@ -39,6 +35,7 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.ButtonUI;
 import javax.swing.plaf.basic.BasicTextAreaUI;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 class CodyToolWindowContent implements UpdatableChat {
@@ -203,9 +200,26 @@ class CodyToolWindowContent implements UpdatableChat {
   }
 
   private void addWelcomeMessage() {
-    var welcomeText =
+    boolean isEnterprise =
+        ConfigUtil.getInstanceType(project).equals(SettingsComponent.InstanceType.ENTERPRISE);
+    String accessToken =
+        isEnterprise
+            ? ConfigUtil.getEnterpriseAccessToken(project)
+            : ConfigUtil.getDotComAccessToken(project);
+    String welcomeText =
         "Hello! I'm Cody. I can write code and answer questions for you. See [Cody documentation](https://docs.sourcegraph.com/cody) for help and tips.";
     addMessageToChat(ChatMessage.createAssistantMessage(welcomeText));
+    if (StringUtils.isEmpty(accessToken)) {
+      String noAccessTokenText =
+          "<p>It looks like you don't have Sourcegraph Access Token configured.</p>"
+              + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
+      AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
+          new AssistantMessageWithSettingsButton(project, noAccessTokenText);
+      var messageContentPanel = new JPanel(new BorderLayout());
+      messageContentPanel.add(assistantMessageWithSettingsButton);
+      ApplicationManager.getApplication()
+          .invokeLater(() -> addComponentToChat(messageContentPanel));
+    }
   }
 
   @NotNull
@@ -248,24 +262,28 @@ class CodyToolWindowContent implements UpdatableChat {
         .invokeLater(
             () -> {
               // Bubble panel
-              var bubblePanel = new JPanel();
-              bubblePanel.setLayout(
-                  new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
-              // Chat bubble
               ChatBubble bubble = new ChatBubble(message);
-              bubblePanel.add(bubble, VerticalFlowLayout.TOP);
-              messagesPanel.add(bubblePanel);
+              addComponentToChat(bubble);
+            });
+  }
+
+  private void addComponentToChat(JPanel message) {
+
+    var bubblePanel = new JPanel();
+    bubblePanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
+    // Chat message
+    bubblePanel.add(message, VerticalFlowLayout.TOP);
+    messagesPanel.add(bubblePanel);
+    messagesPanel.revalidate();
+    messagesPanel.repaint();
+
+    // Need this hacky solution to scroll all the way down after each message
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              needScrollingDown = true;
               messagesPanel.revalidate();
               messagesPanel.repaint();
-
-              // Need this hacky solution to scroll all the way down after each message
-              ApplicationManager.getApplication()
-                  .invokeLater(
-                      () -> {
-                        needScrollingDown = true;
-                        messagesPanel.revalidate();
-                        messagesPanel.repaint();
-                      });
             });
   }
 
@@ -278,6 +296,31 @@ class CodyToolWindowContent implements UpdatableChat {
   public void respondToMessage(@NotNull ChatMessage message, @NotNull String responsePrefix) {
     activateChatTab();
     sendMessage(this.project, message, responsePrefix);
+  }
+
+  @Override
+  public void respondToErrorFromServer(@NotNull String errorMessage) {
+    if (errorMessage.equals("Connection refused")) {
+      this.addMessageToChat(
+          ChatMessage.createAssistantMessage(
+              "I'm sorry, I can't connect to the server. Please make sure that the server is running and try again."));
+    } else if (errorMessage.startsWith("Got error response 401: Invalid access token.")) {
+      String invalidAccessTokenText =
+          "<p>It looks like your Sourcegraph Access Token is invalid or not configured.</p>"
+              + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
+      AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
+          new AssistantMessageWithSettingsButton(project, invalidAccessTokenText);
+      var messageContentPanel = new JPanel(new BorderLayout());
+      messageContentPanel.add(assistantMessageWithSettingsButton);
+      ApplicationManager.getApplication()
+          .invokeLater(() -> this.addComponentToChat(messageContentPanel));
+    } else {
+      this.addMessageToChat(
+          ChatMessage.createAssistantMessage(
+              "I'm sorry, something wet wrong. Please try again. The error message I got was: \""
+                  + errorMessage
+                  + "\"."));
+    }
   }
 
   public synchronized void updateLastMessage(@NotNull ChatMessage message) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
@@ -8,6 +8,8 @@ public interface UpdatableChat {
 
   void respondToMessage(@NotNull ChatMessage message, @NotNull String responsePrefix);
 
+  void respondToErrorFromServer(@NotNull String errorMessage);
+
   void updateLastMessage(@NotNull ChatMessage message);
 
   void finishMessageProcessing();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
@@ -40,17 +40,7 @@ public class ChatUpdaterCallbacks implements CompletionsCallbacks {
 
   @Override
   public void onError(@NotNull Throwable error) {
-    if (error.getMessage().equals("Connection refused")) {
-      chat.addMessageToChat(
-          ChatMessage.createAssistantMessage(
-              "I'm sorry, I can't connect to the server. Please make sure that the server is running and try again."));
-    } else {
-      chat.addMessageToChat(
-          ChatMessage.createAssistantMessage(
-              "I'm sorry, something wet wrong. Please try again. The error message I got was: \""
-                  + error.getMessage()
-                  + "\"."));
-    }
+    chat.respondToErrorFromServer(error.getMessage());
     chat.finishMessageProcessing();
     System.err.println("Error: " + error);
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/AssistantMessageWithSettingsButton.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/AssistantMessageWithSettingsButton.java
@@ -1,0 +1,31 @@
+package com.sourcegraph.cody.chat;
+
+import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.BrowserHyperlinkListener;
+import com.intellij.util.ui.JBInsets;
+import com.intellij.util.ui.SwingHelper;
+import com.intellij.util.ui.UIUtil;
+import com.sourcegraph.cody.api.Speaker;
+import com.sourcegraph.config.GoToPluginSettingsButtonFactory;
+import java.awt.*;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
+
+public class AssistantMessageWithSettingsButton extends MessagePanel {
+  public AssistantMessageWithSettingsButton(
+      @NotNull Project project, @NotNull String htmlTextContent) {
+    super(Speaker.ASSISTANT, ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
+    this.setLayout(new BorderLayout());
+    JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
+    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE);
+    jEditorPane.setFocusable(true);
+    jEditorPane.setMargin(
+        JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
+    SwingHelper.setHtml(jEditorPane, htmlTextContent, UIUtil.getActiveTextColor());
+    this.add(jEditorPane, BorderLayout.CENTER);
+    this.add(
+        GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(project), BorderLayout.EAST);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
@@ -9,7 +9,6 @@ import org.commonmark.parser.Parser;
 import org.jetbrains.annotations.NotNull;
 
 public class ChatBubble extends JPanel {
-  private static final int GRADIENT_WIDTH = 2;
 
   public ChatBubble(@NotNull ChatMessage message) {
     super();
@@ -21,11 +20,13 @@ public class ChatBubble extends JPanel {
 
   @NotNull
   private JPanel buildMessagePanel(@NotNull ChatMessage message) {
-    MessagePanel messagePanel = new MessagePanel(message, GRADIENT_WIDTH);
+    MessagePanel messagePanel =
+        new MessagePanel(message.getSpeaker(), ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
     Parser parser = Parser.builder().extensions(List.of(TablesExtension.create())).build();
     Node document = parser.parse(message.getDisplayText());
     MessageContentCreatorFromMarkdownNodes messageContentCreator =
-        new MessageContentCreatorFromMarkdownNodes(messagePanel, GRADIENT_WIDTH);
+        new MessageContentCreatorFromMarkdownNodes(
+            messagePanel, ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
     document.accept(messageContentCreator);
     return messagePanel;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatUIConstants.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatUIConstants.java
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.chat;
+
+public class ChatUIConstants {
+  public static final int ASSISTANT_MESSAGE_GRADIENT_WIDTH = 2;
+  public static final int TEXT_MARGIN = 14;
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.chat;
 
+import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
+
 import com.intellij.ide.highlighter.HighlighterFactory;
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Document;
@@ -11,6 +13,7 @@ import com.intellij.openapi.editor.highlighter.EditorHighlighter;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
+import com.intellij.ui.BrowserHyperlinkListener;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.SwingHelper;
 import com.intellij.util.ui.UIUtil;
@@ -27,7 +30,6 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
 public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
-  private static final int TEXT_MARGIN = 14;
   private final HtmlRenderer htmlRenderer =
       HtmlRenderer.builder().extensions(List.of(TablesExtension.create())).build();
   private final JPanel messagePanel;
@@ -48,6 +50,7 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
     jEditorPane.setFocusable(true);
     jEditorPane.setMargin(
         JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
+    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE);
     textPane = jEditorPane;
     messagePanel.add(textPane, textPaneIndex++);
     return jEditorPane;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessagePanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessagePanel.java
@@ -15,7 +15,7 @@ public class MessagePanel extends JPanel {
   private final boolean isHuman;
   private final int gradientWidth;
 
-  public MessagePanel(ChatMessage message, int gradientWidth) {
+  public MessagePanel(Speaker speaker, int gradientWidth) {
     super();
     this.gradientWidth = gradientWidth;
     Border emptyBorder = BorderFactory.createEmptyBorder(0, 0, 0, 0);
@@ -26,7 +26,7 @@ public class MessagePanel extends JPanel {
         BorderFactory.createMatteBorder(0, 0, 1, 0, ColorUtil.brighter(background, 3));
     Border topAndBottomBorder = BorderFactory.createCompoundBorder(topBorder, bottomBorder);
 
-    isHuman = message.getSpeaker().equals(Speaker.HUMAN);
+    isHuman = speaker.equals(Speaker.HUMAN);
     this.setBorder(isHuman ? emptyBorder : topAndBottomBorder);
     this.setBackground(isHuman ? ColorUtil.darker(background, 2) : background);
     this.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
@@ -1,0 +1,41 @@
+package com.sourcegraph.config;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.impl.ActionButton;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.IconUtil;
+import com.intellij.util.ui.JBDimension;
+import com.intellij.util.ui.JBUI;
+import com.sourcegraph.Icons;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
+
+public class GoToPluginSettingsButtonFactory {
+
+  @NotNull
+  public static ActionButton createGoToPluginSettingsButton(@NotNull Project project) {
+    JBDimension actionButtonSize = JBUI.size(22, 22);
+
+    AnAction action =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+            ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
+          }
+        };
+    Presentation presentation = new Presentation("Open Plugin Settings");
+
+    ActionButton button =
+        new ActionButton(
+            action, presentation, "Find with Sourcegraph popup header", actionButtonSize);
+
+    Icon scaledIcon = IconUtil.scale(Icons.GearPlain, button, 13f / 12f);
+    presentation.setIcon(scaledIcon);
+
+    return button;
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
@@ -1,22 +1,12 @@
 package com.sourcegraph.find;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.Presentation;
-import com.intellij.openapi.actionSystem.impl.ActionButton;
-import com.intellij.openapi.options.ShowSettingsUtil;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.IconUtil;
-import com.intellij.util.ui.JBDimension;
 import com.intellij.util.ui.JBEmptyBorder;
-import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
-import com.sourcegraph.config.SettingsConfigurable;
+import com.sourcegraph.config.GoToPluginSettingsButtonFactory;
 import java.awt.*;
 import javax.swing.*;
-import org.jetbrains.annotations.NotNull;
 
 public class HeaderPanel extends BorderLayoutPanel {
   public HeaderPanel(Project project) {
@@ -28,32 +18,9 @@ public class HeaderPanel extends BorderLayoutPanel {
     title.add(new JLabel("Find with Sourcegraph", Icons.SourcegraphLogo, SwingConstants.LEFT));
 
     JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
-    buttons.add(createSettingsButton(project));
+    buttons.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(project));
 
     add(title, BorderLayout.WEST);
     add(buttons, BorderLayout.EAST);
-  }
-
-  @NotNull
-  private ActionButton createSettingsButton(@NotNull Project project) {
-    JBDimension actionButtonSize = JBUI.size(22, 22);
-
-    AnAction action =
-        new DumbAwareAction() {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-            ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
-          }
-        };
-    Presentation presentation = new Presentation("Open Plugin Settings");
-
-    ActionButton button =
-        new ActionButton(
-            action, presentation, "Find with Sourcegraph popup header", actionButtonSize);
-
-    Icon scaledIcon = IconUtil.scale(Icons.GearPlain, button, 13f / 12f);
-    presentation.setIcon(scaledIcon);
-
-    return button;
   }
 }


### PR DESCRIPTION
Adds new "welcome" chat message when access token is not configured, and displays appropriate chat message when we get 401 Invalid access token from the server. 

closes #53460


## Test plan
- Chat message with instructions how to set up a token should appear when token is not configured or if is invalid and user tries to interact with cody

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
No access token defined
<img width="564" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/b841d675-86ce-4ee3-a537-11356d2c0cbe">

Getting 401 error from backend
<img width="564" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/6dea681d-bbab-4870-b802-8b2fb492f8ed">

