### PR TITLE
Allow multiple auth providers with the same URL, adjust UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Cody source code (for the VS Code extension, CLI, and client shared libraries) has been moved to the [sourcegraph/cody repository](https://github.com/sourcegraph/cody).
 - `golang.org/x/net/trace` instrumentation, previously available under `/debug/requests` and `/debug/events`, has been removed entirely from core Sourcegraph services. It remains available for Zoekt. [#53795](https://github.com/sourcegraph/sourcegraph/pull/53795)
+- Sourcegraph now supports more than one auth provider per URL. [#54289](https://github.com/sourcegraph/sourcegraph/pull/54289)
 
 ### Fixed
 

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -16,6 +16,7 @@ describe('SignInPage', () => {
             serviceType: 'builtin',
             authenticationURL: '',
             serviceID: '',
+            clientID: '1234',
         },
         {
             serviceType: 'github',
@@ -23,6 +24,7 @@ describe('SignInPage', () => {
             isBuiltin: false,
             authenticationURL: '/.auth/github/login?pc=f00bar',
             serviceID: 'https://github.com',
+            clientID: '1234',
         },
         {
             serviceType: 'gitlab',
@@ -30,6 +32,7 @@ describe('SignInPage', () => {
             isBuiltin: false,
             authenticationURL: '/.auth/gitlab/login?pc=f00bar',
             serviceID: 'https://gitlab.com',
+            clientID: '1234',
         },
     ]
 
@@ -146,6 +149,7 @@ describe('SignInPage', () => {
                 serviceType: 'sourcegraph-operator',
                 authenticationURL: '',
                 serviceID: '',
+                clientID: '',
             },
         ]
 
@@ -175,6 +179,7 @@ describe('SignInPage', () => {
                 serviceType: 'gerrit',
                 authenticationURL: '',
                 serviceID: '',
+                clientID: '',
             },
         ]
         it('does not render the Gerrit provider', () => {

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -20,6 +20,7 @@ describe('SignUpPage', () => {
             serviceType: 'builtin',
             authenticationURL: '',
             serviceID: '',
+            clientID: '',
         },
         {
             serviceType: 'github',
@@ -27,6 +28,7 @@ describe('SignUpPage', () => {
             isBuiltin: false,
             authenticationURL: '/.auth/github/login?pc=f00bar',
             serviceID: 'https://github.com',
+            clientID: '1234',
         },
     ]
 

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -27,6 +27,7 @@ export interface AuthProvider {
     isBuiltin: boolean
     authenticationURL: string
     serviceID: string
+    clientID: string
 }
 
 /**

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -52,15 +52,11 @@ const getNormalizedAccount = (
         name,
     }
 
-    for (let i = 0; i < providerAccounts.length; i++) {
-        const pAcc = providerAccounts[i]
-        if (pAcc && pAcc.clientID === authProvider.clientID) {
-            if (pAcc.publicAccountData) {
-                normalizedAccount.external = {
-                    id: pAcc.id,
-                    ...pAcc.publicAccountData,
-                }
-            }
+    const providerAccount = providerAccounts.find(acc => acc.clientID === authProvider.clientID)
+    if (providerAccount && providerAccount.publicAccountData) {
+        normalizedAccount.external = {
+            id: providerAccount.id,
+            ...providerAccount.publicAccountData,
         }
     }
 

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -53,7 +53,7 @@ const getNormalizedAccount = (
     }
 
     const providerAccount = providerAccounts.find(acc => acc.clientID === authProvider.clientID)
-    if (providerAccount && providerAccount.publicAccountData) {
+    if (providerAccount?.publicAccountData) {
         normalizedAccount.external = {
             id: providerAccount.id,
             ...providerAccount.publicAccountData,

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -41,10 +41,6 @@ const getNormalizedAccount = (
         return null
     }
 
-    const providerAccounts = accounts[authProvider.serviceID]
-    if (!providerAccounts) {
-        return null
-    }
     const { icon, title: name } = defaultExternalAccounts[authProvider.serviceType]
 
     const normalizedAccount: NormalizedExternalAccount = {
@@ -52,7 +48,9 @@ const getNormalizedAccount = (
         name,
     }
 
-    const providerAccount = providerAccounts.find(acc => acc.clientID === authProvider.clientID)
+    const providerAccounts = accounts[authProvider.serviceID]
+
+    const providerAccount = providerAccounts?.find(acc => acc.clientID === authProvider.clientID)
     if (providerAccount?.publicAccountData) {
         normalizedAccount.external = {
             id: providerAccount.id,

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -39,13 +39,13 @@ import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
 // pick only the fields we need
 export type UserExternalAccount = Pick<
     UserExternalAccountFields,
-    'id' | 'serviceID' | 'serviceType' | 'publicAccountData'
+    'id' | 'serviceID' | 'serviceType' | 'publicAccountData' | 'clientID'
 >
 type ServiceType = AuthProvider['serviceType']
 
 export type ExternalAccountsByType = Partial<Record<ServiceType, UserExternalAccount>>
 export type AuthProvidersByBaseURL = Partial<Record<string, AuthProvider>>
-export type AccountByServiceID = Partial<Record<string, UserExternalAccount>>
+export type AccountsByServiceID = Partial<Record<string, UserExternalAccount[]>>
 
 interface UserExternalAccountsResult {
     user: {
@@ -92,8 +92,11 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
     }
 
     // auth providers by service ID
-    const accountByServiceID = accounts.fetched?.reduce((accumulator: AccountByServiceID, account) => {
-        accumulator[account.serviceID] = account
+    const accountsByServiceID = accounts.fetched?.reduce((accumulator: AccountsByServiceID, account) => {
+        let accountMap = accumulator[account.serviceID] ?? []
+        accountMap.push(account)
+        accumulator[account.serviceID] = accountMap
+
         return accumulator
     }, {})
 
@@ -110,7 +113,7 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
 
     const onAccountAdd = (): void => {
         refetch({ username: props.user.username })
-            .then(() => {})
+            .then(() => { })
             .catch(handleError)
     }
 
@@ -206,10 +209,10 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
             )}
 
             {/* fetched external accounts */}
-            {accountByServiceID && (
+            {accountsByServiceID && (
                 <Container>
                     <ExternalAccountsSignIn
-                        accounts={accountByServiceID}
+                        accounts={accountsByServiceID}
                         authProviders={props.context.authProviders}
                         onDidError={handleError}
                         onDidRemove={onAccountRemoval}

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -93,9 +93,9 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
 
     // auth providers by service ID
     const accountsByServiceID = accounts.fetched?.reduce((accumulator: AccountsByServiceID, account) => {
-        let accountMap = accumulator[account.serviceID] ?? []
-        accountMap.push(account)
-        accumulator[account.serviceID] = accountMap
+        let accountArray = accumulator[account.serviceID] ?? []
+        accountArray.push(account)
+        accumulator[account.serviceID] = accountArray
 
         return accumulator
     }, {})

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -93,7 +93,7 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
 
     // auth providers by service ID
     const accountsByServiceID = accounts.fetched?.reduce((accumulator: AccountsByServiceID, account) => {
-        let accountArray = accumulator[account.serviceID] ?? []
+        const accountArray = accumulator[account.serviceID] ?? []
         accountArray.push(account)
         accumulator[account.serviceID] = accountArray
 

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -113,7 +113,7 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
 
     const onAccountAdd = (): void => {
         refetch({ username: props.user.username })
-            .then(() => { })
+            .then(() => {})
             .catch(handleError)
     }
 

--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -38,6 +38,7 @@ export const userExternalAccountFragment = gql`
         id
         serviceID
         serviceType
+        clientID
         publicAccountData {
             displayName
             login
@@ -54,6 +55,7 @@ export const USER_EXTERNAL_ACCOUNTS = gql`
                     id
                     serviceID
                     serviceType
+                    clientID
                     publicAccountData {
                         displayName
                         login

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -44,6 +44,7 @@ type authProviderInfo struct {
 	ServiceType       string  `json:"serviceType"`
 	AuthenticationURL string  `json:"authenticationURL"`
 	ServiceID         string  `json:"serviceID"`
+	ClientID          string  `json:"clientID"`
 }
 
 // GenericPasswordPolicy a generic password policy that holds password requirements
@@ -260,6 +261,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 				ServiceType:       p.ConfigID().Type,
 				AuthenticationURL: info.AuthenticationURL,
 				ServiceID:         info.ServiceID,
+				ClientID:          info.ClientID,
 			})
 		}
 	}

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//enterprise/cmd/frontend/internal/auth/oauth",
         "//internal/actor",
         "//internal/auth/providers",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
@@ -92,7 +92,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			}
 		}
 		if configured {
-			problems = append(problems, conf.NewSiteProblem("Cannot have more than one auth provider for Azure Dev Ops, only the first one will be used"))
+			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Cannot have more than one auth provider for Azure Dev Ops with Client ID %q, only the first one will be used", pr.AzureDevOps.ClientID)))
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/azureoauth/provider.go
@@ -69,7 +69,6 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		return ps, problems
 	}
 
-	var configured bool
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.AzureDevOps == nil {
 			continue
@@ -84,19 +83,10 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			continue
 		}
 
-		// Currently Azure Dev Ops will work only against https://dev.azure.com. If we have more
-		// than one configuration for Azure Dev Ops auth provider, we want to fail early.
-		if configured {
-			problems = append(problems, conf.NewSiteProblem("Cannot have more than one auth provider for Azure Dev Ops, only the first one will be used"))
-			continue
-		}
-
 		ps = append(ps, Provider{
 			AzureDevOpsAuthProvider: pr.AzureDevOps,
 			Provider:                provider,
 		})
-
-		configured = true
 	}
 
 	return ps, problems

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//enterprise/cmd/frontend/internal/auth/oauth",
         "//internal/actor",
         "//internal/auth/providers",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
@@ -1,8 +1,6 @@
 package bitbucketcloudoauth
 
 import (
-	"fmt"
-
 	"github.com/dghubble/gologin"
 	"github.com/sourcegraph/log"
 
@@ -58,11 +56,6 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		provider, providerProblems := parseProvider(logger, pr.Bitbucketcloud, db, pr)
 		problems = append(problems, conf.NewSiteProblems(providerProblems...)...)
 		if provider == nil {
-			continue
-		}
-
-		if _, ok := configured[provider.ServiceID]; ok {
-			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q, only the first one will be used`, provider.ServiceID))...)
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
@@ -61,8 +61,8 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			continue
 		}
 
-		if _, ok := configured[provider.ServiceID+":"+pr.Bitbucketcloud.ClientKey]; ok {
-			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q, only the first one will be used`, provider.ServiceID))...)
+		if _, ok := configured[provider.ServiceID+":"+provider.CachedInfo().ClientID]; ok {
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
 			continue
 		}
 
@@ -70,7 +70,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			BitbucketCloudAuthProvider: pr.Bitbucketcloud,
 			Provider:                   provider,
 		})
-		configured[provider.ServiceID+":"+pr.Bitbucketcloud.ClientKey] = struct{}{}
+		configured[provider.ServiceID+":"+provider.CachedInfo().ClientID] = struct{}{}
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
@@ -64,7 +64,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		}
 
 		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
-			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one Bitbucket Cloud auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
@@ -1,6 +1,8 @@
 package bitbucketcloudoauth
 
 import (
+	"fmt"
+
 	"github.com/dghubble/gologin"
 	"github.com/sourcegraph/log"
 
@@ -59,11 +61,16 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			continue
 		}
 
+		if _, ok := configured[provider.ServiceID+":"+pr.Bitbucketcloud.ClientKey]; ok {
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q, only the first one will be used`, provider.ServiceID))...)
+			continue
+		}
+
 		ps = append(ps, Provider{
 			BitbucketCloudAuthProvider: pr.Bitbucketcloud,
 			Provider:                   provider,
 		})
-		configured[provider.ServiceID] = struct{}{}
+		configured[provider.ServiceID+":"+pr.Bitbucketcloud.ClientKey] = struct{}{}
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -49,7 +50,8 @@ type Provider struct {
 }
 
 func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database.DB) (ps []Provider, problems conf.Problems) {
-	configured := map[string]struct{}{}
+	existingProviders := make(collections.Set[string])
+
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Bitbucketcloud == nil {
 			continue
@@ -61,7 +63,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			continue
 		}
 
-		if _, ok := configured[provider.ServiceID+":"+provider.CachedInfo().ClientID]; ok {
+		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
 			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
 			continue
 		}
@@ -70,7 +72,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 			BitbucketCloudAuthProvider: pr.Bitbucketcloud,
 			Provider:                   provider,
 		})
-		configured[provider.ServiceID+":"+provider.CachedInfo().ClientID] = struct{}{}
+		existingProviders.Add(provider.CachedInfo().UniqueID())
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
@@ -115,7 +115,7 @@ func TestParseConfig(t *testing.T) {
 				},
 			},
 			wantProblems: []string{
-				`Cannot have more than one auth provider with url "https://bitbucket.org/" and client ID "myclientid", only the first one will be used`,
+				`Cannot have more than one Bitbucket Cloud auth provider with url "https://bitbucket.org/" and client ID "myclientid", only the first one will be used`,
 			},
 		},
 		{

--- a/enterprise/cmd/frontend/internal/auth/gerrit/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/gerrit/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
         "//internal/auth/providers",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/extsvc",

--- a/enterprise/cmd/frontend/internal/auth/gerrit/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gerrit/config.go
@@ -2,7 +2,6 @@ package gerrit
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -35,19 +34,13 @@ type Provider struct {
 }
 
 func parseConfig(cfg conftypes.SiteConfigQuerier) (ps []Provider, problems conf.Problems) {
-	seen := make(map[string]struct{})
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Gerrit == nil {
 			continue
 		}
 
 		provider := parseProvider(pr.Gerrit)
-		if _, ok := seen[provider.ServiceID]; !ok {
-			ps = append(ps, provider)
-			seen[provider.ServiceID] = struct{}{}
-		} else {
-			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Cannot have more than one auth provider with url %q", provider.ServiceID)))
-		}
+		ps = append(ps, provider)
 	}
 
 	return ps, problems

--- a/enterprise/cmd/frontend/internal/auth/gerrit/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gerrit/config.go
@@ -48,7 +48,6 @@ func parseConfig(cfg conftypes.SiteConfigQuerier) (ps []Provider, problems conf.
 		} else {
 			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Cannot have more than one auth provider with url %q", provider.ServiceID)))
 		}
-		ps = append(ps, provider)
 	}
 
 	return ps, problems

--- a/enterprise/cmd/frontend/internal/auth/gerrit/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gerrit/config.go
@@ -44,7 +44,7 @@ func parseConfig(cfg conftypes.SiteConfigQuerier) (ps []Provider, problems conf.
 
 		provider := parseProvider(pr.Gerrit)
 		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
-			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Cannot have more than one auth provider with url %q", provider.ServiceID)))
+			problems = append(problems, conf.NewSiteProblem(fmt.Sprintf("Cannot have more than one Gerrit auth provider with url %q", provider.ServiceID)))
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/gerrit/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gerrit/config_test.go
@@ -55,7 +55,7 @@ func TestParseConfig(t *testing.T) {
 				ServiceType: extsvc.TypeGerrit,
 			}},
 			wantProblems: []string{
-				`Cannot have more than one auth provider with url "https://gerrit.example.com"`,
+				`Cannot have more than one Gerrit auth provider with url "https://gerrit.example.com"`,
 			},
 		},
 		"2 gerrit configs with different URLs is okay": {

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//enterprise/cmd/frontend/internal/auth/oauth",
         "//internal/actor",
         "//internal/auth/providers",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -1,8 +1,6 @@
 package githuboauth
 
 import (
-	"fmt"
-
 	"github.com/dghubble/gologin"
 	"github.com/sourcegraph/log"
 
@@ -58,22 +56,10 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 
 		provider, providerProblems := parseProvider(logger, pr.Github, db, pr)
 		problems = append(problems, conf.NewSiteProblems(providerProblems...)...)
-		if provider != nil {
-			alreadyExists := false
-			for _, p := range ps {
-				if p.CachedInfo().ServiceID == provider.ServiceID {
-					problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q, only the first one will be used`, provider.ServiceID))...)
-					alreadyExists = true
-				}
-			}
-			if alreadyExists {
-				continue
-			}
-			ps = append(ps, Provider{
-				GitHubAuthProvider: pr.Github,
-				Provider:           provider,
-			})
-		}
+		ps = append(ps, Provider{
+			GitHubAuthProvider: pr.Github,
+			Provider:           provider,
+		})
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -65,7 +65,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		}
 
 		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
