### PR TITLE
batches: auto-delete Gerrit Change on close

### DIFF
--- a/doc/admin/config/batch_changes.md
+++ b/doc/admin/config/batch_changes.md
@@ -165,16 +165,17 @@ When enabled, Batch Changes will override any setting on the repository on the c
 
 Not every code host supports this in the same way; some code host APIs expose a property on the changeset which can be toggled to enable this behavior, while others require a separate API call to delete the branch after the changeset is merged/closed.
 
-For those that support a changeset property, Batch Changes will automatically set the property to match the site config setting. The property will be updated whenever the changeset is updated, so that the settings stay in sync.
+For those that support a changeset property, Batch Changes will automatically set the property to match the site config setting. The property will be updated whenever the changeset is updated, so that the settings stay in sync. Using a changeset property has the added benefit that the branch will be deleted even if the changeset is merged/closed on the code host itself, rather than through Sourcegraph.
 
 For those that require a separate API call, Batch Changes will only be able to delete the branch if the changeset is merged/closed _using Sourcegraph_. If the changeset is merged/closed on the code host itself, Batch Changes will not be able to delete the branch.
 
 Refer to the table below to see the levels with which each code host is supported:
 
-Code Host | Changeset property or separate API call? | Support on merge | Support on close
---------- | --------- | :-: | :-:
-Azure DevOps | Changeset property | ✓ | ✗
-Bitbucket Cloud | Changeset property | ✓ | ✓
-Bitbucket Server | API call | ✓ | ✓
-GitHub | API call | ✓ | ✓
-GitLab | Changeset property | ✓ | ✓
+Code Host | Changeset property or separate API call? | Support on merge | Support on close | Note
+--------- | --------- | :-: | :-: | ----
+Azure DevOps | Changeset property | ✓ | ✗ |
+Bitbucket Cloud | Changeset property | ✓ | ✓ |
+Bitbucket Server | API call | ✓ | ✓ |
+GitHub | API call | ✓ | ✓ |
+GitLab | Changeset property | ✓ | ✓ |
+Gerrit | API call | ✗ | ✓ | Requires ["delete own changes" permission](https://gerrit-review.googlesource.com/Documentation/access-control.html#category_delete_own_changes) at minimum

--- a/enterprise/internal/authz/gerrit/mocks_test.go
+++ b/enterprise/internal/authz/gerrit/mocks_test.go
@@ -25,6 +25,9 @@ type MockGerritClient struct {
 	// AuthenticatorFunc is an instance of a mock function object
 	// controlling the behavior of the method Authenticator.
 	AuthenticatorFunc *GerritClientAuthenticatorFunc
+	// DeleteChangeFunc is an instance of a mock function object controlling
+	// the behavior of the method DeleteChange.
+	DeleteChangeFunc *GerritClientDeleteChangeFunc
 	// GetAuthenticatedUserAccountFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetAuthenticatedUserAccount.
@@ -75,6 +78,11 @@ func NewMockGerritClient() *MockGerritClient {
 		},
 		AuthenticatorFunc: &GerritClientAuthenticatorFunc{
 			defaultHook: func() (r0 auth.Authenticator) {
+				return
+			},
+		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: func(context.Context, string) (r0 error) {
 				return
 			},
 		},
@@ -155,6 +163,11 @@ func NewStrictMockGerritClient() *MockGerritClient {
 				panic("unexpected invocation of MockGerritClient.Authenticator")
 			},
 		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: func(context.Context, string) error {
+				panic("unexpected invocation of MockGerritClient.DeleteChange")
+			},
+		},
 		GetAuthenticatedUserAccountFunc: &GerritClientGetAuthenticatedUserAccountFunc{
 			defaultHook: func(context.Context) (*gerrit.Account, error) {
 				panic("unexpected invocation of MockGerritClient.GetAuthenticatedUserAccount")
@@ -228,6 +241,9 @@ func NewMockGerritClientFrom(i gerrit.Client) *MockGerritClient {
 		},
 		AuthenticatorFunc: &GerritClientAuthenticatorFunc{
 			defaultHook: i.Authenticator,
+		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: i.DeleteChange,
 		},
 		GetAuthenticatedUserAccountFunc: &GerritClientGetAuthenticatedUserAccountFunc{
 			defaultHook: i.GetAuthenticatedUserAccount,
@@ -472,6 +488,111 @@ func (c GerritClientAuthenticatorFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GerritClientAuthenticatorFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GerritClientDeleteChangeFunc describes the behavior when the DeleteChange
+// method of the parent MockGerritClient instance is invoked.
+type GerritClientDeleteChangeFunc struct {
+	defaultHook func(context.Context, string) error
+	hooks       []func(context.Context, string) error
+	history     []GerritClientDeleteChangeFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteChange delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGerritClient) DeleteChange(v0 context.Context, v1 string) error {
+	r0 := m.DeleteChangeFunc.nextHook()(v0, v1)
+	m.DeleteChangeFunc.appendCall(GerritClientDeleteChangeFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the DeleteChange method
+// of the parent MockGerritClient instance is invoked and the hook queue is
+// empty.
+func (f *GerritClientDeleteChangeFunc) SetDefaultHook(hook func(context.Context, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteChange method of the parent MockGerritClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GerritClientDeleteChangeFunc) PushHook(hook func(context.Context, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GerritClientDeleteChangeFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GerritClientDeleteChangeFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string) error {
+		return r0
+	})
+}
+
+func (f *GerritClientDeleteChangeFunc) nextHook() func(context.Context, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GerritClientDeleteChangeFunc) appendCall(r0 GerritClientDeleteChangeFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GerritClientDeleteChangeFuncCall objects
+// describing the invocations of this function.
+func (f *GerritClientDeleteChangeFunc) History() []GerritClientDeleteChangeFuncCall {
+	f.mutex.Lock()
+	history := make([]GerritClientDeleteChangeFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GerritClientDeleteChangeFuncCall is an object that describes an
+// invocation of method DeleteChange on an instance of MockGerritClient.
+type GerritClientDeleteChangeFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GerritClientDeleteChangeFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GerritClientDeleteChangeFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/enterprise/internal/batches/sources/mocks_test.go
+++ b/enterprise/internal/batches/sources/mocks_test.go
@@ -8492,6 +8492,9 @@ type MockGerritClient struct {
 	// AuthenticatorFunc is an instance of a mock function object
 	// controlling the behavior of the method Authenticator.
 	AuthenticatorFunc *GerritClientAuthenticatorFunc
+	// DeleteChangeFunc is an instance of a mock function object controlling
+	// the behavior of the method DeleteChange.
+	DeleteChangeFunc *GerritClientDeleteChangeFunc
 	// GetAuthenticatedUserAccountFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetAuthenticatedUserAccount.
@@ -8542,6 +8545,11 @@ func NewMockGerritClient() *MockGerritClient {
 		},
 		AuthenticatorFunc: &GerritClientAuthenticatorFunc{
 			defaultHook: func() (r0 auth.Authenticator) {
+				return
+			},
+		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: func(context.Context, string) (r0 error) {
 				return
 			},
 		},
@@ -8622,6 +8630,11 @@ func NewStrictMockGerritClient() *MockGerritClient {
 				panic("unexpected invocation of MockGerritClient.Authenticator")
 			},
 		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: func(context.Context, string) error {
+				panic("unexpected invocation of MockGerritClient.DeleteChange")
+			},
+		},
 		GetAuthenticatedUserAccountFunc: &GerritClientGetAuthenticatedUserAccountFunc{
 			defaultHook: func(context.Context) (*gerrit.Account, error) {
 				panic("unexpected invocation of MockGerritClient.GetAuthenticatedUserAccount")
@@ -8695,6 +8708,9 @@ func NewMockGerritClientFrom(i gerrit.Client) *MockGerritClient {
 		},
 		AuthenticatorFunc: &GerritClientAuthenticatorFunc{
 			defaultHook: i.Authenticator,
+		},
+		DeleteChangeFunc: &GerritClientDeleteChangeFunc{
+			defaultHook: i.DeleteChange,
 		},
 		GetAuthenticatedUserAccountFunc: &GerritClientGetAuthenticatedUserAccountFunc{
 			defaultHook: i.GetAuthenticatedUserAccount,
@@ -8939,6 +8955,111 @@ func (c GerritClientAuthenticatorFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GerritClientAuthenticatorFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// GerritClientDeleteChangeFunc describes the behavior when the DeleteChange
+// method of the parent MockGerritClient instance is invoked.
+type GerritClientDeleteChangeFunc struct {
+	defaultHook func(context.Context, string) error
+	hooks       []func(context.Context, string) error
+	history     []GerritClientDeleteChangeFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteChange delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGerritClient) DeleteChange(v0 context.Context, v1 string) error {
+	r0 := m.DeleteChangeFunc.nextHook()(v0, v1)
+	m.DeleteChangeFunc.appendCall(GerritClientDeleteChangeFuncCall{v0, v1, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the DeleteChange method
+// of the parent MockGerritClient instance is invoked and the hook queue is
+// empty.
+func (f *GerritClientDeleteChangeFunc) SetDefaultHook(hook func(context.Context, string) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteChange method of the parent MockGerritClient instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *GerritClientDeleteChangeFunc) PushHook(hook func(context.Context, string) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GerritClientDeleteChangeFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context, string) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GerritClientDeleteChangeFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context, string) error {
+		return r0
+	})
+}
+
+func (f *GerritClientDeleteChangeFunc) nextHook() func(context.Context, string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GerritClientDeleteChangeFunc) appendCall(r0 GerritClientDeleteChangeFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GerritClientDeleteChangeFuncCall objects
+// describing the invocations of this function.
+func (f *GerritClientDeleteChangeFunc) History() []GerritClientDeleteChangeFuncCall {
+	f.mutex.Lock()
+	history := make([]GerritClientDeleteChangeFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GerritClientDeleteChangeFuncCall is an object that describes an
+// invocation of method DeleteChange on an instance of MockGerritClient.
+type GerritClientDeleteChangeFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GerritClientDeleteChangeFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GerritClientDeleteChangeFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/extsvc/gerrit/BUILD.bazel
+++ b/internal/extsvc/gerrit/BUILD.bazel
@@ -38,5 +38,6 @@ go_test(
         "//internal/lazyregexp",
         "//internal/testutil",
         "@com_github_dnaeon_go_vcr//cassette",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/internal/extsvc/gerrit/changes.go
+++ b/internal/extsvc/gerrit/changes.go
@@ -58,6 +58,30 @@ func (c *client) AbandonChange(ctx context.Context, changeID string) (*Change, e
 	return &change, nil
 }
 
+// DeleteChange permanently deletes a Gerrit change.
+func (c *client) DeleteChange(ctx context.Context, changeID string) error {
+	pathStr, err := url.JoinPath("a/changes", url.PathEscape(changeID))
+	if err != nil {
+		return err
+	}
+	reqURL := url.URL{Path: pathStr}
+	req, err := http.NewRequest("DELETE", reqURL.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return errors.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
 // SubmitChange submits a Gerrit change.
 func (c *client) SubmitChange(ctx context.Context, changeID string) (*Change, error) {
 	pathStr, err := url.JoinPath("a/changes", url.PathEscape(changeID), "submit")

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -149,10 +149,23 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) (*http.R
 
 	defer resp.Body.Close()
 
-	bs, err := io.ReadAll(resp.Body)
+	var bs []byte
+	if resp.StatusCode != http.StatusNoContent {
+		bs, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return nil, err
+		// The first 4 characters of the Gerrit API responses need to be stripped, see: https://gerrit-review.googlesource.com/Documentation/rest-api.html#output .
+		if len(bs) < 4 {
+			return nil, &httpError{
+				URL:        req.URL,
+				StatusCode: resp.StatusCode,
+				Body:       bs,
+			}
+		}
+
+		bs = bs[4:]
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
@@ -162,19 +175,10 @@ func (c *client) do(ctx context.Context, req *http.Request, result any) (*http.R
 			Body:       bs,
 		}
 	}
-
-	// The first 4 characters of the Gerrit API responses need to be stripped, see: https://gerrit-review.googlesource.com/Documentation/rest-api.html#output .
-	if len(bs) < 4 {
-		return nil, &httpError{
-			URL:        req.URL,
-			StatusCode: resp.StatusCode,
-			Body:       bs,
-		}
-	}
 	if result == nil {
 		return resp, nil
 	}
-	return resp, json.Unmarshal(bs[4:], result)
+	return resp, json.Unmarshal(bs, result)
 }
 
 func (c *client) GetURL() *url.URL {

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	ListProjects(ctx context.Context, opts ListProjectsArgs) (projects ListProjectsResponse, nextPage bool, err error)
 	GetChange(ctx context.Context, changeID string) (*Change, error)
 	AbandonChange(ctx context.Context, changeID string) (*Change, error)
+	DeleteChange(ctx context.Context, changeID string) error
 	SubmitChange(ctx context.Context, changeID string) (*Change, error)
 	RestoreChange(ctx context.Context, changeID string) (*Change, error)
 	WriteReviewComment(ctx context.Context, changeID string, comment ChangeReviewComment) error

--- a/internal/extsvc/gerrit/testdata/vcr/DeleteChange.yaml
+++ b/internal/extsvc/gerrit/testdata/vcr/DeleteChange.yaml
@@ -1,0 +1,74 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://gerrit.sgdev.org/a/changes/I2e55bf947cc1fe96b2663f4d3fedaa992628f8d4
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7da626f5cc8ac3a7-SEA
+      Content-Disposition:
+      - attachment
+      Date:
+      - Tue, 20 Jun 2023 18:42:32 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers: {}
+    url: https://gerrit.sgdev.org/a/changes/I2e55bf947cc1fe96b2663f4d3fedaa992628f8d4
+    method: DELETE
+  response:
+    body: |
+      Not found: I2e55bf947cc1fe96b2663f4d3fedaa992628f8d4
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7da626f84ec5c3a7-SEA
+      Content-Disposition:
+      - attachment
+      Content-Type:
+      - text/plain;charset=utf-8
+      Date:
+      - Tue, 20 Jun 2023 18:42:32 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/migrations/BUILD.bazel
+++ b/migrations/BUILD.bazel
@@ -1090,6 +1090,7 @@ go_library(
         "frontend/1686749117_add_last_indexed_at_to_zoekt_repos/metadata.yaml",
         "frontend/1686749117_add_last_indexed_at_to_zoekt_repos/up.sql",
         "frontend/squashed.sql",
+        "frontend/.DS_Store",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/migrations",
     visibility = ["//visibility:public"],

--- a/migrations/BUILD.bazel
+++ b/migrations/BUILD.bazel
@@ -1090,7 +1090,6 @@ go_library(
         "frontend/1686749117_add_last_indexed_at_to_zoekt_repos/metadata.yaml",
         "frontend/1686749117_add_last_indexed_at_to_zoekt_repos/up.sql",
         "frontend/squashed.sql",
-        "frontend/.DS_Store",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/migrations",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/52386.

If the `batchChanges.autoDeleteBranch` site configuration option is enabled, Batch Changes will delete a Change on Gerrit after it is closed/abandoned. It is not possible to delete a Change once it has been merged.

https://github.com/sourcegraph/sourcegraph/assets/8942601/5d9f52cc-b34a-4ef1-a74f-2dc72d39b572

## Test plan

Client unit test coverage. Manual integration test, see video above.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
