### PR TITLE
Improve Cody's preamble to support multi-repo context

### DIFF
--- a/client/cody-shared/src/chat/preamble.ts
+++ b/client/cody-shared/src/chat/preamble.ts
@@ -11,7 +11,15 @@ const rules = `In your responses, obey the following rules:
 - Be as brief and concise as possible without losing clarity.
 - All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
 - Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
-- Only reference file names or URLs if you are sure they exist.`
+- Only reference file names, repository names or URLs if you are sure they exist.`
+
+const multiRepoRules = `In your responses, obey the following rules:
+- If you do not have access to code, files or repositories always stay in character as Cody when you apologize.
+- Be as brief and concise as possible without losing clarity.
+- All code snippets have to be markdown-formatted, and placed in-between triple backticks like this \`\`\`.
+- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don't know and what context I need to provide you for you to answer the question.
+- If you do not have access to a repository, tell me to add additional repositories to the chat context using repositories selector below the input box to help you answer the question.
+- Only reference file names, repository names or URLs if you are sure they exist.`
 
 const answer = `Understood. I am Cody, an AI assistant made by Sourcegraph to help with programming tasks.
 I work inside a text editor. I have access to your currently open files in the editor.
@@ -30,7 +38,8 @@ export function getPreamble(codebase: string | undefined): Message[] {
     if (codebase) {
         const codebasePreamble =
             `You have access to the \`${codebase}\` repository. You are able to answer questions about the \`${codebase}\` repository. ` +
-            `I will provide the relevant code snippets from the \`${codebase}\` repository when necessary to answer my questions.`
+            `I will provide the relevant code snippets from the \`${codebase}\` repository when necessary to answer my questions. ` +
+            `If I ask you a question about a repository other than \`${codebase}\`, tell me to add additional repositories to the chat context using the repositories selector below the input box to help you answer the question.`
 
         preamble.push(codebasePreamble)
         preambleResponse.push(
@@ -51,19 +60,29 @@ export function getPreamble(codebase: string | undefined): Message[] {
 }
 
 export function getMultiRepoPreamble(codebases: string[]): Message[] {
-    const preamble = [actions, rules]
+    const preamble = [actions, multiRepoRules]
     const preambleResponse = [answer]
 
-    if (codebases.length) {
-        const codebase =
-            codebases.map(name => `\`${name}\``).join(', ') + (codebases.length > 1 ? ' repositories' : ' repository')
-        const codebasePreamble =
-            `You have access to the ${codebase}. You are able to answer questions about all the mentioned repositories. ` +
-            'I will provide the relevant code snippets from the mentioned repositories when necessary to answer my questions.'
+    if (codebases.length === 1) {
+        return getPreamble(codebases[0])
+    }
 
-        preamble.push(codebasePreamble)
+    if (codebases.length) {
+        preamble.push(
+            `You have access to ${codebases.length} repositories:\n` +
+                codebases.map((name, index) => `${index + 1}. ${name}`).join('\n') +
+                '\n You are able to answer questions about all the above repositories. ' +
+                'I will provide the relevant code snippets from the files present in the above repositories when necessary to answer my questions. ' +
+                'If I ask you a question about a repository which is not listed above, please tell me to add additional repositories to the chat context using the repositories selector below the input box to help you answer the question.' +
+                '\n If the repository is listed above but you do not know the answer to the quesstion, tell me you do not know and what context I need to provide you for you to answer the question.'
+        )
+
         preambleResponse.push(
-            `I have access to ${codebase} and can answer questions about files present in the mentioned repositories.`
+            'I have access to files present in the following repositories:\n' +
+                codebases.map((name, index) => `${index + 1}. ${name}`).join('\n') +
+                '\\n I can answer questions about code and files present in all the above repositories. ' +
+                'If your ask a question about a repository which I do not have access to, I will ask you to add additional repositories to the chat context using the repositories selector below the input box to help me answer the question. ' +
+                'If I have access to the repository but do not know the answer to the question, I will tell you I do not know and what context you need to provide me for me to answer the question.'
         )
     }
 

--- a/client/cody-shared/src/chat/recipes/chat-question.ts
+++ b/client/cody-shared/src/chat/recipes/chat-question.ts
@@ -79,7 +79,7 @@ export class ChatQuestion implements Recipe {
         }
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
-            populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName),
+            populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName, visibleContent.repoName),
             visibleContent
         )
     }
