### PR TITLE
Setup: Add setup email verification state

### DIFF
--- a/client/web/src/enterprise/app/routes.tsx
+++ b/client/web/src/enterprise/app/routes.tsx
@@ -35,21 +35,11 @@ export const APP_ROUTES: RouteObject[] = [
     {
         path: `${EnterprisePageRoutes.AppSetup}/*`,
         handle: { isFullPage: true },
-        element: (
-            <LegacyRoute
-                render={props => <AppSetup telemetryService={props.telemetryService} />}
-                condition={({ isSourcegraphApp }) => isSourcegraphApp}
-            />
-        ),
+        element: <LegacyRoute render={props => <AppSetup telemetryService={props.telemetryService} />} />,
     },
     {
         path: EnterprisePageRoutes.AppAuthCallback,
-        element: (
-            <LegacyRoute
-                render={() => <AppAuthCallbackPage />}
-                condition={({ isSourcegraphApp }) => isSourcegraphApp}
-            />
-        ),
+        element: <LegacyRoute render={() => <AppAuthCallbackPage />} />,
     },
     {
         path: PageRoutes.User,

--- a/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
@@ -72,7 +72,7 @@ export const AddLocalRepositoriesSetupPage: FC<StepComponentProps> = ({ classNam
                 <Tooltip
                     content={
                         repositories.length > MAX_NUMBER_OF_REPOSITORIES
-                            ? `Select less repositories, Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos`
+                            ? `Select fewer repositories, Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos`
                             : repositories.length === 0
                             ? 'Select at least one repo to continue'
                             : undefined

--- a/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
@@ -72,7 +72,7 @@ export const AddLocalRepositoriesSetupPage: FC<StepComponentProps> = ({ classNam
                 <Tooltip
                     content={
                         repositories.length > MAX_NUMBER_OF_REPOSITORIES
-                            ? `Select less repositores, Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos`
+                            ? `Select less repositories, Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos`
                             : repositories.length === 0
                             ? 'Select at least one repo to continue'
                             : undefined

--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.module.scss
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.module.scss
@@ -70,3 +70,25 @@
         text-decoration: underline;
     }
 }
+
+.email-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    flex-basis: 50%;
+    flex-shrink: 0;
+    padding: 6.75rem 2.5rem 2.5rem;
+    background-color: var(--gray-02);
+
+    &-icon {
+        height: 1.5rem;
+        margin-bottom: 0.75rem;
+        flex-shrink: 0;
+    }
+
+    &-text {
+        font-size: 1.25rem;
+        margin-bottom: 0.5rem;
+    }
+}

--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
@@ -53,7 +53,7 @@ const EmailCheckVerificationForm: FC = () => {
         <div className={styles.emailForm}>
             <Icon svgPath={mdiEmail} inline={false} aria-hidden={true} className={styles.emailFormIcon} />
             <Text className={styles.emailFormText}>
-                You need to <b>verify you email</b> in order to use Cody
+                You need to <b>verify your email</b> in order to use Cody
             </Text>
             <Button
                 variant="primary"

--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
@@ -1,63 +1,118 @@
-import { FC } from 'react'
+import { FC, useContext } from 'react'
 
+import { mdiEmail } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Button, H1, H2, Link, Text } from '@sourcegraph/wildcard'
+import { gql, useQuery } from '@sourcegraph/http-client'
+import { Button, H1, H2, Icon, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
 import { EnterprisePageRoutes } from '../../../../routes.constants'
-import { StepComponentProps } from '../../../../setup-wizard/components'
+import { SetupStepsContext, StepComponentProps } from '../../../../setup-wizard/components'
+import { useQueryParameters } from '../../../insights/hooks'
 
 import styles from './AppWelcomeSetupStep.module.scss'
 
-export const AppWelcomeSetupStep: FC<StepComponentProps> = ({ className }) => (
-    <div className={classNames(styles.root, className)}>
-        <div className={styles.description}>
-            <H1 className={styles.descriptionHeading}>Welcome</H1>
-            <Text className={styles.descriptionText}>
-                Cody is an AI coding assistant that helps you read, write, and understand code 10x faster.
-            </Text>
+const EMAIL_VERIFICATION_QUERY = gql`
+    query EmailVerification {
+        user(username: "admin") {
+            hasVerifiedEmail
+        }
+    }
+`
 
-            <img
-                src="https://storage.googleapis.com/sourcegraph-assets/welcome.png"
-                alt=""
-                className={styles.descriptionImage}
-            />
+export const AppWelcomeSetupStep: FC<StepComponentProps> = ({ className }) => {
+    const { emailCheck } = useQueryParameters(['emailCheck'])
+
+    return (
+        <div className={classNames(styles.root, className)}>
+            <div className={styles.description}>
+                <H1 className={styles.descriptionHeading}>Welcome</H1>
+                <Text className={styles.descriptionText}>
+                    Cody is an AI coding assistant that helps you read, write, and understand code 10x faster.
+                </Text>
+
+                <img
+                    src="https://storage.googleapis.com/sourcegraph-assets/welcome.png"
+                    alt=""
+                    className={styles.descriptionImage}
+                />
+            </div>
+
+            {emailCheck && <EmailCheckVerificationForm />}
+            {!emailCheck && <ConnectToSourcegraphComForm />}
         </div>
+    )
+}
 
-        <div className={styles.actions}>
-            <H2 className={styles.actionsHeading}>You’ll need a Sourcegraph.com account in order to connect Cody.</H2>
+const EmailCheckVerificationForm: FC = () => {
+    const { onNextStep } = useContext(SetupStepsContext)
+    const { data } = useQuery(EMAIL_VERIFICATION_QUERY, { pollInterval: 3000 })
+    const hasEmailBeenVerified = data?.user.hasVerifiedEmail ?? false
 
+    return (
+        <div className={styles.emailForm}>
+            <Icon svgPath={mdiEmail} inline={false} aria-hidden={true} className={styles.emailFormIcon} />
+            <Text className={styles.emailFormText}>
+                You need to <b>verify you email</b> in order to use Cody
+            </Text>
             <Button
-                as={Link}
-                to={`https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=APP&destination=${EnterprisePageRoutes.AppSetup}/local-repositories`}
                 variant="primary"
                 size="lg"
+                disabled={!hasEmailBeenVerified}
                 className={styles.actionsButton}
-                target="_blank"
+                onClick={onNextStep}
             >
-                <SourcegraphLogo />
-                Connect to Sourcegraph.com
+                {hasEmailBeenVerified ? (
+                    <>Email has verified, go to the next step →</>
+                ) : (
+                    <>
+                        <LoadingSpinner /> Waiting for email being verified
+                    </>
+                )}
             </Button>
 
-            <Text className={styles.actionsFooter}>
-                <Text>
-                    Cody will send your code to Sourcegraph servers and our LLM provider, but we won’t retain your code
-                    and we won’t use it to train Cody either.
-                </Text>
-                By signing in, you’re connecting Cody to your app and agreeing to Sourcegraph’s Cody Usage Privacy
-                Notice.{' '}
-                <Link
-                    to="https://about.sourcegraph.com/terms/cody-notice"
-                    target="_blank"
-                    rel="noopener"
-                    className={styles.actionsTermLink}
-                >
-                    Sourcegraph’s Cody Usage Privacy Notice
-                </Link>
-                .
-            </Text>
+            <CodyInfo />
         </div>
+    )
+}
+
+const ConnectToSourcegraphComForm: FC = () => (
+    <div className={styles.actions}>
+        <H2 className={styles.actionsHeading}>You’ll need a Sourcegraph.com account in order to connect Cody.</H2>
+
+        <Button
+            as={Link}
+            to={`https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=APP&destination=${EnterprisePageRoutes.AppSetup}/welcome?emailCheck=true`}
+            variant="primary"
+            size="lg"
+            className={styles.actionsButton}
+            target="_blank"
+        >
+            <SourcegraphLogo />
+            Connect to Sourcegraph.com
+        </Button>
+
+        <CodyInfo />
     </div>
+)
+
+const CodyInfo: FC = () => (
+    <Text className={styles.actionsFooter}>
+        <Text>
+            Cody will send your code to Sourcegraph servers and our LLM provider, but we won’t retain your code and we
+            won’t use it to train Cody either.
+        </Text>
+        By signing in, you’re connecting Cody to your app and agreeing to Sourcegraph’s Cody Usage Privacy Notice.{' '}
+        <Link
+            to="https://about.sourcegraph.com/terms/cody-notice"
+            target="_blank"
+            rel="noopener"
+            className={styles.actionsTermLink}
+        >
+            Sourcegraph’s Cody Usage Privacy Notice
+        </Link>
+        .
+    </Text>
 )
 
 const SourcegraphLogo: FC = () => (

--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
@@ -66,7 +66,7 @@ const EmailCheckVerificationForm: FC = () => {
                     <>Email has verified, go to the next step →</>
                 ) : (
                     <>
-                        <LoadingSpinner /> Waiting for email being verified
+                        <LoadingSpinner /> Waiting for email to be verified
                     </>
                 )}
             </Button>


### PR DESCRIPTION
[Design](https://www.figma.com/file/ZkJFUvVzZW9TgFg7k9w9Oq/App-%5BMAIN%5D?type=design&node-id=76-1782&mode=design&t=T4Ab2kSnq66kRtR9-0)

| State | UI |
| ------ | ------ | 
| Loading state | <img width="1008" alt="Screenshot 2023-06-21 at 17 06 28" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/15425842-de83-4317-ad22-490a405f756f"> |
| Verified state | <img width="1052" alt="Screenshot 2023-06-21 at 17 06 04" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/5c34d288-50ad-4571-bd97-5d34aea7fd8c"> |

## Notes
@danielmarquespt I had to make a few changes to the original designs 
- This implementation doesn't have a re-send button. It turned out that we simply don't have this functionality in our API at the moment. We possible can do it later
- We do polling to get the most recent state about email verification, so the button has two states, as you can see above, with different text; I'm not sure about the copy, so feel free to change/suggest anything. 

## Test plan
- Run production build locally 
- Check that you can complete the email setup

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
