### PR TITLE
policies: clean up repository_pattern_lookup table

### DIFF
--- a/enterprise/internal/codeintel/policies/internal/store/configurations.go
+++ b/enterprise/internal/codeintel/policies/internal/store/configurations.go
@@ -373,6 +373,7 @@ func (s *store) DeleteConfigurationPolicyByID(ctx context.Context, id int) (err 
 }
 
 const deleteConfigurationPolicyByIDQuery = `
+BEGIN;
 WITH
 candidate AS (
 	SELECT id, protected
@@ -382,8 +383,12 @@ candidate AS (
 ),
 deleted AS (
 	DELETE FROM lsif_configuration_policies WHERE id IN (SELECT id FROM candidate WHERE NOT protected)
+),
+deleted2 AS (
+	DELETE FROM lsif_configuration_policies_repository_pattern_lookup WHERE policy_id IN (SELECT id FROM candidate WHERE NOT protected)
 )
-SELECT protected FROM candidate
+SELECT protected FROM candidate;
+COMMIT;
 `
 
 //


### PR DESCRIPTION
I noticed that `lsif_configuration_policies_repository_pattern_lookup` has records of resolved repos for deleted policies

With this change we delete the resolved repos in `lsif_configuration_policies_repository_pattern_lookup` if the corresponding policy in 'lsif_configuration_policies' is deleted.

I considered adding a foreign key constraint to `lsif_configuration_policies_repository_pattern_lookup`, but the BackCompat tests failed because truncation (without CASCADE) doesn't work anymore.

## Test plan:
- CI
- I created a policy and deleted it and verified that the entries for the resolved repos are deleted, too. I also verified that existing entries are not checked against the constraint.
