### PR TITLE
ci: add debugging info if bazel already running

### DIFF
--- a/dev/ci/gen-pipeline.sh
+++ b/dev/ci/gen-pipeline.sh
@@ -6,12 +6,24 @@ echo "--- :books: Annotating build with Glossary"
 buildkite-agent annotate --style info <./enterprise/dev/ci/glossary.md
 
 echo "--- :bazel: Build pipeline generator"
+set +e
 bazel \
   --bazelrc=.bazelrc \
   --bazelrc=.aspect/bazelrc/ci.bazelrc \
   --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
   build \
   //enterprise/dev/ci:ci
+
+exit_code="$?"
+set -e
+
+if [ "$exit_code" -ne 0 ]; then
+  if [ "$exit_code" -eq 36 ]; then
+    echo "--- Another bazel command is running, this is abnormal, please reach #ask-dev-experience"
+    ps aux | grep bazel
+  fi
+  exit "$exit_code"
+fi
 
 pipeline_gen="$(bazel cquery //enterprise/dev/ci:ci --output files)"
 


### PR DESCRIPTION
On rare occasions, we see this: 

![image](https://github.com/sourcegraph/sourcegraph/assets/10151/ac4a93a0-cb6e-4ac9-8338-c569a4ba6ab7)

This is not about waiting for the Bazel command to complete, because it should wait for it to complete. Still, it seems that something fishy is going on. 

This PR would hopefully surface a bit more context so we can understand. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Tested locally. 
