### PR TITLE
Cody for VS Code: Only show User Settings buttons in testing

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -290,13 +290,13 @@
       {
         "command": "cody.auth.signout",
         "category": "Cody",
-        "title": "Sign Out",
+        "title": "Sign Out…",
         "icon": "$(sign-out)"
       },
       {
         "command": "cody.auth.signin",
         "category": "Cody",
-        "title": "Switch Account"
+        "title": "Switch Account…"
       },
       {
         "command": "cody.manual-completions",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -288,6 +288,12 @@
         "title": "Set Access Token"
       },
       {
+        "command": "cody.settings.user",
+        "category": "Cody",
+        "title": "User Settings",
+        "icon": "$(account)"
+      },
+      {
         "command": "cody.auth.signout",
         "category": "Cody",
         "title": "Sign Out…",
@@ -528,6 +534,10 @@
           "when": "!cody.activated"
         },
         {
+          "command": "cody.settings.user",
+          "when": "cody.activated && cody.test.inProgress"
+        },
+        {
           "command": "cody.comment.add",
           "when": "false"
         },
@@ -678,6 +688,11 @@
           "command": "cody.auth.signin",
           "when": "view == cody.chat && cody.activated",
           "group": "9_cody@0"
+        },
+        {
+          "command": "cody.settings.user",
+          "when": "view == cody.chat && cody.activated && cody.test.inProgress",
+          "group": "navigation@3"
         },
         {
           "command": "cody.settings.extension",

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -304,14 +304,6 @@
         "title": "Open Completions Panel"
       },
       {
-        "command": "cody.settings.user",
-        "category": "Cody",
-        "title": "User Settings",
-        "group": "Cody",
-        "icon": "$(account)",
-        "when": "cody.activated"
-      },
-      {
         "command": "cody.settings.extension",
         "category": "Cody",
         "title": "Extension Settings",
@@ -688,19 +680,9 @@
           "group": "9_cody@0"
         },
         {
-          "command": "cody.settings.user",
-          "when": "view == cody.chat && cody.activated && cody.test.inProgress",
-          "group": "navigation@3"
-        },
-        {
           "command": "cody.settings.extension",
           "when": "view == cody.chat",
           "group": "8_cody@1"
-        },
-        {
-          "command": "cody.settings.user",
-          "when": "view == cody.chat && cody.activated",
-          "group": "8_cody@0"
         },
         {
           "command": "cody.fixup.apply-all",

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -245,10 +245,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 // cody.auth.signin or cody.auth.signout
                 await vscode.commands.executeCommand(`cody.auth.${message.type}`)
                 break
-            case 'settings': {
+            case 'settings':
                 await this.authProvider.auth(message.serverEndpoint, message.accessToken, this.config.customHeaders)
                 break
-            }
             case 'insert':
                 await vscode.commands.executeCommand('cody.inline.insert', message.text)
                 break

--- a/client/cody/src/services/FeedbackOptions.ts
+++ b/client/cody/src/services/FeedbackOptions.ts
@@ -32,14 +32,3 @@ export const showFeedbackSupportQuickPick = async (): Promise<void> => {
     const selectedItem = await vscode.window.showQuickPick(FeedbackOptionItems, FeedbackQuickPickOptions)
     await selectedItem?.onSelect()
 }
-
-export const SettingsOptionItems = [
-    {
-        label: '$(gear) Settings',
-        detail: 'Configure your Cody settings.',
-        async onSelect(): Promise<void> {
-            await vscode.commands.executeCommand('cody.settings.user')
-            await vscode.commands.executeCommand('cody.settings.extension')
-        },
-    },
-]

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -4,7 +4,7 @@ import type { Configuration } from '@sourcegraph/cody-shared/src/configuration'
 
 import { getConfiguration } from '../configuration'
 
-import { SettingsOptionItems, FeedbackOptionItems } from './FeedbackOptions'
+import { FeedbackOptionItems } from './FeedbackOptions'
 
 export interface CodyStatusBar {
     dispose(): void
@@ -12,7 +12,7 @@ export interface CodyStatusBar {
 }
 
 const DEFAULT_TEXT = '$(cody-logo-heavy)'
-const DEFAULT_TOOLTIP = 'Cody Features Toggle'
+const DEFAULT_TOOLTIP = 'Cody Settings'
 
 export function createStatusBar(): CodyStatusBar {
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right)
@@ -56,6 +56,7 @@ export function createStatusBar(): CodyStatusBar {
         const option = await vscode.window.showQuickPick(
             // These description should stay in sync with the settings in package.json
             [
+                { label: 'features', kind: vscode.QuickPickItemKind.Separator },
                 createFeatureToggle(
                     'Code Autocomplete',
                     'Beta',
@@ -79,10 +80,16 @@ export function createStatusBar(): CodyStatusBar {
                     c => c.experimentalChatPredictions,
                     true
                 ),
-                { label: 'cody feedback', kind: vscode.QuickPickItemKind.Separator },
+                { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
+                {
+                    label: '$(gear) Settings',
+                    detail: 'Configure your Cody settings.',
+                    async onSelect(): Promise<void> {
+                        await vscode.commands.executeCommand('cody.settings.extension')
+                    },
+                },
+                { label: 'feedback', kind: vscode.QuickPickItemKind.Separator },
                 ...FeedbackOptionItems,
-                { label: 'cody settings', kind: vscode.QuickPickItemKind.Separator },
-                ...SettingsOptionItems,
             ],
             {
                 placeHolder: 'Select an option',

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -56,7 +56,7 @@ export function createStatusBar(): CodyStatusBar {
         const option = await vscode.window.showQuickPick(
             // These description should stay in sync with the settings in package.json
             [
-                { label: 'features', kind: vscode.QuickPickItemKind.Separator },
+                { label: 'enable/disable features', kind: vscode.QuickPickItemKind.Separator },
                 createFeatureToggle(
                     'Code Autocomplete',
                     'Beta',


### PR DESCRIPTION
This removes the old Settings webview from being accessible, now that logout is done via the quickpick menu. This also improves some of the labelling and tooltips.

| Before | After |
| - | - |
| <img width="242" alt="Screenshot 2023-06-24 at 12 29 05 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/b2070125-4747-42dc-962a-b7b473310542"> | <img width="236" alt="Screenshot 2023-06-24 at 12 43 14 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/0c1bc166-aa86-450f-822e-d6c18b851078"> |
| <img width="632" alt="Screenshot 2023-06-24 at 12 38 18 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/26aa0aa4-9f49-4613-881b-f26da38a4199"> | <img width="626" alt="Screenshot 2023-06-24 at 12 38 28 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/f7e69719-a9e9-4bce-8686-fa20543dc4b0"> |

## Test plan

- Load extension, verify menus
