### PR TITLE
executors: Add yq to bundled executor

### DIFF
--- a/enterprise/cmd/bundled-executor/README.md
+++ b/enterprise/cmd/bundled-executor/README.md
@@ -27,3 +27,4 @@ create a new instance when it exits.
 - `pip`
 - Java 11 (OpenJDK)
 - Maven 3.6.3
+- `yq`

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -15,6 +15,7 @@ contents:
     - python3
     - py3-pip
     - xmlstarlet@sourcegraph
+    - yq
 
 paths:
   - path: /usr/local/bin


### PR DESCRIPTION
Requested by user to add `yq` to the bundled executor.

## Test plan

Checked the base image for yq.