### PR TITLE
batches: enforce min-width on configuration form

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.module.scss
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.module.scss
@@ -3,6 +3,7 @@
 .form {
     margin: 2rem auto;
     padding-bottom: 3rem;
+    min-width: min(100%, 720px);
     max-width: 720px;
 
     @media (--md-breakpoint-down) {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53111.


https://github.com/sourcegraph/sourcegraph/assets/8942601/4bf26845-0ac9-4868-b4f1-52f90a426854



The non-read-only version of the form has the description for the name input, which makes it expand to fill the whole `max-width`. The read-only form had shrunk because it doesn't have that description, so its contents didn't require it to be any wider. 

## Test plan

Visually verified the form width.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
