### PR TITLE
app: fix download links not pointing to dmg

### DIFF
--- a/cmd/frontend/codyapp/BUILD.bazel
+++ b/cmd/frontend/codyapp/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     embed = [":codyapp"],
     deps = [
         "//cmd/frontend/internal/app/updatecheck",
+        "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
     ],
 )

--- a/cmd/frontend/codyapp/latest_version_test.go
+++ b/cmd/frontend/codyapp/latest_version_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hexops/autogold/v2"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
@@ -94,5 +95,30 @@ func TestLatestVersionHandler(t *testing.T) {
 			t.Errorf("expected location url %q but got %q", q.expectedURL, loc.String())
 		}
 	}
+}
 
+func Test_patchReleaseURL(t *testing.T) {
+	testCases := []struct {
+		finalURL string
+		expect   autogold.Value
+	}{
+		{
+			finalURL: "https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/Cody.2023.6.21%2B1321.8c3a4999f2.aarch64.app.tar.gz",
+			expect:   autogold.Expect("https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/Cody_2023.6.21%2B1321.8c3a4999f2_aarch64.dmg"),
+		},
+		{
+			finalURL: "https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/Cody.2023.6.21%2B1321.8c3a4999f2.x86_64.app.tar.gz",
+			expect:   autogold.Expect("https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/Cody_2023.6.21%2B1321.8c3a4999f2_x64.dmg"),
+		},
+		{
+			finalURL: "https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/cody_2023.6.21%2B1321.8c3a4999f2_amd64.AppImage.tar.gz",
+			expect:   autogold.Expect("https://github.com/sourcegraph/sourcegraph/releases/download/app-v2023.6.21%2B1321.8c3a4999f2/cody_2023.6.21%2B1321.8c3a4999f2_amd64.AppImage.tar.gz"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.finalURL, func(t *testing.T) {
+			got := patchReleaseURL(tc.finalURL)
+			tc.expect.Equal(t, got)
+		})
+	}
 }


### PR DESCRIPTION
Before, these two links (which are being added to marketing material, etc. as we speak):

* Mac (Apple Silicon): https://sourcegraph.com/.api/app/latest?arch=aarch64&target=darwin
* Mac (Intel): https://sourcegraph.com/.api/app/latest?arch=x86_64&target=darwin"

Would redirect to the `.tar.gz` download - not the `.dmg` Mac users will expect.

I'm positive this isn't the best way to implement this, I'm sure @burmudar will have a better idea later - I'll leave that to him :) But this works right now, and I've added test cases confirming it does so.. good enough?

## Test plan

Added tests