### PR TITLE
Cody: Remove CTA from login notification

### DIFF
--- a/client/cody/src/services/AuthProvider.ts
+++ b/client/cody/src/services/AuthProvider.ts
@@ -204,12 +204,8 @@ export class AuthProvider {
         await this.storeAuthInfo(endpoint, token)
         const authState = await this.auth(endpoint, token, customHeaders)
         if (authState?.isLoggedIn) {
-            const actionButtonLabel = 'Get Started'
             const successMessage = isApp ? 'Connected to Cody App' : `Signed in to ${endpoint}`
-            const action = await vscode.window.showInformationMessage(successMessage, actionButtonLabel)
-            if (action === actionButtonLabel) {
-                await vscode.commands.executeCommand('cody.chat.focus')
-            }
+            await vscode.window.showInformationMessage(successMessage)
         }
     }
 


### PR DESCRIPTION
## Description

Removes CTA from the "Signed in to (endpoint)" notification.

Reasoning: Pretty much all users will still have the Cody screen open - they've just been redirected back to VS Code. This CTA won't do appear to do anything if Cody is open, so remove the avoid confusion.

## Test plan

Tested locally.