### PR TITLE
Cody VSCE: Add a demo of the pane header buttons to the walkthrough

### DIFF
--- a/client/cody/walkthroughs/learn-more.md
+++ b/client/cody/walkthroughs/learn-more.md
@@ -3,3 +3,12 @@
 <a href="https://youtu.be/fmir_bUyygw" alt="Sourcegraph Cody: your AI coding assistant - Use Cases">
   <img src="https://storage.googleapis.com/sourcegraph-assets/cody-usecases-demo-thumb2-optim.jpg">
 </a>
+
+You can start new chats, configure Cody’s settings and more using the buttons at the top of the Cody pane:
+
+<video autoPlay muted loop playsInline width="494" height="254">
+    <source
+        type="video/mp4"
+        src="https://storage.googleapis.com/sourcegraph-assets/cody/vscode-walkthrough/cody-new-chat-and-settings-buttons-27-jun-23.mp4"
+    />
+</video>


### PR DESCRIPTION
Fixes #54231

https://github.com/sourcegraph/sourcegraph/assets/153/51141f30-3fa8-4cbc-8dfa-7d8dfd4dc700

## Test plan

- Opened the walkthrough
- Clicked "Learn More & Feedback"
- Verified video plays