### PR TITLE
release: v5.1.0 bake constants and static content

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -13,7 +13,7 @@ import styles from './BatchChangesListIntro.module.scss'
  * Ie. After 5.0 is cut, this should be bumped to 5.1, and so on. This ensures we
  * always render the right changelog.
  */
-const CURRENT_VERSION = '5.1'
+const CURRENT_VERSION = '5.2'
 /**
  * SHOW_CHANGELOG has to be set to true when a changelog entry is added for a release.
  * After every release, this will be set back to `false`. Chromatic will also verify

--- a/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,14 +27,14 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:2430d1a85f081bceb54d7ae21df7f3f40cff91bed35df124ed45ae134aba3743",
+	"sourcegraph/scip-go":         "sha256:2a04ea639f4f72a23decfd9badf3663275a753fdf6d77c49ed47d8246e49402f",
 	"sourcegraph/lsif-clang":      "sha256:ea814e5ab5c6e1e6ab4d001e4f4afddcc7b44128edbeeedf1d97da553813a4c8",
 	"sourcegraph/lsif-rust":       "sha256:83cb769788987eb52f21a18b62d51ebb67c9436e1b0d2e99904c70fef424f9d1",
 	"sourcegraph/scip-rust":       "sha256:e9c400fd1d3146cd9a3d98f89c6d9a70e0a116618057e0dac452219b1c60b658",
-	"sourcegraph/scip-java":       "sha256:138898b73737087424760dba8dbf998e960bf585c96cbe0d1b17d9920b44c80d",
-	"sourcegraph/scip-python":     "sha256:4cb64c4f62cfa611fcb217581073c2831fb9350bbb1c8e855f152cc4b3428a00",
+	"sourcegraph/scip-java":       "sha256:b0d0a6387d4be4e11bc6305021edf5ba2e58157fecff0fa6a74a7308a9b5a668",
+	"sourcegraph/scip-python":     "sha256:ab7f4b6c42870761248fa0d2c4774e2e1a6f5b1b65dd06f75f064a9418625b83",
 	"sourcegraph/scip-typescript": "sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92",
-	"sourcegraph/scip-ruby":       "sha256:e553fee039973cda8726d4c8c13cdbb851f82a6fca5daa15798a595ee4042906",
+	"sourcegraph/scip-ruby":       "sha256:ffbe40f23bd49a0163417589374f0bda97619e15f18bb09a048135094d21176d",
 }
 
 func DefaultIndexerForLang(language string) (string, bool) {

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "5.0.0"
+const MinimumVersion = "5.1.0"


### PR DESCRIPTION
Retry of https://github.com/sourcegraph/sourcegraph/pull/53718, part of https://github.com/sourcegraph/sourcegraph/issues/49918


## Test plan

CI
