### PR TITLE
Embeddings: retry individually when OpenAI gives us back `null` fields

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/limiter",
         "//enterprise/cmd/cody-gateway/internal/notify",
         "//enterprise/cmd/cody-gateway/internal/response",
+        "//internal/httpcli",
         "//internal/instrumentation",
         "//internal/redispool",
         "//internal/trace",

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/notify",
         "//enterprise/cmd/cody-gateway/internal/response",
         "//internal/codygateway",
-        "//internal/httpcli",
         "//internal/trace",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
@@ -51,34 +51,25 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 	})
 
 	embeddings := make([]codygateway.Embedding, len(response.Data))
-OUTER:
 	for i, d := range response.Data {
 		if len(d.Embedding) > 0 {
 			embeddings[i] = codygateway.Embedding{
 				Index: d.Index,
 				Data:  d.Embedding,
 			}
-			continue
-		}
-
-	INNER:
-		for j := 0; j < 3; j++ {
-			// Nondeterministically, the OpenAI API will occasionally send back a `null` for
-			// an embedding in the response. Try it again a few times and hope for the best.
-			response, err := c.requestEmbeddings(ctx, model, []string{input.Input[d.Index]})
+		} else {
+			// HACK(camdencheek): Nondeterministically, the OpenAI API will
+			// occasionally send back a `null` for an embedding in the
+			// response. Try it again a few times and hope for the best.
+			resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, model, input.Input[d.Index], 3)
 			if err != nil {
 				return nil, 0, err
 			}
-			if len(response.Data) != 1 || len(response.Data[0].Embedding) != model.dimensions {
-				continue INNER // retry
-			}
 			embeddings[i] = codygateway.Embedding{
-				Index: i,
-				Data:  response.Data[0].Embedding,
+				Index: d.Index,
+				Data:  resp.Data[0].Embedding,
 			}
-			continue OUTER // success
 		}
-		return nil, 0, errors.New("null response returned for embedding")
 	}
 
 	return &codygateway.EmbeddingsResponse{
@@ -86,6 +77,20 @@ OUTER:
 		Model:           response.Model,
 		ModelDimensions: model.dimensions,
 	}, response.Usage.TotalTokens, nil
