### PR TITLE
cody: log if embeddings were used in feedback

### DIFF
--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -7,7 +7,7 @@ import { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 import { UnifiedContextFetcher } from '../unified-context'
 import { isError } from '../utils'
 
-import { ContextMessage, ContextFile, getContextMessageWithResponse } from './messages'
+import { ContextMessage, ContextFile, getContextMessageWithResponse, ContextFileSource } from './messages'
 
 export interface ContextSearchOptions {
     numCodeResults: number
@@ -103,6 +103,7 @@ export class CodebaseContext {
         return groupResultsByFile(combinedResults)
             .reverse() // Reverse results so that they appear in ascending order of importance (least -> most).
             .flatMap(groupedResults => this.makeContextMessageWithResponse(groupedResults))
+            .map(message => contextMessageWithSource(message, 'embeddings'))
     }
 
     private async getEmbeddingSearchResults(
@@ -251,4 +252,11 @@ function resultsToMessages(results: ContextResult[]): ContextMessage[] {
         const messageText = populateCodeContextTemplate(content, fileName, repoName)
         return getContextMessageWithResponse(messageText, { fileName, repoName, revision })
     })
+}
+
+function contextMessageWithSource(message: ContextMessage, source: ContextFileSource): ContextMessage {
+    if (message.file) {
+        message.file.source = source
+    }
+    return message
 }

--- a/client/cody-shared/src/codebase-context/messages.ts
+++ b/client/cody-shared/src/codebase-context/messages.ts
@@ -1,9 +1,18 @@
 import { Message } from '../sourcegraph-api'
 
+// tracked for telemetry purposes. Which context source provided this context
+// file.
+//
+// For now we just track "embeddings" since that is the main driver for
+// understanding if it is being useful.
+export type ContextFileSource = 'embeddings'
+
 export interface ContextFile {
     fileName: string
     repoName?: string
     revision?: string
+
+    source?: ContextFileSource
 }
 
 export interface ContextMessage extends Message {


### PR DESCRIPTION
This includes an additional field in the event payload when a user clicks on the thumbs up/thumbs down button. The field is a boolean "lastChatUsedEmbeddings" which is true if any of the context files came from embeddings.

I am unsure if this is the best approach to add this. I augmented the ContextFile interface to optionally specify a source. I then in the only place we directly use embeddings I set the source field. Other sources will not populate this field (yet). Note: things like the unified fetcher do not set this, which we may want to follow up on.

Note that the current implementation of feedback will just send the full latest transcript, no matter which message a user clicked on. As such we only base embeddings use on the last message. This is a limitation in the existing implementation.

Test Plan: I modified the logEvent function to just console.log. I then clicked on a thumbs up button with and without context files and manually inspected the payload for the "lastChatUsedEmbeddings" field.

Fixes https://github.com/sourcegraph/sourcegraph/issues/53048