### PR TITLE
cody docs: add page about one-off jobs

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -23,7 +23,7 @@ Embeddings will not be generated for any repo unless an admin takes action. Ther
 
 The recommended way of configuring embeddings is to use a policy. These are configured through the Admin UI using [policies](https://docs.sourcegraph.com/cody/explanations/policies). Policy based embeddings will be automatically updated based on the [update interval](#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings).
 
-To run a one-time embeddings job, an admin can manually schedule specific repositories for embedding by navigating to **Site admin > Cody** (`/site-admin/cody`) and entering the names of the repositories that should be embeded. Manual embeddings are useful for one-off embeddings or to run an embeddings job immediately. These will not be automatically updated.
+ Admins can also [schedule one-time embeddings jobs for specific repositories](./schedule_one_off_embeddings_jobs.md). These one-off embeddings will not be automatically updated.
 
 Whether created manually or through a policy, embeddings will be generated incrementally if [incremental updates](#incremental-embeddings) are enabled.
 

--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -6,3 +6,4 @@
 - [Configuring code graph context](code_graph_context.md)
 - [Generating Index to Enable Codebase-Aware Answers](indexing.md)
 - [Embeddings Policies](policies.md)
+- [Schedule one-off embeddings jobs](schedule_one_off_embeddings_jobs.md)

--- a/doc/cody/explanations/indexing.md
+++ b/doc/cody/explanations/indexing.md
@@ -1,19 +1,22 @@
-# Generate Index to Enable Codebase-Aware Answers
+# Generate an Embeddings Index to Enable Codebase-Aware Answers
 
 These docs provide instructions on how to generate an index that enables codebase-aware answers for Cody. Codebase-aware answers leverage code graph context to enhance Cody's understanding of code from selected codebases. 
 
 By following the steps outlined in this guide, you can configure the necessary prerequisites and enable Cody to provide more accurate and contextually relevant answers to your coding questions based on the codebase you are working in.
 
-## Generate Index
+## Generate Embeddings Index
 
-You can enhance Cody's understanding of existing code by generating index for your codebases to enable [code graph context](code_graph_context.md).
+You can enhance Cody's understanding of existing code by embedding your code base.
 
 ### Sourcegraph Enterprise
 
-To generate an index for your codebase and enable codebase-aware answers for Cody, your site admin must complete the following:
+To embed your codebase and enable codebase-aware answers for Cody, your site admin must complete the following:
 
 - [Configure Code Graph Context](code_graph_context.md) for your Sourcegraph instance
 - [Enable Cody for your Sourcegraph instance](enabling_cody_enterprise.md#step-1-enable-cody-on-your-sourcegraph-instance)
+- Embed your codebase by either
+  - [scheduling a one-off embeddings job](schedule_one_off_embeddings_jobs), or
+  - [creating an embeddings policy to automatically keep your index up-to-date](policies).
 
 ### Sourcegraph.com
 

--- a/doc/cody/explanations/indexing.md
+++ b/doc/cody/explanations/indexing.md
@@ -15,8 +15,8 @@ To embed your codebase and enable codebase-aware answers for Cody, your site adm
 - [Configure Code Graph Context](code_graph_context.md) for your Sourcegraph instance
 - [Enable Cody for your Sourcegraph instance](enabling_cody_enterprise.md#step-1-enable-cody-on-your-sourcegraph-instance)
 - Embed your codebase by either
-  - [scheduling a one-off embeddings job](schedule_one_off_embeddings_jobs), or
-  - [creating an embeddings policy to automatically keep your index up-to-date](policies).
+  - [scheduling a one-off embeddings job](schedule_one_off_embeddings_jobs.md), or
+  - [creating an embeddings policy to automatically keep your index up-to-date](policies.md).
 
 ### Sourcegraph.com
 

--- a/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
+++ b/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
@@ -5,17 +5,3 @@ Adminstrators can schedule one-off embeddings jobs from the _Site Admin_ page. O
 At the top of the page select the input field and search for the repository you want to index. Multiple repositories can be selected. Once you have selected the repositories, click on **Schedule Embedding**. The new jobs will be shown in the list of jobs below. The initial status of the jobs will be _queued_. 
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/schedule-one-off-jobs.png" class="screenshot" alt="schedule one-off embeddings jobs">
-
-## FAQ
-
-### I scheduled a one-off embeddings job but it is not showing up in the list of jobs. What happened?
-
-There can be several reasons why a job is not showing up in the list of jobs:
-
-- The repository is already queued or being processed
-- A job for the same repository and the same revision already completed successfully
-- Another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window 
-
-### How do I stop a running embeddings job?
-
-Jobs can be canceled while they are in state _queued_ or _processing_. To cancel a job, click on the _Cancel_ button of the job you want to cancel. The job will be marked for cancellation. Note that it might take a few seconds or minutes for the job to actually be canceled depending on the state of the job.

--- a/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
+++ b/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
@@ -1,0 +1,21 @@
+# Schedule one-off embeddings jobs
+
+Adminstrators can schedule one-off embeddings jobs from the _Site Admin_ page. Open the _Site Admin_ page and select **Cody > Embeddings Jobs** from the left-hand navigation menu.
+
+At the top of the page select the input field and search for the repository you want to index. Multiple repositories can be selected. Once you have selected the repositories, click on **Schedule Embedding**. The new jobs will be shown in the list of jobs below. The initial status of the jobs will be _queued_. 
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/schedule-one-off-jobs.png" class="screenshot" alt="schedule one-off embeddings jobs">
+
+## FAQ
+
+### I scheduled a one-off embeddings job but it is not showing up in the list of jobs. What happened?
+
+There can be several reasons why a job is not showing up in the list of jobs:
+
+- The repository is already queued or being processed
+- A job for the same repository and the same revision already completed successfully
+- Another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window 
+
+### How do I stop a running embeddings job?
+
+Jobs can be canceled while they are in state _queued_ or _processing_. To cancel a job, click on the _Cancel_ button of the job you want to cancel. The job will be marked for cancellation. Note that it might take a few seconds or minutes for the job to actually be canceled depending on the state of the job.

--- a/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
+++ b/doc/cody/explanations/schedule_one_off_embeddings_jobs.md
@@ -2,6 +2,6 @@
 
 Adminstrators can schedule one-off embeddings jobs from the _Site Admin_ page. Open the _Site Admin_ page and select **Cody > Embeddings Jobs** from the left-hand navigation menu.
 
-At the top of the page select the input field and search for the repository you want to index. Multiple repositories can be selected. Once you have selected the repositories, click on **Schedule Embedding**. The new jobs will be shown in the list of jobs below. The initial status of the jobs will be _queued_. 
+At the top of the page select the input field and search for the repository you want to index. Multiple repositories can be selected. Once you have selected the repositories, click on **Schedule Embedding**. The new jobs will be shown in the list of jobs below. The initial status of the jobs will be _QUEUED_.
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/embeddings/schedule-one-off-jobs.png" class="screenshot" alt="schedule one-off embeddings jobs">

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -37,7 +37,6 @@ Yes. Sourcegraph is needed both to retrieve context and as a proxy for the LLM p
 
 Embeddings are one of the many ways Sourcegraph uses to retrieve relevant code to feed the large language model as context. Embeddings / vector search are complementary to other strategies. While it matches really well semantically ("what is this code about, what does it do?"), it drops syntax and other important precise matching info. Sourcegraph's overall approach is to blend results from multiple sources to provide the best answer possible.
 
-
 #### When using embeddings, are permissions enforced? Does Cody get fed code that the users doesn't have access to?
 
 Permissions are enforced when using embeddings. Today, Sourcegraph only uses embeddings search on a single repo, first checking that the users has access.
@@ -47,6 +46,18 @@ In the future, here are the steps that Sourcegraph will follow:
 - determine which repo you have access to
 - query embeddings for each of those repo
 - pick the best results and send it back
+
+### I scheduled a one-off embeddings job but it is not showing up in the list of jobs. What happened?
+
+There can be several reasons why a job is not showing up in the list of jobs:
+
+- The repository is already queued or being processed
+- A job for the same repository and the same revision already completed successfully
+- Another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window 
+
+### How do I stop a running embeddings job?
+
+Jobs in state **queued** or **processing** can be canceled by admins from the **Cody > Embeddings Jobs** page. To cancel a job, click on the _Cancel_ button of the job you want to cancel. The job will be marked for cancellation. Note that, depending on the state of the job, it might take a few seconds or minutes for the job to actually be canceled.
 
 ### Third party dependencies
 

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -53,7 +53,7 @@ There can be several reasons why a job is not showing up in the list of jobs:
 
 - The repository is already queued or being processed
 - A job for the same repository and the same revision already completed successfully
-- Another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window 
+- Another job for the same repository has been queued for processing within the [embeddings.MinimumInterval](./explanations/code_graph_context.md#adjust-the-minimum-time-interval-between-automatically-scheduled-embeddings) time window
 
 ### How do I stop a running embeddings job?
 

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -57,7 +57,7 @@ There can be several reasons why a job is not showing up in the list of jobs:
 
 ### How do I stop a running embeddings job?
 
-Jobs in state **queued** or **processing** can be canceled by admins from the **Cody > Embeddings Jobs** page. To cancel a job, click on the _Cancel_ button of the job you want to cancel. The job will be marked for cancellation. Note that, depending on the state of the job, it might take a few seconds or minutes for the job to actually be canceled.
+Jobs in state _QUEUED_ or _PROCESSING_ can be canceled by admins from the **Cody > Embeddings Jobs** page. To cancel a job, click on the _Cancel_ button of the job you want to cancel. The job will be marked for cancellation. Note that, depending on the state of the job, it might take a few seconds or minutes for the job to actually be canceled.
 
 ### Third party dependencies
 


### PR DESCRIPTION
This was missing from the docs. I also updated the parent page to clarify the difference between policies and one-off jobs.



## Test plan
Just a doc change