### PR TITLE
productsubscription/dotcomuser: allow users to use claude-instant for chat

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -210,7 +210,7 @@ func getCompletionsRateLimit(ctx context.Context, db database.DB, userID int32, 
 func allowedModels(scope types.CompletionsFeature) []string {
 	switch scope {
 	case types.CompletionsFeatureChat:
-		return []string{"anthropic/claude-v1"}
+		return []string{"anthropic/claude-v1", "anthropic/claude-instant-v1"}
 	case types.CompletionsFeatureCode:
 		return []string{"anthropic/claude-instant-v1"}
 	default:


### PR DESCRIPTION
Seems like chat can require instant: https://sourcegraph.slack.com/archives/C04NPH6SZMW/p1687812777285669

## Test plan

n/a