### PR TITLE
Fix cody gating & scope state reset

### DIFF
--- a/client/cody-shared/src/chat/useClient.ts
+++ b/client/cody-shared/src/chat/useClient.ts
@@ -136,6 +136,12 @@ export const useClient = ({
         setIsMessageInProgressState(false)
         setTranscriptState(newTranscript)
         setChatMessagesState(newTranscript.toChat())
+        setScopeState(scope => ({
+            includeInferredRepository: true,
+            includeInferredFile: true,
+            repositories: [],
+            editor: scope.editor,
+        }))
         onEvent?.('initializedNewChat')
 
         return newTranscript

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -11,6 +11,7 @@ import {
     mdiStopCircleOutline,
 } from '@mdi/js'
 import classNames from 'classnames'
+import { useLocation } from 'react-router-dom'
 import useResizeObserver from 'use-resize-observer'
 
 import {
@@ -26,7 +27,7 @@ import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourceg
 
 import { eventLogger } from '../../../tracking/eventLogger'
 import { CodyPageIcon } from '../../chat/CodyPageIcon'
-import { isCodyEnabled, isEmailVerificationNeededForCody } from '../../isCodyEnabled'
+import { isCodyEnabled, isEmailVerificationNeededForCody, isSignInRequiredForCody } from '../../isCodyEnabled'
 import { useCodySidebar } from '../../sidebar/Provider'
 import { CodyChatStore } from '../../useCodyChat'
 import { ScopeSelector } from '../ScopeSelector'
@@ -291,11 +292,19 @@ export const AutoResizableTextArea: React.FC<AutoResizableTextAreaProps> = React
         }
 
         return (
-            <Tooltip content={isEmailVerificationNeededForCody() ? 'Verify your email to use Cody.' : ''}>
+            <Tooltip
+                content={
+                    isSignInRequiredForCody()
+                        ? 'Sign in to get access to Cody.'
+                        : isEmailVerificationNeededForCody()
+                        ? 'Verify your email to use Cody.'
+                        : ''
+                }
+            >
                 <TextArea
                     ref={textAreaRef}
                     className={className}
-                    value={value}
+                    value={isSignInRequiredForCody() ? 'Sign in to get access to use Cody' : value}
                     onChange={handleChange}
                     rows={1}
                     autoFocus={false}
@@ -332,6 +341,8 @@ const NeedsEmailVerificationNotice: React.FunctionComponent = React.memo(
 )
 
 const CodyNotEnabledNotice: React.FunctionComponent = React.memo(function CodyNotEnabledNoticeContent() {
+    const location = useLocation()
+
     return (
         <div className={classNames('p-3', styles.notEnabledBlock)}>
             <H2 className={classNames('d-flex gap-1 align-items-center mb-3', styles.codyMessageHeader)}>
@@ -340,8 +351,18 @@ const CodyNotEnabledNotice: React.FunctionComponent = React.memo(function CodyNo
             <div className="d-flex align-items-start">
                 <CodyNotEnabledIcon className="flex-shrink-0" />
                 <Text className="ml-2">
-                    Cody isn't available on this instance, but you can learn more about Cody{' '}
-                    <Link to="https://about.sourcegraph.com/cody?utm_source=server">here</Link>.
+                    {isSignInRequiredForCody() ? (
+                        <>
+                            <Link to={`/sign-in?returnTo=${location.pathname}`}>Sign in</Link> to get access to Cody.
+                            You can learn more about Cody{' '}
+                            <Link to="https://about.sourcegraph.com/cody?utm_source=server">here</Link>.
+                        </>
+                    ) : (
+                        <>
+                            Cody isn't available on this instance, but you can learn more about Cody{' '}
+                            <Link to="https://about.sourcegraph.com/cody?utm_source=server">here</Link>.
+                        </>
+                    )}
                 </Text>
             </div>
         </div>

--- a/client/web/src/cody/isCodyEnabled.tsx
+++ b/client/web/src/cody/isCodyEnabled.tsx
@@ -13,5 +13,4 @@ export const isCodyEnabled = (): boolean => {
     return true
 }
 
-export const isSignInRequiredForCody = (): boolean =>
-    window.context.sourcegraphDotComMode && !window.context.isAuthenticatedUser
+export const isSignInRequiredForCody = (): boolean => !window.context.isAuthenticatedUser

--- a/client/web/src/cody/isCodyEnabled.tsx
+++ b/client/web/src/cody/isCodyEnabled.tsx
@@ -12,3 +12,6 @@ export const isCodyEnabled = (): boolean => {
 
     return true
 }
+
+export const isSignInRequiredForCody = (): boolean =>
+    window.context.sourcegraphDotComMode && !window.context.isAuthenticatedUser


### PR DESCRIPTION
- Update notice in cody sidebar for logged-out users on dotcom
- Reset chat scope state on creating new chat. 

## Test plan

- Open cody sidebar on dotcom being logged out, it should say "sign in to get access to cody"
- Visit /cody, add repos to scope, create new chat, the scope should be reset. 