-			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one GitHub auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -51,6 +52,7 @@ type Provider struct {
 }
 
 func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database.DB) (ps []Provider, problems conf.Problems) {
+	existingProviders := make(collections.Set[string])
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Github == nil {
 			continue
@@ -58,22 +60,21 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 
 		provider, providerProblems := parseProvider(logger, pr.Github, db, pr)
 		problems = append(problems, conf.NewSiteProblems(providerProblems...)...)
-		if provider != nil {
-			alreadyExists := false
-			for _, p := range ps {
-				if p.CachedInfo().ServiceID == provider.ServiceID && p.CachedInfo().ClientID == provider.CachedInfo().ClientID {
-					problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
-					alreadyExists = true
-				}
-			}
-			if alreadyExists {
-				continue
-			}
-			ps = append(ps, Provider{
-				GitHubAuthProvider: pr.Github,
-				Provider:           provider,
-			})
+		if provider == nil {
+			continue
 		}
+
+		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
+			continue
+		}
+
+		ps = append(ps, Provider{
+			GitHubAuthProvider: pr.Github,
+			Provider:           provider,
+		})
+
+		existingProviders.Add(provider.CachedInfo().UniqueID())
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/config_test.go
@@ -181,7 +181,7 @@ func TestParseConfig(t *testing.T) {
 				},
 			},
 			wantProblems: []string{
-				`Cannot have more than one auth provider with url "https://github.com/" and client ID "myclientid", only the first one will be used`,
+				`Cannot have more than one GitHub auth provider with url "https://github.com/" and client ID "myclientid", only the first one will be used`,
 			},
 		},
 		{

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//enterprise/cmd/frontend/internal/auth/oauth",
         "//internal/actor",
         "//internal/auth/providers",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
@@ -1,7 +1,6 @@
 package gitlaboauth
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/sourcegraph/log"
@@ -72,18 +71,6 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		provider, providerMessages := parseProvider(logger, db, callbackURL.String(), pr.Gitlab, pr)
 
 		problems = append(problems, conf.NewSiteProblems(providerMessages...)...)
-		if provider != nil {
-			alreadyExists := false
-			for _, p := range ps {
-				if p.CachedInfo().ServiceID == provider.ServiceID {
-					problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q, only the first one will be used`, provider.ServiceID))...)
-					alreadyExists = true
-				}
-			}
-			if alreadyExists {
-				continue
-			}
-		}
 		ps = append(ps, Provider{
 			GitLabAuthProvider: pr.Gitlab,
 			Provider:           provider,

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
@@ -78,7 +78,7 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		}
 
 		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
-			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one GitLab auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -52,6 +53,7 @@ type Provider struct {
 }
 
 func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database.DB) (ps []Provider, problems conf.Problems) {
+	existingProviders := make(collections.Set[string])
 	for _, pr := range cfg.SiteConfig().AuthProviders {
 		if pr.Gitlab == nil {
 			continue
@@ -70,24 +72,22 @@ func parseConfig(logger log.Logger, cfg conftypes.SiteConfigQuerier, db database
 		callbackURL.Path = "/.auth/gitlab/callback"
 
 		provider, providerMessages := parseProvider(logger, db, callbackURL.String(), pr.Gitlab, pr)
-
 		problems = append(problems, conf.NewSiteProblems(providerMessages...)...)
-		if provider != nil {
-			alreadyExists := false
-			for _, p := range ps {
-				if p.CachedInfo().ServiceID == provider.ServiceID && p.CachedInfo().ClientID == provider.CachedInfo().ClientID {
-					problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
-					alreadyExists = true
-				}
-			}
-			if alreadyExists {
-				continue
-			}
+		if provider == nil {
+			continue
 		}
+
+		if existingProviders.Has(provider.CachedInfo().UniqueID()) {
+			problems = append(problems, conf.NewSiteProblems(fmt.Sprintf(`Cannot have more than one auth provider with url %q and client ID %q, only the first one will be used`, provider.ServiceID, provider.CachedInfo().ClientID))...)
+			continue
+		}
+
 		ps = append(ps, Provider{
 			GitLabAuthProvider: pr.Gitlab,
 			Provider:           provider,
 		})
+
+		existingProviders.Add(provider.CachedInfo().UniqueID())
 	}
 	return ps, problems
 }

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -262,7 +262,7 @@ func TestParseConfig(t *testing.T) {
 				},
 			},
 			wantProblems: []string{
-				`Cannot have more than one auth provider with url "https://gitlab.com/" and client ID "my-client-id", only the first one will be used`,
+				`Cannot have more than one GitLab auth provider with url "https://gitlab.com/" and client ID "my-client-id", only the first one will be used`,
 			},
 		},
 		{

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -84,6 +84,12 @@ type Info struct {
 	AuthenticationURL string
 }
 
+// UniqueID returns a unique identifier that's a combination of the ServiceID and the ClientID of
+// the provider.
+func (i *Info) UniqueID() string {
+	return i.ServiceID + ":" + i.ClientID
+}
+
 var (
 	// curProviders is a map (package name -> (config string -> Provider)). The first key is the
 	// package name under which the provider was registered (this should be unique among


### PR DESCRIPTION
This PR removes the restrictions of having one Auth provider per URL, and instead allows one auth provider for each URL+ClientID combination.

The URL restriction came from the way our old permissions table worked, but with the `user_repo_permissions` table, this restriction no longer applies as permissions are stored against individual external accounts.

This has also become an increasingly common ask from customers, and it also eases the transitioning when switching from one auth provider to another, like switching from traditional GitHub OAuth to GitHub App Oauth.

One caveat that remains: Having multiple auth providers for the same URL does not play well with repo-centric permissions syncing, as we cannot from the repo token's perspective determine which user external account a permission should be bound to. There isn't a clean workaround to make this work, and the suggestion is to turn off repo-centric permissions syncing when using multiple auth providers to the same URL.

The idea is to have a follow-up PR that allows us to disable repo-centric permissions syncs for individual code host connections.

Having two auth providers and account connections that both point to github.com:

<img width="1082" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6427795/f67ecf11-6034-4760-9fd3-4a1db4dd07bc">

Some follow-up tasks:

- [ ] Change [this](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go?L432%3A2-438%3A40) code so that auth providers are grouped by UniqueID and not ServiceID
  - This will require changes to each individual auth provider. But it would allow us to not sync permissions using an external account that no longer has an active auth provider.
- [ ] Allow users to delete external accounts that are no longer associated with a valid auth provider
- [ ] Add a code host connection option that allows disabling repo-permissions syncing on a code host connection level

## Test plan

Lots of tests updated and adjusted to fit the new criteria.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
