### PR TITLE
Reject requests with MaxTokensToSample > 10000

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -3,6 +3,7 @@ package completions
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -24,6 +25,7 @@ func NewAnthropicHandler(
 	rateLimitNotifier notify.RateLimitNotifier,
 	accessToken string,
 	allowedModels []string,
+	maxTokensToSample int,
 ) http.Handler {
 	return makeUpstreamHandler(
 		logger,
@@ -88,6 +90,12 @@ func NewAnthropicHandler(
 					logger.Error("failed to decode Anthropic streaming response", log.Error(err))
 				}
 				return len(lastCompletion)
+			},
+			validateRequest: func(ar anthropicRequest) error {
+				if ar.MaxTokensToSample > int32(maxTokensToSample) {
+					return fmt.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", maxTokensToSample, ar.MaxTokensToSample)
+				}
+				return nil
 			},
 		},
 	)

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -3,7 +3,6 @@ package completions
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/notify"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/completions/client/anthropic"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const anthropicAPIURL = "https://api.anthropic.com/v1/complete"
@@ -93,7 +93,7 @@ func NewAnthropicHandler(
 			},
 			validateRequest: func(ar anthropicRequest) error {
 				if ar.MaxTokensToSample > int32(maxTokensToSample) {
-					return fmt.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", maxTokensToSample, ar.MaxTokensToSample)
+					return errors.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", maxTokensToSample, ar.MaxTokensToSample)
 				}
 				return nil
 			},

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -101,6 +101,9 @@ func NewOpenAIHandler(
 				}
 				return len(finalCompletion)
 			},
+			validateRequest: func(_ openaiRequest) error {
+				return nil
+			},
 		},
 	)
 }

--- a/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
@@ -16,13 +16,14 @@ import (
 )
 
 type Config struct {
-	RateLimitNotifier       notify.RateLimitNotifier
-	AnthropicAccessToken    string
-	AnthropicAllowedModels  []string
-	OpenAIAccessToken       string
-	OpenAIOrgID             string
-	OpenAIAllowedModels     []string
-	EmbeddingsAllowedModels []string
+	RateLimitNotifier          notify.RateLimitNotifier
+	AnthropicAccessToken       string
+	AnthropicAllowedModels     []string
+	AnthropicMaxTokensToSample int
+	OpenAIAccessToken          string
+	OpenAIOrgID                string
+	OpenAIAllowedModels        []string
+	EmbeddingsAllowedModels    []string
 }
 
 func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisStore, authr *auth.Authenticator, config *Config) http.Handler {
@@ -42,6 +43,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 						config.RateLimitNotifier,
 						config.AnthropicAccessToken,
 						config.AnthropicAllowedModels,
+						config.AnthropicMaxTokensToSample,
 					),
 				),
 			),

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -29,8 +29,9 @@ type Config struct {
 	}
 
 	Anthropic struct {
-		AllowedModels []string
-		AccessToken   string
+		AllowedModels     []string
+		AccessToken       string
+		MaxTokensToSample int
 	}
 
 	OpenAI struct {
@@ -92,6 +93,7 @@ func (c *Config) Load() {
 			"claude-instant-v1.1-100k",
 		}, ","),
 		"Anthropic models that can be used."))
+	c.Anthropic.MaxTokensToSample = c.GetInt("CODY_GATEWAY_ANTHROPIC_MAX_TOKENS_TO_SAMPLE", "10000", "Maximum permitted value of maxTokensToSample")
 
 	c.OpenAI.AccessToken = c.GetOptional("CODY_GATEWAY_OPENAI_ACCESS_TOKEN", "The OpenAI access token to be used.")
 	c.OpenAI.OrgID = c.GetOptional("CODY_GATEWAY_OPENAI_ORG_ID", "The OpenAI organization to count billing towards. Setting this ensures we always use the correct negotiated terms.")

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -113,13 +113,14 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	// Set up our handler chain, which is run from the bottom up. Application handlers
 	// come last.
 	handler := httpapi.NewHandler(obctx.Logger, eventLogger, rs, authr, &httpapi.Config{
-		RateLimitNotifier:       rateLimitNotifier,
-		AnthropicAccessToken:    config.Anthropic.AccessToken,
-		AnthropicAllowedModels:  config.Anthropic.AllowedModels,
-		OpenAIAccessToken:       config.OpenAI.AccessToken,
-		OpenAIOrgID:             config.OpenAI.OrgID,
-		OpenAIAllowedModels:     config.OpenAI.AllowedModels,
-		EmbeddingsAllowedModels: config.AllowedEmbeddingsModels,
+		RateLimitNotifier:          rateLimitNotifier,
+		AnthropicAccessToken:       config.Anthropic.AccessToken,
+		AnthropicAllowedModels:     config.Anthropic.AllowedModels,
+		AnthropicMaxTokensToSample: config.Anthropic.MaxTokensToSample,
+		OpenAIAccessToken:          config.OpenAI.AccessToken,
+		OpenAIOrgID:                config.OpenAI.OrgID,
+		OpenAIAllowedModels:        config.OpenAI.AllowedModels,
+		EmbeddingsAllowedModels:    config.AllowedEmbeddingsModels,
 	})
 
 	// Diagnostic layers


### PR DESCRIPTION
See [Slack](https://sourcegraph.slack.com/archives/C04NPH6SZMW/p1686881272805539) for context - this PR adds a limit for `maxTokensToSample` value Cody Gateway will forward to Anthropic.
Also slighly refactors signatures (to replace `any` with a named type) and adds a `validateRequest` hook.

## Test plan
Tested locally with values exceeding the limit and our regular 1000 limit.
Can be tested by running `CODY_GATEWAY_ANTHROPIC_MAX_TOKENS_TO_SAMPLE=50 sg start dotcom` (we use 1000 by default, so all requests will fail). 