### PR TITLE
Own (beta) not experimental in docs sidebar (#53754)

### DIFF
--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -78,8 +78,8 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Background information](dev/background-information/index.md)
   - [Contributing](dev/contributing.md)
 - [Dotcom](dotcom/index.md)
-- [App (experimental)](app/index.md)
-- [Own (experimental)](own/index.md)
+- [Cody App (experimental)](app/index.md)
+- [Own (beta)](own/index.md)
 - <br/>
 - [★ Search query syntax](code_search/reference/queries.md)
 - [★ Sourcegraph API](api/index.md)


### PR DESCRIPTION
Docs sidebar now says _Own (beta)_ rather than _Own (experimental)_.

Docs change only.

---------



## Test plan

Docs change - manually verified
