### PR TITLE
JetBrains: convert `\t` to spaces in leading whitespace for autocomplete suggestions

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Convert `\t` to spaces in leading whitespace for autocomplete suggestions (according to settings) [#53743](https://github.com/sourcegraph/sourcegraph/pull/53743)
+
 ### Deprecated
 
 ### Removed

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/EditorUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/EditorUtils.java
@@ -1,0 +1,47 @@
+package com.sourcegraph.common;
+
+import com.intellij.application.options.CodeStyle;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+public class EditorUtils {
+
+  /**
+   * Returns a new String, using the given indentation settings to determine the tab size.
+   *
+   * @param inputText text with tabs to convert to spaces
+   * @param indentOptions relevant code style settings
+   * @return a new String with all '\t' characters replaced with spaces according to the configured
+   *     tab size
+   */
+  public static @NotNull String tabsToSpaces(
+      @NotNull String inputText, @NotNull CommonCodeStyleSettings.IndentOptions indentOptions) {
+    String tabReplacement = " ".repeat(indentOptions.TAB_SIZE);
+    return inputText.replaceAll("\t", tabReplacement);
+  }
+
+  /**
+   * @param editor given editor
+   * @return Indent options for the given editor, if null falls back to DEFAULT_INDENT_OPTIONS
+   */
+  public static @NotNull CommonCodeStyleSettings.IndentOptions indentOptions(
+      @NotNull Editor editor) {
+    return Optional.ofNullable(codeStyleSettings(editor).getIndentOptions())
+        .orElse(CommonCodeStyleSettings.IndentOptions.DEFAULT_INDENT_OPTIONS);
+  }
+
+  /**
+   * @param editor given editor
+   * @return code style settings for the given editor, if null defaults to default app code style
+   *     settings
+   */
+  public static @NotNull CommonCodeStyleSettings codeStyleSettings(@NotNull Editor editor) {
+    return ReadAction.compute(
+        () ->
+            Optional.ofNullable(CodeStyle.getLanguageSettings(editor))
+                .orElse(CodeStyle.getDefaultSettings()));
+  }
+}

--- a/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
+++ b/client/jetbrains/src/test/java/InlineCompletionsPostProcessingTest.java
@@ -1,5 +1,6 @@
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.sourcegraph.cody.completions.CodyCompletionsManager;
 import com.sourcegraph.cody.completions.CompletionDocumentContext;
 import com.sourcegraph.cody.vscode.InlineCompletionItem;
@@ -85,5 +86,21 @@ public class InlineCompletionsPostProcessingTest {
     assertEquals(
         outputCompletion.range,
         inputCompletion.range.withEnd(inputCompletion.range.end.withCharacter(7)));
+  }
+
+  @Test
+  public void convertCompletionIndentationTabsToSpaces() {
+    String suggestionText = "\t    \tHello world! \tHello once again!";
+    Range inputRange = new Range(new Position(0, 0), new Position(0, 37));
+    InlineCompletionItem inputCompletion =
+        new InlineCompletionItem(suggestionText, sameLineSuffix, inputRange, null);
+    CommonCodeStyleSettings.IndentOptions indentOptions = // default indent options use tabSize = 4
+        CommonCodeStyleSettings.IndentOptions.DEFAULT_INDENT_OPTIONS;
+    InlineCompletionItem outputCompletion =
+        CodyCompletionsManager.normalizeIndentation(inputCompletion, indentOptions);
+    String expectedSuggestionText = "            Hello world! \tHello once again!";
+    Range expectedRange = inputRange.withEnd(inputRange.end.withCharacter(43));
+    assertEquals(outputCompletion.insertText, expectedSuggestionText);
+    assertEquals(outputCompletion.range, expectedRange);
   }
 }


### PR DESCRIPTION
Fixes #53236 

Cody can possibly return suggestions prefixed with mixed whitespace indentation (tabs, spaces).
This makes sure tabs are converted to spaces in that case, according to the tab size configured in the relevant `IndentOptions`.

Note: any tabs after the indentation (leading whitespace string) are preserved in the suggestion. I believe it's the same in our VS Code implementation, correct me if I'm wrong.

## Test plan
I have included a unit test.
