### PR TITLE
Update Cody docs page

### DIFF
--- a/doc/cody/explanations/enabling_cody.md
+++ b/doc/cody/explanations/enabling_cody.md
@@ -7,7 +7,7 @@ Cody uses Sourcegraph to fetch relevant context to generate answers and code. Th
 1. [Create a Sourcegraph.com account](https://sourcegraph.com/sign-up)
 2. Install [the Cody VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
 3. Open the Cody extension in your editor and sign in with your Sourcegraph.com credentials
-4. When prompted by the extesnion, set the Sourcegraph URL to `https://sourcegraph.com`
+4. When prompted by the extension, set the Sourcegraph URL to `https://sourcegraph.com`
 
 You're now ready to use Cody in VS Code!
 

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -6,17 +6,12 @@ Cody uses a combination of Sourcegraph's code graph and Large Language Models (L
 
 ## Get Cody
 
-- **Sourcegraph Enterprise customers:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody#cody-for-work) to use Cody on your existing Sourcegraph instance.
-- **Everyone:** Cody for open source code is available to all users with a Sourcegraph.com account. If you don't yet have a Sourcegraph.com account, you can [create one for free](https://sourcegraph.com/sign-up).
+- **Cody enterprise:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody#cody-for-work) to use Cody on your existing Sourcegraph instance or try Cody with your team.
+- **Cody app:** Download the app to try Cody with the code you have locally for free. [Learn more.](../app/index.md)
 
-There are currently two ways to experience Cody:
-
-- In Sourcegraph itself
-- In your editor
+Cody is also available as an editor extension that can be connected to a Sourcegraph enterprise instance, the Cody app, or Sourcegraph.com (for open source code only):
   - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
   - Jetbrains extension (coming soon)
-
-Cody is available as a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and in the Sourcegraph web interface.
 
 <div class="getting-started">
   <a class="btn btn-primary text-center" href="quickstart">★ Cody quickstart</a>
@@ -84,6 +79,7 @@ See [Cody troubleshooting guide](troubleshooting.md).
 ## Explanations
 
 - [Enabling Cody for Sourcegraph Enterprise customers](explanations/enabling_cody_enterprise.md)
+- [Enabling Cody for the Cody app](../app/index.md)
 - [Enabling Cody for open source Sourcegraph.com users](explanations/enabling_cody.md)
 - [Installing the Cody VS Code extension](explanations/installing_vs_code.md)
 - [Configuring code graph context](explanations/code_graph_context.md)


### PR DESCRIPTION
Replaces instructions for Cody on dotcom with Cody app and streamlines the editor extension description a bit. We still need to articulate why a user should choose enterprise over app (or why they should upgrade from app to enterprise), but I'm guessing that might make more sense on about.sourcegraph.com than in the docs? Either way, it can be a separate update. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
n/a docs update