### PR TITLE
own: add information when Own statistics were last generated.

### DIFF
--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useQuery } from '@sourcegraph/http-client'
 import { Alert, BarChart, Card, ErrorAlert, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
@@ -71,14 +72,13 @@ const OwnAnalyticsPanel: FC = () => {
             fill: 'var(--info-3)',
             tooltip: `Owned files: ${totalOwnedFiles}/${totalFiles}`,
         },
-        // TODO decide whether we remove or keep all files
-        {
-            name: 'All files',
-            count: 100,
-            fill: 'var(--text-muted)',
-            tooltip: 'Total number of files',
-        },
     ]
+
+    const lastUpdatedAt = data.instanceOwnershipStats.updatedAt ? (
+        <>
+            Last generated: <Timestamp date={data.instanceOwnershipStats.updatedAt} />
+        </>
+    ) : undefined
 
     return (
         <>
@@ -113,8 +113,8 @@ const OwnAnalyticsPanel: FC = () => {
                         )}
                     </Card>
                     <Text className="font-italic text-center mt-2">
-                        {/* TODO(#52826): Provide more precise information about how stale data is, and how often it refreshes. */}
-                        Data is generated periodically from CODEOWNERS files and repository contents.
+                        Data is generated periodically from CODEOWNERS files and repository contents.{' '}
+                        {lastUpdatedAt && lastUpdatedAt}
                     </Text>
                 </>
             )}

--- a/client/web/src/enterprise/own/admin-ui/query.ts
+++ b/client/web/src/enterprise/own/admin-ui/query.ts
@@ -36,6 +36,7 @@ export const GET_INSTANCE_OWN_STATS = gql`
             totalCodeownedFiles
             totalOwnedFiles
             totalAssignedOwnershipFiles
+            updatedAt
         }
     }
 `

