### PR TITLE
Autocomplete: Turn on by default

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -25,7 +25,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 ### Changed
 
 - Autocomplete: Improve completion quality. [pull/53720](https://github.com/sourcegraph/sourcegraph/pull/53720)
-- Autocomplete: Completions are now referred to as autocomplete
+- Autocomplete: Completions are now referred to as autocomplete. [pull/53851](https://github.com/sourcegraph/sourcegraph/pull/53851)
+- Autocomplete: Autocomplete is now turned on by default. [pull/54166](https://github.com/sourcegraph/sourcegraph/pull/54166)
 - Improved the response quality when Cody is asked about a selected piece of code through the chat window. [pull/53742](https://github.com/sourcegraph/sourcegraph/pull/53742)
 - Refactored authentication process. [pull/53434](https://github.com/sourcegraph/sourcegraph/pull/53434)
 - New sign-in and sign-out flow. [pull/53434](https://github.com/sourcegraph/sourcegraph/pull/53434)

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -118,7 +118,7 @@
           {
             "id": "autocomplete",
             "title": "Code Autocomplete (Beta)",
-            "description": "Let Cody automatically write code for you. Start writing a comment or a line of code and Cody will suggest the next few lines.\n[Enable in Settings](command:cody.walkthrough.enableCodeAutocomplete)",
+            "description": "Let Cody automatically write code for you. Start writing a comment or a line of code and Cody will suggest the next few lines.",
             "media": {
               "markdown": "walkthroughs/autocomplete.md"
             }
@@ -361,11 +361,6 @@
         "title": "Show Inline Chat"
       },
       {
-        "command": "cody.walkthrough.enableCodeAutocomplete",
-        "category": "Cody Walkthrough",
-        "title": "Enable Code Completions"
-      },
-      {
         "command": "cody.comment.add",
         "title": "Ask Cody",
         "category": "Cody Inline Chat",
@@ -598,10 +593,6 @@
           "when": "false"
         },
         {
-          "command": "cody.walkthrough.enableCodeAutocomplete",
-          "when": "false"
-        },
-        {
           "command": "cody.walkthrough.enableInlineAssist",
           "when": "false"
         }
@@ -814,7 +805,7 @@
           "order": 5,
           "type": "boolean",
           "markdownDescription": "Enables inline code suggestions in your editor.",
-          "default": false
+          "default": true
         },
         "cody.experimental.chatPredictions": {
           "order": 6,

--- a/client/cody/src/configuration.test.ts
+++ b/client/cody/src/configuration.test.ts
@@ -12,7 +12,7 @@ describe('getConfiguration', () => {
             serverEndpoint: DOTCOM_URL.href,
             codebase: '',
             useContext: 'embeddings',
-            autocomplete: false,
+            autocomplete: true,
             experimentalChatPredictions: false,
             experimentalGuardrails: false,
             experimentalInline: false,
@@ -45,7 +45,7 @@ describe('getConfiguration', () => {
                             'Proxy-Authenticate': 'Basic',
                         }
                     case 'cody.autocomplete.enabled':
-                        return true
+                        return false
                     case 'cody.experimental.chatPredictions':
                         return true
                     case 'cody.experimental.guardrails':
@@ -83,7 +83,7 @@ describe('getConfiguration', () => {
                 'Cache-Control': 'no-cache',
                 'Proxy-Authenticate': 'Basic',
             },
-            autocomplete: true,
+            autocomplete: false,
             experimentalChatPredictions: true,
             experimentalGuardrails: true,
             experimentalInline: true,

--- a/client/cody/src/configuration.ts
+++ b/client/cody/src/configuration.ts
@@ -60,7 +60,7 @@ export function getConfiguration(config: ConfigGetter): Configuration {
         debugEnable: config.get<boolean>(CONFIG_KEY.debugEnable, false),
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
-        autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, isTesting),
+        autocomplete: config.get(CONFIG_KEY.autocompleteEnabled, true),
         experimentalChatPredictions: config.get(CONFIG_KEY.experimentalChatPredictions, isTesting),
         experimentalInline: config.get(CONFIG_KEY.experimentalInline, isTesting),
         experimentalGuardrails: config.get(CONFIG_KEY.experimentalGuardrails, isTesting),

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -254,14 +254,6 @@ const register = async (
                 query: 'cody.experimental.inline',
                 openToSide: true,
             })
-        }),
-        vscode.commands.registerCommand('cody.walkthrough.enableCodeAutocomplete', async () => {
-            await workspaceConfig.update('cody.autocomplete.enabled', true, vscode.ConfigurationTarget.Global)
-            // Open VSCode setting view. Provides visual confirmation that the setting is enabled.
-            return vscode.commands.executeCommand('workbench.action.openSettings', {
-                query: 'cody.autocomplete.enabled',
-                openToSide: true,
-            })
         })
     )
 


### PR DESCRIPTION
Closes #54132

Turn on autocomplete by default.

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/458591/b6178fc0-c7a5-43e6-91f3-af89e00d95ec



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
