### PR TITLE
Cody: Add some recipes buttons to the welcome message

### DIFF
--- a/client/cody-shared/src/chat/transcript/messages.ts
+++ b/client/cody-shared/src/chat/transcript/messages.ts
@@ -6,6 +6,7 @@ import { TranscriptJSON } from '.'
 export interface ChatButton {
     label: string
     action: string
+    onClick: (action: string) => void
 }
 
 export interface ChatMessage extends Message {

--- a/client/cody-shared/src/chat/transcript/messages.ts
+++ b/client/cody-shared/src/chat/transcript/messages.ts
@@ -3,9 +3,15 @@ import { Message } from '../../sourcegraph-api'
 
 import { TranscriptJSON } from '.'
 
+export interface ChatButton {
+    label: string
+    action: string
+}
+
 export interface ChatMessage extends Message {
     displayText?: string
     contextFiles?: ContextFile[]
+    buttons?: ChatButton[]
 }
 
 export interface InteractionMessage extends Message {

--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -47,13 +47,19 @@ interface ChatProps extends ChatClassNames {
     abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
     onAbortMessageInProgress?: () => void
     isCodyEnabled: boolean
-    onChatButtonClick: (which: string) => void
+    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
 }
 
 interface ChatClassNames extends TranscriptItemClassNames {
     inputRowClassName?: string
     chatInputContextClassName?: string
     chatInputClassName?: string
+}
+
+export interface ChatButtonProps {
+    label: string
+    action: string
+    onClick: (action: string) => void
 }
 
 export interface ChatUITextAreaProps {
@@ -141,7 +147,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     abortMessageInProgressComponent: AbortMessageInProgressButton,
     onAbortMessageInProgress = () => {},
     isCodyEnabled,
-    onChatButtonClick,
+    ChatButtonComponent,
 }) => {
     const [inputRows, setInputRows] = useState(5)
     const [historyIndex, setHistoryIndex] = useState(inputHistory.length)
@@ -273,7 +279,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     submitButtonComponent={SubmitButton}
                     chatInputClassName={chatInputClassName}
-                    onChatButtonClick={onChatButtonClick}
+                    ChatButtonComponent={ChatButtonComponent}
                 />
             )}
 

--- a/client/cody-ui/src/Chat.tsx
+++ b/client/cody-ui/src/Chat.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import classNames from 'classnames'
 
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
-import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { ChatButton, ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import { isDefined } from '@sourcegraph/common'
 
 import { FileLinkProps } from './chat/ContextFiles'
@@ -32,6 +32,7 @@ interface ChatProps extends ChatClassNames {
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     helpMarkdown?: string
     afterMarkdown?: string
+    gettingStartedButtons?: ChatButton[]
     className?: string
     EditButtonContainer?: React.FunctionComponent<EditButtonProps>
     editButtonOnSubmit?: (text: string) => void
@@ -46,6 +47,7 @@ interface ChatProps extends ChatClassNames {
     abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
     onAbortMessageInProgress?: () => void
     isCodyEnabled: boolean
+    onChatButtonClick: (which: string) => void
 }
 
 interface ChatClassNames extends TranscriptItemClassNames {
@@ -113,6 +115,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     fileLinkComponent,
     helpMarkdown,
     afterMarkdown,
+    gettingStartedButtons,
     className,
     codeBlocksCopyButtonClassName,
     codeBlocksInsertButtonClassName,
@@ -138,6 +141,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     abortMessageInProgressComponent: AbortMessageInProgressButton,
     onAbortMessageInProgress = () => {},
     isCodyEnabled,
+    onChatButtonClick,
 }) => {
     const [inputRows, setInputRows] = useState(5)
     const [historyIndex, setHistoryIndex] = useState(inputHistory.length)
@@ -230,10 +234,11 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             {
                 speaker: 'assistant',
                 displayText: welcomeText({ helpMarkdown, afterMarkdown }),
+                buttons: gettingStartedButtons,
             },
             ...transcript,
         ],
-        [helpMarkdown, afterMarkdown, transcript]
+        [helpMarkdown, afterMarkdown, gettingStartedButtons, transcript]
     )
 
     return (
@@ -268,6 +273,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     submitButtonComponent={SubmitButton}
                     chatInputClassName={chatInputClassName}
+                    onChatButtonClick={onChatButtonClick}
                 />
             )}
 

