### PR TITLE
grpc: add interceptors that convert raw context.[Cancelled/DeadlineExceeded] errors into status errors and vice versa

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -412,8 +412,8 @@ func TestServer_handleP4Exec(t *testing.T) {
 			}
 
 			_, err = readAll(stream)
-			if status.Code(err) != codes.Canceled {
-				t.Fatalf("expected codes.Cancelled error, got %v", err)
+			if !(errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled) {
+				t.Fatalf("expected context cancelation error, got %v", err)
 			}
 		})
 

--- a/cmd/repo-updater/repoupdater/BUILD.bazel
+++ b/cmd/repo-updater/repoupdater/BUILD.bazel
@@ -76,5 +76,7 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/internal/grpc/contextconv/BUILD.bazel
+++ b/internal/grpc/contextconv/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "contextconv",
+    srcs = [
+        "conversion.go",
+        "doc.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/grpc/contextconv",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)
+
+go_test(
+    name = "contextconv_test",
+    srcs = ["conversion_test.go"],
+    embed = [":contextconv"],
+    deps = [
+        "//lib/errors",
+        "@com_github_google_go_cmp//cmp",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/internal/grpc/contextconv/conversion.go
+++ b/internal/grpc/contextconv/conversion.go
@@ -1,0 +1,121 @@
+package contextconv
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryServerInterceptor is a grpc.UnaryServerInterceptor that returns an appropriate status.Cancelled / status.DeadlineExceeded error
+// if the handler call failed and the provided context has been cancelled or expired.
+//
+// The handler's error is propagated as-is if the context is still active or if the error is already one produced by the status package.
+func UnaryServerInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (response any, err error) {
+	response, err = handler(ctx, req)
+	if err == nil {
+		return response, nil
+	}
+
+	if _, ok := status.FromError(err); ok {
+		return response, err
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return response, status.FromContextError(ctxErr).Err()
+	}
+
+	return response, err
+}
+
+// StreamServerInterceptor is a grpc.StreamServerInterceptor that returns an appropriate status.Cancelled / status.DeadlineExceeded error
+// if the handler call failed and the provided context has been cancelled or expired.
+//
+// The handler's error is propagated as-is if the context is still active or if the error is already one produced by the status package.
+func StreamServerInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	err := handler(srv, ss)
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+
+	if ctxErr := ss.Context().Err(); ctxErr != nil {
+		return status.FromContextError(ctxErr).Err()
+	}
+
+	return err
+}
+
+// UnaryClientInterceptor is a grpc.UnaryClientInterceptor that returns an appropriate context.DeadlineExceeded or context.Cancelled error
+// if the call failed with a status.DeadlineExceeded or status.Cancelled error.
+//
+// The call's error is propagated as-is if the error is not status.DeadlineExceeded or status.Cancelled.
+func UnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if err == nil {
+		return nil
+	}
+
+	switch status.Code(err) {
+	case codes.DeadlineExceeded:
+		return context.DeadlineExceeded
+	case codes.Canceled:
+		return context.Canceled
+	default:
+		return err
+	}
+}
+
+// StreamClientInterceptor is a grpc.StreamClientInterceptor that returns an appropriate context.DeadlineExceeded or context.Cancelled error
+// if the call failed with a status.DeadlineExceeded or status.Cancelled error.
+//
+// The call's error is propagated as-is if the error is not status.DeadlineExceeded or status.Cancelled.
+func StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	clientStream, err := streamer(ctx, desc, cc, method, opts...)
+	if err == nil {
+		return &convertingClientStream{ClientStream: clientStream}, nil
+	}
+
+	switch status.Code(err) {
+	case codes.DeadlineExceeded:
+		return nil, context.DeadlineExceeded
+	case codes.Canceled:
+		return nil, context.Canceled
+	default:
+		return &convertingClientStream{ClientStream: clientStream}, err
+	}
+}
+
+type convertingClientStream struct {
+	grpc.ClientStream
+}
+
+func (c *convertingClientStream) RecvMsg(m any) error {
+	err := c.ClientStream.RecvMsg(m)
+	if err == nil {
+		return nil
+	}
+
+	switch status.Code(err) {
+	case codes.DeadlineExceeded:
+		return context.DeadlineExceeded
+	case codes.Canceled:
+		return context.Canceled
+	default:
+		return err
+	}
+}
+
+var (
+	_ grpc.UnaryServerInterceptor  = UnaryServerInterceptor
+	_ grpc.StreamServerInterceptor = StreamServerInterceptor
+
+	_ grpc.UnaryClientInterceptor  = UnaryClientInterceptor
+	_ grpc.StreamClientInterceptor = StreamClientInterceptor
+
+	_ grpc.ClientStream = &convertingClientStream{}
+)

