### PR TITLE
Delete connected GitHub accounts without auth providers

### DIFF
--- a/enterprise/internal/authz/github/authz.go
+++ b/enterprise/internal/authz/github/authz.go
@@ -100,6 +100,21 @@ func NewAuthzProviders(
 		initResults.Providers = append(initResults.Providers, p)
 	}
 
+	if len(githubAuthProviders) > 0 {
+		// We delete all existing user external accounts that have no client IDs in common with the providers
+		clientIDs := make([]string, len(githubAuthProviders))
+		for _, provider := range githubAuthProviders {
+			clientIDs = append(clientIDs, provider.ClientID)
+		}
+
+		opts := database.ExternalAccountsDeleteOptions{
+			ClientIDs: clientIDs,
+			Not: true,
+		}
+
+		_ = db.UserExternalAccounts().Delete(ctx, opts)
+	}
+
 	return initResults
 }
 


### PR DESCRIPTION
Before this PR:
Removing an auth provider left external accounts in tact. This meant that these external accounts, despite not having an associated auth provider, could still be picked up for permissions syncing, and could appear in the UI when unexpected. It makes it difficult to switch to a new auth provider on the same code host (say GitHub OAuth to GitHub App OAuth), because the old account will be associated with the new provider, even though they shouldn't be.

After this PR:
Old external accounts that don't have a matching Auth provider are deleted with the Auth providers are set up within Sourcegraph. This ensures that only valid external accounts are left in the system.

## Test plan

Test added and manual verification.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
