### PR TITLE
[Backport 5.1] reqeuestclient, audit, cody-gateway: log user-agent as well (#53785)

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/events",
         "//enterprise/cmd/cody-gateway/internal/httpapi/completions",
         "//enterprise/cmd/cody-gateway/internal/httpapi/embeddings",
+        "//enterprise/cmd/cody-gateway/internal/httpapi/requestlogger",
         "//enterprise/cmd/cody-gateway/internal/limiter",
         "//enterprise/cmd/cody-gateway/internal/notify",
         "//enterprise/cmd/cody-gateway/internal/response",

--- a/enterprise/cmd/cody-gateway/internal/httpapi/diagnostics.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/diagnostics.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/auth"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/response"
 	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
@@ -90,7 +91,8 @@ func NewDiagnosticsHandler(baseLogger log.Logger, next http.Handler, secret stri
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.URL.Path, "/-/") {
-			instrumentation.HTTPMiddleware("diagnostics", handler).ServeHTTP(w, r)
+			instrumentation.HTTPMiddleware("diagnostics", requestlogger.Middleware(baseLogger, handler)).
+				ServeHTTP(w, r)
 			return
 		}
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "requestlogger",
+    srcs = ["requestlogger.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger",
+    visibility = ["//enterprise/cmd/cody-gateway:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/cody-gateway/internal/actor",
+        "//enterprise/cmd/cody-gateway/internal/response",
+        "//internal/requestclient",
+        "//internal/trace",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)

--- a/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger/requestlogger.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger/requestlogger.go
@@ -1,0 +1,36 @@
+package requestlogger
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/response"
+	"github.com/sourcegraph/sourcegraph/internal/requestclient"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// Middleware logs all requests. Should be placed underneath all instrumentation
+// and/or actor extraction.
+func Middleware(logger log.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		response := response.NewStatusHeaderRecorder(w)
+		next.ServeHTTP(response, r)
+
+		ctx := r.Context()
+		rc := requestclient.FromContext(ctx)
+		logFields := append(rc.LogFields(),
+			log.String("method", r.Method),
+			log.String("path", r.URL.Path),
+			log.Int("response.statusCode", response.StatusCode),
+			log.Duration("duration", time.Since(start)))
+
+		actor.FromContext(ctx).
+			Logger(trace.Logger(ctx, logger)).
+			Debug("Request", logFields...)
+	})
+}

--- a/enterprise/cmd/cody-gateway/shared/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/shared/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//internal/redispool",
         "//internal/requestclient",
         "//internal/service",
-        "//internal/trace",
         "//internal/trace/policy",
         "//internal/tracer/oteldefaults",
         "//internal/tracer/oteldefaults/exporters",

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/internal/service"
-	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/actor"
@@ -125,11 +124,6 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	// Diagnostic layers
 	handler = httpapi.NewDiagnosticsHandler(obctx.Logger, handler, config.DiagnosticsSecret, sources)
 
-	// Basic instrumentation. Note that tracing should be added on individual
-	// handlers rather than here at a high level so that we don't collect traces
-	// for random requests to the service.
-	handler = requestLogger(obctx.Logger.Scoped("requests", "HTTP requests"), handler)
-
 	// Collect request client for downstream handlers. Outside of dev, we always set up
 	// Cloudflare in from of Cody Gateway. This comes first.
 	hasCloudflare := !config.InsecureDev
@@ -174,25 +168,6 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 	goroutine.MonitorBackgroundRoutines(ctx, backgroundRoutines...)
 
 	return nil
