### PR TITLE
Embeddings: check embeddings response length

### DIFF
--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -188,6 +188,9 @@ func embedFiles(
 		if err != nil {
 			return errors.Wrap(err, "error while getting embeddings")
 		}
+		if expected := len(batchChunks) * dimensions; len(batchEmbeddings) != expected {
+			return errors.Newf("expected embeddings for batch to have length %d, got %d", expected, len(batchEmbeddings))
+		}
 		index.Embeddings = append(index.Embeddings, embeddings.Quantize(batchEmbeddings)...)
 
 		batch = batch[:0] // reset batch


### PR DESCRIPTION
We've had a few situations where we generate corrupt indexes because we trust that the embeddings service is returning the correct number of embeddings. In the past, this has failed when the model changes mid-embed (and changes the number of dimensions) and when the embeddings generation service/proxy is misbehaving and returning an empty response with a successful status code.

This moves the error to index time and makes it nice and clear rather than depending on the cryptic panics we get during search time.

## Test plan

Added a test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
