### PR TITLE
internal/trace: remove net/trace integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- `golang.org/x/net/trace` instrumentation, previously available under `/debug/requests` and `/debug/events`, is now disabled by default. It can be re-enabled on a per-service basis with `SRC_ENABLE_NET_TRACE=true`. [#53795](https://github.com/sourcegraph/sourcegraph/pull/53795)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- `golang.org/x/net/trace` instrumentation, previously available under `/debug/requests` and `/debug/events`, is now disabled by default. It can be re-enabled on a per-service basis with `SRC_ENABLE_NET_TRACE=true`. [#53795](https://github.com/sourcegraph/sourcegraph/pull/53795)
+- `golang.org/x/net/trace` instrumentation, previously available under `/debug/requests` and `/debug/events`, has been removed entirely from core Sourcegraph services. It remains available for Zoekt. [#53795](https://github.com/sourcegraph/sourcegraph/pull/53795)
 
 ### Fixed
 

--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -105,6 +105,9 @@ You can test the exporter by [tracing a search query](#trace-a-search-query).
 
 ### net/trace
 
+> WARNING: `net/trace` instrumentation will be disabled by default in Sourcegraph 5.2.
+> To enable it, set `SRC_ENABLE_NET_TRACE=true` on Sourcegraph services of interest.
+
 Sourcegraph uses the [`net/trace`](https://pkg.go.dev/golang.org/x/net/trace) package in its backend
 services, in addition to the other tracing mechanisms listed above.
 This provides simple tracing information within a single process.

--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -102,15 +102,3 @@ Once set up, you can use the following URL template for traces exported to Jaege
 ```
 
 You can test the exporter by [tracing a search query](#trace-a-search-query).
-
-### net/trace
-
-> WARNING: `net/trace` instrumentation will be removed in Sourcegraph 5.2.
-
-Sourcegraph uses the [`net/trace`](https://pkg.go.dev/golang.org/x/net/trace) package in its backend
-services, in addition to the other tracing mechanisms listed above.
-This provides simple tracing information within a single process.
-It can be used as an alternative when Jaeger is not available or as a supplement to Jaeger.
-
-Site admins can access `net/trace` information at `https://sourcegraph.example.com/-/debug/`. From
-there, click **Requests** to view the traces for that service.

--- a/doc/admin/observability/tracing.md
+++ b/doc/admin/observability/tracing.md
@@ -105,8 +105,7 @@ You can test the exporter by [tracing a search query](#trace-a-search-query).
 
 ### net/trace
 
-> WARNING: `net/trace` instrumentation will be disabled by default in Sourcegraph 5.2.
-> To enable it, set `SRC_ENABLE_NET_TRACE=true` on Sourcegraph services of interest.
+> WARNING: `net/trace` instrumentation will be removed in Sourcegraph 5.2.
 
 Sourcegraph uses the [`net/trace`](https://pkg.go.dev/golang.org/x/net/trace) package in its backend
 services, in addition to the other tracing mechanisms listed above.

--- a/internal/debugserver/BUILD.bazel
+++ b/internal/debugserver/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//internal/goroutine",
         "//internal/grpc/defaults",
         "//internal/httpserver",
-        "//internal/trace",
         "//internal/version",
         "//lib/errors",
         "@com_github_felixge_fgprof//:fgprof",
@@ -27,6 +26,5 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_x_net//trace",
     ],
 )

--- a/internal/trace/BUILD.bazel
+++ b/internal/trace/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
-        "@org_golang_x_net//trace",
     ],
 )
 

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -6,14 +6,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	nettrace "golang.org/x/net/trace"
-
-	"github.com/sourcegraph/sourcegraph/internal/env"
 )
-
-// EnableNetTrace toggles golang.org/x/net/trace support (exported via
-// '/debug/requests' and '/debug/events') in internal/trace through SRC_ENABLE_NET_TRACE.
-var EnableNetTrace = env.MustGetBool("SRC_ENABLE_NET_TRACE", false, "Enable golang.org/x/net/trace instrumentation")
 
 // A Tracer for trace creation, parameterised over an opentelemetry.TracerProvider. Set
 // TracerProvider if you don't want to use the global tracer provider, otherwise the
@@ -35,29 +28,13 @@ func (t Tracer) New(ctx context.Context, family, title string, attrs ...attribut
 			oteltrace.WithAttributes(attribute.String("title", title)),
 			oteltrace.WithAttributes(attrs...))
 
-	// Create the nettrace trace to tee to. May be left nil if EnableNetTrace
-	// is false.
-	var ntTrace nettrace.Trace
-	if EnableNetTrace {
-		ntTrace = nettrace.New(family, title)
-	}
-
 	// Set up the split trace.
 	trace := &Trace{
 		family:        family,
 		oteltraceSpan: otelSpan,
-		nettraceTrace: ntTrace,
 	}
 	if parent := TraceFromContext(ctx); parent != nil {
-		if ntTrace != nil {
-			ntTrace.LazyPrintf("parent: %s", parent.family)
-		}
 		trace.family = parent.family + " > " + family
-	}
-	if ntTrace != nil {
-		for _, t := range attrs {
-			ntTrace.LazyPrintf("%s: %s", t.Key, t.Value)
-		}
 	}
 	return trace, contextWithTrace(ctx, trace)
 }

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -13,7 +13,7 @@ import (
 
 // EnableNetTrace toggles golang.org/x/net/trace support (exported via
 // '/debug/requests' and '/debug/events') in internal/trace through SRC_ENABLE_NET_TRACE.
-var EnableNetTrace = env.MustGetBool("SRC_ENABLE_NET_TRACE", true, "Enable golang.org/x/net/trace")
+var EnableNetTrace = env.MustGetBool("SRC_ENABLE_NET_TRACE", false, "Enable golang.org/x/net/trace instrumentation")
 
 // A Tracer for trace creation, parameterised over an opentelemetry.TracerProvider. Set
 // TracerProvider if you don't want to use the global tracer provider, otherwise the


### PR DESCRIPTION
Follow-up from https://github.com/sourcegraph/sourcegraph/pull/53435#issuecomment-1597050970 and INC-214 - this removes `net/trace` instrumentation entirely in the next release.

It seems [this gets low usage and may be difficult to use](https://github.com/sourcegraph/sourcegraph/pull/53795#pullrequestreview-1489890896), and it seems to introduce some risk and overhead. This will also make it easier to drop our internal trace wrapper entirely and/or integrate it as part of OpenTelemetry's APIs instead of having a proprietary way of doing traces.

## Test plan

Already tested in https://github.com/sourcegraph/sourcegraph/pull/53435
