### PR TITLE
ci: do not error on `page.close()` timeout

### DIFF
--- a/client/shared/src/testing/integration/context.ts
+++ b/client/shared/src/testing/integration/context.ts
@@ -328,7 +328,18 @@ export const createSharedIntegrationTestContext = async <
                 )
             }
 
-            await pTimeout(driver.page.close(), DISPOSE_ACTION_TIMEOUT, new Error('Closing Puppeteer page timed out'))
+            /**
+             * We close the browser instance on every test completion via `after(() => driver?.close())`
+             * See the implementation details here: `client/shared/src/testing/driver.ts`.
+             *
+             * So it's OK to continue running tests even if `page.close()` times out.
+             * The issue of `page.close()` timing out is tracked here without a resolution:
+             * 1. https://github.com/puppeteer/puppeteer/issues/4882
+             * 2. https://github.com/puppeteer/puppeteer/issues/4104
+             */
+            await pTimeout(driver.page.close(), DISPOSE_ACTION_TIMEOUT, () =>
+                logger.warn('Closing Puppeteer page timed out')
+            )
             await pTimeout(polly.stop(), DISPOSE_ACTION_TIMEOUT, new Error('Stopping Polly timed out'))
         },
     }


### PR DESCRIPTION
## Context

Our client integration tests are flaking quite a bit on the `driver.page.close()` call that's run after each test suite. After diving into Puppeteer's issues, it seems like this is a common hiccup. Apparently, Chrome is unreliable at consistently sending the page-close signal back to Puppeteer.

I dug around in the blame diffs, which slipped in the `page.close()` call, and didn't see any heavy-duty reasons for keeping it other than it being a good housekeeper — it leaves fewer tabs open, using less memory. So, I've removed the bit that throws when the `page.close()` call times out.

We're still shutting down the browser instance when a test suite wraps up, so we should be OK.

## Test plan

CI
