### PR TITLE
bump: scip-go image

### DIFF
--- a/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/enterprise/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,14 +27,14 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:2a04ea639f4f72a23decfd9badf3663275a753fdf6d77c49ed47d8246e49402f",
+	"sourcegraph/scip-go":         "sha256:e4465acfaf6f7b6272fb46339e297de3a83c92190a08947ef1e75fbacb8a7d82",
 	"sourcegraph/lsif-clang":      "sha256:ea814e5ab5c6e1e6ab4d001e4f4afddcc7b44128edbeeedf1d97da553813a4c8",
 	"sourcegraph/lsif-rust":       "sha256:83cb769788987eb52f21a18b62d51ebb67c9436e1b0d2e99904c70fef424f9d1",
 	"sourcegraph/scip-rust":       "sha256:e9c400fd1d3146cd9a3d98f89c6d9a70e0a116618057e0dac452219b1c60b658",
 	"sourcegraph/scip-java":       "sha256:b0d0a6387d4be4e11bc6305021edf5ba2e58157fecff0fa6a74a7308a9b5a668",
 	"sourcegraph/scip-python":     "sha256:ab7f4b6c42870761248fa0d2c4774e2e1a6f5b1b65dd06f75f064a9418625b83",
 	"sourcegraph/scip-typescript": "sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92",
-	"sourcegraph/scip-ruby":       "sha256:ffbe40f23bd49a0163417589374f0bda97619e15f18bb09a048135094d21176d",
+	"sourcegraph/scip-ruby":       "sha256:f18eb10da9cc1998a7d5b123deefae0f69016614cbf323ec5edcd09a529d466e",
 }
 
 func DefaultIndexerForLang(language string) (string, bool) {


### PR DESCRIPTION
Bump scip-go image after latest release. Includes several bug fixes.

## Test plan

- [ ] Green CI