### PR TITLE
JetBrains: Hotfix: Add a backslash at the end of the local app url if not present

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -14,7 +14,7 @@ import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class LocalAppManager {
-  public static final String DEFAULT_LOCAL_APP_URL = "http://localhost:3080";
+  public static final String DEFAULT_LOCAL_APP_URL = "http://localhost:3080/";
   private static final Map<String, LocalAppPaths> appPathsByPlatform =
       Map.of(
           "darwin", // only support macOS for now
@@ -73,6 +73,7 @@ public class LocalAppManager {
   public static String getLocalAppUrl() {
     return getLocalAppInfo()
         .flatMap(appInfo -> Optional.ofNullable(appInfo.getEndpoint()))
+        .map(endpoint -> endpoint.endsWith("/") ? endpoint : endpoint + "/")
         .orElse(DEFAULT_LOCAL_APP_URL);
   }
 


### PR DESCRIPTION
So this is just a hotfix.
The bug occurs because the agent doesn't know how to recover from errors, so it just breaks after the first connection error. 
The proper fix to do later is to either fix error handling in the agent or add a recovery mechanism for when it breaks.

## Test plan
Go through the bug replication steps and double checks if it doesn't occur anymore
1. turn off the local Cody app, ask the plugin about something and let it get a connection error
2. turn the app back on
3. the plugin should return valid answers once again