### PR TITLE
App - update extension statuses

### DIFF
--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -23,22 +23,24 @@ enum ExtensionStatus {
     Beta = 'Beta',
     ComingSoon = 'Coming soon',
     Unknown = 'Unknown',
+    Experimental = 'Experimental',
+    GA = '',
 }
 
 const EXTENSIONS: Extension[] = [
     {
         name: 'Visual Studio Code',
-        status: ExtensionStatus.Beta,
+        status: ExtensionStatus.GA,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/vscode-icon.png',
         docLink: null,
         extensionDeepLink: 'vscode:extension/sourcegraph.cody-ai',
     },
     {
         name: 'IntelliJ Idea',
-        status: ExtensionStatus.ComingSoon,
+        status: ExtensionStatus.Experimental,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/idea-icon.png',
         docLink: null,
-        extensionDeepLink: null,
+        extensionDeepLink: 'https://plugins.jetbrains.com/plugin/9682-sourcegraph',
     },
     {
         name: 'NeoVim',
@@ -128,6 +130,7 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
 function getBadgeStatus(status: ExtensionStatus): BadgeVariantType {
     switch (status) {
         case ExtensionStatus.Beta:
+        case ExtensionStatus.Experimental:
             return 'secondary'
         case ExtensionStatus.ComingSoon:
             return 'outlineSecondary'


### PR DESCRIPTION
Removes the Beta label from VS Code extension and includes link to IntelliJ with experimental label 
## Test plan
<img width="1052" alt="Screenshot 2023-06-27 at 12 00 00 PM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/52a0fa31-1129-4f90-9bad-251d90a3def2">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
