### PR TITLE
Cody for VS Code: Simplify the Cody status bar menu text

### DIFF
--- a/client/cody/src/services/FeedbackOptions.ts
+++ b/client/cody/src/services/FeedbackOptions.ts
@@ -4,22 +4,19 @@ import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
 
 export const FeedbackOptionItems = [
     {
-        label: '$(feedback) Feedback',
-        detail: 'Have an idea, found a bug, or need help? Let us know.',
+        label: '$(feedback) Cody Feedback',
         async onSelect(): Promise<void> {
             await vscode.env.openExternal(vscode.Uri.parse(CODY_FEEDBACK_URL.href))
         },
     },
     {
-        label: '$(remote-explorer-documentation) Documentation',
-        detail: 'Search the Cody documentation.',
+        label: '$(remote-explorer-documentation) Cody Documentation',
         async onSelect(): Promise<void> {
             await vscode.env.openExternal(vscode.Uri.parse(CODY_DOC_URL.href))
         },
     },
     {
-        label: '$(organization) Discord Channel',
-        detail: 'Join our Discord community’s #cody channel.',
+        label: '$(organization) Sourcegraph Discord Channel',
         async onSelect(): Promise<void> {
             await vscode.env.openExternal(vscode.Uri.parse(DISCORD_URL.href))
         },

--- a/client/cody/src/services/FeedbackOptions.ts
+++ b/client/cody/src/services/FeedbackOptions.ts
@@ -16,7 +16,7 @@ export const FeedbackOptionItems = [
         },
     },
     {
-        label: '$(organization) Sourcegraph Discord Channel',
+        label: '$(organization) Cody Discord Channel',
         async onSelect(): Promise<void> {
             await vscode.env.openExternal(vscode.Uri.parse(DISCORD_URL.href))
         },

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -82,13 +82,12 @@ export function createStatusBar(): CodyStatusBar {
                 ),
                 { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
                 {
-                    label: '$(gear) Settings',
-                    detail: 'Configure your Cody settings.',
+                    label: '$(gear) Cody Settings',
                     async onSelect(): Promise<void> {
                         await vscode.commands.executeCommand('cody.settings.extension')
                     },
                 },
-                { label: 'feedback', kind: vscode.QuickPickItemKind.Separator },
+                { label: 'feedback & support', kind: vscode.QuickPickItemKind.Separator },
                 ...FeedbackOptionItems,
             ],
             {

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -60,14 +60,14 @@ export function createStatusBar(): CodyStatusBar {
                 createFeatureToggle(
                     'Code Autocomplete',
                     'Beta',
-                    'Enables inline code suggestions in your editor',
+                    'Enable Cody-powered code autocompletions',
                     'cody.autocomplete.enabled',
                     c => c.autocomplete
                 ),
                 createFeatureToggle(
                     'Inline Chat',
                     'Beta',
-                    'An inline way to explicitly ask questions and propose modifications to code',
+                    'Enable starting chats, and requesting edits, directly from lines of code',
                     'cody.experimental.inline',
                     c => c.experimentalInline
                 ),
@@ -75,7 +75,7 @@ export function createStatusBar(): CodyStatusBar {
                 createFeatureToggle(
                     'Chat Suggestions',
                     'Experimental',
-                    'Adds suggestions of possible relevant messages in the chat window',
+                    'Enable automatically suggested chat questions',
                     'cody.experimental.chatPredictions',
                     c => c.experimentalChatPredictions,
                     true

--- a/client/cody/src/services/StatusBar.ts
+++ b/client/cody/src/services/StatusBar.ts
@@ -67,7 +67,7 @@ export function createStatusBar(): CodyStatusBar {
                 createFeatureToggle(
                     'Inline Chat',
                     'Beta',
-                    'Enable starting chats, and requesting edits, directly from lines of code',
+                    'Enable chatting and editing with Cody, directly in your code',
                     'cody.experimental.inline',
                     c => c.experimentalInline
                 ),


### PR DESCRIPTION
The statusbar quickpick menu is so tall that it doesn't fit on small screens, and it's so much text to parse. This simplifies it, so people can find what they need more quickly.

| Before | After | 
| - | - |
| <img width="618" alt="Screenshot 2023-06-26 at 5 01 03 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/481640e0-96b1-431a-820a-6bd026f377fc"> |  <img width="616" alt="Screenshot 2023-06-26 at 6 06 44 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/9c8a1560-901f-4690-afc9-c409ada885ce"> |

## Test plan

- Open extension
- Click Cody icon in statusbar
- Review quickpick items