### PR TITLE
Completions: Add hugging face provider

### DIFF
--- a/client/cody-shared/src/configuration.ts
+++ b/client/cody-shared/src/configuration.ts
@@ -13,8 +13,9 @@ export interface Configuration {
     experimentalInline: boolean
     experimentalGuardrails: boolean
     experimentalNonStop: boolean
-    completionsAdvancedProvider: 'anthropic' | 'unstable-codegen'
+    completionsAdvancedProvider: 'anthropic' | 'unstable-codegen' | 'unstable-huggingface'
     completionsAdvancedServerEndpoint: string | null
+    completionsAdvancedAccessToken: string | null
 }
 
 export interface ConfigurationWithAccessToken extends Configuration {

--- a/client/cody/BUILD.bazel
+++ b/client/cody/BUILD.bazel
@@ -53,6 +53,7 @@ ts_project(
         "src/completions/providers/anthropic.ts",
         "src/completions/providers/provider.ts",
         "src/completions/providers/unstable-codegen.ts",
+        "src/completions/providers/unstable-huggingface.ts",
         "src/completions/utils.ts",
         "src/configuration.ts",
         "src/editor/vscode-editor.ts",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -827,11 +827,15 @@
         "cody.completions.advanced.provider": {
           "type": "string",
           "default": "anthropic",
-          "markdownDescription": "Overwrite the provider used for generating code completions. Only supported values at the moment are `anthropic` (default) or `unstable-codegen`."
+          "markdownDescription": "Overwrite the provider used for generating code completions. Only supported values at the moment are `anthropic` (default), `unstable-codegen`, or `unstable-huggingface`."
         },
         "cody.completions.advanced.serverEndpoint": {
           "type": "string",
-          "markdownDescription": "Overwrite the server endpoint used for generating code completions. This is only supported with the `unstable-codegen` provider right now."
+          "markdownDescription": "Overwrite the server endpoint used for generating code completions. This is only supported with the `unstable-codegen` or `unstable-huggingface` provider."
+        },
+        "cody.completions.advanced.accessToken": {
+          "type": "string",
+          "markdownDescription": "Overwrite the access token used for generating code completions. This is only supported with the `unstable-huggingface` provider."
         }
       }
     },

