### PR TITLE
JetBrains: add basic integration with the local Cody app [WIP]

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Background color and font of inline code blocks differs from regular text in message [#53761](https://github.com/sourcegraph/sourcegraph/pull/53761)
 - Autofocus Cody chat prompt input [#53836](https://github.com/sourcegraph/sourcegraph/pull/53836)
+- Basic integration with the local Cody App [#54061](https://github.com/sourcegraph/sourcegraph/pull/54061)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -202,12 +202,7 @@ class CodyToolWindowContent implements UpdatableChat {
   }
 
   private void addWelcomeMessage() {
-    boolean isEnterprise =
-        ConfigUtil.getInstanceType(project).equals(SettingsComponent.InstanceType.ENTERPRISE);
-    String accessToken =
-        isEnterprise
-            ? ConfigUtil.getEnterpriseAccessToken(project)
-            : ConfigUtil.getDotComAccessToken(project);
+    String accessToken = ConfigUtil.getProjectAccessToken(project);
     String welcomeText =
         "Hello! I'm Cody. I can write code and answer questions for you. See [Cody documentation](https://docs.sourcegraph.com/cody) for help and tips.";
     addMessageToChat(ChatMessage.createAssistantMessage(welcomeText));
@@ -378,12 +373,8 @@ class CodyToolWindowContent implements UpdatableChat {
     // Build message
     boolean isEnterprise =
         ConfigUtil.getInstanceType(project).equals(SettingsComponent.InstanceType.ENTERPRISE);
-    String instanceUrl =
-        isEnterprise ? ConfigUtil.getEnterpriseUrl(project) : "https://sourcegraph.com/";
-    String accessToken =
-        isEnterprise
-            ? ConfigUtil.getEnterpriseAccessToken(project)
-            : ConfigUtil.getDotComAccessToken(project);
+    String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+    String accessToken = ConfigUtil.getProjectAccessToken(project);
 
     var chat = new Chat("", instanceUrl, accessToken != null ? accessToken : "");
     ArrayList<String> contextFiles =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppInfo.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppInfo.java
@@ -1,0 +1,50 @@
+package com.sourcegraph.cody.localapp;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
+
+/** This is just a data object for the local Cody app.json */
+@JsonIgnoreProperties(
+    ignoreUnknown = true) // we don't care if the json contains fields we don't know about
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LocalAppInfo {
+  @JsonProperty("token")
+  @Nullable
+  private String token;
+
+  @JsonProperty("endpoint")
+  @Nullable
+  private String endpoint;
+
+  @JsonProperty("version")
+  @Nullable
+  private String version;
+
+  @Nullable
+  public String getToken() {
+    return token;
+  }
+
+  public void setToken(@Nullable String token) {
+    this.token = token;
+  }
+
+  @Nullable
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(@Nullable String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public @Nullable String getVersion() {
+    return version;
+  }
+
+  public void setVersion(@Nullable String version) {
+    this.version = version;
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -51,12 +51,9 @@ public class LocalAppManager {
 
   @NotNull
   public static Optional<String> getLocalAppAccessToken() {
-    Optional<String> token =
-        getLocalAppInfo()
-            .flatMap(appInfo -> Optional.ofNullable(appInfo.getToken()))
-            .filter(AuthorizationUtil::isValidAccessToken);
-    System.err.println("Local Cody app access token: " + token.orElse("none"));
-    return token;
+    return getLocalAppInfo()
+        .flatMap(appInfo -> Optional.ofNullable(appInfo.getToken()))
+        .filter(AuthorizationUtil::isValidAccessToken);
   }
 
   @NotNull
@@ -95,7 +92,7 @@ public class LocalAppManager {
                 + responseBody);
         return Optional.empty();
       } else {
-        System.err.println("Running local Cody app version: " + responseBody);
+        System.out.println("Running local Cody app version: " + responseBody);
         return Optional.of(responseBody);
       }
     } catch (ConnectException e) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.localapp;
 
+import com.sourcegraph.common.AuthorizationUtil;
 import java.net.ConnectException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -51,7 +52,9 @@ public class LocalAppManager {
   @NotNull
   public static Optional<String> getLocalAppAccessToken() {
     Optional<String> token =
-        getLocalAppInfo().flatMap(appInfo -> Optional.ofNullable(appInfo.getToken()));
+        getLocalAppInfo()
+            .flatMap(appInfo -> Optional.ofNullable(appInfo.getToken()))
+            .filter(AuthorizationUtil::isValidAccessToken);
     System.err.println("Local Cody app access token: " + token.orElse("none"));
     return token;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -1,0 +1,106 @@
+package com.sourcegraph.cody.localapp;
+
+import java.net.ConnectException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang.SystemUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class LocalAppManager {
+  public static final String DEFAULT_LOCAL_APP_URL = "http://localhost:3080";
+  private static final Map<String, LocalAppPaths> appPathsByPlatform =
+      Map.of(
+          "darwin", // only support macOS for now
+          new LocalAppPaths(
+              Path.of("/Applications/Sourcegraph.app"),
+              Path.of("/Applications/Cody.app"),
+              Path.of(
+                  SystemUtils.getUserHome()
+                      + "/Library/Application Support/com.sourcegraph.cody/site.config.json"),
+              Path.of(
+                  SystemUtils.getUserHome()
+                      + "/Library/Application Support/com.sourcegraph.cody/app.json")));
+
+  public static boolean isLocalAppInstalled() {
+    return getLocalAppPaths().map(LocalAppPaths::anyPathExists).orElse(false);
+  }
+
+  @NotNull
+  public static Optional<LocalAppPaths> getLocalAppPaths() {
+    return Optional.ofNullable(System.getProperty("os.name"))
+        .map(String::toLowerCase)
+        .map(
+            osName -> {
+              if (osName.contains("mac")) return "darwin";
+              else if (osName.contains("windows")) return "windows";
+              else return osName;
+            })
+        .flatMap(osKey -> Optional.ofNullable(appPathsByPlatform.get(osKey)));
+  }
+
+  public static boolean isPlatformSupported() {
+    return getLocalAppPaths().isPresent();
+  }
+
+  @NotNull
+  public static Optional<String> getLocalAppAccessToken() {
+    Optional<String> token =
+        getLocalAppInfo().flatMap(appInfo -> Optional.ofNullable(appInfo.getToken()));
+    System.err.println("Local Cody app access token: " + token.orElse("none"));
+    return token;
+  }
+
+  @NotNull
+  public static Optional<LocalAppInfo> getLocalAppInfo() {
+    return getLocalAppPaths().flatMap(LocalAppPaths::getAppInfo);
+  }
+
+  public static boolean isLocalAppRunning() {
+    return getRunningAppVersion().isPresent();
+  }
+
+  /**
+   * @return gets the local app url from the local app json file, falls back to
+   *     [[DEFAULT_LOCAL_APP_URL]] if not present
+   */
+  @NotNull
+  public static String getLocalAppUrl() {
+    return getLocalAppInfo()
+        .flatMap(appInfo -> Optional.ofNullable(appInfo.getEndpoint()))
+        .orElse(DEFAULT_LOCAL_APP_URL);
+  }
+
+  @NotNull
+  private static Optional<String> getRunningAppVersion() {
+    // TODO: do this asynchronously
+    try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+      HttpGet request = new HttpGet(getLocalAppUrl() + "/__version");
+      HttpResponse response = httpClient.execute(request);
+      int statusCode = response.getStatusLine().getStatusCode();
+      String responseBody = EntityUtils.toString(response.getEntity());
+      if (statusCode != 200) {
+        System.err.println(
+            "Could not fetch local Cody app version. Got status code "
+                + statusCode
+                + ": "
+                + responseBody);
+        return Optional.empty();
+      } else {
+        System.err.println("Running local Cody app version: " + responseBody);
+        return Optional.of(responseBody);
+      }
+    } catch (ConnectException e) {
+      System.err.println("Could not connect to the local Cody app.");
+      return Optional.empty();
+    } catch (Exception e) {
+      e.printStackTrace();
+      return Optional.empty();
+    }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
@@ -1,0 +1,53 @@
+package com.sourcegraph.cody.localapp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class LocalAppPaths {
+  public final Path sourcegraphAppFile;
+  public final Path codyAppFile;
+  public final Path siteConfigJsonFile;
+  public final Path appJsonFile;
+
+  LocalAppPaths(
+      Path sourcegraphAppFile, Path codyAppFile, Path siteConfigJsonFile, Path appJsonFile) {
+    this.sourcegraphAppFile = sourcegraphAppFile;
+    this.codyAppFile = codyAppFile;
+    this.siteConfigJsonFile = siteConfigJsonFile;
+    this.appJsonFile = appJsonFile;
+  }
+
+  public boolean anyPathExists() {
+    return pathExists(sourcegraphAppFile)
+        || pathExists(codyAppFile)
+        || pathExists(siteConfigJsonFile)
+        || pathExists(appJsonFile);
+  }
+
+  private static boolean pathExists(Path path) {
+    try {
+      return path.toFile().exists();
+    } catch (SecurityException | UnsupportedOperationException e) {
+      // in case we can't read the path for whatever reason, we assume it doesn't exist
+      return false;
+    }
+  }
+
+  public Optional<LocalAppInfo> getAppInfo() {
+    if (pathExists(appJsonFile)) {
+      try {
+        String jsonContent = Files.readString(appJsonFile);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        LocalAppInfo appInfo = objectMapper.readValue(jsonContent, LocalAppInfo.class);
+        return Optional.of(appInfo);
+      } catch (IOException e) {
+        System.err.println("Error reading local Cody app JSON file: " + e.getMessage());
+        return Optional.empty();
+      }
+    } else return Optional.empty();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -1,0 +1,11 @@
+package com.sourcegraph.common;
+
+import org.jetbrains.annotations.NotNull;
+
+public class AuthorizationUtil {
+  public static boolean isValidAccessToken(@NotNull String accessToken) {
+    return accessToken.isEmpty()
+        || accessToken.length() == 40
+        || (accessToken.startsWith("sgp_") && accessToken.length() == 44);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -6,10 +6,13 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.agent.ConnectionConfiguration;
+import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.find.Search;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,33 +42,36 @@ public class ConfigUtil {
 
   @NotNull
   public static SettingsComponent.InstanceType getInstanceType(Project project) {
-    // Project level
-    String projectLevelSetting = getProjectLevelConfig(project).getInstanceType();
-    if (projectLevelSetting != null && !projectLevelSetting.isEmpty()) {
-      return projectLevelSetting.equals(SettingsComponent.InstanceType.ENTERPRISE.name())
-          ? SettingsComponent.InstanceType.ENTERPRISE
-          : SettingsComponent.InstanceType.DOTCOM;
-    }
-
-    // Application level
-    String applicationLevelSetting = getApplicationLevelConfig().getInstanceType();
-    if (applicationLevelSetting != null && !applicationLevelSetting.isEmpty()) {
-      return applicationLevelSetting.equals(SettingsComponent.InstanceType.ENTERPRISE.name())
-          ? SettingsComponent.InstanceType.ENTERPRISE
-          : SettingsComponent.InstanceType.DOTCOM;
-    }
-
-    // User level or default
-    String enterpriseUrl = getEnterpriseUrl(project);
-    return (enterpriseUrl.equals("") || enterpriseUrl.startsWith(DOTCOM_URL))
-        ? SettingsComponent.InstanceType.DOTCOM
-        : SettingsComponent.InstanceType.ENTERPRISE;
+    return Optional.ofNullable(getProjectLevelConfig(project).getInstanceType()) // Project level
+        .flatMap(SettingsComponent.InstanceType::optionalValueOf)
+        .or( // Application level
+            () ->
+                Optional.ofNullable(getApplicationLevelConfig().getInstanceType())
+                    .flatMap(SettingsComponent.InstanceType::optionalValueOf))
+        .or( // User level
+            () ->
+                Optional.of(getEnterpriseUrl(project))
+                    .filter(StringUtils::isNotEmpty)
+                    .flatMap(
+                        url -> {
+                          if (url.startsWith(DOTCOM_URL)) {
+                            return Optional.of(SettingsComponent.InstanceType.DOTCOM);
+                          } else if (url.startsWith(LocalAppManager.getLocalAppUrl())) {
+                            return Optional.of(SettingsComponent.InstanceType.LOCAL_APP);
+                          } else {
+                            return Optional.empty();
+                          }
+                        }))
+        .orElse(SettingsComponent.InstanceType.ENTERPRISE); // or default
   }
 
   @NotNull
   public static String getSourcegraphUrl(@NotNull Project project) {
-    if (getInstanceType(project) == SettingsComponent.InstanceType.DOTCOM) {
+    SettingsComponent.InstanceType instanceType = getInstanceType(project);
+    if (instanceType == SettingsComponent.InstanceType.DOTCOM) {
       return DOTCOM_URL;
+    } else if (instanceType == SettingsComponent.InstanceType.LOCAL_APP) {
+      return LocalAppManager.getLocalAppUrl();
     } else {
       String enterpriseUrl = getEnterpriseUrl(project);
       return !enterpriseUrl.isEmpty() ? enterpriseUrl : DOTCOM_URL;
@@ -269,12 +275,19 @@ public class ConfigUtil {
     return System.getProperty("user.home");
   }
 
+  @Nullable
   public static String getProjectAccessToken(Project project) {
-    return ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE
-        ? ConfigUtil.getEnterpriseAccessToken(project)
-        : ConfigUtil.getProjectAccessToken(project);
+    SettingsComponent.InstanceType instanceType = ConfigUtil.getInstanceType(project);
+    if (instanceType == SettingsComponent.InstanceType.ENTERPRISE) {
+      return getEnterpriseAccessToken(project);
+    } else if (instanceType == SettingsComponent.InstanceType.LOCAL_APP) {
+      return LocalAppManager.getLocalAppAccessToken().orElse(null);
+    } else {
+      return getDotComAccessToken(project);
+    }
   }
 
+  @Nullable
   public static String getEnterpriseAccessToken(Project project) {
     // Project level → application level
     String projectLevelAccessToken = getProjectLevelConfig(project).getEnterpriseAccessToken();
@@ -283,6 +296,7 @@ public class ConfigUtil {
         : getApplicationLevelConfig().getEnterpriseAccessToken();
   }
 
+  @Nullable
   public static String getDotComAccessToken(Project project) {
     // Project level → application level
     String projectLevelAccessToken = getProjectLevelConfig(project).getDotComAccessToken();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -42,6 +42,9 @@ public class SettingsComponent {
   private JBCheckBox isUrlNotificationDismissedCheckBox;
   private JBCheckBox areCompletionsEnabledCheckBox;
 
+  private JButton testCodyAppConnectionButton;
+  private JLabel testCodyAppConnectionLabel;
+
   public JComponent getPreferredFocusedComponent() {
     return defaultBranchNameTextField;
   }
@@ -175,10 +178,6 @@ public class SettingsComponent {
             UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     codyAppComment.setEnabled(isCodyAppInstalledAndConfigured);
-    //    JPanel codyAppPanelContent =
-    //        FormBuilder.createFormBuilder()
-    //            .addComponentToRightColumn(dotComAccessTokenComment, 1)
-    //            .getPanel();
     JPanel codyAppPanel =
         FormBuilder.createFormBuilder()
             .addComponent(codyAppRadioButton, 1)

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -11,9 +11,11 @@ import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.jetbrains.jsonSchema.settings.mappings.JsonSchemaConfigurable;
+import com.sourcegraph.cody.localapp.LocalAppManager;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.Enumeration;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.swing.*;
@@ -64,12 +66,8 @@ public class SettingsComponent {
 
   @NotNull
   public InstanceType getInstanceType() {
-    return instanceTypeButtonGroup
-            .getSelection()
-            .getActionCommand()
-            .equals(InstanceType.DOTCOM.name())
-        ? InstanceType.DOTCOM
-        : InstanceType.ENTERPRISE;
+    return InstanceType.optionalValueOf(instanceTypeButtonGroup.getSelection().getActionCommand())
+        .orElse(InstanceType.ENTERPRISE);
   }
 
   public void setInstanceType(@NotNull InstanceType instanceType) {
@@ -80,7 +78,7 @@ public class SettingsComponent {
       button.setSelected(button.getActionCommand().equals(instanceType.name()));
     }
 
-    setEnterpriseSettingsEnabled(instanceType == InstanceType.ENTERPRISE);
+    setInstanceSettingsEnabled(instanceType);
   }
 
   @NotNull
@@ -143,8 +141,17 @@ public class SettingsComponent {
     // Set up radio buttons
     ActionListener actionListener =
         event ->
-            setEnterpriseSettingsEnabled(
-                event.getActionCommand().equals(InstanceType.ENTERPRISE.name()));
+            setInstanceSettingsEnabled(
+                InstanceType.optionalValueOf(event.getActionCommand())
+                    .orElse(InstanceType.ENTERPRISE));
+    JRadioButton codyAppRadioButton = new JRadioButton("Use the local Cody App");
+    boolean isCodyAppInstalledAndConfigured =
+        LocalAppManager.isLocalAppInstalled()
+            && LocalAppManager.getLocalAppAccessToken().isPresent();
+    codyAppRadioButton.setMnemonic(KeyEvent.VK_A);
+    codyAppRadioButton.setActionCommand(InstanceType.LOCAL_APP.name());
+    codyAppRadioButton.addActionListener(actionListener);
+    codyAppRadioButton.setEnabled(isCodyAppInstalledAndConfigured);
     JRadioButton sourcegraphDotComRadioButton = new JRadioButton("Use sourcegraph.com");
     sourcegraphDotComRadioButton.setMnemonic(KeyEvent.VK_C);
     sourcegraphDotComRadioButton.setActionCommand(InstanceType.DOTCOM.name());
@@ -154,10 +161,29 @@ public class SettingsComponent {
     enterpriseInstanceRadioButton.setActionCommand(InstanceType.ENTERPRISE.name());
     enterpriseInstanceRadioButton.addActionListener(actionListener);
     instanceTypeButtonGroup = new ButtonGroup();
+    instanceTypeButtonGroup.add(codyAppRadioButton);
     instanceTypeButtonGroup.add(sourcegraphDotComRadioButton);
     instanceTypeButtonGroup.add(enterpriseInstanceRadioButton);
 
-    // Assemble the two main panels
+    // Assemble the three main panels
+
+    JBLabel codyAppComment =
+        new JBLabel(
+            "Use Sourcegraph through the locally installed Cody App",
+            UIUtil.ComponentStyle.SMALL,
+            UIUtil.FontColor.BRIGHTER);
+    codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
+    codyAppComment.setEnabled(isCodyAppInstalledAndConfigured);
+    //    JPanel codyAppPanelContent =
+    //        FormBuilder.createFormBuilder()
+    //            .addComponentToRightColumn(dotComAccessTokenComment, 1)
+    //            .getPanel();
+    JPanel codyAppPanel =
+        FormBuilder.createFormBuilder()
+            .addComponent(codyAppRadioButton, 1)
+            .addComponent(codyAppComment, 2)
+            //            .addComponent(codyAppPanelContent, 1)
+            .getPanel();
     JBLabel dotComComment =
         new JBLabel(
             "Use sourcegraph.com to search public code",
@@ -224,7 +250,8 @@ public class SettingsComponent {
     // Assemble the main panel
     JPanel userAuthenticationPanel =
         FormBuilder.createFormBuilder()
-            .addComponent(dotComPanel)
+            .addComponent(codyAppPanel)
+            .addComponent(dotComPanel, 5)
             .addComponent(enterprisePanel, 5)
             .addLabeledComponent(customRequestHeadersLabel, customRequestHeadersTextField)
             .addTooltip("Any custom headers to send with every request to Sourcegraph.")
@@ -307,21 +334,34 @@ public class SettingsComponent {
     areCompletionsEnabledCheckBox.setSelected(value);
   }
 
-  private void setEnterpriseSettingsEnabled(boolean enable) {
-    urlTextField.setEnabled(enable);
-    enterpriseAccessTokenTextField.setEnabled(enable);
-    userDocsLinkComment.setEnabled(enable);
-    userDocsLinkComment.setCopyable(enable);
-    enterpriseAccessTokenLinkComment.setEnabled(enable);
-    enterpriseAccessTokenLinkComment.setCopyable(enable);
+  private void setInstanceSettingsEnabled(@NotNull InstanceType instanceType) {
+    // enterprise stuff
+    boolean isEnterprise = instanceType == InstanceType.ENTERPRISE;
+    urlTextField.setEnabled(isEnterprise);
+    enterpriseAccessTokenTextField.setEnabled(isEnterprise);
+    userDocsLinkComment.setEnabled(isEnterprise);
+    userDocsLinkComment.setCopyable(isEnterprise);
+    enterpriseAccessTokenLinkComment.setEnabled(isEnterprise);
+    enterpriseAccessTokenLinkComment.setCopyable(isEnterprise);
 
     // dotCom stuff
-    dotComAccessTokenTextField.setEnabled(!enable);
+    boolean isDotCom = instanceType == InstanceType.DOTCOM;
+    dotComAccessTokenTextField.setEnabled(isDotCom);
   }
 
   public enum InstanceType {
     DOTCOM,
     ENTERPRISE,
+    LOCAL_APP;
+
+    @NotNull
+    public static Optional<InstanceType> optionalValueOf(@NotNull String name) {
+      try {
+        return Optional.of(InstanceType.valueOf(name));
+      } catch (IllegalArgumentException e) {
+        return Optional.empty();
+      }
+    }
   }
 
   private void addValidation(

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -12,6 +12,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.jetbrains.jsonSchema.settings.mappings.JsonSchemaConfigurable;
 import com.sourcegraph.cody.localapp.LocalAppManager;
+import com.sourcegraph.common.AuthorizationUtil;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.Enumeration;
@@ -106,7 +107,7 @@ public class SettingsComponent {
     addValidation(
         enterpriseAccessTokenTextField,
         () ->
-            !isValidAccessToken(enterpriseAccessTokenTextField.getText())
+            !AuthorizationUtil.isValidAccessToken(enterpriseAccessTokenTextField.getText())
                 ? new ValidationInfo("Invalid access token", enterpriseAccessTokenTextField)
                 : null);
 
@@ -123,7 +124,7 @@ public class SettingsComponent {
     addValidation(
         dotComAccessTokenTextField,
         () ->
-            !isValidAccessToken(dotComAccessTokenTextField.getText())
+            !AuthorizationUtil.isValidAccessToken(dotComAccessTokenTextField.getText())
                 ? new ValidationInfo("Invalid access token", dotComAccessTokenTextField)
                 : null);
 
@@ -410,12 +411,6 @@ public class SettingsComponent {
 
   private boolean isUrlValid(@NotNull String url) {
     return JsonSchemaConfigurable.isValidURL(url);
-  }
-
-  private boolean isValidAccessToken(@NotNull String accessToken) {
-    return accessToken.isEmpty()
-        || accessToken.length() == 40
-        || (accessToken.startsWith("sgp_") && accessToken.length() == 44);
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SourcegraphProjectService.java
@@ -105,6 +105,7 @@ public class SourcegraphProjectService
   }
 
   @Override
+  @Nullable
   public String getEnterpriseAccessToken() {
     // configuring enterpriseAccessToken overrides the deprecated accessToken field
     String configuredEnterpriseAccessToken =

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.api.GraphQlClient;
 import com.sourcegraph.config.ConfigUtil;
-import com.sourcegraph.config.SettingsComponent;
 import java.io.IOException;
 import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
@@ -39,10 +38,7 @@ public class GraphQlLogger {
   private static void logEvent(
       Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
     String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
-    String accessToken =
-        ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.ENTERPRISE
-            ? ConfigUtil.getEnterpriseAccessToken(project)
-            : ConfigUtil.getDotComAccessToken(project);
+    String accessToken = ConfigUtil.getProjectAccessToken(project);
     String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
     new Thread(
             () -> {

--- a/client/jetbrains/src/test/java/LocalAppManagerTest.java
+++ b/client/jetbrains/src/test/java/LocalAppManagerTest.java
@@ -1,0 +1,33 @@
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.sourcegraph.cody.localapp.LocalAppManager;
+import org.junit.jupiter.api.Test;
+
+public class LocalAppManagerTest {
+  // these tests are just a sanity check to make sure the LocalAppManager API doesn't throw random
+  // exceptions, not verifying if they actually work for now
+  @Test
+  public void localAppInstallCheckDoesntFail() {
+    LocalAppManager.isLocalAppInstalled();
+  }
+
+  @Test
+  public void localAppRunningCheckDoesntFail() {
+    LocalAppManager.isLocalAppRunning();
+  }
+
+  @Test
+  public void localAppInfoGettingDoesntFail() {
+    LocalAppManager.getLocalAppInfo();
+  }
+
+  @Test
+  public void localAppAccessTokenGettingDoesntFail() {
+    LocalAppManager.getLocalAppAccessToken();
+  }
+
+  @Test
+  public void localAppUrlGettingDoesntFail() {
+    LocalAppManager.getLocalAppUrl();
+  }
+}


### PR DESCRIPTION
~Fixes #53834~
Addresses most of #53834, the sidebar stuff + some other UX and other stuff will be added in a follow-up PR later.

This adds a third instance type for the local Cody App.
Only Macs are supported for now.
Make sure the app is running in the background when testing.

https://github.com/sourcegraph/sourcegraph/assets/18601388/88304210-d375-49d0-9c90-761efb844ff7

## Test plan
- some sanity-checks are included in the form of unit tests
- the local app setting should be greyed out if the app is not installed or if you're running on an unsupported platform (so not on Mac, for now)
- no access token should have to be set, the plugin should reuse the local app access token
- all API calls for Cody, including completions, chat and recipes should be done via the local app when enabled