-}
-
-func requestLogger(logger log.Logger, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		next.ServeHTTP(w, r)
-
-		// Log after everything has been served, all context should be available
-		// now.
-		rc := requestclient.FromContext(r.Context())
-		actor.FromContext(r.Context()).
-			Logger(sgtrace.Logger(r.Context(), logger)).
-			Debug("Request",
-				log.String("method", r.Method),
-				log.String("path", r.URL.Path),
-				log.String("requestclient.ip", rc.IP),
-				log.String("requestclient.forwardedFor", rc.ForwardedFor),
-				log.Duration("duration", time.Since(start)))
-	})
 }
 
 func newRedisStore(store redispool.KeyValue) limiter.RedisStore {

--- a/internal/audit/BUILD.bazel
+++ b/internal/audit/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//internal/env",
         "//internal/requestclient",
         "//schema",
+        "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hexops/autogold/v2"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestLog(t *testing.T) {
 		actor             *actor.Actor
 		client            *requestclient.Client
 		additionalContext []log.Field
-		expectedEntry     map[string]interface{}
+		expectedEntry     autogold.Value
 	}{
 		{
 			name:  "fully populated audit data",
@@ -29,19 +30,19 @@ func TestLog(t *testing.T) {
 			client: &requestclient.Client{
 				IP:           "192.168.0.1",
 				ForwardedFor: "192.168.0.1",
+				UserAgent:    "Foobar",
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
-			expectedEntry: map[string]interface{}{
-				"audit": map[string]interface{}{
-					"entity": "test entity",
-					"actor": map[string]interface{}{
-						"actorUID":        "1",
-						"ip":              "192.168.0.1",
-						"X-Forwarded-For": "192.168.0.1",
-					},
+			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"actor": map[string]interface{}{
+					"X-Forwarded-For": "192.168.0.1",
+					"actorUID":        "1",
+					"ip":              "192.168.0.1",
+					"userAgent":       "Foobar",
 				},
-				"additional": "stuff",
-			},
+				"auditId": "test-audit-id-1234",
+				"entity":  "test entity",
+			}}),
 		},
 		{
 			name:  "anonymous actor",
@@ -49,19 +50,19 @@ func TestLog(t *testing.T) {
 			client: &requestclient.Client{
 				IP:           "192.168.0.1",
 				ForwardedFor: "192.168.0.1",
+				UserAgent:    "Foobar",
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
-			expectedEntry: map[string]interface{}{
-				"audit": map[string]interface{}{
-					"entity": "test entity",
-					"actor": map[string]interface{}{
-						"actorUID":        "anonymous",
-						"ip":              "192.168.0.1",
-						"X-Forwarded-For": "192.168.0.1",
-					},
+			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"actor": map[string]interface{}{
+					"X-Forwarded-For": "192.168.0.1",
+					"actorUID":        "anonymous",
+					"ip":              "192.168.0.1",
+					"userAgent":       "Foobar",
 				},
-				"additional": "stuff",
-			},
+				"auditId": "test-audit-id-1234",
+				"entity":  "test entity",
+			}}),
 		},
 		{
 			name:  "missing actor",
@@ -69,36 +70,35 @@ func TestLog(t *testing.T) {
 			client: &requestclient.Client{
 				IP:           "192.168.0.1",
 				ForwardedFor: "192.168.0.1",
+				UserAgent:    "Foobar",
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
-			expectedEntry: map[string]interface{}{
-				"audit": map[string]interface{}{
-					"entity": "test entity",
-					"actor": map[string]interface{}{
-						"actorUID":        "unknown",
-						"ip":              "192.168.0.1",
-						"X-Forwarded-For": "192.168.0.1",
-					},
+			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"actor": map[string]interface{}{
+					"X-Forwarded-For": "192.168.0.1",
+					"actorUID":        "unknown",
+					"ip":              "192.168.0.1",
+					"userAgent":       "Foobar",
 				},
-				"additional": "stuff",
-			},
+				"auditId": "test-audit-id-1234",
+				"entity":  "test entity",
+			}}),
 		},
 		{
 			name:              "missing client info",
 			actor:             &actor.Actor{UID: 1},
 			client:            nil,
 			additionalContext: []log.Field{log.String("additional", "stuff")},
-			expectedEntry: map[string]interface{}{
-				"audit": map[string]interface{}{
-					"entity": "test entity",
-					"actor": map[string]interface{}{
-						"actorUID":        "1",
-						"ip":              "unknown",
-						"X-Forwarded-For": "unknown",
-					},
+			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"actor": map[string]interface{}{
+					"X-Forwarded-For": "unknown",
+					"actorUID":        "1",
+					"ip":              "unknown",
+					"userAgent":       "unknown",
 				},
-				"additional": "stuff",
-			},
+				"auditId": "test-audit-id-1234",
+				"entity":  "test entity",
+			}}),
 		},
 		{
 			name:  "no additional context",
@@ -106,18 +106,17 @@ func TestLog(t *testing.T) {
 			client: &requestclient.Client{
 				IP:           "192.168.0.1",
 				ForwardedFor: "192.168.0.1",
+				UserAgent:    "Foobar",
 			},
 			additionalContext: nil,
-			expectedEntry: map[string]interface{}{
-				"audit": map[string]interface{}{
-					"entity": "test entity",
-					"actor": map[string]interface{}{
-						"actorUID":        "1",
-						"ip":              "192.168.0.1",
-						"X-Forwarded-For": "192.168.0.1",
-					},
+			expectedEntry: autogold.Expect(map[string]interface{}{"audit": map[string]interface{}{
+				"actor": map[string]interface{}{
+					"X-Forwarded-For": "192.168.0.1", "actorUID": "1", "ip": "192.168.0.1",
+					"userAgent": "Foobar",
 				},
-			},
+				"auditId": "test-audit-id-1234",
+				"entity":  "test entity",
+			}}),
 		},
 	}
 
@@ -131,6 +130,8 @@ func TestLog(t *testing.T) {
 				Entity: "test entity",
 				Action: "test audit action",
 				Fields: tc.additionalContext,
+
+				auditIDGenerator: func() string { return "test-audit-id-1234" },
 			}
 
 			logger, exportLogs := logtest.Captured(t)
@@ -145,18 +146,7 @@ func TestLog(t *testing.T) {
 			assert.Contains(t, logs[0].Message, "test audit action (sampling immunity token")
 
 			// non-audit fields are preserved
-			assert.Equal(t, tc.expectedEntry["additional"], logs[0].Fields["additional"])
-
-			expectedAudit := tc.expectedEntry["audit"].(map[string]interface{})
-			actualAudit := logs[0].Fields["audit"].(map[string]interface{})
-			assert.Equal(t, expectedAudit["entity"], actualAudit["entity"])
-			assert.NotEmpty(t, actualAudit["auditId"])
-
-			expectedActor := expectedAudit["actor"].(map[string]interface{})
-			actualActor := actualAudit["actor"].(map[string]interface{})
-			assert.Equal(t, expectedActor["actorUID"], actualActor["actorUID"])
-			assert.Equal(t, expectedActor["ip"], actualActor["ip"])
-			assert.Equal(t, expectedActor["X-Forwarded-For"], actualActor["X-Forwarded-For"])
+			tc.expectedEntry.Equal(t, logs[0].Fields)
 		})
 	}
 }