--- a/client/cody-ui/src/chat/Transcript.tsx
+++ b/client/cody-ui/src/chat/Transcript.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
 import {
+    ChatButtonProps,
     ChatUITextAreaProps,
     EditButtonProps,
     FeedbackButtonsProps,
@@ -32,7 +33,7 @@ export const Transcript: React.FunctionComponent<
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CopyButtonProps['copyButtonOnSubmit']
         submitButtonComponent?: React.FunctionComponent<ChatUISubmitButtonProps>
-        onChatButtonClick: (which: string) => void
+        ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -55,7 +56,7 @@ export const Transcript: React.FunctionComponent<
     copyButtonOnSubmit,
     submitButtonComponent,
     chatInputClassName,
-    onChatButtonClick,
+    ChatButtonComponent,
 }) {
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
     useEffect(() => {
@@ -118,7 +119,7 @@ export const Transcript: React.FunctionComponent<
                             showFeedbackButtons={index > 0 && transcript.length - index === 1}
                             submitButtonComponent={submitButtonComponent}
                             chatInputClassName={chatInputClassName}
-                            onChatButtonClick={onChatButtonClick}
+                            ChatButtonComponent={ChatButtonComponent}
                         />
                     )
             )}
@@ -139,7 +140,7 @@ export const Transcript: React.FunctionComponent<
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     submitButtonComponent={submitButtonComponent}
                     chatInputClassName={chatInputClassName}
-                    onChatButtonClick={onChatButtonClick}
+                    ChatButtonComponent={ChatButtonComponent}
                 />
             )}
         </div>

--- a/client/cody-ui/src/chat/Transcript.tsx
+++ b/client/cody-ui/src/chat/Transcript.tsx
@@ -32,6 +32,7 @@ export const Transcript: React.FunctionComponent<
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CopyButtonProps['copyButtonOnSubmit']
         submitButtonComponent?: React.FunctionComponent<ChatUISubmitButtonProps>
+        onChatButtonClick: (which: string) => void
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -54,6 +55,7 @@ export const Transcript: React.FunctionComponent<
     copyButtonOnSubmit,
     submitButtonComponent,
     chatInputClassName,
+    onChatButtonClick,
 }) {
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
     useEffect(() => {
@@ -116,6 +118,7 @@ export const Transcript: React.FunctionComponent<
                             showFeedbackButtons={index > 0 && transcript.length - index === 1}
                             submitButtonComponent={submitButtonComponent}
                             chatInputClassName={chatInputClassName}
+                            onChatButtonClick={onChatButtonClick}
                         />
                     )
             )}
@@ -136,6 +139,7 @@ export const Transcript: React.FunctionComponent<
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     submitButtonComponent={submitButtonComponent}
                     chatInputClassName={chatInputClassName}
+                    onChatButtonClick={onChatButtonClick}
                 />
             )}
         </div>

--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -52,6 +52,7 @@ export const TranscriptItem: React.FunctionComponent<
         submitButtonComponent?: React.FunctionComponent<ChatUISubmitButtonProps>
         abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
         onAbortMessageInProgress?: () => void
+        onChatButtonClick: (which: string) => void
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     message,
@@ -75,6 +76,7 @@ export const TranscriptItem: React.FunctionComponent<
     copyButtonOnSubmit,
     submitButtonComponent: SubmitButton,
     chatInputClassName,
+    onChatButtonClick,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
     const textarea =
@@ -168,6 +170,19 @@ export const TranscriptItem: React.FunctionComponent<
                     <BlinkingCursor />
                 ) : null}
             </div>