+}
+
+func (c *openaiClient) requestSingleEmbeddingWithRetryOnNull(ctx context.Context, model openAIModel, input string, retries int) (resp *openaiEmbeddingsResponse, err error) {
+	for i := 0; i < retries; i++ {
+		resp, err = c.requestEmbeddings(ctx, model, []string{input})
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Data) != 1 || len(resp.Data[0].Embedding) != model.dimensions {
+			continue // retry
+		}
+		return resp, err
+	}
+	return nil, errors.Newf("null response for embedding after %d retries", retries)
 }
 
 func (c *openaiClient) requestEmbeddings(ctx context.Context, model openAIModel, input []string) (*openaiEmbeddingsResponse, error) {

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
@@ -27,63 +27,15 @@ type openaiClient struct {
 const apiURL = "https://api.openai.com/v1/embeddings"
 
 func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway.EmbeddingsRequest) (*codygateway.EmbeddingsResponse, int, error) {
-	for _, s := range input.Input {
-		if s == "" {
-			// The OpenAI API will return an error if any of the strings in texts is an empty string,
-			// so fail fast to avoid making tons of retryable requests.
-			return nil, 0, response.NewHTTPStatusCodeError(http.StatusBadRequest, errors.New("cannot generate embeddings for an empty string"))
-		}
-	}
-
-	openAIModel, ok := openAIModelMappings[input.Model]
+	model, ok := openAIModelMappings[input.Model]
 	if !ok {
 		return nil, 0, response.NewHTTPStatusCodeError(http.StatusBadRequest, errors.Newf("no OpenAI model found for %q", input.Model))
 	}
 
-	request := openaiEmbeddingsRequest{
-		Model: openAIModel.upstreamName,
-		Input: input.Input,
-		// TODO: Maybe set user.
-	}
-
-	bodyBytes, err := json.Marshal(request)
+	response, err := c.requestEmbeddings(ctx, model, input.Input)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, 0, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.accessToken)
-
-	resp, err := httpcli.ExternalDoer.Do(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
-		// If we are being rate limited by OpenAI, we don't want to forward that error and instead
-		// return a 503 to the client. It's not them being limited, it's us and that an operations
-		// error on our side.
-		if resp.StatusCode == http.StatusTooManyRequests {
-			return nil, 0, response.NewHTTPStatusCodeError(http.StatusServiceUnavailable, errors.Newf("we're facing too much load at the moment, please retry"))
-		}
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		// We don't forward the status code here, everything but 429 should turn into a 500 error.
-		return nil, 0, errors.Errorf("embeddings: %s %q: failed with status %d: %s", req.Method, req.URL.String(), resp.StatusCode, string(respBody))
-	}
-
-	var response openaiEmbeddingsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		// Although we might've incurred cost at this point, we don't want to count
-		// that towards the rate limit of the requester, so return 0 for the consumed
-		// token count.
-		return nil, 0, err
-	}
-
 	// Ensure embedding responses are sorted in the original order.
 	sort.Slice(response.Data, func(i, j int) bool {
 		return response.Data[i].Index < response.Data[j].Index
@@ -91,6 +43,22 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 
 	embeddings := make([]codygateway.Embedding, len(response.Data))
 	for i, d := range response.Data {
+		if len(d.Embedding) == 0 {
+			// Nondeterministically, the OpenAI API will occasionally send back a `null` for
+			// an embedding in the response. Try it again and hope for the best.
+			response, err := c.requestEmbeddings(ctx, model, []string{input.Input[d.Index]})
+			if err != nil {
+				return nil, 0, err
+			}
+			if len(response.Data) != 1 || len(response.Data[0].Embedding) != model.dimensions {
+				return nil, 0, errors.New("null response returned for embedding")
+			}
+			embeddings[i] = codygateway.Embedding{
+				Index: i,
+				Data:  response.Data[0].Embedding,
+			}
+			continue
+		}
 		embeddings[i] = codygateway.Embedding{
 			Index: d.Index,
 			Data:  d.Embedding,
@@ -100,8 +68,64 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 	return &codygateway.EmbeddingsResponse{
 		Embeddings:      embeddings,
 		Model:           response.Model,
-		ModelDimensions: openAIModel.dimensions,
+		ModelDimensions: model.dimensions,
 	}, response.Usage.TotalTokens, nil
+}
+
+func (c *openaiClient) requestEmbeddings(ctx context.Context, model openAIModel, input []string) (*openaiEmbeddingsResponse, error) {
+	for _, s := range input {
+		if s == "" {
+			// The OpenAI API will return an error if any of the strings in texts is an empty string,
+			// so fail fast to avoid making tons of retryable requests.
+			return nil, response.NewHTTPStatusCodeError(http.StatusBadRequest, errors.New("cannot generate embeddings for an empty string"))
+		}
+	}
+
+	request := openaiEmbeddingsRequest{
+		Model: model.upstreamName,
+		Input: input,
+		// TODO: Maybe set user.
+	}
+
+	bodyBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.accessToken)
+
+	resp, err := httpcli.ExternalDoer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
+		// If we are being rate limited by OpenAI, we don't want to forward that error and instead
+		// return a 503 to the client. It's not them being limited, it's us and that an operations
+		// error on our side.
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return nil, response.NewHTTPStatusCodeError(http.StatusServiceUnavailable, errors.Newf("we're facing too much load at the moment, please retry"))
+		}
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		// We don't forward the status code here, everything but 429 should turn into a 500 error.
+		return nil, errors.Errorf("embeddings: %s %q: failed with status %d: %s", req.Method, req.URL.String(), resp.StatusCode, string(respBody))
+	}
+
+	var response openaiEmbeddingsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		// Although we might've incurred cost at this point, we don't want to count
+		// that towards the rate limit of the requester, so return 0 for the consumed
+		// token count.
+		return nil, err
+	}
+
+	return &response, nil
 }
 
 type openaiEmbeddingsRequest struct {

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
@@ -10,17 +10,18 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/response"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func NewOpenAIClient(accessToken string) EmbeddingsClient {
+func NewOpenAIClient(httpClient *http.Client, accessToken string) EmbeddingsClient {
 	return &openaiClient{
+		httpClient:  httpClient,
 		accessToken: accessToken,
 	}
 }
 
 type openaiClient struct {
+	httpClient  *http.Client
 	accessToken string
 }
 
@@ -99,7 +100,7 @@ func (c *openaiClient) requestEmbeddings(ctx context.Context, model openAIModel,
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.accessToken)
 
-	resp, err := httpcli.ExternalDoer.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
@@ -2,7 +2,10 @@ package embeddings
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
@@ -17,4 +20,126 @@ func TestOpenAI(t *testing.T) {
 		})
 		require.ErrorContains(t, err, "empty string")
 	})
