### PR TITLE
cody site-admin: fix refetch for one-time jobs

### DIFF
--- a/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
@@ -216,7 +216,7 @@ export const useShowMorePagination = <TResult, TVariables extends {}, TData>({
             ...variables,
             first,
         })
-    }, [refetch, variables])
+    }, [first, refetch, variables])
 
     // We use `refetchAll` to poll for all the nodes currently loaded in the
     // connection, vs. just providing a `pollInterval` to the underlying `useQuery`, which

--- a/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
@@ -16,6 +16,7 @@ export interface UseShowMorePaginationResult<TResult, TData> {
     error?: ApolloError
     fetchMore: () => void
     refetchAll: () => void
+    refetchFirst: () => void
     loading: boolean
     hasNextPage: boolean
     /**
@@ -198,6 +199,7 @@ export const useShowMorePagination = <TResult, TVariables extends {}, TData>({
         })
     }
 
+    // Refetch the current nodes
     const refetchAll = useCallback(async (): Promise<void> => {
         const first = connection?.nodes.length || firstReference.current.actual
 
@@ -206,6 +208,15 @@ export const useShowMorePagination = <TResult, TVariables extends {}, TData>({
             first,
         })
     }, [connection?.nodes.length, refetch, variables])
+
+    // Refetch the first page. Use this function if the number of nodes in the
+    // connection might have changed have changed since the last refetch.
+    const refetchFirst = useCallback(async (): Promise<void> => {
+        await refetch({
+            ...variables,
+            first,
+        })
+    }, [refetch, variables])
 
     // We use `refetchAll` to poll for all the nodes currently loaded in the
     // connection, vs. just providing a `pollInterval` to the underlying `useQuery`, which
@@ -218,6 +229,7 @@ export const useShowMorePagination = <TResult, TVariables extends {}, TData>({
         loading,
         error,
         fetchMore: fetchMoreData,
+        refetchFirst,
         refetchAll,
         hasNextPage: connection ? hasNextPage(connection) : false,
         startPolling: startExecution,

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -122,7 +122,7 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
             await scheduleRepoEmbeddingJobs({ variables: { repoNames } })
             refetchFirst()
         },
-        [refetchFirst(), scheduleRepoEmbeddingJobs]
+        [refetchFirst, scheduleRepoEmbeddingJobs]
     )
 
     const form = useForm<RepoEmbeddingJobsFormValues>({

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -111,10 +111,8 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
         return val === defaultStateFilterValue ? null : val
     }
 
-    const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useRepoEmbeddingJobsConnection(
-        query,
-        getStateFilterValue(filterValues)
-    )
+    const { loading, hasNextPage, fetchMore, refetchAll, refetchFirst, connection, error } =
+        useRepoEmbeddingJobsConnection(query, getStateFilterValue(filterValues))
 
     const [scheduleRepoEmbeddingJobs, { loading: repoEmbeddingJobsLoading, error: repoEmbeddingJobsError }] =
         useScheduleRepoEmbeddingJobs()
@@ -122,9 +120,9 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
     const onSubmit = useCallback(
         async (repoNames: string[]) => {
             await scheduleRepoEmbeddingJobs({ variables: { repoNames } })
-            refetchAll()
+            refetchFirst()
         },
-        [refetchAll, scheduleRepoEmbeddingJobs]
+        [refetchFirst(), scheduleRepoEmbeddingJobs]
     )
 
     const form = useForm<RepoEmbeddingJobsFormValues>({


### PR DESCRIPTION
When a user clicks on "Schedule Embedding", we schedule the repos for embedding and refetch the job list to update the view. However, the current refetch logic fetches only `n` results, where `n` is the number of jobs currently displayed. This leads to a confusing behavior (1 job visible, user schedules 3 more => 1 job visible), which the user can fix with a page refresh. Not ideal.

With this PR we always fetch a full page, i.e. 10 jobs, which makes more sense, because the number of jobs likely will have increased after the user clicked on "Schedule Embedding".

The root cause of the bug is that `refetchAll` closes over the current list of jobs, which I believe is the intention for the other call sites. I don't think it is a good idea to modify `refetchAll` during the code freeze. Returning a new function `fetchFirst` keeps the surface of this change small. 

## Test plan
CI

