### PR TITLE
Push wolfi base images to Dockerhub

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -1,6 +1,6 @@
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
-# Quick script to get the latest tags for each of the base images:
+# Quick script to get the latest tags for each of the base images from GCR:
 #
 # grep 'image = ' ./dev/oci_deps.bzl | while read -r str ; do
 #   str_no_spaces="${str#"${str%%[![:space:]]*}"}"  # remove leading spaces
@@ -14,160 +14,177 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 #   echo $url
 #   echo $DIGEST
 # done
+#
+#
+# Quick script to get the latest tags for each of the base images from Dockerhub:
+# grep 'image = ' ./dev/oci_deps.bzl | while read -r str ; do
+#   str_no_spaces="${str#"${str%%[![:space:]]*}"}"  # remove leading spaces
+#   url="${str_no_spaces#*\"}"  # remove prefix until first quote
+#   url="${url%%\"*}"  # remove suffix from first quote
+
+#     TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${url}:pull" | jq -r .token)
+
+#   DIGEST=$(curl -I -s -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+#     https://registry-1.docker.io/v2/${url}/manifests/latest \
+#     | grep -i Docker-Content-Digest | awk '{print $2}')
+
+#   echo -e "$url\n$DIGEST\n\n"
+# done
 
 def oci_deps():
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:8d80271a8d8f7b8fa7ff62b2e009ab3f0f81c5407872144db8cb30b396801853",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-sourcegraph-base",
+        digest = "sha256:787447d9103e52faf924e7fcd71bb052f5cecb99b75ec6cd2f37453405781bd3",
+        image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:2e5aec9ba5a4835b4c35103bd27ad2ad3e65a064ec5001a35168044dd8c06a4a",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-cadvisor-base",
+        digest = "sha256:42e9626596c7e3873f9ea66b87732273bc93f20d05499d410160468f40d585f5",
+        image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:a5d6a10698466e1a7198ca17e41a3c6c8cd7228ae562352abbdac829e539fc75",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-symbols-base",
+        digest = "sha256:4bc66d4d457f0d32ff359389bf4da1d3b6864043a7ee2e679f80a8d0d5daae32",
+        image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:d1c7262de00d6d87a001e208c23c9551c67ec722f1eeac2a016b77ca6d539c2d",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-server-base",
+        digest = "sha256:56bbb8bc2ae9b591f23ef6acc249eca3ca8678c02fd5a04b4260bee2a56f2437",
+        image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:eae7c238c7c33d59752973b6bcb678b25dce1a759a0cece6d8350e4230d4ea49",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-gitserver-base",
+        digest = "sha256:37100ed0a90e13f0a84fb7e05b49e75700ebb0b036612f36f5afca69fbcbf86f",
+        image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
     oci_pull(
         name = "wolfi_grafana_base",
         digest = "sha256:ec1049f35ff7e4ab6ff7b4cc6790996ad74d196b8dcee8ea5283fca759156637",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-grafana",
+        image = "index.docker.io/sourcegraph/wolfi-grafana",
     )
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:b51ae2b70cd7cd7883e8057d69a74c959fd5f03d723538908ea8f47a0a322e02",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-postgres-exporter-base",
+        digest = "sha256:21fe5b8ada61899c7f5afeb3fa36078471d555d0d4237c66d87c105770d868b2",
+        image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:6d978aa3cc31e3410088ef4a3220fe419878c0b53e604c9323b343d0044ed9d3",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-jaeger-all-in-one-base",
+        digest = "sha256:232c2761cf712a820eeb428fc8d023fb6cecca6af4bbb8bfc7ff2c7f8396a9cc",
+        image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:a7dd18fa67c5c02f1f6ba6f503a2249a1fe103bfe47775a2faa041b16895c59c",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-jaeger-agent-base",
+        digest = "sha256:6ab25a722ef49bbe29d0682cfb9db2dc122e21ce0e25184b45ce77ed2b1a978d",
+        image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:d72b41d737473226ddf3a752bec885caaf1bd93adaecbb33dc0cce693f261b5e",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-redis-base",
+        digest = "sha256:12deb901ebeb581e0fc1b175f63235e1915795e1821d0f06dcde0c2030018d17",
+        image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:97924b18f530386f524df14b8172963c54d1378727cea72004bef8ae2490e871",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-redis-exporter-base",
+        digest = "sha256:540db7c4d1a033d7cfc242e6c7a87ae4682459e3c82d99fe6f8d04a004e95367",
+        image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:06ce2e349550d2e99c96a5610746fa2a3b743790bd0c16d896847434551afead",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-syntax-highlighter-base",
+        digest = "sha256:a637dc7a1045e6324048c35b8d2dd427d421304eaba64b486581f0a1d1f3e0c6",
+        image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:7a3f1327e75de7d3ace2240e650b82a44f4a70bd988548786880c3eebb02143e",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-search-indexer-base",
+        digest = "sha256:bdd50db38bf7562c142f8d88a618c9a9b4bcb060e1c374a7fcd8bef33c06a831",
+        image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:2e49220a8e69a8f1f92fe1c2da08efd35a9d7226e76220a5b39c124d8231092b",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-repo-updater-base",
+        digest = "sha256:2a891f3d48272b4e4adc7a7aa7f9597c18c2685ce5ba3a42f8d6745e9e3eeac5",
+        image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:3029998bad3b614efde5ff2dbe8287b4fa5e38cbf1a22c40b37f97f6257aed16",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-searcher-base",
+        digest = "sha256:e7a2efcd084da4057fed5ba342fab6a58f2e20cfb839d383729786ab1a00942a",
+        image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:03c0e699760fda087702baa090b0827471395cbf891807b1f73b48280f345041",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-executor-base",
+        digest = "sha256:7ff7c9030d39e7345d6c8479f5c7a27818f28ddd76a195f30af50bfa5362388b",
+        image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
+    # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:b9a217e4f71e767a19bed1e3d39618ed7258ea726d339776ddf1523267452c8c",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-bundled-executor-base",
+        digest = "sha256:7418c2c8a4da7a044f2e16e6e36f730fe3d3ad41e9af32f1bb471c2026b613c3",
+        image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:0cb7a64371b29f2689ab18f41a71cab51f0976de1a3b850a2d468601f8ab9c48",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-executor-kubernetes-base",
+        digest = "sha256:4afb06ca2d4c4585fecb0443546b7f61f4b88bf8b4f74cb005e712e3e76dda21",
+        image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:3c6c8b6ef31d062c4b9faa461d4533bf0589fab7de9b89040b03e27ca25a4176",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-batcheshelper-base",
+        digest = "sha256:2572c8ed4a5286fab501c209e88261fe21347fca6b749f90eea3d90a768f894b",
+        image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:5089836fad63b647d0a1c1dbb3a10d7abdeea2f0fc76f4c977df21d26d70cf06",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-prometheus-base",
+        digest = "sha256:cc529187858e9e019a6ff2fdb5da4f5cff2d8222987bdc59b386e53eb1fa1a63",
+        image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:e3f597e118056f6c555dbb284b59bf6c29b8ebbd3a4fc6c3df7889db368855a9",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-postgresql-12-base",
+        digest = "sha256:e3272de2b6958aa64d7429aa2251470c4adab777496bb7290fa1a51d53193e7d",
+        image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:78061eee8c728a9d732c1bfd6012baf5f4ad2f087acd18c17a6d749f7a0d459f",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-postgresql-12-codeinsights-base",
+        digest = "sha256:a242c9a88552a7af2d70f4be835267cf89e4639f8607dea7a9f98c2909136734",
+        image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:9f7149d05afad6e3581a7a4bc13c60cad5d314bab7307e1dcd47d1c6bb42c497",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-node-exporter-base",
+        digest = "sha256:958a60217909ab5986cd5e116151a7f5ba96cf4cb0a7c25843ccbc0b6d1440c2",
+        image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:2b410f0807c8db91ac324edf48b9b657bf7ddabfe7553d0d32d2f5e77db23a7e",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-opentelemetry-collector-base",
+        digest = "sha256:7db1b0609502e55e55bade8fd22852456cd81f8cbb780cfdb233b28c5778ce50",
+        image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:3029998bad3b614efde5ff2dbe8287b4fa5e38cbf1a22c40b37f97f6257aed16",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-searcher-base",
+        digest = "sha256:e7a2efcd084da4057fed5ba342fab6a58f2e20cfb839d383729786ab1a00942a",
+        image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:92614e804e5a5cb5316f8d9235286b659d8957c557170ddefda2973053ca5e4d",
-        image = "us.gcr.io/sourcegraph-dev/wolfi-blobstore-base",
+        digest = "sha256:7e9e3e471fe8a3483e86a3c246b023684b20ebe249dc6ea0c5a9fef1bced5395",
+        image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )

