### PR TITLE
ci: install asdf plugins on publish docker registery

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,7 +15,7 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" && "$BUILDKITE_AGENT_META_DA
     asdf install golang
   elif [[ "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
     echo "pipeline-upload step: skipping asdf install"
-  elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" && ! "${BUILDKITE_STEP_KEY:-""}" =~  "Publishexecutorimage" ]]; then
+  elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" && ! "${BUILDKITE_STEP_KEY:-""}" =~  "Publishexecutorimage|Publishdockerregistrymirrorimage" ]]; then
     echo "publish image step: skipping asdf install"
   else
     echo "running normal install"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,8 +15,13 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" != "bazel" && "$BUILDKITE_AGENT_META_DA
     asdf install golang
   elif [[ "$BUILDKITE_STEP_KEY" == "pipeline-upload" ]]; then
     echo "pipeline-upload step: skipping asdf install"
-  elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" && ! "${BUILDKITE_STEP_KEY:-""}" =~  "Publishexecutorimage|Publishdockerregistrymirrorimage" ]]; then
-    echo "publish image step: skipping asdf install"
+elif [[ "${BUILDKITE_GROUP_KEY:=\"\"}" == "Publishimages" ]]; then
+    if [[ "${BUILDKITE_STEP_KEY}" =~  "Publishexecutorimage" || "${BUILDKITE_STEP_KEY}" =~ "Publishdockerregistry" ]]; then
+        echo "publish image step that requires asdf"
+        ./dev/ci/asdf-install.sh
+    else
+        echo "publish image step: skipping asdf install"
+    fi
   else
     echo "running normal install"
     ./dev/ci/asdf-install.sh


### PR DESCRIPTION
We normally skip install of asdf images when GROUP_KEY is `Publish Images`, except for certains steps:

* Publish executor image in https://github.com/sourcegraph/sourcegraph/commit/bc0049c818fea6774d8aa7eb688f5b0cea7f7583

and now also Publish Docker registry image
## Test plan
BUILDKITE_GROUP_KEY="Publishimages" BUILDKITE_STEP_KEY="packerwhitecheckmarkPublishdockerregistrymirrorimage" .buildkite/hooks/pre-command
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
