### PR TITLE
sg: restore symbols for sg

### DIFF
--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -1,0 +1,91 @@
+# NOTE: This layer of the docker image is also used in local development as a wrapper around universal-ctags
+FROM sourcegraph/alpine-3.14:213466_2023-04-17_5.0-bdda34a71619@sha256:6354a4ff578b685e36c8fbde81f62125ae0011b047fb2cc22d1b0de616b3c59a AS ctags
+# hadolint ignore=DL3002
+COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
+RUN /ctags-install-alpine.sh
+
+FROM rust:1.68.0-alpine3.17@sha256:d119a621ae12f84ec0c5fed77c24795120ed1c7874b2428b5a6ccc0f294dbe18 as scip-ctags
+# hadolint ignore=DL3002
+USER root
+RUN apk add --no-cache musl-dev>=1.1.24-r10 build-base
+COPY docker-images/syntax-highlighter /repo
+WORKDIR /repo
+RUN cargo fetch
+
+ARG TARGETARCH
+
+# Because .cargo/config.toml doesnt support triplet-specific env
+COPY cmd/symbols/cargo-config.sh /cargo-config.sh
+RUN /cargo-config.sh
+
+RUN cargo rustc --release --bin scip-ctags
+
+RUN cp ./target/release/scip-ctags /usr/local/bin/scip-ctags
+
+FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS symbols-build
+# hadolint ignore=DL3002
+USER root
+
+ENV GO111MODULE on
+ENV GOARCH amd64
+ENV GOOS linux
+ENV CGO_ENABLED 1
+
+RUN apk add --no-cache gcc g++
+
+COPY . /repo
+
+WORKDIR /repo
+
+ARG VERSION="unknown"
+ENV VERSION $VERSION
+
+ARG PKG
+ENV PKG=$PKG
+
+RUN \
+  --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/root/go/pkg/mod \
+  go build \
+  -trimpath \
+  -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.version=$VERSION  -X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$(date +%s)" \
+  -buildmode exe \
+  -tags dist \
+  -o /symbols \
+  $PKG
+
+FROM sourcegraph/alpine-3.14:213466_2023-04-17_5.0-bdda34a71619@sha256:6354a4ff578b685e36c8fbde81f62125ae0011b047fb2cc22d1b0de616b3c59a AS symbols
+
+# TODO(security): This container should not run as root!
+#
+# See https://github.com/sourcegraph/sourcegraph/issues/13237
+# hadolint ignore=DL3002
+USER root
+
+ARG COMMIT_SHA="unknown"
+ARG DATE="unknown"
+ARG VERSION="unknown"
+
+LABEL org.opencontainers.image.revision=${COMMIT_SHA}
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+# ctags is dynamically linked against jansson
+# libstdc++ and libgcc are for tree-sitter
+RUN apk add --no-cache bind-tools ca-certificates mailcap tini jansson libstdc++ libgcc
+
+COPY --from=ctags /usr/local/bin/universal-ctags /usr/local/bin/universal-ctags
+COPY --from=scip-ctags /usr/local/bin/scip-ctags /usr/local/bin/scip-ctags
+
+COPY --from=symbols-build /symbols /usr/local/bin/symbols
+
+# symbols is cgo, ensure we have the requisite dynamic libraries
+RUN env SANITY_CHECK=true /usr/local/bin/symbols
+
+# Use SYMBOLS_CACHE_DIR to set the cache dir at runtime for the symbols service. Setting CACHE_DIR
+# will also apply to other services and is deprecated.
+ENV CACHE_DIR=/mnt/cache/symbols
+RUN mkdir -p ${CACHE_DIR}
+EXPOSE 3184
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/symbols"]

--- a/cmd/symbols/build.sh
+++ b/cmd/symbols/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script builds the symbols docker image.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -eu
+
+echo "--- docker build symbols"
+docker build -f cmd/symbols/Dockerfile -t "$IMAGE" "$(pwd)" \
+  --progress=plain \
+  --build-arg COMMIT_SHA \
+  --build-arg DATE \
+  --build-arg VERSION \
+  --build-arg PKG="${PKG:-github.com/sourcegraph/sourcegraph/cmd/symbols}"

--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# This script installs universal-ctags within an alpine container.
+
+# Commit hash of github.com/universal-ctags/ctags.
+# Last bumped 2022-04-04.
+# When bumping please remember to also update Zoekt: https://github.com/sourcegraph/zoekt/blob/d3a8fbd8385f0201dd54ab24114ebd588dfcf0d8/install-ctags-alpine.sh
+CTAGS_VERSION=f95bb3497f53748c2b6afc7f298cff218103ab90
+
+cleanup() {
+  apk --no-cache --purge del ctags-build-deps || true
+  cd /
+  rm -rf /tmp/ctags-$CTAGS_VERSION
+}
+
+trap cleanup EXIT
+
+set -eux
+
+apk --no-cache add \
+  --virtual ctags-build-deps \
+  autoconf \
+  automake \
+  binutils \
+  curl \
+  g++ \
+  gcc \
+  jansson-dev \
+  make \
+  pkgconfig
+
+# ctags is dynamically linked against jansson
+apk --no-cache add jansson
+
+NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
+
+# Installation
+curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
+cd /tmp/ctags-$CTAGS_VERSION
+./autogen.sh
+./configure --program-prefix=universal- --enable-json
+make -j"$NUMCPUS" --load-average="$NUMCPUS"
+make install

--- a/enterprise/cmd/symbols/build.sh
+++ b/enterprise/cmd/symbols/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This script builds the symbols docker image.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+set -eu
+
+env \
+  PKG=github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols \
+  cmd/symbols/build.sh


### PR DESCRIPTION
Restore bash scripts for those building symbols locally outside bazel, primary with `sg start`


## Test plan

run `sg start` locally