### PR TITLE
batches: UI papercut fixes

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -357,6 +357,7 @@ ts_project(
         "src/components/fuzzyFinder/FuzzyTabs.tsx",
         "src/components/fuzzyFinder/HighlightedLink.tsx",
         "src/components/fuzzyFinder/LazyFuzzyFinder.tsx",
+        "src/components/gitHubApps/AppLogo.tsx",
         "src/components/gitHubApps/AuthProviderMessage.tsx",
         "src/components/gitHubApps/CreateGitHubAppPage.tsx",
         "src/components/gitHubApps/GitHubAppCard.tsx",

--- a/client/web/src/components/gitHubApps/AppLogo.tsx
+++ b/client/web/src/components/gitHubApps/AppLogo.tsx
@@ -17,9 +17,11 @@ export const AppLogo: React.FC<AppLogoProps> = ({ src, name, className }) => {
             src={src}
             alt="App logo"
             aria-hidden={true}
-            onError={() => {
-                setFallbackImage(true)
-            }}
+			// On certain code hosts, the image resource may be locked behind a login
+			// screen. It's not practical to authenticate the user in this context, so instead,
+			// we catch when there's an error loading the image and toggle the component
+			// state to render a fallback icon instead.
+            onError={() => setFallbackImage(true)}
         />
     ) : (
         <UserAvatar user={{ avatarURL: null, username: name, displayName: name }} className={className} />

--- a/client/web/src/components/gitHubApps/AppLogo.tsx
+++ b/client/web/src/components/gitHubApps/AppLogo.tsx
@@ -2,25 +2,42 @@ import React, { useState } from 'react'
 
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 
+/**
+ * Displays the GitHub App or installation account logo, or a
+ * fallback icon of the accounts initials when the image isn't available (this
+ * happens when the image is locked behind a login we don't want to
+ * authenticate here)
+ */
 interface AppLogoProps {
+    /**
+     * GitHub App logo or GitHub App installation account avatar
+     */
     src: string | undefined
+    /**
+     * GitHub App name or GitHub App installation account login name
+     */
     name: string
+    /**
+     * Specified alt string when used for non-GitHub App's specifically,
+     * e.g. a GitHub App's installation account
+     */
+    alt?: string
     className: string
 }
 
-export const AppLogo: React.FC<AppLogoProps> = ({ src, name, className }) => {
+export const AppLogo: React.FC<AppLogoProps> = ({ src, name, alt = 'App logo', className }) => {
     const [fallbackImage, setFallbackImage] = useState<boolean>(false)
 
     return !fallbackImage ? (
         <img
             className={className}
             src={src}
-            alt="App logo"
+            alt={alt}
             aria-hidden={true}
-			// On certain code hosts, the image resource may be locked behind a login
-			// screen. It's not practical to authenticate the user in this context, so instead,
-			// we catch when there's an error loading the image and toggle the component
-			// state to render a fallback icon instead.
+            // On certain code hosts, the image resource may be locked behind a login
+            // screen. It's not practical to authenticate the user in this context, so instead,
+            // we catch when there's an error loading the image and toggle the component
+            // state to render a fallback icon instead.
             onError={() => setFallbackImage(true)}
         />
     ) : (

--- a/client/web/src/components/gitHubApps/AppLogo.tsx
+++ b/client/web/src/components/gitHubApps/AppLogo.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react'
+
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+
+import { BatchChangesCodeHostFields } from '../../graphql-operations'
+
+import { GitHubApp } from './GitHubAppCard'
+
+interface AppLogoProps {
+    app: GitHubApp | BatchChangesCodeHostFields['commitSigningConfiguration']
+    className: string
+}
+
+export const AppLogo: React.FC<AppLogoProps> = ({ app, className }) => {
+    const [fallbackImage, setFallbackImage] = useState<boolean>(false)
+
+    return !fallbackImage ? (
+        <img
+            className={className}
+            src={app!.logo}
+            alt="App logo"
+            aria-hidden={true}
+            onError={() => {
+                setFallbackImage(true)
+            }}
+        />
+    ) : (
+        <UserAvatar user={{ avatarURL: null, username: app!.name, displayName: app!.name }} className={className} />
+    )
+}

--- a/client/web/src/components/gitHubApps/AppLogo.tsx
+++ b/client/web/src/components/gitHubApps/AppLogo.tsx
@@ -2,22 +2,19 @@ import React, { useState } from 'react'
 
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 
-import { BatchChangesCodeHostFields } from '../../graphql-operations'
-
-import { GitHubApp } from './GitHubAppCard'
-
 interface AppLogoProps {
-    app: GitHubApp | BatchChangesCodeHostFields['commitSigningConfiguration']
+    src: string | undefined
+    name: string
     className: string
 }
 
-export const AppLogo: React.FC<AppLogoProps> = ({ app, className }) => {
+export const AppLogo: React.FC<AppLogoProps> = ({ src, name, className }) => {
     const [fallbackImage, setFallbackImage] = useState<boolean>(false)
 
     return !fallbackImage ? (
         <img
             className={className}
-            src={app!.logo}
+            src={src}
             alt="App logo"
             aria-hidden={true}
             onError={() => {
@@ -25,6 +22,6 @@ export const AppLogo: React.FC<AppLogoProps> = ({ app, className }) => {
             }}
         />
     ) : (
-        <UserAvatar user={{ avatarURL: null, username: app!.name, displayName: app!.name }} className={className} />
+        <UserAvatar user={{ avatarURL: null, username: name, displayName: name }} className={className} />
     )
 }

--- a/client/web/src/components/gitHubApps/GitHubAppCard.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppCard.tsx
@@ -5,11 +5,12 @@ import classNames from 'classnames'
 
 import { Button, Icon, Container, AnchorLink, ButtonLink } from '@sourcegraph/wildcard'
 
+import { AppLogo } from './AppLogo'
 import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
 
 import styles from './GitHubAppCard.module.scss'
 
-interface GitHubApp {
+export interface GitHubApp {
     id: string
     appID: number
     appURL: string
@@ -33,7 +34,7 @@ export const GitHubAppCard: React.FC<GitHubAppCardProps> = ({ app, refetch }) =>
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={app} />
             )}
             <span className={classNames(styles.appLink, 'd-flex align-items-center')}>
-                <img className={classNames('mr-3', styles.logo)} src={app.logo} alt="app logo" aria-hidden={true} />
+                <AppLogo app={app} className={classNames(styles.logo, 'mr-2')} />
                 <span>
                     <div className="font-weight-bold">{app.name}</div>
                     <div className="text-muted">AppID: {app.appID}</div>

--- a/client/web/src/components/gitHubApps/GitHubAppCard.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppCard.tsx
@@ -10,7 +10,7 @@ import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
 
 import styles from './GitHubAppCard.module.scss'
 
-export interface GitHubApp {
+interface GitHubApp {
     id: string
     appID: number
     appURL: string
@@ -34,7 +34,7 @@ export const GitHubAppCard: React.FC<GitHubAppCardProps> = ({ app, refetch }) =>
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={app} />
             )}
             <span className={classNames(styles.appLink, 'd-flex align-items-center')}>
-                <AppLogo app={app} className={classNames(styles.logo, 'mr-2')} />
+                <AppLogo src={app.logo} name={app.name} className={classNames(styles.logo, 'mr-2')} />
                 <span>
                     <div className="font-weight-bold">{app.name}</div>
                     <div className="text-muted">AppID: {app.appID}</div>

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -101,7 +101,11 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                             {
                                 text: (
                                     <span className="d-flex align-items-center">
-                                        <AppLogo app={app} className={classNames(styles.logo, 'mr-2')} />
+                                        <AppLogo
+                                            src={app.logo}
+                                            name={app.name}
+                                            className={classNames(styles.logo, 'mr-2')}
+                                        />
                                         <span>{app.name}</span>
                                     </span>
                                 ),
@@ -202,10 +206,10 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                                     <Container className={classNames(styles.installation, 'p-3')} key={installation.id}>
                                         <div className="d-flex align-items-center">
                                             <Link to={installation.account.url} className="d-flex align-items-center">
-                                                <img
-                                                    className={styles.logo}
+                                                <AppLogo
                                                     src={installation.account.avatarURL}
-                                                    alt="account avatar"
+                                                    name={installation.account.login}
+                                                    className={styles.logo}
                                                 />
                                                 <div className="d-flex flex-column ml-3">
                                                     {installation.account.login}

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -30,6 +30,7 @@ import { ExternalServiceNode } from '../externalServices/ExternalServiceNode'
 import { ConnectionList, SummaryContainer, ConnectionSummary } from '../FilteredConnection/ui'
 import { PageTitle } from '../PageTitle'
 
+import { AppLogo } from './AppLogo'
 import { AuthProviderMessage } from './AuthProviderMessage'
 import { GITHUB_APP_BY_ID_QUERY } from './backend'
 import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
@@ -100,11 +101,7 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                             {
                                 text: (
                                     <span className="d-flex align-items-center">
-                                        <img
-                                            className={classNames(styles.logo, 'mr-2')}
-                                            src={app.logo}
-                                            alt="App logo"
-                                        />
+                                        <AppLogo app={app} className={classNames(styles.logo, 'mr-2')} />
                                         <span>{app.name}</span>
                                     </span>
                                 ),

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -209,6 +209,7 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                                                 <AppLogo
                                                     src={installation.account.avatarURL}
                                                     name={installation.account.login}
+                                                    alt="Account avatar"
                                                     className={styles.logo}
                                                 />
                                                 <div className="d-flex flex-column ml-3">

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -113,19 +113,19 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                         className="mb-3"
                         headingElement="h2"
                     />
-                    <div className="d-flex align-items-center">
-                        <span className="timestamps text-muted">
+                    <div className="d-flex align-items-sm-center flex-sm-row flex-column">
+                        <span className="timestamps text-muted mb-2">
                             Created <Timestamp date={app.createdAt} /> | Updated <Timestamp date={app.updatedAt} />
                         </span>
-                        <span className="ml-auto">
-                            <AnchorLink to={app.appURL} target="_blank" className="mr-3">
+                        <span className="ml-sm-auto">
+                            <AnchorLink to={app.appURL} target="_blank">
                                 View In GitHub <Icon inline={true} svgPath={mdiOpenInNew} aria-hidden={true} />
                             </AnchorLink>
-                            <Button onClick={() => navigate(-1)} variant="secondary">
+                            <Button onClick={() => navigate(-1)} variant="secondary" className="mx-2">
                                 Cancel
                             </Button>
                             <Button
-                                className="ml-2 text-nowrap"
+                                className="text-nowrap"
                                 aria-label="Remove GitHub App"
                                 onClick={() => setRemoveModalOpen(true)}
                                 variant="danger"
@@ -137,12 +137,12 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                 </>
             )}
             {app && (
-                <Container className="mt-3 mb-3">
+                <Container className="my-3">
                     <Grid columnCount={2} templateColumns="auto 1fr" spacing={[0.6, 2]}>
                         <span className="font-weight-bold">GitHub App Name</span>
                         <span>{app.name}</span>
                         <span className="font-weight-bold">URL</span>
-                        <AnchorLink to={app.appURL} target="_blank" className="text-decoration-none">
+                        <AnchorLink to={app.appURL} target="_blank" className="text-decoration-none text-break">
                             {app.appURL}
                         </AnchorLink>
                         <span className="font-weight-bold">AppID</span>
@@ -154,9 +154,13 @@ export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcr
                     <hr className="mt-4 mb-4" />
 
                     <div>
-                        <H2 className="d-flex align-items-center mb-3">
+                        <H2 className="d-flex flex-sm-row flex-column align-items-sm-center mb-3">
                             Installations
-                            <Button className="ml-auto" onClick={() => onAddInstallation(app)} variant="primary">
+                            <Button
+                                className="ml-sm-auto mr-sm-0 mr-auto mt-sm-0 mt-2"
+                                onClick={() => onAddInstallation(app)}
+                                variant="primary"
+                            >
                                 <Icon svgPath={mdiPlus} aria-hidden={true} /> Add installation
                             </Button>
                         </H2>

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.module.scss
@@ -42,7 +42,6 @@
     height: 1.75rem;
     border-radius: 50%;
     background-color: var(--gray-02);
-    border: 2px solid var(--gray-02);
 }
 
 .app-logo-large {

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiCogOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
+import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { AnchorLink, Button, ButtonLink, H3, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
@@ -69,6 +70,7 @@ interface AppDetailsControlsProps {
 
 const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ baseURL, config, refetch }) => {
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
+    const [fallbackImage, setFallbackImage] = useState<boolean>(false)
 
     const createURL = `/site-admin/batch-changes/github-apps/new?baseURL=${encodeURIComponent(baseURL)}`
     return config ? (
@@ -77,7 +79,19 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={config} />
             )}
             <div className="d-flex align-items-center">
-                <img className={styles.appLogoLarge} src={config.logo} alt="app logo" aria-hidden={true} />
+                {!fallbackImage ? (
+                    <img
+                        className={classNames(styles.appLogoLarge, 'mr-2')}
+                        src={config.logo}
+                        alt="App logo"
+                        aria-hidden={true}
+                        onError={() => {
+                            setFallbackImage(true)
+                        }}
+                    />
+                ) : (
+                    <UserAvatar user={{ avatarURL: null, username: config.name, displayName: config.name }} />
+                )}
                 <div className={styles.appDetailsColumn}>
                     <Text size="small" className="font-weight-bold mb-0">
                         {config.name}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -3,10 +3,10 @@ import React, { useState } from 'react'
 import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiCogOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { AnchorLink, Button, ButtonLink, H3, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
+import { AppLogo } from '../../../components/gitHubApps/AppLogo'
 import { RemoveGitHubAppModal } from '../../../components/gitHubApps/RemoveGitHubAppModal'
 import { BatchChangesCodeHostFields } from '../../../graphql-operations'
 
@@ -70,7 +70,6 @@ interface AppDetailsControlsProps {
 
 const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ baseURL, config, refetch }) => {
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
-    const [fallbackImage, setFallbackImage] = useState<boolean>(false)
 
     const createURL = `/site-admin/batch-changes/github-apps/new?baseURL=${encodeURIComponent(baseURL)}`
     return config ? (
@@ -79,19 +78,8 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={config} />
             )}
             <div className="d-flex align-items-center">
-                {!fallbackImage ? (
-                    <img
-                        className={classNames(styles.appLogoLarge, 'mr-2')}
-                        src={config.logo}
-                        alt="App logo"
-                        aria-hidden={true}
-                        onError={() => {
-                            setFallbackImage(true)
-                        }}
-                    />
-                ) : (
-                    <UserAvatar user={{ avatarURL: null, username: config.name, displayName: config.name }} />
-                )}
+                <AppLogo app={config} className={classNames(styles.appLogoLarge, 'mr-2')} />
+
                 <div className={styles.appDetailsColumn}>
                     <Text size="small" className="font-weight-bold mb-0">
                         {config.name}

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -78,7 +78,7 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                 <RemoveGitHubAppModal onCancel={() => setRemoveModalOpen(false)} afterDelete={refetch} app={config} />
             )}
             <div className="d-flex align-items-center">
-                <AppLogo app={config} className={classNames(styles.appLogoLarge, 'mr-2')} />
+                <AppLogo src={config.logo} name={config.name} className={classNames(styles.appLogoLarge, 'mr-2')} />
 
                 <div className={styles.appDetailsColumn}>
                     <Text size="small" className="font-weight-bold mb-0">


### PR DESCRIPTION
1. GitHub App logo error fallback image
**BEFORE**
<img width="309" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/a88a2e54-8909-4255-9847-a7212c3eb5ff">

**AFTER**
<img width="283" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/db5c5530-9f0a-4b39-a8c3-dff6e3e0b2fa">

2. GitHub App Edit screen mobile responsiveness (Down to 320px screenwidth)
**BEFORE**
<img width="318" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/db7444cb-2cc4-4f10-a4fd-0143b93dfc1f">

**AFTER**
<img width="317" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/e97e6442-33f7-4702-9705-98940ca37234">

## Test plan
- Manual visual testing