### PR TITLE
auth: add rcache.SetupForTest for all NewInstallationAccessToken

### DIFF
--- a/enterprise/internal/github_apps/auth/auth_test.go
+++ b/enterprise/internal/github_apps/auth/auth_test.go
@@ -118,6 +118,7 @@ invalid key
 }
 
 func TestGitHubAppInstallationAuthenticator_Authenticate(t *testing.T) {
+	rcache.SetupForTest(t)
 	installationID := 1
 	appAuthenticator := &mockAuthenticator{}
 	u, err := url.Parse("https://github.com")
@@ -144,6 +145,8 @@ func TestGitHubAppInstallationAuthenticator_Refresh(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("token refreshes", func(t *testing.T) {
+		rcache.SetupForTest(t)
+
 		token := NewInstallationAccessToken(
 			u,
 			1,


### PR DESCRIPTION
This was missing from a few of the uses of NewInstallationAccessToken, which for me lead to test failures locally.

Test Plan: go test passes locally