### PR TITLE
embeddings: apply model transformations

### DIFF
--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -69,7 +69,7 @@ func embedQueries(queries []string, siteConfigPath string) error {
 		if err != nil {
 			return err
 		}
-		v, err := c.GetEmbeddingsWithRetries(ctx, []string{query}, 0)
+		v, err := c.GetQueryEmbeddingWithRetries(ctx, query, 0)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get embeddings for query %s", query)
 		}

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -176,7 +176,7 @@ func getQueryEmbedding(ctx context.Context, query string) ([]float32, string, er
 		return nil, "", errors.Wrap(err, "getting embeddings client")
 	}
 
-	floatQuery, err := client.GetEmbeddingsWithRetries(ctx, []string{query}, queryEmbeddingRetries)
+	floatQuery, err := client.GetQueryEmbeddingWithRetries(ctx, query, queryEmbeddingRetries)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting query embedding")
 	}

--- a/enterprise/internal/embeddings/embed/client/client.go
+++ b/enterprise/internal/embeddings/embed/client/client.go
@@ -6,8 +6,10 @@ import (
 )
 
 type EmbeddingsClient interface {
-	// GetEmbeddingsWithRetries returns embeddings for the given texts.
-	GetEmbeddingsWithRetries(ctx context.Context, texts []string, maxRetries int) ([]float32, error)
+	// GetQueryEmbeddingWithRetries returns embedding for the given query.
+	GetQueryEmbeddingWithRetries(ctx context.Context, query string, maxRetries int) ([]float32, error)
+	// GetDocumentEmbeddingsWithRetries returns embeddings for the documents.
+	GetDocumentEmbeddingsWithRetries(ctx context.Context, documents []string, maxRetries int) ([]float32, error)
 	// GetDimensions returns the dimensionality of the embedding space.
 	GetDimensions() (int, error)
 	// GetModelIdentifier returns the identifier of the model used to generate embeddings. The format is

--- a/enterprise/internal/embeddings/embed/client/modeltransformations/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/client/modeltransformations/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "modeltransformations",
+    srcs = ["model_transformations.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed/client/modeltransformations",
+    visibility = ["//enterprise:__subpackages__"],
+)
+
+go_test(
+    name = "modeltransformations_test",
+    srcs = ["model_transformations_test.go"],
+    embed = [":modeltransformations"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/enterprise/internal/embeddings/embed/client/modeltransformations/model_transformations.go
+++ b/enterprise/internal/embeddings/embed/client/modeltransformations/model_transformations.go
@@ -1,0 +1,43 @@
+package modeltransformations
+
+import "strings"
+
+// Replace newlines for certain (OpenAI) models, because they can negatively affect performance.
+var modelsWithoutNewlines = map[string]struct{}{
+	"openai/text-embedding-ada-002": {},
+}
+
+const E5_QUERY_PREFIX = "query: "
+const E5_DOCUMENT_PREFIX = "passage: "
+
+func isE5LikeModel(model string) bool {
+	return strings.HasPrefix(model, "sourcegraph/scout") || strings.HasPrefix(model, "sourcegraph/e5")
+}
+
+func ApplyModelTransformationsForQuery(query string, model string) string {
+	transformedQuery := query
+	if isE5LikeModel(model) {
+		transformedQuery = E5_QUERY_PREFIX + query
+	}
+	_, replaceNewlines := modelsWithoutNewlines[model]
+	if replaceNewlines {
+		transformedQuery = strings.ReplaceAll(transformedQuery, "\n", " ")
+	}
+	return transformedQuery
+}
+
+func ApplyModelTransformationsForDocuments(documents []string, model string) []string {
+	_, replaceNewlines := modelsWithoutNewlines[model]
+	hasE5Prefix := isE5LikeModel(model)
+
+	transformedDocuments := documents
+	for idx, text := range transformedDocuments {
+		if hasE5Prefix {
+			transformedDocuments[idx] = E5_DOCUMENT_PREFIX + text
+		}
+		if replaceNewlines {
+			transformedDocuments[idx] = strings.ReplaceAll(text, "\n", " ")
+		}
+	}
+	return transformedDocuments
+}

--- a/enterprise/internal/embeddings/embed/client/modeltransformations/model_transformations_test.go
+++ b/enterprise/internal/embeddings/embed/client/modeltransformations/model_transformations_test.go
@@ -1,0 +1,38 @@
+package modeltransformations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const query = "query1\nquery2\nquery3"
+
+var documents = []string{
+	"line1\nline2\nline3",
+	"line4\nline5\nline6",
+}
+
+func TestOpenAIModel(t *testing.T) {
+	transformedQuery := ApplyModelTransformationsForQuery(query, "openai/text-embedding-ada-002")
+	require.Equal(t, "query1 query2 query3", transformedQuery)
+
+	transformedDocuments := ApplyModelTransformationsForDocuments(documents, "openai/text-embedding-ada-002")
+	require.Equal(t, []string{"line1 line2 line3", "line4 line5 line6"}, transformedDocuments)
+}
+
+func TestE5LikeModel(t *testing.T) {
+	transformedQuery := ApplyModelTransformationsForQuery(query, "sourcegraph/scout-base-v2")
+	require.Equal(t, "query: query1\nquery2\nquery3", transformedQuery)
+
+	transformedDocuments := ApplyModelTransformationsForDocuments(documents, "sourcegraph/scout-base-v2")
+	require.Equal(t, []string{"passage: line1\nline2\nline3", "passage: line4\nline5\nline6"}, transformedDocuments)
+}
+
+func TestModelWithoutTransformations(t *testing.T) {
+	transformedQuery := ApplyModelTransformationsForQuery(query, "no-transform")
+	require.Equal(t, query, transformedQuery)
+
+	transformedDocuments := ApplyModelTransformationsForDocuments(documents, "no-transform")
+	require.Equal(t, documents, transformedDocuments)
+}

--- a/enterprise/internal/embeddings/embed/client/openai/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/client/openai/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed/client/openai",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
+        "//enterprise/internal/embeddings/embed/client/modeltransformations",
         "//internal/conf/conftypes",
         "//lib/errors",
     ],

--- a/enterprise/internal/embeddings/embed/client/openai/client_test.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client_test.go
@@ -8,15 +8,16 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
 func TestOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
 		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
 		invalidTexts := []string{"a", ""} // empty string is invalid
-		_, err := client.GetEmbeddingsWithRetries(context.Background(), invalidTexts, 10)
+		_, err := client.GetDocumentEmbeddingsWithRetries(context.Background(), invalidTexts, 10)
 		require.ErrorContains(t, err, "empty string")
 	})
 
