### PR TITLE
Search: URL encode path components

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -229,17 +229,17 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-    | 'document-match-limit'
-    | 'shard-match-limit'
-    | 'repository-limit'
-    | 'shard-timedout'
-    | 'repository-cloning'
-    | 'repository-missing'
-    | 'backend-missing'
-    | 'excluded-fork'
-    | 'excluded-archive'
-    | 'display'
-    | 'error'
+        | 'document-match-limit'
+        | 'shard-match-limit'
+        | 'repository-limit'
+        | 'shard-timedout'
+        | 'repository-cloning'
+        | 'repository-missing'
+        | 'backend-missing'
+        | 'excluded-fork'
+        | 'excluded-archive'
+        | 'display'
+        | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -229,17 +229,17 @@ export interface Skipped {
      * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
-        | 'document-match-limit'
-        | 'shard-match-limit'
-        | 'repository-limit'
-        | 'shard-timedout'
-        | 'repository-cloning'
-        | 'repository-missing'
-        | 'backend-missing'
-        | 'excluded-fork'
-        | 'excluded-archive'
-        | 'display'
-        | 'error'
+    | 'document-match-limit'
+    | 'shard-match-limit'
+    | 'repository-limit'
+    | 'shard-timedout'
+    | 'repository-cloning'
+    | 'repository-missing'
+    | 'backend-missing'
+    | 'excluded-fork'
+    | 'excluded-archive'
+    | 'display'
+    | 'error'
     /**
      * A short message. eg 1,200 timed out.
      */
@@ -573,7 +573,8 @@ export function getRevision(branches?: string[], version?: string): string {
 
 export function getFileMatchUrl(fileMatch: ContentMatch | SymbolMatch | PathMatch): string {
     const revision = getRevision(fileMatch.branches, fileMatch.commit)
-    return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${fileMatch.path}`
+    const encodedFilePath = fileMatch.path.split('/').map(encodeURIComponent).join('/')
+    return `/${fileMatch.repository}${revision ? '@' + revision : ''}/-/blob/${encodedFilePath}`
 }
 
 export function getRepoMatchLabel(repoMatch: RepositoryMatch): string {


### PR DESCRIPTION
We do not URL-encode paths, so special characters (`%`) break the links. This splits paths on `/`, encodes the components, then re-joins on `/` so that we still get nice looking URLs (we don't need to escape `/`). 

Fixes https://github.com/sourcegraph/sourcegraph/issues/40578

## Test plan

Tested that file paths containing `%` generate usable links.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
