### PR TITLE
Cody: Fix web markdown links

### DIFF
--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -35,7 +35,7 @@ const DOMPURIFY_CONFIG = {
         's',
         'u',
     ],
-    ALLOWED_URI_REGEXP: /^vscode:?\/\/[^\s#$./?].\S*$/i,
+    ALLOWED_URI_REGEXP: /^(https?|vscode):\/\/[^\s#$./?].\S*$/i,
 }
 
 /**


### PR DESCRIPTION
## Description

Updates our `ALLOWED_URI_REGEXP` to allow http/https links in addition to VS Code links.

Fixes Markdown links not being clickable in Cody chat, and specifically also fixes the "See Cody documentation for help and tips." link.

## Test plan

1. Check Cody documentation link works
2. Check that manually adding a markdown link in chat works
3. Check that vscode links returned from the `/search` command work

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
