### PR TITLE
app: add endpoint that redirects to latest version

### DIFF
--- a/cmd/frontend/codyapp/BUILD.bazel
+++ b/cmd/frontend/codyapp/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "codyapp",
+    srcs = ["latest_version.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/codyapp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/frontend/internal/app/updatecheck",
+        "//internal/conf/deploy",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "codyapp_test",
+    srcs = ["latest_version_test.go"],
+    embed = [":codyapp"],
+    deps = [
+        "//cmd/frontend/internal/app/updatecheck",
+        "@com_github_sourcegraph_log//logtest",
+    ],
+)

--- a/cmd/frontend/codyapp/latest_version.go
+++ b/cmd/frontend/codyapp/latest_version.go
@@ -1,0 +1,99 @@
+package codyapp
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
+)
+
+// RouteCodyAppLatestVersion is the name of the route that that returns a URL where to download the latest Cody App version
+const RouteCodyAppLatestVersion = "codyapp.latest.version"
+
+const gitHubReleaseBaseURL = "https://github.com/sourcegraph/sourcegraph/releases/tag/"
+
+type latestVersion struct {
+	logger           log.Logger
+	manifestResolver updatecheck.UpdateManifestResolver
+}
+
+func (l *latestVersion) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		manifest, err := l.manifestResolver.Resolve(ctx)
+		if err != nil {
+			l.logger.Error("failed to resolve manifest", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		query := r.URL.Query()
+		target := query.Get("target")
+		arch := query.Get("arch")
+		platform := updatecheck.PlatformString(arch, target) // x86_64-darwin
+
+		releaseURL, err := url.Parse(gitHubReleaseBaseURL)
+		if err != nil {
+			l.logger.Error("failed to create release url from base release url", log.Error(err), log.String("releaseTag", manifest.GitHubReleaseTag()))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		releaseURL = releaseURL.JoinPath(manifest.GitHubReleaseTag())
+
+		releaseLoc, hasPlatform := manifest.Platforms[platform]
+		// if we have the platform, get it's release URL and redirect to it.
+		// if we don't have it or something goes wrong while converting to a URL, we
+		// redirect to the GitHub release page
+		if hasPlatform {
+			u, err := url.Parse(releaseLoc.URL)
+			if err != nil {
+				l.logger.Error("failed to create release url for platform - redirecting to release page instead",
+					log.Error(err),
+					log.String("platform", platform),
+					log.String("releaseTag", manifest.GitHubReleaseTag()),
+				)
+				http.Redirect(w, r, releaseURL.String(), http.StatusSeeOther)
+				return
+			}
+			releaseURL = u
+		}
+
+		http.Redirect(w, r, releaseURL.String(), http.StatusSeeOther)
+	}
+}
+
+func newLatestVersion(logger log.Logger, resolver updatecheck.UpdateManifestResolver) *latestVersion {
+	return &latestVersion{
+		logger:           logger,
+		manifestResolver: resolver,
+	}
+}
+
+func LatestVersionHandler(logger log.Logger) http.HandlerFunc {
+	var bucket = updatecheck.ManifestBucket
+
+	if deploy.IsDev(deploy.Type()) {
+		bucket = updatecheck.ManifestBucketDev
+	}
+
+	resolver, err := updatecheck.NewGCSManifestResolver(context.Background(), bucket, updatecheck.ManifestName)
+	if err != nil {
+		logger.Error("failed to initialize GCS Manifest resolver",
+			log.String("bucket", bucket),
+			log.String("manifestName", updatecheck.ManifestName),
+			log.Error(err),
+		)
+		return func(w http.ResponseWriter, _ *http.Request) {
+			logger.Warn("GCS Manifest resolver not initialized. Unable to respond with latest App version")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+
+	return newLatestVersion(logger, resolver).Handler()
+}

--- a/cmd/frontend/codyapp/latest_version_test.go
+++ b/cmd/frontend/codyapp/latest_version_test.go
@@ -1,0 +1,98 @@
+package codyapp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
+)
+
+func TestLatestVersionHandler(t *testing.T) {
+	var resolver = updatecheck.StaticManifestResolver{
+		Manifest: updatecheck.AppUpdateManifest{
+			Version: "3023.5.8", // set the year part of the version FAR ahead so that there is always a version to update to
+			Notes:   "This is a test",
+			PubDate: time.Date(2023, time.May, 8, 12, 0, 0, 0, &time.Location{}),
+			Platforms: map[string]updatecheck.AppLocation{
+				"x86_64-linux": {
+					Signature: "Yippy Kay YAY",
+					URL:       "https://example.com/linux",
+				},
+				"x86_64-windows": {
+					Signature: "Yippy Kay YAY",
+					URL:       "https://example.com/windows",
+				},
+				"aarch64-darwin": {
+					Signature: "Yippy Kay YAY",
+					URL:       "https://example.com/darwin",
+				},
+			},
+		},
+	}
+
+	var queries = []struct {
+		target      string
+		arch        string
+		expectedURL string
+	}{
+		{
+			"linux",
+			"x86_64",
+			"https://example.com/linux",
+		},
+		{
+			"windows",
+			"x86_64",
+			"https://example.com/windows",
+		},
+		{
+			"darwin",
+			"aarch64",
+			"https://example.com/darwin",
+		},
+		// if arch and target are empty we provide the release page for the tag
+		{
+			"",
+			"",
+			gitHubReleaseBaseURL + resolver.Manifest.GitHubReleaseTag(),
+		},
+		{
+			"toaster",
+			"gameboy",
+			gitHubReleaseBaseURL + resolver.Manifest.GitHubReleaseTag(),
+		},
+	}
+
+	for _, q := range queries {
+		urlPath := "/app/latest"
+		if q.target != "" || q.arch != "" {
+			urlPath = fmt.Sprintf("/app/latest?target=%s&arch=%s", q.target, q.arch)
+		}
+
+		req := httptest.NewRequest("GET", urlPath, nil)
+		w := httptest.NewRecorder()
+
+		latest := newLatestVersion(logtest.NoOp(t), &resolver)
+		latest.Handler().ServeHTTP(w, req)
+
+		resp := w.Result()
+		if resp.StatusCode != http.StatusSeeOther {
+			t.Errorf("expected HTTP Status %d for exact version match, but got %d", http.StatusSeeOther, resp.StatusCode)
+		}
+
+		loc, err := resp.Location()
+		if err != nil {
+			t.Fatalf("failed to get location from response: %v", err)
+		}
+
+		if loc.String() != q.expectedURL {
+			t.Errorf("expected location url %q but got %q", q.expectedURL, loc.String())
+		}
+	}
+
+}

--- a/cmd/frontend/internal/app/updatecheck/app_update_check_test.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_check_test.go
@@ -114,7 +114,7 @@ func TestReadAppClientVersion(t *testing.T) {
 
 func TestAppUpdateCheckHandler(t *testing.T) {
 	var resolver = StaticManifestResolver{
-		manifest: AppUpdateManifest{
+		Manifest: AppUpdateManifest{
 			Version: "3023.5.8", // set the year part of the version FAR ahead so that there is always a version to update to
 			Notes:   "This is a test",
 			PubDate: time.Date(2023, time.May, 8, 12, 0, 0, 0, &time.Location{}),
@@ -128,7 +128,7 @@ func TestAppUpdateCheckHandler(t *testing.T) {
 	}
 
 	t.Run("with static manifest resolver, and exact version", func(t *testing.T) {
-		req, err := clientVersionRequest(t, "unknown-linux-gnu", "x86_64", resolver.manifest.Version+"+1234.DEADBEEF")
+		req, err := clientVersionRequest(t, "unknown-linux-gnu", "x86_64", resolver.Manifest.Version+"+1234.DEADBEEF")
 		if err != nil {
 			t.Fatalf("failed to create client version request: %v", err)
 		}
@@ -171,14 +171,14 @@ func TestAppUpdateCheckHandler(t *testing.T) {
 			t.Fatalf("failed to decode AppUpdateManifest: %v", err)
 		}
 
-		if resolver.manifest.Version != updateResp.Version {
-			t.Errorf("Wanted %s manifest version, got %s", resolver.manifest.Version, updateResp.Version)
+		if resolver.Manifest.Version != updateResp.Version {
+			t.Errorf("Wanted %s manifest version, got %s", resolver.Manifest.Version, updateResp.Version)
 		}
-		if resolver.manifest.PubDate.String() != updateResp.PubDate.String() {
-			t.Errorf("Wanted %s manifest version, got %s", resolver.manifest.Version, updateResp.Version)
+		if resolver.Manifest.PubDate.String() != updateResp.PubDate.String() {
+			t.Errorf("Wanted %s manifest version, got %s", resolver.Manifest.Version, updateResp.Version)
 		}
 
-		if platform, ok := resolver.manifest.Platforms[clientVersion.Platform()]; !ok {
+		if platform, ok := resolver.Manifest.Platforms[clientVersion.Platform()]; !ok {
 			t.Fatalf("failed to get %q platform from manifest", clientVersion.Platform())
 		} else if updateResp.Signature != platform.Signature {
 			t.Errorf("signature mismatch. Got %q wanted %q", updateResp.Signature, platform.Signature)

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -83,7 +83,11 @@ type GCSManifestResolver struct {
 }
 
 type StaticManifestResolver struct {
-	manifest AppUpdateManifest
+	Manifest AppUpdateManifest
+}
+
+func (m *AppUpdateManifest) GitHubReleaseTag() string {
+	return fmt.Sprintf("app-v%s", m.Version)
 }
 
 func (v *AppVersion) Platform() string {
@@ -91,7 +95,7 @@ func (v *AppVersion) Platform() string {
 	// x86_64-darwin
 	// x86_64-linux
 	// aarch64-darwin
-	return fmt.Sprintf("%s-%s", v.Arch, v.Target)
+	return PlatformString(v.Arch, v.Target)
 }
 
 func NewGCSManifestResolver(ctx context.Context, bucket, manifestName string) (UpdateManifestResolver, error) {
@@ -125,7 +129,7 @@ func (r *GCSManifestResolver) Resolve(ctx context.Context) (*AppUpdateManifest, 
 }
 
 func (r *StaticManifestResolver) Resolve(_ context.Context) (*AppUpdateManifest, error) {
-	return &r.manifest, nil
+	return &r.Manifest, nil
 }
 
 func NewAppUpdateChecker(logger log.Logger, resolver UpdateManifestResolver) *AppUpdateChecker {
@@ -294,4 +298,11 @@ func mustConstraint(c string) *semver.Constraints {
 	}
 
 	return constraint
+}
+
+func PlatformString(arch, target string) string {
+	if arch == "" || target == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s", arch, target)
 }

--- a/cmd/frontend/internal/app/updatecheck/app_update_checker.go
+++ b/cmd/frontend/internal/app/updatecheck/app_update_checker.go
@@ -1,3 +1,4 @@
+// TODO(burmudar): move this app update endpoint code to codyapp package
 package updatecheck
 
 import (

--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/backend",
+        "//cmd/frontend/codyapp",
         "//cmd/frontend/enterprise",
         "//cmd/frontend/envvar",
         "//cmd/frontend/globals",

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -18,6 +18,7 @@ import (
 	proto "github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/codyapp"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
@@ -161,6 +162,7 @@ func NewHandler(
 
 	if envvar.SourcegraphDotComMode() {
 		m.Path("/app/check/update").Name(updatecheck.RouteAppUpdateCheck).Handler(trace.Route(updatecheck.AppUpdateHandler(logger)))
+		m.Path("/app/latest").Name(codyapp.RouteCodyAppLatestVersion).Handler(trace.Route(codyapp.LatestVersionHandler(logger)))
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.Route(http.HandlerFunc(updatecheck.HandlerWithLog(logger))))
 		m.Path("/license/check").Methods("POST").Name("dotcom.license.check").Handler(trace.Route(handlers.NewDotcomLicenseCheckHandler()))
 	}


### PR DESCRIPTION
Add an endpoint `/app/latest` which when requested without params will redirect the client to the GitHub release page ie. https://github.com/sourcegraph/sourcegraph/releases/tag/app-v2023.6.23%2B1323.5b8242ddbc

If a request with params `target=windows&arch=x86_64` is sent, it will redirect the client to the download link for that release. Unless the target and arch don't exist, then we fallback to redirecting the client to the GitHub release page.

## Test plan
* Unit Tests
* Manually tested with:
```
sourcegraph on  wb/app/latest-version-handler [$!?] via 🐹 v1.19.8 
❯ curl -k https://sourcegraph.test:3443/.api/app/latest
<a href="https://github.com/sourcegraph/sourcegraph/releases/tag/app-v2023.5.30+1306.85e549168c">See Other</a>.


sourcegraph on  wb/app/latest-version-handler [$!?] via 🐹 v1.19.8 
❯ curl -k "https://sourcegraph.test:3443/.api/app/latest?target=linux&arch=x86_64"
<a href="https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.5.30%2B1306.85e549168c/sourcegraph_2023.5.30%2B1306.85e549168c_amd64.AppImage.tar.gz">See Other</a>.
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
