### PR TITLE
Cody: Fix error handling for local context fetching

### DIFF
--- a/client/cody-shared/src/codebase-context/index.ts
+++ b/client/cody-shared/src/codebase-context/index.ts
@@ -167,15 +167,24 @@ export class CodebaseContext {
     }
 
     private async getLocalContextMessages(query: string, options: ContextSearchOptions): Promise<ContextMessage[]> {
-        const keywordResultsPromise = this.getKeywordSearchResults(query, options)
-        const filenameResultsPromise = this.getFilenameSearchResults(query, options)
+        try {
+            const keywordResultsPromise = this.getKeywordSearchResults(query, options)
+            const filenameResultsPromise = this.getFilenameSearchResults(query, options)
 
-        const [keywordResults, filenameResults] = await Promise.all([keywordResultsPromise, filenameResultsPromise])
+            const [keywordResults, filenameResults] = await Promise.all([keywordResultsPromise, filenameResultsPromise])
 
-        const combinedResults = this.mergeContextResults(keywordResults, filenameResults)
-        const rerankedResults = await (this.rerank ? this.rerank(query, combinedResults) : combinedResults)
-        const messages = resultsToMessages(rerankedResults)
-        return messages
+            const combinedResults = this.mergeContextResults(keywordResults, filenameResults)
+            const rerankedResults = await (this.rerank ? this.rerank(query, combinedResults) : combinedResults)
+            const messages = resultsToMessages(rerankedResults)
+
+            this.embeddingResultsError = ''
+
+            return messages
+        } catch (error) {
+            console.error('Error retrieving local context:', error)
+            this.embeddingResultsError = `Error retrieving local context: ${error}`
+            return []
+        }
     }
 
     private async getKeywordSearchResults(query: string, options: ContextSearchOptions): Promise<ContextResult[]> {


### PR DESCRIPTION
When an error happens during the local context, we need to handle it in the same way we do it for embeddings so we can bubble it up to the user.

## Test plan

https://github.com/sourcegraph/sourcegraph/assets/458591/52d4c13e-b1ce-4e65-aaf4-4f4146cf53f0


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
