### PR TITLE
Cody: Change keyboard shortcut to avoid conflicts

### DIFF
--- a/client/cody-shared/src/chat/recipes/file-touch.ts
+++ b/client/cody-shared/src/chat/recipes/file-touch.ts
@@ -154,7 +154,7 @@ export class FileTouch implements Recipe {
     - Include all the import statements that are required for the new code to work.
     - If there are already content in the file with the same name, the new code will be appended to the file.
     - If my selected code is empty, it means I am working in an empty file.
-    - Do not remove code that is being used by the the shared filesd.
+    - Do not remove code that is being used by the the shared files.
     - Do not suggest code that are not related to any of the shared context.
     - Do not make up code, including function names, that could break the selected code.
     `
@@ -196,13 +196,17 @@ export class FileTouch implements Recipe {
             // Get the context from each file
             const fileName = vscode.Uri.joinPath(currentDirUri, file[0]).fsPath
             const fileUri = vscode.Uri.joinPath(currentDirUri, file[0])
-            const fileContent = await vscode.workspace.openTextDocument(fileUri)
-            const truncatedContent = truncateText(fileContent.getText(), MAX_CURRENT_FILE_TOKENS)
-            const contextMessage = getContextMessageWithResponse(
-                populateCurrentEditorContextTemplate(truncatedContent, fileName),
-                { fileName }
-            )
-            contextMessages.push(...contextMessage)
+            try {
+                const fileContent = await vscode.workspace.openTextDocument(fileUri)
+                const truncatedContent = truncateText(fileContent.getText(), MAX_CURRENT_FILE_TOKENS)
+                const contextMessage = getContextMessageWithResponse(
+                    populateCurrentEditorContextTemplate(truncatedContent, fileName),
+                    { fileName }
+                )
+                contextMessages.push(...contextMessage)
+            } catch (error) {
+                console.error(error)
+            }
         }
 
         return contextMessages

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -40,7 +40,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Analytical logs are now displayed in the Output view. [pull/53870](https://github.com/sourcegraph/sourcegraph/pull/53870)
 - Renamed Inline Assist to Inline Chat. [pull/53725](https://github.com/sourcegraph/sourcegraph/pull/53725)
 - Chat: Link to the "Getting Started" guide directly from the first chat message instead of the external documentation website. [pull/54175](https://github.com/sourcegraph/sourcegraph/pull/54175)
-- Changed the keyboard shortcut for the file touch recipe to `ctrl+alt+/` to avoid conflicts. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Changed the keyboard shortcut for the file touch recipe to `ctrl+alt+/` to avoid conflicts. [pull/54275](https://github.com/sourcegraph/sourcegraph/pull/54275)
 
 ## [0.2.5]
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -40,6 +40,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Analytical logs are now displayed in the Output view. [pull/53870](https://github.com/sourcegraph/sourcegraph/pull/53870)
 - Renamed Inline Assist to Inline Chat. [pull/53725](https://github.com/sourcegraph/sourcegraph/pull/53725)
 - Chat: Link to the "Getting Started" guide directly from the first chat message instead of the external documentation website. [pull/54175](https://github.com/sourcegraph/sourcegraph/pull/54175)
+- Changed the keyboard shortcut for the file touch recipe to `ctrl+alt+/` to avoid conflicts. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
 
 ## [0.2.5]
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -473,8 +473,8 @@
       },
       {
         "command": "cody.recipe.file-touch",
-        "key": "ctrl+shift+t",
-        "mac": "shift+cmd+t",
+        "key": "ctrl+alt+/",
+        "mac": "cmd+alt+/",
         "when": "cody.activated && editorTextFocus && !editorReadonly"
       },
       {


### PR DESCRIPTION
Closes #54254 

`cmd+shift+t` is used by VS Code to reopen the last file, we should use a different shortcut instead.

## Test plan

- tested locally
- also noticed that the recipe crashes when it tries to open non binary file (A `.DS_Store` in my example) so I fixed this too

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