@@ -87,7 +87,7 @@ export class ChatQuestion implements Recipe {
     public static getEditorSelectionContext(selection: ActiveTextEditorSelection): ContextMessage[] {
         const truncatedContent = truncateText(selection.selectedText, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
-            populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName),
+            populateCurrentEditorSelectedContextTemplate(truncatedContent, selection.fileName, selection.repoName),
             selection
         )
     }

--- a/client/cody-shared/src/chat/recipes/helpers.ts
+++ b/client/cody-shared/src/chat/recipes/helpers.ts
@@ -45,7 +45,7 @@ export async function getContextMessagesFromSelection(
 
     return selectedTextContext.concat(
         [precedingText, followingText].flatMap(text =>
-            getContextMessageWithResponse(populateCodeContextTemplate(text, fileName), {
+            getContextMessageWithResponse(populateCodeContextTemplate(text, fileName, repoName), {
                 fileName,
                 repoName,
                 revision,

--- a/client/cody-shared/src/chat/recipes/next-questions.ts
+++ b/client/cody-shared/src/chat/recipes/next-questions.ts
@@ -68,7 +68,7 @@ export class NextQuestions implements Recipe {
         }
         const truncatedContent = truncateText(visibleContent.content, MAX_CURRENT_FILE_TOKENS)
         return getContextMessageWithResponse(
-            populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName),
+            populateCurrentEditorContextTemplate(truncatedContent, visibleContent.fileName, visibleContent.repoName),
             visibleContent
         )
     }

--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -134,7 +134,10 @@ export class CodebaseContext {
             : populateCodeContextTemplate
 
         return groupedResults.results.flatMap<Message>(text =>
-            getContextMessageWithResponse(contextTemplateFn(text, groupedResults.file.fileName), groupedResults.file)
+            getContextMessageWithResponse(
+                contextTemplateFn(text, groupedResults.file.fileName, groupedResults.file.repoName),
+                groupedResults.file
+            )
         )
     }
 
@@ -155,7 +158,10 @@ export class CodebaseContext {
         }
 
         return results.flatMap(({ content, filePath, repoName, revision }) => {
-            const messageText = populateCodeContextTemplate(content, filePath)
+            const messageText = isMarkdownFile(filePath)
+                ? populateMarkdownContextTemplate(content, filePath, repoName)
+                : populateCodeContextTemplate(content, filePath, repoName)
+
             return getContextMessageWithResponse(messageText, { fileName: filePath, repoName, revision })
         })
     }
@@ -233,7 +239,7 @@ function mergeConsecutiveResults(results: EmbeddingsSearchResult[]): string[] {
 
 function resultsToMessages(results: ContextResult[]): ContextMessage[] {
     return results.flatMap(({ content, fileName, repoName, revision }) => {
-        const messageText = populateCodeContextTemplate(content, fileName)
+        const messageText = populateCodeContextTemplate(content, fileName, repoName)
         return getContextMessageWithResponse(messageText, { fileName, repoName, revision })
     })
 }

--- a/client/cody-shared/src/prompt/templates.ts
+++ b/client/cody-shared/src/prompt/templates.ts
@@ -5,34 +5,65 @@ const CODE_CONTEXT_TEMPLATE = `Use following code snippet from file \`{filePath}
 {text}
 \`\`\``
 
-export function populateCodeContextTemplate(code: string, filePath: string): string {
-    return CODE_CONTEXT_TEMPLATE.replace('{filePath}', filePath)
+const CODE_CONTEXT_TEMPLATE_WITH_REPO = `Use following code snippet from file \`{filePath}\` in repository \`{repoName}\`:
+\`\`\`{language}
+{text}
+\`\`\``
+
+export function populateCodeContextTemplate(code: string, filePath: string, repoName?: string): string {
+    return (repoName ? CODE_CONTEXT_TEMPLATE_WITH_REPO.replace('{repoName}', repoName) : CODE_CONTEXT_TEMPLATE)
+        .replace('{filePath}', filePath)
         .replace('{language}', getExtension(filePath))
         .replace('{text}', code)
 }
 
 const MARKDOWN_CONTEXT_TEMPLATE = 'Use the following text from file `{filePath}`:\n{text}'
 
-export function populateMarkdownContextTemplate(markdown: string, filePath: string): string {
-    return MARKDOWN_CONTEXT_TEMPLATE.replace('{filePath}', filePath).replace('{text}', markdown)
+const MARKDOWN_CONTEXT_TEMPLATE_WITH_REPO =
+    'Use the following text from file `{filePath}` in repository `{repoName}`:\n{text}'
+
+export function populateMarkdownContextTemplate(markdown: string, filePath: string, repoName?: string): string {
+    return (repoName ? MARKDOWN_CONTEXT_TEMPLATE_WITH_REPO.replace('{repoName}', repoName) : MARKDOWN_CONTEXT_TEMPLATE)
+        .replace('{filePath}', filePath)
+        .replace('{text}', markdown)
 }
 
 const CURRENT_EDITOR_CODE_TEMPLATE = 'I have the `{filePath}` file opened in my editor. '
 
-export function populateCurrentEditorContextTemplate(code: string, filePath: string): string {
+const CURRENT_EDITOR_CODE_TEMPLATE_WITH_REPO =
+    'I have the `{filePath}` file from the repository `{repoName}` opened in my editor. '
+
+export function populateCurrentEditorContextTemplate(code: string, filePath: string, repoName?: string): string {
     const context = isMarkdownFile(filePath)
-        ? populateMarkdownContextTemplate(code, filePath)
-        : populateCodeContextTemplate(code, filePath)
-    return CURRENT_EDITOR_CODE_TEMPLATE.replace(/{filePath}/g, filePath) + context
+        ? populateMarkdownContextTemplate(code, filePath, repoName)
+        : populateCodeContextTemplate(code, filePath, repoName)
+    return (
+        (repoName
+            ? CURRENT_EDITOR_CODE_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
+            : CURRENT_EDITOR_CODE_TEMPLATE
+        ).replace(/{filePath}/g, filePath) + context
+    )
 }
 
 const CURRENT_EDITOR_SELECTED_CODE_TEMPLATE = 'I am currently looking at this part of the code from `{filePath}`. '
 
-export function populateCurrentEditorSelectedContextTemplate(code: string, filePath: string): string {
+const CURRENT_EDITOR_SELECTED_CODE_TEMPLATE_WITH_REPO =
+    'I am currently looking at this part of the code from `{filePath}` in repository {repoName}. '
+
+export function populateCurrentEditorSelectedContextTemplate(
+    code: string,
+    filePath: string,
+    repoName?: string
+): string {
     const context = isMarkdownFile(filePath)
-        ? populateMarkdownContextTemplate(code, filePath)
-        : populateCodeContextTemplate(code, filePath)
-    return CURRENT_EDITOR_SELECTED_CODE_TEMPLATE.replace(/{filePath}/g, filePath) + context
+        ? populateMarkdownContextTemplate(code, filePath, repoName)
+        : populateCodeContextTemplate(code, filePath, repoName)
+    return (
+        (repoName
+            ? CURRENT_EDITOR_SELECTED_CODE_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
+            : CURRENT_EDITOR_SELECTED_CODE_TEMPLATE
+        ).replace(/{filePath}/g, filePath) + context
+    )
 }
 
 const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown'])

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -69,6 +69,10 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
     )
     const [messageBeingEdited, setMessageBeingEdited] = useState<boolean>(false)
 
+    useEffect(() => {
+        setMessageBeingEdited(false)
+    }, [transcript?.id])
+
     const onSubmit = useCallback((text: string) => submitMessage(text), [submitMessage])
     const onEdit = useCallback((text: string) => editMessage(text), [editMessage])
 


### PR DESCRIPTION
Improves Cody's context to clearly tell what repos are in the context and ask cody to suggestion the user add additional repos using the repo selector below the input box.

Also with each context files code snippet, include name of the repo the files belongs to. 
closes: #54002

## Test plan

- start a new chat
- Ask cody "explain sourcegraph/sourcegraph repo"
- Cody should apologise and ask to add additional repos to the context using the repo selector below the input box.
- Add sourcegraph/sourcegraph repo using the repo selector
- Again, ask cody to "explain sourcegraph/sourcegraph repo."
- Cody should reply correctly this time.
- Now, continue the same conversation by asking the same question for a different repo.