### PR TITLE
embeddings: don't fail job if file cannot be read

### DIFF
--- a/enterprise/internal/embeddings/embed/files.go
+++ b/enterprise/internal/embeddings/embed/files.go
@@ -91,6 +91,12 @@ const (
 
 	// File was excluded because we hit the max embedding limit for the repo
 	SkipReasonMaxEmbeddings SkipReason = "maxEmbeddings"
+
+	// File was excluded because gitserver failed to read it
+	SkipReasonReadError SkipReason = "readError"
+
+	// File was excluded because of an error during chunking
+	SkipReasonChunkError SkipReason = "chunkError"
 )
 
 func isEmbeddableFileContent(content []byte) (embeddable bool, reason SkipReason) {


### PR DESCRIPTION
With this change we log and continue if we fail to embed or chunk a
file. This should make the embedding jobs a bit more resilient.

## Test plan:
updated unit test
