### PR TITLE
cody-gateway: remove link in dotcomuser usage notify

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/notify/rate_limit.go
+++ b/enterprise/cmd/cody-gateway/internal/notify/rate_limit.go
@@ -140,8 +140,6 @@ func handleNotify(
 	switch actorSource {
 	case codygateway.ActorSourceProductSubscription:
 		actorLink = fmt.Sprintf("<%[1]s/site-admin/dotcom/product/subscriptions/%[2]s|%[2]s>", dotcomURL, actorID)
-	case codygateway.ActorSourceDotcomUser:
-		actorLink = fmt.Sprintf("<%[1]s/users/%[2]s|%[2]s>", dotcomURL, actorID)
 	default:
 		actorLink = fmt.Sprintf("`%s`", actorID)
 	}


### PR DESCRIPTION
The actor ID of the dotcom user type [has changed to be the database ID](https://github.com/sourcegraph/sourcegraph/pull/53967), and because we currently don't have the ability to produce a direct link with database ID through URL hacking for that user, we downgrade to the pure-text version for the usage notifications.

## Test plan

CI