### PR TITLE
Cody: Add button to poll for app setup completion

### DIFF
--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -244,7 +244,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 await this.executeRecipe(message.recipe)
                 break
             case 'auth':
-                if (message.type === 'app' && message.endpoint) {
+                if ((message.type === 'app' && message.endpoint) || message.type === 'app-poll') {
                     await this.authProvider.appAuth(message.endpoint)
                     break
                 }

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -21,7 +21,7 @@ export type WebviewMessage =
     | { command: 'openFile'; filePath: string }
     | { command: 'edit'; text: string }
     | { command: 'insert'; text: string }
-    | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app' | 'callback'; endpoint?: string }
+    | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app' | 'app-poll' | 'callback'; endpoint?: string }
     | { command: 'abort' }
 
 /**
@@ -60,6 +60,7 @@ export const CODY_FEEDBACK_URL = new URL(
 export const LOCAL_APP_URL = new URL('http://localhost:3080')
 export const APP_LANDING_URL = new URL('https://about.sourcegraph.com/app')
 export const APP_CALLBACK_URL = new URL('sourcegraph://user/settings/tokens/new/callback')
+export const APP_OPEN_URL = new URL('sourcegraph://')
 // TODO: Update URLs to always point to the latest app release: https://github.com/sourcegraph/sourcegraph/issues/53511
 export const APP_DOWNLOAD_URLS: { [os: string]: { [arch: string]: string } } = {
     darwin: {

--- a/client/cody/webviews/ConnectApp.tsx
+++ b/client/cody/webviews/ConnectApp.tsx
@@ -1,6 +1,6 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
-import { APP_CALLBACK_URL, APP_DOWNLOAD_URLS, APP_LANDING_URL } from '../src/chat/protocol'
+import { APP_CALLBACK_URL, APP_DOWNLOAD_URLS, APP_LANDING_URL, APP_OPEN_URL } from '../src/chat/protocol'
 
 import { VSCodeWrapper } from './utils/VSCodeApi'
 
@@ -12,25 +12,41 @@ interface ConnectAppProps {
     appArch?: string
     callbackScheme?: string
     isAppRunning: boolean
+    isAppAuthenticated: boolean
 }
 
 export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
     vscodeAPI,
     isAppInstalled,
     isAppRunning = false,
+    isAppAuthenticated,
     isOSSupported,
     appOS = '',
     appArch = '',
     callbackScheme,
 }) => {
     const inDownloadMode = !isAppInstalled && isOSSupported && !isAppRunning
-    const buttonText = inDownloadMode ? 'Download Cody App' : isAppRunning ? 'Connect Cody App' : 'Open Cody App'
+    const buttonText = inDownloadMode
+        ? 'Download Cody App'
+        : isAppRunning
+        ? isAppAuthenticated
+            ? 'Connect Cody App'
+            : 'Open Cody App'
+        : 'Open Cody App'
     const buttonIcon = inDownloadMode ? 'cloud-download' : isAppRunning ? 'link' : 'rocket'
-    // Open landing page if download link for user's arch cannot be found
-    const DOWNLOAD_URL = APP_DOWNLOAD_URLS[appOS]?.[appArch] || APP_LANDING_URL.href
-    // If the user already has the app installed, open the callback URL directly.
-    const callbackUri = new URL(APP_CALLBACK_URL.href)
-    callbackUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
+    let callbackUri: URL
+    if (!isAppInstalled) {
+        // Open landing page if download link for user's arch cannot be found
+        const DOWNLOAD_URL = APP_DOWNLOAD_URLS[appOS]?.[appArch] || APP_LANDING_URL.href
+        callbackUri = new URL(DOWNLOAD_URL)
+    } else if (!isAppRunning) {
+        // If the user already has the app installed, open the callback URL directly to authorize.
+        callbackUri = new URL(APP_CALLBACK_URL.href)
+        callbackUri.searchParams.append('requestFrom', callbackScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY')
+    } else {
+        // The user has app installed and authorized, but has not authenticated in app.
+        callbackUri = new URL(APP_OPEN_URL)
+    }
 
     // Use postMessage to open because it won't open otherwise due to the sourcegraph:// scheme.
     const authApp = (url: string): void =>
@@ -42,11 +58,7 @@ export const ConnectApp: React.FunctionComponent<ConnectAppProps> = ({
 
     return (
         <div>
-            <VSCodeButton
-                type="button"
-                disabled={!isOSSupported}
-                onClick={() => authApp(isAppInstalled ? callbackUri.href : DOWNLOAD_URL)}
-            >
+            <VSCodeButton type="button" disabled={!isOSSupported} onClick={() => authApp(callbackUri.href)}>
                 <i className={'codicon codicon-' + buttonIcon} slot="start" />
                 {buttonText}
             </VSCodeButton>

--- a/client/cody/webviews/Error.tsx
+++ b/client/cody/webviews/Error.tsx
@@ -16,6 +16,7 @@ export const ErrorContainer: React.FunctionComponent<{
     isApp: {
         isInstalled: boolean
         isRunning: boolean
+        isAuthenticated: boolean
     }
     endpoint?: string | null
 }> = ({ authStatus, isApp, endpoint }) => {
@@ -34,9 +35,10 @@ export const ErrorContainer: React.FunctionComponent<{
         return null
     }
     // Errors for app are handled in the ConnectApp component
-    if (isApp.isInstalled && !isApp.isRunning) {
+    if (isApp.isInstalled && (!isApp.isRunning || !isApp.isAuthenticated)) {
         return null
     }
+
     // new users will not have an endpoint
     if (!endpoint) {
         return null


### PR DESCRIPTION
This suppresses an error message about your email address not being verified if you're setting up app, have authorized VScode to connect to App, but haven't authenticated with Sourcegraph yet.

![Screenshot 2023-06-27 at 18 51 14](https://github.com/sourcegraph/sourcegraph/assets/55120/cf87d13f-b9fc-41fc-b940-b64ca8be7c12)

Ameliorates Issue #54225 . This is racy and can still get wedged, in which case reloading the window helps. But I believe this change is at least an improvement on the status quo.

## Test plan

Install this release of App: https://github.com/sourcegraph/sourcegraph/releases/tag/untagged-d80b0570a7694fd6d8cd

To reset App and browser state, do this:

```
rm -rf ~/.sourcegraph-psql \               
  ~/Library/Application\ Support/com.sourcegraph.cody \
  ~/Library/Caches/com.sourcegraph.cody \
  ~/Library/WebKit/com.sourcegraph.cody
```

VScode-insiders 1.80.0-insider (Universal) Commit: 45b31e9a872da8cc3cc8fff41c1eeb2063be04b7 seems flaky. In VScode, use Cody's ..., Sign Out, Cody App/current to sign out.

Then, check that an install flow where the VScode extension runs first works:

1. Run the VScode extension.
2. Get to the Cody App Not Running/Open Cody App stage and push that button.
3. Authorize, etc. The view above should show. You shouldn't see an error message about an unverified email address.
4. The "Open Cody App" button should focus App.
5. In App, Connect to Sourcegraph.com and Authorize.
6. In VScode, hit Refresh. You should be in the chat view, can chat, etc.

Then, check that an install flow where App runs first works:

1. Run App, go through the setup flow.
2. At the point where you run the extension, do that flow.
3. You should be logged into the chat view, can chat, etc.