### PR TITLE
cody: fix callback redirect sign in

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -248,6 +248,10 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                     await this.authProvider.appAuth(message.endpoint)
                     break
                 }
+                if (message.type === 'callback' && message.endpoint) {
+                    await this.authProvider.redirectToEndpointLogin(message.endpoint)
+                    break
+                }
                 // cody.auth.signin or cody.auth.signout
                 await vscode.commands.executeCommand(`cody.auth.${message.type}`)
                 break

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -21,7 +21,7 @@ export type WebviewMessage =
     | { command: 'openFile'; filePath: string }
     | { command: 'edit'; text: string }
     | { command: 'insert'; text: string }
-    | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app'; endpoint?: string }
+    | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app' | 'callback'; endpoint?: string }
     | { command: 'abort' }
 
 /**

--- a/client/cody/src/services/AuthProvider.ts
+++ b/client/cody/src/services/AuthProvider.ts
@@ -272,7 +272,6 @@ export class AuthProvider {
             return
         }
         await this.localStorage.saveEndpoint(endpoint)
-        await updateConfiguration('serverEndpoint', endpoint)
         if (token) {
             await this.secretStorage.storeToken(endpoint, token)
         }

--- a/client/cody/src/services/AuthProvider.ts
+++ b/client/cody/src/services/AuthProvider.ts
@@ -71,11 +71,11 @@ export class AuthProvider {
                     return
                 }
                 this.authStatus.endpoint = input.endpoint
-                await this.redirectToEndpointLogin(false)
+                await this.redirectToEndpointLogin(input.endpoint)
                 break
             }
             case 'dotcom':
-                await this.redirectToEndpointLogin(true)
+                await this.redirectToEndpointLogin(DOTCOM_URL.href)
                 break
             case 'token': {
                 const endpoint = uri || item.uri
@@ -234,9 +234,9 @@ export class AuthProvider {
     }
 
     // Open callback URL in browser to get token from instance
-    private async redirectToEndpointLogin(isDotCom: boolean): Promise<void> {
-        const uri = isDotCom ? DOTCOM_URL.href : this.authStatus.endpoint || ''
+    public async redirectToEndpointLogin(uri: string): Promise<void> {
         const endpoint = formatURL(uri)
+        const isDotComOrApp = uri === LOCAL_APP_URL.href || uri === DOTCOM_URL.href
         if (!endpoint) {
             return
         }
@@ -244,7 +244,7 @@ export class AuthProvider {
             .then(async res => {
                 // Read the string response body
                 const version = await res.text()
-                if (version < '5.1.0') {
+                if (!isDotComOrApp && version < '5.1.0') {
                     void this.signinMenu('token', uri)
                     return
                 }
@@ -272,6 +272,7 @@ export class AuthProvider {
             return
         }
         await this.localStorage.saveEndpoint(endpoint)
+        await updateConfiguration('serverEndpoint', endpoint)
         if (token) {
             await this.secretStorage.storeToken(endpoint, token)
         }

--- a/client/cody/webviews/App.tsx
+++ b/client/cody/webviews/App.tsx
@@ -105,6 +105,17 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         vscodeAPI.postMessage({ command: 'auth', type: 'signout' })
     }, [vscodeAPI])
 
+    const onLoginRedirect = useCallback(
+        (uri: string) => {
+            setConfig(null)
+            setEndpoint(null)
+            setAuthStatus(null)
+            setView('login')
+            vscodeAPI.postMessage({ command: 'auth', type: 'callback', endpoint: uri })
+        },
+        [setEndpoint, vscodeAPI]
+    )
+
     if (!view || !authStatus || !config) {
         return <LoadingPage />
     }
@@ -122,7 +133,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     appOS={config?.os}
                     appArch={config?.arch}
                     callbackScheme={config?.uriScheme}
-                    setEndpoint={setEndpoint}
+                    onLoginRedirect={onLoginRedirect}
                 />
             ) : (
                 <>

--- a/client/cody/webviews/Login.story.tsx
+++ b/client/cody/webviews/Login.story.tsx
@@ -57,7 +57,7 @@ export const Simple: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
-                setEndpoint={() => {}}
+                onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
                 appArch={supportedAppArch}
@@ -73,7 +73,7 @@ export const InvalidLogin: ComponentStoryObj<typeof Login> = {
                 authStatus={invalidAccessTokenAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
-                setEndpoint={() => {}}
+                onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
                 appArch={supportedAppArch}
@@ -89,7 +89,7 @@ export const UnverifiedEmailLogin: ComponentStoryObj<typeof Login> = {
                 authStatus={requiresVerifiedEmailAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
-                setEndpoint={() => {}}
+                onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
                 appArch={supportedAppArch}
@@ -105,7 +105,7 @@ export const LoginWithAppInstalled: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={true}
                 vscodeAPI={vscodeAPI}
-                setEndpoint={() => {}}
+                onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={supportedAppOS}
                 appArch={supportedAppArch}
@@ -121,7 +121,7 @@ export const UnsupportedAppOS: ComponentStoryObj<typeof Login> = {
                 authStatus={validAuthStatus}
                 isAppInstalled={false}
                 vscodeAPI={vscodeAPI}
-                setEndpoint={() => {}}
+                onLoginRedirect={() => {}}
                 endpoint={endpoint}
                 appOS={unsupportedAppOS}
                 appArch={unsupportedAppArch}

--- a/client/cody/webviews/Login.tsx
+++ b/client/cody/webviews/Login.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
-import { AuthStatus, DOTCOM_CALLBACK_URL, DOTCOM_URL, LOCAL_APP_URL } from '../src/chat/protocol'
+import { AuthStatus, DOTCOM_URL, LOCAL_APP_URL } from '../src/chat/protocol'
 
 import { ConnectApp } from './ConnectApp'
 import { ErrorContainer } from './Error'
@@ -20,7 +20,7 @@ interface LoginProps {
     callbackScheme?: string
     appOS?: string
     appArch?: string
-    setEndpoint: (endpoint: string) => void
+    onLoginRedirect: (uri: string) => void
 }
 
 const APP_DESC = {
@@ -41,16 +41,9 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
     appArch,
     isAppInstalled = false,
     isAppRunning = false,
-    setEndpoint,
+    onLoginRedirect,
 }) => {
     const isOSSupported = appOS === 'darwin' && appArch === 'arm64'
-
-    const loginWithDotCom = useCallback(() => {
-        const callbackUri = new URL(DOTCOM_CALLBACK_URL.href)
-        callbackUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
-        setEndpoint(DOTCOM_URL.href)
-        vscodeAPI.postMessage({ command: 'links', value: callbackUri.href })
-    }, [callbackScheme, setEndpoint, vscodeAPI])
 
     const onFooterButtonClick = useCallback(
         (title: 'signin' | 'support') => {
@@ -88,7 +81,7 @@ export const Login: React.FunctionComponent<React.PropsWithChildren<LoginProps>>
         <section className={classNames(styles.section, styles.codyGradient)}>
             <h2 className={styles.sectionHeader}>Cody App for {appOS} coming soon</h2>
             <p className={styles.openMessage}>{APP_DESC.comingSoon}</p>
-            <VSCodeButton className={styles.button} type="button" onClick={() => loginWithDotCom()}>
+            <VSCodeButton className={styles.button} type="button" onClick={() => onLoginRedirect(DOTCOM_URL.href)}>
                 Signin with Sourcegraph.com
             </VSCodeButton>
         </section>


### PR DESCRIPTION
Fix issue where cody would not sign users in with tokens returned from callback links due to the endpoint not being configured when token is returned.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Loom for fix: https://www.loom.com/share/27b874292c614f57b32142ec742fa069?sid=1ef5a8ef-9e89-427a-a225-845acf80693c


https://github.com/sourcegraph/sourcegraph/assets/68532117/5024a168-ca4a-4d1b-846b-03b9952bd850

