### PR TITLE
Cody: Ensure links are not matching hallucination detector logic

### DIFF
--- a/client/cody-shared/src/hallucinations-detector/index.test.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.test.ts
@@ -4,6 +4,8 @@ import { findFilePaths, highlightTokens } from '.'
 
 const markdownText = `# Title
 
+This is a markdown [link](https://example.com)
+
 This is \`/some/hallucinated/file/path\`. Hosted on github.com/sourcegraph.
 
 Quoted "file/path.js". Unquoted hallucinated file/path/Class.java file.
@@ -20,6 +22,8 @@ This code client/cody-shared/test/ is usable.
 `
 
 const expectedHighlightedTokensText = `# Title
+
+This is a markdown [link](https://example.com)
 
 This is  <span class="token-file token-hallucinated" title="Hallucination detected: file does not exist">\`/some/hallucinated/file/path\`</span> . Hosted on github.com/sourcegraph.
 

--- a/client/cody-shared/src/hallucinations-detector/index.ts
+++ b/client/cody-shared/src/hallucinations-detector/index.ts
@@ -120,12 +120,14 @@ export function findFilePaths(line: string): { fullMatch: string; pathMatch: str
 }
 
 const filePathCharacters = '[\\@\\*\\w\\/\\._-]'
+// The root path can not include a `/`
+const fileRootPathCharacters = '[\\@\\*\\w\\._-]'
 
 const filePathRegexpParts = [
     // File path can start with a `, ", ', or a whitespace
     '[`"\'\\s]?',
     // Capture a file path-like sequence.
-    `(\\/?${filePathCharacters}+\\/${filePathCharacters}+)`,
+    `(\\/?${fileRootPathCharacters}+\\/${filePathCharacters}+)`,
     //  File path can end with a `, ", ', ., or a whitespace.
     '[`"\'\\s\\.]?',
 ]

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -22,6 +22,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Autocomplete: Fix network issues when using remote VS Code setups. [pull/53956](https://github.com/sourcegraph/sourcegraph/pull/53956)
 - Autocomplete: Fix an issue where the loading indicator would not reset when a network error ocurred. [pull/53956](https://github.com/sourcegraph/sourcegraph/pull/53956)
 - Autocomplete: Improve local context performance. [pull/54124](https://github.com/sourcegraph/sourcegraph/pull/54124)
+- Fixes an issue with link formatting. [pull/54200](https://github.com/sourcegraph/sourcegraph/pull/54200)
 
 ### Changed
 


### PR DESCRIPTION
Fixes #54046

There was an issue in the regex because the first `fileRootPathCharacters` could pass as `/` which is obviously not a valid root directory name. This PR fixes that (although i think the whole regex could use some more love, I don't think they are encoding what I think they are doing very well?

Anyway, release coming up soon and this fixes the issue without regressing tests and seems relatively low risk. 🚢 

## Test plan

- added a test
- <img width="653" alt="Screenshot 2023-06-26 at 19 34 42" src="https://github.com/sourcegraph/sourcegraph/assets/458591/e5e15fe2-d48b-4419-9d51-6d95e6d04c1c">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
