### PR TITLE
default vscode config: recommend installation of Cody

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "sourcegraph.sourcegraph",
+    "sourcegraph.cody-ai",
     "editorconfig.editorconfig",
     "esbenp.prettier-vscode",
     "graphql.vscode-graphql",


### PR DESCRIPTION
Setup fresh VS Code instance and opened `sourcegraph/sourcegraph` only to end up without Cody :(

## Test plan

- No