### PR TITLE
Cody Gateway - switch dotcom actor id to userid instead of username

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
         "//internal/codygateway",
         "//internal/trace",
         "//lib/errors",
+        "@com_github_graph_gophers_graphql_go//:graphql-go",
+        "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_khan_genqlient//graphql",
         "@com_github_sourcegraph_log//:log",
@@ -26,6 +28,7 @@ go_test(
     deps = [
         "//enterprise/cmd/cody-gateway/internal/dotcom",
         "//internal/codygateway",
+        "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_stretchr_testify//assert",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/dotcom"
@@ -29,7 +30,7 @@ func TestNewActor(t *testing.T) {
 			name: "enabled with rate limits",
 			args: args{
 				dotcom.DotcomUserState{
-					Username: "user",
+					Id: string(relay.MarshalID("User", 10)),
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: true,
@@ -57,7 +58,7 @@ func TestNewActor(t *testing.T) {
 			name: "disabled with rate limits",
 			args: args{
 				dotcom.DotcomUserState{
-					Username: "user",
+					Id: string(relay.MarshalID("User", 10)),
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: false,
@@ -85,7 +86,7 @@ func TestNewActor(t *testing.T) {
 			name: "enabled no limits",
 			args: args{
 				dotcom.DotcomUserState{
-					Username: "user",
+					Id: string(relay.MarshalID("User", 10)),
 					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
 						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
 							Enabled: true,
@@ -94,6 +95,31 @@ func TestNewActor(t *testing.T) {
 				},
 			},
 			wantEnabled:   true,
+			wantChatLimit: 0,
+			wantCodeLimit: 0,
+		},
+		{
+			name: "empty user",
+			args: args{
+				dotcom.DotcomUserState{},
+			},
+			wantEnabled:   false,
+			wantChatLimit: 0,
+			wantCodeLimit: 0,
+		},
+		{
+			name: "invalid userID",
+			args: args{
+				dotcom.DotcomUserState{
+					Id: "NOT_A_VALID_GQL_ID",
+					CodyGatewayAccess: dotcom.DotcomUserStateCodyGatewayAccess{
+						CodyGatewayAccessFields: dotcom.CodyGatewayAccessFields{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			wantEnabled:   false,
 			wantChatLimit: 0,
 			wantCodeLimit: 0,
 		},

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.go
@@ -158,9 +158,9 @@ type CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCody
 	DotcomUserState `json:"-"`
 }
 
-// GetUsername returns CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser.Username, and is useful for accessing the field via an interface.
-func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) GetUsername() string {
-	return v.DotcomUserState.Username
+// GetId returns CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser.Id, and is useful for accessing the field via an interface.
+func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) GetId() string {
+	return v.DotcomUserState.Id
 }
 
 // GetCodyGatewayAccess returns CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser.CodyGatewayAccess, and is useful for accessing the field via an interface.
@@ -194,7 +194,7 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByToken
 }
 
 type __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser struct {
-	Username string `json:"username"`
+	Id string `json:"id"`
 
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
@@ -210,7 +210,7 @@ func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByToken
 func (v *CheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser) __premarshalJSON() (*__premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser, error) {
 	var retval __premarshalCheckDotcomUserAccessTokenDotcomDotcomQueryCodyGatewayDotcomUserByTokenCodyGatewayDotcomUser
 
-	retval.Username = v.DotcomUserState.Username
+	retval.Id = v.DotcomUserState.Id
 	retval.CodyGatewayAccess = v.DotcomUserState.CodyGatewayAccess
 	return &retval, nil
 }
@@ -525,14 +525,14 @@ const (
 // A dotcom user allowed to access the Cody Gateway
 // FOR INTERNAL USE ONLY.
 type DotcomUserState struct {
-	// The user name of the user
-	Username string `json:"username"`
+	// The id of the user
+	Id string `json:"id"`
 	// Cody Gateway access granted to this user. Properties may be inferred from dotcom site config, or be defined in overrides on the user.
 	CodyGatewayAccess DotcomUserStateCodyGatewayAccess `json:"codyGatewayAccess"`
 }
 
-// GetUsername returns DotcomUserState.Username, and is useful for accessing the field via an interface.
-func (v *DotcomUserState) GetUsername() string { return v.Username }
+// GetId returns DotcomUserState.Id, and is useful for accessing the field via an interface.
+func (v *DotcomUserState) GetId() string { return v.Id }
 
 // GetCodyGatewayAccess returns DotcomUserState.CodyGatewayAccess, and is useful for accessing the field via an interface.
 func (v *DotcomUserState) GetCodyGatewayAccess() DotcomUserStateCodyGatewayAccess {
@@ -1184,7 +1184,7 @@ query CheckDotcomUserAccessToken ($token: String!) {
 	}
 }
 fragment DotcomUserState on CodyGatewayDotcomUser {
-	username
+	id
 	codyGatewayAccess {
 		... CodyGatewayAccessFields
 	}

--- a/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
+++ b/enterprise/cmd/cody-gateway/internal/dotcom/operations.graphql
@@ -63,7 +63,7 @@ query ListProductSubscriptions {
 }
 
 fragment DotcomUserState on CodyGatewayDotcomUser {
-    username
+    id
     codyGatewayAccess {
         ...CodyGatewayAccessFields
     }


### PR DESCRIPTION
This converts the dotcom user actor to use the userid as the actor id instead of the username.   
## Test plan
Updated and added tests
`sg start dotcom` with access token generated from a dotcom user  verified chat worked and was rate limited.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
