### PR TITLE
Hide repositories from the Cody App advanced settings

### DIFF
--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -97,6 +97,7 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
         {
             label: 'Repositories',
             to: '/site-admin/repositories',
+            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
             label: 'Packages',


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53698

## Test plan
- Check that app doesn't have repositories setting tab in advanced settings

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
