### PR TITLE
JetBrains: autofocus prompt input in Cody chat

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Background color and font of inline code blocks differs from regular text in message [#53761](https://github.com/sourcegraph/sourcegraph/pull/53761)
+- Autofocus Cody chat prompt input [#53836](https://github.com/sourcegraph/sourcegraph/pull/53836)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -166,7 +166,7 @@ class CodyToolWindowContent implements UpdatableChat {
     contentPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
     contentPanel.add(chatPanel, BorderLayout.CENTER);
     contentPanel.add(controlsPanel, BorderLayout.SOUTH);
-
+    tabbedPane.addChangeListener(e -> this.focusPromptInput());
     // Add welcome message
     addWelcomeMessage();
   }
@@ -240,6 +240,7 @@ class CodyToolWindowContent implements UpdatableChat {
     promptInput.setFont(UIUtil.getLabelFont());
     promptInput.setLineWrap(true);
     promptInput.setWrapStyleWord(true);
+    promptInput.requestFocusInWindow();
     KeyboardShortcut CTRL_ENTER =
         new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
     KeyboardShortcut META_ENTER =
@@ -403,5 +404,13 @@ class CodyToolWindowContent implements UpdatableChat {
 
   public @NotNull JComponent getContentPanel() {
     return tabbedPane;
+  }
+
+  public void focusPromptInput() {
+    if (tabbedPane.getSelectedIndex() == CHAT_TAB_INDEX) {
+      promptInput.requestFocusInWindow();
+      int textLength = promptInput.getDocument().getLength();
+      promptInput.setCaretPosition(textLength);
+    }
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
@@ -5,13 +5,17 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.FocusWatcher;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
   @Override
@@ -30,6 +34,15 @@ public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
             .getInstance()
             .createContent(toolWindowContent.getContentPanel(), "", false);
     toolWindow.getContentManager().addContent(content);
+    new FocusWatcher() {
+      @Override
+      protected void focusedComponentChanged(Component focusedComponent, @Nullable AWTEvent cause) {
+        if (focusedComponent != null
+            && SwingUtilities.isDescendingFrom(focusedComponent, toolWindow.getComponent())) {
+          toolWindowContent.focusPromptInput();
+        }
+      }
+    }.install(toolWindow.getComponent());
     List<AnAction> titleActions = new ArrayList<>();
     createTitleActions(titleActions);
     if (!titleActions.isEmpty()) {


### PR DESCRIPTION
Cody input prompt gets autofocus when Cody tool window is opened or when we switch between "Chat" and "Recipes" tabs inside the Cody

## Test plan
- Prompt input gets focus when Cody Chat window is opened

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
