### PR TITLE
bzl: set version on bins, not lib + add missing

### DIFF
--- a/cmd/blobstore/BUILD.bazel
+++ b/cmd/blobstore/BUILD.bazel
@@ -8,10 +8,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/blobstore",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/blobstore/shared",
         "//cmd/sourcegraph-oss/osscmd",
@@ -23,6 +19,10 @@ go_binary(
     name = "blobstore",
     embed = [":blobstore_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/cmd/github-proxy/BUILD.bazel
+++ b/cmd/github-proxy/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["github-proxy.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/github-proxy",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/github-proxy/shared",
         "//cmd/sourcegraph-oss/osscmd",
@@ -24,6 +20,10 @@ go_binary(
     name = "github-proxy",
     embed = [":github-proxy_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/cmd/gitserver/BUILD.bazel
+++ b/cmd/gitserver/BUILD.bazel
@@ -8,10 +8,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/gitserver",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/gitserver/shared",
         "//cmd/sourcegraph-oss/osscmd",
@@ -23,6 +19,10 @@ go_binary(
     name = "gitserver",
     embed = [":gitserver_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/cmd/loadtest/BUILD.bazel
+++ b/cmd/loadtest/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/loadtest",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//internal/env",
         "//internal/sanitycheck",
@@ -25,6 +21,10 @@ go_binary(
     name = "loadtest",
     embed = [":loadtest_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/cmd/migrator/BUILD.bazel
+++ b/cmd/migrator/BUILD.bazel
@@ -8,10 +8,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/migrator",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/migrator/shared",
         "//internal/env",
@@ -25,6 +21,10 @@ go_binary(
     name = "migrator",
     embed = [":migrator_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 genrule(

--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -20,6 +20,10 @@ go_binary(
     name = "server",
     embed = [":server_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/cmd/sourcegraph-oss/BUILD.bazel
+++ b/cmd/sourcegraph-oss/BUILD.bazel
@@ -25,4 +25,8 @@ go_binary(
     name = "sourcegraph-oss",
     embed = [":sourcegraph-oss_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -133,6 +133,10 @@ go_binary(
     name = "sg",
     embed = [":sg_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 go_test(

--- a/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
+++ b/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
@@ -48,6 +48,10 @@ go_binary(
     ],
     static = "on",
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 go_test(

--- a/enterprise/cmd/batcheshelper/BUILD.bazel
+++ b/enterprise/cmd/batcheshelper/BUILD.bazel
@@ -25,6 +25,10 @@ go_binary(
     name = "batcheshelper",
     embed = [":batcheshelper_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 go_test(

--- a/enterprise/cmd/cody-gateway/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/BUILD.bazel
@@ -24,6 +24,10 @@ go_binary(
     name = "cody-gateway",
     embed = [":cody-gateway_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/embeddings/BUILD.bazel
+++ b/enterprise/cmd/embeddings/BUILD.bazel
@@ -20,6 +20,10 @@ go_binary(
     name = "embeddings",
     embed = [":embeddings_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/executor/BUILD.bazel
+++ b/enterprise/cmd/executor/BUILD.bazel
@@ -27,6 +27,10 @@ go_binary(
     name = "executor",
     embed = [":executor_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/frontend/BUILD.bazel
+++ b/enterprise/cmd/frontend/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/frontend/shared",
         "//internal/conf",
@@ -29,6 +25,10 @@ go_binary(
     name = "frontend",
     embed = [":frontend_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/gitserver/BUILD.bazel
+++ b/enterprise/cmd/gitserver/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/gitserver",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/gitserver/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
@@ -24,6 +20,10 @@ go_binary(
     name = "gitserver",
     embed = [":gitserver_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/migrator/BUILD.bazel
+++ b/enterprise/cmd/migrator/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/migrator",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/migrator/shared",
         "//enterprise/internal/oobmigration/migrations",
@@ -28,6 +24,10 @@ go_binary(
     name = "migrator",
     embed = [":migrator_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
+++ b/enterprise/cmd/precise-code-intel-worker/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-worker",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/precise-code-intel-worker/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
@@ -24,6 +20,10 @@ go_binary(
     name = "precise-code-intel-worker",
     embed = [":precise-code-intel-worker_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/repo-updater/BUILD.bazel
+++ b/enterprise/cmd/repo-updater/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/repo-updater/shared",
         "//enterprise/cmd/sourcegraph/enterprisecmd",
@@ -24,6 +20,10 @@ go_binary(
     name = "repo-updater",
     embed = [":repo-updater_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -21,6 +21,10 @@ go_binary(
     name = "server",
     embed = [":server_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/sourcegraph/BUILD.bazel
+++ b/enterprise/cmd/sourcegraph/BUILD.bazel
@@ -5,11 +5,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/sourcegraph",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//cmd/blobstore/shared",
         "//cmd/github-proxy/shared",
@@ -47,8 +42,10 @@ go_binary(
         "-s",
         "-w",
     ],
-    # x_defs = {
-    #     "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
-    # },
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType": "app",
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )

--- a/enterprise/cmd/symbols/BUILD.bazel
+++ b/enterprise/cmd/symbols/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/sourcegraph/enterprisecmd",
         "//enterprise/cmd/symbols/shared",
@@ -24,6 +20,10 @@ go_binary(
     name = "symbols",
     embed = [":symbols_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/enterprise/cmd/worker/BUILD.bazel
+++ b/enterprise/cmd/worker/BUILD.bazel
@@ -9,10 +9,6 @@ go_library(
     srcs = ["main.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker",
     visibility = ["//visibility:private"],
-    x_defs = {
-        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
-        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
-    },
     deps = [
         "//enterprise/cmd/sourcegraph/enterprisecmd",
         "//enterprise/cmd/worker/shared",
@@ -24,6 +20,10 @@ go_binary(
     name = "worker",
     embed = [":worker_lib"],
     visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 pkg_tar(

--- a/internal/cmd/ghe-feeder/BUILD.bazel
+++ b/internal/cmd/ghe-feeder/BUILD.bazel
@@ -31,4 +31,8 @@ go_binary(
     name = "ghe-feeder",
     embed = [":ghe-feeder_lib"],
     visibility = ["//:__subpackages__"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )

--- a/internal/cmd/search-blitz/BUILD.bazel
+++ b/internal/cmd/search-blitz/BUILD.bazel
@@ -35,6 +35,10 @@ go_binary(
     name = "search-blitz",
     embed = [":search-blitz_lib"],
     visibility = ["//:__subpackages__"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )
 
 go_test(

--- a/internal/cmd/src-cli-version/BUILD.bazel
+++ b/internal/cmd/src-cli-version/BUILD.bazel
@@ -12,4 +12,8 @@ go_binary(
     name = "src-cli-version",
     embed = [":src-cli-version_lib"],
     visibility = ["//:__subpackages__"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )

--- a/internal/database/migration/shared/data/cmd/generator/BUILD.bazel
+++ b/internal/database/migration/shared/data/cmd/generator/BUILD.bazel
@@ -20,4 +20,8 @@ go_binary(
     name = "generator",
     embed = [":generator_lib"],
     visibility = ["//:__subpackages__"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
 )


### PR DESCRIPTION
A few `x_defs` attributes were missing on binaries, which is now fixed. Also moved to stamping from `go_library` rules to `go_binaries` to ease caching. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + main-dry-run + locally tested + `strings github-proxy | grep version` on `us.gcr.io/sourcegraph-dev/github-proxy:323c450504f8` 