### PR TITLE
App setup: Lock window size in the setup flow

### DIFF
--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -1,5 +1,7 @@
 import { FC, useCallback, useLayoutEffect } from 'react'
 
+import { appWindow, LogicalSize } from '@tauri-apps/api/window'
+
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Theme, ThemeContext, ThemeSetting, useTheme } from '@sourcegraph/shared/src/theme'
@@ -49,6 +51,10 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         onView: () => {
             localStorage.setItem('app.setup.finished', 'true')
         },
+        onNext: async () => {
+            await appWindow.setResizable(true)
+            await appWindow.setSize(new LogicalSize(1024, 760))
+        },
     },
 ]
 
@@ -86,6 +92,18 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
             document.documentElement.classList.toggle('theme-dark', !isLightTheme)
         }
     }, [theme])
+
+    // Local screen size when we are in app setup flow,
+    // see last step onNext for window size restore and resize
+    // unblock
+    useLayoutEffect(() => {
+        async function lockSize() {
+            await appWindow.setSize(new LogicalSize(940, 640))
+            await appWindow.setResizable(false)
+        }
+
+        lockSize().catch(() => {})
+    }, [])
 
     if (status !== 'loaded') {
         return null

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -97,7 +97,7 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
     // see last step onNext for window size restore and resize
     // unblock
     useLayoutEffect(() => {
-        async function lockSize() {
+        async function lockSize(): Promise<void> {
             await appWindow.setSize(new LogicalSize(940, 640))
             await appWindow.setResizable(false)
         }

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -53,7 +53,7 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         },
         onNext: async () => {
             await appWindow.setResizable(true)
-            await appWindow.setSize(new LogicalSize(1024, 760))
+            await appWindow.setSize(new LogicalSize(1024, 768)
         },
     },
 ]

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -53,7 +53,7 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         },
         onNext: async () => {
             await appWindow.setResizable(true)
-            await appWindow.setSize(new LogicalSize(1024, 768)
+            await appWindow.setSize(new LogicalSize(1024, 768))
         },
     },
 ]

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -33,7 +33,7 @@ const CORE_STEPS: StepConfiguration[] = [
         // If user clicked next button in setup remote repositories
         // this mean that setup was completed, and they're ready to go
         // to app UI. See https://github.com/sourcegraph/sourcegraph/issues/50122
-        onNext: async (client: ApolloClient<{}>) => {
+        onNext: (client: ApolloClient<{}>) => {
             // Mutate initial needsRepositoryConfiguration value
             // in order to avoid loop in Layout page redirection logic
             // TODO Remove this as soon as we have a proper Sourcegraph context store

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -33,7 +33,7 @@ const CORE_STEPS: StepConfiguration[] = [
         // If user clicked next button in setup remote repositories
         // this mean that setup was completed, and they're ready to go
         // to app UI. See https://github.com/sourcegraph/sourcegraph/issues/50122
-        onNext: (client: ApolloClient<{}>) => {
+        onNext: async (client: ApolloClient<{}>) => {
             // Mutate initial needsRepositoryConfiguration value
             // in order to avoid loop in Layout page redirection logic
             // TODO Remove this as soon as we have a proper Sourcegraph context store

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -36,7 +36,7 @@ export interface StepConfiguration {
     nextURL?: string
     component: ComponentType<StepComponentProps>
     onView?: () => void
-    onNext?: (client: ApolloClient<{}>) => void
+    onNext?: (client: ApolloClient<{}>) => Promise<void>
 }
 
 interface SetupStepsContextData {

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -36,7 +36,7 @@ export interface StepConfiguration {
     nextURL?: string
     component: ComponentType<StepComponentProps>
     onView?: () => void
-    onNext?: (client: ApolloClient<{}>) => Promise<void>
+    onNext?: (client: ApolloClient<{}>) => Promise<void> | void
 }
 
 interface SetupStepsContextData {
@@ -114,11 +114,13 @@ export const SetupStepsRoot: FC<SetupStepsProps> = props => {
         onStepChange(currentStep)
     }, [currentStep, onStepChange])
 
-    const handleGoToNextStep = useCallback(() => {
+    const handleGoToNextStep = useCallback(async () => {
         const activeStep = steps[activeStepIndex]
         const nextStepIndex = activeStepIndex + 1
 
-        activeStep.onNext?.(client)
+        if (activeStep.onNext) {
+            await activeStep.onNext(client)
+        }
 
         if (activeStep.nextURL) {
             navigate(activeStep.nextURL)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ tauri-utils = { git = "https://github.com/tauri-apps/tauri", branch = "dev" }
 [dependencies.tauri]
 git = "https://github.com/tauri-apps/tauri"
 branch = "dev"
-features = ["fs-remove-dir", "dialog-confirm", "updater", "dialog-open", "devtools", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "window-start-dragging"]
+features = [ "window-set-size", "window-set-resizable","fs-remove-dir", "dialog-confirm", "updater", "dialog-open", "devtools", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "window-start-dragging"]
 
 [patch.crates-io]
 tauri = { git = "https://github.com/tauri-apps/tauri", branch = "dev" }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -32,7 +32,9 @@
         "open": "^(vscode:|https?:)|com.sourcegraph.cody/.*.log$"
       },
       "window": {
-        "startDragging": true
+        "startDragging": true,
+        "setSize": true,
+        "setResizable": true
       }
     },
     "systemTray": {
@@ -79,11 +81,11 @@
     },
     "windows": [
       {
-        "fullscreen": false,
-        "height": 768,
-        "resizable": true,
         "title": "Cody",
-        "width": 1024
+        "fullscreen": false,
+        "resizable": true,
+        "width": 1024,
+        "height": 768
       }
     ]
   }


### PR DESCRIPTION
[Desings ](https://www.figma.com/file/ZkJFUvVzZW9TgFg7k9w9Oq/App-%5BMAIN%5D?type=design&node-id=62-661&t=PZMjaLVAmJdI4ZIx-0)

Based on setup flow designs, we have to lock the window size when we are in the setup flow (the window should be fixed-sized and shouldn't be able to resize); right after the setup flow is finished, we should reset the setup flow to a fixed size and unlock resize. 

@danielmarquespt note that I used a bit increased height value here because the suggested 540 was too small for steps with the progress bar below. I can reevaluate the height value after we get the progress bar UI in place. 

## Test plan
- Check that in the setup flow, you can't resize the window, and it has a fixed 940x640 size
- Check that after setup flow window has standard 1024x768 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
