### PR TITLE
Add nil checks on usages of ExperimentalFeatures

### DIFF
--- a/cmd/gitserver/server/perforce/perforce.go
+++ b/cmd/gitserver/server/perforce/perforce.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -71,7 +72,7 @@ func NewService(ctx context.Context, obctx *observation.Context, logger log.Logg
 // experimental config for PerforceChangelistMapping is enabled and if the repo belongs to a code
 // host of type PERFORCE.
 func (s *Service) EnqueueChangelistMappingJob(job *changelistMappingJob) {
-	if conf.Get().ExperimentalFeatures.PerforceChangelistMapping != "enabled" {
+	if c := conf.Get(); c.ExperimentalFeatures == nil || c.ExperimentalFeatures.PerforceChangelistMapping != "enabled" {
 		return
 	}
 

--- a/enterprise/internal/batches/types/util.go
+++ b/enterprise/internal/batches/types/util.go
@@ -30,7 +30,7 @@ func GetSupportedExternalServices() map[string]CodehostCapabilities {
 		extsvc.TypeAzureDevOps:     {CodehostCapabilityDraftChangesets: true},
 		extsvc.TypeGerrit:          {CodehostCapabilityDraftChangesets: true},
 	}
-	if conf.Get().ExperimentalFeatures != nil && conf.Get().ExperimentalFeatures.BatchChangesEnablePerforce {
+	if c := conf.Get(); c.ExperimentalFeatures != nil && c.ExperimentalFeatures.BatchChangesEnablePerforce {
 		supportedExternalServices[extsvc.TypePerforce] = CodehostCapabilities{}
 	}
 

--- a/internal/grpc/grpc.go
+++ b/internal/grpc/grpc.go
@@ -39,5 +39,8 @@ func IsGRPCEnabled(ctx context.Context) bool {
 	if val, err := strconv.ParseBool(os.Getenv(envGRPCEnabled)); err == nil {
 		return val
 	}
-	return conf.Get().ExperimentalFeatures.EnableGRPC
+	if c := conf.Get(); c.ExperimentalFeatures != nil {
+		return c.ExperimentalFeatures.EnableGRPC
+	}
+	return false
 }


### PR DESCRIPTION
`ExperimentalFeatures` is not guaranteed to be non-nil. That can cause problems, especially in tests that don't mock the site config.

## Test plan

existing tests should still succeed
