### PR TITLE
[backport] bzl: use old method for getting VERSION stamping

### DIFF
--- a/dev/bazel_stamp_vars.sh
+++ b/dev/bazel_stamp_vars.sh
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 
-build_number="${BUILDKITE_BUILD_NUMBER:-000000}"
-date_fragment="$(date +%Y-%m-%d)"
-latest_tag="5.0"
-
-# We historically use 12 chars for short commits.
-commit="$(git rev-parse HEAD)"
-commit="${commit:0:12}"
-
-stamp_version="${build_number}_${date_fragment}_${latest_tag}-${commit}"
-
-echo STABLE_VERSION "$stamp_version"
+echo STABLE_VERSION "$VERSION"
 echo VERSION_TIMESTAMP "$(date +%s)"
 
 # Unstable Buildkite env vars


### PR DESCRIPTION
New way of handling version stamping was written with the idea that we'll move away from the pipeline generator. But I didn't follow-up with that impl on the tagged release versions stamping. 

So the best approach at this point is to revert to using the CI generated `VERSION`. 

Need to be backported so we can have a proper release tag and version in the binaries. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + main-dry-run to inspect images 
