### PR TITLE
WIP: Use streaming API for parsing indexes

### DIFF
--- a/enterprise/internal/codeintel/uploads/internal/background/processor/metrics_resetter.go
+++ b/enterprise/internal/codeintel/uploads/internal/background/processor/metrics_resetter.go
@@ -29,7 +29,7 @@ func NewResetterMetrics(observationCtx *observation.Context) *resetterMetrics {
 	)
 	numUploadResetFailures := counter(
 		"src_codeintel_background_upload_record_reset_failures_total",
-		"The number of upload reset failures.",
+		"The number of upload seekToStart failures.",
 	)
 	numUploadResetErrors := counter(
 		"src_codeintel_background_upload_record_reset_errors_total",

--- a/enterprise/internal/codeintel/uploads/shared/types.go
+++ b/enterprise/internal/codeintel/uploads/shared/types.go
@@ -45,6 +45,16 @@ func (u Upload) RecordUID() string {
 	return strconv.Itoa(u.ID)
 }
 
+type UploadSizeStats struct {
+	ID               int
+	UploadSize       *int64
+	UncompressedSize *int64
+}
+
+func (u Upload) SizeStats() UploadSizeStats {
+	return UploadSizeStats{u.ID, u.UploadSize, u.UncompressedSize}
+}
+
 // TODO - unify with Upload
 // Dump is a subset of the lsif_uploads table (queried via the lsif_dumps_with_repository_name view)
 // and stores only processed records.

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf
 	github.com/sourcegraph/log v0.0.0-20230523201558-ad2d71b4d2ee
 	github.com/sourcegraph/run v0.12.0
-	github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3
+	github.com/sourcegraph/scip v0.3.0
 	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images v0.0.0-20220203145655-4d2a39d3038a
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20230613175844-f031949c72f5
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -2062,8 +2062,8 @@ github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67 h1:NSYSPQOE7
 github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67/go.mod h1:4DAabK408OEbyK2NUEQ5YRApyB/p0XNGJyC1YPBAKq4=
 github.com/sourcegraph/run v0.12.0 h1:3A8w5e8HIYPfafHekvmdmmh42RHKGVhmiTZAPJclg7I=
 github.com/sourcegraph/run v0.12.0/go.mod h1:PwaP936BTnAJC1cqR5rSbG5kOs/EWStTK3lqvMX5GUA=
-github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3 h1:6PgJPdhDHRGskCu7+NxodNtX1z8umdC40QvoQt4FsP8=
-github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
+github.com/sourcegraph/scip v0.3.0 h1:pXxGMarSxBMsGxD6s0djRuqEiNduwz3dSmuRex5CmiA=
+github.com/sourcegraph/scip v0.3.0/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20230619155016-edf0c8b4e978 h1:CTKmuHsEmO0T+CH3d3wYimeENVprNKip51L/sUfZVCA=


### PR DESCRIPTION
One difference in behavior is that the sorting operation is gone,
but the order of iteration is still deterministic as it matches the
order of documents in the index

## Test plan

TODO:
- [ ] Update existing tests