### PR TITLE
Rename Cody Inline Assist to Cody Inline Chat

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -28,6 +28,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Refactored authentication process. [pull/53434](https://github.com/sourcegraph/sourcegraph/pull/53434)
 - New sign-in and sign-out flow. [pull/53434](https://github.com/sourcegraph/sourcegraph/pull/53434)
 - Analytical logs are now displayed in the Output view. [pull/53870](https://github.com/sourcegraph/sourcegraph/pull/53870)
+- Renamed Inline Assist to Inline Chat. [pull/53725](https://github.com/sourcegraph/sourcegraph/pull/53725)
 
 ## [0.2.5]
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -109,8 +109,8 @@
           },
           {
             "id": "inline-assist",
-            "title": "Inline Assist (Experimental)",
-            "description": "Chat with Cody without leaving your file. Click the + button next to any line number in a file to bring up Inline Assist.\n[Enable in Settings](command:cody.walkthrough.enableInlineAssist)",
+            "title": "Inline Chat (Experimental)",
+            "description": "Chat with Cody without leaving your file. Click the + button next to any line number in a file to bring up Inline Chat.\n[Enable in Settings](command:cody.walkthrough.enableInlineAssist)",
             "media": {
               "markdown": "walkthroughs/inline-assist.md"
             }
@@ -360,7 +360,7 @@
       {
         "command": "cody.walkthrough.enableInlineAssist",
         "category": "Cody Walkthrough",
-        "title": "Show Inline Assist"
+        "title": "Show Inline Chat"
       },
       {
         "command": "cody.walkthrough.enableCodeAutocomplete",
@@ -370,14 +370,14 @@
       {
         "command": "cody.comment.add",
         "title": "Ask Cody",
-        "category": "Cody Inline Assist",
+        "category": "Cody Inline Chat",
         "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentIsEmpty"
       },
       {
         "command": "cody.comment.delete",
         "title": "Remove Comment",
-        "category": "Cody Inline Assist",
+        "category": "Cody Inline Chat",
         "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentThreadIsEmpty",
         "icon": "$(trash)"
@@ -385,7 +385,7 @@
       {
         "command": "cody.comment.load",
         "title": "Loading",
-        "category": "Cody Inline Assist",
+        "category": "Cody Inline Chat",
         "when": "cody.activated && cody.inline-assist.enabled",
         "enablement": "!commentThreadIsEmpty",
         "icon": "$(sync~spin)"
@@ -827,9 +827,9 @@
         },
         "cody.experimental.inline": {
           "order": 7,
-          "title": "Cody Inline Assist",
+          "title": "Cody Inline Chat",
           "type": "boolean",
-          "markdownDescription": "Enables Cody Inline Assist, an inline way to explicitly ask questions and propose modifications to code.",
+          "markdownDescription": "Enables asking questions and requesting code changes directly from within the code editor. Use the + button next to any line of code to start an inline chat.",
           "default": false
         },
         "cody.experimental.guardrails": {

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -22,7 +22,7 @@ export class VSCodeEditor implements Editor {
             const config = vscode.workspace.getConfiguration('cody')
             const isTesting = process.env.CODY_TESTING === 'true'
             if (e.affectsConfiguration('cody')) {
-                // Inline Assist
+                // Inline Chat
                 const enableInlineAssist = (config.get('experimental.inline') as boolean) || isTesting
                 const inlineController = this.controllers.inline
                 void vscode.commands.executeCommand('setContext', 'cody.inline-assist.enabled', enableInlineAssist)

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -90,7 +90,7 @@ const register = async (
     const disposables: vscode.Disposable[] = []
 
     await updateEventLogger(initialConfig, localStorage)
-    // Controller for inline assist
+    // Controller for inline Chat
     const commentController = new InlineController(context.extensionPath)
     disposables.push(commentController.get())
 
@@ -166,7 +166,7 @@ const register = async (
     const statusBar = createStatusBar()
 
     disposables.push(
-        // Inline Assist Provider
+        // Inline Chat Provider
         vscode.commands.registerCommand('cody.comment.add', async (comment: vscode.CommentReply) => {
             const isFixMode = /^\/f(ix)?\s/i.test(comment.text.trimStart())
             await commentController.chat(comment, isFixMode)
@@ -309,7 +309,7 @@ const register = async (
         }
     })
 
-    // Initiate inline assist when feature flag is on
+    // Initiate inline chat when feature flag is on
     if (initialConfig.experimentalInline) {
         commentController.get().commentingRangeProvider = {
             provideCommentingRanges: (document: vscode.TextDocument) => {

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -64,7 +64,7 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.autocomplete
                 ),
                 createFeatureToggle(
-                    'Inline Assist',
+                    'Inline Chat',
                     'Beta',
                     'An inline way to explicitly ask questions and propose modifications to code',
                     'cody.experimental.inline',

--- a/client/cody/test/e2e/inline-assist-file-touch.test.ts
+++ b/client/cody/test/e2e/inline-assist-file-touch.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
-test.skip('start a fixup job from inline assist with valid auth', async ({ page, sidebar }) => {
+test.skip('start a fixup job from inline chat with valid auth', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 

--- a/client/cody/test/e2e/inline-assist.test.ts
+++ b/client/cody/test/e2e/inline-assist.test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { test } from './helpers'
 
-test('start a fixup job from inline assist with valid auth', async ({ page, sidebar }) => {
+test('start a fixup job from inline chat with valid auth', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 

--- a/client/cody/walkthroughs/inline-assist.md
+++ b/client/cody/walkthroughs/inline-assist.md
@@ -1,4 +1,4 @@
-## Inline Assist (Experimental)
+## Inline Chat (Experimental)
 
 <video autoPlay muted loop playsInline>
     <source
@@ -7,4 +7,4 @@
     />
 </video>
 
-Talk to Cody directly within the context of your code. Use Inline Assist to ask Cody questions about lines of code while remaining in your editor flow. Want to make changes? Use the "/fix" command and Cody will automatically update the code for you.
+Talk to Cody directly within the context of your code. Use Inline Chat to ask Cody questions about lines of code while remaining in your editor flow. Want to make changes? Use the "/fix" command and Cody will automatically update the code for you.

--- a/doc/cody/client_feature_availability.md
+++ b/doc/cody/client_feature_availability.md
@@ -5,8 +5,8 @@
 |Chat                         | ChatGPT-like chat functionality                         |✅|✅|✅|✅|
 |Code autocomplete                  | Start typing a line of code and Cody will suggest a completion|✅|✅|✖️|✖️| 
 |Mutli-line code autocomplete      | Cody suggests multiple lines of a completion            |✅|✖️|✖️|✖️| 
-|Inline assist                | Prompt Cody within the lines of your IDE                |✅|✖️|✖️|✖️| 
+|Inline chat                | Start chats and fix code from within the code editor                |✅|✖️|✖️|✖️| 
 |Recipes                      | Predefined prompts |✅|✅|✅|✖️|
-|Mutli-repo context          | Prompts can gather context from up to 10 repositories |✖️|✖️|✅|✅|
+|Multi-repo context          | Prompts can gather context from up to 10 repositories |✖️|✖️|✅|✅|
 |Context selection            | Specify repos you want the prompt to gather context from|✖️|✖️|✅|✅|
 


### PR DESCRIPTION
As part of https://github.com/sourcegraph/sourcegraph/issues/53017 this renames "Inline Assist" to "Inline Chat"

## Test plan

- Run the automated tests
- Manually created inline chats, and tested fixups from chats