### PR TITLE
grpc: gitserver: use generated getters to access fields for BatchLog

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -33,18 +33,19 @@ type GRPCServer struct {
 func (gs *GRPCServer) BatchLog(ctx context.Context, req *proto.BatchLogRequest) (*proto.BatchLogResponse, error) {
 	gs.Server.operations = gs.Server.ensureOperations()
 
-	var internalReq protocol.BatchLogRequest
-	internalReq.FromProto(req)
 	// Validate request parameters
-	if len(req.RepoCommits) == 0 {
+	if len(req.GetRepoCommits()) == 0 {
 		return &proto.BatchLogResponse{}, nil
 	}
-	if !strings.HasPrefix(req.Format, "--format=") {
+	if !strings.HasPrefix(req.GetFormat(), "--format=") {
 		return nil, status.Error(codes.InvalidArgument, "format parameter expected to be of the form `--format=<git log format>`")
 	}
 
+	var r protocol.BatchLogRequest
+	r.FromProto(req)
+
 	// Handle unexpected error conditions
-	resp, err := gs.Server.batchGitLogInstrumentedHandler(ctx, internalReq)
+	resp, err := gs.Server.batchGitLogInstrumentedHandler(ctx, r)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}


### PR DESCRIPTION
Using the generated getters protects against the request itself being nil (which is possible since all fields are optional in protobuf 3).



## Test plan

Unit tests
