### PR TITLE
executors: Fix flakey test

### DIFF
--- a/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
@@ -90,7 +90,7 @@ func TestKubernetesCommand_CreateSecrets(t *testing.T) {
 
 	assert.Equal(t, "my-secret", createSecrets.Name)
 	assert.Len(t, createSecrets.Keys, 2)
-	assert.Equal(t, []string{"foo", "baz"}, createSecrets.Keys)
+	assert.ElementsMatch(t, []string{"foo", "baz"}, createSecrets.Keys)
 }
 
 func TestKubernetesCommand_DeleteSecret(t *testing.T) {


### PR DESCRIPTION
Change to use `ElementsMatch` from `Equal`

## Test plan

Updated existing test