### PR TITLE
Cody: Replace link with plain text in cody app chat

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -370,7 +370,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                     New chat
                                 </Button>
                             </div>
-                            <ChatUI codyChatStore={codyChatStore} />
+                            <ChatUI codyChatStore={codyChatStore} isSourcegraphApp={true} />
                         </div>
 
                         {showMobileHistory && (

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -39,9 +39,10 @@ const onFeedbackSubmit = (feedback: string): void => eventLogger.log(`web:cody:f
 
 interface IChatUIProps {
     codyChatStore: CodyChatStore
+    isSourcegraphApp?: boolean
 }
 
-export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore }): JSX.Element => {
+export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp }): JSX.Element => {
     const {
         submitMessage,
         editMessage,
@@ -93,7 +94,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore }): JSX.Element =
                 setInputHistory={setInputHistory}
                 onSubmit={onSubmit}
                 submitButtonComponent={SubmitButton}
-                fileLinkComponent={FileLink}
+                fileLinkComponent={isSourcegraphApp ? AppFileLink : FileLink}
                 className={styles.container}
                 afterTips={transcriptHistory.length > 1 ? '' : CODY_TERMS_MARKDOWN}
                 transcriptItemClassName={styles.transcriptItem}
@@ -245,6 +246,15 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = React.memo(funct
     ) : (
         <>{path}</>
     )
+})
+
+/**
+ * Since App doesn't support search UI we don't user link to the blob UI as we do
+ * in the standard FileLink component, instead at the moment we render just a plain text
+ * see https://github.com/sourcegraph/sourcegraph/issues/53776 for more details.
+ */
+export const AppFileLink: React.FunctionComponent<FileLinkProps> = React.memo(function AppFileLink({ path }) {
+    return <>{path}</>
 })
 
 interface AutoResizableTextAreaProps extends ChatUITextAreaProps {}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53415

This PR makes links plain text in the Cody app chat, it will be improved later with IDE/editors deep link here https://github.com/sourcegraph/sourcegraph/issues/53776

## Test plan
- Check that links in chat are just plain text and not interactive links.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
