### PR TITLE
JetBrains: enable send button after conversation reset

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Reset prompt input on message send [#53543](https://github.com/sourcegraph/sourcegraph/pull/53543)
 - Fixed UI of the prompt input [#53548](https://github.com/sourcegraph/sourcegraph/pull/53548)
 - Fixed zero-width spaces popping up in inline autocomplete [#53599](https://github.com/sourcegraph/sourcegraph/pull/53599)
+- Reset conversation button re-enables "Send" button [#53669](https://github.com/sourcegraph/sourcegraph/pull/53669)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -27,7 +27,6 @@ import com.sourcegraph.cody.prompts.SupportedLanguages;
 import com.sourcegraph.cody.recipes.*;
 import com.sourcegraph.cody.ui.RoundedJBTextArea;
 import com.sourcegraph.cody.ui.SelectOptionManager;
-import com.sourcegraph.cody.vcs.*;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
 import java.awt.*;
@@ -309,6 +308,7 @@ class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
+              sendButton.setEnabled(true);
               messagesPanel.removeAll();
               addWelcomeMessage();
               messagesPanel.revalidate();


### PR DESCRIPTION
Closes #53504 
## Test plan
- In case of broken Cody chat state reset conversation button should re-enable "Send" button
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
