### PR TITLE
refactor event name to comply with standards

### DIFF
--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -140,7 +140,7 @@ export async function migrateConfiguration(): Promise<void> {
     )
 
     if (didMigrate) {
-        logEvent('ConfigMigrator:migrated')
+        logEvent('CodyVSCodeExtension:configMigrator:migrated')
     }
 }
 


### PR DESCRIPTION
changes the logged event name to follow our standard.

[More info on this doc](https://docs.google.com/document/d/1hHUsKWqDDHaB7mL5MgNLEdIWOPnbR-9KVBWSMQMSbO4/edit)

## Test plan
test locally