### PR TITLE
client/web: Use perforce cid in tree URL

### DIFF
--- a/client/web/src/components/diff/FileDiffNode.tsx
+++ b/client/web/src/components/diff/FileDiffNode.tsx
@@ -10,6 +10,7 @@ import { Button, Badge, Link, Icon, Text, createLinkUrl, Tooltip } from '@source
 
 import { FileDiffFields } from '../../graphql-operations'
 import { DiffMode } from '../../repo/commit/RepositoryCommitPage'
+import { isPerforceChangelistMappingEnabled } from '../../repo/utils'
 
 import { DiffStat, DiffStatSquares } from './DiffStat'
 import { FileDiffHunks } from './FileDiffHunks'
@@ -81,7 +82,7 @@ export const FileDiffNode: React.FunctionComponent<React.PropsWithChildren<FileD
     const anchor = `diff-${node.internalID}`
 
     const gitBlobURL =
-        window.context.experimentalFeatures.perforceChangelistMapping &&
+        isPerforceChangelistMappingEnabled() &&
         node.mostRelevantFile.__typename === 'GitBlob' &&
         node.mostRelevantFile.changelistURL
             ? node.mostRelevantFile.changelistURL

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -247,15 +247,12 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
 
         return null
     }
-    const getPerforceTreeCanonnicalURL = (url: string, cid: string) => url.split('@')[0] + '@' + cid
 
     if (!node.tree) {
         return <ErrorAlert className="mt-2" error={new Error('missing information about tree')} />
     }
 
