### PR TITLE
App - update the signin url query param name

### DIFF
--- a/internal/auth/userpasswd/app.go
+++ b/internal/auth/userpasswd/app.go
@@ -82,7 +82,7 @@ func AppSignInMiddleware(db database.DB, handler func(w http.ResponseWriter, r *
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) error {
-		secret := r.URL.Query().Get("secret")
+		secret := r.URL.Query().Get("s")
 		if secret == "" {
 			return handler(w, r)
 		}
@@ -177,7 +177,7 @@ func appSignInURL() string {
 	}
 	u.Path = "/sign-in"
 	query := u.Query()
-	query.Set("secret", secret)
+	query.Set("s", secret)
 	u.RawQuery = query.Encode()
 	return u.String()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
   "build": {
     "beforeBuildCommand": "bash ./src-tauri/compose-assets.sh",
-    "devPath": "http://localhost:3080/sign-in?secret=foobar&returnTo=/",
+    "devPath": "http://localhost:3080/sign-in?s=foobar&returnTo=/",
     "distDir": "./assets",
     "withGlobalTauri": true
   },
@@ -17,7 +17,9 @@
         "confirm": true
       },
       "fs": {
-        "scope": ["$APPDATA/postgresql/data"],
+        "scope": [
+          "$APPDATA/postgresql/data"
+        ],
         "removeDir": true
       },
       "shell": {
@@ -26,7 +28,12 @@
           {
             "name": "../.bin/sourcegraph-backend",
             "sidecar": true,
-            "args": ["--cacheDir", "$APPCONFIG", "--configDir", "$APPLOCALDATA"]
+            "args": [
+              "--cacheDir",
+              "$APPCONFIG",
+              "--configDir",
+              "$APPLOCALDATA"
+            ]
           }
         ],
         "open": "^(vscode:|https?:)|com.sourcegraph.cody/.*.log$"
@@ -48,8 +55,16 @@
       "deb": {
         "depends": []
       },
-      "externalBin": ["../.bin/sourcegraph-backend"],
-      "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+      "externalBin": [
+        "../.bin/sourcegraph-backend"
+      ],
+      "icon": [
+        "icons/32x32.png",
+        "icons/128x128.png",
+        "icons/128x128@2x.png",
+        "icons/icon.icns",
+        "icons/icon.ico"
+      ],
       "identifier": "com.sourcegraph.cody",
       "longDescription": "",
       "macOS": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,9 +17,7 @@
         "confirm": true
       },
       "fs": {
-        "scope": [
-          "$APPDATA/postgresql/data"
-        ],
+        "scope": ["$APPDATA/postgresql/data"],
         "removeDir": true
       },
       "shell": {
@@ -28,12 +26,7 @@
           {
             "name": "../.bin/sourcegraph-backend",
             "sidecar": true,
-            "args": [
-              "--cacheDir",
-              "$APPCONFIG",
-              "--configDir",
-              "$APPLOCALDATA"
-            ]
+            "args": ["--cacheDir", "$APPCONFIG", "--configDir", "$APPLOCALDATA"]
           }
         ],
         "open": "^(vscode:|https?:)|com.sourcegraph.cody/.*.log$"
@@ -55,16 +48,8 @@
       "deb": {
         "depends": []
       },
-      "externalBin": [
-        "../.bin/sourcegraph-backend"
-      ],
-      "icon": [
-        "icons/32x32.png",
-        "icons/128x128.png",
-        "icons/128x128@2x.png",
-        "icons/icon.icns",
-        "icons/icon.ico"
-      ],
+      "externalBin": ["../.bin/sourcegraph-backend"],
+      "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
       "identifier": "com.sourcegraph.cody",
       "longDescription": "",
       "macOS": {


### PR DESCRIPTION
Updates the name of the query param used to allow the tauri shell to open the UI
closes https://github.com/sourcegraph/sourcegraph/issues/53849
## Test plan
`sg start app` ui loaded
build local release version - opened app UI appeared checked logs to verify new query param name
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
