### PR TITLE
JetBrains: add background color to inline code blocks in chat message

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Background color and font of inline code blocks differs from regular text in message [#53761](https://github.com/sourcegraph/sourcegraph/pull/53761)
+
 ### Changed
 
 ### Deprecated

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
@@ -26,7 +26,7 @@ public class ChatBubble extends JPanel {
     Node document = parser.parse(message.getDisplayText());
     MessageContentCreatorFromMarkdownNodes messageContentCreator =
         new MessageContentCreatorFromMarkdownNodes(
-            messagePanel, ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
+            messagePanel, message.getSpeaker(), ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
     document.accept(messageContentCreator);
     return messagePanel;
   }


### PR DESCRIPTION
Added some styles to distinguish inline code blocks in message from regular text

## Test plan
- Inline code blocks should get a different background color and the font should match current font from the main editor

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
![image (2)](https://github.com/sourcegraph/sourcegraph/assets/7345368/2696e4ac-ccec-4b48-be82-ab35ef9084eb)