@@ -67,7 +68,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		resp, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		resp, err := client.GetDocumentEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
 		require.NoError(t, err)
 		var expected []float32
 		{
@@ -119,7 +120,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		_, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		_, err := client.GetDocumentEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
 		require.Error(t, err, "expected request to error on failed retry")
 	})
 }

--- a/enterprise/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//enterprise:__subpackages__"],
     deps = [
         "//enterprise/internal/embeddings/embed/client",
+        "//enterprise/internal/embeddings/embed/client/modeltransformations",
         "//internal/codygateway",
         "//internal/conf/conftypes",
         "//internal/httpcli",

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -185,7 +185,7 @@ func embedFiles(
 			index.Ranks = append(index.Ranks, float32(repoPathRanks.Paths[chunk.FileName]))
 		}
 
-		batchEmbeddings, err := client.GetEmbeddingsWithRetries(ctx, batchChunks, getEmbeddingsMaxRetries)
+		batchEmbeddings, err := client.GetDocumentEmbeddingsWithRetries(ctx, batchChunks, getEmbeddingsMaxRetries)
 		if err != nil {
 			return errors.Wrap(err, "error while getting embeddings")
 		}

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -298,7 +298,15 @@ func (c *mockEmbeddingsClient) GetModelIdentifier() string {
 	return "mock/some-model"
 }
 
-func (c *mockEmbeddingsClient) GetEmbeddingsWithRetries(_ context.Context, texts []string, _ int) ([]float32, error) {
+func (c *mockEmbeddingsClient) GetQueryEmbeddingWithRetries(_ context.Context, query string, _ int) ([]float32, error) {
+	dimensions, err := c.GetDimensions()
+	if err != nil {
+		return nil, err
+	}
+	return make([]float32, dimensions), nil
+}
+
+func (c *mockEmbeddingsClient) GetDocumentEmbeddingsWithRetries(_ context.Context, texts []string, _ int) ([]float32, error) {
 	dimensions, err := c.GetDimensions()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add support for model-specific transformations. We have to:

* replace newlines with spaces for OpenAI (already implemented)
* add query-specific and document (code chunk)-specific prefixes for the E5 family of models.

## Test plan

* Embed with the OpenAI model and confirm the search still works.
* Embed with the Scout model and confirm the search still works.