+
+	t.Run("retry on empty embedding", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingsResponse{
+					Data: []openaiEmbeddingsData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 1),
+					}, {
+						Index:     1,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. This time, actually return a value.
+			if !gotRequest2 {
+				resp := openaiEmbeddingsResponse{
+					Data: []openaiEmbeddingsData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 2),
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewOpenAIClient(s.Client(), "")
+		resp, _, err := client.GenerateEmbeddings(context.Background(), codygateway.EmbeddingsRequest{
+			Model: string(ModelNameOpenAIAda),
+			Input: []string{"a", "b"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, &codygateway.EmbeddingsResponse{
+			ModelDimensions: 1536,
+			Embeddings: []codygateway.Embedding{{
+				Index: 0,
+				Data:  append(make([]float32, 1535), 1),
+			}, {
+				Index: 1,
+				Data:  append(make([]float32, 1535), 2),
+			}},
+		}, resp)
+		require.True(t, gotRequest1)
+		require.True(t, gotRequest2)
+	})
+
+	t.Run("retry on empty embedding fails", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingsResponse{
+					Data: []openaiEmbeddingsData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 1),
+					}, {
+						Index:     1,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. Return null again. The client should fail.
+			if !gotRequest2 {
+				resp := openaiEmbeddingsResponse{
+					Data: []openaiEmbeddingsData{{
+						Index:     0,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+
+		// HACK: override the URL to always go to the test server
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewOpenAIClient(s.Client(), "")
+		_, _, err := client.GenerateEmbeddings(context.Background(), codygateway.EmbeddingsRequest{
+			Model: string(ModelNameOpenAIAda),
+			Input: []string{"a", "b"},
+		})
+		require.Error(t, err, "expected request to error on failed retry")
+	})
 }
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
@@ -87,7 +87,6 @@ func TestOpenAI(t *testing.T) {
 
 	t.Run("retry on empty embedding fails", func(t *testing.T) {
 		gotRequest1 := false
-		gotRequest2 := false
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			// On the first request, respond with a null embedding
 			if !gotRequest1 {
@@ -105,20 +104,15 @@ func TestOpenAI(t *testing.T) {
 				return
 			}
 
-			// The client should try that embedding once more. Return null again. The client should fail.
-			if !gotRequest2 {
-				resp := openaiEmbeddingsResponse{
-					Data: []openaiEmbeddingsData{{
-						Index:     0,
-						Embedding: nil,
-					}},
-				}
-				json.NewEncoder(w).Encode(resp)
-				gotRequest2 = true
-				return
+			// After the first request, always respond with an invalid response
+			resp := openaiEmbeddingsResponse{
+				Data: []openaiEmbeddingsData{{
+					Index:     0,
+					Embedding: nil,
+				}},
 			}
-
-			panic("only expected 2 responses")
+			json.NewEncoder(w).Encode(resp)
+			return
 		}))
 		defer s.Close()
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
@@ -2,6 +2,7 @@ package embeddings
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
@@ -10,7 +11,7 @@ import (
 
 func TestOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
-		client := NewOpenAIClient("")
+		client := NewOpenAIClient(http.DefaultClient, "")
 		_, _, err := client.GenerateEmbeddings(context.Background(), codygateway.EmbeddingsRequest{
 			Input: []string{"a", ""}, // empty string is invalid
 		})

--- a/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/notify"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 )
 
@@ -95,7 +96,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 							rs,
 							config.RateLimitNotifier,
 							embeddings.ModelFactoryMap{
-								embeddings.ModelNameOpenAIAda: embeddings.NewOpenAIClient(config.OpenAIAccessToken),
+								embeddings.ModelNameOpenAIAda: embeddings.NewOpenAIClient(httpcli.ExternalClient, config.OpenAIAccessToken),
 							},
 							config.EmbeddingsAllowedModels,
 						),

--- a/enterprise/internal/embeddings/embed/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/binary",
         "//internal/codeintel/types",
         "//internal/conf/conftypes",
+        "//internal/httpcli",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/enterprise/internal/embeddings/embed/client/openai/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/client/openai/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//internal/conf/conftypes",
-        "//internal/httpcli",
         "//lib/errors",
     ],
 )

--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -115,8 +115,9 @@ func (c *openaiEmbeddingsClient) getEmbeddings(ctx context.Context, texts []stri
 		if len(embedding.Embedding) != 0 {
 			embeddings = append(embeddings, embedding.Embedding...)
 		} else {
-			// Nondeterministically, the OpenAI API will occasionally send back a `null` for
-			// an embedding in the response. Try it again a few times and hope for the best.
+			// HACK(camdencheek): Nondeterministically, the OpenAI API will
+			// occasionally send back a `null` for an embedding in the
+			// response. Try it again a few times and hope for the best.
 			resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, augmentedTexts[embedding.Index], 3)
 			if err != nil {
 				return nil, err

--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -18,6 +18,7 @@ import (
 
 func NewClient(httpClient *http.Client, config *conftypes.EmbeddingsConfig) *openaiEmbeddingsClient {
 	return &openaiEmbeddingsClient{
+		httpClient:  httpClient,
 		dimensions:  config.Dimensions,
 		accessToken: config.AccessToken,
 		model:       config.Model,
@@ -165,8 +166,10 @@ type openaiEmbeddingAPIRequest struct {
 }
 
 type openaiEmbeddingAPIResponse struct {
-	Data []struct {
-		Index     int       `json:"index"`
-		Embedding []float32 `json:"embedding"`
-	} `json:"data"`
+	Data []openaiEmbeddingAPIResponseData `json:"data"`
+}
+
+type openaiEmbeddingAPIResponseData struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
 }

--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -111,19 +111,28 @@ func (c *openaiEmbeddingsClient) getEmbeddings(ctx context.Context, texts []stri
 
 	dimensionality := len(response.Data[0].Embedding)
 	embeddings := make([]float32, 0, len(response.Data)*dimensionality)
+OUTER:
 	for _, embedding := range response.Data {
-		if len(embedding.Embedding) == 0 {
+		if len(embedding.Embedding) != 0 {
+			embeddings = append(embeddings, embedding.Embedding...)
+			continue
+		}
+
+		// Nondeterministically, the OpenAI API will occasionally send back a `null` for
+		// an embedding in the response. Try it again a few times and hope for the best.
+	INNER:
+		for i := 0; i < 3; i++ {
 			response, err := c.do(ctx, openaiEmbeddingAPIRequest{Model: c.model, Input: []string{augmentedTexts[embedding.Index]}})
 			if err != nil {
 				return nil, err
 			}
 			if len(response.Data) != 1 || len(response.Data[0].Embedding) == 0 {
-				return nil, errors.New("null response for embedding")
+				continue INNER // retry
 			}
 			embeddings = append(embeddings, response.Data[0].Embedding...)
-			continue
+			continue OUTER // success
 		}
-		embeddings = append(embeddings, embedding.Embedding...)
+		return nil, errors.New("null response for embedding")
 	}
 
 	return embeddings, nil

--- a/enterprise/internal/embeddings/embed/client/openai/client.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client.go
@@ -13,11 +13,10 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func NewClient(config *conftypes.EmbeddingsConfig) *openaiEmbeddingsClient {
+func NewClient(httpClient *http.Client, config *conftypes.EmbeddingsConfig) *openaiEmbeddingsClient {
 	return &openaiEmbeddingsClient{
 		dimensions:  config.Dimensions,
 		accessToken: config.AccessToken,
@@ -27,6 +26,7 @@ func NewClient(config *conftypes.EmbeddingsConfig) *openaiEmbeddingsClient {
 }
 
 type openaiEmbeddingsClient struct {
+	httpClient  *http.Client
 	model       string
 	dimensions  int
 	endpoint    string
@@ -141,7 +141,7 @@ func (c *openaiEmbeddingsClient) do(ctx context.Context, request openaiEmbedding
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.accessToken)
 
-	resp, err := httpcli.ExternalDoer.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/embeddings/embed/client/openai/client_test.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -10,7 +11,7 @@ import (
 
 func TestOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
-		client := NewClient(&conftypes.EmbeddingsConfig{})
+		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
 		invalidTexts := []string{"a", ""} // empty string is invalid
 		_, err := client.GetEmbeddingsWithRetries(context.Background(), invalidTexts, 10)
 		require.ErrorContains(t, err, "empty string")

--- a/enterprise/internal/embeddings/embed/client/openai/client_test.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client_test.go
@@ -83,7 +83,6 @@ func TestOpenAI(t *testing.T) {
 
 	t.Run("retry on empty embedding fails", func(t *testing.T) {
 		gotRequest1 := false
-		gotRequest2 := false
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			// On the first request, respond with a null embedding
 			if !gotRequest1 {
@@ -101,20 +100,14 @@ func TestOpenAI(t *testing.T) {
 				return
 			}
 
-			// The client should try that embedding once more. Return null again. The client should fail.
-			if !gotRequest2 {
-				resp := openaiEmbeddingAPIResponse{
-					Data: []openaiEmbeddingAPIResponseData{{
-						Index:     0,
-						Embedding: nil,
-					}},
-				}
-				json.NewEncoder(w).Encode(resp)
-				gotRequest2 = true
-				return
+			// Always return an invalid response to all the retry requests
+			resp := openaiEmbeddingAPIResponse{
+				Data: []openaiEmbeddingAPIResponseData{{
+					Index:     0,
+					Embedding: nil,
+				}},
 			}
-
-			panic("only expected 2 responses")
+			json.NewEncoder(w).Encode(resp)
 		}))
 		defer s.Close()
 

--- a/enterprise/internal/embeddings/embed/client/openai/client_test.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client_test.go
@@ -2,7 +2,10 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -16,4 +19,118 @@ func TestOpenAI(t *testing.T) {
 		_, err := client.GetEmbeddingsWithRetries(context.Background(), invalidTexts, 10)
 		require.ErrorContains(t, err, "empty string")
 	})
+
+	t.Run("retry on empty embedding", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 1),
+					}, {
+						Index:     1,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. This time, actually return a value.
+			if !gotRequest2 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 2),
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+
+		// HACK: override the URL to always go to the test server
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		resp, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		require.NoError(t, err)
+		var expected []float32
+		{
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 1)
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 2)
+		}
+		require.Equal(t, expected, resp)
+		require.True(t, gotRequest1)
+		require.True(t, gotRequest2)
+	})
+
+	t.Run("retry on empty embedding fails", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 1),
+					}, {
+						Index:     1,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. Return null again. The client should fail.
+			if !gotRequest2 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		_, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		require.Error(t, err, "expected request to error on failed retry")
+	})
 }
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -23,7 +24,7 @@ func NewEmbeddingsClient(config *conftypes.EmbeddingsConfig) (client.EmbeddingsC
 	case "sourcegraph":
 		return sourcegraph.NewClient(config), nil
 	case "openai":
-		return openai.NewClient(config), nil
+		return openai.NewClient(httpcli.ExternalClient, config), nil
 	default:
 		return nil, errors.Newf("invalid provider %q", config.Provider)
 	}


### PR DESCRIPTION
The OpenAI embeddings API will nondeterministically return `null` for the `embedding:` field in the bulk embeddings API response payload. This is problematic because it causes our embeddings jobs to fail (previously, it would corrupt them, now we error). Retrying the whole request will sometimes help, but for some repos, there might be many duplicated chunks, so all of them need to succeed together for the full bulk request to succeed. 

This PR retries the failed chunks individually so that we don't need to depend on all the failing chunks to succeed in the same request. It's pretty hacky, and has a lot of duplication since we have two independent OpenAI clients, but refactoring that will need to be a followup. 

## Test plan

Added tests with a real HTTP server that repsonds with the invalid payloads like we were seeing from OpenAI. Also manually tested that this allows a repo whose embeddings job was previously consistently failing to now consistently succeed. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
