### PR TITLE
Revert "Cody: Add warning message for recipes (#54025)"

### DIFF
--- a/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-detailed.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -18,14 +18,6 @@ export class ExplainCodeDetailed implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
 
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Please explain the following ${languageName} code. Be very detailed and specific, and indicate when it is not clear to you what is going on. Format your response as an ordered list.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`

--- a/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
+++ b/client/cody-shared/src/chat/recipes/explain-code-high-level.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getContextMessagesFromSelection, getNormalizedLanguageName, MARKDOWN_FORMAT_PROMPT } from './helpers'
@@ -18,14 +18,6 @@ export class ExplainCodeHighLevel implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
 
         const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Explain the following ${languageName} code at a high level. Only include details that are essential to an overal understanding of what's happening in the code.\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`

--- a/client/cody-shared/src/chat/recipes/file-touch.ts
+++ b/client/cody-shared/src/chat/recipes/file-touch.ts
@@ -9,7 +9,7 @@ import {
     MAX_RECIPE_SURROUNDING_TOKENS,
 } from '../../prompt/constants'
 import { populateCurrentEditorContextTemplate } from '../../prompt/templates'
-import { truncateText, isTextTruncated } from '../../prompt/truncation'
+import { truncateText } from '../../prompt/truncation'
 import { BufferedBotResponseSubscriber } from '../bot-response-multiplexer'
 import { Interaction } from '../transcript/interaction'
 
@@ -64,13 +64,7 @@ export class FileTouch implements Recipe {
 
         const truncatedText = truncateText(humanInput, MAX_HUMAN_INPUT_TOKENS)
         const MAX_RECIPE_CONTENT_TOKENS = MAX_RECIPE_INPUT_TOKENS + MAX_RECIPE_SURROUNDING_TOKENS * 2
-        const truncatedSelectedText = truncateText(
-            selection.selectedText,
-            Math.min(MAX_RECIPE_CONTENT_TOKENS, MAX_RECIPE_INPUT_TOKENS)
-        )
-        if (isTextTruncated(selection.selectedText, truncatedSelectedText)) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
+        const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_CONTENT_TOKENS)
 
         // Reconstruct Cody's prompt using user's context
         // Replace placeholders in reverse order to avoid collisions if a placeholder occurs in the input

--- a/client/cody-shared/src/chat/recipes/find-code-smells.ts
+++ b/client/cody-shared/src/chat/recipes/find-code-smells.ts
@@ -1,5 +1,5 @@
 import { CHARS_PER_TOKEN, MAX_AVAILABLE_PROMPT_LENGTH, MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText, isTextTruncated } from '../../prompt/truncation'
+import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { getNormalizedLanguageName } from './helpers'
@@ -27,9 +27,6 @@ If you have no ideas because the code looks fine, feel free to say that it alrea
             selection.selectedText,
             Math.min(maxTokenCount, MAX_RECIPE_INPUT_TOKENS)
         )
-        if (isTextTruncated(selection.selectedText, truncatedSelectedText)) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedSelectedText}\n\`\`\`\n\n${promptSuffix}`
 
         const displayText = `Find code smells in the following code: \n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/generate-docstring.ts
+++ b/client/cody-shared/src/chat/recipes/generate-docstring.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,14 +23,6 @@ export class GenerateDocstring implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
 
         const extension = getFileExtension(selection.fileName)
         const languageName = getNormalizedLanguageName(selection.fileName)

--- a/client/cody-shared/src/chat/recipes/generate-release-notes.ts
+++ b/client/cody-shared/src/chat/recipes/generate-release-notes.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'child_process'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText, isTextTruncated } from '../../prompt/truncation'
+import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -77,14 +77,14 @@ export class ReleaseNotes implements Recipe {
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
-        if (isTextTruncated(gitLogOutput, truncatedGitLogOutput)) {
-            await context.editor.showWarningMessage(
-                'Truncated extra long git log output, so release notes may miss some changes.'
-            )
+        console.log(truncatedGitLogOutput)
+        let truncatedLogMessage = ''
+        if (truncatedGitLogOutput.length < gitLogOutput.length) {
+            truncatedLogMessage = 'Truncated extra long git log output, so release notes may miss some changes.'
         }
 
         const promptMessage = `Generate release notes by summarising these commits:\n${truncatedGitLogOutput}\n\nUse proper heading format for the release notes.\n\n${tagsPromptText}.Do not include other changes and dependency updates.`
-        const assistantResponsePrefix = `Here is the generated release notes for ${selectedLabel}\n`
+        const assistantResponsePrefix = `Here is the generated release notes for ${selectedLabel}\n${truncatedLogMessage}`
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/generate-test.ts
+++ b/client/cody-shared/src/chat/recipes/generate-test.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,18 +23,9 @@ export class GenerateTest implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
-
         const extension = getFileExtension(selection.fileName)
-        const languageName = getNormalizedLanguageName(selection.fileName)
 
+        const languageName = getNormalizedLanguageName(selection.fileName)
         const promptMessage = `Generate a unit test in ${languageName} for the following code:\n\`\`\`${extension}\n${truncatedSelectedText}\n\`\`\`\n${MARKDOWN_FORMAT_PROMPT}`
         const assistantResponsePrefix = `Here is the generated unit test:\n\`\`\`${extension}\n`
 

--- a/client/cody-shared/src/chat/recipes/git-log.ts
+++ b/client/cody-shared/src/chat/recipes/git-log.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'child_process'
 import path from 'path'
 
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText, isTextTruncated } from '../../prompt/truncation'
+import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { Recipe, RecipeContext, RecipeID } from './recipe'
@@ -71,14 +71,13 @@ export class GitHistory implements Recipe {
         }
 
         const truncatedGitLogOutput = truncateText(gitLogOutput, MAX_RECIPE_INPUT_TOKENS)
