### PR TITLE
cody: config options for setting token limits

### DIFF
--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -153,7 +153,7 @@ export class Transcript {
 
     public async getPromptForLastInteraction(
         preamble: Message[] = [],
-        max_prompt_length: number = MAX_AVAILABLE_PROMPT_LENGTH
+        maxPromptLength: number = MAX_AVAILABLE_PROMPT_LENGTH
     ): Promise<{ prompt: Message[]; contextFiles: ContextFile[] }> {
         if (this.interactions.length === 0) {
             return { prompt: [], contextFiles: [] }

--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -174,7 +174,7 @@ export class Transcript {
         }
 
         const preambleTokensUsage = preamble.reduce((acc, message) => acc + estimateTokensUsage(message), 0)
-        let truncatedMessages = truncatePrompt(messages, max_prompt_length - preambleTokensUsage)
+        let truncatedMessages = truncatePrompt(messages, maxPromptLength - preambleTokensUsage)
 
         // Return what context fits in the window
         const contextFiles: ContextFile[] = []
@@ -265,7 +265,6 @@ function truncatePrompt(messages: Message[], maxTokens: number): Message[] {
             newPromptMessages.push(botMessage, humanMessage)
             availablePromptTokensBudget -= combinedTokensUsage
         } else {
-            console.error('token budget exceeded')
             break
         }
     }

--- a/client/cody-shared/src/chat/transcript/index.ts
+++ b/client/cody-shared/src/chat/transcript/index.ts
@@ -152,7 +152,8 @@ export class Transcript {
     }
 
     public async getPromptForLastInteraction(
-        preamble: Message[] = []
+        preamble: Message[] = [],
+        max_prompt_length: number = MAX_AVAILABLE_PROMPT_LENGTH
     ): Promise<{ prompt: Message[]; contextFiles: ContextFile[] }> {
         if (this.interactions.length === 0) {
             return { prompt: [], contextFiles: [] }
@@ -173,7 +174,7 @@ export class Transcript {
         }
 
         const preambleTokensUsage = preamble.reduce((acc, message) => acc + estimateTokensUsage(message), 0)
-        let truncatedMessages = truncatePrompt(messages, MAX_AVAILABLE_PROMPT_LENGTH - preambleTokensUsage)
+        let truncatedMessages = truncatePrompt(messages, max_prompt_length - preambleTokensUsage)
 
         // Return what context fits in the window
         const contextFiles: ContextFile[] = []
@@ -264,6 +265,7 @@ function truncatePrompt(messages: Message[], maxTokens: number): Message[] {
             newPromptMessages.push(botMessage, humanMessage)
             availablePromptTokensBudget -= combinedTokensUsage
         } else {
+            console.error('token budget exceeded')
             break
         }
     }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -76,7 +76,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
     private inputHistory: string[] = []
     private chatHistory: ChatHistory = {}
 
-    private max_prompt_limit = MAX_AVAILABLE_PROMPT_LENGTH
+    private maxPromptLimit = MAX_AVAILABLE_PROMPT_LENGTH
     private transcript: Transcript = new Transcript()
 
     // Allows recipes to hook up subscribers to process sub-streams of bot output
@@ -140,10 +140,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.disposables.push(this.localAppDetector)
 
         const codyConfig = vscode.workspace.getConfiguration('cody')
-        const token_limit = codyConfig.get<number>('provider.limit.prompt')
-        const solution_limit = codyConfig.get<number>('provider.limit.solution') || SOLUTION_TOKEN_LENGTH
-        if (token_limit) {
-            this.max_prompt_limit = token_limit - solution_limit
+        const tokenLimit = codyConfig.get<number>('provider.limit.prompt')
+        const solutionLimit = codyConfig.get<number>('provider.limit.solution') || SOLUTION_TOKEN_LENGTH
+        if (tokenLimit) {
+            this.maxPromptLimit = tokenLimit - solutionLimit
         }
     }
 

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -507,7 +507,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
                 const { prompt, contextFiles } = await this.transcript.getPromptForLastInteraction(
                     getPreamble(this.codebaseContext.getCodebase()),
-                    this.max_prompt_limit
+                    this.maxPromptLimit
                 )
                 this.transcript.setUsedContextFilesForLastInteraction(contextFiles)
                 this.sendPrompt(prompt, interaction.getAssistantMessage().prefix ?? '')
@@ -540,7 +540,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
 
         const { prompt, contextFiles } = await transcript.getPromptForLastInteraction(
             getPreamble(this.codebaseContext.getCodebase()),
-            this.max_prompt_limit
+            this.maxPromptLimit
         )
         transcript.setUsedContextFilesForLastInteraction(contextFiles)
 


### PR DESCRIPTION
A temporary workaround for setting token limits in clients until appropriate configuration options are added to the backend.

Setting `cody.provider.limit.prompt` and `cody.provider.limit.solution` creates a replacement for [MAX_AVAILABLE_PROMPT_LENGTH](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/cody-shared/src/prompt/constants.ts?L7) to use in getPromptForLastInteraction, which truncates the list of messages to fit within a maximum prompt length defined by `MAX_AVAILABLE_PROMPT_LENGTH`.

From Cody:

```
MAX_AVAILABLE_PROMPT_LENGTH is being used to calculate the maximum length of the prompt that can be shown to the user.

It is calculated by subtracting the SOLUTION_TOKEN_LENGTH (which represents the length of the solution code) from the MAX_PROMPT_TOKEN_LENGTH (which is the maximum total length of the prompt in tokens).

So if MAX_PROMPT_TOKEN_LENGTH is 7000 tokens, and SOLUTION_TOKEN_LENGTH is 1000 tokens, then MAX_AVAILABLE_PROMPT_LENGTH would be 6000 tokens - the maximum length available for the prompt after accounting for the solution.
```

Question for @mrnugget @philipp-spiess: are there other config options we should include?

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

1. In User settings, set the following:
  - `cody.provider.limit.prompt` as a replacement for MAX_PROMPT_TOKEN_LENGTH
  - `cody.provider.limit.solution` as a replacement for SOLUTION_TOKEN_LENGTH
2. Reload the extension
3. When the `MAX_AVAILABLE_PROMPT_LENGTH` (`cody.provider.limit.prompt` - `cody.provider.limit.solution`) limit has reached, you will see `'token budget exceeded'` in your console.log