### PR TITLE
Cody-gateway - add user id to the dotcom user actor resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/dotcom.go
+++ b/cmd/frontend/graphqlbackend/dotcom.go
@@ -162,6 +162,7 @@ type CodyGatewayUsersByAccessTokenArgs struct {
 type CodyGatewayUser interface {
 	Username() string
 	CodyGatewayAccess() CodyGatewayAccess
+	ID() graphql.ID
 }
 
 type CodyGatewayAccess interface {

--- a/cmd/frontend/graphqlbackend/dotcom.graphql
+++ b/cmd/frontend/graphqlbackend/dotcom.graphql
@@ -515,6 +515,10 @@ FOR INTERNAL USE ONLY.
 """
 type CodyGatewayDotcomUser {
     """
+    The id of the user
+    """
+    id: ID!
+    """
     The user name of the user
     """
     username: String!

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
@@ -78,6 +81,10 @@ type dotcomCodyUserResolver struct {
 
 func (u *dotcomCodyUserResolver) Username() string {
 	return u.user.Username
+}
+
+func (u *dotcomCodyUserResolver) ID() graphql.ID {
+	return relay.MarshalID("User", u.user.ID)
 }
 
 func (u *dotcomCodyUserResolver) CodyGatewayAccess() graphqlbackend.CodyGatewayAccess {


### PR DESCRIPTION
In preparation to cut over to using the user id as the actor ID for the dotcom user actor, this adds the user id to the specific resolver that the cody gateway accesses.


## Test plan
`sg start dotcom`
```graphql
{
  dotcom{
    codyGatewayDotcomUserByToken(token:{TOKEN}){
      username
      id
      codyGatewayAccess{
        enabled        
      }
    }
  }
}
```

```json
{
  "data": {
    "dotcom": {
      "codyGatewayDotcomUserByToken": {
        "username": "chrislocaldotcom",
        "id": "VXNlcjo3",
        "codyGatewayAccess": {
          "enabled": true
        }
      }
    }
  }
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
