### PR TITLE
Update grafana base image

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -64,7 +64,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_grafana_base",
-        digest = "sha256:ec1049f35ff7e4ab6ff7b4cc6790996ad74d196b8dcee8ea5283fca759156637",
+        digest = "sha256:1989633b60c45edf330f1161f7be37bc75b905b0947607e175bb82db224ce50a",
         image = "us.gcr.io/sourcegraph-dev/wolfi-grafana",
     )
 

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,7 +52,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:75e0770f4c9a0336d823361211fbf9dcfe8a41ab15b9e3c05caed7870d5afca7",
+        digest = "sha256:fd88efe0dbdf1f8d73c847d2fcd501736a93dfec97169569979658b855ebddf7",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,7 +52,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:56bbb8bc2ae9b591f23ef6acc249eca3ca8678c02fd5a04b4260bee2a56f2437",
+        digest = "sha256:75e0770f4c9a0336d823361211fbf9dcfe8a41ab15b9e3c05caed7870d5afca7",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 


### PR DESCRIPTION
Pull latest grafana version to patch vulns.

- [x] Update grafana base image to latest version
- [ ] Update server image to use latest grafana package


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- green main-dry-run
- Container structure tests
- Manual image QA
