### PR TITLE
fix update link routed to the wrong page

### DIFF
--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -33,6 +33,7 @@ import {
     H3,
     H4,
     Label,
+    AnchorLink,
 } from '@sourcegraph/wildcard'
 
 import { LogOutput } from '../components/LogOutput'
@@ -85,10 +86,15 @@ const SiteUpdateCheck: React.FC = () => {
                         {!data.site.updateCheck.errorMessage && (
                             <small>
                                 {data.site.updateCheck.updateVersionAvailable ? (
-                                    <Link to="https://about.sourcegraph.com">
+                                    <AnchorLink
+                                        to="/help/admin/updates"
+                                        target="_blank"
+                                        rel="noopener"
+                                        className="ml-1"
+                                    >
                                         Update available to version {data.site.updateCheck.updateVersionAvailable}{' '}
                                         <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
-                                    </Link>
+                                    </AnchorLink>
                                 ) : (
                                     <span>
                                         <Icon


### PR DESCRIPTION
Fixes #52969 
- Before, update link in the Maintenance page routed to the about page
- Now, it routes to the update instructional docs

## Test plan
Test link manually. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
