### PR TITLE
ci: `percy` defer snapshots upload

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -19,4 +19,9 @@ percy:
   # Defer uploading snapshots until the very end of the test suite.
   # This allows many snapshots with the same name AND different widths to be merged together.
   # This is useful for flaky client integration tests that can be retried automatically.
+  #
+  # This should prevent creating a Percy build if the test suite fails according to sources:
+  # 1. The exit code is used force stop the local Percy server: https://github.com/percy/cli/blob/9c89383d6e1a9aa41f0c83f8e4b9ddcdf827583b/packages/cli-exec/src/exec.js#L78-L81
+  # 2. The `force` options is propagated to `this.#snapshots.close(true)`: https://github.com/percy/cli/blob/master/packages/core/src/percy.js#L219-L223
+  # 3. The snapshots queue is cleared if `force` is true: https://github.com/percy/cli/blob/9c89383d6e1a9aa41f0c83f8e4b9ddcdf827583b/packages/core/src/queue.js#L177
   defer-uploads: true

--- a/.percy.yml
+++ b/.percy.yml
@@ -15,3 +15,8 @@ snapshot:
     }
 discovery:
   disable-cache: true
+percy:
+  # Defer uploading snapshots until the very end of the test suite.
+  # This allows many snapshots with the same name AND different widths to be merged together.
+  # This is useful for flaky client integration tests that can be retried automatically.
+  defer-uploads: true


### PR DESCRIPTION
## Context

When running client integration tests, we create a new Percy build on a first `percySnapshot` call and upload snapshots as soon as they are taken. If a build fails because of a flake and an auto-retry is triggered, we create another Percy build and upload all snapshots again. This is the reason for the rising Percy costs since migrating to Bazel because the number of snapshots didn't change since then. See [this Slack thread](https://sourcegraph.slack.com/archives/C04931KQVRC/p1686911527274019) for more details. 

This PR defers Percy's build creation and snapshots upload until the test suite completion. No Percy build will be created if tests fail so that we can keep the auto-retry logic without changes.

## Test plan

CI