--- a/cmd/frontend/graphqlbackend/own.go
+++ b/cmd/frontend/graphqlbackend/own.go
@@ -86,6 +86,7 @@ type OwnershipStatsResolver interface {
 	TotalCodeownedFiles(context.Context) (int32, error)
 	TotalOwnedFiles(context.Context) (int32, error)
 	TotalAssignedOwnershipFiles(context.Context) (int32, error)
+	UpdatedAt(ctx context.Context) (*gqlutil.DateTime, error)
 }
 
 type Ownable interface {

--- a/cmd/frontend/graphqlbackend/own.graphql
+++ b/cmd/frontend/graphqlbackend/own.graphql
@@ -86,21 +86,22 @@ type OwnershipStats {
     Total files considered for ownership statistics (owned + unowned).
     """
     totalFiles: Int!
-
     """
     Total files with ownership stemming from CODEOWNERS files.
     """
     totalCodeownedFiles: Int!
-
     """
     Total files with any ownership defined (both CODEOWNERS and assigned).
     """
     totalOwnedFiles: Int!
-
     """
     Total files with assigned ownership.
     """
     totalAssignedOwnershipFiles: Int!
+    """
+    When statistics were last updated.
+    """
+    updatedAt: DateTime
 }
 
 """

--- a/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/enterprise/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -2235,11 +2236,13 @@ func TestDisplayOwnershipStats(t *testing.T) {
 	fakeRepoPaths.AggregateFileCountFunc.SetDefaultReturn(350000, nil)
 	db.RepoPathsFunc.SetDefaultReturn(fakeRepoPaths)
 	fakeOwnershipStats := database.NewMockOwnershipStatsStore()
+	updateTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	fakeOwnershipStats.QueryAggregateCountsFunc.SetDefaultReturn(
 		database.PathAggregateCounts{
 			CodeownedFileCount:         150000,
 			AssignedOwnershipFileCount: 20000,
 			TotalOwnedFileCount:        165000,
+			UpdatedAt:                  updateTime,
 		}, nil)
 	db.OwnershipStatsFunc.SetDefaultReturn(fakeOwnershipStats)
 	ctx := context.Background()
@@ -2255,15 +2258,17 @@ func TestDisplayOwnershipStats(t *testing.T) {
 					totalCodeownedFiles
 					totalOwnedFiles
 					totalAssignedOwnershipFiles
+					updatedAt
 				}
 			}`,
 		ExpectedResult: `
 			{
 				"instanceOwnershipStats": {
 					"totalFiles": 350000,
-					"totalCodeownedFiles" : 150000,
-					"totalOwnedFiles" : 165000,
-					"totalAssignedOwnershipFiles" : 20000
+					"totalCodeownedFiles": 150000,
+					"totalOwnedFiles": 165000,
+					"totalAssignedOwnershipFiles": 20000,
+					"updatedAt": "2023-01-01T00:00:00Z"
 				}
 			}`,
 	})

--- a/enterprise/internal/own/background/analytics_test.go
+++ b/enterprise/internal/own/background/analytics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/stretchr/testify/assert"
@@ -80,10 +81,14 @@ func TestAnalyticsIndexerSuccess(t *testing.T) {
 
 	gotCounts, err := db.OwnershipStats().QueryAggregateCounts(ctx, database.TreeLocationOpts{})
 	require.NoError(t, err)
+	// We don't really need to compare time here.
+	defaultTime := time.Time{}
+	gotCounts.UpdatedAt = defaultTime
 	wantCounts := database.PathAggregateCounts{
 		CodeownedFileCount:         3,
 		AssignedOwnershipFileCount: 2,
 		TotalOwnedFileCount:        4,
+		UpdatedAt:                  defaultTime,
 	}
 	assert.Equal(t, wantCounts, gotCounts)
 }
@@ -141,6 +146,8 @@ func TestAnalyticsIndexerNoCodeowners(t *testing.T) {
 	assert.Equal(t, int32(5), totalFileCount)
 
 	codeownedCount, err := db.OwnershipStats().QueryAggregateCounts(ctx, database.TreeLocationOpts{})
+	defaultTime := time.Time{}
+	codeownedCount.UpdatedAt = defaultTime
 	require.NoError(t, err)
-	assert.Equal(t, database.PathAggregateCounts{CodeownedFileCount: 0}, codeownedCount)
+	assert.Equal(t, database.PathAggregateCounts{CodeownedFileCount: 0, UpdatedAt: defaultTime}, codeownedCount)
 }

--- a/internal/database/ownership_stats.go
+++ b/internal/database/ownership_stats.go
@@ -46,6 +46,8 @@ type PathAggregateCounts struct {
 	// TotalOwnedFileCount is the total number of files in tree that have any ownership associated
 	// - either via CODEOWNERS or via assigned ownership.
 	TotalOwnedFileCount int
+	// UpdatedAt shows When statistics were last updated.
+	UpdatedAt time.Time
 }
 
 // TreeLocationOpts allows locating and aggregating statistics on file trees.
@@ -87,7 +89,7 @@ type ownershipStats struct {
 	*basestore.Store
 }
 
-var codeownerQueryFmtstr = `
+const codeownerQueryFmtstr = `
 	WITH existing (id) AS (
 		SELECT a.id
 		FROM codeowners_owners AS a
@@ -103,7 +105,7 @@ var codeownerQueryFmtstr = `
 	SELECT id FROM inserted
 `
 
-var codeownerUpsertCountsFmtstr = `
+const codeownerUpsertCountsFmtstr = `
 	INSERT INTO codeowners_individual_stats (file_path_id, owner_id, tree_owned_files_count, updated_at)
 	VALUES (%s, %s, %s, %s)
 	ON CONFLICT (file_path_id, owner_id)
@@ -151,7 +153,7 @@ func (s *ownershipStats) UpdateIndividualCounts(ctx context.Context, repoID api.
 	return totalRows, nil
 }
 
-var aggregateCountsUpdateFmtstr = `
+const aggregateCountsUpdateFmtstr = `
 	INSERT INTO ownership_path_stats (
 		file_path_id,
 		tree_codeowned_files_count,
@@ -199,13 +201,14 @@ func (s *ownershipStats) UpdateAggregateCounts(ctx context.Context, repoID api.R
 	return totalUpdates, err
 }
 
-var aggregateOwnershipFmtstr = `
+const aggregateOwnershipFmtstr = `
 	SELECT o.reference, SUM(COALESCE(s.tree_owned_files_count, 0))
 	FROM codeowners_individual_stats AS s
 	INNER JOIN repo_paths AS p ON s.file_path_id = p.id
 	INNER JOIN codeowners_owners AS o ON o.id = s.owner_id
 	WHERE p.absolute_path = %s
 `
+
 var treeCountsScanner = basestore.NewSliceScanner(func(s dbutil.Scanner) (PathCodeownersCounts, error) {
 	var cs PathCodeownersCounts
 	err := s.Scan(&cs.CodeownersReference, &cs.CodeownedFileCount)
@@ -222,11 +225,12 @@ func (s *ownershipStats) QueryIndividualCounts(ctx context.Context, opts TreeLoc
 	return treeCountsScanner(s.Store.Query(ctx, sqlf.Join(qs, "\n")))
 }
 
-var treeAggregateCountsFmtstr = `
+const treeAggregateCountsFmtstr = `
 	SELECT
 		SUM(COALESCE(s.tree_codeowned_files_count, 0)),
 		SUM(COALESCE(s.tree_assigned_ownership_files_count, 0)),
-		SUM(COALESCE(s.tree_any_ownership_files_count, 0))
+		SUM(COALESCE(s.tree_any_ownership_files_count, 0)),
+		MAX(s.last_updated_at)
 	FROM ownership_path_stats AS s
 	INNER JOIN repo_paths AS p ON s.file_path_id = p.id
 	WHERE p.absolute_path = %s
@@ -242,6 +246,7 @@ func (s *ownershipStats) QueryAggregateCounts(ctx context.Context, opts TreeLoca
 		&dbutil.NullInt{N: &cs.CodeownedFileCount},
 		&dbutil.NullInt{N: &cs.AssignedOwnershipFileCount},
 		&dbutil.NullInt{N: &cs.TotalOwnedFileCount},
+		&dbutil.NullTime{Time: &cs.UpdatedAt},
 	)
 	return cs, err
 }

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -273,6 +273,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 		want := PathAggregateCounts{
 			CodeownedFileCount:  1,
 			TotalOwnedFileCount: 1,
+			UpdatedAt:           timestamp,
 		}
 		assert.DeepEqual(t, want, got)
 	})
@@ -288,6 +289,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 			CodeownedFileCount:         1,
 			AssignedOwnershipFileCount: 1,
 			TotalOwnedFileCount:        2,
+			UpdatedAt:                  timestamp,
 		}
 		assert.DeepEqual(t, want, got)
 	})
