### PR TITLE
App: Hide repetitive docs link

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -205,7 +205,16 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                         {!isSourcegraphDotCom && isCTADismissed && (
                             <>
                                 {' '}
-                                <Link to="/help/cody#get-cody">Cody is more powerful in the IDE</Link>.
+                                <Link
+                                    to={
+                                        isSourcegraphApp
+                                            ? 'https://docs.sourcegraph.com/cody#get-cody'
+                                            : '/help/cody#get-cody'
+                                    }
+                                >
+                                    Cody is more powerful in the IDE
+                                </Link>
+                                .
                             </>
                         )}
                     </>

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -202,19 +202,10 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                     <>
                         Cody answers code questions and writes code for you by leveraging your entire codebase and the
                         code graph.
-                        {!isSourcegraphDotCom && isCTADismissed && (
+                        {!isSourcegraphDotCom && !isSourcegraphApp && isCTADismissed && (
                             <>
                                 {' '}
-                                <Link
-                                    to={
-                                        isSourcegraphApp
-                                            ? 'https://docs.sourcegraph.com/cody#get-cody'
-                                            : '/help/cody#get-cody'
-                                    }
-                                >
-                                    Cody is more powerful in the IDE
-                                </Link>
-                                .
+                                <Link to="/help/cody#get-cody">Cody is more powerful in the IDE</Link>.
                             </>
                         )}
                     </>


### PR DESCRIPTION
## Description

<img width="153" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/9516420/781b7030-a8b9-4963-b85c-9dd8b1bb33ce">


We had a few reports that this link was appearing inside App. I can't see how `isCTADismissed` can be triggered from App but unsure if dated is shared from dotcom or if it can be preserved from older versions.

This change just guards to always ensure we don't show this link.

Related Slack discussion: https://sourcegraph.slack.com/archives/C04F9E7GUDP/p1687861211915609


## Test plan

Tested locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
