### PR TITLE
App: Fix paper cuts in UI and rename sourcegraph to cody app

### DIFF
--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -21,7 +21,7 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = props => {
                 type="button"
                 onClick={() => openLink('sourcegraph://user/settings/tokens/new/callback?requestFrom=CODY')}
             >
-                Connect Sourcegraph App
+                Connect Cody App
             </VSCodeButton>
         </p>
     )

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -16,9 +16,7 @@ export const Settings: React.FunctionComponent<React.PropsWithChildren<SettingsP
     <div className="inner-container">
         <div className="non-transcript-container">
             <div className="settings">
-                {serverEndpoint && (
-                    <p>🟢 Connected to {isLocalApp(serverEndpoint) ? 'Sourcegraph App' : serverEndpoint}</p>
-                )}
+                {serverEndpoint && <p>🟢 Connected to {isLocalApp(serverEndpoint) ? 'Cody App' : serverEndpoint}</p>}
                 <VSCodeButton className="logout-button" type="button" onClick={onLogout}>
                     Logout
                 </VSCodeButton>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -166,7 +166,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                                 to="https://about.sourcegraph.com/app"
                                 onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
                             >
-                                download Sourcegraph app
+                                download Cody app
                             </Link>{' '}
                             or{' '}
                             <Link

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -93,7 +93,7 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
 
     return (
         <ThemeContext.Provider value={{ themeSetting: ThemeSetting.Light }}>
-            <PageTitle title="Sourcegraph App setup" />
+            <PageTitle title="Cody App setup" />
 
             <SetupStepsRoot
                 baseURL="/app-setup/"

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -123,7 +123,7 @@ ListOfBatchChanges.argTypes = {
         defaultValue: false,
     },
     isApp: {
-        name: 'is Sourcegraph App',
+        name: 'is Cody App',
         control: { type: 'boolean' },
         defaultValue: false,
     },

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -183,8 +183,8 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
             </PageHeader>
             {isSourcegraphApp && (
                 <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.batchChanges" className="my-4">
-                    Batch Changes is currently available to try for free, up to 10 changesets, while Sourcegraph App is
-                    in beta. Pricing and availability for Batch Changes is subject to change in future releases.{' '}
+                    Batch Changes is currently available to try for free, up to 10 changesets, while Cody App is in
+                    beta. Pricing and availability for Batch Changes is subject to change in future releases.{' '}
                     <strong>
                         For unlimited access to Batch Changes,{' '}
                         <Link

--- a/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
+++ b/client/web/src/enterprise/insights/components/code-insights-page/limit-access-banner/CodeInsightsLimitAccessAppBanner.tsx
@@ -10,8 +10,8 @@ interface Props {
 }
 export const CodeInsightsLimitedAccessAppBanner: React.FC<Props> = props => (
     <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.codeInsights" className={props.className}>
-        Code Insights is currently available to try for free, up to 2 insights, while Sourcegraph App is in beta.
-        Pricing and availability for Code Insights is subject to change in future releases.{' '}
+        Code Insights is currently available to try for free, up to 2 insights, while Cody App is in beta. Pricing and
+        availability for Code Insights is subject to change in future releases.{' '}
         <strong>
             For unlimited access to Insights,{' '}
             <Link

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/components/InsightsDashboardCreationContent.tsx
@@ -159,7 +159,7 @@ export const InsightsDashboardCreationContent: React.FunctionComponent<
             {!licensed && isSourcegraphApp && (
                 <LimitedAccessLabel
                     className={classNames(styles.limitedBanner)}
-                    message="Dashboards aren't available yet for the Sourcegraph app"
+                    message="Dashboards aren't available yet for the Cody app"
                 />
             )}
 

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -197,12 +197,14 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
             <NavBar
                 ref={navbarReference}
                 logo={
-                    <BrandLogo
-                        branding={branding}
-                        isLightTheme={isLightTheme}
-                        variant="symbol"
-                        className={styles.logo}
-                    />
+                    !isSourcegraphApp && (
+                        <BrandLogo
+                            branding={branding}
+                            isLightTheme={isLightTheme}
+                            variant="symbol"
+                            className={styles.logo}
+                        />
+                    )
                 }
             >
                 <NavGroup>
@@ -336,7 +338,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         </>
                     )}
                     {fuzzyFinderNavbar && FuzzyFinderNavItem(props.setFuzzyFinderIsVisible)}
-                    {props.authenticatedUser?.siteAdmin && (
+                    {props.authenticatedUser?.siteAdmin && !isSourcegraphApp && (
                         <NavAction>
                             <StatusMessagesNavItem isSourcegraphApp={isSourcegraphApp} />
                         </NavAction>

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -52,12 +52,16 @@ export interface NavLinkProps extends NavItemProps, Pick<LinkProps, 'to'> {
 export const NavBar = forwardRef(function NavBar({ children, logo }, reference): JSX.Element {
     return (
         <nav aria-label="Main" className={navBarStyles.navbar} ref={reference}>
-            <H1 className={navBarStyles.logo}>
-                <RouterNavLink className="d-flex align-items-center" to={PageRoutes.Search}>
-                    {logo}
-                </RouterNavLink>
-            </H1>
-            <hr className={navBarStyles.divider} aria-hidden={true} />
+            {logo && (
+                <>
+                    <H1 className={navBarStyles.logo}>
+                        <RouterNavLink className="d-flex align-items-center" to={PageRoutes.Search}>
+                            {logo}
+                        </RouterNavLink>
+                    </H1>
+                    <hr className={navBarStyles.divider} aria-hidden={true} />
+                </>
+            )}
             {children}
         </nav>
     )

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -149,7 +149,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                                 </MenuLink>
                             )}
                             {isSourcegraphApp && <AppUserConnectDotComAccount />}
-                            {!isSourcegraphDotCom && (
+                            {!isSourcegraphDotCom && !isSourcegraphApp && (
                                 <MenuLink as={Link} to="/teams">
                                     Teams
                                 </MenuLink>

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -263,7 +263,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
 
                 {isSourcegraphApp && (
                     <LimitedAccessBanner storageKey="app.limitedAccessBannerDismissed.notebooks" className="my-4">
-                        Notebooks is currently available to try for free while Sourcegraph App is in beta. Pricing and
+                        Notebooks is currently available to try for free while Cody App is in beta. Pricing and
                         availability for Notebooks is subject to change in future releases.
                     </LimitedAccessBanner>
                 )}

--- a/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/local-repositories-step/LocalRepositoriesStep.tsx
@@ -189,7 +189,7 @@ const LocalRepositoriesForm: FC<LocalRepositoriesFormProps> = props => {
             {initialState && (
                 <Alert variant="secondary" className="mt-3 mb-0">
                     <Text className="mb-0 text-muted">
-                        Pick a path to see a list of local repositories that you want to have in the Sourcegraph App
+                        Pick a path to see a list of local repositories that you want to have in the Cody App
                     </Text>
                 </Alert>
             )}
@@ -269,7 +269,7 @@ const BuiltInRepositories: FC<BuiltInRepositoriesProps> = props => {
             <hr />
             <H4 className="mt-3 mb-1">Built-in repositories</H4>
             <Text size="small" className="text-muted">
-                You're running the Sourcegraph app from your terminal. We found the repositories below in your path.
+                You're running the Cody app from your terminal. We found the repositories below in your path.
             </Text>
             <ul className={styles.list}>
                 {foundRepositories.map(repository => (

--- a/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
@@ -110,7 +110,7 @@ export const SiteAdminBackgroundJobsPage: React.FunctionComponent<
             <Text>Terminology:</Text>
             <ul>
                 <li>
-                    <strong>Job</strong>: a bag of routines, started when the Sourcegraph app is launched
+                    <strong>Job</strong>: a bag of routines, started when the Cody app is launched
                 </li>
                 <li>
                     <strong>Routine</strong>: a background process that repeatedly executes its task indefinitely, using

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -365,7 +365,7 @@ export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService, isSour
             <Container className="mb-3">
                 {isSourcegraphApp ? (
                     <Text className="mb-1">
-                        We're making regular improvements to the Sourcegraph app.
+                        We're making regular improvements to the Cody app.
                         <br /> For information on how to upgrade to the latest version, see{' '}
                         <Link to="/help/app#upgrading" target="_blank" rel="noopener">
                             our docs

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -58,10 +58,10 @@ const REQUESTERS: Record<string, TokenRequester> = {
         callbackType: 'new-tab',
     },
     APP: {
-        name: 'Sourcegraph App',
+        name: 'Cody App',
         redirectURL: 'sourcegraph://app/auth/callback?code=$TOKEN',
-        successMessage: 'Now opening the Sourcegraph App...',
-        infoMessage: 'You will be redirected to Sourcegraph App.',
+        successMessage: 'Now opening the Cody App...',
+        infoMessage: 'You will be redirected to Cody App.',
         callbackType: 'open',
         onlyDotCom: true,
         forwardDestination: true,

--- a/client/web/src/user/settings/research/ProductResearch.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.tsx
@@ -37,7 +37,7 @@ export const ProductResearchPage: React.FunctionComponent<React.PropsWithChildre
             <PageHeader headingElement="h2" path={[{ text: 'Product research and feedback' }]} className="mb-3" />
             {isSourcegraphApp && (
                 <Container className="mb-2">
-                    <Text>Do you have feedback or need help with Sourcegraph App?</Text>
+                    <Text>Do you have feedback or need help with Cody App?</Text>
                     {[
                         {
                             content: 'File an issue',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53629

## TODO 
- [ ] The App system tray icon should be updated to the Cody Icon. 
- [x] I still see the Sourcegraph logo in the top lefthand corner. We probably don't need this anymore, since we have the "Cody AI" tab and they direct to the same chat view. 
- [x] In the settings dropdown in the app UI there's a "Teams" option that doesn't go anywhere. I don't know what this is or where it's supposed to go.
- [x] The cloud icon in the app UI still always says "indexing." This is pretty prominent UI and (I believe) refers to Code Search indexing, not embeddings jobs. If it isn't doing anything, we should remove it.
- [x] Update the Authorization page to say "Cody App" instead of "Sourcegraph App" when connecting App to dotcom.

## Test plan
- Check the points from the todo section 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