@@ -302,6 +304,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 			CodeownedFileCount:         1,
 			AssignedOwnershipFileCount: 1,
 			TotalOwnedFileCount:        2,
+			UpdatedAt:                  timestamp,
 		}
 		assert.DeepEqual(t, want, got)
 	})
@@ -314,6 +317,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 			CodeownedFileCount:         11,
 			AssignedOwnershipFileCount: 1,
 			TotalOwnedFileCount:        12,
+			UpdatedAt:                  timestamp,
 		}
 		assert.DeepEqual(t, want, got)
 	})

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -230,7 +230,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 	})
 
 	// 2. Insert aggregate counts:
-	timestamp := time.Now()
+	timestamp := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 	repo1Counts := fakeAggregateStatsIterator{
 		"": {
 			CodeownedFileCount:         1,

--- a/internal/database/repo_paths.go
+++ b/internal/database/repo_paths.go
@@ -130,7 +130,7 @@ type repoPathStore struct {
 	*basestore.Store
 }
 
-var updateFileCountsFmtstr = `
+const updateFileCountsFmtstr = `
 	UPDATE repo_paths
 	SET tree_files_count = %s,
 	tree_files_counts_updated_at = %s
@@ -161,7 +161,7 @@ func (s *repoPathStore) UpdateFileCounts(ctx context.Context, repoID api.RepoID,
 	return rowsUpdated, err
 }
 
-var aggregateFileCountFmtstr = `
+const aggregateFileCountFmtstr = `
     SELECT SUM(COALESCE(p.tree_files_count, 0))
     FROM repo_paths AS p
     WHERE p.absolute_path = %s


### PR DESCRIPTION
Test plan:
Unit tests updated.
GraphQL tests updated.
Local sg run and visual checks.

Closes https://github.com/sourcegraph/sourcegraph/issues/53658

### When we have the timestamp
<img width="919" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/4f3c366c-fdd6-4dee-acac-ee4bfbe133d5">

### When we don't have it (shouldn't happen, guarded against it just in case)
<img width="924" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/ca8d76ce-b4bf-433c-8d66-4a7c0b252be5">

