### PR TITLE
Cody for VS Code: Remove Cody App and sourcegraph.com from previously used endpoints

### DIFF
--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -136,3 +136,7 @@ export function isLoggedIn(authStatus: AuthStatus): boolean {
 export function isLocalApp(url: string): boolean {
     return new URL(url).origin === LOCAL_APP_URL.origin
 }
+
+export function isDotCom(url: string): boolean {
+    return new URL(url).origin === DOTCOM_URL.origin
+}

--- a/client/cody/src/services/CodyMenus.ts
+++ b/client/cody/src/services/CodyMenus.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isLocalApp } from '../chat/protocol'
+import { isLocalApp, isDotCom } from '../chat/protocol'
 
 export interface LoginMenuItem {
     id: string
@@ -21,6 +21,9 @@ function getItemLabel(uri: string, current: boolean): string {
     const icon = current ? '$(check) ' : ''
     if (isLocalApp(uri)) {
         return `${icon}Cody App`
+    }
+    if (isDotCom(uri)) {
+        return `${icon}Sourcegraph.com`
     }
     return `${icon}${uri}`
 }

--- a/client/cody/src/services/CodyMenus.ts
+++ b/client/cody/src/services/CodyMenus.ts
@@ -40,6 +40,10 @@ export const AuthMenu = async (type: AuthMenuType, historyItems: string[]): Prom
                       description: type === 'signout' && i === 0 ? 'current' : '',
                       uri,
                   }))
+                  // We don't want to show App and Dot Com in previously used
+                  // signins, because they're already in the menu item, and
+                  // they use a different type of auth (callback URLs)
+                  .filter(({ uri }) => type !== 'signin' || (!isLocalApp(uri) && !isDotCom(uri)))
                   .reverse()
             : []
     const seperator = [{ label: type === 'signin' ? 'previously used' : 'current', kind: -1 }]


### PR DESCRIPTION
Currently Cody App and Sourcegraph.com appear in the "previously used" list of sign in endpoints, but if you select them you are asked to enter an Access Token, which is confusing because that's not how you originally logged into these services. Logging into Cody App uses its own flow picking up the credentials from `app.json`, and Sourcegraph.com uses a callback style auth.

Given they already appear in other ways in the UI, this removes them from the previously used list.

Before:

https://github.com/sourcegraph/sourcegraph/assets/153/59e44283-4c72-4a2e-a733-d3a9aab57459

After:

https://github.com/sourcegraph/sourcegraph/assets/153/e0da267f-d4bc-4b86-b455-3fb381970692

## Test plan

- Open extension
- Login to sg dot com
- Logout
- See "Other Sign In Options…" menu

## Follow up fixes

This doesn't fix people who have logged into an SG Enterprise instance using the callback style login too — they too will be asked for access token, which they never created manually. We should fix that.