### PR TITLE
batches: fix namespace displayed in readonly field of configuration form

### DIFF
--- a/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.tsx
@@ -85,20 +85,39 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
         CreateBatchSpecFromRawVariables
     >(CREATE_BATCH_SPEC_FROM_RAW)
 
-    const { namespaces, defaultSelectedNamespace } = useNamespaces(
-        authenticatedUser,
-        batchChange?.namespace.id || initialNamespaceID
-    )
-
-    // When creating a batch change we want to disable the `Create` button, to avoid user's clicking
-    // on it again.
+    // When creating a batch change we want to disable the `Create` button, to avoid
+    // users clicking on it again.
     const isButtonDisabled = batchChangeLoading || batchSpecLoading
     const error = batchChangeError || batchSpecError
 
-    // The namespace selected for creating the new batch change under.
+    // The set of namespaces the user has permissions to create batch changes in, and the
+    // namespace among those that should be selected by default.
+    const { namespaces, defaultSelectedNamespace } = useNamespaces(authenticatedUser, initialNamespaceID)
+
+    // If the user is creating a new batch change, this is the namespace selected.
     const [selectedNamespace, setSelectedNamespace] = useState<
         Pick<UserSettingFields, 'id'> | Pick<OrgSettingFields, 'id'>
     >(defaultSelectedNamespace)
+
+    // If the batch change already exists and we're in read-only mode, the namespace it
+    // was created in is the only one we care about showing in the selector. The current
+    // viewer may or may not have permissions to create batch changes in this namespace,
+    // so it's important that we don't necessarily include it for the non-read-only
+    // version.
+    const namespaceSelector = isReadOnly ? (
+        <NamespaceSelector
+            namespaces={[batchChange.namespace]}
+            selectedNamespace={batchChange.namespace.id}
+            onSelect={noop}
+            disabled={true}
+        />
+    ) : (
+        <NamespaceSelector
+            namespaces={namespaces}
+            selectedNamespace={selectedNamespace.id}
+            onSelect={setSelectedNamespace}
+        />
+    )
 
     const [nameInput, setNameInput] = useState(batchChange?.name || '')
     const [isNameValid, setIsNameValid] = useState<boolean>()
@@ -168,12 +187,7 @@ export const ConfigurationForm: React.FunctionComponent<React.PropsWithChildren<
                     </Alert>
                 )}
                 {error && <ErrorAlert error={error} />}
-                <NamespaceSelector
-                    namespaces={namespaces}
-                    selectedNamespace={selectedNamespace.id}
-                    onSelect={setSelectedNamespace}
-                    disabled={isReadOnly}
-                />
+                {namespaceSelector}
                 <Input
                     label="Batch change name"
                     value={nameInput}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/53318.

Fixes bug where the wrong namespace would be displayed in the read-only selector for namespace on a batch change's configuration tab. This was due to a mistaken assumption that the viewer would always have access to that namespace. If the viewer didn't, we'd default to the viewer's own namespace, hence the bug.

The namespace shown in the selector on the read-only form should *always* match the namespace shown in the page title breadcrumb:

<img width="822" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/3c437bff-68af-4ac1-8a23-7bf9ed3c91a6">

And the viewer should continue to only be able to select from namespaces they can actually create batch changes in, when creating a new one:

<img width="767" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/7d27f843-72c9-4a12-9048-ec49c186bb09">

## Test plan

Manually verified.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
