### PR TITLE
ui: Fix ownership panel for CLs in a p4 depot

### DIFF
--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -71,9 +71,10 @@ export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & T
     }
 
     if (data?.node?.__typename === 'Repository') {
+        const commit = data.node.commit || data.node.changelist?.commit
         return (
             <OwnerList
-                data={data?.node?.commit?.blob?.ownership}
+                data={commit?.blob?.ownership}
                 isDirectory={false}
                 makeOwnerButton={makeOwnerButton}
                 makeOwnerError={makeOwnerError}

--- a/client/web/src/repo/blob/own/grapqlQueries.ts
+++ b/client/web/src/repo/blob/own/grapqlQueries.ts
@@ -67,25 +67,34 @@ export const FETCH_OWNERS = gql`
         ruleLineMatch
     }
 
+    fragment BlobOwnershipFields on GitCommit {
+        blob(path: $currentPath) {
+            ownership {
+                totalOwners
+                nodes {
+                    owner {
+                        ...OwnerFields
+                    }
+                    reasons {
+                        ...CodeownersFileEntryFields
+                        ...RecentContributorOwnershipSignalFields
+                        ...RecentViewOwnershipSignalFields
+                        ...AssignedOwnerFields
+                    }
+                }
+            }
+        }
+    }
+
     query FetchOwnership($repo: ID!, $revision: String!, $currentPath: String!) {
         node(id: $repo) {
             ... on Repository {
                 commit(rev: $revision) {
-                    blob(path: $currentPath) {
-                        ownership {
-                            totalOwners
-                            nodes {
-                                owner {
-                                    ...OwnerFields
-                                }
-                                reasons {
-                                    ...CodeownersFileEntryFields
-                                    ...RecentContributorOwnershipSignalFields
-                                    ...RecentViewOwnershipSignalFields
-                                    ...AssignedOwnerFields
-                                }
-                            }
-                        }
+                    ...BlobOwnershipFields
+                }
+                changelist(cid: $revision) {
+                    commit {
+                        ...BlobOwnershipFields
                     }
                 }
             }


### PR DESCRIPTION
When viewing a file at a specific CL the ownership data is now correctly shown.

Part of #53739 and #53846.

## Test plan

- Tested manually
- Builds should pass

<img width="2559" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/2682729/de721cb0-1ae3-4574-a4b0-5830d6149e7c">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
