### PR TITLE
Autocomplete: Mark panel view as experimental

### DIFF
--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -307,7 +307,7 @@
       {
         "command": "cody.manual-completions",
         "category": "Cody",
-        "title": "Open Completions Panel"
+        "title": "Open Autocomplete Panel (Experimental)"
       },
       {
         "command": "cody.settings.extension",


### PR DESCRIPTION
This feature is currently not on parity with the rest of the autocomplete logic so I thought it makes sense to mark it as experimental to make this clear. 

I've also removed it from the latest marketing video.

## Test plan

<img width="630" alt="Screenshot 2023-06-26 at 14 28 56" src="https://github.com/sourcegraph/sourcegraph/assets/458591/3a9c9821-fef8-4221-b8d2-5454877309cb">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
