### PR TITLE
dev/ci: push prod tags on all release branch builds

### DIFF
--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -64,6 +64,13 @@ if [ "$BUILDKITE_BRANCH" == "main" ]; then
   push_prod=true
 fi
 
+# All release branch builds must be published to prod tags to support
+# format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050
+# by release branch deployments.
+if [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  push_prod=true
+fi
+
 if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   dev_tags+=("${BUILDKITE_TAG:1}")
   prod_tags+=("${BUILDKITE_TAG:1}")


### PR DESCRIPTION
This should restore support for release branch preview builds of the format `5.0_227766_2023-06-14_5.0-87c77ce7f9ee` that is used in Cloud to CD builds from release branches: https://sourcegraph.sourcegraph.com/github.com/sourcegraph/controller/-/blob/internal/version/branchimagetag/branch_image_tag.go?L43:1-59:46

## Test plan

Not sure how to test this, just cherry-pick into 5.1 maybe?
