### PR TITLE
Cody: Fix error handling in chat messages

### DIFF
--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -135,9 +135,14 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
             }
         )
 
-        request.on('error', error => {
-            log?.onError(error.message)
-            cb.onError(error.message)
+        request.on('error', e => {
+            let message = e.message
+            if (message.includes('ECONNREFUSED')) {
+                message =
+                    'Could not connect to Cody. Please ensure that Cody app is running or that you are connected to the Sourcegraph server.'
+            }
+            log?.onError(message)
+            cb.onError(message)
         })
 
         request.write(JSON.stringify(params))

--- a/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/client/cody-shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -135,6 +135,11 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
             }
         )
 
+        request.on('error', error => {
+            log?.onError(error.message)
+            cb.onError(error.message)
+        })
+
         request.write(JSON.stringify(params))
         request.end()
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -27,6 +27,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Codebase index status does not get updated on workspace change. [pull/54106](https://github.com/sourcegraph/sourcegraph/pull/54106)
 - Button for connect to App after user is signed out. [pull/54106](https://github.com/sourcegraph/sourcegraph/pull/54106)
 - Fixes an issue with link formatting. [pull/54200](https://github.com/sourcegraph/sourcegraph/pull/54200)
+- Fixes am issue where Cody would sometimes not respond. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -27,7 +27,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Codebase index status does not get updated on workspace change. [pull/54106](https://github.com/sourcegraph/sourcegraph/pull/54106)
 - Button for connect to App after user is signed out. [pull/54106](https://github.com/sourcegraph/sourcegraph/pull/54106)
 - Fixes an issue with link formatting. [pull/54200](https://github.com/sourcegraph/sourcegraph/pull/54200)
-- Fixes am issue where Cody would sometimes not respond. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Fixes am issue where Cody would sometimes not respond. [pull/54268](https://github.com/sourcegraph/sourcegraph/pull/54268)
 
 ### Changed
 

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -381,7 +381,9 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                         this.config.customHeaders
                     )
                 }
-                this.onCompletionEnd()
+                // We ignore embeddings errors in this instance because we're already showing an
+                // error message and don't want to overwhelm the user.
+                this.onCompletionEnd(true)
                 void this.editor.controllers.inline.error()
                 console.error(`Completion request failed: ${err}`)
             },
@@ -393,14 +395,16 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
         this.cancelCompletionCallback = null
     }
 
-    private onCompletionEnd(): void {
+    private onCompletionEnd(ignoreEmbeddingsError: boolean = false): void {
         this.isMessageInProgress = false
         this.cancelCompletionCallback = null
         this.sendTranscript()
         void this.saveTranscriptToChatHistory()
         this.sendChatHistory()
         void vscode.commands.executeCommand('setContext', 'cody.reply.pending', false)
-        this.logEmbeddingsSearchErrors()
+        if (!ignoreEmbeddingsError) {
+            this.logEmbeddingsSearchErrors()
+        }
         this.scheduleIdleRecipes()
     }
 
@@ -729,6 +733,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Send embedding connections or results error to output
      */
     private logEmbeddingsSearchErrors(): void {
+        console.log(this.int)
         if (this.config.useContext !== 'embeddings') {
             return
         }

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -733,7 +733,6 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
      * Send embedding connections or results error to output
      */
     private logEmbeddingsSearchErrors(): void {
-        console.log(this.int)
         if (this.config.useContext !== 'embeddings') {
             return
         }


### PR DESCRIPTION
Closes #54256

Fix error handling when the client <> server connection is closed when sending chat messages.

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/458591/c8852225-5c1f-41ec-bb0d-1e13c6c22db2




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
