### PR TITLE
Cody: Add warning message for recipes

### DIFF
--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -18,6 +18,14 @@ export class ExplainCodeDetailed implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
+
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
 
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Please explain the following ${languageName} code. Be very detailed and specific, and indicate when it is not clear to you what is going on. Format your response as an ordered list.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -18,6 +18,14 @@ export class ExplainCodeHighLevel implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
+
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
 
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Explain the following ${languageName} code at a high level. Only include details that are essential to an overal understanding of what's happening in the code.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -1,5 +1,5 @@
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText } from '../../prompt/truncation'
+import { truncateText, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getNormalizedLanguageName } from './helpers'
@@ -27,6 +27,9 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
             selection.selectedText,
             Math.min(maxTokenCount, MAX_RECIPE_INPUT_TOKENS)
         )
+        if (isTextTruncated(selection.selectedText, truncatedSelectedText)) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n\n${promptSuffix}`
 
         const displayText = `Find code smells in the following code: \n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,6 +23,14 @@ export class GenerateDocstring implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
+
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
 
         const extension = getFileExtension(selection.fileName)
         const languageName = getNormalizedLanguageName(selection.fileName)

--- a/client/cody-shared/src/chat/recipes/generate-pr-description.ts
+++ b/client/cody-shared/src/chat/recipes/generate-pr-description.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs'
 import path from 'path'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText } from '../../prompt/truncation'
