### PR TITLE
search: temporarily record stats values

### DIFF
--- a/internal/search/BUILD.bazel
+++ b/internal/search/BUILD.bazel
@@ -32,6 +32,8 @@ go_library(
         "//lib/errors",
         "//schema",
         "@com_github_grafana_regexp//:regexp",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
@@ -70,11 +72,36 @@ func Indexed() zoekt.Streamer {
 	return indexedSearch
 }
 
+var (
+	metricReposLen = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_temp_frontend_index_repos_len",
+		Help: "A temporary metric recording different ways to calculate the indexed number of repos.",
+	})
+	metricReposRepos = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_temp_frontend_index_repos_repos",
+		Help: "A temporary metric recording different ways to calculate the indexed number of repos.",
+	})
+	metricReposCrash = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "src_temp_frontend_index_repos_crash",
+		Help: "A temporary metric recording different ways to calculate the indexed number of repos.",
+	})
+)
+
 // ListAllIndexed lists all indexed repositories with `Minimal: true`.
 func ListAllIndexed(ctx context.Context) (*zoekt.RepoList, error) {
 	q := &query.Const{Value: true}
 	opts := &zoekt.ListOptions{Minimal: true}
-	return Indexed().List(ctx, q, opts)
+
+	repos, err := Indexed().List(ctx, q, opts)
+
+	// TODO(keegan) remove this before 2023-08-01. Temporary metric collection.
+	if err == nil {
+		metricReposLen.Set(float64(len(repos.Minimal))) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+		metricReposRepos.Set(float64(repos.Stats.Repos))
+		metricReposCrash.Set(float64(repos.Crashes))
+	}
+
+	return repos, err
 }
 
 func Indexers() *backend.Indexers {


### PR DESCRIPTION
I noticed in some places we use "len(repos.Minimal)" to indicate the number of indexed repos. However, in practice this should be the same as Stats.Repos. The only time Stats.Repos should be inaccurate is when rebalancing between zoekt shards.

I am going to collect data on sourcegraph.com via these metrics to see what happens in practice. I am recording two ways to calculate as well as if we have any crashes (which may also not be reported correctly in some places)

Test Plan: CI