### PR TITLE
App - disable code insights 

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -52,6 +52,9 @@ func Init(logger log.Logger) CleanupFunc {
 	// hostname.
 	setDefaultEnv(logger, "SRC_SYNTECT_SERVER", "http://localhost:9238")
 
+	// Code Insights does not run in App
+	setDefaultEnv(logger, "DISABLE_CODE_INSIGHTS", "true")
+
 	// Jaeger might not be running, but this is a better default than an internal hostname.
 	//
 	// TODO(sqs) TODO(single-binary): this isnt taking effect

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1439,7 +1439,7 @@ commandsets:
       - caddy
       - tauri
     env:
-      DISABLE_CODE_INSIGHTS: false
+      DISABLE_CODE_INSIGHTS: true
       SOURCEGRAPH_APP: 1
       EXTSVC_CONFIG_ALLOW_EDITS: true
 


### PR DESCRIPTION
Code insights is not run in App so it can be safely disabled.  Improves initial startup time with fewer migrations to run.
## Test plan
`sg start app` app runs
build local release version - app runs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
