### PR TITLE
App - Make app startup faster

### DIFF
--- a/dev/check/go-dbconn-import.sh
+++ b/dev/check/go-dbconn-import.sh
@@ -31,6 +31,15 @@ allowed_prefix=(
   # Main entrypoints for running all services, so they must be allowed to import it.
   github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss
   github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph
+
+  # these packages actually do not import dbconn but it is because of ./internal/singleprogram
+  # you can check this with the following query:
+  # bazel query 'kind("go_binary", rdeps(//cmd/blobstore/..., //internal/database/dbconn))' --keep_going > out.do | dot -Tsvg < out.dot > out.svg
+  # TODO(burmudar): use bazel query instead fo this lint
+  github.com/sourcegraph/sourcegraph/cmd/blobstore
+  github.com/sourcegraph/sourcegraph/cmd/github-proxy
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/llm-proxy
 )
 
 # Create regex ^(a|b|c)

--- a/dev/check/go-dbconn-import.sh
+++ b/dev/check/go-dbconn-import.sh
@@ -32,9 +32,9 @@ allowed_prefix=(
   github.com/sourcegraph/sourcegraph/cmd/sourcegraph-oss
   github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph
 
-  # these packages actually do not import dbconn but it is because of ./internal/singleprogram
+  # these packages actually do not import dbconn directly but transitively, because of ./internal/singleprogram
   # you can check this with the following query:
-  # bazel query 'kind("go_binary", rdeps(//cmd/blobstore/..., //internal/database/dbconn))' --keep_going > out.do | dot -Tsvg < out.dot > out.svg
+  # bazel query 'kind("go_binary", rdeps(//cmd/blobstore/..., //internal/database/dbconn))' --keep_going > out.dot | dot -Tsvg < out.dot > out.svg
   # TODO(burmudar): use bazel query instead fo this lint
   github.com/sourcegraph/sourcegraph/cmd/blobstore
   github.com/sourcegraph/sourcegraph/cmd/github-proxy

--- a/internal/singleprogram/BUILD.bazel
+++ b/internal/singleprogram/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     deps = [
         "//internal/conf/confdefaults",
         "//internal/conf/deploy",
+        "//internal/database/connections/live",
         "//internal/env",
+        "//internal/observation",
         "//internal/version",
         "//lib/errors",
         "@com_github_fatih_color//:color",

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -104,12 +104,12 @@ func Init(logger log.Logger) CleanupFunc {
 	}
 
 	// Force migrations prior to start any services
-	_, err = connections.EnsureNewFrontendDB(observation.NewContext(logger), os.Getenv("PGDATASOURCE"), "frontend")
+	_, err = connections.MigrateNewFrontendDB(observation.NewContext(logger), os.Getenv("PGDATASOURCE"), "frontend")
 	if err != nil {
 		logger.Fatal("Failed to migrate to codeintel database", log.Error(err))
 	}
 
-	_, err = connections.EnsureNewCodeIntelDB(observation.NewContext(logger), os.Getenv("CODEINTEL_PGDATASOURCE"), "codeintel")
+	_, err = connections.MigrateNewCodeIntelDB(observation.NewContext(logger), os.Getenv("CODEINTEL_PGDATASOURCE"), "codeintel")
 	if err != nil {
 		logger.Fatal("Failed to migrate to codeintel database", log.Error(err))
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1439,7 +1439,7 @@ commandsets:
       - caddy
       - tauri
     env:
-      DISABLE_CODE_INSIGHTS: false
+      DISABLE_CODE_INSIGHTS: true
       SOURCEGRAPH_APP: 1
       EXTSVC_CONFIG_ALLOW_EDITS: true
 


### PR DESCRIPTION
The initial startup of app is slower then we would like.  Now that Code Insights is not in app, this disables Code Insights, which means that the schema migrations are no longer forced to run.

I also ensured the db connections prior to starting any services, previously the each service would ensure the db connection which caused a slow down as they fought over running the migrations. 

## Test plan
dev version
```
 rm -rf ~/.sourcegraph-psql ~/Library/Application\ Support/sourcegraph-dev ~/Library/Caches/sourcegraph-dev ~/Library/WebKit/sourcegraph-dev
```
`sg start app` observe time to run migrations - dropped from approx 4 seconds - approx 1.5 seconds

prod build
```
rm -rf ~/.sourcegraph-psql ~/Library/Application\ Support/com.sourcegraph.cody ~/Library/Caches/com.sourcegraph.cody ~/Library/WebKit/com.sourcegraph.cody
```
build local copy and ensure startup continues to work and restarts are successful.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