--- a/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
@@ -63,8 +63,16 @@ apko build --debug "${name}.yaml" \
 # Tag image and upload to GCP Artifact Registry
 docker load <"$tarball"
 
+# Push to internal dev repo
 docker tag "$image_name" "us.gcr.io/sourcegraph-dev/wolfi-${name}-base:$tag"
 docker push "us.gcr.io/sourcegraph-dev/wolfi-${name}-base:$tag"
-# Temporary convenience during initial development, as this doesn't scale to multiple branches!
+# TODO(will): Limit to main branch when Wolfi CI is running on main
 docker tag "$image_name" "us.gcr.io/sourcegraph-dev/wolfi-${name}-base:latest"
 docker push "us.gcr.io/sourcegraph-dev/wolfi-${name}-base:latest"
+
+# Push to dockerhub
+# TODO(will): Limit to main branch when Wolfi CI is running on main
+docker tag "$image_name" "sourcegraph/wolfi-${name}-base:$tag"
+docker push "sourcegraph/wolfi-${name}-base:$tag"
+docker tag "$image_name" "sourcegraph/wolfi-${name}-base:latest"
+docker push "sourcegraph/wolfi-${name}-base:latest"

--- a/wolfi-images/batcheshelper.yaml
+++ b/wolfi-images/batcheshelper.yaml
@@ -9,4 +9,4 @@ contents:
     ## batcheshelper packages
     - 'git>=2.38.1'
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/blobstore.yaml
+++ b/wolfi-images/blobstore.yaml
@@ -18,4 +18,4 @@ paths:
 
 work-dir: /opt/s3proxy
 
