### PR TITLE
cody: add padding for stop-generating btn

### DIFF
--- a/client/cody-ui/src/chat/TranscriptItem.module.css
+++ b/client/cody-ui/src/chat/TranscriptItem.module.css
@@ -9,6 +9,11 @@
     padding: var(--spacing);
 }
 
+/* Additional padding for the stop-generating button */
+.row-in-progress {
+    padding-bottom: calc(var(--spacing) * 2);
+}
+
 .row:before {
     position: absolute;
     top: 0;

--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -148,7 +148,13 @@ export const TranscriptItem: React.FunctionComponent<
                     />
                 </div>
             )}
-            <div className={classNames(styles.contentPadding, textarea ? undefined : styles.content)}>
+            <div
+                className={classNames(
+                    styles.contentPadding,
+                    textarea ? undefined : styles.content,
+                    inProgress && styles.rowInProgress
+                )}
+            >
                 {message.displayText ? (
                     textarea ?? (
                         <CodeBlocks


### PR DESCRIPTION
close https://github.com/sourcegraph/sourcegraph/issues/53729

Add temporary padding to last message while message is in progress so that the `stop-generating` button does not block the response

### Before

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/ff39e1ff-f38f-45a3-bce1-d8892db749e9)


### After

![image](https://github.com/sourcegraph/sourcegraph/assets/68532117/5f069dc5-c1fc-430f-b351-848e932230b9)


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Loom:

https://github.com/sourcegraph/sourcegraph/assets/68532117/0ee48380-854e-4bdf-91d8-7f1500a59614

