### PR TITLE
JetBrains: display information about invalid access token on any 401

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -304,7 +304,7 @@ class CodyToolWindowContent implements UpdatableChat {
       this.addMessageToChat(
           ChatMessage.createAssistantMessage(
               "I'm sorry, I can't connect to the server. Please make sure that the server is running and try again."));
-    } else if (errorMessage.startsWith("Got error response 401: Invalid access token.")) {
+    } else if (errorMessage.startsWith("Got error response 401")) {
       String invalidAccessTokenText =
           "<p>It looks like your Sourcegraph Access Token is invalid or not configured.</p>"
               + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";


### PR DESCRIPTION
It turns out that backend responds with different 401 response messages, for example "Invalid access token." or "Invalid Authorization header." are possible, and we should  display informative message on any 401 error. 

## Test plan
- Receiving any 401 error should display message with information about invalid access token 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
