### PR TITLE
Revert "Update s3proxy to latest custom release"

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -36,7 +36,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:d1c7262de00d6d87a001e208c23c9551c67ec722f1eeac2a016b77ca6d539c2d",
+        digest = "sha256:b4f5d5927d4e53937fdaf8fc9b54414ee87c2e2f288e566cc25bb98771e88008",
         image = "us.gcr.io/sourcegraph-dev/wolfi-server-base",
     )
 
@@ -168,6 +168,6 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:92614e804e5a5cb5316f8d9235286b659d8957c557170ddefda2973053ca5e4d",
+        digest = "sha256:4299634c0e403059a5a2aeda323181feb8189648c23fd69d0b5d057e0e7966eb",
         image = "us.gcr.io/sourcegraph-dev/wolfi-blobstore-base",
     )

--- a/wolfi-images/blobstore.yaml
+++ b/wolfi-images/blobstore.yaml
@@ -18,4 +18,4 @@ paths:
 
 work-dir: /opt/s3proxy
 
-# MANUAL REBUILD: Wed Jun 21 16:29:51 BST 2023
+# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -78,4 +78,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 21 16:30:05 BST 2023
+# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023

--- a/wolfi-packages/s3proxy.yaml
+++ b/wolfi-packages/s3proxy.yaml
@@ -1,7 +1,7 @@
 package:
   name: s3proxy
   version: 2.0.0
-  epoch: 2
+  epoch: 1
   description: "Access other storage backends via the S3 API"
   target-architecture:
     - x86_64
@@ -12,7 +12,7 @@ package:
       license: 'Apache License 2.0'
   dependencies:
     runtime:
-      - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
+      - openjdk-11
       - openjdk-11-default-jvm # Set Java 11 as default JVM
 
 environment:
@@ -26,14 +26,14 @@ environment:
       - busybox
       - ca-certificates-bundle
       - maven
-      - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
+      - openjdk-11
       - openjdk-11-default-jvm
 
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/sourcegraph/s3proxy/archive/refs/tags/s3proxy-${{package.version}}-${{package.epoch}}.tar.gz
-      expected-sha256: efeda0b7e2d87dbfb053510d706b109f8dcbf83fb7833e9d43b2231a2beaf247
+      uri: https://github.com/sourcegraph/s3proxy/archive/refs/tags/s3proxy-${{package.version}}.tar.gz
+      expected-sha256: e2d3f8f217d67ab8cc074490f27b4d649f4ec73f5bf540aa9da1ad4dda818d0b
       extract: true
   - runs: |
       JAVA_HOME=/usr/lib/jvm/java-11-openjdk/ mvn package -DskipTests


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#53872

This is blocking main. The change seems to have caused an issue with the backend_integration_test. Will investigate tomorrow.

## Test Plan

- Manually checking main is green again