### PR TITLE
gitserver: Add recordingfactory to Fetch of git vcs syncer

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -434,7 +435,7 @@ func TestCleanupExpired(t *testing.T) {
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB: database.NewMockDB(),
 	}
@@ -523,7 +524,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 				return remote, nil
 			},
 			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-				return NewGitRepoSyncer(), nil
+				return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 			},
 			DB:                mockDB,
 			skipCloneForTests: true,

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -435,7 +435,7 @@ func TestCleanupExpired(t *testing.T) {
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB: database.NewMockDB(),
 	}
@@ -524,7 +524,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 				return remote, nil
 			},
 			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-				return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+				return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 			},
 			DB:                mockDB,
 			skipCloneForTests: true,

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -434,7 +434,7 @@ func TestCleanupExpired(t *testing.T) {
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return &GitRepoSyncer{}, nil
+			return NewGitRepoSyncer(), nil
 		},
 		DB: database.NewMockDB(),
 	}
@@ -523,7 +523,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 				return remote, nil
 			},
 			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-				return &GitRepoSyncer{}, nil
+				return NewGitRepoSyncer(), nil
 			},
 			DB:                mockDB,
 			skipCloneForTests: true,

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -437,7 +437,8 @@ func TestCleanupExpired(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
 			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
-		DB: database.NewMockDB(),
+		DB:                      database.NewMockDB(),
+		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 	}
 	s.testSetup(t)
 	s.cleanupRepos(context.Background(), gitserver.GitserverAddresses{Addresses: []string{"gitserver-0"}})

--- a/cmd/gitserver/server/list_gitolite_test.go
+++ b/cmd/gitserver/server/list_gitolite_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -124,7 +125,7 @@ func TestCheckSSRFHeader(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB: db,
 	}

--- a/cmd/gitserver/server/list_gitolite_test.go
+++ b/cmd/gitserver/server/list_gitolite_test.go
@@ -124,7 +124,7 @@ func TestCheckSSRFHeader(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return &GitRepoSyncer{}, nil
+			return NewGitRepoSyncer(), nil
 		},
 		DB: db,
 	}

--- a/cmd/gitserver/server/list_gitolite_test.go
+++ b/cmd/gitserver/server/list_gitolite_test.go
@@ -125,7 +125,7 @@ func TestCheckSSRFHeader(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB: db,
 	}

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -148,7 +148,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 		t := time.Now()
 		// runRemoteGitCommand since one of our commands could be git push
-		out, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, nil)
+		out, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, nil)
 
 		logger := logger.With(
 			log.String("prefix", prefix),

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2714,6 +2714,14 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 
 	redactor := newURLRedactor(remoteURL)
 
+	// Note: We want to make sure that the latest config is always applied so we cannot set this
+	// where the syncer is initialised.
+	if gitSyncer, ok := syncer.(*gitRepoSyncer); ok {
+		if recordingConf := conf.Get().SiteConfig().GitRecorder; recordingConf != nil {
+			gitSyncer.RecordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos), recordingConf.Size)
+		}
+	}
+
 	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
 
 	// best-effort update the output of the fetch

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -430,7 +430,6 @@ func (s *Server) Handler() http.Handler {
 	s.locker = &RepositoryLocker{}
 	s.repoUpdateLocks = make(map[api.RepoName]*locks)
 
-	s.RecordingCommandFactory = wrexec.NewRecordingCommandFactory(nil, 0)
 	conf.Watch(func() {
 		// We update the factory with a predicate func. Each subsequent recordable command will use this predicate
 		// to determine whether a command should be recorded or not.

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2714,14 +2714,6 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 
 	redactor := newURLRedactor(remoteURL)
 
-	// Note: We want to make sure that the latest config is always applied so we cannot set this
-	// where the syncer is initialised.
-	if gitSyncer, ok := syncer.(*gitRepoSyncer); ok {
-		if recordingConf := conf.Get().SiteConfig().GitRecorder; recordingConf != nil {
-			gitSyncer.RecordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos), recordingConf.Size)
-		}
-	}
-
 	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
 
 	// best-effort update the output of the fetch

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1005,7 +1005,7 @@ func (s *Server) IsRepoCloneable(ctx context.Context, repo api.RepoName) (protoc
 		remoteURL, _ = vcs.ParseURL("https://" + string(repo) + ".git")
 
 		// At this point we are assuming it's a git repo
-		syncer = &GitRepoSyncer{}
+		syncer = NewGitRepoSyncer()
 	} else {
 		syncer, err = s.GetVCSSyncer(ctx, repo)
 		if err != nil {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -183,7 +183,7 @@ func TestExecRequest(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB: db,
 	}
@@ -714,7 +714,7 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		ReposDir:         repoDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB:                      db,
 		CloneQueue:              NewCloneQueue(obctx, list.New()),

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -723,7 +723,7 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		cloneLimiter:            limiter.NewMutable(1),
 		cloneableLimiter:        limiter.NewMutable(1),
 		rpsLimiter:              ratelimit.NewInstrumentedLimiter("GitserverTest", rate.NewLimiter(rate.Inf, 10)),
-		recordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0),
+		RecordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0),
 		Perforce:                perforce.NewService(ctx, obctx, logger, db, list.New()),
 	}
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -183,7 +183,7 @@ func TestExecRequest(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return &GitRepoSyncer{}, nil
+			return NewGitRepoSyncer(), nil
 		},
 		DB: db,
 	}
