### PR TITLE
App: Remove link to repo when in App

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -24,6 +24,7 @@ import styles from './RepoEmbeddingJobNode.module.scss'
 
 interface RepoEmbeddingJobNodeProps extends RepoEmbeddingJobFields {
     onCancel: (id: string) => void
+    isSourcegraphApp: boolean
 }
 
 export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
@@ -38,61 +39,59 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
     failureMessage,
     stats,
     onCancel,
-}) => {
-    const isSourcegraphApp = window.context?.sourcegraphAppMode
-    return (
-        <li className="list-group-item p-2">
-            <div className="d-flex justify-content-between">
-                <div className="d-flex align-items-center">
-                    <div className={styles.badgeWrapper}>
-                        <RepoEmbeddingJobStateBadge state={state} />
-                    </div>
-                    <div className="d-flex flex-column ml-3">
-                        {repo && revision ? (
-                            isSourcegraphApp ? (
-                                <>
-                                    {repo.name}@{revision.abbreviatedOID}
-                                </>
-                            ) : (
-                                <Link to={`${repo.url}@${revision.oid}`}>
-                                    {repo.name}@{revision.abbreviatedOID}
-                                </Link>
-                            )
-                        ) : (
-                            <div>Unknown repository</div>
-                        )}
-                        <div className="mt-1">
-                            <RepoEmbeddingJobExecutionInfo
-                                state={state}
-                                cancel={cancel}
-                                finishedAt={finishedAt}
-                                queuedAt={queuedAt}
-                                startedAt={startedAt}
-                                failureMessage={failureMessage}
-                                stats={stats}
-                            />
-                        </div>
-                    </div>
+    isSourcegraphApp,
+}) => (
+    <li className="list-group-item p-2">
+        <div className="d-flex justify-content-between">
+            <div className="d-flex align-items-center">
+                <div className={styles.badgeWrapper}>
+                    <RepoEmbeddingJobStateBadge state={state} />
                 </div>
-                <div className="d-flex align-items-center">
-                    {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
-                        <Tooltip content="Cancel repository embedding job">
-                            <Button
-                                aria-label="Cancel"
-                                onClick={() => onCancel(id)}
-                                variant="secondary"
-                                size="sm"
-                                disabled={cancel}
-                            >
-                                Cancel
-                            </Button>
-                        </Tooltip>
-                    ) : null}
+                <div className="d-flex flex-column ml-3">
+                    {repo && revision ? (
+                        isSourcegraphApp ? (
+                            <>
+                                {repo.name}@{revision.abbreviatedOID}
+                            </>
+                        ) : (
+                            <Link to={`${repo.url}@${revision.oid}`}>
+                                {repo.name}@{revision.abbreviatedOID}
+                            </Link>
+                        )
+                    ) : (
+                        <div>Unknown repository</div>
+                    )}
+                    <div className="mt-1">
+                        <RepoEmbeddingJobExecutionInfo
+                            state={state}
+                            cancel={cancel}
+                            finishedAt={finishedAt}
+                            queuedAt={queuedAt}
+                            startedAt={startedAt}
+                            failureMessage={failureMessage}
+                            stats={stats}
+                        />
+                    </div>
                 </div>
             </div>
-        </li>
-    )
-}
+            <div className="d-flex align-items-center">
+                {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
+                    <Tooltip content="Cancel repository embedding job">
+                        <Button
+                            aria-label="Cancel"
+                            onClick={() => onCancel(id)}
+                            variant="secondary"
+                            size="sm"
+                            disabled={cancel}
+                        >
+                            Cancel
+                        </Button>
+                    </Tooltip>
+                ) : null}
+            </div>
+        </div>
+    </li>
+)
 
 const RepoEmbeddingJobExecutionInfo: FC<
     Pick<

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -38,52 +38,61 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
     failureMessage,
     stats,
     onCancel,
