### PR TITLE
[Cody] remove link for non site admins

### DIFF
--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -502,7 +502,17 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
                         : 'Embeddings are missing for this repository. Enable embeddings to improve the quality of Cody’s responses.'
                 }
             >
-                <Link to="/site-admin/embeddings" className="text-body" onClick={event => event.stopPropagation()}>
+                {window.context.currentUser?.siteAdmin ? (
+                    <Link to="/site-admin/embeddings" className="text-body" onClick={event => event.stopPropagation()}>
+                        <Icon
+                            aria-hidden={true}
+                            className={classNames({
+                                [styles.embeddingIconNoEmbeddings]: !embeddingExists,
+                            })}
+                            svgPath={embeddingExists ? mdiDatabaseCheckOutline : mdiDatabaseRemoveOutline}
+                        />
+                    </Link>
+                ) : (
                     <Icon
                         aria-hidden={true}
                         className={classNames({
@@ -510,7 +520,7 @@ const EmbeddingExistsIcon: React.FC<{ repo: { embeddingExists: boolean } }> = Re
                         })}
                         svgPath={embeddingExists ? mdiDatabaseCheckOutline : mdiDatabaseRemoveOutline}
                     />
-                </Link>
+                )}
             </Tooltip>
         )
     }


### PR DESCRIPTION
Resolving: https://github.com/sourcegraph/sourcegraph/pull/54041#discussion_r1240170393

Forgot to render the link only for site admins.
## Test plan

- log in as site admin
- open the scope selector and click on the embeddings icon
- should redirect to site admin embeddings page

- login as non site admin
- open the scope selector and click on the embeddings icon
- should not redirect to site admin embeddings page
