### PR TITLE
Cody Context: Better usage of editor selection and UI update

### DIFF
--- a/client/cody-shared/src/chat/context.ts
+++ b/client/cody-shared/src/chat/context.ts
@@ -1,9 +1,11 @@
 import { ConfigurationUseContext } from '../configuration'
+import { ActiveTextEditorSelectionRange } from '../editor'
 
 export interface ChatContextStatus {
     mode?: ConfigurationUseContext
     connection?: boolean
     codebase?: string
     filePath?: string
+    selection?: ActiveTextEditorSelectionRange
     supportsKeyword?: boolean
 }

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -47,11 +47,6 @@ export class ChatQuestion implements Recipe {
     ): Promise<ContextMessage[]> {
         const contextMessages: ContextMessage[] = []
 
-        // Add selected text as context when available
-        if (selection?.selectedText) {
-            contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
-        }
-
         const isCodebaseContextRequired = firstInteraction || (await intentDetector.isCodebaseContextRequired(text))
 
         this.debug('ChatQuestion:getContextMessages', 'isCodebaseContextRequired', isCodebaseContextRequired)
@@ -65,7 +60,12 @@ export class ChatQuestion implements Recipe {
 
         const isEditorContextRequired = intentDetector.isEditorContextRequired(text)
         this.debug('ChatQuestion:getContextMessages', 'isEditorContextRequired', isEditorContextRequired)
-        if (isCodebaseContextRequired || isEditorContextRequired) {
+
+        if (selection?.selectedText) {
+            // Assume that the selectedText is most relevant to the question
+            contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
+        } else if (isCodebaseContextRequired || isEditorContextRequired) {
+            // Otherwise add possibly relevant information from the editor if required
             contextMessages.push(...ChatQuestion.getEditorContext(editor))
         }
 

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -60,13 +60,13 @@ export class ChatQuestion implements Recipe {
 
         const isEditorContextRequired = intentDetector.isEditorContextRequired(text)
         this.debug('ChatQuestion:getContextMessages', 'isEditorContextRequired', isEditorContextRequired)
-
-        if (selection?.selectedText) {
-            // Assume that the selectedText is most relevant to the question
-            contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
-        } else if (isCodebaseContextRequired || isEditorContextRequired) {
-            // Otherwise add possibly relevant information from the editor if required
+        if (isCodebaseContextRequired || isEditorContextRequired) {
             contextMessages.push(...ChatQuestion.getEditorContext(editor))
+        }
+
+        // Add selected text as context when available
+        if (selection?.selectedText) {
+            contextMessages.push(...ChatQuestion.getEditorSelectionContext(selection))
         }
 
         return contextMessages

--- a/client/cody-shared/src/editor/index.ts
+++ b/client/cody-shared/src/editor/index.ts
@@ -3,6 +3,18 @@ export interface ActiveTextEditor {
     filePath: string
     repoName?: string
     revision?: string
+    selection?: ActiveTextEditorSelectionRange
+}
+
+export interface ActiveTextEditorSelectionRange {
+    start: {
+        line: number
+        character: number
+    }
+    end: {
+        line: number
+        character: number
+    }
 }
 
 export interface ActiveTextEditorSelection {

--- a/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
@@ -20,11 +20,14 @@ const formatFilePath = (filePath: string, selection: ChatContextStatus['selectio
         return fileName
     }
 
-    if (selection.start.line === selection.end.line) {
-        return `${fileName}:L${selection.start.line}`
+    if (
+        selection.start.line === selection.end.line ||
+        (selection.start.line + 1 === selection.end.line && selection.end.character === 0) // A single line selected with the cursor at the start of the next line
+    ) {
+        return `${fileName}:${selection.start.line}`
     }
 
-    return `${fileName}:L${selection.start.line}-${selection.end.line}`
+    return `${fileName}:${selection.start.line}-${selection.end.line}`
 }
 
 export const ChatInputContext: React.FunctionComponent<{

--- a/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
+++ b/client/cody-ui/src/chat/inputContext/ChatInputContext.tsx
@@ -13,6 +13,20 @@ import styles from './ChatInputContext.module.css'
 const warning =
     'This repository has not yet been configured for Cody indexing on Sourcegraph, and response quality will be poor. To enable Cody’s code graph indexing, click here to see the Cody documentation, or email support@sourcegraph.com for assistance.'
 
+const formatFilePath = (filePath: string, selection: ChatContextStatus['selection']): string => {
+    const fileName = basename(filePath)
+
+    if (!selection) {
+        return fileName
+    }
+
+    if (selection.start.line === selection.end.line) {
+        return `${fileName}:L${selection.start.line}`
+    }
+
+    return `${fileName}:L${selection.start.line}-${selection.end.line}`
+}
+
 export const ChatInputContext: React.FunctionComponent<{
     contextStatus: ChatContextStatus
     className?: string
@@ -30,12 +44,12 @@ export const ChatInputContext: React.FunctionComponent<{
                 contextStatus.filePath
                     ? {
                           icon: mdiFileDocumentOutline,
-                          text: basename(contextStatus.filePath),
+                          text: formatFilePath(contextStatus.filePath, contextStatus.selection),
                           tooltip: contextStatus.filePath,
                       }
                     : null,
             ].filter(isDefined),
-        [contextStatus.codebase, contextStatus.connection, contextStatus.filePath]
+        [contextStatus.codebase, contextStatus.connection, contextStatus.filePath, contextStatus.selection]
     )
 
     return (

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -701,6 +701,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                     connection: this.codebaseContext.checkEmbeddingsConnection(),
                     codebase: this.codebaseContext.getCodebase(),
                     filePath: editorContext ? vscode.workspace.asRelativePath(editorContext.filePath) : undefined,
+                    selection: editorContext ? editorContext.selection : undefined,
                     supportsKeyword: true,
                 },
             })

--- a/client/cody/src/editor/vscode-editor.ts
+++ b/client/cody/src/editor/vscode-editor.ts
@@ -58,7 +58,13 @@ export class VSCodeEditor implements Editor {
         }
         const documentUri = activeEditor.document.uri
         const documentText = activeEditor.document.getText()
-        return { content: documentText, filePath: documentUri.fsPath }
+        const documentSelection = activeEditor.selection
+
+        return {
+            content: documentText,
+            filePath: documentUri.fsPath,
+            selection: !documentSelection.isEmpty ? documentSelection : undefined,
+        }
     }
 
     private getActiveTextEditorInstance(): vscode.TextEditor | null {


### PR DESCRIPTION
## Description

This PR improves how Cody uses the current editor selection and displays it is part of the UI.

### UI Changes:

We now display the selected lines against the file in the context footer. I went with `start.line-end.line` but happy to tweak if others feel a better UI would work.

Alternatives I considered: 
- `start.line:start.character-end.line:end.character` (feels too noisy/verbose)
- `L(start.line)-L(end.line)`

![image](https://github.com/sourcegraph/sourcegraph/assets/9516420/8412afac-2c69-4140-8415-21eeb719b1a4)

### Prompt changes:

We have always included the editor selection if present, but now we include it as the last piece of context. Cody uses it a lot more consistently now. I think this makes sense: broad context (embeddings) -> file context (editor contents) -> selection context (selection contents).

Example improvement:

| BEFORE             | AFTER             |
:-------------------------:|:-------------------------:
![image](https://github.com/sourcegraph/sourcegraph/assets/9516420/ed49b5a9-b562-473e-9063-96d6e738121a)| ![image](https://github.com/sourcegraph/sourcegraph/assets/9516420/fe0d1968-2bbb-47d3-8cc5-2be94aff7667)



## Test plan

Tested various prompts with different editor selections. 