### PR TITLE
search: move DetermineStatusForLogs out of graphqlbackend

### DIFF
--- a/cmd/frontend/internal/search/BUILD.bazel
+++ b/cmd/frontend/internal/search/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/internal/highlight",
         "//cmd/frontend/internal/search/logs",
         "//internal/api",

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -180,7 +179,7 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 
 func logSearch(ctx context.Context, logger log.Logger, alert *search.Alert, err error, duration time.Duration, latency *time.Duration, originalQuery string, progress *streamclient.ProgressAggregator) {
 	if honey.Enabled() {
-		status := graphqlbackend.DetermineStatusForLogs(alert, progress.Stats, err)
+		status := client.DetermineStatusForLogs(alert, progress.Stats, err)
 		var alertType string
 		if alert != nil {
 			alertType = alert.PrometheusType

--- a/internal/search/client/BUILD.bazel
+++ b/internal/search/client/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "client.go",
         "mocks_temp.go",
+        "telemetry.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/client",
     visibility = ["//:__subpackages__"],

--- a/internal/search/client/telemetry.go
+++ b/internal/search/client/telemetry.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+)
+
+// DetermineStatusForLogs determines the final status of a search for logging
+// purposes.
+func DetermineStatusForLogs(alert *search.Alert, stats streaming.Stats, err error) string {
+	switch {
+	case err == context.DeadlineExceeded:
+		return "timeout"
+	case err != nil:
+		return "error"
+	case stats.Status.All(search.RepoStatusTimedout) && stats.Status.Len() == len(stats.Repos):
+		return "timeout"
+	case stats.Status.Any(search.RepoStatusTimedout):
+		return "partial_timeout"
+	case alert != nil:
+		return "alert"
+	default:
+		return "success"
+	}
+}


### PR DESCRIPTION
This was a weird dependency on graphqlbackend in the streaming endpoint. I chose client as the package for this to live in with the intention to move and unify search telemetry into the client. So this is a work in progress and will evolve quickly.

Test Plan: CI