### PR TITLE
Add target=_blank to all links in Cody markdown

### DIFF
--- a/client/cody-shared/src/chat/markdown.ts
+++ b/client/cody-shared/src/chat/markdown.ts
@@ -54,6 +54,7 @@ export function renderCodyMarkdown(markdown: string): string {
     return renderMarkdownCommon(markdown, {
         breaks: true,
         dompurifyConfig: DOMPURIFY_CONFIG,
+        addTargetBlankToAllLinks: true,
     })
 }
 

--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -108,8 +108,10 @@ describe('renderMarkdown', () => {
         expect(renderMarkdown(input)).toBe('<p><a href="/">Link</a></p>')
     })
     it('adds target="_blank" attribute on links with addTargetBlankToAllLinks: true', () => {
-        const input = '<a href="/" target="_blank">Link</a>'
-        expect(renderMarkdown(input, { addTargetBlankToAllLinks: true })).toBe('<p><a href="/">Link</a></p>')
+        const input = '<a href="/">Link</a>'
+        expect(renderMarkdown(input, { addTargetBlankToAllLinks: true })).toBe(
+            '<p><a href="/" target="_blank" rel="noopener">Link</a></p>'
+        )
     })
     test('forbids data URI links', () => {
         const input = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'

--- a/client/common/src/util/markdown/markdown.test.ts
+++ b/client/common/src/util/markdown/markdown.test.ts
@@ -103,6 +103,14 @@ describe('renderMarkdown', () => {
         const input = '<a href="/" rel="evil" style="foo:bar">Link</a><script>alert("x")</script>'
         expect(renderMarkdown(input)).toBe('<p><a href="/">Link</a></p>')
     })
+    it('forbids target attribute on links', () => {
+        const input = '<a href="/" target="_blank">Link</a>'
+        expect(renderMarkdown(input)).toBe('<p><a href="/">Link</a></p>')
+    })
+    it('adds target="_blank" attribute on links with addTargetBlankToAllLinks: true', () => {
+        const input = '<a href="/" target="_blank">Link</a>'
+        expect(renderMarkdown(input, { addTargetBlankToAllLinks: true })).toBe('<p><a href="/">Link</a></p>')
+    })
     test('forbids data URI links', () => {
         const input = '<a href="data:text/plain,foobar" download>D</a>\n[D2](data:text/plain,foobar)'
         expect(renderMarkdown(input)).toBe('<p><a download="">D</a>\n<a>D2</a></p>')

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -62,7 +62,9 @@ export const renderMarkdown = (
         dompurifyConfig?: DOMPurifyConfig & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false }
 
         /**
-         * Add target="_blank" and rel="noopener" to all <a> links that have a href value.
+         * Add target="_blank" and rel="noopener" to all <a> links that have a
+         * href value. This affects all markdown-formatted links and all inline
+         * HTML links.
          */
         addTargetBlankToAllLinks?: boolean
     } = {}
@@ -101,7 +103,7 @@ export const renderMarkdown = (
               }
 
     if (options.addTargetBlankToAllLinks) {
-        // Add a hook that adds target="_blank" to all links. DOMPurify does not
+        // Add a hook that adds target="_blank" and rel="noopener" to all links. DOMPurify does not
         // support setting hooks per individual call to sanitize() so we have to
         // temporarily add the hook on the global module. This hook is removed
         // after the call to sanitize().
@@ -116,9 +118,9 @@ export const renderMarkdown = (
     const result = DOMPurify.sanitize(rendered, dompurifyConfig).trim()
 
     if (options.addTargetBlankToAllLinks) {
-        // Unfortunately DOMPurify doesn't have a way to add a hook per
-        // individual call to sanitize(), so we have to clean up by removing the
-        // hook that we added for addTargetBlankToAllLinks.
+        // Because DOMPurify doesn't have a way to set hooks per individual call
+        // to sanitize(), we have to clean up by removing the hook that we added
+        // for addTargetBlankToAllLinks.
         DOMPurify.removeHook('afterSanitizeAttributes')
     }
 

--- a/client/common/src/util/markdown/markdown.ts
+++ b/client/common/src/util/markdown/markdown.ts
@@ -107,7 +107,7 @@ export const renderMarkdown = (
         // support setting hooks per individual call to sanitize() so we have to
         // temporarily add the hook on the global module. This hook is removed
         // after the call to sanitize().
-        DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+        DOMPurify.addHook('afterSanitizeAttributes', node => {
             if (node.tagName.toLowerCase() === 'a' && node.getAttribute('href')) {
                 node.setAttribute('target', '_blank')
                 node.setAttribute('rel', 'noopener')


### PR DESCRIPTION
## What this changes

Add `target="_blank"` to all links in the markdown of Cody chat messages, which are rendered with `renderCodyMarkdown()`.

This opens all links within Cody chats in a new browser tab.

## Purpose

This is necessary (and the reason we're making this change) for the Cody UI specifically within App, because App needs to open all links in a browser instead of opening them inside of the App frame, which replaces the App's UI and it breaks it.

## How it's implemented

Add a new boolean option for `renderMarkdown` called `addTargetBlankToAllLinks`. 

It's used only in `renderCodyMarkdown` so this change only affects markdown rendered inside of Cody chat messages.

It adds `target="_blank"` and `rel="noopener"` to all `<a>` links that have a `href`, after converting from markdown, so this includes markdown-formatted links as well as inline `<a>` links inside of chat messages.

This is implemented at the HTML sanitization step with DOMPurify. This is because DOMPurify runs after markdown rendering so it strips/modifies HTML attributes already anyway, and we can hook into that step.

## Test plan

- Added tests for the `renderMarkdown` function to cover `addTargetBlankToAllLinks`
