### PR TITLE
executors: Use a custom git cert when cloning repos for the single job k8s option

### DIFF
--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -81,6 +81,8 @@ type Config struct {
 	KubernetesAdditionalJobVolumes      []corev1.Volume
 	KubernetesAdditionalJobVolumeMounts []corev1.VolumeMount
 	KubernetesSingleJobStepImage        string
+	// TODO remove in 5.2 if we have moved to a custom image to do the setup work.
+	KubernetesGitCACert string
 
 	dockerAuthConfigStr                                          string
 	dockerAuthConfigUnmarshalError                               error
@@ -162,6 +164,7 @@ func (c *Config) Load() {
 	c.kubernetesAdditionalJobVolumes = c.GetOptional("KUBERNETES_ADDITIONAL_JOB_VOLUMES", "Additional volumes to associate with the Jobs. e.g. [{\"name\": \"my-volume\", \"configMap\": {\"name\": \"cluster-volume\"}}]")
 	c.kubernetesAdditionalJobVolumeMounts = c.GetOptional("KUBERNETES_ADDITIONAL_JOB_VOLUME_MOUNTS", "Volumes to mount to the Jobs. e.g. [{\"name\":\"my-volume\", \"mountPath\":\"/foo/bar\"}]")
 	c.KubernetesSingleJobStepImage = c.Get("KUBERNETES_SINGLE_JOB_STEP_IMAGE", "sourcegraph/batcheshelper:insiders", "The image to use for intermediate steps in the single job. Defaults to sourcegraph/batcheshelper:latest.")
+	c.KubernetesGitCACert = c.GetOptional("KUBERNETES_GIT_CA_CERT", "The CA certificate to use for git operations. If not set, the system CA bundle will be used. e.g. /path/to/ca.crt")
 
 	if c.QueueNamesStr != "" {
 		c.QueueNames = strings.Split(c.QueueNamesStr, ",")

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -236,6 +236,7 @@ func kubernetesOptions(c *config.Config) runner.KubernetesOptions {
 			},
 			SingleJobPod: c.KubernetesSingleJobPod,
 			StepImage:    c.KubernetesSingleJobStepImage,
+			GitCACert:    c.KubernetesGitCACert,
 			JobVolume: command.KubernetesJobVolume{
 				Type:    command.KubernetesVolumeType(c.KubernetesJobVolumeType),
 				Size:    resource.MustParse(c.KubernetesJobVolumeSize),

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -58,6 +58,7 @@ type KubernetesContainerOptions struct {
 	SecurityContext       KubernetesSecurityContext
 	SingleJobPod          bool
 	StepImage             string
+	GitCACert             string
 	JobVolume             KubernetesJobVolume
 }
 
@@ -560,9 +561,16 @@ func NewKubernetesSingleJob(
 	if repoOptions.RepositoryDirectory != "" {
 		repoDir = repoOptions.RepositoryDirectory
 	}
+
+	sslCAInfo := ""
+	if options.GitCACert != "" {
+		sslCAInfo = fmt.Sprintf("git config --global http.sslCAInfo %s; ", options.GitCACert)
+	}
+
 	setupArgs := []string{
 		"set -e; " +
 			fmt.Sprintf("mkdir -p %s; ", repoDir) +
+			sslCAInfo +
 			fmt.Sprintf("git -C %s init; ", repoDir) +
 			fmt.Sprintf("git -C %s remote add origin %s; ", repoDir, repoOptions.CloneURL) +
 			fmt.Sprintf("git -C %s config --local gc.auto 0; ", repoDir) +


### PR DESCRIPTION
Be able to load custom git certs when running with the single job option.

## Test plan

Tested locally.