### PR TITLE
grpc: gitserver: exec/archive: convert context errors to gRPC status codes, convert signal:killed to status.Aborted

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -695,6 +695,10 @@ func convertGRPCErrorToGitDomainError(err error) error {
 		return context.Canceled
 	}
 
+	if st.Code() == codes.DeadlineExceeded {
+		return context.DeadlineExceeded
+	}
+
 	for _, detail := range st.Details() {
 		switch payload := detail.(type) {
 


### PR DESCRIPTION
## overview

This PR tweaks the gRPC gitserver.Archive and gitserver.Exec methods to translate some classes of well-known errors to particular gRPC status [codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html). 

In particular, the following errors get these [specific status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) instead of codes.Unknown (previously)

- `context.Cancelled` -> `codes.Cancelled`
- `context.DeadlineExceeded` -> `codes.DeadlineExceeded`
- (if a `git` process is terminated via `SIGKILL`) -> `codes.Aborted`

## background

When I was QA'ing the new gitserver.Archive implementation, I noticed that it has a fairly high error rate on sourcegraph.com: https://sourcegraph.com/-/debug/grafana/d/gitserver/git-server?viewPanel=100711&orgId=1&var-alert_level=&var-shard=&var-method=Archive&from=now-90d&to=now. 

However, when I looked our honeycomb metrics, it was clear to me that the vast majority of these errors were related to context cancellations, deadlines, and process kills - all of which aren't related to the gRPC-specific implementation. Making the above change to give them unique status codes (instead of the generic "Unknown") status makes this more obvious.


## Test plan

I manually tested the new error codes by applying the diffs below to deliberately induce an error, and seeing the new error codes show up on the local sourcegraph Gitserver grafana dashboards:

(notice the new codes on the legend)

<img width="1897" alt="Screenshot 2023-06-20 at 2 44 08 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/ad66f2aa-ea75-4569-8260-959fcf66d559">

**context.Cancelled**

```diff
ggilmore@geoffreyslaptop ~/d/sourcegraph (utf8-server-logs-grpc)> git diff -- internal/gitserver/commands.go 
diff --git a/internal/gitserver/commands.go b/internal/gitserver/commands.go
index 8b656d0089..aca77ac189 100644
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2544,6 +2544,11 @@ func (c *clientImplementor) ArchiveReader(
                ctx, cancel := context.WithCancel(ctx)
 
                stream, err := client.Archive(ctx, req)
+               go func() {
+                       time.Sleep(1 * time.Second)
+                       cancel()
+               }()
+
                if err != nil {
                        cancel()
                        return nil, err
```


**context.DeadlineExceeded**

```diff
ggilmore@geoffreyslaptop ~/d/sourcegraph (git-archive-grpc-logs)> git diff -- internal/gitserver/commands.go
diff --git a/internal/gitserver/commands.go b/internal/gitserver/commands.go
index 5c279d0e49..b41b00b6b5 100644
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2541,7 +2541,7 @@ func (c *clientImplementor) ArchiveReader(

                req := options.ToProto(string(repo)) // HACK: ArchiveOptions doesn't have a repository here, so we have to add it ourselves.

-               ctx, cancel := context.WithCancel(ctx)
+               ctx, cancel := context.WithDeadline(ctx, time.Now().Add(6*time.Millisecond))

                stream, err := client.Archive(ctx, req)
                if err != nil {
```

**signal: killed error** (manually kill the git-archive command after it starts)


```diff
ggilmore@geoffreyslaptop ~/d/sourcegraph (git-archive-grpc-logs)> git diff -- cmd/gitserver/server/run.go
diff --git a/cmd/gitserver/server/run.go b/cmd/gitserver/server/run.go
index 0c1e583398..a6698bc093 100644
--- a/cmd/gitserver/server/run.go
+++ b/cmd/gitserver/server/run.go
@@ -9,6 +9,7 @@ import (
        "os/exec"
        "path"
        "syscall"
+       "time"

        "github.com/sourcegraph/log"
        "github.com/sourcegraph/sourcegraph/cmd/gitserver/server/internal/cacert"
@@ -42,7 +43,17 @@ func runCommand(ctx context.Context, cmd wrexec.Cmder) (exitCode int, err error)
                tr.FinishWithErr(&err)
        }()

-       err = cmd.Run()
+       err = cmd.Start()
+       go func() {
+               args := cmd.Unwrap().Args
+               if len(args) > 1 && args[0] == "git" && args[1] == "archive" {
+                       time.Sleep(1 * time.Millisecond)
+                       cmd.Unwrap().Process.Signal(syscall.SIGKILL)
+               }
+       }()
+
+       err = cmd.Wait()
+
        exitStatus := unsetExitStatus
        if cmd.Unwrap().ProcessState != nil { // is nil if process failed to start
                exitStatus = cmd.Unwrap().ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
```