### PR TITLE
Revert "flake: skip client integ test about codeinsights (#53768)"

### DIFF
--- a/client/web/src/integration/insights/create-insights.test.ts
+++ b/client/web/src/integration/insights/create-insights.test.ts
@@ -13,8 +13,7 @@ import { createEditorAPI, percySnapshotWithVariants } from '../utils'
 import { SEARCH_INSIGHT_LIVE_PREVIEW_FIXTURE, LANG_STATS_INSIGHT_DATA_FIXTURE } from './fixtures/runtime-insights'
 import { overrideInsightsGraphQLApi } from './utils/override-insights-graphql-api'
 
-// Flake issue https://github.com/sourcegraph/sourcegraph/issues/53767
-describe.skip('Code insight create insight page', () => {
+describe('Code insight create insight page', () => {
     let driver: Driver
     let testContext: WebIntegrationTestContext
 


### PR DESCRIPTION
This reverts commit 2390d5fa7a3a3d3d8121c0028c33fbbea89712ec.

## Context

- This root cause is addressed in https://github.com/sourcegraph/sourcegraph/pull/54117
- Closes https://github.com/sourcegraph/sourcegraph/issues/53767

## Test plan

CI
