### PR TITLE
lib/output: Remove `Style` interface

### DIFF
--- a/lib/output/line.go
+++ b/lib/output/line.go
@@ -42,12 +42,12 @@ func Linef(emoji string, style Style, format string, a ...any) FancyLine {
 
 // Emoji creates a new FancyLine with an emoji prefix.
 func Emoji(emoji string, s string) FancyLine {
-	return Line(emoji, nil, s)
+	return Line(emoji, StyleReset, s)
 }
 
 // Emoji creates a new FancyLine with an emoji prefix and style.
 func Emojif(emoji string, s string, a ...any) FancyLine {
-	return Linef(emoji, nil, s, a...)
+	return Linef(emoji, StyleReset, s, a...)
 }
 
 // Styled creates a new FancyLine with style.
@@ -66,10 +66,6 @@ func (fl FancyLine) write(w io.Writer, caps capabilities) {
 	}
 	if fl.emoji != "" {
 		fmt.Fprint(w, fl.emoji+" ")
-	}
-
-	if fl.style == nil {
-		fl.style = StyleReset
 	}
 
 	fmt.Fprintf(w, "%s"+fl.format+"%s", caps.formatArgs(append(append([]any{fl.style}, fl.args...), StyleReset))...)

--- a/lib/output/style.go
+++ b/lib/output/style.go
@@ -5,27 +5,23 @@ import (
 	"strings"
 )
 
-type Style interface {
-	fmt.Stringer
-}
+type Style struct{ code string }
+
+func (s Style) String() string { return s.code }
 
 func CombineStyles(styles ...Style) Style {
 	sb := strings.Builder{}
 	for _, s := range styles {
 		fmt.Fprint(&sb, s)
 	}
-	return &style{sb.String()}
+	return Style{sb.String()}
 }
 
-func Fg256Color(code int) Style { return &style{fmt.Sprintf("\033[38;5;%dm", code)} }
-func Bg256Color(code int) Style { return &style{fmt.Sprintf("\033[48;5;%dm", code)} }
-
-type style struct{ code string }
-
-func (s *style) String() string { return s.code }
+func Fg256Color(code int) Style { return Style{fmt.Sprintf("\033[38;5;%dm", code)} }
+func Bg256Color(code int) Style { return Style{fmt.Sprintf("\033[48;5;%dm", code)} }
 
 var (
-	StyleReset      = &style{"\033[0m"}
+	StyleReset      = Style{"\033[0m"}
 	StyleLogo       = Fg256Color(57)
 	StylePending    = Fg256Color(4)
 	StyleWarning    = Fg256Color(124)
@@ -33,9 +29,9 @@ var (
 	StyleSuccess    = Fg256Color(2)
 	StyleSuggestion = Fg256Color(244)
 
-	StyleBold      = &style{"\033[1m"}
-	StyleItalic    = &style{"\033[3m"}
-	StyleUnderline = &style{"\033[4m"}
+	StyleBold      = Style{"\033[1m"}
+	StyleItalic    = Style{"\033[3m"}
+	StyleUnderline = Style{"\033[4m"}
 
 	// Search-specific colors.
 	StyleSearchQuery         = Fg256Color(68)
@@ -55,9 +51,9 @@ var (
 	// Search alert specific colors.
 	StyleSearchAlertTitle               = Fg256Color(124)
 	StyleSearchAlertDescription         = Fg256Color(124)
-	StyleSearchAlertProposedTitle       = &style{""}
+	StyleSearchAlertProposedTitle       = Style{""}
 	StyleSearchAlertProposedQuery       = Fg256Color(69)
-	StyleSearchAlertProposedDescription = &style{""}
+	StyleSearchAlertProposedDescription = Style{""}
 
 	StyleLinesDeleted = Fg256Color(196)
 	StyleLinesAdded   = Fg256Color(2)


### PR DESCRIPTION
and make it a struct! Supersedes #54161.

## Test plan

Tested sg and stack locally.