### PR TITLE
[Cody App] autoload repos into context on new chat and reset

### DIFF
--- a/client/cody-shared/src/chat/useClient.ts
+++ b/client/cody-shared/src/chat/useClient.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useMemo } from 'react'
 
+import { isErrorLike } from '@sourcegraph/common'
+
 import { CodebaseContext } from '../codebase-context'
 import { ConfigurationWithAccessToken } from '../configuration'
 import { Editor, NoopEditor } from '../editor'
@@ -69,6 +71,7 @@ export interface CodyClient {
     toggleIncludeInferredRepository: () => void
     toggleIncludeInferredFile: () => void
     abortMessageInProgress: () => void
+    fetchRepositoryNames: (count: number) => Promise<string[]>
 }
 
 interface CodyClientProps {
@@ -127,25 +130,6 @@ export const useClient = ({
     }, [])
 
     const [config, setConfig] = useState<CodyClientConfig>(initialConfig)
-
-    const initializeNewChat = useCallback((): Transcript | null => {
-        if (config.needsEmailVerification) {
-            return transcript
-        }
-        const newTranscript = new Transcript()
-        setIsMessageInProgressState(false)
-        setTranscriptState(newTranscript)
-        setChatMessagesState(newTranscript.toChat())
-        setScopeState(scope => ({
-            includeInferredRepository: true,
-            includeInferredFile: true,
-            repositories: [],
-            editor: scope.editor,
-        }))
-        onEvent?.('initializedNewChat')
-
-        return newTranscript
-    }, [onEvent, config.needsEmailVerification, transcript])
 
     const { graphqlClient, chatClient, intentDetector } = useMemo(() => {
         const completionsClient = new SourcegraphBrowserCompletionsClient(config)
@@ -220,6 +204,41 @@ export const useClient = ({
 
         return results.map(({ id }) => id)
     }, [codebases, graphqlClient])
+
+    const fetchRepositoryNames = useCallback(
+        async (count: number): Promise<string[]> =>
+            graphqlClient
+                .getRepoNames(count)
+                .then(repositories => (isErrorLike(repositories) ? [] : repositories))
+                .catch(error => {
+                    console.error(
+                        `Cody could not fetch the list of repositories on your Sourcegraph instance. Details: ${error}`
+                    )
+
+                    return []
+                }),
+        [graphqlClient]
+    )
+
+    const initializeNewChat = useCallback((): Transcript | null => {
+        if (config.needsEmailVerification) {
+            return transcript
+        }
+        const newTranscript = new Transcript()
+        setIsMessageInProgressState(false)
+        setTranscriptState(newTranscript)
+        setChatMessagesState(newTranscript.toChat())
+        setScopeState(scope => ({
+            includeInferredRepository: true,
+            includeInferredFile: true,
+            repositories: [],
+            editor: scope.editor,
+        }))
+
+        onEvent?.('initializedNewChat')
+
+        return newTranscript
+    }, [onEvent, config.needsEmailVerification, transcript])
 
     const executeRecipe = useCallback(
         async (
@@ -410,6 +429,7 @@ export const useClient = ({
             toggleIncludeInferredRepository,
             toggleIncludeInferredFile,
             abortMessageInProgress,
+            fetchRepositoryNames,
         }),
         [
             transcript,
@@ -429,6 +449,7 @@ export const useClient = ({
             toggleIncludeInferredRepository,
             toggleIncludeInferredFile,
             abortMessageInProgress,
+            fetchRepositoryNames,
         ]
     )
 }

--- a/client/cody-shared/src/sourcegraph-api/graphql/client.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/client.ts
@@ -10,6 +10,7 @@ import {
     IS_CONTEXT_REQUIRED_QUERY,
     REPOSITORY_ID_QUERY,
     REPOSITORY_IDS_QUERY,
+    REPOSITORY_NAMES_QUERY,
     SEARCH_ATTRIBUTION_QUERY,
     SEARCH_EMBEDDINGS_QUERY,
     LEGACY_SEARCH_EMBEDDINGS_QUERY,
@@ -52,6 +53,10 @@ interface RepositoryIdResponse {
 }
 
 interface RepositoryIdsResponse {
+    repositories: { nodes: { id: string; name: string }[] }
+}
+
+interface RepositoryNamesResponse {
     repositories: { nodes: { id: string; name: string }[] }
 }
 
@@ -212,6 +217,16 @@ export class SourcegraphGraphQLAPIClient {
             extractDataOrError(response, data =>
                 data.repository ? data.repository.id : new RepoNotFoundError(`repository ${repoName} not found`)
             )
+        )
+    }
+
+    public async getRepoNames(first: number): Promise<string[] | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<RepositoryNamesResponse>>(REPOSITORY_NAMES_QUERY, { first }).then(
+            response =>
+                extractDataOrError(
+                    response,
+                    data => data?.repositories?.nodes?.map((node: { id: string; name: string }) => node?.name) || []
+                )
         )
     }
 

--- a/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
+++ b/client/cody-shared/src/sourcegraph-api/graphql/queries.ts
@@ -53,6 +53,16 @@ query Repositories($names: [String!]!, $first: Int!) {
 	}
 }`
 
+export const REPOSITORY_NAMES_QUERY = `
+query Repositories($first: Int!) {
+	repositories(first: $first) {
+                nodes {
+		        id
+                        name
+                }
+	}
+}`
+
 export const REPOSITORY_EMBEDDING_EXISTS_QUERY = `
 query Repository($name: String!) {
 	repository(name: $name) {

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -105,6 +105,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     const codyChatStore = useCodyChat({
         onTranscriptHistoryLoad,
         autoLoadTranscriptFromHistory: false,
+        autoLoadScopeWithRepositories: isSourcegraphApp,
     })
     const {
         initializeNewChat,

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -57,6 +57,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
         toggleIncludeInferredRepository,
         toggleIncludeInferredFile,
         abortMessageInProgress,
+        fetchRepositoryNames,
     } = codyChatStore
 
     const [formInput, setFormInput] = useState('')
@@ -77,8 +78,22 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
     const onEdit = useCallback((text: string) => editMessage(text), [editMessage])
 
     const scopeSelectorProps = useMemo(
-        () => ({ scope, setScope, toggleIncludeInferredRepository, toggleIncludeInferredFile }),
-        [scope, setScope, toggleIncludeInferredRepository, toggleIncludeInferredFile]
+        () => ({
+            scope,
+            setScope,
+            toggleIncludeInferredRepository,
+            toggleIncludeInferredFile,
+            fetchRepositoryNames,
+            isSourcegraphApp,
+        }),
+        [
+            scope,
+            setScope,
+            toggleIncludeInferredRepository,
+            toggleIncludeInferredFile,
+            fetchRepositoryNames,
+            isSourcegraphApp,
+        ]
     )
 
     if (!loaded) {

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -53,7 +53,7 @@ export const RepositoriesSelectorPopover: React.FC<{
     inferredRepository: IRepo | null
     inferredFilePath: string | null
     additionalRepositories: IRepo[]
-    resetScope: () => void
+    resetScope: () => Promise<void>
     addRepository: (repoName: string) => void
     removeRepository: (repoName: string) => void
     toggleIncludeInferredRepository: () => void


### PR DESCRIPTION
closes: #54086

**Only for Cody App**, the first 10 repos on the instance are autoloaded into the chat context on initializing a new chat or resetting the chat scope.

Demo: https://www.loom.com/share/fc1289d2f32846348a8c51572293a909

## Test plan

- Open Cody App
- Modify the scope of the currently opened chat.
- Reset the scope, it should load up to 10 repos available on the instance.
- Modify the scope again.
- Create a new chat, it should load up to 10 repos available on the instance again.