### PR TITLE
wrexec: handle unsetting GitRecorder config

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -436,6 +436,7 @@ func (s *Server) Handler() http.Handler {
 		// to determine whether a command should be recorded or not.
 		recordingConf := conf.Get().SiteConfig().GitRecorder
 		if recordingConf == nil {
+			s.recordingCommandFactory.Disable()
 			return
 		}
 		s.recordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos), recordingConf.Size)

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -135,6 +135,12 @@ func (rf *RecordingCommandFactory) Update(shouldRecord ShouldRecordFunc, max int
 	rf.maxSize = max
 }
 
+// Disable will modify the RecordingCommandFactory so that from that point, it
+// will not record. This is a convenience around Update.
+func (rf *RecordingCommandFactory) Disable() {
+	rf.Update(nil, 0)
+}
+
 // Command returns a new RecordingCommand with the ShouldRecordFunc already set.
 func (rf *RecordingCommandFactory) Command(ctx context.Context, logger log.Logger, name string, args ...string) *RecordingCmd {
 	store := rcache.NewFIFOList(KeyPrefix, rf.maxSize)


### PR DESCRIPTION
Minor issue I came across while reading code. Previously if a site-admin removed GitRecorder configuration that would be ignored until the next process restart. This explicitly handles that.

Additionally a test is added that we handle nil predicates. We already relied on this behaviour since if GitRecorder was not configured we would never call update => we had a nil predicate.

Test Plan: CI