### PR TITLE
cody: unblock auth view

### DIFF
--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -30,7 +30,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [messageBeingEdited, setMessageBeingEdited] = useState<boolean>(false)
     const [transcript, setTranscript] = useState<ChatMessage[]>([])
     const [authStatus, setAuthStatus] = useState<AuthStatus>()
-    const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false)
     const [formInput, setFormInput] = useState('')
     const [inputHistory, setInputHistory] = useState<string[] | []>([])
     const [userHistory, setUserHistory] = useState<ChatHistory | null>(null)
@@ -62,7 +61,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     break
                 case 'login':
                     setAuthStatus(message.authStatus)
-                    setIsAuthenticated(isLoggedIn(message.authStatus))
                     setView(isLoggedIn(message.authStatus) ? 'chat' : 'login')
                     if (message.authStatus.endpoint) {
                         setEndpoint(message.authStatus.endpoint)
@@ -105,7 +103,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     }, [config?.serverEndpoint, debugLog, endpoint, errorMessages, transcript, view, vscodeAPI])
 
     const onLogout = useCallback(() => {
-        setIsAuthenticated(false)
+        setAuthStatus(undefined)
         vscodeAPI.postMessage({ command: 'auth', type: 'signout' })
     }, [vscodeAPI])
 

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -116,7 +116,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     return (
         <div className="outer-container">
             <Header />
-            {view === 'login' || !isAuthenticated || !authStatus ? (
+            {view === 'login' || !authStatus?.authenticated ? (
                 <Login
                     authStatus={authStatus}
                     endpoint={endpoint}


### PR DESCRIPTION
bug introduced by my last commit where I switched to using `isAuthenticated` instead of staying with `authStatus`, and did not `setisAuthenticated` when the config is first loaded, so it might cause some people unable to sign in automatically on restart.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Still passing all the current auth tests 🙏 
