### PR TITLE
ci: detect rc releases as push-prod too

### DIFF
--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -75,7 +75,7 @@ fi
 # ok: v5.1.0-rc.5
 # no: v5.1.0-beta.1
 # no: v5.1.0-rc5
-if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(?:\-rc\.[0-9]+)?$ ]]; then
+if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-rc\.[0-9]+)?$ ]]; then
   dev_tags+=("${BUILDKITE_TAG:1}")
   prod_tags+=("${BUILDKITE_TAG:1}")
   push_prod=true

--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -71,7 +71,11 @@ if [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
   push_prod=true
 fi
 
-if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+# ok: v5.1.0
+# ok: v5.1.0-rc.5
+# no: v5.1.0-beta.1
+# no: v5.1.0-rc5
+if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(?:\-rc\.[0-9]+)?$ ]]; then
   dev_tags+=("${BUILDKITE_TAG:1}")
   prod_tags+=("${BUILDKITE_TAG:1}")
   push_prod=true


### PR DESCRIPTION
The previous predicate to detect if our tag is a prod related one was failing to consider an ...-rc.X tag as being prod, leading to not pushing the tags to prod at all.

Test plan: used a regex tester to ensure it matches

Test script: 

```
# foo.sh 
BUILDKITE_TAG="v5.1.0-rc.5"

if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-rc\.[0-9]+)?$ ]]; then
  dev_tags+=("${BUILDKITE_TAG:1}")
  prod_tags+=("${BUILDKITE_TAG:1}")
  push_prod=true

  echo $dev_tags
  echo $prod_tags
else 
  echo "NOPE"
fi

~ $ bash foo.sh 
5.1.0-rc.5
5.1.0-rc.5
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
