### PR TITLE
cody-web: change wording from 'available' to 'enabled'

### DIFF
--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -369,7 +369,7 @@ const CodyNotEnabledNotice: React.FunctionComponent = React.memo(function CodyNo
                         </>
                     ) : (
                         <>
-                            Cody isn't available on this instance, but you can learn more about Cody{' '}
+                            Cody isn't enabled on this instance, but you can learn more about Cody{' '}
                             <Link to="https://about.sourcegraph.com/cody?utm_source=server">here</Link>.
                         </>
                     )}


### PR DESCRIPTION
I think "enabled" is better since it suggests it _can_ be enabled vs. not available which means to me that I have the wrong version or something.

## Test plan

- Manual testing