### PR TITLE
Drop link from inferred github teams in select:file.owners

### DIFF
--- a/client/branded/src/search-ui/components/OwnerSearchResult.tsx
+++ b/client/branded/src/search-ui/components/OwnerSearchResult.tsx
@@ -53,6 +53,14 @@ export const OwnerSearchResult: React.FunctionComponent<OwnerSearchResultProps> 
     const url = useMemo(() => {
         const url = getOwnerMatchUrl(result)
         const validUrlPrefixes = ['/teams/', '/users/', 'mailto:']
+        // TODO(#54209): Introduce a proper solution where a streamed team
+        // is returned with a URL if present. Temporarily return no URL
+        // in case name contains /. This indicates a Github team, and these
+        // are not linkable within code search - where / is not an allowed
+        // character for team names.
+        if (result.type === 'team' && result.name.includes('/')) {
+            return ''
+        }
         if (!validUrlPrefixes.some(prefix => url.startsWith(prefix))) {
             // This is not a real URL, remove it.
             return ''


### PR DESCRIPTION
Part of #54209

Context:

- In Github all team names contain `/`
- So in case of github repo CODEOWNERS entries, if `@teamName/withForwardSlash` is seen, it's determined to be a team.
- But formerly in the front-end, all teams streamed from `select:file.owners` search were Sourcegraph teams

Bug:

- So all of these team names were linked to a teams page.
- Which in case of such a Github-repo CODEOWNERS entry that is determined to be a team, leads to linking to a team that does not exist on Code Search (so 404) 

Solution:

- Temporarily for 5.1 drop the link if the team name contains `/`
- This is safe because teams registered (so linked) do not contain `/` - it's not an allowed character
- All the other references from CODEOWNERS that are not resolved will be considered persons, and linking there follows different route.

## Test plan

Visual assessment and loom: https://www.loom.com/share/b9f8179c5cac481fb18e6badd5f5d6d3?sid=a35a5c68-b9e2-466b-b489-b411384922ce