### PR TITLE
codeintel: Fix package set construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Slow request logs now have the correct trace and span IDs attached if a trace is present on the request. [#51826](https://github.com/sourcegraph/sourcegraph/pull/51826)
 - The braindot menu on the blob view no longer fetches data eagerly to prevent performance issues for larger monorepo users. [#53039](https://github.com/sourcegraph/sourcegraph/pull/53039)
 - Fixed an issue where commenting out redacted site-config secrets would re-add the secrets. [#53152](https://github.com/sourcegraph/sourcegraph/pull/53152)
+- Fixed an issue where SCIP packages would sometimes not be written to the database, breaking cross-repository jump to definition. [#53763](https://github.com/sourcegraph/sourcegraph/pull/53763)
 
 ### Removed
 

--- a/enterprise/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -72,12 +72,14 @@ func correlateSCIP(
 
 			for _, symbol := range document.Symbols {
 				if pkg, ok := packageFromSymbol(symbol.Symbol); ok {
-					packageSet[pkg] = false
+					// no-op if key exists; add false if key is absent
+					packageSet[pkg] = packageSet[pkg] || false
 				}
 
 				for _, relationship := range symbol.Relationships {
 					if pkg, ok := packageFromSymbol(relationship.Symbol); ok {
-						packageSet[pkg] = false
+						// no-op if key exists; add false if key is absent
+						packageSet[pkg] = packageSet[pkg] || false
 					}
 				}
 			}
@@ -88,8 +90,12 @@ func correlateSCIP(
 				}
 
 				if pkg, ok := packageFromSymbol(occurrence.Symbol); ok {
-					isDefinition := scip.SymbolRole_Definition.Matches(occurrence)
-					packageSet[pkg] = packageSet[pkg] || isDefinition
+					if isDefinition := scip.SymbolRole_Definition.Matches(occurrence); isDefinition {
+						packageSet[pkg] = true
+					} else {
+						// no-op if key exists; add false if key is absent
+						packageSet[pkg] = packageSet[pkg] || false
+					}
 				}
 			}
 		}


### PR DESCRIPTION
We're neglecting to add some packages to the `lsif_packages` table. Tracked this down to the `packageSet` map having false values when they should've been true.

Turns out that when processing documents in a particular order we can re-assign false over a true assignment in this map, counting definitions instead as references. This makes it unable to be the target of a jump-to-definition operation.

This PR fixes it so that we don't mark definitions as references once marked as definition.

## Test plan

Ran QA tests locally.
