### PR TITLE
cody-gateway: treat incoming traces as links instead of parents

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -28,5 +28,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//hook",
         "@com_github_sourcegraph_log//output",
+        "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:otelhttp",
     ],
 )

--- a/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/events"
@@ -51,6 +52,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 						),
 					),
 				),
+				otelhttp.WithPublicEndpoint(),
 			),
 		)
 	}
@@ -71,6 +73,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 						),
 					),
 				),
+				otelhttp.WithPublicEndpoint(),
 			),
 		)
 
@@ -82,6 +85,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 						embeddings.NewListHandler(),
 					),
 				),
+				otelhttp.WithPublicEndpoint(),
 			),
 		)
 
@@ -102,6 +106,7 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 						),
 					),
 				),
+				otelhttp.WithPublicEndpoint(),
 			),
 		)
 	}

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -64,9 +64,6 @@ type Config struct {
 type TraceConfig struct {
 	Policy       policy.TracePolicy
 	GCPProjectID string
-
-	QueueSize int
-	Blocking  bool
 }
 
 func (c *Config) Load() {
@@ -118,8 +115,6 @@ func (c *Config) Load() {
 
 	c.Trace.Policy = policy.TracePolicy(c.Get("CODY_GATEWAY_TRACE_POLICY", "all", "Trace policy, one of 'all', 'selective', 'none'."))
 	c.Trace.GCPProjectID = c.Get("CODY_GATEWAY_TRACE_GCP_PROJECT_ID", os.Getenv("GOOGLE_CLOUD_PROJECT"), "Google Cloud Traces project ID.")
-	c.Trace.QueueSize = c.GetInt("CODY_GATEWAY_TRACE_QUEUE_SIZE", "2048", "Maximum spans to queue for export.")
-	c.Trace.Blocking = c.GetBool("CODY_GATEWAY_TRACE_BLOCKING", "true", "Never drop spans - block until span can be exported.")
 
 	c.ActorConcurrencyLimit.Percentage = float32(c.GetPercent("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_PERCENTAGE", "50", "The percentage of daily rate limit to be allowed as concurrent requests limit from an actor.")) / 100
 	c.ActorConcurrencyLimit.Interval = c.GetInterval("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_INTERVAL", "10s", "The interval at which to check the concurrent requests limit from an actor.")

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -64,6 +64,9 @@ type Config struct {
 type TraceConfig struct {
 	Policy       policy.TracePolicy
 	GCPProjectID string
+
+	QueueSize int
+	Blocking  bool
 }
 
 func (c *Config) Load() {
@@ -115,6 +118,8 @@ func (c *Config) Load() {
 
 	c.Trace.Policy = policy.TracePolicy(c.Get("CODY_GATEWAY_TRACE_POLICY", "all", "Trace policy, one of 'all', 'selective', 'none'."))
 	c.Trace.GCPProjectID = c.Get("CODY_GATEWAY_TRACE_GCP_PROJECT_ID", os.Getenv("GOOGLE_CLOUD_PROJECT"), "Google Cloud Traces project ID.")
+	c.Trace.QueueSize = c.GetInt("CODY_GATEWAY_TRACE_QUEUE_SIZE", "2048", "Maximum spans to queue for export.")
+	c.Trace.Blocking = c.GetBool("CODY_GATEWAY_TRACE_BLOCKING", "true", "Never drop spans - block until span can be exported.")
 
 	c.ActorConcurrencyLimit.Percentage = float32(c.GetPercent("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_PERCENTAGE", "50", "The percentage of daily rate limit to be allowed as concurrent requests limit from an actor.")) / 100
 	c.ActorConcurrencyLimit.Interval = c.GetInterval("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_INTERVAL", "10s", "The interval at which to check the concurrent requests limit from an actor.")


### PR DESCRIPTION
Lately I've noticed many (most?) of our Sentry events come with `TraceId` that 404's on Cloud Trace, which kind of defeats the whole purpose of our tracing. I've spot-checked and see that all our traces in Cloud Trace have corresponding `Request` logs, but when attempting the inverse we often get a 404 in Cloud Trace.

I think the problem is that we are treating incoming traces as parents instead of linked traces. Treating the incoming request as a parent is cool because you get to see the whole thing end-to-end across projects, but it has the issue where half our traces are missing parents, and I think this is what causes logs to include traces that 404 when you query it on Cloud Trace

Was thinking of performing the parent/linking based on whether the request emits a ShouldTrace policy, but we have the same issue with on-prem customers etc if they enable tracing we'll end up with traces missing parents on our end that causes misbehaviour in Cloud Trace. I think I'm going to revert our usage of having remote traces be treated as parents, and just preserve them as links instead. This still gives us some bidirectional linking:

- In Sourcegraph/App/etc, we keep the return trace/span in trace attributes and also send it back to clients.
- In Cody Gateway, the span link will point us to the Sourcegraph trace

## Test plan

CI