### PR TITLE
GitLab: Fix fetching repository name from DOM

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -50,7 +50,15 @@ export const getPageKindFromPathName = (owner: string, projectName: string, path
  * Gets repo URL from on GitLab.
  */
 export const getGitlabRepoURL = (): string => {
-    const projectLink = document.querySelector<HTMLAnchorElement>('.context-header a')
+    /**
+     * Attempt to extract the project URL from the DOM.
+     * Supports both the older UI (still used for logged-out users)
+     * and the newer UI (shown for logged-in users).
+     */
+    const projectLink =
+        document.querySelector<HTMLAnchorElement>('.context-header a') ||
+        document.querySelector<HTMLAnchorElement>('.breadcrumbs li:last-of-type a')
+
     if (!projectLink) {
         throw new Error('Unable to determine project name')
     }


### PR DESCRIPTION
## Description

GitLab has a newer UI that means our existing repository name scraper no longer works. This UI is only shown for logged-in users.

This PR updates the code to check for both UIs.

## Test plan

Not yet, @umpox to test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
