### PR TITLE
JetBrains: Clear all rendered completions when they are disabled

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed the y position at which autocomplete suggestions are rendered [#53677](https://github.com/sourcegraph/sourcegraph/pull/53677)
+- Fixed rendered completions being cleared after disabling them in settings [#53758](https://github.com/sourcegraph/sourcegraph/pull/53758)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -7,6 +7,7 @@ public class PluginSettingChangeContext {
 
   @Nullable public final String oldDotComAccessToken;
   @Nullable public final String oldEnterpriseAccessToken;
+  public final boolean oldCodyCompletionsEnabled;
 
   @Nullable public final String newUrl;
 
@@ -14,21 +15,26 @@ public class PluginSettingChangeContext {
   @Nullable public final String newEnterpriseAccessToken;
 
   @Nullable public final String newCustomRequestHeaders;
+  public final boolean newCodyCompletionsEnabled;
 
   public PluginSettingChangeContext(
       @Nullable String oldUrl,
       @Nullable String oldDotComAccessToken,
       @Nullable String oldEnterpriseAccessToken,
+      boolean oldCodyCompletionsEnabled,
       @Nullable String newUrl,
       @Nullable String newDotComAccessToken,
       @Nullable String newEnterpriseAccessToken,
-      @Nullable String newCustomRequestHeaders) {
+      @Nullable String newCustomRequestHeaders,
+      boolean newCodyCompletionsEnabled) {
     this.oldUrl = oldUrl;
     this.oldDotComAccessToken = oldDotComAccessToken;
     this.oldEnterpriseAccessToken = oldEnterpriseAccessToken;
+    this.oldCodyCompletionsEnabled = oldCodyCompletionsEnabled;
     this.newUrl = newUrl;
     this.newDotComAccessToken = newDotComAccessToken;
     this.newEnterpriseAccessToken = newEnterpriseAccessToken;
     this.newCustomRequestHeaders = newCustomRequestHeaders;
+    this.newCodyCompletionsEnabled = newCodyCompletionsEnabled;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -7,15 +7,20 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
+import com.sourcegraph.cody.completions.CodyCompletionsManager;
 import com.sourcegraph.find.browser.JavaToJSBridge;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
@@ -78,6 +83,19 @@ public class SettingsChangeListener implements Disposable {
                     ConfigUtil.setAuthenticationFailedLastTime(
                         status != ApiAuthenticator.ConnectionStatus.AUTHENTICATED);
                   });
+            }
+
+            // clear completions if freshly disabled
+            if (context.oldCodyCompletionsEnabled && !context.newCodyCompletionsEnabled) {
+              Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+              CodyCompletionsManager codyCompletionsManager = CodyCompletionsManager.getInstance();
+              Arrays.stream(openProjects)
+                  .flatMap(
+                      project ->
+                          Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()))
+                  .filter(fileEditor -> fileEditor instanceof TextEditor)
+                  .map(fileEditor -> ((TextEditor) fileEditor).getEditor())
+                  .forEach(codyCompletionsManager::clearCompletions);
             }
           }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -72,6 +72,7 @@ public class SettingsConfigurable implements Configurable {
     SourcegraphApplicationService aSettings = SourcegraphApplicationService.getInstance();
     SourcegraphProjectService pSettings = SourcegraphService.getInstance(project);
 
+    boolean oldCodyCompletionsEnabled = ConfigUtil.areCodyCompletionsEnabled();
     String oldUrl = ConfigUtil.getSourcegraphUrl(project);
     String oldDotComAccessToken = ConfigUtil.getDotComAccessToken(project);
     String oldEnterpriseAccessToken = ConfigUtil.getEnterpriseAccessToken(project);
@@ -79,15 +80,18 @@ public class SettingsConfigurable implements Configurable {
     String newDotComAccessToken = mySettingsComponent.getDotComAccessToken();
     String newEnterpriseAccessToken = mySettingsComponent.getEnterpriseAccessToken();
     String newCustomRequestHeaders = mySettingsComponent.getCustomRequestHeaders();
+    boolean newCodyCompletionsEnabled = mySettingsComponent.areCodyCompletionsEnabled();
     PluginSettingChangeContext context =
         new PluginSettingChangeContext(
             oldUrl,
             oldDotComAccessToken,
             oldEnterpriseAccessToken,
+            oldCodyCompletionsEnabled,
             newUrl,
             newDotComAccessToken,
             newEnterpriseAccessToken,
-            newCustomRequestHeaders);
+            newCustomRequestHeaders,
+            newCodyCompletionsEnabled);
 
     publisher.beforeAction(context);
 
@@ -127,7 +131,7 @@ public class SettingsConfigurable implements Configurable {
       aSettings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
     }
     aSettings.isUrlNotificationDismissed = mySettingsComponent.isUrlNotificationDismissed();
-    aSettings.areCodyCompletionsEnabled = mySettingsComponent.areCodyCompletionsEnabled();
+    aSettings.areCodyCompletionsEnabled = newCodyCompletionsEnabled;
 
     publisher.afterAction(context);
   }


### PR DESCRIPTION
Fixes #53748 

Should work as expected now.

https://github.com/sourcegraph/sourcegraph/assets/18601388/2eaab5ef-f2e3-4108-930b-bd788226c139

## Test plan
Make sure the following steps work on your local (as on the attached screen recording):
- enable completions
- have a suggestion rendered in an editor
- go back to settings, disable completions, save
- the previously rendered completion should disappear immediately