--- a/client/cody/src/completions/providers/unstable-huggingface.ts
+++ b/client/cody/src/completions/providers/unstable-huggingface.ts
@@ -1,0 +1,88 @@
+import { Completion } from '..'
+import { logger } from '../../log'
+import { isAbortError } from '../utils'
+
+import { Provider, ProviderConfig, ProviderOptions } from './provider'
+
+interface UnstableHuggingFaceOptions {
+    serverEndpoint: string
+    accessToken: null | string
+}
+
+const PROVIDER_IDENTIFIER = 'huggingface'
+const STOP_WORD = '<|endoftext|>'
+
+export class UnstableHuggingFaceProvider extends Provider {
+    private serverEndpoint: string
+    private accessToken: null | string
+
+    constructor(options: ProviderOptions, unstableHuggingFaceOptions: UnstableHuggingFaceOptions) {
+        super(options)
+        this.serverEndpoint = unstableHuggingFaceOptions.serverEndpoint
+        this.accessToken = unstableHuggingFaceOptions.accessToken
+    }
+
+    public async generateCompletions(abortSignal: AbortSignal): Promise<Completion[]> {
+        // TODO: Add context and language
+        const prompt = `<fim_prefix>${this.prefix}<fim_suffix>${this.suffix}<fim_middle>`
+
+        const request = {
+            inputs: prompt,
+            parameters: {
+                num_return_sequences: 1,
+                max_new_tokens: this.multilineMode === null ? 40 : 128,
+            },
+        }
+
+        const log = logger.startCompletion({
+            request,
+            provider: PROVIDER_IDENTIFIER,
+            serverEndpoint: this.serverEndpoint,
+        })
+
+        const response = await fetch(this.serverEndpoint, {
+            method: 'POST',
+            body: JSON.stringify(request),
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${this.accessToken}`,
+            },
+            signal: abortSignal,
+        })
+
+        try {
+            const data = (await response.json()) as { generated_text: string }[] | { error: string }
+
+            if ('error' in data) {
+                throw new Error(data.error)
+            }
+
+            const completions: string[] = data.map((c: { generated_text: string }) =>
+                c.generated_text.replace(STOP_WORD, '')
+            )
+            log?.onComplete(completions)
+
+            return completions.map(content => ({
+                prefix: this.prefix,
+                content,
+            }))
+        } catch (error) {
+            if (!isAbortError(error)) {
+                log?.onError(error)
+            }
+
+            throw error
+        }
+    }
+}
+
+export function createProviderConfig(unstableHuggingFaceOptions: UnstableHuggingFaceOptions): ProviderConfig {
+    const contextWindowChars = 8_000 // ~ 2k token limit
+    return {
+        create(options: ProviderOptions) {
+            return new UnstableHuggingFaceProvider(options, unstableHuggingFaceOptions)
+        },
+        maximumContextCharacters: contextWindowChars,
+        identifier: PROVIDER_IDENTIFIER,
+    }
+}

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -22,6 +22,7 @@ describe('getConfiguration', () => {
             debugFilter: null,
             completionsAdvancedProvider: 'anthropic',
             completionsAdvancedServerEndpoint: null,
+            completionsAdvancedAccessToken: null,
         })
     })
 
@@ -60,6 +61,8 @@ describe('getConfiguration', () => {
                         return 'unstable-codegen'
                     case 'cody.completions.advanced.serverEndpoint':
                         return 'https://example.com/llm'
+                    case 'cody.completions.advanced.accessToken':
+                        return 'foobar'
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -83,6 +86,7 @@ describe('getConfiguration', () => {
             debugFilter: /.*/,
             completionsAdvancedProvider: 'unstable-codegen',
             completionsAdvancedServerEndpoint: 'https://example.com/llm',
+            completionsAdvancedAccessToken: 'foobar',
         })
     })
 })

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -33,7 +33,11 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         'cody.completions.advanced.provider',
         'anthropic'
     )
-    if (completionsAdvancedProvider !== 'anthropic' && completionsAdvancedProvider !== 'unstable-codegen') {
+    if (
+        completionsAdvancedProvider !== 'anthropic' &&
+        completionsAdvancedProvider !== 'unstable-codegen' &&
+        completionsAdvancedProvider !== 'unstable-huggingface'
+    ) {
         completionsAdvancedProvider = 'anthropic'
         void vscode.window.showInformationMessage(
             "Unrecognized cody.completions.advanced.provider, defaulting to 'anthropic'"
@@ -55,6 +59,7 @@ export function getConfiguration(config: Pick<vscode.WorkspaceConfiguration, 'ge
         experimentalNonStop: config.get('cody.experimental.nonStop', isTesting),
         completionsAdvancedProvider,
         completionsAdvancedServerEndpoint: config.get<string | null>('cody.completions.advanced.serverEndpoint', null),
+        completionsAdvancedAccessToken: config.get<string | null>('cody.completions.advanced.accessToken', null),
     }
 }
 

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -16,6 +16,7 @@ import { ManualCompletionService } from './completions/manual'
 import { createProviderConfig as createAnthropicProviderConfig } from './completions/providers/anthropic'
 import { ProviderConfig } from './completions/providers/provider'
 import { createProviderConfig as createUnstableCodeGenProviderConfig } from './completions/providers/unstable-codegen'
+import { createProviderConfig as createUnstableHuggingFaceProviderConfig } from './completions/providers/unstable-huggingface'
 import { getConfiguration, getFullConfig } from './configuration'
 import { VSCodeEditor } from './editor/vscode-editor'
 import { logEvent, updateEventLogger, eventLogger } from './event-logger'
@@ -406,26 +407,41 @@ function createCompletionsProvider(
         codebaseContext
     )
 
-    let providerConfig: ProviderConfig
+    let providerConfig: null | ProviderConfig = null
     switch (config.completionsAdvancedProvider) {
         case 'unstable-codegen': {
             if (config.completionsAdvancedServerEndpoint !== null) {
                 providerConfig = createUnstableCodeGenProviderConfig({
                     serverEndpoint: config.completionsAdvancedServerEndpoint,
                 })
-                break
             }
 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             webviewErrorMessenger(
                 'Provider `unstable-codegen` can not be used without configuring `cody.completions.advanced.serverEndpoint`. Falling back to `anthropic`.'
             )
+            break
         }
-        default:
-            providerConfig = createAnthropicProviderConfig({
-                completionsClient,
-                contextWindowTokens: 2048,
-            })
+        case 'unstable-huggingface': {
+            if (config.completionsAdvancedServerEndpoint !== null) {
+                providerConfig = createUnstableHuggingFaceProviderConfig({
+                    serverEndpoint: config.completionsAdvancedServerEndpoint,
+                    accessToken: config.completionsAdvancedAccessToken,
+                })
+            }
+
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            webviewErrorMessenger(
+                'Provider `unstable-huggingface` can not be used without configuring `cody.completions.advanced.serverEndpoint`. Falling back to `anthropic`.'
+            )
+            break
+        }
+    }
+    if (!providerConfig) {
+        providerConfig = createAnthropicProviderConfig({
+            completionsClient,
+            contextWindowTokens: 2048,
+        })
     }
     const completionsProvider = new CodyCompletionItemProvider(providerConfig, history, statusBar, codebaseContext)
 


### PR DESCRIPTION
This PR adds an experimental hugging face provider that we can use to test OSS models.

We currently have an instance with a deployed version for WizardCoder available, so this prompt is based on the StarCoder FIM prompt and seems to work great in my limited tests.

The biggest issue we have with this approach is latency. So we'll need to work on this next.

## Test plan

- Set the following settings:
   ```
  "cody.completions.advanced.provider": "unstable-huggingface",
  "cody.completions.advanced.serverEndpoint": "https://tjjgqj2ub71aikaq.us-east-1.aws.endpoints.huggingface.cloud",
  "cody.completions.advanced.accessToken": "<TOKEN>",
   ```
- Start a completion request:  
<img width="761" alt="Screenshot 2023-06-19 at 12 03 25" src="https://github.com/sourcegraph/sourcegraph/assets/458591/47f08a59-c03e-47f3-bc9b-38d4ff69c586">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
