### PR TITLE
grpc: gitserver: use generated getters to access fields for archive

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -99,10 +99,10 @@ func (gs *GRPCServer) Exec(req *proto.ExecRequest, ss proto.GitserverService_Exe
 
 func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverService_ArchiveServer) error {
 	// Log which which actor is accessing the repo.
-	accesslog.Record(ss.Context(), req.Repo,
-		log.String("treeish", req.Treeish),
-		log.String("format", req.Format),
-		log.Strings("path", req.Pathspecs),
+	accesslog.Record(ss.Context(), req.GetRepo(),
+		log.String("treeish", req.GetTreeish()),
+		log.String("format", req.GetFormat()),
+		log.Strings("path", req.GetPathspecs()),
 	)
 
 	if err := checkSpecArgSafety(req.GetTreeish()); err != nil {
@@ -118,7 +118,7 @@ func (gs *GRPCServer) Archive(req *proto.ArchiveRequest, ss proto.GitserverServi
 		Args: []string{
 			"archive",
 			"--worktree-attributes",
-			"--format=" + req.Format,
+			"--format=" + req.GetFormat(),
 		},
 	}
 


### PR DESCRIPTION
Using the generated getters protects against the request itself being nil (which is possible since all fields are optional in protobuf 3).



## Test plan

Unit tests 
