### PR TITLE
[Backport] s3proxy vulnerability fixes

### DIFF
--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -95,6 +95,10 @@ oci_image(
         "JCLOUDS_KEYSTONE_SCOPE": "",
         "JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME": "",
         "JCLOUDS_FILESYSTEM_BASEDIR": "/data",
+        # We don't use the secure endpoint, but these values must be set
+        "S3PROXY_SECURE_ENDPOINT": "https://0.0.0.0:9443",
+        "S3PROXY_KEYSTORE_PATH": "test-classes/keystore.jks",
+        "S3PROXY_KEYSTORE_PASSWORD": "password",
     },
     user = "sourcegraph",
 )

--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -50,6 +50,10 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	SetDefaultEnv("JCLOUDS_KEYSTONE_SCOPE", "")
 	SetDefaultEnv("JCLOUDS_KEYSTONE_PROJECT_DOMAIN_NAME", "")
 	// SetDefaultEnv("JCLOUDS_FILESYSTEM_BASEDIR", dataDir) // overridden above; here for equality with Dockerfile
+	// We don't use the secure endpoint, but these values must be set
+	SetDefaultEnv("S3PROXY_SECURE_ENDPOINT", "https://0.0.0.0:9443")
+	SetDefaultEnv("S3PROXY_KEYSTORE_PATH", "/opt/s3proxy/test-classes/keystore.jks")
+	SetDefaultEnv("S3PROXY_KEYSTORE_PASSWORD", "password")
 
 	// Configure blobstore service
 	blobstoreDataDir := os.Getenv("JCLOUDS_FILESYSTEM_BASEDIR")

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -36,7 +36,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:b4f5d5927d4e53937fdaf8fc9b54414ee87c2e2f288e566cc25bb98771e88008",
+        digest = "sha256:d1c7262de00d6d87a001e208c23c9551c67ec722f1eeac2a016b77ca6d539c2d",
         image = "us.gcr.io/sourcegraph-dev/wolfi-server-base",
     )
 
@@ -168,6 +168,6 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:4299634c0e403059a5a2aeda323181feb8189648c23fd69d0b5d057e0e7966eb",
+        digest = "sha256:92614e804e5a5cb5316f8d9235286b659d8957c557170ddefda2973053ca5e4d",
         image = "us.gcr.io/sourcegraph-dev/wolfi-blobstore-base",
     )


### PR DESCRIPTION
Backport this PR: https://github.com/sourcegraph/sourcegraph/pull/53921

Because some of the build pipeline has diverged, this couldn't be backported automatically so I've created this separate PR to backport the required changes.
This commit is not on main, but it implements the same changes as the above PR.

This is worth backporting as it fixes a number of CVEs in s3proxy.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Green CI main-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/229796
- Manually check final images