@@ -714,7 +714,7 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		ReposDir:         repoDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return &GitRepoSyncer{}, nil
+			return NewGitRepoSyncer(), nil
 		},
 		DB:                      db,
 		CloneQueue:              NewCloneQueue(obctx, list.New()),

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -183,7 +183,7 @@ func TestExecRequest(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB: db,
 	}
@@ -714,7 +714,7 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		ReposDir:         repoDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
-			return NewGitRepoSyncer(), nil
+			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB:                      db,
 		CloneQueue:              NewCloneQueue(obctx, list.New()),

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -281,10 +281,11 @@ func TestServer_handleP4Exec(t *testing.T) {
 		logger := logtest.Scoped(t)
 
 		s := &Server{
-			Logger:            logger,
-			ObservationCtx:    observation.TestContextTB(t),
-			skipCloneForTests: true,
-			DB:                database.NewMockDB(),
+			Logger:                  logger,
+			ObservationCtx:          observation.TestContextTB(t),
+			skipCloneForTests:       true,
+			DB:                      database.NewMockDB(),
+			RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 		}
 
 		server := defaults.NewServer(logger)

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -185,7 +185,8 @@ func TestExecRequest(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
 			return NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
-		DB: db,
+		DB:                      db,
+		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 	}
 	h := s.Handler()
 
@@ -1732,6 +1733,7 @@ func TestHandleBatchLog(t *testing.T) {
 				ObservationCtx:          observation.TestContextTB(t),
 				GlobalBatchLogSemaphore: semaphore.NewWeighted(8),
 				DB:                      database.NewMockDB(),
+				RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 			}
 			h := server.Handler()
 

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -15,11 +15,11 @@ import (
 
 // gitRepoSyncer is a syncer for Git repositories.
 type gitRepoSyncer struct {
-	RecordingCommandFactory *wrexec.RecordingCommandFactory
+	recordingCommandFactory *wrexec.RecordingCommandFactory
 }
 
 func NewGitRepoSyncer(r *wrexec.RecordingCommandFactory) *gitRepoSyncer {
-	return &gitRepoSyncer{RecordingCommandFactory: r}
+	return &gitRepoSyncer{recordingCommandFactory: r}
 }
 
 func (s *gitRepoSyncer) Type() string {
@@ -74,7 +74,7 @@ func (s *gitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
-	if output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
+	if output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
 		return nil, &common.GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
 	}
 	return nil, nil

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -18,8 +18,8 @@ type gitRepoSyncer struct {
 	RecordingCommandFactory *wrexec.RecordingCommandFactory
 }
 
-func NewGitRepoSyncer() *gitRepoSyncer {
-	return &gitRepoSyncer{RecordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0)}
+func NewGitRepoSyncer(r *wrexec.RecordingCommandFactory) *gitRepoSyncer {
+	return &gitRepoSyncer{RecordingCommandFactory: r}
 }
 
 func (s *gitRepoSyncer) Type() string {

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -13,15 +13,21 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// GitRepoSyncer is a syncer for Git repositories.
-type GitRepoSyncer struct{}
+// gitRepoSyncer is a syncer for Git repositories.
+type gitRepoSyncer struct {
+	RecordingCommandFactory *wrexec.RecordingCommandFactory
+}
 
-func (s *GitRepoSyncer) Type() string {
+func NewGitRepoSyncer() *gitRepoSyncer {
+	return &gitRepoSyncer{RecordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0)}
+}
+
+func (s *gitRepoSyncer) Type() string {
 	return "git"
 }
 
 // IsCloneable checks to see if the Git remote URL is cloneable.
-func (s *GitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
+func (s *gitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
 	if isAlwaysCloningTestRemoteURL(remoteURL) {
 		return nil
 	}
@@ -48,7 +54,7 @@ func (s *GitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) err
 }
 
 // CloneCommand returns the command to be executed for cloning a Git repository.
-func (s *GitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tmpPath string) (cmd *exec.Cmd, err error) {
+func (s *gitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tmpPath string) (cmd *exec.Cmd, err error) {
 	if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
 		return nil, errors.Wrapf(err, "clone failed to create tmp dir")
 	}
@@ -65,21 +71,21 @@ func (s *GitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 }
 
 // Fetch tries to fetch updates of a Git repository.
-func (s *GitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
+func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
-	if output, err := runRemoteGitCommand(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
+	if output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
 		return nil, &common.GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
 	}
 	return nil, nil
 }
 
 // RemoteShowCommand returns the command to be executed for showing remote of a Git repository.
-func (s *GitRepoSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error) {
+func (s *gitRepoSyncer) RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error) {
 	return exec.CommandContext(ctx, "git", "remote", "show", remoteURL.String()), nil
 }
 
-func (s *GitRepoSyncer) fetchCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, configRemoteOpts bool) {
+func (s *gitRepoSyncer) fetchCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, configRemoteOpts bool) {
 	configRemoteOpts = true
 	if customCmd := customFetchCmd(ctx, remoteURL); customCmd != nil {
 		cmd = customCmd

--- a/cmd/gitserver/shared/BUILD.bazel
+++ b/cmd/gitserver/shared/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//internal/requestclient",
         "//internal/service",
         "//internal/trace",
+        "//internal/wrexec",
         "//lib/errors",
         "//schema",
         "@com_github_json_iterator_go//:go",

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -52,6 +52,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -134,6 +135,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return errors.Wrap(err, "creating sub-repo client")
 	}
 
+	recordingCommandFactory := wrexec.NewRecordingCommandFactory(nil, 0)
 	gitserver := server.Server{
 		Logger:             logger,
 		ObservationCtx:     observationCtx,
@@ -143,13 +145,22 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 			return getRemoteURLFunc(ctx, externalServiceStore, repoStore, repo)
 		},
 		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
-			return getVCSSyncer(ctx, externalServiceStore, repoStore, dependenciesSvc, repo, config.ReposDir, config.CoursierCacheDir)
+			return getVCSSyncer(ctx, &newVCSSyncerOpts{
+				externalServiceStore:    externalServiceStore,
+				repoStore:               repoStore,
+				depsSvc:                 dependenciesSvc,
+				repo:                    repo,
+				reposDir:                config.ReposDir,
+				coursierCacheDir:        config.CoursierCacheDir,
+				recordingCommandFactory: recordingCommandFactory,
+			})
 		},
 		Hostname:                externalAddress(),
 		DB:                      db,
 		CloneQueue:              server.NewCloneQueue(observationCtx, list.New()),
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(int64(batchLogGlobalConcurrencyLimit)),
 		Perforce:                perforce.NewService(ctx, observationCtx, logger, db, list.New()),
+		RecordingCommandFactory: recordingCommandFactory,
 	}
 
 	configurationWatcher := conf.DefaultClient()
@@ -362,26 +373,28 @@ func getRemoteURLFunc(
 	return "", errors.Errorf("no sources for %q", repo)
 }
 
-func getVCSSyncer(
-	ctx context.Context,
-	externalServiceStore database.ExternalServiceStore,
-	repoStore database.RepoStore,
-	depsSvc *dependencies.Service,
-	repo api.RepoName,
-	reposDir string,
-	coursierCacheDir string,
-) (server.VCSSyncer, error) {
+type newVCSSyncerOpts struct {
+	externalServiceStore    database.ExternalServiceStore
+	repoStore               database.RepoStore
+	depsSvc                 *dependencies.Service
+	repo                    api.RepoName
+	reposDir                string
+	coursierCacheDir        string
+	recordingCommandFactory *wrexec.RecordingCommandFactory
+}
+
+func getVCSSyncer(ctx context.Context, opts *newVCSSyncerOpts) (server.VCSSyncer, error) {
 	// We need an internal actor in case we are trying to access a private repo. We
 	// only need access in order to find out the type of code host we're using, so
 	// it's safe.
-	r, err := repoStore.GetByName(actor.WithInternalActor(ctx), repo)
+	r, err := opts.repoStore.GetByName(actor.WithInternalActor(ctx), opts.repo)
 	if err != nil {
 		return nil, errors.Wrap(err, "get repository")
 	}
 
 	extractOptions := func(connection any) (string, error) {
 		for _, info := range r.Sources {
-			extSvc, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
+			extSvc, err := opts.externalServiceStore.GetByID(ctx, info.ExternalServiceID())
 			if err != nil {
 				return "", errors.Wrap(err, "get external service")
 			}
@@ -408,7 +421,7 @@ func getVCSSyncer(
 			return nil, err
 		}
 
-		p4Home := filepath.Join(reposDir, server.P4HomeName)
+		p4Home := filepath.Join(opts.reposDir, server.P4HomeName)
 		// Ensure the directory exists
 		if err := os.MkdirAll(p4Home, os.ModePerm); err != nil {
 			return nil, errors.Wrapf(err, "ensuring p4Home exists: %q", p4Home)
@@ -425,7 +438,7 @@ func getVCSSyncer(
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
-		return server.NewJVMPackagesSyncer(&c, depsSvc, coursierCacheDir), nil
+		return server.NewJVMPackagesSyncer(&c, opts.depsSvc, opts.coursierCacheDir), nil
 	case extsvc.TypeNpmPackages:
 		var c schema.NpmPackagesConnection
 		urn, err := extractOptions(&c)
@@ -436,7 +449,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		return server.NewNpmPackagesSyncer(c, depsSvc, cli), nil
+		return server.NewNpmPackagesSyncer(c, opts.depsSvc, cli), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
 		urn, err := extractOptions(&c)
@@ -444,7 +457,7 @@ func getVCSSyncer(
 			return nil, err
 		}
 		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.ExternalClientFactory)
-		return server.NewGoModulesSyncer(&c, depsSvc, cli), nil
+		return server.NewGoModulesSyncer(&c, opts.depsSvc, cli), nil
 	case extsvc.TypePythonPackages:
 		var c schema.PythonPackagesConnection
 		urn, err := extractOptions(&c)
@@ -455,7 +468,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		return server.NewPythonPackagesSyncer(&c, depsSvc, cli, reposDir), nil
+		return server.NewPythonPackagesSyncer(&c, opts.depsSvc, cli, opts.reposDir), nil
 	case extsvc.TypeRustPackages:
 		var c schema.RustPackagesConnection
 		urn, err := extractOptions(&c)
@@ -466,7 +479,7 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		return server.NewRustPackagesSyncer(&c, depsSvc, cli), nil
+		return server.NewRustPackagesSyncer(&c, opts.depsSvc, cli), nil
 	case extsvc.TypeRubyPackages:
 		var c schema.RubyPackagesConnection
 		urn, err := extractOptions(&c)
@@ -477,9 +490,9 @@ func getVCSSyncer(
 		if err != nil {
 			return nil, err
 		}
-		return server.NewRubyPackagesSyncer(&c, depsSvc, cli), nil
+		return server.NewRubyPackagesSyncer(&c, opts.depsSvc, cli), nil
 	}
-	return server.NewGitRepoSyncer(), nil
+	return server.NewGitRepoSyncer(opts.recordingCommandFactory), nil
 }
 
 func syncExternalServiceRateLimiters(ctx context.Context, store database.ExternalServiceStore) error {

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -479,7 +479,7 @@ func getVCSSyncer(
 		}
 		return server.NewRubyPackagesSyncer(&c, depsSvc, cli), nil
 	}
-	return &server.GitRepoSyncer{}, nil
+	return server.NewGitRepoSyncer(), nil
 }
 
 func syncExternalServiceRateLimiters(ctx context.Context, store database.ExternalServiceStore) error {

--- a/cmd/gitserver/shared/shared_test.go
+++ b/cmd/gitserver/shared/shared_test.go
@@ -79,7 +79,6 @@ func TestGetVCSSyncer(t *testing.T) {
 	repo := api.RepoName("foo/bar")
 	extsvcStore := database.NewMockExternalServiceStore()
 	repoStore := database.NewMockRepoStore()
-	depsSvc := new(dependencies.Service)
 
 	repoStore.GetByNameFunc.SetDefaultHook(func(ctx context.Context, name api.RepoName) (*types.Repo, error) {
 		return &types.Repo{
@@ -104,7 +103,14 @@ func TestGetVCSSyncer(t *testing.T) {
 		}, nil
 	})
 
-	s, err := getVCSSyncer(context.Background(), extsvcStore, repoStore, depsSvc, repo, tempReposDir, tempCoursierCacheDir)
+	s, err := getVCSSyncer(context.Background(), &newVCSSyncerOpts{
+		externalServiceStore: extsvcStore,
+		repoStore:            repoStore,
+		depsSvc:              new(dependencies.Service),
+		repo:                 repo,
+		reposDir:             tempReposDir,
+		coursierCacheDir:     tempCoursierCacheDir,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//internal/httpcli",
         "//internal/observation",
         "//internal/types",
+        "//internal/wrexec",
         "//lib/errors",
         "//schema",
         "@com_github_google_go_cmp//cmp",

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -522,7 +522,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 					return "", errors.Errorf("no remote for %s", test.name)
 				},
 				GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-					return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+					return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 				},
 			}
 
@@ -1072,7 +1072,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 			return remote, nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB:       db,
 		Perforce: perforce.NewService(ctx, observation.TestContextTB(t), logger, db, list.New()),
@@ -1574,7 +1574,7 @@ func TestGitserverClient_RepoClone(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		DB:         db,
 		CloneQueue: server.NewCloneQueue(observation.TestContextTB(t), list.New()),

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -521,7 +521,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 					return "", errors.Errorf("no remote for %s", test.name)
 				},
 				GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-					return &server.GitRepoSyncer{}, nil
+					return server.NewGitRepoSyncer(), nil
 				},
 			}
 
@@ -1071,7 +1071,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 			return remote, nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return &server.GitRepoSyncer{}, nil
+			return server.NewGitRepoSyncer(), nil
 		},
 		DB:       db,
 		Perforce: perforce.NewService(ctx, observation.TestContextTB(t), logger, db, list.New()),
@@ -1573,7 +1573,7 @@ func TestGitserverClient_RepoClone(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return &server.GitRepoSyncer{}, nil
+			return server.NewGitRepoSyncer(), nil
 		},
 		DB:         db,
 		CloneQueue: server.NewCloneQueue(observation.TestContextTB(t), list.New()),

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -524,6 +524,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 				GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
 					return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 				},
+				RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 			}
 
 			grpcServer := defaults.NewServer(logtest.Scoped(t))
@@ -1074,8 +1075,9 @@ func TestClient_ResolveRevisions(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
 			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
-		DB:       db,
-		Perforce: perforce.NewService(ctx, observation.TestContextTB(t), logger, db, list.New()),
+		DB:                      db,
+		Perforce:                perforce.NewService(ctx, observation.TestContextTB(t), logger, db, list.New()),
+		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 	}
 
 	grpcServer := defaults.NewServer(logtest.Scoped(t))
@@ -1576,8 +1578,9 @@ func TestGitserverClient_RepoClone(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
 			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
-		DB:         db,
-		CloneQueue: server.NewCloneQueue(observation.TestContextTB(t), list.New()),
+		DB:                      db,
+		CloneQueue:              server.NewCloneQueue(observation.TestContextTB(t), list.New()),
+		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 	}
 
 	grpcServer := defaults.NewServer(logtest.Scoped(t))

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -521,7 +522,7 @@ func TestClient_ArchiveReader(t *testing.T) {
 					return "", errors.Errorf("no remote for %s", test.name)
 				},
 				GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-					return server.NewGitRepoSyncer(), nil
+					return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 				},
 			}
 
@@ -1071,7 +1072,7 @@ func TestClient_ResolveRevisions(t *testing.T) {
 			return remote, nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB:       db,
 		Perforce: perforce.NewService(ctx, observation.TestContextTB(t), logger, db, list.New()),
@@ -1573,7 +1574,7 @@ func TestGitserverClient_RepoClone(t *testing.T) {
 			return "https://" + string(name) + ".git", nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		DB:         db,
 		CloneQueue: server.NewCloneQueue(observation.TestContextTB(t), list.New()),

--- a/internal/gitserver/integration_tests/BUILD.bazel
+++ b/internal/gitserver/integration_tests/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/httpcli",
         "//internal/observation",
         "//internal/types",
+        "//internal/wrexec",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_x_sync//semaphore",
     ],

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -82,6 +82,7 @@ func InitGitserver() {
 		},
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(32),
 		DB:                      db,
+		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 	}
 
 	grpcServer := defaults.NewServer(logger)

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 )
 
 var root string
@@ -77,7 +78,7 @@ func InitGitserver() {
 			return filepath.Join(root, "remotes", string(name)), nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
 		},
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(32),
 		DB:                      db,

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -78,7 +78,7 @@ func InitGitserver() {
 			return filepath.Join(root, "remotes", string(name)), nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCOmmandFactory()), nil
+			return server.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(32),
 		DB:                      db,

--- a/internal/gitserver/integration_tests/test_utils.go
+++ b/internal/gitserver/integration_tests/test_utils.go
@@ -77,7 +77,7 @@ func InitGitserver() {
 			return filepath.Join(root, "remotes", string(name)), nil
 		},
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
-			return &server.GitRepoSyncer{}, nil
+			return server.NewGitRepoSyncer(), nil
 		},
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(32),
 		DB:                      db,

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -154,7 +154,7 @@ func (rf *RecordingCommandFactory) Wrap(ctx context.Context, logger log.Logger, 
 	return RecordingWrap(ctx, logger, rf.shouldRecord, store, cmd)
 }
 