+import { truncateText, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -58,13 +58,15 @@ export class PrDescription implements Recipe {
         }
 
         const truncatedGitCommitOutput = truncateText(gitCommitOutput, MAX_RECIPE_INPUT_TOKENS)
-        let truncatedCommitMessage = ''
-        if (truncatedGitCommitOutput.length < gitCommitOutput.length) {
-            truncatedCommitMessage = 'Truncated extra long git log output, so PR description may be incomplete.'
+
+        if (isTextTruncated(gitCommitOutput, truncatedGitCommitOutput)) {
+            await context.editor.showWarningMessage(
+                'Truncated extra long git log output, so PR description may be incomplete.'
+            )
         }
 
         const promptMessage = `Summarise these changes:\n${gitCommitOutput}\n\n made while working in the current git branch.\nUse this pull request template to ${prTemplateContent} generate a pull request description based on the committed changes.\nIf the PR template mentions a requirement to check the contribution guidelines, then just summarise the changes in bulletin format.\n If it mentions a test plan for the changes use N/A\n.`
-        const assistantResponsePrefix = `Here is the PR description for the work done in your current branch:\n${truncatedCommitMessage}`
+        const assistantResponsePrefix = 'Here is the PR description for the work done in your current branch:\n'
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/generate-release-notes.ts
+++ b/client/cody-shared/src/chat/recipes/generate-release-notes.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'child_process'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText } from '../../prompt/truncation'
+import { truncateText, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -77,14 +77,14 @@ export class ReleaseNotes implements Recipe {
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
-        console.log(truncatedGitLogOutput)
-        let truncatedLogMessage = ''
-        if (truncatedGitLogOutput.length < gitLogOutput.length) {
-            truncatedLogMessage = 'Truncated extra long git log output, so release notes may miss some changes.'
+        if (isTextTruncated(gitLogOutput, truncatedGitLogOutput)) {
+            await context.editor.showWarningMessage(
+                'Truncated extra long git log output, so release notes may miss some changes.'
+            )
         }
 
         const promptMessage = `Generate release notes by summarising these commits:\n${truncatedGitLogOutput}\n\nUse proper heading format for the release notes.\n\n${tagsPromptText}.Do not include other changes and dependency updates.`
-        const assistantResponsePrefix = `Here is the generated release notes for ${selectedLabel}\n${truncatedLogMessage}`
+        const assistantResponsePrefix = `Here is the generated release notes for ${selectedLabel}\n`
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,9 +23,18 @@ export class GenerateTest implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-        const extension = getFileExtension(selection.fileName)
 
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
+
+        const extension = getFileExtension(selection.fileName)
         const languageName = getNormalizedLanguageName(selection.fileName)
+
         const promptMessage = `Generate a unit test in ${languageName} for the following code:\n\`\`\`${extension}\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
         const assistantResponsePrefix = `Here is the generated unit test:\n\`\`\`${extension}\n`
 

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,6 +23,14 @@ export class ImproveVariableNames implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
+
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection.')
+        }
         const extension = getFileExtension(selection.fileName)
 
         const displayText = `Improve the variable names in the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/next-questions.ts
+++ b/client/cody-shared/src/chat/recipes/next-questions.ts
@@ -19,7 +19,7 @@ export class NextQuestions implements Recipe {
 
         const maxTokenCount =
             MAX_AVAILABLE_PROMPT_LENGTH - (promptPrefix.length + promptSuffix.length) / CHARS_PER_TOKEN
-        const truncatedText = truncateText(humanChatInput, maxTokenCount)
+        const truncatedText = truncateText(humanChatInput, Math.min(maxTokenCount, MAX_AVAILABLE_PROMPT_LENGTH))
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedText}\n\`\`\`\n\n${promptSuffix}`
 
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '

--- a/client/cody-shared/src/chat/recipes/optimize-code.ts
+++ b/client/cody-shared/src/chat/recipes/optimize-code.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart } from '../../prompt/truncation'
+import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -22,6 +22,14 @@ export class OptimizeCode implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
+
+        if (
+            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
+            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
+            isTextTruncated(selection.followingText, truncatedFollowingText)
+        ) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
         const extension = getFileExtension(selection.fileName)
 
         const displayText = `Optimize the time and space consumption of the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText } from '../../prompt/truncation'
+import { truncateText, isTextTruncated } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
@@ -19,12 +19,15 @@ export class TranslateToLanguage implements Recipe {
 
         const toLanguage = await context.editor.showQuickPick(languageNames)
         if (!toLanguage) {
-            // TODO: Show the warning within the Chat UI.
-            // editor.showWarningMessage('Must pick a language to translate to.')
+            await context.editor.showWarningMessage('No language selected. Please select a language and try again.')
             return null
         }
 
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
+
+        if (isTextTruncated(selection.selectedText, truncatedSelectedText)) {
+            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
+        }
 
         const promptMessage = `Translate the following code into ${toLanguage}\n\`\`\`\n${truncatedSelectedText}\n\`\`\``
         const displayText = `Translate the following code into ${toLanguage}\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/prompt/truncation.ts
+++ b/client/cody-shared/src/prompt/truncation.ts
@@ -15,3 +15,13 @@ export function truncateTextStart(text: string, maxTokens: number): string {
     const maxLength = maxTokens * CHARS_PER_TOKEN
     return text.length <= maxLength ? text : text.slice(-maxLength - 1)
 }
+
+/**
+ * Checks if the text has been truncated
+ */
+export function isTextTruncated(text: string, truncateText: string): boolean {
+    if (truncateText.length < text.length) {
+        return true
+    }
+    return false
+}

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - The range of the editor selection, if present, is now displayed alongside the file name in the chat footer. [pull/53742](https://github.com/sourcegraph/sourcegraph/pull/53742)
 - Support switching between multiple instances with `Switch Account`. [pull/53434](https://github.com/sourcegraph/sourcegraph/pull/53434)
 - Automate sign-in flow with Cody App. [pull/53908](https://github.com/sourcegraph/sourcegraph/pull/53908)
+- Add a warning message to recipes when the selection gets truncated. [pull/54025](https://github.com/sourcegraph/sourcegraph/pull/54025)
 
 ### Fixed
 


### PR DESCRIPTION
This PR closes #53920

Changes made:
1. Added warning message for each long truncated text
2. Fixed the args of token length for some of the recipes

## Test plan
Tested manually for long code snippets.