### PR TITLE
Cody: Log analytical events in the output logs

### DIFF
--- a/client/cody/src/event-logger.ts
+++ b/client/cody/src/event-logger.ts
@@ -4,6 +4,7 @@ import { EventLogger } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
 
 import { version as packageVersion } from '../package.json'
 
+import { debug } from './log'
 import { LocalStorage } from './services/LocalStorageProvider'
 
 let eventLoggerGQLClient: SourcegraphGraphQLAPIClient
@@ -53,6 +54,7 @@ export function logEvent(eventName: string, eventProperties?: any, publicPropert
         version: packageVersion,
     }
     try {
+        debug('EventLogger', eventName, JSON.stringify(argument, null, 2))
         eventLogger.log(eventName, anonymousUserID, argument, publicArgument)
     } catch (error) {
         console.error(error)


### PR DESCRIPTION
This PR makes sure all analytical event logs also appear in the output view. See my [internal petition](https://sourcegraph.slack.com/archives/C05AGQYD528/p1687354919604099) for some context.

## Test plan

<img width="661" alt="Screenshot 2023-06-21 at 16 48 19" src="https://github.com/sourcegraph/sourcegraph/assets/458591/4ae4a7a2-adb7-4102-a29d-0d56a7c35c94">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