-// NewNoOpRecordingCOmmandFactory is a recording command factory that is intiailised with a nil shouldRecord and maxSize 0. This is a helper for use in tests.
-func NewNoOpRecordingCOmmandFactory() *RecordingCommandFactory {
+// NewNoOpRecordingCommandFactory is a recording command factory that is intialised with a nil shouldRecord and maxSize 0. This is a helper for use in tests.
+func NewNoOpRecordingCommandFactory() *RecordingCommandFactory {
 	return &RecordingCommandFactory{shouldRecord: nil, maxSize: 0}
 }

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -153,3 +153,8 @@ func (rf *RecordingCommandFactory) Wrap(ctx context.Context, logger log.Logger, 
 	store := rcache.NewFIFOList(KeyPrefix, rf.maxSize)
 	return RecordingWrap(ctx, logger, rf.shouldRecord, store, cmd)
 }
+
+// NewNoOpRecordingCOmmandFactory is a recording command factory that is intiailised with a nil shouldRecord and maxSize 0. This is a helper for use in tests.
+func NewNoOpRecordingCOmmandFactory() *RecordingCommandFactory {
+	return &RecordingCommandFactory{shouldRecord: nil, maxSize: 0}
+}


### PR DESCRIPTION
In this commit we wrap the fetch command in a RecordingCommandFactory similar to what is currently done at the call site of CloneCommand.

In order to make this cleaner - we add the RecordingCommandFactory on the GitRepoSyncer and introduce a constructor - NewGitRepoSyncer to ensure that the factory is always initialised and make GitRepoSyncer private.

## Note

The recording factory is initialised with a nil `shouldRecord` at the moment so this won't start recording fetch commands immediately. We update the factory similar to that in the server's handler and even then it should only affect those repos that are listed in the conf. So in addition to recording the clone path, now we will also record all fetches of those repos - which could be a source of more writes to redis (the backing store of the recording factory).

Maybe we want to guard this behind an experimental site config to guard against performane regressions?

## Test plan

- Tested manually that repos can be cloned and new commits can be fetched on existing repos
- Builds should pass
- main-dry-run

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