+            {message.buttons?.length && (
+                <div className={styles.actions}>
+                    {...message.buttons.map(chatButton => (
+                        <button
+                            type="button"
+                            key={chatButton.action}
+                            onClick={() => onChatButtonClick(chatButton.action)}
+                        >
+                            {chatButton.label}
+                        </button>
+                    ))}
+                </div>
+            )}
             {showFeedbackButtons &&
                 FeedbackButtonsContainer &&
                 feedbackButtonsOnSubmit &&

--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -10,6 +10,7 @@ import {
     FeedbackButtonsProps,
     CopyButtonProps,
     ChatUISubmitButtonProps,
+    ChatButtonProps,
 } from '../Chat'
 
 import { BlinkingCursor } from './BlinkingCursor'
@@ -52,7 +53,7 @@ export const TranscriptItem: React.FunctionComponent<
         submitButtonComponent?: React.FunctionComponent<ChatUISubmitButtonProps>
         abortMessageInProgressComponent?: React.FunctionComponent<{ onAbortMessageInProgress: () => void }>
         onAbortMessageInProgress?: () => void
-        onChatButtonClick: (which: string) => void
+        ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     message,
@@ -76,7 +77,7 @@ export const TranscriptItem: React.FunctionComponent<
     copyButtonOnSubmit,
     submitButtonComponent: SubmitButton,
     chatInputClassName,
-    onChatButtonClick,
+    ChatButtonComponent,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
     const textarea =
@@ -170,18 +171,8 @@ export const TranscriptItem: React.FunctionComponent<
                     <BlinkingCursor />
                 ) : null}
             </div>
-            {message.buttons?.length && (
-                <div className={styles.actions}>
-                    {...message.buttons.map(chatButton => (
-                        <button
-                            type="button"
-                            key={chatButton.action}
-                            onClick={() => onChatButtonClick(chatButton.action)}
-                        >
-                            {chatButton.label}
-                        </button>
-                    ))}
-                </div>
+            {message.buttons?.length && ChatButtonComponent && (
+                <div className={styles.actions}>{...message.buttons.map(ChatButtonComponent)}</div>
             )}
             {showFeedbackButtons &&
                 FeedbackButtonsContainer &&

--- a/client/cody-ui/src/chat/TranscriptItem.tsx
+++ b/client/cody-ui/src/chat/TranscriptItem.tsx
@@ -172,7 +172,7 @@ export const TranscriptItem: React.FunctionComponent<
                 ) : null}
             </div>
             {message.buttons?.length && ChatButtonComponent && (
-                <div className={styles.actions}>{...message.buttons.map(ChatButtonComponent)}</div>
+                <div className={styles.actions}>{message.buttons.map(ChatButtonComponent)}</div>
             )}
             {showFeedbackButtons &&
                 FeedbackButtonsContainer &&

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -303,7 +303,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 switch (message.action) {
                     case 'explain-code-high-level':
                     case 'find-code-smells':
-                    case 'fixup':
+                    case 'generate-unit-test':
                         void this.executeRecipe(message.action)
                         break
                     default:

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -299,6 +299,18 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
                 }
                 break
             }
+            case 'chat-button': {
+                switch (message.action) {
+                    case 'explain-code-high-level':
+                    case 'find-code-smells':
+                    case 'fixup':
+                        void this.executeRecipe(message.action)
+                        break
+                    default:
+                        break
+                }
+                break
+            }
             default:
                 this.sendErrorToWebview('Invalid request type from Webview')
         }

--- a/client/cody/src/chat/protocol.ts
+++ b/client/cody/src/chat/protocol.ts
@@ -24,6 +24,7 @@ export type WebviewMessage =
     | { command: 'insert'; text: string }
     | { command: 'auth'; type: 'signin' | 'signout' | 'support' | 'app' | 'callback'; endpoint?: string }
     | { command: 'abort' }
