### PR TITLE
Cody for VS Code: Make signup quickpicks more easily dismissible

### DIFF
--- a/client/cody/src/services/CodyMenus.ts
+++ b/client/cody/src/services/CodyMenus.ts
@@ -69,17 +69,14 @@ export const AuthMenuOptions = {
     signin: {
         title: 'Other Sign in Options',
         placeholder: 'Select a sign in option',
-        ignoreFocusOut: true,
     },
     signout: {
         title: 'Sign Out',
         placeHolder: 'Select instance to sign out',
-        ignoreFocusOut: true,
     },
     switch: {
         title: 'Switch Account',
         placeHolder: 'Press Esc to cancel',
-        ignoreFocusOut: true,
     },
 }
 


### PR DESCRIPTION
This removes the `ignoreFocusOut` for quick picks, which you really only want if you're supporting something that needs copy+pasting (i.e. an input in a multi-step flow). For everyone else, it just feels unnecessarily sticky/finicky. 

Before:

https://github.com/sourcegraph/sourcegraph/assets/153/6d225da3-3859-4762-867e-92a3ffeb61dc

After:

https://github.com/sourcegraph/sourcegraph/assets/153/d5a73260-767d-40cb-974f-fcb9d341dd95

## Test plan

- Open extension
- Click "Other Sign In Options…"
- Click outside the quickpick
