### PR TITLE
JetBrains: Disable the agent by default

### DIFF
--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -43,9 +43,9 @@ New issues and feature requests can be filed through our [issue tracker](https:/
   agent binary to function properly. This agent binary is automatically built from source if it does not exist. To
   speed up edit/test/debug feedback loops, the agent binary does not get rebuilt unless you provide the
   `-PforceAgentBuild=true` flag when running Gradle. For example, `./gradlew :runIde -PforceAgentBuild=true`.
-- The Cody agent is enabled by default for local `./gradlew :runIde` task only.
-  Use the `-PdisableAgent=true` property to disable the Cody agent. For example, `./gradlew :runIde -PdisableAgent=true`.
-  When the agent is disabled, the plugin falls back to the non-agent based implementation.
+- The Cody agent is disabled by default for local `./gradlew :runIde` task only.
+  Use the `-PenableAgent=true` property to enable the Cody agent. For example, `./gradlew :runIde -PenableAgent=true`.
+  Unless the agent is enabled, the plugin falls back to the non-agent based implementation.
 
 ## Publishing a new version
 

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -45,7 +45,7 @@ New issues and feature requests can be filed through our [issue tracker](https:/
   `-PforceAgentBuild=true` flag when running Gradle. For example, `./gradlew :runIde -PforceAgentBuild=true`.
 - The Cody agent is disabled by default for local `./gradlew :runIde` task only.
   Use the `-PenableAgent=true` property to enable the Cody agent. For example, `./gradlew :runIde -PenableAgent=true`.
-  Unless the agent is enabled, the plugin falls back to the non-agent based implementation.
+  When the agent is disabled, the plugin falls back to the non-agent-based implementation.
 
 ## Publishing a new version
 

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -146,8 +146,8 @@ tasks {
         jvmArgs("-Djdk.module.illegalAccess.silent=true")
         systemProperty("cody-agent.trace-path", "$buildDir/sourcegraph/cody-agent-trace.json")
         systemProperty("cody-agent.directory", agentTargetDirectory.parent.toString())
-        val isAgentEnabled = findProperty("disableAgent") == "true"
-        systemProperty("cody-agent.enabled", (!isAgentEnabled).toString())
+        val isAgentEnabled = findProperty("enableAgent") == "true"
+        systemProperty("cody-agent.enabled", isAgentEnabled.toString())
     }
 
     // Configure UI tests plugin


### PR DESCRIPTION
This disables the agent.
You can enable it with `-PenableAgent=true` when needed.
Some of our APIs were already using it, which caused some stability issues.

## Test plan
- green CI
- double check if the Cody chat isn't using the agent