### PR TITLE
App - remove embeddings settings that already have defaults

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -99,16 +99,7 @@ var App = conftypes.RawUnified{
 	},
 	"embeddings": {
 		"enabled": true,
-		"provider": "sourcegraph",
-		"incremental": true,
-		"excludedFilePathPatterns": [
-			"*.svg",
-			"*.png",
-			"*.jpeg",
-			"*.jpg",
-			"**/__mocks__/**",
-			"**/test/**"
-   	 	]
+		"provider": "sourcegraph"		
 	}
 }`,
 }


### PR DESCRIPTION
This removes default App settings that are not needed.

`incremental=true` the default currently
`excludedFilePathPatterns` has a better [default](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/embeddings/embed/files.go?L29:5&popover=pinned)

closes https://github.com/sourcegraph/sourcegraph/issues/53724
## Test plan
Made a local release build
Went though setup verified embeddings created 
Verified proper defaults
<img width="542" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/ac3cd92d-4117-4998-a5f2-c209287f3cb7">
 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