-}) => (
-    <li className="list-group-item p-2">
-        <div className="d-flex justify-content-between">
-            <div className="d-flex align-items-center">
-                <div className={styles.badgeWrapper}>
-                    <RepoEmbeddingJobStateBadge state={state} />
-                </div>
-                <div className="d-flex flex-column ml-3">
-                    {repo && revision ? (
-                        <Link to={`${repo.url}@${revision.oid}`}>
-                            {repo.name}@{revision.abbreviatedOID}
-                        </Link>
-                    ) : (
-                        <div>Unknown repository</div>
-                    )}
-                    <div className="mt-1">
-                        <RepoEmbeddingJobExecutionInfo
-                            state={state}
-                            cancel={cancel}
-                            finishedAt={finishedAt}
-                            queuedAt={queuedAt}
-                            startedAt={startedAt}
-                            failureMessage={failureMessage}
-                            stats={stats}
-                        />
+}) => {
+    const isSourcegraphApp = window.context?.sourcegraphAppMode
+    return (
+        <li className="list-group-item p-2">
+            <div className="d-flex justify-content-between">
+                <div className="d-flex align-items-center">
+                    <div className={styles.badgeWrapper}>
+                        <RepoEmbeddingJobStateBadge state={state} />
+                    </div>
+                    <div className="d-flex flex-column ml-3">
+                        {repo && revision ? (
+                            isSourcegraphApp ? (
+                                <>
+                                    {repo.name}@{revision.abbreviatedOID}
+                                </>
+                            ) : (
+                                <Link to={`${repo.url}@${revision.oid}`}>
+                                    {repo.name}@{revision.abbreviatedOID}
+                                </Link>
+                            )
+                        ) : (
+                            <div>Unknown repository</div>
+                        )}
+                        <div className="mt-1">
+                            <RepoEmbeddingJobExecutionInfo
+                                state={state}
+                                cancel={cancel}
+                                finishedAt={finishedAt}
+                                queuedAt={queuedAt}
+                                startedAt={startedAt}
+                                failureMessage={failureMessage}
+                                stats={stats}
+                            />
+                        </div>
                     </div>
                 </div>
+                <div className="d-flex align-items-center">
+                    {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
+                        <Tooltip content="Cancel repository embedding job">
+                            <Button
+                                aria-label="Cancel"
+                                onClick={() => onCancel(id)}
+                                variant="secondary"
+                                size="sm"
+                                disabled={cancel}
+                            >
+                                Cancel
+                            </Button>
+                        </Tooltip>
+                    ) : null}
+                </div>
             </div>
-            <div className="d-flex align-items-center">
-                {state === RepoEmbeddingJobState.QUEUED || state === RepoEmbeddingJobState.PROCESSING ? (
-                    <Tooltip content="Cancel repository embedding job">
-                        <Button
-                            aria-label="Cancel"
-                            onClick={() => onCancel(id)}
-                            variant="secondary"
-                            size="sm"
-                            disabled={cancel}
-                        >
-                            Cancel
-                        </Button>
-                    </Tooltip>
-                ) : null}
-            </div>
-        </div>
-    </li>
-)
+        </li>
+    )
+}
 
 const RepoEmbeddingJobExecutionInfo: FC<
     Pick<

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -73,6 +73,8 @@ const enumToFilterValues = <T extends string>(enumeration: { [key in T]: T }): F
 }
 
 export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService }) => {
+    const isSourcegraphApp = window.context?.sourcegraphAppMode
+
     useEffect(() => {
         telemetryService.logPageView('SiteAdminCodyPage')
     }, [telemetryService])
@@ -229,7 +231,12 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
                     {loading && !connection && <ConnectionLoading />}
                     <ConnectionList as="ul" className="list-group" aria-label="Repository embeddings jobs">
                         {connection?.nodes?.map(node => (
-                            <RepoEmbeddingJobNode key={node.id} {...node} onCancel={onCancel} />
+                            <RepoEmbeddingJobNode
+                                key={node.id}
+                                {...node}
+                                onCancel={onCancel}
+                                isSourcegraphApp={isSourcegraphApp}
+                            />
                         ))}
                     </ConnectionList>
                     {connection && (


### PR DESCRIPTION
In App, removes the link from the repo names in "Embeddings jobs"

The repo name will no longer be a link, in App only.

Fix #53893

## Test plan

- Run App
- Test manually
