### PR TITLE
App - remove blob links from context files for app

### DIFF
--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -238,7 +238,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = React.memo(funct
     repoName,
     revision,
 }) {
-    return repoName ? (
+    return repoName && !window.context.sourcegraphAppMode ? (
         <Tooltip content={`${repoName}/-/blob/${path}`}>
             <Link to={`/${repoName}${revision ? `@${revision}` : ''}/-/blob/${path}`}>{path}</Link>
         </Tooltip>


### PR DESCRIPTION
Sourcegraph app does not have access to the blob view, so links on the context files did not work.

resolves https://github.com/sourcegraph/sourcegraph/issues/53415

## Test plan
Chat and verify the context files are not links.

<img width="1136" alt="Screenshot 2023-06-19 at 10 14 04 PM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/47b2b8a4-6d94-4529-a94d-4a604ed35f54">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
