### PR TITLE
cody: fix view load condition

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Endpoint URL without protocol causing sign-ins to fail. [pull/53908](https://github.com/sourcegraph/sourcegraph/pull/53908)
 - Autocomplete: Fix network issues when using remote VS Code setups. [pull/53956](https://github.com/sourcegraph/sourcegraph/pull/53956)
 - Autocomplete: Fix an issue where the loading indicator would not reset when a network error ocurred. [pull/53956](https://github.com/sourcegraph/sourcegraph/pull/53956)
+- Start up view loading issue. [pull/54063](https://github.com/sourcegraph/sourcegraph/pull/54063)
 
 ### Changed
 

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -17,7 +17,7 @@ export type WebviewMessage =
     | { command: 'removeHistory' }
     | { command: 'restoreHistory'; chatID: string }
     | { command: 'deleteHistory'; chatID: string }
-    | { command: 'links'; value: string }
+    | { command: 'links'; value: string; type?: string }
     | { command: 'openFile'; filePath: string }
     | { command: 'edit'; text: string }
     | { command: 'insert'; text: string }

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -29,7 +29,7 @@ export type WebviewMessage =
  */
 export type ExtensionMessage =
     | { type: 'showTab'; tab: string }
-    | { type: 'config'; config: ConfigurationSubsetForWebview & LocalEnv; authStatus: AuthStatus }
+    | { type: 'config'; config: ConfigurationSubsetForWebview & LocalEnv }
     | { type: 'login'; authStatus: AuthStatus }
     | { type: 'history'; messages: UserLocalHistory | null }
     | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean }
@@ -122,8 +122,6 @@ export interface LocalEnv {
     hasAppJson: boolean
     isAppInstalled: boolean
     isAppRunning: boolean
-    // TODO: remove this once the experimental period for connect app is over
-    isAppConnectEnabled: boolean
 }
 
 export function isLoggedIn(authStatus: AuthStatus): boolean {

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -6,7 +6,7 @@ import { Configuration, ConfigurationWithAccessToken } from '@sourcegraph/cody-s
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
 import { ChatViewProvider } from './chat/ChatViewProvider'
-import { AuthStatus, CODY_FEEDBACK_URL } from './chat/protocol'
+import { CODY_FEEDBACK_URL } from './chat/protocol'
 import { CodyCompletionItemProvider } from './completions'
 import { CompletionsDocumentProvider } from './completions/docprovider'
 import { History } from './completions/history'
@@ -184,7 +184,7 @@ const register = async (
             }
         }),
         // Auth
-        vscode.commands.registerCommand('cody.auth.sync', (state: AuthStatus) => chatProvider.syncAuthStatus(state)),
+        vscode.commands.registerCommand('cody.auth.sync', () => chatProvider.syncAuthStatus()),
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),

--- a/client/cody/src/services/AuthProvider.ts
+++ b/client/cody/src/services/AuthProvider.ts
@@ -89,8 +89,8 @@ export class AuthProvider {
             default: {
                 // Auto log user if token for the selected instance was found in secret
                 const selectedEndpoint = item.uri
-                const token = await this.secretStorage.get(selectedEndpoint)
-                const authState = await this.auth(selectedEndpoint, token || null)
+                const token = (await this.secretStorage.get(selectedEndpoint)) || null
+                const authState = await this.auth(selectedEndpoint, token)
                 if (!authState) {
                     return
                 }
@@ -204,7 +204,7 @@ export class AuthProvider {
         await this.storeAuthInfo(endpoint, token)
         const authState = await this.auth(endpoint, token, customHeaders)
         if (authState?.isLoggedIn) {
-            const successMessage = isApp ? 'Connected to Cody App' : `Signed in to ${endpoint}`
+            const successMessage = isApp ? 'Connected to Cody App' : `Signed in to ${isLocalApp(endpoint)}`
             await vscode.window.showInformationMessage(successMessage)
         }
     }

--- a/client/cody/src/services/LocalAppDetector.ts
+++ b/client/cody/src/services/LocalAppDetector.ts
@@ -30,16 +30,10 @@ export class LocalAppDetector implements vscode.Disposable {
         this.localAppMarkers = LOCAL_APP_LOCATIONS[this.localEnv.os]
         // Only Mac is supported for now
         this.isSupported = this.localEnv.os === 'darwin' && this.localEnv.homeDir !== undefined
-        const codyConfiguration = vscode.workspace.getConfiguration('cody')
-        // TODO: remove this once the experimental period for connect app is over
-        this.localEnv.isAppConnectEnabled = codyConfiguration.get<boolean>('experimental.app.connect') ?? false
         void this.init()
     }
 
-    public async getProcessInfo(isLoggedIn = false): Promise<LocalEnv> {
-        if (isLoggedIn && this._watchers.length > 0) {
-            this.dispose()
-        }
+    public async getProcessInfo(): Promise<LocalEnv> {
         await this.fetchServer()
         return this.localEnv
     }
@@ -185,7 +179,4 @@ const envInit = {
     isAppInstalled: false,
     isAppRunning: false,
     hasAppJson: false,
-
-    // TODO: remove this once the experimental period for connect app is over
-    isAppConnectEnabled: false,
 }

--- a/client/cody/src/services/LocalAppDetector.ts
+++ b/client/cody/src/services/LocalAppDetector.ts
@@ -37,6 +37,7 @@ export class LocalAppDetector implements vscode.Disposable {
         await this.fetchServer()
         return this.localEnv
     }
+
     private async init(): Promise<void> {
         debug('LocalAppDetector:init:', 'initializing')
         const homeDir = this.localEnv.homeDir
@@ -61,6 +62,7 @@ export class LocalAppDetector implements vscode.Disposable {
         }
         debug('LocalAppDetector:init', 'initialized')
         await this.fetchApp()
+        await this.fetchToken()
     }
 
     // Check if App is installed
@@ -115,7 +117,7 @@ export class LocalAppDetector implements vscode.Disposable {
             if (response.status === 200) {
                 debug('LocalAppDetector:fetchServer', 'found')
                 this.localEnv.isAppRunning = true
-                await this.found('server', this.token)
+                await this.found('server')
                 return
             }
         } catch {
@@ -126,10 +128,10 @@ export class LocalAppDetector implements vscode.Disposable {
 
     // Notify the caller that the app has been found. send the token if it exists
     // NOTE: Call this function only when the app is found
-    private async found(type: 'app' | 'token' | 'server', token: string | null = null): Promise<void> {
-        await this.onChange(token)
+    private async found(type: 'app' | 'token' | 'server'): Promise<void> {
         debug('LocalAppDetector:found', type)
         this.localEnv.isAppInstalled = true
+        await this.onChange(this.token)
     }
 
     // We can dispose the file watcher when app is found or when user has logged in
@@ -140,6 +142,7 @@ export class LocalAppDetector implements vscode.Disposable {
         this._watchers = []
         this.appFsPaths = []
         this.tokenFsPath = null
+        debug('LocalAppDetector:dispose', 'disposed')
     }
 }
 

--- a/client/cody/src/services/LocalAppFsPaths.ts
+++ b/client/cody/src/services/LocalAppFsPaths.ts
@@ -2,10 +2,6 @@ export const LOCAL_APP_LOCATIONS: LocalAppPaths = {
     darwin: [
         {
             dir: '/Applications/',
-            file: 'Sourcegraph.app',
-        },
-        {
-            dir: '/Applications/',
             file: 'Cody.app',
         },
         {

--- a/client/cody/test/e2e/helpers.ts
+++ b/client/cody/test/e2e/helpers.ts
@@ -59,7 +59,7 @@ export const test = base
             // Bring the cody sidebar to the foreground
             await page.click('[aria-label="Sourcegraph Cody"]')
             // Ensure that we remove the hover from the activity icon
-            await page.getByRole('heading', { name: 'Sourcegraph Cody: Chat' }).hover()
+            await page.getByRole('heading', { name: 'Sourcegraph Cody' }).hover()
             // Wait for Cody to become activated
             // TODO(philipp-spiess): Figure out which playwright matcher we can use that works for
             // the signed-in and signed-out cases

--- a/client/cody/webviews/App.story.tsx
+++ b/client/cody/webviews/App.story.tsx
@@ -1,7 +1,5 @@
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
 
-import { defaultAuthStatus } from '../src/chat/protocol'
-
 import { App } from './App'
 import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'
 import { VSCodeWrapper } from './utils/VSCodeApi'
@@ -53,19 +51,9 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 arch: 'x64',
                 homeDir: '/home/user',
                 isAppInstalled: false,
-                isAppConnectEnabled: false,
                 isAppRunning: false,
                 hasAppJson: false,
                 extensionVersion: '0.0.0',
-            },
-            authStatus: {
-                ...defaultAuthStatus,
-                authenticated: true,
-                hasVerifiedEmail: true,
-                requiresVerifiedEmail: false,
-                siteHasCodyEnabled: true,
-                siteVersion: '5.1.0',
-                endpoint: 'https://example.com',
             },
         })
         return () => {}

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -37,6 +37,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [errorMessages, setErrorMessages] = useState<string[]>([])
     const [suggestions, setSuggestions] = useState<string[] | undefined>()
     const [isAppInstalled, setIsAppInstalled] = useState<boolean>(false)
+    const [isAppRunning, setIsAppRunning] = useState<boolean>(false)
 
     useEffect(() => {
         vscodeAPI.onMessage(message => {
@@ -54,6 +55,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 }
                 case 'config':
                     setConfig(message.config)
+                    setIsAppInstalled(message.config.isAppInstalled)
+                    setIsAppRunning(message.config.isAppRunning)
                     break
                 case 'login':
                     setAuthStatus(message.authStatus)
@@ -94,8 +97,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     }, [vscodeAPI])
 
     const onLogout = useCallback(() => {
-        setAuthStatus(null)
         setEndpoint(null)
+        setView('login')
         vscodeAPI.postMessage({ command: 'auth', type: 'signout' })
     }, [vscodeAPI])
 
@@ -106,12 +109,12 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     return (
         <div className="outer-container">
             <Header />
-            {view === 'login' ? (
+            {view === 'login' || !authStatus.isLoggedIn ? (
                 <Login
                     authStatus={authStatus}
                     endpoint={endpoint || null}
                     isAppInstalled={isAppInstalled}
-                    isAppRunning={config?.isAppRunning}
+                    isAppRunning={isAppRunning}
                     vscodeAPI={vscodeAPI}
                     appOS={config?.os}
                     appArch={config?.arch}

--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -2,26 +2,24 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
 import { APP_CALLBACK_URL, APP_DOWNLOAD_URLS, APP_LANDING_URL } from '../src/chat/protocol'
 
-import { VSCodeWrapper } from './utils/VSCodeApi'
-
 interface ConnectAppProps {
-    vscodeAPI: VSCodeWrapper
     isAppInstalled: boolean
     isOSSupported: boolean
     appOS?: string
     appArch?: string
     callbackScheme?: string
     isAppRunning: boolean
+    onAppButtonClick: (type: string) => void
 }
 
 export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
-    vscodeAPI,
     isAppInstalled,
     isAppRunning = false,
     isOSSupported,
     appOS = '',
     appArch = '',
     callbackScheme,
+    onAppButtonClick,
 }) => {
     const inDownloadMode = !isAppInstalled && isOSSupported && !isAppRunning
     const buttonText = inDownloadMode ? 'Download Cody App' : isAppRunning ? 'Connect Cody App' : 'Open Cody App'
@@ -32,19 +30,12 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
     const callbackUri = new URL(APP_CALLBACK_URL.href)
     callbackUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
 
-    // Use postMessage to open because it won't open otherwise due to the sourcegraph:// scheme.
-    const openLink = (url: string): void =>
-        vscodeAPI.postMessage({
-            command: 'links',
-            value: url,
-        })
-
     return (
         <div>
             <VSCodeButton
                 type="button"
                 disabled={!isOSSupported}
-                onClick={() => openLink(isAppInstalled ? callbackUri.href : DOWNLOAD_URL)}
+                onClick={() => onAppButtonClick(isAppInstalled ? callbackUri.href : DOWNLOAD_URL)}
             >
                 <i className={'codicon codicon-' + buttonIcon} slot="start" />
                 {buttonText}

--- a/client/cody/webviews/Error.tsx
+++ b/client/cody/webviews/Error.tsx
@@ -1,4 +1,4 @@
-import { AuthStatus } from '../src/chat/protocol'
+import { AuthStatus, isLocalApp } from '../src/chat/protocol'
 
 import styles from './Login.module.css'
 
@@ -43,7 +43,7 @@ export const ErrorContainer: React.FunctionComponent<{
     const isInsiderBuild = siteVersion.length > 12 || siteVersion.includes('dev')
     const isVersionCompatible = isInsiderBuild || siteVersion >= '5.1.0'
     const isVersionBeforeCody = !isVersionCompatible && siteVersion < '5.0.0'
-    const prefix = `Failed: ${isApp ? 'Cody App' : endpoint}`
+    const prefix = `Failed: ${isLocalApp(endpoint) ? 'Cody App' : endpoint}`
     // When doesn't have a valid token
     if (showInvalidAccessTokenError) {
         return (

--- a/client/cody/webviews/LoadingPage.module.css
+++ b/client/cody/webviews/LoadingPage.module.css
@@ -1,0 +1,35 @@
+.container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+.dots-holder {
+    display: flex;
+    gap: 1rem;
+}
+
+.dot {
+    animation: 1s flash infinite;
+    width: calc(var(--vscode-editor-font-size) / 2) !important;
+    height: calc(var(--vscode-editor-font-size) / 2) !important;
+    border-radius: 5rem;
+    background-color: #b200f8;
+}
+
+.dot:nth-child(2) {
+    animation-delay: 250ms;
+    background-color: #ff5543;
+}
+
+.dot:nth-child(3) {
+    animation-delay: 500ms;
+    background-color: #00cbec;
+}
+
+@keyframes flash {
+    50% {
+        background-color: transparent;
+    }
+}

--- a/client/cody/webviews/LoadingPage.tsx
+++ b/client/cody/webviews/LoadingPage.tsx
@@ -1,11 +1,17 @@
-import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react'
+import styles from './LoadingPage.module.css'
 
 export const LoadingPage: React.FunctionComponent<{}> = () => (
     <div className="outer-container">
-        <div className="inner-container">
-            <div className="non-transcript-container">
-                <VSCodeProgressRing />
-            </div>
+        <div className={styles.container}>
+            <LoadingDots />
         </div>
+    </div>
+)
+
+const LoadingDots: React.FunctionComponent = () => (
+    <div className={styles.dotsHolder}>
+        <div className={styles.dot} />
+        <div className={styles.dot} />
+        <div className={styles.dot} />
     </div>
 )

--- a/client/cody/webviews/Login.story.tsx
+++ b/client/cody/webviews/Login.story.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStoryObj } from '@storybook/react'
 
-import { AuthStatus, defaultAuthStatus, unauthenticatedStatus } from '../src/chat/protocol'
+import { AuthStatus, LOCAL_APP_URL, defaultAuthStatus, unauthenticatedStatus } from '../src/chat/protocol'
 
 import { Login } from './Login'
 import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'
@@ -48,7 +48,13 @@ export default meta
 export const Simple: ComponentStoryObj<typeof Login> = {
     render: () => (
         <div style={{ background: 'rgb(28, 33, 40)' }}>
-            <Login authStatus={validAuthStatus} isAppInstalled={false} vscodeAPI={vscodeAPI} setEndpoint={() => {}} />
+            <Login
+                authStatus={validAuthStatus}
+                isAppInstalled={false}
+                vscodeAPI={vscodeAPI}
+                setEndpoint={() => {}}
+                endpoint={endpoint}
+            />
         </div>
     ),
 }
@@ -61,6 +67,7 @@ export const InvalidLogin: ComponentStoryObj<typeof Login> = {
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
                 setEndpoint={() => {}}
+                endpoint={endpoint}
             />
         </div>
     ),
@@ -74,6 +81,7 @@ export const UnverifiedEmailLogin: ComponentStoryObj<typeof Login> = {
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
                 setEndpoint={() => {}}
+                endpoint={endpoint}
             />
         </div>
     ),
@@ -82,7 +90,13 @@ export const UnverifiedEmailLogin: ComponentStoryObj<typeof Login> = {
 export const LoginWithAppInstalled: ComponentStoryObj<typeof Login> = {
     render: () => (
         <div style={{ background: 'rgb(28, 33, 40)' }}>
-            <Login authStatus={validAuthStatus} isAppInstalled={true} vscodeAPI={vscodeAPI} setEndpoint={() => {}} />
+            <Login
+                authStatus={validAuthStatus}
+                isAppInstalled={true}
+                vscodeAPI={vscodeAPI}
+                setEndpoint={() => {}}
+                endpoint={LOCAL_APP_URL.href}
+            />
         </div>
     ),
 }

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
@@ -20,14 +20,13 @@ interface LoginProps {
     callbackScheme?: string
     appOS?: string
     appArch?: string
-    isAppConnectEnabled?: boolean
     setEndpoint: (endpoint: string) => void
 }
 
 const APP_DESC = {
     getStarted: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
     download: 'Download and run the Cody desktop app to configure your local code graph.',
-    connectApp: 'Cody App detected. All that’s left is to do is connect VS Code with Cody App.',
+    connectApp: 'Cody App detected. All that’s left to do is connect VS Code with Cody App.',
     notRunning: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
     comingSoon:
         'We’re working on bringing Cody App to your platform. In the meantime, you can try Cody with open source repositories by signing in to Sourcegraph.com.',
@@ -42,12 +41,13 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     appArch,
     isAppInstalled = false,
     isAppRunning = false,
-    isAppConnectEnabled = false,
     setEndpoint,
 }) => {
     const isOSSupported = appOS === 'darwin' && appArch === 'arm64'
+    const [enableCodyAppConnect, setEnableCodyAppConnect] = useState(callbackScheme === 'vscode-insiders')
 
     const loginWithDotCom = useCallback(() => {
+        setEnableCodyAppConnect(false)
         const callbackUri = new URL(DOTCOM_CALLBACK_URL.href)
         callbackUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
         setEndpoint(DOTCOM_URL.href)
@@ -98,7 +98,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const EnterpriseSignin: React.FunctionComponent = () => (
         <section
-            className={classNames(styles.section, !isAppConnectEnabled ? styles.codyGradient : styles.greyGradient)}
+            className={classNames(styles.section, !enableCodyAppConnect ? styles.codyGradient : styles.greyGradient)}
         >
             <h2 className={styles.sectionHeader}>Sourcegraph Enterprise</h2>
             <p className={styles.openMessage}>
@@ -112,7 +112,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const DotComSignin: React.FunctionComponent = () => (
         <section
-            className={classNames(styles.section, !isAppConnectEnabled ? styles.codyGradient : styles.greyGradient)}
+            className={classNames(styles.section, !enableCodyAppConnect ? styles.codyGradient : styles.greyGradient)}
         >
             <h2 className={styles.sectionHeader}>Sourcegraph.com</h2>
             <p className={styles.openMessage}>
@@ -133,10 +133,10 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             {authStatus && <ErrorContainer authStatus={authStatus} isApp={isApp} endpoint={endpoint} />}
             {/* Signin Sections */}
             <div className={styles.sectionsContainer}>
-                <EnterpriseSignin />
-                <DotComSignin />
-                {isAppConnectEnabled && <AppConnect />}
-                {isAppConnectEnabled && !isOSSupported && <NoAppConnect />}
+                {!enableCodyAppConnect && <EnterpriseSignin />}
+                {!enableCodyAppConnect && <DotComSignin />}
+                <AppConnect />
+                {enableCodyAppConnect && !isOSSupported && <NoAppConnect />}
             </div>
             {/* Footer */}
             <footer className={styles.footer}>

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -13,7 +13,7 @@ import styles from './Login.module.css'
 
 interface LoginProps {
     authStatus?: AuthStatus
-    endpoint?: string
+    endpoint: string | null
     isAppInstalled: boolean
     isAppRunning?: boolean
     vscodeAPI: VSCodeWrapper

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -12,7 +12,7 @@ import { VSCodeWrapper } from './utils/VSCodeApi'
 import styles from './Login.module.css'
 
 interface LoginProps {
-    authStatus?: AuthStatus
+    authStatus: AuthStatus
     endpoint: string | null
     isAppInstalled: boolean
     isAppRunning?: boolean
@@ -61,6 +61,14 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
         [vscodeAPI]
     )
 
+    const onAppButtonClick = useCallback(
+        (uri: string) => {
+            // Use postMessage to open because it won't open otherwise due to the sourcegraph:// scheme.
+            vscodeAPI.postMessage({ command: 'links', value: uri, type: 'app' })
+        },
+        [vscodeAPI]
+    )
+
     const title = isAppInstalled ? (isAppRunning ? 'Connect with Cody App' : 'Cody App Not Running') : 'Get Started'
     const openMsg = !isAppInstalled ? APP_DESC.getStarted : !isAppRunning ? APP_DESC.notRunning : APP_DESC.connectApp
 
@@ -71,12 +79,12 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             {!isAppInstalled && <p className={styles.openMessage}>{APP_DESC.download}</p>}
             <ConnectApp
                 isAppInstalled={isAppInstalled}
-                vscodeAPI={vscodeAPI}
                 isOSSupported={isOSSupported}
                 appOS={appOS}
                 appArch={appArch}
                 isAppRunning={isAppRunning}
                 callbackScheme={callbackScheme}
+                onAppButtonClick={onAppButtonClick}
             />
             {!isOSSupported && (
                 <small>
@@ -98,7 +106,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const EnterpriseSignin: React.FunctionComponent = () => (
         <section
-            className={classNames(styles.section, !enableCodyAppConnect ? styles.codyGradient : styles.greyGradient)}
+            className={classNames(styles.section, !enableCodyAppConnect ? styles.greyGradient : styles.codyGradient)}
         >
             <h2 className={styles.sectionHeader}>Sourcegraph Enterprise</h2>
             <p className={styles.openMessage}>
@@ -112,7 +120,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const DotComSignin: React.FunctionComponent = () => (
         <section
-            className={classNames(styles.section, !enableCodyAppConnect ? styles.codyGradient : styles.greyGradient)}
+            className={classNames(styles.section, !enableCodyAppConnect ? styles.greyGradient : styles.codyGradient)}
         >
             <h2 className={styles.sectionHeader}>Sourcegraph.com</h2>
             <p className={styles.openMessage}>

--- a/client/cody/webviews/Settings.tsx
+++ b/client/cody/webviews/Settings.tsx
@@ -6,7 +6,7 @@ import { isLocalApp } from '../src/chat/protocol'
 
 interface SettingsProps {
     onLogout: () => void
-    endpoint?: string
+    endpoint: string
     version?: string
 }
 


### PR DESCRIPTION
Close https://github.com/sourcegraph/sourcegraph/issues/54045

Notice we were setting authStatus on config change, which would first pick up the default config when the view is first loaded.

Since we now actually have a Login logic that log users in and out on config change that is related to auth (endpoint, token, customheader), where config is shared with the webview on every text doc change to update codebase context (we should look into refactoring this too 😓 ), we should not update auth status on the config change logic (which is actually text doc change unrelated to auth), and rely on the `login` logic for auth status and use that to update view instead.

Here you can see what is called when we first load the extension:
<img width="725" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/68532117/aca21b66-1941-4abb-b1b7-ce2ec4cd1696">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Here is a video of how the changes would look:

https://github.com/sourcegraph/sourcegraph/assets/68532117/3875d28c-1ee9-4ab5-9334-cd0154462d44

