### PR TITLE
[Backport 5.1] codeintel: add additional relationship data to snapshot view

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -110,7 +110,7 @@ export interface BlobInfo extends AbsoluteRepoFile, ModeSpec {
     /** External URLs for the file */
     externalURLs?: ExternalLinkFields[]
 
-    snapshotData?: { offset: number; data: string }[] | null
+    snapshotData?: { offset: number; data: string; additional: string[] | null }[] | null
 }
 
 const staticExtensions: Extension = [

--- a/client/web/src/repo/blob/backend.ts
+++ b/client/web/src/repo/blob/backend.ts
@@ -52,7 +52,9 @@ interface FetchBlobOptions {
 export const fetchBlob = memoizeObservable(
     (
         options: FetchBlobOptions
-    ): Observable<(BlobFileFields & { snapshot?: { offset: number; data: string }[] | null }) | null> => {
+    ): Observable<
+        (BlobFileFields & { snapshot?: { offset: number; data: string; additional: string[] | null }[] | null }) | null
+    > => {
         const {
             repoName,
             revision,
@@ -88,6 +90,7 @@ export const fetchBlob = memoizeObservable(
                                     snapshot(indexID: $visibleIndexID) {
                                         offset
                                         data
+                                        additional
                                     }
                                 }
                             }

--- a/client/web/src/repo/blob/codemirror/scip-snapshot.ts
+++ b/client/web/src/repo/blob/codemirror/scip-snapshot.ts
@@ -2,26 +2,37 @@ import { Extension } from '@codemirror/state'
 import { Decoration, EditorView, WidgetType } from '@codemirror/view'
 
 class SCIPSnapshotDecorations extends WidgetType {
-    constructor(private line: string) {
+    constructor(private line: string, private additional: string[] | null) {
         super()
     }
 
     public toDOM(view: EditorView): HTMLElement {
-        const span = document.createElement('div')
-        span.style.color = 'grey'
-        span.innerText = this.line
-        return span
+        const div = document.createElement('div')
+        const lineDiv = document.createElement('div')
+        lineDiv.style.color = 'grey'
+        lineDiv.innerText = this.line
+        div.append(lineDiv)
+        for (const extra of this.additional || []) {
+            const extraDiv = document.createElement('div')
+            extraDiv.style.color = 'grey'
+            extraDiv.innerText = extra
+            div.append(extraDiv)
+        }
+        return div
     }
 }
 
-export const scipSnapshot = (blob: string, data?: { offset: number; data: string }[] | null): Extension =>
+export const scipSnapshot = (
+    blob: string,
+    data?: { offset: number; data: string; additional: string[] | null }[] | null
+): Extension =>
     data
         ? [
               EditorView.decorations.of(
                   Decoration.set(
                       data.map(line =>
                           Decoration.widget({
-                              widget: new SCIPSnapshotDecorations(line.data),
+                              widget: new SCIPSnapshotDecorations(line.data, line.additional),
                               block: true,
                           }).range(
                               // If the offset is beyond the document, we have to bring it back one

--- a/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.codenav.graphql
@@ -259,6 +259,11 @@ type SnapshotData {
     The formatted SCIP symbol string.
     """
     data: String!
+
+    """
+    Any additional lines of snapshot output such as relationships, documentation etc.
+    """
+    additional: [String!]
 }
 
 """

--- a/enterprise/internal/codeintel/codenav/BUILD.bazel
+++ b/enterprise/internal/codeintel/codenav/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/enterprise/internal/codeintel/codenav/service.go
+++ b/enterprise/internal/codeintel/codenav/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/internal/lsifstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/codenav/shared"
@@ -1426,9 +1427,11 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 
 	linemap := newLinemap(string(file))
 	formatter := scip.LenientVerboseSymbolFormatter
-	// symtab := document.SymbolTable()
+	symtab := document.SymbolTable()
 
 	for _, occ := range document.Occurrences {
+		var snapshotData shared.SnapshotData
+
 		formatted, err := formatter.Format(occ.Symbol)
 		if err != nil {
 			formatted = fmt.Sprintf("error formatting %q", occ.Symbol)
@@ -1446,13 +1449,57 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 		snap.WriteString(strings.Repeat("^", int(originalRange.End.Character-originalRange.Start.Character)))
 		snap.WriteRune(' ')
 
-		if occ.SymbolRoles&int32(scip.SymbolRole_Definition) > 0 {
+		isDefinition := occ.SymbolRoles&int32(scip.SymbolRole_Definition) > 0
+		if isDefinition {
 			snap.WriteString("definition")
 		} else {
 			snap.WriteString("reference")
 		}
 		snap.WriteRune(' ')
 		snap.WriteString(formatted)
+
+		snapshotData.Symbol = snap.String()
+
+		// hasOverrideDocumentation := len(occ.OverrideDocumentation) > 0
+		// if hasOverrideDocumentation {
+		// 	documentation := occ.OverrideDocumentation[0]
+		// 	writeDocumentation(&b, documentation, prefix, true)
+		// }
+
+		if info, ok := symtab[occ.Symbol]; ok && isDefinition {
+			// for _, documentation := range info.Documentation {
+			// 	// At least get the first line of documentation if there is leading whitespace
+			// 	documentation = strings.TrimSpace(documentation)
+			// 	writeDocumentation(&b, documentation, prefix, false)
+			// }
+			slices.SortFunc(info.Relationships, func(a, b *scip.Relationship) bool {
+				return a.Symbol < b.Symbol
+			})
+			for _, relationship := range info.Relationships {
+				var b strings.Builder
+				b.WriteString(strings.Repeat(" ", (int(originalRange.Start.Character)-tabCount)+(tabCount*4)))
+				b.WriteString(strings.Repeat("^", int(originalRange.End.Character-originalRange.Start.Character)))
+				b.WriteString(" relationship ")
+
+				formatted, err = formatter.Format(relationship.Symbol)
+				if err != nil {
+					formatted = fmt.Sprintf("error formatting %q", occ.Symbol)
+				}
+
+				b.WriteString(formatted)
+				if relationship.IsImplementation {
+					b.WriteString(" implementation")
+				}
+				if relationship.IsReference {
+					b.WriteString(" reference")
+				}
+				if relationship.IsTypeDefinition {
+					b.WriteString(" type_definition")
+				}
+
+				snapshotData.AdditionalData = append(snapshotData.AdditionalData, b.String())
+			}
+		}
 
 		_, newRange, ok, err := gittranslator.GetTargetCommitPositionFromSourcePosition(ctx, dump.Commit, shared.Position{
 			Line:      int(originalRange.Start.Line),
@@ -1466,10 +1513,9 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 			continue
 		}
 
-		data = append(data, shared.SnapshotData{
-			DocumentOffset: linemap.positions[newRange.Line+1],
-			Symbol:         snap.String(),
-		})
+		snapshotData.DocumentOffset = linemap.positions[newRange.Line+1]
+
+		data = append(data, snapshotData)
 	}
 
 	return

--- a/enterprise/internal/codeintel/codenav/shared/types.go
+++ b/enterprise/internal/codeintel/codenav/shared/types.go
@@ -41,6 +41,7 @@ type UploadLocation struct {
 type SnapshotData struct {
 	DocumentOffset int
 	Symbol         string
+	AdditionalData []string
 }
 
 type Range struct {

--- a/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_raw_scip.go
+++ b/enterprise/internal/codeintel/codenav/transport/graphql/root_resolver_raw_scip.go
@@ -48,3 +48,7 @@ func (r *snapshotDataResolver) Offset() int32 {
 func (r *snapshotDataResolver) Data() string {
 	return r.data.Symbol
 }
+
+func (r *snapshotDataResolver) Additional() *[]string {
+	return &r.data.AdditionalData
+}

--- a/internal/codeintel/resolvers/codenav.go
+++ b/internal/codeintel/resolvers/codenav.go
@@ -41,6 +41,7 @@ type GitBlobLSIFDataResolver interface {
 type SnapshotDataResolver interface {
 	Offset() int32
 	Data() string
+	Additional() *[]string
 }
 
 type LSIFRangesArgs struct {


### PR DESCRIPTION
Adds relationship data to scip snapshot UI in blob view

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/085bfefd-6162-4b17-97a6-f0c3944e4be5)


Backport f6a16f4c from #53679 

