### PR TITLE
JetBrains: disable line highlighting in Cody messages with code blocks

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Convert `\t` to spaces in leading whitespace for autocomplete suggestions (according to settings) [#53743](https://github.com/sourcegraph/sourcegraph/pull/53743)
+- Disabled line highlighting in code blocks in chat [#53829](https://github.com/sourcegraph/sourcegraph/pull/53829)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -230,5 +230,6 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
     editorSettings.setIndentGuidesShown(false);
     editorSettings.setLineNumbersShown(false);
     editorSettings.setUseSoftWraps(false);
+    editorSettings.setCaretRowShown(false);
   }
 }


### PR DESCRIPTION
Line highlight in code editor in Cody message is disabled, so the colors of the highlighted line in editor it doesn't blend with the background of the regular text
Before:
<img width="518" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/2c94c4fa-1222-42f6-a64f-1a03381d0612">

Now:
<img width="518" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/f2cb9f24-aea9-4b79-b4e5-d6610e1d6d07">


## Test plan
- Line highlighting of code inside code blocks is disabled

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
