### PR TITLE
App: Better formatting of uninstall command

### DIFF
--- a/doc/app/index.md
+++ b/doc/app/index.md
@@ -72,7 +72,10 @@ The setup experience allows users to select up to 10 repos for embeddings. Addit
 
 ## Uninstallation
 
-We're working on a better way to clear all data including webkit storage, but for now you can run `rm -rf ~/.sourcegraph-psql ~/Library/Application\ Support/com.sourcegraph.cody ~/Library/Caches/com.sourcegraph.cody ~/Library/WebKit/com.sourcegraph.cody` to uninstall the app.
+We're working on a better way to clear all data including webkit storage, but for now you can run the following command to uninstall the app:
+```bash
+rm -rf ~/.sourcegraph-psql ~/Library/Application\ Support/com.sourcegraph.cody ~/Library/Caches/com.sourcegraph.cody ~/Library/WebKit/com.sourcegraph.cody
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Description

### Before
<img width="841" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/9516420/2aa44d54-a67c-43e1-ae14-0c8acf00d60d">

I totally misread the installation instructions and thought the third line was another command. Updated to be in line with the rest of our command examples in the docs.

### After (scrollable)
<img width="871" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/9516420/a13a98ea-5cb2-4752-b17f-77f29e487832">



## Test plan

Load docs, copy command