--- a/internal/requestclient/BUILD.bazel
+++ b/internal/requestclient/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/grpc/propagator",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//peer",
     ],

--- a/internal/requestclient/client.go
+++ b/internal/requestclient/client.go
@@ -2,6 +2,8 @@ package requestclient
 
 import (
 	"context"
+
+	"github.com/sourcegraph/log"
 )
 
 type clientKey struct{}
@@ -15,6 +17,9 @@ type Client struct {
 	// Note: This header can be spoofed and relies on trusted clients/proxies.
 	// For sourcegraph.com we use cloudflare headers to avoid spoofing.
 	ForwardedFor string
+	// UserAgent is value of the User-Agent header:
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+	UserAgent string
 }
 
 // FromContext retrieves the client IP, if available, from context.
@@ -29,4 +34,15 @@ func FromContext(ctx context.Context) *Client {
 // WithClient adds client IP information to context for propagation.
 func WithClient(ctx context.Context, client *Client) context.Context {
 	return context.WithValue(ctx, clientKey{}, client)
+}
+
+func (c *Client) LogFields() []log.Field {
+	if c == nil {
+		return []log.Field{log.String("requestClient", "<nil>")}
+	}
+	return []log.Field{
+		log.String("requestClient.ip", c.IP),
+		log.String("requestClient.forwardedFor", c.ForwardedFor),
+		log.String("requestClient.userAgent", c.UserAgent),
+	}
 }

--- a/internal/requestclient/grpc.go
+++ b/internal/requestclient/grpc.go
@@ -26,6 +26,7 @@ func (Propagator) FromContext(ctx context.Context) metadata.MD {
 	return metadata.Pairs(
 		headerKeyClientIP, client.IP,
 		headerKeyForwardedFor, client.ForwardedFor,
+		headerKeyUserAgent, client.UserAgent,
 	)
 }
 

--- a/internal/requestclient/http.go
+++ b/internal/requestclient/http.go
@@ -11,6 +11,10 @@ const (
 	// De-facto standard for identifying original IP address of a client:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 	headerKeyForwardedFor = "X-Forwarded-For"
+	// Standard for identifyying the application, operating system, vendor,
+	// and/or version of the requesting user agent.
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+	headerKeyUserAgent = "User-Agent"
 )
 
 // HTTPTransport is a roundtripper that sets client IP information within request context as
@@ -76,6 +80,7 @@ func httpMiddleware(next http.Handler, hasCloudflareProxy bool) http.Handler {
 		ctxWithClient := WithClient(req.Context(), &Client{
 			IP:           strings.Split(req.RemoteAddr, ":")[0],
 			ForwardedFor: req.Header.Get(headerKeyForwardedFor),
+			UserAgent:    req.Header.Get(headerKeyUserAgent),
 		})
 		next.ServeHTTP(rw, req.WithContext(ctxWithClient))
 	})


### PR DESCRIPTION
Backport https://github.com/sourcegraph/sourcegraph/pull/53785

Clientside this is a pretty minimal diff - mostly tests and some diff in Cody Gateway which is not part of the Sourcegraph service

## Test plan

 https://github.com/sourcegraph/sourcegraph/pull/53785
