### PR TITLE
Update `extensionDetails` in EventLogger.ts

### DIFF
--- a/client/jetbrains/webview/src/telemetry/EventLogger.ts
+++ b/client/jetbrains/webview/src/telemetry/EventLogger.ts
@@ -94,8 +94,8 @@ export class EventLogger implements TelemetryService {
     ): void {
         this.tracker(
             eventName,
-            { ...eventProperties, ...this.editorInfo, ...this.extensionDetails },
-            { ...publicArgument, ...this.editorInfo, ...this.extensionDetails },
+            { ...eventProperties, ...this.editorInfo, extensionDetails: this.extensionDetails },
+            { ...publicArgument, ...this.editorInfo, extensionDetails: this.extensionDetails },
             uri
         )
     }


### PR DESCRIPTION
This change nests the `extensionDetails` object under a single `extensionDetails` property in `public_arguements`. This change makes it consistent with how we are storing it in VSCode.

Before:
```
{
  "editor": "...",
  "version": "...", 
  "extensionID": "..." 
}
```
After:
```
{
  "editor": "...",
  "version": "...", 
  "extensionDetails": { 
    "ide": "..." 
  }
}
```
This keeps the extensionDetails object nested under a single property, rather than merging all its properties at the top level.

No functionality is changed, this is just a minor syntax improvement to keep the public_argument object a bit more organized.



## Test plan
test locally