+    | { command: 'chat-button'; action: string }
 
 /**
  * A message sent from the extension host to the webview.

--- a/client/cody/webviews/Chat.module.css
+++ b/client/cody/webviews/Chat.module.css
@@ -97,6 +97,11 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .transcript-item:not(.human-
     color: var(--vscode-problemsWarningIcon-foreground);
 }
 
+.chat-button {
+    margin-top: 0.5rem;
+    padding: 0.25rem;
+}
+
 .feedback-buttons {
     display: flex;
     flex-direction: row;

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -165,13 +165,11 @@ const AbortMessageInProgress: React.FunctionComponent<AbortMessageInProgressProp
     </div>
 )
 
-const ChatButton: React.FunctionComponent<ChatButtonProps> = ({ label, action, onClick }) => {
-    return (
-        <VSCodeButton type="button" onClick={() => onClick(action)}>
-            {label}
-        </VSCodeButton>
-    )
-}
+const ChatButton: React.FunctionComponent<ChatButtonProps> = ({ label, action, onClick }) => (
+    <VSCodeButton type="button" onClick={() => onClick(action)} className={styles.chatButton}>
+        {label}
+    </VSCodeButton>
+)
 
 const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     className,

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import { ChatContextStatus } from '@sourcegraph/cody-shared/src/chat/context'
 import { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import {
+    ChatButtonProps,
     Chat as ChatUI,
     ChatUISubmitButtonProps,
     ChatUISuggestionButtonProps,
@@ -139,11 +140,11 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 
 To get started, select some code and run one of Cody's recipes:"
             gettingStartedButtons={[
-                { label: 'Explain Code (High Level)', action: 'explain-code-high-level' },
-                { label: 'Smell Code', action: 'find-code-smells' },
-                { label: 'Fixup code from inline instructions', action: 'fixup' },
+                { label: 'Explain Code (High Level)', action: 'explain-code-high-level', onClick: onChatButtonClick },
+                { label: 'Smell Code', action: 'find-code-smells', onClick: onChatButtonClick },
+                { label: 'Fixup code from inline instructions', action: 'fixup', onClick: onChatButtonClick },
             ]}
-            onChatButtonClick={onChatButtonClick}
+            ChatButtonComponent={ChatButton}
         />
     )
 }
@@ -163,6 +164,14 @@ const AbortMessageInProgress: React.FunctionComponent<AbortMessageInProgressProp
         </VSCodeButton>
     </div>
 )
+
+const ChatButton: React.FunctionComponent<ChatButtonProps> = ({ label, action, onClick }) => {
+    return (
+        <VSCodeButton type="button" onClick={() => onClick(action)}>
+            {label}
+        </VSCodeButton>
+    )
+}
 
 const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     className,

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -89,6 +89,13 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         [vscodeAPI]
     )
 
+    const onChatButtonClick = useCallback(
+        (which: string) => {
+            vscodeAPI.postMessage({ command: 'chat-button', action: which })
+        },
+        [vscodeAPI]
+    )
+
     return (
         <ChatUI
             messageInProgress={messageInProgress}
@@ -128,7 +135,15 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             // down here to render cody is disabled on the instance nicely.
             isCodyEnabled={true}
             codyNotEnabledNotice={undefined}
-            helpMarkdown="See [Getting Started](command:cody.welcome) for help and tips."
+            helpMarkdown="See [Getting Started](command:cody.welcome) for help and tips.
+
+To get started, select some code and run one of Cody's recipes:"
+            gettingStartedButtons={[
+                { label: 'Explain Code (High Level)', action: 'explain-code-high-level' },
+                { label: 'Smell Code', action: 'find-code-smells' },
+                { label: 'Fixup code from inline instructions', action: 'fixup' },
+            ]}
+            onChatButtonClick={onChatButtonClick}
         />
     )
 }

--- a/client/cody/webviews/Chat.tsx
+++ b/client/cody/webviews/Chat.tsx
@@ -140,9 +140,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
 
 To get started, select some code and run one of Cody's recipes:"
             gettingStartedButtons={[
-                { label: 'Explain Code (High Level)', action: 'explain-code-high-level', onClick: onChatButtonClick },
-                { label: 'Smell Code', action: 'find-code-smells', onClick: onChatButtonClick },
-                { label: 'Fixup code from inline instructions', action: 'fixup', onClick: onChatButtonClick },
+                { label: 'Explain code (high level)', action: 'explain-code-high-level', onClick: onChatButtonClick },
+                { label: 'Smell code', action: 'find-code-smells', onClick: onChatButtonClick },
+                { label: 'Generate a unit test', action: 'generate-unit-test', onClick: onChatButtonClick },
             ]}
             ChatButtonComponent={ChatButton}
         />


### PR DESCRIPTION
This adds three recipes to the welcome chat message in VScode to help users get started. Fixes issue #54232 .

![Screenshot 2023-06-27 at 20 41 51](https://github.com/sourcegraph/sourcegraph/assets/55120/2a87b960-4bf8-4184-8212-31f3bf0947d2)

## Test plan

Open Cody. A new chat now has buttons. Clicking the buttons starts those recipes.