### PR TITLE
Cody: PR description recipe fix

### DIFF
--- a/client/cody-shared/src/chat/recipes/generate-pr-description.ts
+++ b/client/cody-shared/src/chat/recipes/generate-pr-description.ts
@@ -67,7 +67,7 @@ export class PrDescription implements Recipe {
         }
 
         const promptMessage = `Summarise these changes:\n${gitCommitOutput}\n\n made while working in the current git branch.\nUse this pull request template to ${prTemplateContent} generate a pull request description based on the committed changes.\nIf the PR template mentions a requirement to check the contribution guidelines, then just summarise the changes in bulletin format.\n If it mentions a test plan for the changes use N/A\n.`
-        const assistantResponsePrefix = `Here is the PR description for the work done in your current branch: \n${truncatedCommitMessage}`
+        const assistantResponsePrefix = `Here is the PR description for the work done in your current branch:\n${truncatedCommitMessage}`
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/generate-pr-description.ts
+++ b/client/cody-shared/src/chat/recipes/generate-pr-description.ts
@@ -40,7 +40,10 @@ export class PrDescription implements Recipe {
             prTemplateContent = readFileSync(templatePath).toString()
         }
 
-        const gitCommit = spawnSync('git', ['log', 'origin/HEAD..HEAD', logFormat], { cwd: dirPath })
+        const userName = spawnSync('git', ['config', 'user.name'], { cwd: dirPath })
+        const user = userName.stdout.toString().trim()
+
+        const gitCommit = spawnSync('git', ['log', `--author=${user}`, logFormat], { cwd: dirPath })
         const gitCommitOutput = gitCommit.stdout.toString().trim()
 
         if (!gitCommitOutput) {
@@ -64,7 +67,7 @@ export class PrDescription implements Recipe {
         }
 
         const promptMessage = `Summarise these changes:\n${gitCommitOutput}\n\n made while working in the current git branch.\nUse this pull request template to ${prTemplateContent} generate a pull request description based on the committed changes.\nIf the PR template mentions a requirement to check the contribution guidelines, then just summarise the changes in bulletin format.\n If it mentions a test plan for the changes use N/A\n.`
-        const assistantResponsePrefix = `Here is the PR description for the work done in your current branch:\n${truncatedCommitMessage}`
+        const assistantResponsePrefix = `Here is the PR description for the work done in your current branch: \n${truncatedCommitMessage}`
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/generate-pr-description.ts
+++ b/client/cody-shared/src/chat/recipes/generate-pr-description.ts
@@ -40,10 +40,12 @@ export class PrDescription implements Recipe {
             prTemplateContent = readFileSync(templatePath).toString()
         }
 
-        const userName = spawnSync('git', ['config', 'user.name'], { cwd: dirPath })
-        const user = userName.stdout.toString().trim()
+        const userEmail = spawnSync('git', ['config', 'user.email'], { cwd: dirPath })
+        const email = userEmail.stdout.toString().trim()
 
-        const gitCommit = spawnSync('git', ['log', `--author=${user}`, logFormat], { cwd: dirPath })
+        const gitCommit = spawnSync('git', ['log', `--author=<${email}>`, 'origin/HEAD..HEAD', logFormat], {
+            cwd: dirPath,
+        })
         const gitCommitOutput = gitCommit.stdout.toString().trim()
 
         if (!gitCommitOutput) {


### PR DESCRIPTION
This PR is a minor fix for the PR description recipe. As I realised later, when you checkout from any other branch to a new branch, the `git log` command will carry all the commits not done by the current user and a long list of other user commits too. So, I updated the command to consider that.  I have tested these changes, and it works well now!

## Test plan

![iScreen Shoter - Code - 230620173451](https://github.com/sourcegraph/sourcegraph/assets/44617923/0a3034b3-be1c-40b9-93bc-92c8c818a1d1)