--- a/internal/grpc/contextconv/conversion_test.go
+++ b/internal/grpc/contextconv/conversion_test.go
@@ -1,0 +1,378 @@
+package contextconv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestConversionUnaryInterceptor(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineExceededCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+	t.Cleanup(cancel) // only cancel after all subtests have run, we want the context to be deadline exceeded in the relevant subtest
+
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		handlerErr  error
+		expectedErr error
+	}{
+		{
+			name:        "handler success",
+			ctx:         context.Background(),
+			handlerErr:  nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "status error",
+			ctx:         context.Background(),
+			handlerErr:  status.Error(codes.Internal, "internal error"),
+			expectedErr: status.Error(codes.Internal, "internal error"),
+		},
+		{
+			name:        "context cancellation error",
+			ctx:         cancelledCtx,
+			handlerErr:  cancelledCtx.Err(),
+			expectedErr: status.Error(codes.Canceled, "context canceled"),
+		},
+		{
+			name:        "context deadline error",
+			ctx:         deadlineExceededCtx,
+			handlerErr:  deadlineExceededCtx.Err(),
+			expectedErr: status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+		},
+		{
+			name:        "unknown error",
+			ctx:         context.Background(),
+			handlerErr:  errors.New("unknown error"),
+			expectedErr: errors.New("unknown error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sentinelResponse := struct{}{}
+
+			called := false
+			handler := func(ctx context.Context, request any) (response any, err error) {
+				called = true
+				return sentinelResponse, tc.handlerErr
+			}
+
+			request := struct{}{}
+			info := grpc.UnaryServerInfo{}
+
+			actualResponse, err := UnaryServerInterceptor(tc.ctx, request, &info, handler)
+			if !called {
+				t.Fatal("handler was not called")
+			}
+
+			if actualResponse != sentinelResponse {
+				t.Fatalf("unexpected response: %+v", actualResponse)
+			}
+
+			expectedErrString := fmt.Sprintf("%s", tc.expectedErr)
+			actualErrString := fmt.Sprintf("%s", err)
+
+			if diff := cmp.Diff(expectedErrString, actualErrString); diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStreamServerInterceptor(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineExceededCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+	t.Cleanup(cancel) // only cancel after all subtests have run, we want the context to be deadline exceeded in the relevant subtest
+
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		handlerErr  error
+		expectedErr error
+	}{
+		{
+			name:        "handler success",
+			ctx:         context.Background(),
+			handlerErr:  nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "status error",
+			ctx:         context.Background(),
+			handlerErr:  status.Error(codes.Internal, "internal error"),
+			expectedErr: status.Error(codes.Internal, "internal error"),
+		},
+		{
+			name:        "context cancellation error",
+			ctx:         cancelledCtx,
+			handlerErr:  cancelledCtx.Err(),
+			expectedErr: status.Error(codes.Canceled, "context canceled"),
+		},
+		{
+			name:        "context deadline error",
+			ctx:         deadlineExceededCtx,
+			handlerErr:  deadlineExceededCtx.Err(),
+			expectedErr: status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+		},
+		{
+			name:        "unknown error",
+			ctx:         context.Background(),
+			handlerErr:  errors.New("unknown error"),
+			expectedErr: errors.New("unknown error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+
+			handler := func(_ any, _ grpc.ServerStream) error {
+				called = true
+				return tc.handlerErr
+			}
+
+			srv := struct{}{}
+			info := grpc.StreamServerInfo{}
+
+			err := StreamServerInterceptor(srv, &mockServerStream{ctx: tc.ctx}, &info, handler)
+			if !called {
+				t.Fatal("handler was not called")
+			}
+
+			expectedErrString := fmt.Sprintf("%s", tc.expectedErr)
+			actualErrString := fmt.Sprintf("%s", err)
+			if diff := cmp.Diff(expectedErrString, actualErrString); diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// mockServerStream is a fake grpc.ServerStream that returns the provided context
+type mockServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (m *mockServerStream) Context() context.Context {
+	return m.ctx
+}
+
+func TestUnaryClientInterceptor(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineExceededCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+	t.Cleanup(cancel)
+
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		invokerErr  error
+		expectedErr error
+	}{
+		{
+			name:        "invoker success",
+			ctx:         context.Background(),
+			invokerErr:  nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "status error",
+			ctx:         context.Background(),
+			invokerErr:  status.Error(codes.Internal, "internal error"),
+			expectedErr: status.Error(codes.Internal, "internal error"),
+		},
+		{
+			name:        "context cancellation error",
+			ctx:         cancelledCtx,
+			invokerErr:  status.Error(codes.Canceled, "context canceled"),
+			expectedErr: context.Canceled,
+		},
+		{
+			name:        "context deadline error",
+			ctx:         deadlineExceededCtx,
+			invokerErr:  status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name:        "unknown error",
+			ctx:         context.Background(),
+			invokerErr:  errors.New("unknown error"),
+			expectedErr: errors.New("unknown error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			invoker := func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+				called = true
+				return tc.invokerErr
+			}
+
+			method := "Test"
+			req := struct{}{}
+			reply := struct{}{}
+			cc := &grpc.ClientConn{}
+
+			err := UnaryClientInterceptor(tc.ctx, method, req, &reply, cc, invoker)
+			if !called {
+				t.Fatal("invoker was not called")
+			}
+
+			expectedErrString := fmt.Sprintf("%s", tc.expectedErr)
+			actualErrString := fmt.Sprintf("%s", err)
+			if diff := cmp.Diff(expectedErrString, actualErrString); diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestStreamClientInterceptor(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deadlineExceededCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+	t.Cleanup(cancel)
+
+	testCases := []struct {
+		name        string
+		ctx         context.Context
+		streamerErr error
+		expectedErr error
+	}{
+		{
+			name:        "streamer success",
+			ctx:         context.Background(),
+			streamerErr: nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "status error",
+			ctx:         context.Background(),
+			streamerErr: status.Error(codes.Internal, "internal error"),
+			expectedErr: status.Error(codes.Internal, "internal error"),
+		},
+		{
+			name:        "context cancellation error",
+			ctx:         cancelledCtx,
+			streamerErr: status.Error(codes.Canceled, "context canceled"),
+			expectedErr: context.Canceled,
+		},
+		{
+			name:        "context deadline error",
+			ctx:         deadlineExceededCtx,
+			streamerErr: status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name:        "unknown error",
+			ctx:         context.Background(),
+			streamerErr: errors.New("unknown error"),
+			expectedErr: errors.New("unknown error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			streamer := func(_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
+				called = true
+				if tc.streamerErr != nil {
+					return nil, tc.streamerErr
+				}
+				return &mockClientStream{}, nil
+			}
+
+			desc := &grpc.StreamDesc{}
+			cc := &grpc.ClientConn{}
+			method := "Test"
+
+			_, clientErr := StreamClientInterceptor(tc.ctx, desc, cc, method, streamer)
+			if !called {
+				t.Fatal("streamer was not called")
+			}
+
+			expectedErrString := fmt.Sprintf("%s", tc.expectedErr)
+			actualErrString := fmt.Sprintf("%s", clientErr)
+			if diff := cmp.Diff(expectedErrString, actualErrString); diff != "" {
+				t.Fatalf("unexpected error (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConvertingClientStream(t *testing.T) {
+	testCases := []struct {
+		name        string
+		streamErr   error
+		expectedErr error
+	}{
+		{
+			name:        "status error",
+			streamErr:   status.Error(codes.Internal, "internal error"),
+			expectedErr: status.Error(codes.Internal, "internal error"),
+		},
+		{
+			name:        "context cancellation error",
+			streamErr:   status.Error(codes.Canceled, "context canceled"),
+			expectedErr: context.Canceled,
+		},
+		{
+			name:        "context deadline error",
+			streamErr:   status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+			expectedErr: context.DeadlineExceeded,
+		},
+		{
+			name:        "unknown error",
+			streamErr:   errors.New("unknown error"),
+			expectedErr: errors.New("unknown error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockStream := &mockClientStream{
+				err: tc.streamErr,
+			}
+			wrappedStream := &convertingClientStream{
+				ClientStream: mockStream,
+			}
+
+			err := wrappedStream.RecvMsg(nil)
+
+			expectedErrString := fmt.Sprintf("%s", tc.expectedErr)
+			actualErrString := fmt.Sprintf("%s", err)
+
+			if diff := cmp.Diff(expectedErrString, actualErrString); diff != "" {
+				t.Errorf("unexpected error (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// mockClientStream is a fake grpc.ClientStream
+type mockClientStream struct {
+	grpc.ClientStream
+	err error
+}
+
+func (m *mockClientStream) RecvMsg(x interface{}) error {
+	return m.err
+}

--- a/internal/grpc/contextconv/doc.go
+++ b/internal/grpc/contextconv/doc.go
@@ -1,0 +1,59 @@
+/*
+Package contextconv provides gRPC interceptors that convert context errors
+to gRPC status errors and vice versa. These interceptors are useful for providing
+a defensive mechanism for servers to ensure that errors are properly converted
+between context errors and gRPC status errors.
+
+The package includes UnaryServerInterceptor, StreamServerInterceptor,
+UnaryClientInterceptor, and StreamClientInterceptor. These interceptors convert
+context errors like context.DeadlineExceeded or context.Canceled into their
+corresponding gRPC status errors (status.DeadlineExceeded or status.Canceled)
+and vice versa.
+
+It is important for server authors to check for context errors specifically
+before returning errors from the status package (like codes.Internal, etc.).
+This conversion mechanism only handles errors that do not already have a gRPC
+status associated with them.
+
+Example usage:
+
+	import (
+	    "google.golang.org/grpc"
+	    "github.com/yourusername/yourproject/contextconv"
+	)
+
+	func main() {
+	    server := grpc.NewServer(
+	        grpc.UnaryInterceptor(contextconv.UnaryServerInterceptor),
+	        grpc.StreamInterceptor(contextconv.StreamServerInterceptor),
+	    )
+	    // ...
+	}
+
+Example for demonstrating the need to still check for context errors in a server method:
+
+	func (gs *GRPCServer) ListGitolite(ctx context.Context, req *proto.ListGitoliteRequest) (*proto.ListGitoliteResponse, error) {
+	    host := req.GetGitoliteHost()
+	    repos, err := defaultGitolite.listRepos(ctx, host)
+
+	    // Check for context errors before returning a status.Error()
+	    if ctxErr := ctx.Err(); ctxErr != nil {
+	        return nil, status.FromContextError(ctxErr).Err()
+	    }
+
+	    if err != nil {
+	        return nil, status.Error(codes.Internal, err.Error())
+	    }
+
+	    protoRepos := make([]*proto.GitoliteRepo, 0, len(repos))
+
+	    for _, repo := range repos {
+	        protoRepos = append(protoRepos, repo.ToProto())
+	    }
+
+	    return &proto.ListGitoliteResponse{
+	        Repos: protoRepos,
+	    }, nil
+	}
+*/
+package contextconv

--- a/internal/grpc/defaults/BUILD.bazel
+++ b/internal/grpc/defaults/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//internal/actor",
         "//internal/env",
         "//internal/grpc",
+        "//internal/grpc/contextconv",
         "//internal/grpc/internalerrs",
         "//internal/grpc/messagesize",
         "//internal/grpc/propagator",

--- a/internal/grpc/internalerrs/logging.go
+++ b/internal/grpc/internalerrs/logging.go
@@ -194,8 +194,10 @@ func doLog(logger log.Logger, serviceName, methodName string, initialRequest *pr
 		return
 	}
 
-	s, ok := status.FromError(err)
+	s, ok := massageIntoStatusErr(err)
 	if !ok {
+		// If the error isn't a grpc error, we don't know how to handle it.
+		// Just return.
 		return
 	}
 

--- a/internal/grpc/internalerrs/prometheus.go
+++ b/internal/grpc/internalerrs/prometheus.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var metricGRPCMethodStatus = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -97,7 +96,7 @@ func doObservation(serviceName, methodName string, rpcErr error) {
 		return
 	}
 
-	s, ok := status.FromError(rpcErr)
+	s, ok := massageIntoStatusErr(rpcErr)
 	if !ok {
 		// An error occurred, but it was not an error that has a status.Status implementation. We record this as an unknown error.
 		metricGRPCMethodStatus.WithLabelValues(serviceName, methodName, codes.Unknown.String(), "false").Inc()

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -216,9 +216,10 @@ func (c *Client) EnqueueRepoUpdate(ctx context.Context, repo api.RepoName) (*pro
 		req := proto.EnqueueRepoUpdateRequest{Repo: string(repo)}
 		resp, err := client.EnqueueRepoUpdate(ctx, &req)
 		if err != nil {
-			if st := status.Convert(err); st.Code() == codes.NotFound {
-				return nil, &repoNotFoundError{repo: string(repo), responseBody: st.Message()}
+			if s, ok := status.FromError(err); ok && s.Code() == codes.NotFound {
+				return nil, &repoNotFoundError{repo: string(repo), responseBody: s.Message()}
 			}
+
 			return nil, err
 		}
 


### PR DESCRIPTION
This PR adds interceptors that convert _raw_ `context.Cancelled/DeadlineExceeded` errors into [status.Cancelled / status.DeadlineExceeded](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) errors and vice versa.

For **clients**, this greatly simplifies error handling as we shouldn't need to sprinkle checks like "if status.Code(err)== Cancelled: return context.Cancelled" all over the place any more.

For **servers**, this is more of a defensive mechanism. These interceptors _only_ operate on errors that don't already have a status code associated with them, since it can't assume when it is or isn't appropriate to "override" a specific status code that a server author chose for any given method. (I am willing to revisit this after the code freeze if we find this restriction too annoying). 

Therefore, it's still important for server author to check for context cancellation errors where appropriate if they're already returning a specific status code. For example, in this RPC method:

```go 
func (gs *GRPCServer) ListGitolite(ctx context.Context, req *proto.ListGitoliteRequest) (*proto.ListGitoliteResponse, error) {
	host := req.GetGitoliteHost()
	repos, err := defaultGitolite.listRepos(ctx, host)
	if err != nil {
		return nil, status.Error(codes.Internal, err.Error())
	}

	// ...
}
```

The interceptor won't operate since the server author is already providing a specific status code. In this scenario, the explicit check is still needed:

```go
func (gs *GRPCServer) ListGitolite(ctx context.Context, req *proto.ListGitoliteRequest) (*proto.ListGitoliteResponse, error) {
	host := req.GetGitoliteHost()
	repos, err := defaultGitolite.listRepos(ctx, host)

	// Check for context errors before returning a status.Error()
	if ctxErr := ctx.Err(); ctxErr != nil {
		return nil, status.FromContextError(ctxErr).Err()
	}

	if err != nil {
		return nil, status.Error(codes.Internal, err.Error())
	}

       // ...
}
```


## Test plan

Unit test suite
