### PR TITLE
Cody vsce: remove app connect flag

### DIFF
--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -122,8 +122,6 @@ export interface LocalEnv {
     hasAppJson: boolean
     isAppInstalled: boolean
     isAppRunning: boolean
-    // TODO: remove this once the experimental period for connect app is over
-    isAppConnectEnabled: boolean
 }
 
 export function isLoggedIn(authStatus: AuthStatus): boolean {

--- a/client/cody/src/services/CodyMenus.ts
+++ b/client/cody/src/services/CodyMenus.ts
@@ -69,17 +69,13 @@ export const AuthMenuOptions = {
     signin: {
         title: 'Other Sign in Options',
         placeholder: 'Select a sign in option',
-        ignoreFocusOut: true,
     },
     signout: {
         title: 'Sign Out',
         placeHolder: 'Select instance to sign out',
-        ignoreFocusOut: true,
     },
     switch: {
         title: 'Switch Account',
-        placeHolder: 'Press Esc to cancel',
-        ignoreFocusOut: true,
     },
 }
 

--- a/client/cody/src/services/LocalAppDetector.ts
+++ b/client/cody/src/services/LocalAppDetector.ts
@@ -31,8 +31,6 @@ export class LocalAppDetector implements vscode.Disposable {
         // Only Mac is supported for now
         this.isSupported = this.localEnv.os === 'darwin' && this.localEnv.homeDir !== undefined
         const codyConfiguration = vscode.workspace.getConfiguration('cody')
-        // TODO: remove this once the experimental period for connect app is over
-        this.localEnv.isAppConnectEnabled = codyConfiguration.get<boolean>('experimental.app.connect') ?? false
         void this.init()
     }
 
@@ -185,7 +183,4 @@ const envInit = {
     isAppInstalled: false,
     isAppRunning: false,
     hasAppJson: false,
-
-    // TODO: remove this once the experimental period for connect app is over
-    isAppConnectEnabled: false,
 }

--- a/client/cody/webviews/App.story.tsx
+++ b/client/cody/webviews/App.story.tsx
@@ -53,7 +53,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 arch: 'x64',
                 homeDir: '/home/user',
                 isAppInstalled: false,
-                isAppConnectEnabled: false,
                 isAppRunning: false,
                 hasAppJson: false,
                 extensionVersion: '0.0.0',

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -124,7 +124,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     appOS={config?.os}
                     appArch={config?.arch}
                     callbackScheme={config?.uriScheme}
-                    isAppConnectEnabled={config?.isAppConnectEnabled}
                     setEndpoint={setEndpoint}
                 />
             ) : (

--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -25,7 +25,6 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
 }) => {
     const inDownloadMode = !isAppInstalled && isOSSupported && !isAppRunning
     const buttonText = inDownloadMode ? 'Download Cody App' : isAppRunning ? 'Connect Cody App' : 'Open Cody App'
-    const buttonIcon = inDownloadMode ? 'cloud-download' : isAppRunning ? 'link' : 'rocket'
     // Open landing page if download link for user's arch cannot be found
     const DOWNLOAD_URL = APP_DOWNLOAD_URLS[appOS]?.[appArch] || APP_LANDING_URL.href
     // If the user already has the app installed, open the callback URL directly.
@@ -46,7 +45,6 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
                 disabled={!isOSSupported}
                 onClick={() => openLink(isAppInstalled ? callbackUri.href : DOWNLOAD_URL)}
             >
-                <i className={'codicon codicon-' + buttonIcon} slot="start" />
                 {buttonText}
             </VSCodeButton>
         </div>

--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -24,7 +24,7 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
     callbackScheme,
 }) => {
     const inDownloadMode = !isAppInstalled && isOSSupported && !isAppRunning
-    const buttonText = inDownloadMode ? 'Download Cody App' : isAppRunning ? 'Connect Cody App' : 'Open Cody App'
+    const buttonText = inDownloadMode ? 'Download Cody App' : isAppRunning ? 'Connect Cody App' : 'Get Started'
     // Open landing page if download link for user's arch cannot be found
     const DOWNLOAD_URL = APP_DOWNLOAD_URLS[appOS]?.[appArch] || APP_LANDING_URL.href
     // If the user already has the app installed, open the callback URL directly.

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -25,7 +25,7 @@ interface LoginProps {
 
 const APP_DESC = {
     getStarted: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
-    download: 'Download and run the Cody desktop app to configure your local code graph.',
+    download: 'Download and open the Cody desktop app to configure your local code graph.',
     connectApp: 'All that’s left is to do is connect VS Code with Cody App.',
     notRunning: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
     comingSoon:
@@ -64,7 +64,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
 
     const AppConnect: React.FunctionComponent = () => (
         <section className={classNames(styles.section, isOSSupported ? styles.codyGradient : styles.greyGradient)}>
-            <h2 className={styles.sectionHeader}>{isAppInstalled ? title : 'Get Started'}</h2>
+            <h2 className={styles.sectionHeader}>{isAppInstalled ? title : 'Download & Open Cody App'}</h2>
             <p className={styles.openMessage}>{openMsg}</p>
             {!isAppInstalled && <p className={styles.openMessage}>{APP_DESC.download}</p>}
             <ConnectApp

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -20,14 +20,13 @@ interface LoginProps {
     callbackScheme?: string
     appOS?: string
     appArch?: string
-    isAppConnectEnabled?: boolean
     setEndpoint: (endpoint: string) => void
 }
 
 const APP_DESC = {
     getStarted: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
     download: 'Download and run the Cody desktop app to configure your local code graph.',
-    connectApp: 'Cody App detected. All that’s left is to do is connect VS Code with Cody App.',
+    connectApp: 'All that’s left is to do is connect VS Code with Cody App.',
     notRunning: 'Cody for VS Code requires the Cody desktop app to enable context fetching for your private code.',
     comingSoon:
         'We’re working on bringing Cody App to your platform. In the meantime, you can try Cody with open source repositories by signing in to Sourcegraph.com.',
@@ -42,7 +41,6 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     appArch,
     isAppInstalled = false,
     isAppRunning = false,
-    isAppConnectEnabled = false,
     setEndpoint,
 }) => {
     const isOSSupported = appOS === 'darwin' && appArch === 'arm64'
@@ -61,7 +59,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
         [vscodeAPI]
     )
 
-    const title = isAppInstalled ? (isAppRunning ? 'Connect with Cody App' : 'Cody App Not Running') : 'Get Started'
+    const title = isAppInstalled ? (isAppRunning ? 'Connect with Cody App' : 'Open Cody App') : 'Get Started'
     const openMsg = !isAppInstalled ? APP_DESC.getStarted : !isAppRunning ? APP_DESC.notRunning : APP_DESC.connectApp
 
     const AppConnect: React.FunctionComponent = () => (
@@ -97,9 +95,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     )
 
     const EnterpriseSignin: React.FunctionComponent = () => (
-        <section
-            className={classNames(styles.section, !isAppConnectEnabled ? styles.codyGradient : styles.greyGradient)}
-        >
+        <section className={classNames(styles.section, styles.greyGradient)}>
             <h2 className={styles.sectionHeader}>Sourcegraph Enterprise</h2>
             <p className={styles.openMessage}>
                 Sign in by entering an access token created through your user settings on Sourcegraph.
@@ -111,9 +107,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     )
 
     const DotComSignin: React.FunctionComponent = () => (
-        <section
-            className={classNames(styles.section, !isAppConnectEnabled ? styles.codyGradient : styles.greyGradient)}
-        >
+        <section className={classNames(styles.section, styles.greyGradient)}>
             <h2 className={styles.sectionHeader}>Sourcegraph.com</h2>
             <p className={styles.openMessage}>
                 Cody for open source code is available to all users with a Sourcegraph.com account.
@@ -133,10 +127,8 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
             {authStatus && <ErrorContainer authStatus={authStatus} isApp={isApp} endpoint={endpoint} />}
             {/* Signin Sections */}
             <div className={styles.sectionsContainer}>
-                <EnterpriseSignin />
-                <DotComSignin />
-                {isAppConnectEnabled && <AppConnect />}
-                {isAppConnectEnabled && !isOSSupported && <NoAppConnect />}
+                <AppConnect />
+                {!isOSSupported && <NoAppConnect />}
             </div>
             {/* Footer */}
             <footer className={styles.footer}>


### PR DESCRIPTION
Now that App has app.json support, we can remove this flag and start testing it in pre-release.

It also has:
* Some minor copy tweaks
* Removing the two big grey login boxes above the App

<img width="1403" alt="Screenshot 2023-06-24 at 1 10 35 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/6a98db39-9dad-43ae-a111-dba94686837b">

## Test plan

- Open extension
