### PR TITLE
Autocomplete: Fix truncation for matching next non-empty line

### DIFF
--- a/client/cody/src/completions/completion.test.ts
+++ b/client/cody/src/completions/completion.test.ts
@@ -358,15 +358,15 @@ describe('Cody completions', () => {
             )
 
             expect(completions).toMatchInlineSnapshot(`
-            Array [
-              InlineCompletionItem {
-                "insertText": "
-                    const unsortedArray = [4,3,78,2,0,2]
-                    const sortedArray = bubbleSort(unsortedArray)
-                    expect(sortedArray).toEqual([0,2,2,3,4,78])",
-              },
-            ]
-        `)
+                            Array [
+                              InlineCompletionItem {
+                                "insertText": "
+                                    const unsortedArray = [4,3,78,2,0,2]
+                                    const sortedArray = bubbleSort(unsortedArray)
+                                    expect(sortedArray).toEqual([0,2,2,3,4,78])",
+                              },
+                            ]
+                    `)
         })
 
         it('cuts-off redundant closing brackets on the start indent level', async () => {
@@ -388,14 +388,14 @@ describe('Cody completions', () => {
             )
 
             expect(completions).toMatchInlineSnapshot(`
-            Array [
-              InlineCompletionItem {
-                "insertText": "const unsortedArray = [4,3,78,2,0,2]
-                    const sortedArray = bubbleSort(unsortedArray)
-                    expect(sortedArray).toEqual([0,2,2,3,4,78])",
-              },
-            ]
-        `)
+                            Array [
+                              InlineCompletionItem {
+                                "insertText": "const unsortedArray = [4,3,78,2,0,2]
+                                    const sortedArray = bubbleSort(unsortedArray)
+                                    expect(sortedArray).toEqual([0,2,2,3,4,78])",
+                              },
+                            ]
+                    `)
         })
 
         it('keeps the closing bracket', async () => {
@@ -406,14 +406,14 @@ describe('Cody completions', () => {
             ])
 
             expect(completions).toMatchInlineSnapshot(`
-            Array [
-              InlineCompletionItem {
-                "insertText": "{
-                console.log('Hello');
-            }",
-              },
-            ]
-        `)
+                            Array [
+                              InlineCompletionItem {
+                                "insertText": "{
+                                console.log('Hello');
+                            }",
+                              },
+                            ]
+                    `)
         })
 
         it('triggers a multi-line completion at the start of a block', async () => {
@@ -458,6 +458,30 @@ describe('Cody completions', () => {
                             console.log('foo1');
                         }",
                   },
+                  InlineCompletionItem {
+                    "insertText": "console.log('foo')",
+                  },
+                ]
+            `)
+        })
+
+        it('cuts-off completions when the next non-empty line matches', async () => {
+            const { completions } = await complete(
+                `
+                function() {
+                    ${CURSOR_MARKER}
+                    console.log('bar')
+                }`,
+                [
+                    createCompletionResponse(`
+                    console.log('foo')
+                        console.log('bar')
+                    }`),
+                ]
+            )
+
+            expect(completions).toMatchInlineSnapshot(`
+                Array [
                   InlineCompletionItem {
                     "insertText": "console.log('foo')",
                   },

--- a/client/cody/src/completions/shared-post-process.ts
+++ b/client/cody/src/completions/shared-post-process.ts
@@ -24,7 +24,7 @@ export function sharedPostProcess({
     if (multiline) {
         content = truncateMultilineCompletion(content, prefix, suffix, languageId)
     }
-    content = trimUntilSuffix(content, suffix)
+    content = trimUntilSuffix(content, prefix, suffix)
 
     return {
         ...completion,

--- a/client/cody/src/completions/text-processing.ts
+++ b/client/cody/src/completions/text-processing.ts
@@ -131,7 +131,7 @@ function trimSpace(s: string): TrimmedString {
  * Oftentimes, the last couple of lines of the completion may match against the suffix
  * (the code following the cursor).
  */
-export function trimUntilSuffix(insertion: string, suffix: string): string {
+export function trimUntilSuffix(insertion: string, prefix: string, suffix: string): string {
     insertion = insertion.trimEnd()
     let firstNonEmptySuffixLine = ''
     for (const line of suffix.split('\n')) {
@@ -147,8 +147,16 @@ export function trimUntilSuffix(insertion: string, suffix: string): string {
     const insertionLines = insertion.split('\n')
     let insertionEnd = insertionLines.length
     for (let i = 0; i < insertionLines.length; i++) {
-        const line = insertionLines[i]
-        if (line === firstNonEmptySuffixLine) {
+        let line = insertionLines[i]
+
+        // Include the current indentation of the prefix in the first line
+        if (i === 0) {
+            const lastNewlineOfPrefix = prefix.lastIndexOf('\n')
+            line = prefix.slice(lastNewlineOfPrefix + 1) + line
+        }
+
+        // Trim the end of the lines to avoid trailing whitespace causing issues
+        if (line.trimEnd() === firstNonEmptySuffixLine.trimEnd()) {
             insertionEnd = i
             break
         }


### PR DESCRIPTION
Closes #54145

This fixes a small regression from #53720 that we previously fixed by including the prefix in the comparison.

## Test plan

- Added a unit test
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