-# MANUAL REBUILD: Wed Jun 21 16:29:51 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -10,7 +10,7 @@ contents:
     - ca-certificates
     - git
     - maven
-    - openjdk-11
+    - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
     - openjdk-11-default-jvm
     - python3
     - py3-pip

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -21,4 +21,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/cadvisor.yaml
+++ b/wolfi-images/cadvisor.yaml
@@ -9,4 +9,4 @@ contents:
     ## cadvisor dependencies
     - cadvisor
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/executor-kubernetes.yaml
+++ b/wolfi-images/executor-kubernetes.yaml
@@ -9,4 +9,4 @@ contents:
     ## executor-kubernetes packages
     - git
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/executor.yaml
+++ b/wolfi-images/executor.yaml
@@ -16,4 +16,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -27,4 +27,4 @@ paths:
 
 work-dir: /
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/jaeger-agent.yaml
+++ b/wolfi-images/jaeger-agent.yaml
@@ -20,4 +20,4 @@ accounts:
       uid: 10001
       gid: 10002
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/jaeger-all-in-one.yaml
+++ b/wolfi-images/jaeger-all-in-one.yaml
@@ -26,4 +26,4 @@ paths:
     uid: 10001
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/node-exporter.yaml
+++ b/wolfi-images/node-exporter.yaml
@@ -5,4 +5,4 @@ contents:
     ## node-exporter-specific packages
     - 'prometheus-node-exporter=1.5.0-r3' # IMPORTANT: Pinned version for managed updates
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/opentelemetry-collector.yaml
+++ b/wolfi-images/opentelemetry-collector.yaml
@@ -16,4 +16,4 @@ paths:
 
 work-dir: /otel-collector
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/postgres-exporter.yaml
+++ b/wolfi-images/postgres-exporter.yaml
@@ -19,4 +19,4 @@ accounts:
       uid: 20001
       gid: 102
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/postgresql-12-codeinsights.yaml
+++ b/wolfi-images/postgresql-12-codeinsights.yaml
@@ -33,4 +33,4 @@ accounts:
       uid: 70
       gid: 70
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/postgresql-12.yaml
+++ b/wolfi-images/postgresql-12.yaml
@@ -59,4 +59,4 @@ paths:
     gid: 999
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/prometheus.yaml
+++ b/wolfi-images/prometheus.yaml
@@ -24,4 +24,4 @@ paths:
 
 work-dir: /prometheus
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/redis-exporter.yaml
+++ b/wolfi-images/redis-exporter.yaml
@@ -9,4 +9,4 @@ contents:
     ## redis_exporter packages
     - redis_exporter@sourcegraph
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/redis.yaml
+++ b/wolfi-images/redis.yaml
@@ -31,4 +31,4 @@ work-dir: /redis-data
 entrypoint:
   command: redis-server
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/repo-updater.yaml
+++ b/wolfi-images/repo-updater.yaml
@@ -10,4 +10,4 @@ contents:
     - coursier@sourcegraph
     - p4cli@sourcegraph
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/search-indexer.yaml
+++ b/wolfi-images/search-indexer.yaml
@@ -23,4 +23,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/searcher.yaml
+++ b/wolfi-images/searcher.yaml
@@ -19,4 +19,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -78,4 +78,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 21 16:30:05 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -42,4 +42,4 @@ annotations:
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://docs.sourcegraph.com/
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/sourcegraph-dev.yaml
+++ b/wolfi-images/sourcegraph-dev.yaml
@@ -9,4 +9,4 @@ contents:
     ## Dev-specific tools
     - apk-tools
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/sourcegraph.yaml
+++ b/wolfi-images/sourcegraph.yaml
@@ -37,4 +37,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/symbols.yaml
+++ b/wolfi-images/symbols.yaml
@@ -19,4 +19,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/syntax-highlighter.yaml
+++ b/wolfi-images/syntax-highlighter.yaml
@@ -10,4 +10,4 @@ contents:
     - libstdc++
     - http-server-stabilizer@sourcegraph
 
-# MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023
+# MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023


### PR DESCRIPTION
We need to push Wolfi base images to dockerhub to make them publicly accessible.

Once a first review pass has been made on this, we can push to a `wolfi/*` branch and check it works as expected.

I'll follow this with a second PR to switch `oci_deps.bzl` to point to dockerhub as well.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
- Manually checking images are uploaded to dockerhub.
- Green `wolfi/` CI: https://buildkite.com/sourcegraph/sourcegraph/builds/229782
- Green main-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/229784