### PR TITLE
completions/httpapi: log trace context from upstream

### DIFF
--- a/internal/completions/types/BUILD.bazel
+++ b/internal/completions/types/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )


### PR DESCRIPTION
Sometimes, we'll get Sentry events indicating chat/completions failed, but it's hard to diagnose if this is something in Cody Gateway because we can't link it to a request on our end if the Sourcegraph request isn't traced. This change always adds an upstream trace if one looks like our internal standards to the log entry, so that it'll show up as a field in Sentry reports.

I think with this we should be good enough to close #53091, now there's always a way to get the corresponding request in Cody Gateway from all environments (logs and/or traces).

This must be added as log fields instead of in the error message to avoid breaking Sentry's error grouping.

## Test plan

CI
