### PR TITLE
search: introduce ExecutionResult to enforce telemetry collection

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -397,6 +397,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	agg := streaming.NewAggregatingStream()
 	done := r.client.Execute(ctx, agg, r.SearchInputs)
 	alert, err := done(searchclient.TelemetryArgs{
+		Stats:          agg.Stats,
 		UserResultSize: len(agg.Results),
 	})
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -395,7 +395,10 @@ func logBatch(ctx context.Context, searchInputs *search.Inputs, srr *SearchResul
 func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
 	agg := streaming.NewAggregatingStream()
-	alert, err := r.client.Execute(ctx, agg, r.SearchInputs)
+	done := r.client.Execute(ctx, agg, r.SearchInputs)
+	alert, err := done(searchclient.TelemetryArgs{
+		UserResultSize: len(agg.Results),
+	})
 	srr := r.resultsToResolver(agg.Results, alert, agg.Stats)
 	srr.elapsed = time.Since(start)
 	logBatch(ctx, r.SearchInputs, srr, err)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -330,6 +330,7 @@ func TestSearchResultsHydration(t *testing.T) {
 		query,
 		search.Precise,
 		search.Batch,
+		"test",
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -566,6 +567,7 @@ func TestEvaluateAnd(t *testing.T) {
 				tt.query,
 				search.Precise,
 				search.Batch,
+				"test",
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -672,6 +674,7 @@ func TestSubRepoFiltering(t *testing.T) {
 				tt.searchQuery,
 				search.Precise,
 				search.Batch,
+				"test",
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -171,8 +171,9 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr *trace.Trace, eventWriter 
 		return h.searchClient.Execute(ctx, batchedStream, inputs)
 	}()
 	alert, err := done(client.TelemetryArgs{
-		Latency:        latency,
+		Stats:          progress.Stats,
 		UserResultSize: progress.MatchCount,
+		Latency:        latency,
 	})
 	if alert != nil {
 		eventWriter.Alert(alert)

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -55,6 +55,7 @@ func run(w io.Writer, args []string) error {
 		query,
 		mode,
 		search.Streaming,
+		"search-plan",
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to plan")

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/compute"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/job/jobutil"
 	streamclient "github.com/sourcegraph/sourcegraph/internal/search/streaming/client"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
@@ -151,7 +152,11 @@ LOOP:
 
 	matchesFlush()
 
-	alert, err := getResults()
+	done := getResults()
+	alert, err := done(client.TelemetryArgs{
+		// TODO(keegancsmith) looks like we could report a Latency here.
+		UserResultSize: progress.MatchCount,
+	})
 	if err != nil {
 		_ = eventWriter.Event("error", streamhttp.EventError{Message: err.Error()})
 		return

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -155,6 +155,7 @@ LOOP:
 	done := getResults()
 	alert, err := done(client.TelemetryArgs{
 		// TODO(keegancsmith) looks like we could report a Latency here.
+		Stats:          progress.Stats,
 		UserResultSize: progress.MatchCount,
 	})
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/enterprise/cmd/frontend/internal/context/resolvers/context_test.go
@@ -91,10 +91,10 @@ func TestContextResolver(t *testing.T) {
 	}
 
 	mockSearchClient := client.NewMockSearchClient()
-	mockSearchClient.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, query string, _ search.Mode, _ search.Protocol) (*search.Inputs, error) {
+	mockSearchClient.PlanFunc.SetDefaultHook(func(_ context.Context, _ string, _ *string, query string, _ search.Mode, _ search.Protocol, _ string) (*search.Inputs, error) {
 		return &search.Inputs{OriginalQuery: query}, nil
 	})
-	mockSearchClient.ExecuteFunc.SetDefaultHook(func(_ context.Context, stream streaming.Sender, inputs *search.Inputs) (*search.Alert, error) {
+	mockSearchClient.ExecuteFunc.SetDefaultHook(func(_ context.Context, stream streaming.Sender, inputs *search.Inputs) client.ExecutionResult {
 		if strings.Contains(inputs.OriginalQuery, "-file") {
 			stream.Send(streaming.SearchEvent{
 				Results: result.Matches{&result.FileMatch{
@@ -123,7 +123,7 @@ func TestContextResolver(t *testing.T) {
 			})
 
 		}
-		return nil, nil
+		return client.MockExecutionResult(nil, nil)
 	})
 
 	contextClient := codycontext.NewCodyContextClient(

--- a/enterprise/internal/codemonitors/search.go
+++ b/enterprise/internal/codemonitors/search.go
@@ -33,6 +33,7 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 		query,
 		search.Precise,
 		search.Streaming,
+		"codemonitors_search",
 	)
 	if err != nil {
 		return nil, errcode.MakeNonRetryable(err)
@@ -55,7 +56,7 @@ func Search(ctx context.Context, logger log.Logger, db database.DB, enterpriseJo
 
 	// Execute the search
 	agg := streaming.NewAggregatingStream()
-	_, err = planJob.Run(ctx, clients, agg)
+	_, err = planJob.Run(ctx, clients, agg) // TODO(keegancsmith) does not record telemetry
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +85,7 @@ func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterprise
 		query,
 		search.Precise,
 		search.Streaming,
+		"codemonitors_snapshot",
 	)
 	if err != nil {
 		return err
@@ -109,7 +111,7 @@ func Snapshot(ctx context.Context, logger log.Logger, db database.DB, enterprise
 	// and transactions cannot be used concurrently.
 	planJob = limitConcurrency(planJob)
 
-	_, err = planJob.Run(ctx, clients, streaming.NewNullStream())
+	_, err = planJob.Run(ctx, clients, streaming.NewNullStream()) // TODO(keegancsmith) does not record telemetry
 	return err
 }
 

--- a/enterprise/internal/codycontext/context.go
+++ b/enterprise/internal/codycontext/context.go
@@ -209,6 +209,7 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 			query,
 			search.Precise,
 			search.Streaming,
+			"codycontext",
 		)
 		if err != nil {
 			return nil, err
@@ -233,7 +234,10 @@ func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetConte
 			}
 		})
 
-		alert, err := c.searchClient.Execute(ctx, stream, plan)
+		done := c.searchClient.Execute(ctx, stream, plan)
+		alert, err := done(client.TelemetryArgs{
+			UserResultSize: len(collected),
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -33,15 +33,18 @@ import (
 )
 
 type TelemetryArgs struct {
-	// Latency is an optional field to log the time the first result was sent
-	// to the user. Note: we will always log total duration. This field only
-	// makes sense for endpoints that stream to the user.
-	Latency time.Duration
-
 	// UserResultSize is the number of results sent to the user. We can't
 	// infer this from Execute since the streamer may mutate/truncate results
 	// before sending to the user.
 	UserResultSize int
+
+	// Stats is used to calculate the status of the search for telemetry.
+	Stats streaming.Stats
+
+	// Latency is an optional field to log the time the first result was sent
+	// to the user. Note: we will always log total duration. This field only
+	// makes sense for endpoints that stream to the user.
+	Latency time.Duration
 }
 
 // ExecutionResult exists so we can capture telemetry which is recorded

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -38,6 +38,12 @@ type Inputs struct {
 	Features               *Features
 	Protocol               Protocol
 	SanitizeSearchPatterns []*regexp.Regexp
+
+	// Start is when searchclient.Plan was called. Used by telemetry.
+	Start time.Time
+
+	// Subsystem is the value passed in via searchclient.Plan. Used by telemetry.
+	Subsystem string
 }
 
 // MaxResults computes the limit for the query.


### PR DESCRIPTION
This just introduces the type without actually recording the telemetry. Additionally we introduce a new parameter to Plan to capture the subsystem. The goal is to start recording prometheus, honeycomb and logging across all search clients. Currently we only record this for GraphQL and streaming http requests.

This commit doesn't actually implement the telemetry sending. That will come in the next (much smaller) commit.

Additionally code monitors does not yet support telemetry since it directly uses the job interface. That will be followed up with.

Test Plan: go test

Part of https://github.com/sourcegraph/sourcegraph/issues/53766