### PR TITLE
own: fix panic in bag resolver

### DIFF
--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -232,7 +233,7 @@ func (b bag) FindResolved(ref Reference) (codeowners.ResolvedOwner, bool) {
 		if refCtx, ok := b.references[k]; ok {
 			if id := refCtx.resolvedUserID; id != 0 {
 				userRefs := b.resolvedUsers[id]
-				if userRefs == nil {
+				if userRefs == nil || userRefs.user == nil {
 					continue
 				}
 				// TODO: Email resolution here is best effort,

--- a/enterprise/internal/own/ownref.go
+++ b/enterprise/internal/own/ownref.go
@@ -252,6 +252,9 @@ func (b bag) FindResolved(ref Reference) (codeowners.ResolvedOwner, bool) {
 			}
 			if id := refCtx.resolvedTeamID; id != 0 {
 				teamRefs := b.resolvedTeams[id]
+				if teamRefs == nil || teamRefs.team == nil {
+					continue
+				}
 				return &codeowners.Team{
 					Team:   teamRefs.team,
 					Handle: teamRefs.team.Name,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53800

It isn't clear to me _why_, but there are userRefs with a nil user. This adds some simple guards to the user and team code to only dereference is we are sure we can.

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
