### PR TITLE
Autocomplete: Log when another completion provider might be interfering

### DIFF
--- a/client/cody/src/completions/logger.ts
+++ b/client/cody/src/completions/logger.ts
@@ -1,4 +1,5 @@
 import { LRUCache } from 'lru-cache'
+import * as vscode from 'vscode'
 
 import { logEvent } from '../event-logger'
 
@@ -75,7 +76,11 @@ export function accept(id: string, lines: number): void {
     completionEvent.acceptedAt = Date.now()
 
     logSuggestionEvent()
-    logCompletionEvent('accepted', { ...completionEvent.params, lines })
+    logCompletionEvent('accepted', {
+        ...completionEvent.params,
+        lines,
+        otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
+    })
 }
 
 export function noResponse(id: string): void {
@@ -118,10 +123,21 @@ function logSuggestionEvent(): void {
             latency,
             displayDuration,
             read: forceRead || read,
+            otherCompletionProviderEnabled: otherCompletionProviderEnabled(),
         })
     })
 
     // Completions are kept in the LRU cache for longer. This is because they
     // can still become visible if e.g. they are served from the cache and we
     // need to retain the ability to mark them as seen
+}
+
+const otherCompletionProviders = [
+    'GitHub.copilot',
+    'GitHub.copilot-nightly',
+    'TabNine.tabnine-vscode',
+    'TabNine.tabnine-vscode-self-hosted-updater',
+]
+function otherCompletionProviderEnabled(): boolean {
+    return !!otherCompletionProviders.find(id => vscode.extensions.getExtension(id)?.isActive)
 }

--- a/client/cody/src/testutils/mocks.ts
+++ b/client/cody/src/testutils/mocks.ts
@@ -180,4 +180,9 @@ export const vsCodeMocks = {
             path,
         }),
     },
+    extensions: {
+        getExtension() {
+            return undefined
+        },
+    },
 } as const


### PR DESCRIPTION
Closes #52687

This adds some logging to find enabled extension that match known completion providers so we can mark completions in these scenarios and exclude them from our top line metrics.

## Test plan

<img width="756" alt="Screenshot 2023-06-26 at 15 58 58" src="https://github.com/sourcegraph/sourcegraph/assets/458591/0b44b1cd-906e-46b5-8f8b-f143edbed2f1">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