-        if (isTextTruncated(gitLogOutput, truncatedGitLogOutput)) {
-            await context.editor.showWarningMessage(
-                'Truncated extra long git log output, so summary may be incomplete.'
-            )
+        let truncatedLogMessage = ''
+        if (truncatedGitLogOutput.length < gitLogOutput.length) {
+            truncatedLogMessage = 'Truncated extra long git log output, so summary may be incomplete.'
         }
 
         const promptMessage = `Summarize these commits:\n${truncatedGitLogOutput}\n\nProvide your response in the form of a bulleted list. Do not mention the commit hashes.`
-        const assistantResponsePrefix = 'Here is a summary of recent changes:\n'
+        const assistantResponsePrefix = `Here is a summary of recent changes:\n${truncatedLogMessage}`
         return new Interaction(
             { speaker: 'human', text: promptMessage, displayText: rawDisplayText },
             {

--- a/client/cody-shared/src/chat/recipes/improve-variable-names.ts
+++ b/client/cody-shared/src/chat/recipes/improve-variable-names.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -23,14 +23,6 @@ export class ImproveVariableNames implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection.')
-        }
         const extension = getFileExtension(selection.fileName)
 
         const displayText = `Improve the variable names in the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/next-questions.ts
+++ b/client/cody-shared/src/chat/recipes/next-questions.ts
@@ -19,7 +19,7 @@ export class NextQuestions implements Recipe {
 
         const maxTokenCount =
             MAX_AVAILABLE_PROMPT_LENGTH - (promptPrefix.length + promptSuffix.length) / CHARS_PER_TOKEN
-        const truncatedText = truncateText(humanChatInput, Math.min(maxTokenCount, MAX_AVAILABLE_PROMPT_LENGTH))
+        const truncatedText = truncateText(humanChatInput, maxTokenCount)
         const promptMessage = `${promptPrefix}\n\n\`\`\`\n${truncatedText}\n\`\`\`\n\n${promptSuffix}`
 
         const assistantResponsePrefix = 'Sure, here are great follow-up discussion topics and learning ideas:\n\n - '

--- a/client/cody-shared/src/chat/recipes/optimize-code.ts
+++ b/client/cody-shared/src/chat/recipes/optimize-code.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS, MAX_RECIPE_SURROUNDING_TOKENS } from '../../prompt/constants'
-import { truncateText, truncateTextStart, isTextTruncated } from '../../prompt/truncation'
+import { truncateText, truncateTextStart } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import {
@@ -22,14 +22,6 @@ export class OptimizeCode implements Recipe {
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
         const truncatedPrecedingText = truncateTextStart(selection.precedingText, MAX_RECIPE_SURROUNDING_TOKENS)
         const truncatedFollowingText = truncateText(selection.followingText, MAX_RECIPE_SURROUNDING_TOKENS)
-
-        if (
-            isTextTruncated(selection.selectedText, truncatedSelectedText) ||
-            isTextTruncated(selection.precedingText, truncatedPrecedingText) ||
-            isTextTruncated(selection.followingText, truncatedFollowingText)
-        ) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
         const extension = getFileExtension(selection.fileName)
 
         const displayText = `Optimize the time and space consumption of the following code:\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/chat/recipes/translate.ts
+++ b/client/cody-shared/src/chat/recipes/translate.ts
@@ -1,5 +1,5 @@
 import { MAX_RECIPE_INPUT_TOKENS } from '../../prompt/constants'
-import { truncateText, isTextTruncated } from '../../prompt/truncation'
+import { truncateText } from '../../prompt/truncation'
 import { Interaction } from '../transcript/interaction'
 
 import { languageMarkdownID, languageNames } from './langs'
@@ -19,15 +19,12 @@ export class TranslateToLanguage implements Recipe {
 
         const toLanguage = await context.editor.showQuickPick(languageNames)
         if (!toLanguage) {
-            await context.editor.showWarningMessage('No language selected. Please select a language and try again.')
+            // TODO: Show the warning within the Chat UI.
+            // editor.showWarningMessage('Must pick a language to translate to.')
             return null
         }
 
         const truncatedSelectedText = truncateText(selection.selectedText, MAX_RECIPE_INPUT_TOKENS)
-
-        if (isTextTruncated(selection.selectedText, truncatedSelectedText)) {
-            await context.editor.showWarningMessage('Truncated extra long selection so output may be incomplete.')
-        }
 
         const promptMessage = `Translate the following code into ${toLanguage}\n\`\`\`\n${truncatedSelectedText}\n\`\`\``
         const displayText = `Translate the following code into ${toLanguage}\n\`\`\`\n${selection.selectedText}\n\`\`\``

--- a/client/cody-shared/src/prompt/truncation.ts
+++ b/client/cody-shared/src/prompt/truncation.ts
@@ -15,13 +15,3 @@ export function truncateTextStart(text: string, maxTokens: number): string {
     const maxLength = maxTokens * CHARS_PER_TOKEN
     return text.length <= maxLength ? text : text.slice(-maxLength - 1)
 }
-
-/**
- * Checks if the text has been truncated
- */
-export function isTextTruncated(text: string, truncateText: string): boolean {
-    if (truncateText.length < text.length) {
-        return true
-    }
-    return false
-}


### PR DESCRIPTION
This reverts commit e40e0d0f2c1336a039ca281c92a523a967596b46 (cc @deepak2431)

We noticed that there is some unexpected behavior in some recipes where this warning is shown even if only 5 lines of code are selected. It's probably because the context lines are truncated but we don't have time to look into this and fix it just yet (we were supposed to release a few hours ago 😓). We'll take a closer look after the release.

## Test plan

- It's a revert

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
