### PR TITLE
JetBrains: Integrate plugin with Cody App

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Background color and font of inline code blocks differs from regular text in message [#53761](https://github.com/sourcegraph/sourcegraph/pull/53761)
 - Autofocus Cody chat prompt input [#53836](https://github.com/sourcegraph/sourcegraph/pull/53836)
 - Basic integration with the local Cody App [#54061](https://github.com/sourcegraph/sourcegraph/pull/54061)
+- Onboarding of the user when using local Cody App [#54298](https://github.com/sourcegraph/sourcegraph/pull/54298)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
@@ -64,6 +65,7 @@ import com.sourcegraph.cody.ui.RoundedJBTextArea;
 import com.sourcegraph.cody.ui.SelectOptionManager;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
+import com.sourcegraph.config.SettingsConfigurable;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import com.sourcegraph.vcs.RepoUtil;
 import java.awt.BorderLayout;
@@ -312,9 +314,12 @@ class CodyToolWindowContent implements UpdatableChat {
     blankPanel.setBorder(margin);
     blankPanel.setOpaque(false);
     appNotInstalledPanel.add(blankPanel);
-    JPanel wrapperAppNotInstalledPanel = new JPanel(new BorderLayout());
+    JPanel wrapperAppNotInstalledPanel =
+        new JPanel(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
     wrapperAppNotInstalledPanel.setBorder(margin);
-    wrapperAppNotInstalledPanel.add(appNotInstalledPanel, BorderLayout.NORTH);
+    wrapperAppNotInstalledPanel.add(appNotInstalledPanel);
+    JPanel goToSettingsPanel = createPanelWithGoToSettingsButton();
+    wrapperAppNotInstalledPanel.add(goToSettingsPanel);
     return wrapperAppNotInstalledPanel;
   }
 
@@ -342,10 +347,26 @@ class CodyToolWindowContent implements UpdatableChat {
     blankPanel.setBorder(margin);
     blankPanel.setOpaque(false);
     appNotRunningPanel.add(blankPanel);
-    JPanel wrapperAppNotInstalledPanel = new JPanel(new BorderLayout());
-    wrapperAppNotInstalledPanel.setBorder(margin);
-    wrapperAppNotInstalledPanel.add(appNotRunningPanel, BorderLayout.NORTH);
-    return wrapperAppNotInstalledPanel;
+    JPanel wrapperAppNotRunningPanel =
+        new JPanel(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
+    wrapperAppNotRunningPanel.setBorder(margin);
+    wrapperAppNotRunningPanel.add(appNotRunningPanel);
+    JPanel goToSettingsPanel = createPanelWithGoToSettingsButton();
+    wrapperAppNotRunningPanel.add(goToSettingsPanel);
+    return wrapperAppNotRunningPanel;
+  }
+
+  private JPanel createPanelWithGoToSettingsButton() {
+    JButton goToSettingsButton = new JButton("Sign in with an enterprise account");
+    goToSettingsButton.addActionListener(
+        e ->
+            ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class));
+    ButtonUI buttonUI = (ButtonUI) DarculaButtonUI.createUI(goToSettingsButton);
+    goToSettingsButton.setUI(buttonUI);
+    JPanel panelWithSettingsButton = new JPanel(new BorderLayout());
+    panelWithSettingsButton.setBorder(JBUI.Borders.empty(TEXT_MARGIN, 0));
+    panelWithSettingsButton.add(goToSettingsButton, BorderLayout.CENTER);
+    return panelWithSettingsButton;
   }
 
   private void executeRecipeWithPromptProvider(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -37,6 +37,8 @@ import com.sourcegraph.cody.chat.AssistantMessageWithSettingsButton;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatBubble;
 import com.sourcegraph.cody.chat.ChatMessage;
+import com.sourcegraph.cody.chat.ChatUIConstants;
+import com.sourcegraph.cody.chat.ContentWithGradientBorder;
 import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.Interaction;
 import com.sourcegraph.cody.chat.Transcript;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -1,11 +1,13 @@
 package com.sourcegraph.cody;
 
 import static com.intellij.openapi.util.SystemInfoRt.isMac;
+import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
 import static java.awt.event.InputEvent.CTRL_DOWN_MASK;
 import static java.awt.event.InputEvent.META_DOWN_MASK;
 import static java.awt.event.KeyEvent.VK_ENTER;
 import static javax.swing.KeyStroke.getKeyStroke;
 
+import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI;
 import com.intellij.ide.ui.laf.darcula.ui.DarculaTextAreaUI;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -41,6 +43,7 @@ import com.sourcegraph.cody.context.ContextGetter;
 import com.sourcegraph.cody.context.ContextMessage;
 import com.sourcegraph.cody.editor.EditorContext;
 import com.sourcegraph.cody.editor.EditorContextGetter;
+import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.cody.prompts.Preamble;
 import com.sourcegraph.cody.prompts.Prompter;
 import com.sourcegraph.cody.prompts.SupportedLanguages;
@@ -56,12 +59,15 @@ import com.sourcegraph.cody.recipes.PromptProvider;
 import com.sourcegraph.cody.recipes.RecipeRunner;
 import com.sourcegraph.cody.recipes.SummarizeRecentChangesRecipe;
 import com.sourcegraph.cody.recipes.TranslateToLanguagePromptProvider;
+import com.sourcegraph.cody.ui.HtmlViewer;
 import com.sourcegraph.cody.ui.RoundedJBTextArea;
 import com.sourcegraph.cody.ui.SelectOptionManager;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import com.sourcegraph.vcs.RepoUtil;
 import java.awt.BorderLayout;
+import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridLayout;
@@ -75,7 +81,9 @@ import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;
+import javax.swing.JEditorPane;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.ButtonUI;
 import javax.swing.plaf.basic.BasicTextAreaUI;
@@ -87,13 +95,18 @@ class CodyToolWindowContent implements UpdatableChat {
   public static Logger logger = Logger.getInstance(CodyToolWindowContent.class);
   private static final int CHAT_TAB_INDEX = 0;
   private static final int RECIPES_TAB_INDEX = 1;
+  private final @NotNull CardLayout allContentLayout = new CardLayout();
+  private final @NotNull JPanel allContentPanel = new JPanel(allContentLayout);
   private final @NotNull JBTabbedPane tabbedPane = new JBTabbedPane();
   private final @NotNull JPanel messagesPanel = new JPanel();
   private final @NotNull JBTextArea promptInput;
   private final @NotNull JButton sendButton;
   private final @NotNull Project project;
+  private final JPanel appNotInstalledPanel;
+  private final JPanel appNotRunningPanel;
   private boolean needScrollingDown = true;
   private @NotNull Transcript transcript = new Transcript();
+  private boolean isChatVisible = false;
 
   public CodyToolWindowContent(@NotNull Project project) {
     this.project = project;
@@ -243,8 +256,96 @@ class CodyToolWindowContent implements UpdatableChat {
     contentPanel.add(chatPanel, BorderLayout.CENTER);
     contentPanel.add(controlsPanel, BorderLayout.SOUTH);
     tabbedPane.addChangeListener(e -> this.focusPromptInput());
+
+    appNotInstalledPanel = createAppNotInstalledPanel();
+    appNotRunningPanel = createAppNotRunningPanel();
+    allContentPanel.add(tabbedPane, "tabbedPane");
+    allContentPanel.add(appNotInstalledPanel, "appNotInstalledPanel");
+    allContentPanel.add(appNotRunningPanel, "appNotRunningPanel");
+    allContentLayout.show(allContentPanel, "appNotInstalledPanel");
+    updateVisibilityOfContentPanels();
     // Add welcome message
     addWelcomeMessage();
+  }
+
+  private void updateVisibilityOfContentPanels() {
+    if (LocalAppManager.isPlatformSupported()
+        && ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.LOCAL_APP) {
+      if (!LocalAppManager.isLocalAppInstalled()) {
+        allContentLayout.show(allContentPanel, "appNotInstalledPanel");
+        isChatVisible = false;
+      } else if (!LocalAppManager.isLocalAppRunning()) {
+        allContentLayout.show(allContentPanel, "appNotRunningPanel");
+        isChatVisible = false;
+      } else {
+        allContentLayout.show(allContentPanel, "tabbedPane");
+        isChatVisible = true;
+      }
+    } else {
+      allContentLayout.show(allContentPanel, "tabbedPane");
+      isChatVisible = true;
+    }
+  }
+
+  @NotNull
+  private JPanel createAppNotInstalledPanel() {
+    JPanel appNotInstalledPanel =
+        new ContentWithGradientBorder(ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
+    JEditorPane jEditorPane = HtmlViewer.createHtmlViewer(UIUtil.getPanelBackground());
+    jEditorPane.setText(
+        "<html><body><h2>Get Started</h2>"
+            + "<p>This plugin requires the Cody desktop app to enable context fetching for your private code."
+            + " Download and run the Cody desktop app to Configure your local code graph.</p><"
+            + "/body></html>");
+    appNotInstalledPanel.add(jEditorPane);
+    JButton downloadCodyAppButton = createMainButton("Download Cody App");
+    downloadCodyAppButton.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, Boolean.TRUE);
+    downloadCodyAppButton.addActionListener(
+        e -> {
+          BrowserUtil.browse("https://about.sourcegraph.com/app");
+          updateVisibilityOfContentPanels();
+        });
+    Border margin = JBUI.Borders.empty(TEXT_MARGIN);
+    jEditorPane.setBorder(margin);
+    appNotInstalledPanel.add(downloadCodyAppButton);
+    JPanel blankPanel = new JPanel();
+    blankPanel.setBorder(margin);
+    blankPanel.setOpaque(false);
+    appNotInstalledPanel.add(blankPanel);
+    JPanel wrapperAppNotInstalledPanel = new JPanel(new BorderLayout());
+    wrapperAppNotInstalledPanel.setBorder(margin);
+    wrapperAppNotInstalledPanel.add(appNotInstalledPanel, BorderLayout.NORTH);
+    return wrapperAppNotInstalledPanel;
+  }
+
+  @NotNull
+  private JPanel createAppNotRunningPanel() {
+    JPanel appNotRunningPanel =
+        new ContentWithGradientBorder(ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
+    JEditorPane jEditorPane = HtmlViewer.createHtmlViewer(UIUtil.getPanelBackground());
+    jEditorPane.setText(
+        "<html><body><h2>Cody App Not Running</h2>"
+            + "<p>This plugin requires the Cody desktop app to enable context fetching for your private code.</p><"
+            + "/body></html>");
+    appNotRunningPanel.add(jEditorPane);
+    JButton downloadCodyAppButton = createMainButton("Open Cody App");
+    downloadCodyAppButton.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, Boolean.TRUE);
+    downloadCodyAppButton.addActionListener(
+        e -> {
+          LocalAppManager.runLocalApp();
+          updateVisibilityOfContentPanels();
+        });
+    Border margin = JBUI.Borders.empty(TEXT_MARGIN);
+    jEditorPane.setBorder(margin);
+    appNotRunningPanel.add(downloadCodyAppButton);
+    JPanel blankPanel = new JPanel();
+    blankPanel.setBorder(margin);
+    blankPanel.setOpaque(false);
+    appNotRunningPanel.add(blankPanel);
+    JPanel wrapperAppNotInstalledPanel = new JPanel(new BorderLayout());
+    wrapperAppNotInstalledPanel.setBorder(margin);
+    wrapperAppNotInstalledPanel.add(appNotRunningPanel, BorderLayout.NORTH);
+    return wrapperAppNotInstalledPanel;
   }
 
   private void executeRecipeWithPromptProvider(
@@ -270,6 +371,15 @@ class CodyToolWindowContent implements UpdatableChat {
     JButton button = new JButton(text);
     button.setAlignmentX(Component.CENTER_ALIGNMENT);
     button.setMaximumSize(new Dimension(Integer.MAX_VALUE, button.getPreferredSize().height));
+    ButtonUI buttonUI = (ButtonUI) DarculaButtonUI.createUI(button);
+    button.setUI(buttonUI);
+    return button;
+  }
+
+  @NotNull
+  private static JButton createMainButton(@NotNull String text) {
+    JButton button = new JButton(text);
+    button.setAlignmentX(Component.CENTER_ALIGNMENT);
     ButtonUI buttonUI = (ButtonUI) DarculaButtonUI.createUI(button);
     button.setUI(buttonUI);
     return button;
@@ -436,6 +546,16 @@ class CodyToolWindowContent implements UpdatableChat {
               messagesPanel.revalidate();
               messagesPanel.repaint();
             });
+  }
+
+  @Override
+  public void refreshPanelsVisibility() {
+    this.updateVisibilityOfContentPanels();
+  }
+
+  @Override
+  public boolean isChatVisible() {
+    return this.isChatVisible;
   }
 
   private void sendMessage(@NotNull Project project) {
@@ -610,7 +730,7 @@ class CodyToolWindowContent implements UpdatableChat {
   }
 
   public @NotNull JComponent getContentPanel() {
-    return tabbedPane;
+    return allContentPanel;
   }
 
   public void focusPromptInput() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChat.java
@@ -20,5 +20,9 @@ public interface UpdatableChat {
 
   void resetConversation();
 
+  void refreshPanelsVisibility();
+
+  boolean isChatVisible();
+
   void activateChatTab();
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ContentWithGradientBorder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ContentWithGradientBorder.java
@@ -1,0 +1,53 @@
+package com.sourcegraph.cody.chat;
+
+import com.sourcegraph.cody.ui.Colors;
+import java.awt.GradientPaint;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
+
+public class ContentWithGradientBorder extends JPanel {
+  private final int gradientWidth;
+
+  public ContentWithGradientBorder(int gradientWidth) {
+    super();
+    this.gradientWidth = gradientWidth;
+    this.setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+  }
+
+  @Override
+  protected void paintComponent(@NotNull Graphics g) {
+    super.paintComponent(g);
+    paintBorderGradient(g);
+  }
+
+  private void paintBorderGradient(Graphics g) {
+    int panelHeight = getHeight();
+    int panelWidth = getWidth();
+    int halfOfHeight = panelHeight / 2;
+
+    GradientPaint firstPartGradient =
+        new GradientPaint(0, 0, Colors.PURPLE, 0, halfOfHeight, Colors.ORANGE);
+    GradientPaint secondPartGradient =
+        new GradientPaint(0, halfOfHeight, Colors.ORANGE, 0, panelHeight, Colors.CYAN);
+    final Graphics2D g2d = (Graphics2D) g;
+    // top border
+    g2d.setPaint(Colors.PURPLE);
+    g2d.fillRect(0, 0, panelWidth, gradientWidth);
+    // left border
+    g2d.setPaint(firstPartGradient);
+    g2d.fillRect(0, 0, gradientWidth, halfOfHeight);
+    g2d.setPaint(secondPartGradient);
+    g2d.fillRect(0, halfOfHeight, gradientWidth, panelHeight);
+    // right border
+    g2d.setPaint(firstPartGradient);
+    g2d.fillRect(panelWidth - gradientWidth, 0, gradientWidth, halfOfHeight);
+    g2d.setPaint(secondPartGradient);
+    g2d.fillRect(panelWidth - gradientWidth, halfOfHeight, gradientWidth, panelHeight);
+    // bottom border
+    g2d.setPaint(Colors.CYAN);
+    g2d.fillRect(0, panelHeight - gradientWidth, panelWidth, gradientWidth);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -1,31 +1,27 @@
 package com.sourcegraph.cody.chat;
 
-import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
-
 import com.intellij.ide.highlighter.HighlighterFactory;
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.EditorSettings;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
-import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.highlighter.EditorHighlighter;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
-import com.intellij.ui.BrowserHyperlinkListener;
 import com.intellij.ui.ColorUtil;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.SwingHelper;
 import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.cody.api.Speaker;
+import com.sourcegraph.cody.ui.HtmlViewer;
 import java.awt.*;
 import java.util.List;
 import java.util.Optional;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.text.html.HTMLEditorKit;
 import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.node.*;
 import org.commonmark.node.Image;
@@ -48,30 +44,12 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
     this.messagePanel = messagePanel;
     this.speaker = speaker;
     this.gradientWidth = gradientWidth;
-    textPane = createNewEmptyTextPane();
+    createNewEmptyTextPane();
   }
 
-  @NotNull
-  private JEditorPane createNewEmptyTextPane() {
-    JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
-    jEditorPane.setEditorKit(new UIUtil.JBWordWrapHtmlEditorKit());
-    HTMLEditorKit htmlEditorKit = (HTMLEditorKit) jEditorPane.getEditorKit();
-    EditorColorsScheme schemeForCurrentUITheme =
-        EditorColorsManager.getInstance().getSchemeForCurrentUITheme();
-    String editorFontName = schemeForCurrentUITheme.getEditorFontName();
-    int editorFontSize = schemeForCurrentUITheme.getEditorFontSize();
-    String fontFamilyAndSize =
-        "font-family:'" + editorFontName + "'; font-size:" + editorFontSize + "pt;";
-    String backgroundColor =
-        "background-color: #" + ColorUtil.toHex(getInlineCodeBackgroundColor()) + ";";
-    htmlEditorKit.getStyleSheet().addRule("code { " + backgroundColor + fontFamilyAndSize + "}");
-    jEditorPane.setFocusable(true);
-    jEditorPane.setMargin(
-        JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
-    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE);
-    textPane = jEditorPane;
+  private void createNewEmptyTextPane() {
+    textPane = HtmlViewer.createHtmlViewer(getInlineCodeBackgroundColor());
     messagePanel.add(textPane, textPaneIndex++);
-    return jEditorPane;
   }
 
   @NotNull
@@ -145,7 +123,7 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
     editorPanel.setOpaque(false);
     messagePanel.add(editorPanel, BorderLayout.CENTER, textPaneIndex++);
     htmlContent = new StringBuilder();
-    textPane = createNewEmptyTextPane();
+    createNewEmptyTextPane();
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/RefreshCodyAppDetection.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/RefreshCodyAppDetection.java
@@ -1,43 +1,39 @@
 package com.sourcegraph.cody.chat;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.UpdatableChat;
 import com.sourcegraph.cody.UpdatableChatHolderService;
-import com.sourcegraph.common.ErrorNotification;
 import org.jetbrains.annotations.NotNull;
 
-public class ResetCurrentConversationAction extends DumbAwareAction {
+public class RefreshCodyAppDetection extends DumbAwareAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
     Project project = e.getProject();
     if (project == null) {
-      displayUnableToResetConversationError();
       return;
     }
     UpdatableChatHolderService updatableChatHolderService =
-        ServiceManager.getService(project, UpdatableChatHolderService.class);
+        project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-    updatableChat.resetConversation();
+    updatableChat.refreshPanelsVisibility();
   }
 
+  /**
+   * This action is being updated in the background by the intellij action system, and we're using
+   * it to show one of the selected panels in the Cody
+   */
   @Override
   public void update(@NotNull AnActionEvent e) {
+    e.getPresentation().setVisible(false);
     Project project = e.getProject();
     if (project != null) {
       UpdatableChatHolderService updatableChatHolderService =
           project.getService(UpdatableChatHolderService.class);
       UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-      e.getPresentation().setVisible(updatableChat.isChatVisible());
+      updatableChat.refreshPanelsVisibility();
     }
-  }
-
-  private static void displayUnableToResetConversationError() {
-    ErrorNotification.show(
-        null,
-        "Unable to reset the current conversation with Cody. Please try again or reach out to us at support@sourcegraph.com.");
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Responsible for triggering and clearing inline code completions. */
 public class CodyCompletionsManager {
@@ -40,7 +41,7 @@ public class CodyCompletionsManager {
   }
 
   @RequiresEdt
-  public void clearCompletions(Editor editor) {
+  public void clearCompletions(@NotNull Editor editor) {
     cancelCurrentJob();
     for (Inlay<?> inlay :
         editor.getInlayModel().getInlineElementsInRange(0, editor.getDocument().getTextLength())) {
@@ -59,7 +60,7 @@ public class CodyCompletionsManager {
         && isEditorSupported(editor);
   }
 
-  public void triggerCompletion(Editor editor, int offset) {
+  public void triggerCompletion(@NotNull Editor editor, int offset) {
     if (!ConfigUtil.areCodyCompletionsEnabled()) {
       return;
     }
@@ -98,8 +99,9 @@ public class CodyCompletionsManager {
     }
   }
 
-  public static InlineCompletionItem postProcessInlineCompletionBasedOnDocumentContext(
-      InlineCompletionItem resultItem, CompletionDocumentContext documentCompletionContext) {
+  public static @NotNull InlineCompletionItem postProcessInlineCompletionBasedOnDocumentContext(
+      @NotNull InlineCompletionItem resultItem,
+      @NotNull CompletionDocumentContext documentCompletionContext) {
     String sameLineSuffix = documentCompletionContext.getSameLineSuffix();
     if (resultItem.insertText.endsWith(sameLineSuffix)) {
       // if the completion already has the same line suffix, we strip it
@@ -126,12 +128,12 @@ public class CodyCompletionsManager {
   }
 
   private CompletableFuture<Void> triggerCompletionAsync(
-      Editor editor,
+      @NotNull Editor editor,
       int offset,
-      CancellationToken token,
-      CodyCompletionItemProvider provider,
-      TextDocument textDocument,
-      CompletionDocumentContext documentCompletionContext) {
+      @NotNull CancellationToken token,
+      @NotNull CodyCompletionItemProvider provider,
+      @NotNull TextDocument textDocument,
+      @NotNull CompletionDocumentContext documentCompletionContext) {
     return provider
         .provideInlineCompletions(
             textDocument,
@@ -188,7 +190,7 @@ public class CodyCompletionsManager {
   }
 
   // TODO: handle tabs in multiline completions when we add them
-  public static InlineCompletionItem normalizeIndentation(
+  public static @NotNull InlineCompletionItem normalizeIndentation(
       @NotNull InlineCompletionItem item,
       @NotNull CommonCodeStyleSettings.IndentOptions indentOptions) {
     if (item.insertText.matches("^[\t ]*.+")) {
@@ -205,7 +207,8 @@ public class CodyCompletionsManager {
     } else return item;
   }
 
-  public static InlineCompletionItem removeUndesiredCharacters(InlineCompletionItem item) {
+  public static @NotNull InlineCompletionItem removeUndesiredCharacters(
+      @NotNull InlineCompletionItem item) {
     // no zero-width spaces or line separator chars, pls
     String newInsertText = item.insertText.replaceAll("[\u200b\u2028]", "");
     int rangeDiff = item.insertText.length() - newInsertText.length();
@@ -218,7 +221,7 @@ public class CodyCompletionsManager {
     return project != null && !project.isDisposed();
   }
 
-  private boolean isEditorSupported(Editor editor) {
+  private boolean isEditorSupported(@NotNull Editor editor) {
     if (editor.isDisposed()) {
       return false;
     }
@@ -235,7 +238,7 @@ public class CodyCompletionsManager {
     return isSupported;
   }
 
-  public static boolean isEditorInstanceSupported(Editor editor) {
+  public static boolean isEditorInstanceSupported(@NotNull Editor editor) {
     return !editor.isViewer()
         && !editor.isOneLineMode()
         && !(editor instanceof EditorWindow)
@@ -243,28 +246,24 @@ public class CodyCompletionsManager {
         && (!(editor instanceof EditorEx) || !((EditorEx) editor).isEmbeddedIntoDialogWrapper());
   }
 
-  private CompletionsService completionsService(Editor editor) {
-    Project project = editor.getProject();
-    String srcEndpoint = System.getenv("SRC_ENDPOINT");
+  @Nullable
+  private CompletionsService completionsService(@NotNull Editor editor) {
+    Optional<Project> project = Optional.ofNullable(editor.getProject());
     String instanceUrl =
-        srcEndpoint != null
-            ? srcEndpoint
-            : Optional.ofNullable(project)
-                .map(ConfigUtil::getSourcegraphUrl)
-                .orElse(ConfigUtil.DOTCOM_URL); // fallback to dotcom in case Project is null
-    String accessToken = ConfigUtil.getProjectAccessToken(project);
-    if (!instanceUrl.endsWith("/")) {
-      instanceUrl = instanceUrl + "/";
+        Optional.ofNullable(System.getenv("SRC_ENDPOINT"))
+            .or(() -> project.map(ConfigUtil::getSourcegraphUrl))
+            .map(url -> url.endsWith("/") ? url : url + "/")
+            .orElse(ConfigUtil.DOTCOM_URL);
+    Optional<String> accessToken =
+        Optional.ofNullable(System.getenv("SRC_ACCESS_TOKEN"))
+            .or(
+                () ->
+                    project.flatMap(p -> Optional.ofNullable(ConfigUtil.getProjectAccessToken(p))))
+            .filter(StringUtils::isNotEmpty);
+    if (accessToken.isEmpty() && !ConfigUtil.isAccessTokenNotificationDismissed()) {
+      NotificationActivity.notifyAboutSourcegraphAccessToken(Optional.of(instanceUrl));
     }
-    if (accessToken == null) {
-      accessToken = System.getenv("SRC_ACCESS_TOKEN");
-    }
-    if (StringUtils.isEmpty(accessToken)) {
-      if (!ConfigUtil.isAccessTokenNotificationDismissed())
-        NotificationActivity.notifyAboutSourcegraphAccessToken(Optional.of(instanceUrl));
-      return null;
-    }
-    return new CompletionsService(instanceUrl, accessToken);
+    return accessToken.map(token -> new CompletionsService(instanceUrl, token)).orElse(null);
   }
 
   private void cancelCurrentJob() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyEditorFactoryListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyEditorFactoryListener.java
@@ -83,7 +83,7 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
   private static class CodyDocumentListener implements BulkAwareDocumentListener {
     private final Editor editor;
 
-    public CodyDocumentListener(Editor editor) {
+    public CodyDocumentListener(@NotNull Editor editor) {
       this.editor = editor;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -33,7 +33,7 @@ public class LocalAppManager {
                       + "/Library/Application Support/com.sourcegraph.cody/app.json")));
 
   public static boolean isLocalAppInstalled() {
-    return getLocalAppPaths().map(LocalAppPaths::anyPathExists).orElse(false);
+    return getLocalAppPaths().map(LocalAppPaths::isCodyInstalled).orElse(false);
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.localapp;
 
+import com.intellij.ide.BrowserUtil;
 import com.sourcegraph.common.AuthorizationUtil;
 import java.awt.*;
 import java.io.File;
@@ -120,5 +121,9 @@ public class LocalAppManager {
                 e.printStackTrace();
               }
             });
+  }
+
+  public static void browseLocalAppInstallPage() {
+    BrowserUtil.browse("https://about.sourcegraph.com/app");
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -1,6 +1,9 @@
 package com.sourcegraph.cody.localapp;
 
 import com.sourcegraph.common.AuthorizationUtil;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
 import java.net.ConnectException;
 import java.nio.file.Path;
 import java.util.Map;
@@ -103,5 +106,19 @@ public class LocalAppManager {
       e.printStackTrace();
       return Optional.empty();
     }
+  }
+
+  public static void runLocalApp() {
+    System.out.println("Running local Cody app...");
+    getLocalAppPaths()
+        .filter(paths -> !isLocalAppRunning()) // only run the app if it's not already running
+        .ifPresent(
+            p -> {
+              try {
+                Desktop.getDesktop().open(new File(p.codyAppFile.toString()));
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            });
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -27,7 +27,7 @@ public class LocalAppManager {
               Path.of("/Applications/Cody.app"),
               Path.of(
                   SystemUtils.getUserHome()
-                      + "/Library/Application Support/com.sourcegraph.cody/site.config.json"),
+                      + "/Library/Application Support/com.sourcegraph.cody/site-config.json"),
               Path.of(
                   SystemUtils.getUserHome()
                       + "/Library/Application Support/com.sourcegraph.cody/app.json")));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
@@ -27,6 +27,10 @@ public class LocalAppPaths {
         || pathExists(appJsonFile);
   }
 
+  public boolean isCodyInstalled() {
+    return pathExists(codyAppFile);
+  }
+
   private static boolean pathExists(Path path) {
     try {
       return path.toFile().exists();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/ui/HtmlViewer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/ui/HtmlViewer.java
@@ -1,0 +1,38 @@
+package com.sourcegraph.cody.ui;
+
+import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
+
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.ui.BrowserHyperlinkListener;
+import com.intellij.ui.ColorUtil;
+import com.intellij.util.ui.JBInsets;
+import com.intellij.util.ui.SwingHelper;
+import com.intellij.util.ui.UIUtil;
+import java.awt.Color;
+import java.awt.Insets;
+import javax.swing.JEditorPane;
+import javax.swing.text.html.HTMLEditorKit;
+import org.jetbrains.annotations.NotNull;
+
+public class HtmlViewer {
+  @NotNull
+  public static JEditorPane createHtmlViewer(@NotNull Color backgroundColor) {
+    JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
+    jEditorPane.setEditorKit(new UIUtil.JBWordWrapHtmlEditorKit());
+    HTMLEditorKit htmlEditorKit = (HTMLEditorKit) jEditorPane.getEditorKit();
+    EditorColorsScheme schemeForCurrentUITheme =
+        EditorColorsManager.getInstance().getSchemeForCurrentUITheme();
+    String editorFontName = schemeForCurrentUITheme.getEditorFontName();
+    int editorFontSize = schemeForCurrentUITheme.getEditorFontSize();
+    String fontFamilyAndSize =
+        "font-family:'" + editorFontName + "'; font-size:" + editorFontSize + "pt;";
+    String backgroundColorCss = "background-color: #" + ColorUtil.toHex(backgroundColor) + ";";
+    htmlEditorKit.getStyleSheet().addRule("code { " + backgroundColorCss + fontFamilyAndSize + "}");
+    jEditorPane.setFocusable(true);
+    jEditorPane.setMargin(
+        JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
+    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE);
+    return jEditorPane;
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -62,7 +62,7 @@ public class ConfigUtil {
                             return Optional.empty();
                           }
                         }))
-        .orElse(SettingsComponent.InstanceType.ENTERPRISE); // or default
+        .orElse(SettingsComponent.getDefaultInstanceType()); // or default
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -41,7 +41,7 @@ public class ConfigUtil {
   }
 
   @NotNull
-  public static SettingsComponent.InstanceType getInstanceType(Project project) {
+  public static SettingsComponent.InstanceType getInstanceType(@NotNull Project project) {
     return Optional.ofNullable(getProjectLevelConfig(project).getInstanceType()) // Project level
         .flatMap(SettingsComponent.InstanceType::optionalValueOf)
         .or( // Application level
@@ -276,7 +276,7 @@ public class ConfigUtil {
   }
 
   @Nullable
-  public static String getProjectAccessToken(Project project) {
+  public static String getProjectAccessToken(@NotNull Project project) {
     SettingsComponent.InstanceType instanceType = ConfigUtil.getInstanceType(project);
     if (instanceType == SettingsComponent.InstanceType.ENTERPRISE) {
       return getEnterpriseAccessToken(project);
@@ -290,18 +290,14 @@ public class ConfigUtil {
   @Nullable
   public static String getEnterpriseAccessToken(Project project) {
     // Project level → application level
-    String projectLevelAccessToken = getProjectLevelConfig(project).getEnterpriseAccessToken();
-    return projectLevelAccessToken != null
-        ? projectLevelAccessToken
-        : getApplicationLevelConfig().getEnterpriseAccessToken();
+    return Optional.ofNullable(getProjectLevelConfig(project).getEnterpriseAccessToken())
+        .orElse(getApplicationLevelConfig().getEnterpriseAccessToken());
   }
 
   @Nullable
-  public static String getDotComAccessToken(Project project) {
+  public static String getDotComAccessToken(@NotNull Project project) {
     // Project level → application level
-    String projectLevelAccessToken = getProjectLevelConfig(project).getDotComAccessToken();
-    return projectLevelAccessToken != null
-        ? projectLevelAccessToken
-        : getApplicationLevelConfig().getDotComAccessToken();
+    return Optional.ofNullable(getProjectLevelConfig(project).getDotComAccessToken())
+        .orElse(getApplicationLevelConfig().getDotComAccessToken());
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -182,7 +182,6 @@ public class SettingsComponent {
         FormBuilder.createFormBuilder()
             .addComponent(codyAppRadioButton, 1)
             .addComponent(codyAppComment, 2)
-            //            .addComponent(codyAppPanelContent, 1)
             .getPanel();
     JBLabel dotComComment =
         new JBLabel(

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -163,6 +163,7 @@ public class SettingsComponent {
     boolean isLocalAppInstalled = LocalAppManager.isLocalAppInstalled();
     boolean isLocalAppAccessTokenConfigured = LocalAppManager.getLocalAppAccessToken().isPresent();
     boolean isLocalAppRunning = LocalAppManager.isLocalAppRunning();
+    boolean isLocalAppPlatformSupported = LocalAppManager.isPlatformSupported();
     JRadioButton codyAppRadioButton = new JRadioButton("Use the local Cody App");
     codyAppRadioButton.setMnemonic(KeyEvent.VK_A);
     codyAppRadioButton.setActionCommand(InstanceType.LOCAL_APP.name());
@@ -181,22 +182,26 @@ public class SettingsComponent {
     instanceTypeButtonGroup.add(sourcegraphDotComRadioButton);
     instanceTypeButtonGroup.add(enterpriseInstanceRadioButton);
 
-    // Assemble the three main panels
+    // Assemble the three main panels String platformName =
+    String platformName =
+        Optional.ofNullable(System.getProperty("os.name")).orElse("Your platform");
+    String codyAppCommentText =
+        isLocalAppPlatformSupported
+            ? "Use Sourcegraph through the locally installed Cody App."
+            : platformName
+                + " is not yet supported by the local Cody App. Keep an eye on future updates!";
     JBLabel codyAppComment =
-        new JBLabel(
-            "Use Sourcegraph through the locally installed Cody App.",
-            UIUtil.ComponentStyle.SMALL,
-            UIUtil.FontColor.BRIGHTER);
+        new JBLabel(codyAppCommentText, UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     boolean shouldShowInstallLocalAppLink =
-        !isLocalAppInstalled && LocalAppManager.isPlatformSupported();
-      JLabel installLocalAppComment =
-          new JBLabel(
-              "The local Cody App wasn't detected on this system, it seems it hasn't been installed yet.",
-              UIUtil.ComponentStyle.SMALL,
-              UIUtil.FontColor.BRIGHTER);
-      installLocalAppComment.setVisible(shouldShowInstallLocalAppLink);
-      installLocalAppComment.setBorder(JBUI.Borders.emptyLeft(20));
+        !isLocalAppInstalled && isLocalAppPlatformSupported;
+    JLabel installLocalAppComment =
+        new JBLabel(
+            "The local Cody App wasn't detected on this system, it seems it hasn't been installed yet.",
+            UIUtil.ComponentStyle.SMALL,
+            UIUtil.FontColor.BRIGHTER);
+    installLocalAppComment.setVisible(shouldShowInstallLocalAppLink);
+    installLocalAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     ActionLink installLocalAppLink =
         simpleActionLink("Install Cody App...", LocalAppManager::browseLocalAppInstallPage);
     installLocalAppLink.setVisible(shouldShowInstallLocalAppLink);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComponentValidator;
 import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.components.ActionLink;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
@@ -148,14 +149,13 @@ public class SettingsComponent {
             setInstanceSettingsEnabled(
                 InstanceType.optionalValueOf(event.getActionCommand())
                     .orElse(InstanceType.ENTERPRISE));
+    boolean isLocalAppInstalled = LocalAppManager.isLocalAppInstalled();
+    boolean isLocalAppAccessTokenConfigured = LocalAppManager.getLocalAppAccessToken().isPresent();
     JRadioButton codyAppRadioButton = new JRadioButton("Use the local Cody App");
-    boolean isCodyAppInstalledAndConfigured =
-        LocalAppManager.isLocalAppInstalled()
-            && LocalAppManager.getLocalAppAccessToken().isPresent();
     codyAppRadioButton.setMnemonic(KeyEvent.VK_A);
     codyAppRadioButton.setActionCommand(InstanceType.LOCAL_APP.name());
     codyAppRadioButton.addActionListener(actionListener);
-    codyAppRadioButton.setEnabled(isCodyAppInstalledAndConfigured);
+    codyAppRadioButton.setEnabled(isLocalAppInstalled && isLocalAppAccessTokenConfigured);
     JRadioButton sourcegraphDotComRadioButton = new JRadioButton("Use sourcegraph.com");
     sourcegraphDotComRadioButton.setMnemonic(KeyEvent.VK_C);
     sourcegraphDotComRadioButton.setActionCommand(InstanceType.DOTCOM.name());
@@ -170,18 +170,26 @@ public class SettingsComponent {
     instanceTypeButtonGroup.add(enterpriseInstanceRadioButton);
 
     // Assemble the three main panels
-
     JBLabel codyAppComment =
         new JBLabel(
             "Use Sourcegraph through the locally installed Cody App",
             UIUtil.ComponentStyle.SMALL,
             UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
-    codyAppComment.setEnabled(isCodyAppInstalledAndConfigured);
+    ActionLink installLocalAppLink =
+        new ActionLink(
+            "Download Cody App...",
+            e -> {
+              LocalAppManager.browseLocalAppInstallPage();
+            });
+    installLocalAppLink.setVisible(!isLocalAppInstalled);
+    installLocalAppLink.setBorder(JBUI.Borders.emptyLeft(20));
+    installLocalAppLink.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
     JPanel codyAppPanel =
         FormBuilder.createFormBuilder()
             .addComponent(codyAppRadioButton, 1)
             .addComponent(codyAppComment, 2)
+            .addComponent(installLocalAppLink, 2)
             .getPanel();
     JBLabel dotComComment =
         new JBLabel(

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -193,8 +193,7 @@ public class SettingsComponent {
     JBLabel codyAppComment =
         new JBLabel(codyAppCommentText, UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
-    boolean shouldShowInstallLocalAppLink =
-        !isLocalAppInstalled && isLocalAppPlatformSupported;
+    boolean shouldShowInstallLocalAppLink = !isLocalAppInstalled && isLocalAppPlatformSupported;
     JLabel installLocalAppComment =
         new JBLabel(
             "The local Cody App wasn't detected on this system, it seems it hasn't been installed yet.",

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -69,10 +69,16 @@ public class SettingsComponent {
     return panel;
   }
 
+  public static InstanceType getDefaultInstanceType() {
+    return LocalAppManager.isLocalAppInstalled() && LocalAppManager.isPlatformSupported()
+        ? InstanceType.LOCAL_APP
+        : InstanceType.DOTCOM;
+  }
+
   @NotNull
   public InstanceType getInstanceType() {
     return InstanceType.optionalValueOf(instanceTypeButtonGroup.getSelection().getActionCommand())
-        .orElse(InstanceType.ENTERPRISE);
+        .orElse(getDefaultInstanceType());
   }
 
   public void setInstanceType(@NotNull InstanceType instanceType) {
@@ -159,7 +165,7 @@ public class SettingsComponent {
         event ->
             setInstanceSettingsEnabled(
                 InstanceType.optionalValueOf(event.getActionCommand())
-                    .orElse(InstanceType.ENTERPRISE));
+                    .orElse(getDefaultInstanceType()));
     boolean isLocalAppInstalled = LocalAppManager.isLocalAppInstalled();
     boolean isLocalAppAccessTokenConfigured = LocalAppManager.getLocalAppAccessToken().isPresent();
     boolean isLocalAppRunning = LocalAppManager.isLocalAppRunning();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -184,14 +184,21 @@ public class SettingsComponent {
     // Assemble the three main panels
     JBLabel codyAppComment =
         new JBLabel(
-            "Use Sourcegraph through the locally installed Cody App",
+            "Use Sourcegraph through the locally installed Cody App.",
             UIUtil.ComponentStyle.SMALL,
             UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     boolean shouldShowInstallLocalAppLink =
         !isLocalAppInstalled && LocalAppManager.isPlatformSupported();
+      JLabel installLocalAppComment =
+          new JBLabel(
+              "The local Cody App wasn't detected on this system, it seems it hasn't been installed yet.",
+              UIUtil.ComponentStyle.SMALL,
+              UIUtil.FontColor.BRIGHTER);
+      installLocalAppComment.setVisible(shouldShowInstallLocalAppLink);
+      installLocalAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     ActionLink installLocalAppLink =
-        simpleActionLink("Download Cody App...", LocalAppManager::browseLocalAppInstallPage);
+        simpleActionLink("Install Cody App...", LocalAppManager::browseLocalAppInstallPage);
     installLocalAppLink.setVisible(shouldShowInstallLocalAppLink);
     installLocalAppLink.setBorder(JBUI.Borders.emptyLeft(20));
     boolean shouldShowRunLocalAppLink = isLocalAppInstalled && !isLocalAppRunning;
@@ -209,6 +216,7 @@ public class SettingsComponent {
         FormBuilder.createFormBuilder()
             .addComponent(codyAppRadioButton, 1)
             .addComponent(codyAppComment, 2)
+            .addComponent(installLocalAppComment, 2)
             .addComponent(installLocalAppLink, 2)
             .addComponent(runLocalAppComment, 2)
             .addComponent(runLocalAppLink, 2)

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -132,8 +132,14 @@
                 class="com.sourcegraph.cody.chat.ResetCurrentConversationAction">
         </action>
 
+        <action id="cody.refreshCodyAppDetection" icon="AllIcons.Actions.Refresh"
+                text="Refresh"
+                class="com.sourcegraph.cody.chat.RefreshCodyAppDetection" internal="true">
+        </action>
+
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>
+            <reference ref="cody.refreshCodyAppDetection"/>
         </group>
 
         <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Sourcegraph"


### PR DESCRIPTION
Show onboarding messages when cody app is not installed/running 
## Test plan
- When Cody app is not installed and user selected local app in the settings we should see information with the link to download Cody app
- When Cody app is installed but not running we should see the link to Open the Cody app
- Panel automatically changes when Cody app is closed/opened or installed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
