### PR TITLE
Fix empty own analytics in case zero-data is served

### DIFF
--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
@@ -1,0 +1,113 @@
+import { MockedResponse } from '@apollo/client/testing'
+import { Meta, Story } from '@storybook/react'
+
+import { getDocumentNode } from '@sourcegraph/http-client'
+
+import { WebStory } from '../../../components/WebStory'
+import {
+    GetInstanceOwnStatsResult,
+    GetInstanceOwnStatsVariables,
+    GetOwnSignalConfigurationsResult,
+    GetOwnSignalConfigurationsVariables,
+} from '../../../graphql-operations'
+
+import { OwnAnalyticsPage } from './OwnAnalyticsPage'
+import { GET_INSTANCE_OWN_STATS, GET_OWN_JOB_CONFIGURATIONS } from './query'
+
+const config: Meta = {
+    title: 'web/enterprise/own/admin-ui/OwnAnalyticsPage',
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
+}
+
+export default config
+
+const ownAnalyticsDisabled: MockedResponse<GetOwnSignalConfigurationsResult, GetOwnSignalConfigurationsVariables> = {
+    request: {
+        query: getDocumentNode(GET_OWN_JOB_CONFIGURATIONS),
+    },
+    result: {
+        data: {
+            ownSignalConfigurations: [
+                {
+                    __typename: 'OwnSignalConfiguration',
+                    name: 'analytics',
+                    description: 'unused',
+                    isEnabled: false,
+                    excludedRepoPatterns: [],
+                },
+            ],
+        },
+    },
+}
+
+export const AnalyticsDisabled: Story = () => (
+    <WebStory mocks={[ownAnalyticsDisabled]}>{() => <OwnAnalyticsPage />}</WebStory>
+)
+AnalyticsDisabled.storyName = 'AnalyticsDisabled - need to enable own analytics in site admin'
+
+const ownAnalyticsEnabled: MockedResponse<GetOwnSignalConfigurationsResult, GetOwnSignalConfigurationsVariables> = {
+    request: {
+        query: getDocumentNode(GET_OWN_JOB_CONFIGURATIONS),
+    },
+    result: {
+        data: {
+            ownSignalConfigurations: [
+                {
+                    __typename: 'OwnSignalConfiguration',
+                    name: 'analytics',
+                    description: 'unused',
+                    isEnabled: true,
+                    excludedRepoPatterns: [],
+                },
+            ],
+        },
+    },
+}
+
+const presentStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStatsVariables> = {
+    request: {
+        query: getDocumentNode(GET_INSTANCE_OWN_STATS),
+    },
+    result: {
+        data: {
+            instanceOwnershipStats: {
+                totalFiles: 375311,
+                totalCodeownedFiles: 5404,
+                totalOwnedFiles: 5528,
+                totalAssignedOwnershipFiles: 200,
+                updatedAt: '2023-06-20T12:46:54Z',
+                __typename: 'OwnershipStats',
+            },
+        },
+    },
+}
+
+export const PresentStats: Story = () => (
+    <WebStory mocks={[ownAnalyticsEnabled, presentStats]}>{() => <OwnAnalyticsPage />}</WebStory>
+)
+PresentStats.storyName = 'PresentStats - statistics available'
+
+const zeroStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStatsVariables> = {
+    request: {
+        query: getDocumentNode(GET_INSTANCE_OWN_STATS),
+    },
+    result: {
+        data: {
+            instanceOwnershipStats: {
+                totalFiles: 0,
+                totalCodeownedFiles: 0,
+                totalOwnedFiles: 0,
+                totalAssignedOwnershipFiles: 0,
+                updatedAt: null,
+                __typename: 'OwnershipStats',
+            },
+        },
+    },
+}
+
+export const ZeroStats: Story = () => (
+    <WebStory mocks={[ownAnalyticsEnabled, zeroStats]}>{() => <OwnAnalyticsPage />}</WebStory>
+)
+ZeroStats.storyName = 'ZeroStats - no statistics computed yet'

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -40,25 +40,22 @@ export const OwnAnalyticsPage: FC = () => {
 const OwnAnalyticsPanel: FC = () => {
     const { data, loading, error } = useQuery<GetInstanceOwnStatsResult>(GET_INSTANCE_OWN_STATS, {})
 
-    if (!data?.instanceOwnershipStats?.totalFiles) {
-        return <>{error && <ErrorAlert prefix="Error getting own analytics" error={error} />}</>
-    }
+    const totalFiles = data?.instanceOwnershipStats.totalFiles || 0
+    const totalCodeownedFiles = data?.instanceOwnershipStats.totalCodeownedFiles || 0
+    const totalAssignedOwnershipFiles = data?.instanceOwnershipStats.totalAssignedOwnershipFiles || 0
+    const totalOwnedFiles = data?.instanceOwnershipStats.totalOwnedFiles || 0
 
-    const totalFiles = data.instanceOwnershipStats.totalFiles
-    const totalCodeownedFiles = data.instanceOwnershipStats.totalCodeownedFiles
-    const totalAssignedOwnershipFiles = data.instanceOwnershipStats.totalAssignedOwnershipFiles
-    const totalOwnedFiles = data.instanceOwnershipStats.totalOwnedFiles
-
-    const totalCodeownedFilesPercent = Math.round((totalCodeownedFiles / totalFiles) * 100)
-    const totalAssignedOwnershipFilesPercent = Math.round((totalAssignedOwnershipFiles / totalFiles) * 100)
-    const totalOwnedFilesPercent = Math.round((totalOwnedFiles / totalFiles) * 100)
+    // Use Math.max(totalFiles, 1) to make sure we do not divide by 0.
+    const totalCodeownedFilesPercent = Math.round((totalCodeownedFiles / Math.max(totalFiles, 1)) * 100)
+    const totalAssignedOwnershipFilesPercent = Math.round((totalAssignedOwnershipFiles / Math.max(totalFiles, 1)) * 100)
+    const totalOwnedFilesPercent = Math.round((totalOwnedFiles / Math.max(totalFiles, 1)) * 100)
 
     const ownSignalsData: OwnCoverageDatum[] = [
         {
             name: 'CODEOWNERS',
             count: totalCodeownedFilesPercent,
             fill: 'var(--info-2)',
-            tooltip: `Files owned through CODEOWNERS:${totalCodeownedFiles}/${totalFiles}`,
+            tooltip: `Files owned through CODEOWNERS: ${totalCodeownedFiles}/${totalFiles}`,
         },
         {
             name: 'Assigned ownership',
@@ -74,11 +71,11 @@ const OwnAnalyticsPanel: FC = () => {
         },
     ]
 
-    const lastUpdatedAt = data.instanceOwnershipStats.updatedAt ? (
+    const lastUpdatedAt = data?.instanceOwnershipStats.updatedAt && (
         <>
             Last generated: <Timestamp date={data.instanceOwnershipStats.updatedAt} />
         </>
-    ) : undefined
+    )
 
     return (
         <>


### PR DESCRIPTION
Closes #53735

This change displays a zero-valued graph in own analytics rather than an empty page when zero-data is served.

Minor fixes drive-by:

- ensure `totalFiles` that values are divided by to compute percentages is non zero
- add space after colon in _Files owned through CODEOWNERS:_ tooltip
- in `lastUpdatedAt` use `x && y` instead of `x ? y : undefined` 

Before (graph absent):
<img width="1160" alt="247053360-85f5b3ef-ead2-41d0-9e97-830e78a73f76" src="https://github.com/sourcegraph/sourcegraph/assets/153410/8f23cd36-e2ef-4e7a-9e2d-fc7415626fbe">

After (graph present):
<img width="1014" alt="Screenshot 2023-06-21 at 11 00 51 AM" src="https://github.com/sourcegraph/sourcegraph/assets/153410/c7c21fd5-4f7b-44d8-837f-e1f1f243fef4">

## Test plan

NEW STORYBOOK 🎉 
