### PR TITLE
App - setup progress add field to indicate 1 repo complete

### DIFF
--- a/cmd/frontend/graphqlbackend/app.go
+++ b/cmd/frontend/graphqlbackend/app.go
@@ -31,6 +31,7 @@ type EmbeddingsSetupProgressResolver interface {
 	CurrentRepository(ctx context.Context) *string
 	CurrentRepositoryFilesProcessed(ctx context.Context) *int32
 	CurrentRepositoryTotalFilesToProcess(ctx context.Context) *int32
+	OneRepositoryReady(ctx context.Context) bool
 }
 
 type LocalDirectoryResolver interface {

--- a/cmd/frontend/graphqlbackend/app.graphql
+++ b/cmd/frontend/graphqlbackend/app.graphql
@@ -40,6 +40,11 @@ type EmbeddingsSetupProgress {
     The total number of files to process for the current repository
     """
     currentRepositoryTotalFilesToProcess: Int
+
+    """
+    Indicates that at least 1 repository has successfully completed
+    """
+    oneRepositoryReady: Boolean!
 }
 
 """

--- a/enterprise/cmd/frontend/internal/app/resolvers/progress.go
+++ b/enterprise/cmd/frontend/internal/app/resolvers/progress.go
@@ -21,6 +21,7 @@ type embeddingsSetupProgressResolver struct {
 	currentProcessed *int32
 	currentTotal     *int32
 	overallProgress  int32
+	oneRepoCompleted bool
 	err              error
 }
 
@@ -77,6 +78,13 @@ func (r *embeddingsSetupProgressResolver) CurrentRepositoryTotalFilesToProcess(c
 	}
 	return r.currentTotal
 }
+func (r *embeddingsSetupProgressResolver) OneRepositoryReady(ctx context.Context) bool {
+	r.getStatus(ctx)
+	if r.err != nil {
+		return false
+	}
+	return r.oneRepoCompleted
+}
 
 func getAllRepos(ctx context.Context, db database.DB, repoNames []string) ([]types.MinimalRepo, error) {
 	opts := database.ReposListOptions{}
@@ -118,6 +126,7 @@ func (r *embeddingsSetupProgressResolver) getProgressForRepo(ctx context.Context
 		}
 		switch job.State {
 		case "completed":
+			r.oneRepoCompleted = true
 			return 1, nil
 		case "processing":
 			r.currentRepo = pointers.Ptr(string(current.Name))

--- a/enterprise/cmd/frontend/internal/app/resolvers/progress.go
+++ b/enterprise/cmd/frontend/internal/app/resolvers/progress.go
@@ -115,16 +115,23 @@ func getAllRepos(ctx context.Context, db database.DB, repoNames []string) ([]typ
 // - Returns the progress percentage, defaulting to 0 if no processing job found.
 func (r *embeddingsSetupProgressResolver) getProgressForRepo(ctx context.Context, current types.MinimalRepo) (float64, error) {
 	var progress float64
+	hasFailedJob := false
+	hasPendingJob := false
 	embeddingsStore := repo.NewRepoEmbeddingJobsStore(r.db)
 	jobs, err := embeddingsStore.ListRepoEmbeddingJobs(ctx, repo.ListOpts{Repo: &current.ID, PaginationArgs: &database.PaginationArgs{First: pointers.Ptr(10)}})
 	if err != nil {
 		return progress, err
 	}
 	for _, job := range jobs {
+		if job.IsRepoEmbeddingJobScheduledOrCompleted() {
+			hasPendingJob = true
+		}
 		if job.StartedAt == nil {
 			continue
 		}
 		switch job.State {
+		case "canceled", "failed":
+			hasFailedJob = true
 		case "completed":
 			r.oneRepoCompleted = true
 			return 1, nil
@@ -138,8 +145,16 @@ func (r *embeddingsSetupProgressResolver) getProgressForRepo(ctx context.Context
 				continue
 			}
 			r.currentProcessed, r.currentTotal, progress = getProgress(status)
+			// we continue to process the rest of the jobs incase there is another job that is already completed
 		}
 	}
+
+	// if we have a failed or canceled job and there are no jobs scheduled or completed
+	// we advance the progress to 100% for that repo because it will not completed
+	if hasFailedJob && !hasPendingJob {
+		return 1, nil
+	}
+
 	return progress, nil
 }
 


### PR DESCRIPTION
This adds another resolver to indicate when at least repo has completed embeddings.

Also add better support for failed/canceled jobs.  Now if a job fails it will advance the progress bar, it does this because that repo is done and it will not full complete otherwise.
## Test plan
**Check that when all jobs fail it still gets to 100%**

misconfigure embeddings with an invalid url 
`sg start app` and monitor progress
```
 {embeddingsSetupProgress: {__typename: "EmbeddingsSetupProgress", overallPercentComplete: 100, oneRepositoryReady: false}}
```

Check for one repository ready
`sg start app` and monitor progress

```
 {embeddingsSetupProgress: {__typename: "EmbeddingsSetupProgress", overallPercentComplete: 34, oneRepositoryReady: true}}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
