### PR TITLE
Tracing: inherit from raw OTel trace for TraceFromContext

### DIFF
--- a/internal/trace/BUILD.bazel
+++ b/internal/trace/BUILD.bazel
@@ -35,10 +35,14 @@ go_library(
 
 go_test(
     name = "trace_test",
-    srcs = ["attributes_test.go"],
+    srcs = [
+        "attributes_test.go",
+        "context_test.go",
+    ],
     embed = [":trace"],
     deps = [
         "//lib/errors",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel_trace//:trace",
     ],
 )

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -26,6 +26,13 @@ func contextWithTrace(ctx context.Context, tr *Trace) context.Context {
 // nil if no such Trace could be found.
 func TraceFromContext(ctx context.Context) *Trace {
 	tr, _ := ctx.Value(traceKey).(*Trace)
+	if tr == nil {
+		// There is no Trace in the context, so check for a raw OTel span we can use.
+		span := oteltrace.SpanFromContext(ctx)
+		if span.IsRecording() {
+			tr = &Trace{oteltraceSpan: span}
+		}
+	}
 	return tr
 }
 

--- a/internal/trace/context_test.go
+++ b/internal/trace/context_test.go
@@ -1,0 +1,33 @@
+package trace
+
+import (
+	"context"
+	"testing"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceFromContext(t *testing.T) {
+	t.Run("set in context", func(t *testing.T) {
+		ctx := contextWithTrace(context.Background(), &Trace{})
+		tr := TraceFromContext(ctx)
+		require.NotNil(t, tr)
+	})
+
+	t.Run("not set in context", func(t *testing.T) {
+		tr := TraceFromContext(context.Background())
+		require.Nil(t, tr)
+	})
+
+	t.Run("not set in context, but raw opentelemetry span is", func(t *testing.T) {
+		ctx := oteltrace.ContextWithSpan(context.Background(), recordingSpan{})
+		tr := TraceFromContext(ctx)
+		require.NotNil(t, tr)
+	})
+}
+
+type recordingSpan struct{ oteltrace.Span }
+
+func (r recordingSpan) IsRecording() bool { return true }


### PR DESCRIPTION
Currently, if we have a raw OTel trace in the context but no active `trace.Trace`, we `TraceFromContext` will not use that, so we can lose some tracing information. This provides a temporary fix to make `TraceFromContext` create a new, ephemeral `*Trace` that contains the OTel span if it exists.

I think the real solution here is to just go all in on the OTel tooling and make our custom trace stuff conform to the OTel interfaces. I'll work on that in the background, but I want to get this out before 5.1.

## Test plan

Added unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
