### PR TITLE
Setup : Add auto-redirection UI to the welcome setup step

### DIFF
--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.module.scss
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.module.scss
@@ -92,3 +92,20 @@
         margin-bottom: 0.5rem;
     }
 }
+
+.loading {
+    flex-basis: 50%;
+    flex-shrink: 0;
+    padding: 9.6rem 2.5rem 2.5rem;
+    background-color: var(--gray-02);
+    color: var(--text-muted);
+
+    &-text {
+        font-size: 1.25rem;
+        margin-bottom: 1.5rem;
+    }
+
+    &-icon {
+        --icon-inline-size: 2rem;
+    }
+}

--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
@@ -21,7 +21,22 @@ const EMAIL_VERIFICATION_QUERY = gql`
 `
 
 export const AppWelcomeSetupStep: FC<StepComponentProps> = ({ className }) => {
+    const { onNextStep } = useContext(SetupStepsContext)
     const { emailCheck } = useQueryParameters(['emailCheck'])
+    const { loading } = useQuery(EMAIL_VERIFICATION_QUERY, {
+        skip: !emailCheck,
+        fetchPolicy: 'network-only',
+        onCompleted: data => {
+            const isEmailVerified = data?.user.hasVerifiedEmail
+
+            // In case if email has already verified we should
+            // skip the email verification state of the current step
+            // and navigate to the next step automatically
+            if (isEmailVerified) {
+                onNextStep()
+            }
+        },
+    })
 
     return (
         <div className={classNames(styles.root, className)}>
@@ -38,11 +53,18 @@ export const AppWelcomeSetupStep: FC<StepComponentProps> = ({ className }) => {
                 />
             </div>
 
-            {emailCheck && <EmailCheckVerificationForm />}
-            {!emailCheck && <ConnectToSourcegraphComForm />}
+            {loading && <SigningInState />}
+            {!loading && emailCheck && <EmailCheckVerificationForm />}
+            {!loading && !emailCheck && <ConnectToSourcegraphComForm />}
         </div>
     )
 }
+
+const SigningInState: FC = () => (
+    <div className={styles.loading}>
+        <Text className={styles.loadingText}>Signing in…</Text> <LoadingSpinner className={styles.loadingIcon} />
+    </div>
+)
 
 const EmailCheckVerificationForm: FC = () => {
     const { onNextStep } = useContext(SetupStepsContext)


### PR DESCRIPTION
This PR adds a special state to the welcome setup step right after connect to .com has been clicked. Previously users had to click the email verified button even if the email had been verified before. In this PR, you don't need to click anything and will be redirected automatically to the next setup step. 

https://github.com/sourcegraph/sourcegraph/assets/18492575/e5422a3b-ee5d-4f88-9068-e15f0907b6ad

## Test plan
- Check that the setup flow works properly if you have the email verified before you run the app
- Check that the setup flow works properly if you don't have your email verified before you run app