-    const treeCanonicalURL = isPerforceDepot
-        ? getPerforceTreeCanonnicalURL(node.tree.canonicalURL, refID)
-        : node.tree.canonicalURL
+    const treeCanonicalURL = isPerforceDepot ? node.tree.canonicalURL.replace(node.oid, refID) : node.tree.canonicalURL
 
     const viewFilesCommitElement = node.tree && (
         <div className="d-flex justify-content-between align-items-start">

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -7,7 +7,7 @@ import { capitalize } from 'lodash'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
-import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
+import { Button, ButtonGroup, ErrorAlert, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
 import { GitCommitFields, RepositoryType } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -15,7 +15,7 @@ import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { DiffModeSelector } from '../commit/DiffModeSelector'
 import { DiffMode } from '../commit/RepositoryCommitPage'
 import { Linkified } from '../linkifiy/Linkified'
-import { getCanonicalURL, getRefType, isPerforceDepotSource } from '../utils'
+import { getCanonicalURL, getRefType, isPerforceChangelistMappingEnabled, isPerforceDepotSource } from '../utils'
 
 import { GitCommitNodeByline } from './GitCommitNodeByline'
 
@@ -249,10 +249,13 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     }
 
     if (!node.tree) {
-        return <ErrorAlert className="mt-2" error={new Error('missing information about tree')} />
+        return <ErrorAlert error={new Error('missing information about tree')} />
     }
 
-    const treeCanonicalURL = isPerforceDepot ? node.tree.canonicalURL.replace(node.oid, refID) : node.tree.canonicalURL
+    const treeCanonicalURL =
+        isPerforceChangelistMappingEnabled() && isPerforceDepot
+            ? node.tree.canonicalURL.replace(node.oid, refID)
+            : node.tree.canonicalURL
 
     const viewFilesCommitElement = node.tree && (
         <div className="d-flex justify-content-between align-items-start">

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -7,7 +7,7 @@ import { capitalize } from 'lodash'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
-import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
+import { Button, ButtonGroup, Link, Icon, Code, screenReaderAnnounce, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
 
 import { GitCommitFields, RepositoryType } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
@@ -247,13 +247,22 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
 
         return null
     }
+    const getPerforceTreeCanonnicalURL = (url: string, cid: string) => url.split('@')[0] + '@' + cid
+
+    if (!node.tree) {
+        return <ErrorAlert className="mt-2" error={new Error('missing information about tree')} />
+    }
+
+    const treeCanonicalURL = isPerforceDepot
+        ? getPerforceTreeCanonnicalURL(node.tree.canonicalURL, refID)
+        : node.tree.canonicalURL
 
     const viewFilesCommitElement = node.tree && (
         <div className="d-flex justify-content-between align-items-start">
             <Tooltip content="Browse files in the repository at this point in history">
                 <Button
                     className="align-center d-inline-flex"
-                    to={node.tree.canonicalURL}
+                    to={treeCanonicalURL}
                     variant="secondary"
                     outline={true}
                     size="sm"
@@ -316,7 +325,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                                             <Tooltip content={`View files at this ${refType}`}>
                                                 <Button
                                                     aria-label="View files"
-                                                    to={node.tree.canonicalURL}
+                                                    to={treeCanonicalURL}
                                                     variant="secondary"
                                                     size="sm"
                                                     as={Link}

--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -9,6 +9,7 @@ import { Button, Link, Icon, Code } from '@sourcegraph/wildcard'
 import { eventLogger } from '../../tracking/eventLogger'
 import { CommitMessageWithLinks } from '../commit/CommitMessageWithLinks'
 import { Linkified } from '../linkifiy/Linkified'
+import { isPerforceChangelistMappingEnabled } from '../utils'
 
 import { GitCommitNodeProps } from './GitCommitNode'
 import { GitCommitNodeByline } from './GitCommitNodeByline'
@@ -34,7 +35,7 @@ export const GitCommitNodeTableRow: React.FC<
     }, [showCommitMessageBody])
 
     const canonicalURL =
-        window.context.experimentalFeatures.perforceChangelistMapping && node.perforceChangelist?.canonicalURL
+        isPerforceChangelistMappingEnabled() && node.perforceChangelist?.canonicalURL
             ? node.perforceChangelist.canonicalURL
             : node.canonicalURL
 

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -54,7 +54,7 @@ import { canWriteRepoMetadata } from '../../util/rbac'
 import { OWNER_FIELDS, RECENT_CONTRIBUTOR_FIELDS, RECENT_VIEW_FIELDS } from '../blob/own/grapqlQueries'
 import { GitCommitNodeTableRow } from '../commits/GitCommitNodeTableRow'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
-import { getRefType } from '../utils'
+import { getRefType, isPerforceChangelistMappingEnabled } from '../utils'
 
 import { DiffStat, FilesCard, ReadmePreviewCard } from './TreePagePanels'
 
@@ -769,8 +769,7 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
     const connection = node?.commit?.ancestors
 
     const revisionType =
-        window.context.experimentalFeatures.perforceChangelistMapping === 'enabled' &&
-        node?.sourceType === RepositoryType.PERFORCE_DEPOT
+        isPerforceChangelistMappingEnabled() && node?.sourceType === RepositoryType.PERFORCE_DEPOT
             ? '/-/changelists'
             : '/-/commits'
 

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -1,13 +1,14 @@
 import { GitCommitFields, RepositoryType } from '../graphql-operations'
 
+export const isPerforceChangelistMappingEnabled = (): boolean =>
+    window.context.experimentalFeatures.perforceChangelistMapping === 'enabled'
+
 export const isPerforceDepotSource = (sourceType: string): boolean => sourceType === RepositoryType.PERFORCE_DEPOT
 
 export const getRefType = (sourceType: RepositoryType | string): string =>
     isPerforceDepotSource(sourceType) ? 'changelist' : 'commit'
 
 export const getCanonicalURL = (sourceType: RepositoryType | string, node: GitCommitFields): string =>
-    window.context.experimentalFeatures?.perforceChangelistMapping === 'enabled' &&
-    isPerforceDepotSource(sourceType) &&
-    node.perforceChangelist
+    isPerforceChangelistMappingEnabled() && isPerforceDepotSource(sourceType) && node.perforceChangelist
         ? node.perforceChangelist.canonicalURL
         : node.canonicalURL


### PR DESCRIPTION
Links to "Browse files @CID" will now directly go to the URL pointing to the CID instead of the Commit SHA.

## Test plan

- Tested manually
- Builds should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
