### PR TITLE
Deprecate enablePermissionsWebhooks feature flag

### DIFF
--- a/cmd/frontend/internal/httpapi/webhookhandlers/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//internal/api",
         "//internal/authz",
         "//internal/authz/permssync",
-        "//internal/conf",
         "//internal/database",
         "//internal/extsvc",
         "//internal/repoupdater/protocol",

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -23,10 +22,6 @@ import (
 // field, and enqueues the contained repo for permissions synchronisation.
 func handleGitHubRepoAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions) webhooks.Handler {
 	return func(ctx context.Context, db database.DB, urn extsvc.CodeHostBaseURL, payload any) error {
-		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
-			return nil
-		}
-
 		logger.Debug("handleGitHubRepoAuthzEvent: Got github event", log.String("type", fmt.Sprintf("%T", payload)))
 
 		e, ok := payload.(repoGetter)

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -24,10 +23,6 @@ import (
 // scheduling it for a perms update in repo-updater
 func handleGitHubUserAuthzEvent(logger log.Logger, opts authz.FetchPermsOptions) webhooks.Handler {
 	return func(ctx context.Context, db database.DB, _ extsvc.CodeHostBaseURL, payload any) error {
-		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
-			return nil
-		}
-
 		logger.Debug("handleGitHubUserAuthzEvent: Got github event", log.String("type", fmt.Sprintf("%T", payload)))
 
 		var user *gh.User

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -805,7 +805,7 @@ type ExperimentalFeatures struct {
 	EnableGRPC bool `json:"enableGRPC,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visibility of internal Github repositories
 	EnableGithubInternalRepoVisibility bool `json:"enableGithubInternalRepoVisibility,omitempty"`
-	// EnablePermissionsWebhooks description: Enables webhook consumers to sync permissions from external services faster than the defaults schedule
+	// EnablePermissionsWebhooks description: DEPRECATED: No longer has any effect.
 	EnablePermissionsWebhooks bool `json:"enablePermissionsWebhooks,omitempty"`
 	// EnableStorm description: Enables the Storm frontend architecture changes.
 	EnableStorm bool `json:"enableStorm,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -388,7 +388,7 @@
           }
         },
         "enablePermissionsWebhooks": {
-          "description": "Enables webhook consumers to sync permissions from external services faster than the defaults schedule",
+          "description": "DEPRECATED: No longer has any effect.",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Removes the checks for the `enablePermissionsWebhooks` flag so that the feature is enabled by default.

## Test plan

Just removes the checks that return nil if the feature is not enabled.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
