### PR TITLE
grpc: gitserver: use generated getters to access fields for RepoCloneProgress

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -346,10 +346,12 @@ func (gs *GRPCServer) RepoClone(ctx context.Context, in *proto.RepoCloneRequest)
 }
 
 func (gs *GRPCServer) RepoCloneProgress(ctx context.Context, req *proto.RepoCloneProgressRequest) (*proto.RepoCloneProgressResponse, error) {
+	repositories := req.GetRepos()
+
 	resp := protocol.RepoCloneProgressResponse{
-		Results: make(map[api.RepoName]*protocol.RepoCloneProgress, len(req.Repos)),
+		Results: make(map[api.RepoName]*protocol.RepoCloneProgress, len(repositories)),
 	}
-	for _, repo := range req.Repos {
+	for _, repo := range repositories {
 		repoName := api.RepoName(repo)
 		result := gs.Server.repoCloneProgress(repoName)
 		resp.Results[repoName] = result


### PR DESCRIPTION
Using the generated getters protects against the request itself being nil (which is possible since all fields are optional in protobuf 3).



## Test plan
Unit tests 