### PR TITLE
batches: update cancel url based on GitHub app domain

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -192,6 +192,8 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
 
     const handleOrgChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => setOrg(event.target.value), [])
     const toggleIsPublic = useCallback(() => setIsPublic(isPublic => !isPublic), [])
+    const cancelUrl = `/site-admin/${appDomain === GitHubAppDomain.BATCHES ? 'batch-changes' : 'github-apps'}`
+    console.log(cancelUrl, '<====')
 
     return (
         <>
@@ -300,7 +302,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                     <Button variant="primary" onClick={createState} disabled={!!nameError || !!urlError}>
                         Create Github App
                     </Button>
-                    <ButtonLink className="ml-3" to="/site-admin/github-apps" variant="secondary">
+                    <ButtonLink className="ml-3" to={cancelUrl} variant="secondary">
                         Cancel
                     </ButtonLink>
                 </div>

--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -193,7 +193,6 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     const handleOrgChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => setOrg(event.target.value), [])
     const toggleIsPublic = useCallback(() => setIsPublic(isPublic => !isPublic), [])
     const cancelUrl = `/site-admin/${appDomain === GitHubAppDomain.BATCHES ? 'batch-changes' : 'github-apps'}`
-    console.log(cancelUrl, '<====')
 
     return (
         <>


### PR DESCRIPTION
Closes [#54291](https://github.com/sourcegraph/sourcegraph/issues/54291)

While creating a GitHub app for Commit Signing, I noticed that clicking on the `Cancel` button redirects me to the GitHub Apps section for code host connections instead of the Batch Changes Admin settings page.
I've shared the walk through below.
![CleanShot 2023-06-27 at 14 53 24](https://github.com/sourcegraph/sourcegraph/assets/25608335/2b7a09fa-3e08-4559-9ba4-c3a77b0aef87)

I fixed that by introducing a `cancelUrl` variable to the `CreateGitHubAppPage` component, which depending on the GitHub app domain, switches where the cancel button should take the user to.

| Domain  | Cancel URL  |
|---|---|
| BATCHES   |   `/site-admin/batch-changes`  |
|  REPO |  `/site-admin/github-apps` |

![CleanShot 2023-06-27 at 15 21 01](https://github.com/sourcegraph/sourcegraph/assets/25608335/b13a49c6-868f-484d-a4fe-b1c0b7485463)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
#### For Batch Changes

* Navigate to the Batch Changes admin page `/site-admin/batch-changes`
* Create a commit signing integration for any code host
* Click on the `Cancel` button
* You should be redirected back to the Batch Changes admin page

#### For Repos

* Navigate to the GitHub apps page `/site-admin/github-apps`
* Click on create a GitHub app button
* Then click on the `Cancel` button, after being redirected to the form for creating GitHub apps
* You should be redirected back to the GitHub apps page.
