### PR TITLE
app: only use hide on mac otherwise use event window hide

### DIFF
--- a/enterprise/dev/app/tauri-build.sh
+++ b/enterprise/dev/app/tauri-build.sh
@@ -35,7 +35,7 @@ upload_dist() {
   local target_dir
   path="$(bundle_path)"
   echo "searching for artefacts in '${path}' and moving them to dist/"
-  src=$(find "${path}" -type f \( -name "Cody*.dmg" -o -name "Cody*.tar.gz" -o -name "Cody*.deb" -o -name "cody*.AppImage" -o -name "cody*.tar.gz" -o -name "*.sig" \))
+  src=$(find "${path}" -type f \( -name "Cody*.dmg" -o -name "Cody*.tar.gz" -o -name "cody*.deb" -o -name "cody*.AppImage" -o -name "cody*.tar.gz" -o -name "*.sig" \))
   target_dir="./${DIST_DIR}"
 
   mkdir -p "${target_dir}"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -110,7 +110,17 @@ fn main() {
                     // This is a temporary solution that only works if the app has a single window.
                     // If we need to add more windows in the future, we need to wait until
                     // https://github.com/tauri-apps/tauri/issues/3084 is fixed.
-                    tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
+                    #[allow(unused_unsafe)]
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        event.window().hide().unwrap();
+                    }
+
+                    #[allow(unused_unsafe)]
+                    #[cfg(target_os = "macos")]
+                    unsafe {
+                        tauri::AppHandle::hide(&event.window().app_handle()).unwrap();
+                    }
                     api.prevent_close();
                 }
             }


### PR DESCRIPTION
- fix script which uploads .deb
- add config for rust to only use the hide api on Mac

## Test plan
Pushed a release on `app-release/debug` and the app built successfully (previously it didn't)

- [Release](https://github.com/sourcegraph/sourcegraph/releases/tag/untagged-e8a2bdd5e13eadfc6b35)
- [Build](https://buildkite.com/sourcegraph/cody-app-release/builds/1319#0188dc45-dde0-4f98-90b4-1351e2671785)
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
