### PR TITLE
app: clicking on dock icon should open main window

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -105,7 +105,7 @@ fn main() {
             tauri::WindowEvent::CloseRequested { api, .. } => {
                 // Ensure the app stays open after the last window is closed.
                 if event.window().label() == "main" {
-                    event.window().hide().unwrap();
+                    tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
                     api.prevent_close();
                 }
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -105,6 +105,11 @@ fn main() {
             tauri::WindowEvent::CloseRequested { api, .. } => {
                 // Ensure the app stays open after the last window is closed.
                 if event.window().label() == "main" {
+                    // We use `tauri::AppHandle::hide` instead of `event.window().hide` because
+                    // hiding the app allows clicking the dock icon to show the app again.
+                    // This is a temporary solution that only works if the app has a single window.
+                    // If we need to add more windows in the future, we need to wait until
+                    // https://github.com/tauri-apps/tauri/issues/3084 is fixed.
                     tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
                     api.prevent_close();
                 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53756

This allows clicking the dock icon to show the main window if it is closed but the app is still running.

This is a temporary solution that only works if the app has a single window. If we need to add more windows in the future, we need to wait until https://github.com/tauri-apps/tauri/issues/3084 is fixed.

## Test plan

1. Open app
2. Close with red button on top-left of window
3. Click on Cody icon in dock

App main window should be shown again.