### PR TITLE
App - remove the repos settings group in advanced settings

### DIFF
--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -105,6 +105,7 @@ export const repositoriesGroup: SiteAdminSideBarGroup = {
             condition: isPackagesEnabled,
         },
     ],
+    condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
 }
 
 export const usersGroup: SiteAdminSideBarGroup = {


### PR DESCRIPTION
The items in the repos group are not relevant to App since all repositories need to sit on the current computer.  Users can manage cloning via the tool of their choice and then add the local once they are local.
## Test plan
`sg start app` ensure section not shown
<img width="996" alt="Screenshot 2023-06-23 at 9 09 53 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/dba3c37c-d18b-4a55-af01-a5864c3650f9">

`sg start` ensure repos section is visible

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
