### PR TITLE
JetBrains: wrap long words in the chat message

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Fixed the y position at which autocomplete suggestions are rendered [#53677](https://github.com/sourcegraph/sourcegraph/pull/53677)
 - Fixed rendered completions being cleared after disabling them in settings [#53758](https://github.com/sourcegraph/sourcegraph/pull/53758)
+- Wrap long words in the chat message [#54244](https://github.com/sourcegraph/sourcegraph/pull/54244)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -54,6 +54,7 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   @NotNull
   private JEditorPane createNewEmptyTextPane() {
     JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
+    jEditorPane.setEditorKit(new UIUtil.JBWordWrapHtmlEditorKit());
     HTMLEditorKit htmlEditorKit = (HTMLEditorKit) jEditorPane.getEditorKit();
     EditorColorsScheme schemeForCurrentUITheme =
         EditorColorsManager.getInstance().getSchemeForCurrentUITheme();


### PR DESCRIPTION
This fixes the issue when long text in the chat message wasn't wrapped and it was displayed somewhere outside of the view

closes #54125 

before:
<img width="557" alt="Screenshot 2023-06-27 at 07 40 08" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/69fb6e9e-980e-48b9-832a-37bbdbc264bd">

now:
<img width="497" alt="Screenshot 2023-06-27 at 07 34 12" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/edb7c8e9-5d52-4f13-942c-44a867f8e58d">


## Test plan
- Long words in the message are wrapped to new lines

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
