### PR TITLE
search: populate Stats.Repos and ReposMap from List

### DIFF
--- a/internal/search/backend/cached_test.go
+++ b/internal/search/backend/cached_test.go
@@ -36,6 +36,9 @@ func TestCachedSearcher(t *testing.T) {
 			1: {},
 			2: {HasSymbols: true},
 		},
+		Stats: zoekt.RepoStats{
+			Repos: 2,
+		},
 	}
 
 	if !cmp.Equal(have, want) {
@@ -51,7 +54,12 @@ func TestCachedSearcher(t *testing.T) {
 	s.List(ctx, &zoektquery.Const{Value: true}, nil)
 
 	have, _ = s.List(ctx, &zoektquery.Const{Value: true}, nil)
-	want = &zoekt.RepoList{Repos: ms.FakeStreamer.Repos}
+	want = &zoekt.RepoList{
+		Repos: ms.FakeStreamer.Repos,
+		Stats: zoekt.RepoStats{
+			Repos: len(ms.FakeStreamer.Repos),
+		},
+	}
 
 	diffOpts := cmpopts.IgnoreUnexported(zoekt.Repository{})
 	if d := cmp.Diff(want, have, diffOpts); d != "" {
@@ -68,7 +76,12 @@ func TestCachedSearcher(t *testing.T) {
 
 	for {
 		have, _ = s.List(ctx, &zoektquery.Const{Value: true}, nil)
-		want = &zoekt.RepoList{Repos: ms.FakeStreamer.Repos}
+		want = &zoekt.RepoList{
+			Repos: ms.FakeStreamer.Repos,
+			Stats: zoekt.RepoStats{
+				Repos: len(ms.FakeStreamer.Repos),
+			},
+		}
 
 		if !cmp.Equal(have, want, diffOpts) {
 			time.Sleep(10 * time.Millisecond)

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -564,7 +564,8 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 	// does deduplication.
 
 	aggregate := zoekt.RepoList{
-		Minimal: make(map[uint32]*zoekt.MinimalRepoListEntry),
+		Minimal:  make(map[uint32]*zoekt.MinimalRepoListEntry),
+		ReposMap: make(zoekt.ReposMap),
 	}
 	for range clients {
 		r := <-results
@@ -584,7 +585,17 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 		for k, v := range r.rl.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 			aggregate.Minimal[k] = v //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 		}
+
+		for k, v := range r.rl.ReposMap {
+			aggregate.ReposMap[k] = v
+		}
 	}
+
+	// Only one of these fields is populated and in all cases the size of that
+	// field is the number of Repos. We may overcount in the case of asking
+	// for Repos since we don't deduplicate, but this should be very rare
+	// (only happens in the case of rebalancing)
+	aggregate.Stats.Repos = len(aggregate.Repos) + len(aggregate.Minimal) + len(aggregate.ReposMap) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	return &aggregate, nil
 }

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -120,6 +120,19 @@ func TestHorizontalSearcher(t *testing.T) {
 		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
 			t.Fatalf("list mismatch (-want +got):\n%s", cmp.Diff(want, got))
 		}
+
+		rle, err = searcher.List(context.Background(), nil, &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = []string{}
+		for r := range rle.ReposMap {
+			got = append(got, strconv.Itoa(int(r)))
+		}
+		sort.Strings(got)
+		if !cmp.Equal(want, got, cmpopts.EquateEmpty()) {
+			t.Fatalf("list mismatch (-want +got):\n%s", cmp.Diff(want, got))
+		}
 	}
 
 	searcher.Close()


### PR DESCRIPTION
Not aggregating ReposMap was an oversight which luckily we do not use yet (but intend on migrating too). Stats.Repos is a field we want to start using to avoid the need of caching the full list in memory.

Test Plan: updated our fakes to populate Repos and ReposMap which then exercised the changed code paths.