### PR TITLE
guardrails: add observability for attribution

### DIFF
--- a/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
@@ -3,17 +3,24 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "attribution",
-    srcs = ["attribution.go"],
+    srcs = [
+        "attribution.go",
+        "observability.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/attribution",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
         "//enterprise/cmd/frontend/internal/guardrails/dotcom",
         "//internal/api",
+        "//internal/metrics",
+        "//internal/observation",
         "//internal/search",
         "//internal/search/client",
         "//internal/search/streaming",
         "//lib/errors",
         "@com_github_sourcegraph_conc//pool",
+        "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 
@@ -24,6 +31,7 @@ go_test(
     deps = [
         "//enterprise/cmd/frontend/internal/guardrails/dotcom",
         "//internal/database",
+        "//internal/observation",
         "//internal/search/backend",
         "//internal/search/client",
         "//internal/types",

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/guardrails/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -29,11 +30,11 @@ func TestAttribution(t *testing.T) {
 	wantCount := localCount + dotcomCount
 	wantNames := append(genRepoNames("localrepo-", localCount), genRepoNames("dotcomrepo-", dotcomCount)...)
 
-	svc := &Service{
+	svc := NewService(observation.TestContextTB(t), ServiceOpts{
 		SearchClient:              mockSearchClient(t, localNames),
 		SourcegraphDotComClient:   mockDotComClient(t, dotcomNames),
 		SourcegraphDotComFederate: true,
-	}
+	})
 
 	result, err := svc.SnippetAttribution(ctx, "test", limit)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/observability.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/observability.go
@@ -1,0 +1,69 @@
+package attribution
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/metrics"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type operations struct {
+	snippetAttribution       *observation.Operation
+	snippetAttributionLocal  *observation.Operation
+	snippetAttributionDotCom *observation.Operation
+}
+
+func newOperations(observationCtx *observation.Context) *operations {
+	redMetrics := metrics.NewREDMetrics(
+		observationCtx.Registerer,
+		"guardrails",
+		metrics.WithLabels("op"),
+		metrics.WithCountHelp("Total number of method invocations."),
+	)
+
+	op := func(name string) *observation.Operation {
+		return observationCtx.Operation(observation.Op{
+			Name:              fmt.Sprintf("Guardrails.%s", name),
+			MetricLabelValues: []string{name},
+			Metrics:           redMetrics,
+		})
+	}
+
+	return &operations{
+		snippetAttribution:       op("SnippetAttribution"),
+		snippetAttributionLocal:  op("SnippetAttributionLocal"),
+		snippetAttributionDotCom: op("SnippetAttributionDotCom"),
+	}
+}
+
+// endObservationWithResult is a helper which will automatically include the
+// results logging attribute if it is non-nil.
+func endObservationWithResult(traceLogger observation.TraceLogger, endObservation observation.FinishFunc, result **SnippetAttributions) func() {
+	// While this feature is experimental we also debug log successful
+	// requests. We need to independently capture duration.
+	start := time.Now()
+
+	return func() {
+		var args observation.Args
+		final := *result
+		if final != nil {
+			args.Attrs = []attribute.KeyValue{
+				attribute.Int("len", len(final.RepositoryNames)),
+				attribute.Int("total_count", final.TotalCount),
+				attribute.Bool("limit_hit", final.LimitHit),
+			}
+
+			// Temporary logging code, so duplication is fine with above.
+			traceLogger.Debug("successful snippet attribution search",
+				log.Int("len", len(final.RepositoryNames)),
+				log.Int("total_count", final.TotalCount),
+				log.Bool("limit_hit", final.LimitHit),
+				log.Duration("duration", time.Since(start)),
+			)
+		}
+		endObservation(1, args)
+	}
+}

--- a/enterprise/cmd/frontend/internal/guardrails/init.go
+++ b/enterprise/cmd/frontend/internal/guardrails/init.go
@@ -25,7 +25,7 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	attributionService := &attribution.Service{
+	opts := attribution.ServiceOpts{
 		SearchClient: client.New(observationCtx.Logger, db, enterpriseServices.EnterpriseSearchJobs),
 	}
 
@@ -38,12 +38,12 @@ func Init(
 		endpoint := "https://sourcegraph.com/.api/graphql"
 		accessToken := ""
 
-		attributionService.SourcegraphDotComFederate = true
-		attributionService.SourcegraphDotComClient = dotcom.NewClient(httpClient, endpoint, accessToken)
+		opts.SourcegraphDotComFederate = true
+		opts.SourcegraphDotComClient = dotcom.NewClient(httpClient, endpoint, accessToken)
 	}
 
 	enterpriseServices.GuardrailsResolver = &resolvers.GuardrailsResolver{
-		AttributionService: attributionService,
+		AttributionService: attribution.NewService(observationCtx, opts),
 	}
 
 	return nil


### PR DESCRIPTION
This adds traces, logs and metrics via the Operation abstraction. It is my first time using it, but I believe I am using it correctly. To use this we introduce a constructor which initializes the Operation for the attribution service.

Test Plan: go test and sg start and visiting the prometheus metrics.

Part of #53766 
Part of #52366 