### PR TITLE
Cody: Fix input style issue when the abort button is shown

### DIFF
--- a/client/cody-ui/src/Chat.module.css
+++ b/client/cody-ui/src/Chat.module.css
@@ -56,7 +56,8 @@
 
 .abort-button-container {
     display: flex;
-    width: 100%;
+    /* Remove the padding of the form container from the width */
+    width: calc(100% - 2rem);
     justify-content: center;
     align-items: center;
     position: absolute;


### PR DESCRIPTION
This annoyed me a lot and made the experience feel unpolished: When the abort button was displayed, the width was set to `100%` which was causing a horizontal overflow that caused a strange padding on the bottom to appear:

<img width="555" alt="Screenshot 2023-06-23 at 12 05 35" src="https://github.com/sourcegraph/sourcegraph/assets/458591/733cc938-6d4c-4e89-a803-d4af02aa7e57">

## Test plan

This PR fixes it:

<img width="535" alt="Screenshot 2023-06-23 at 12 17 20" src="https://github.com/sourcegraph/sourcegraph/assets/458591/7ee4515a-72cf-419b-b913-1ae48a2beab8">

And works on Web:

 
<img width="631" alt="Screenshot 2023-06-23 at 12 23 45" src="https://github.com/sourcegraph/sourcegraph/assets/458591/4ddbbd46-5dde-4faa-8c84-496e0e6ed6bb">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
