### PR TITLE
App: Add checks to validate paths in deep links

### DIFF
--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -13,18 +13,25 @@ pub fn show_window(app: &AppHandle, label: &str) {
 }
 
 /// Extracts the path from a URL that starts with the scheme followed by `://`.
-///
-/// # Examples
-///
-/// ```
-/// let url = "sourcegraph://settings";
-/// assert_eq!(extract_path_from_url(url), "/settings");
-///
-/// let url = "sourcegraph://user/admin";
-/// assert_eq!(extract_path_from_url(url), "/user/admin");
-/// ```
-pub fn extract_path_from_scheme_url<'a>(url: &'a str, scheme: &str) -> &'a str {
-    &url[(scheme.len() + 2)..]
+pub fn extract_path_from_scheme_url<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
+    // Ensure that the scheme is the one we expect
+    if !url.starts_with(scheme) {
+        return None;
+    }
+
+    // Ensure that there is enough path to extract
+    if url.len() < scheme.len() + 2 {
+        return None;
+    }
+
+    let tentative_path = &url[(scheme.len() + 2)..];
+
+    // Only allow relative paths that start with a slash
+    if tentative_path.starts_with('/') {
+        Some(tentative_path)
+    } else {
+        None
+    }
 }
 
 /// Checks if a URL starts with the scheme (sourcegraph://)
@@ -85,4 +92,36 @@ fn clear_local_storage(app: &AppHandle) {
     // Note that this will clear localStorage only for the current origin, which
     // is fine assuming the webview is still on localhost:3080.
     window.eval("localStorage.clear();").unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_path_from_scheme_url() {
+        let url = "sourcegraph://settings";
+        assert_eq!(
+            extract_path_from_scheme_url(url, "sourcegraph"),
+            Some("/settings")
+        );
+
+        let url = "sourcegraph://user/admin";
+        assert_eq!(
+            extract_path_from_scheme_url(url, "sourcegraph"),
+            Some("/user/admin")
+        );
+
+        let url = "sourcegraph:/http://example.com";
+        assert_eq!(extract_path_from_scheme_url(url, "sourcegraph"), None);
+
+        let url = "sourcegraph://";
+        assert_eq!(extract_path_from_scheme_url(url, "sourcegraph"), Some("/"));
+
+        let url = "sourcegraph:/";
+        assert_eq!(extract_path_from_scheme_url(url, "sourcegraph"), None);
+
+        let url = "sourcegraph:";
+        assert_eq!(extract_path_from_scheme_url(url, "sourcegraph"), None);
+    }
 }

--- a/src-tauri/src/common.rs
+++ b/src-tauri/src/common.rs
@@ -26,7 +26,7 @@ pub fn extract_path_from_scheme_url<'a>(url: &'a str, scheme: &str) -> Option<&'
 
     let tentative_path = &url[(scheme.len() + 2)..];
 
-    // Only allow relative paths that start with a slash
+    // Only allow paths that start with a slash
     if tentative_path.starts_with('/') {
         Some(tentative_path)
     } else {


### PR DESCRIPTION
Add validation for to the deep link handler in App to allow only paths that start with a slash. 

This makes sure that you can't use a deep link to open an unwanted URL in App.

## Test plan

- Added automated tests for `extract_path_from_scheme_url`
- Run `cargo test` in `src-tauri/`