### PR TITLE
JetBrains: Chat: Send on enter

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -452,11 +452,16 @@ class CodyToolWindowContent implements UpdatableChat {
     promptInput.requestFocusInWindow();
 
     /* Insert Enter on Shift+Enter, Ctrl+Enter, Alt/Option+Enter, and Meta+Enter */
-    KeyboardShortcut SHIFT_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, SHIFT_DOWN_MASK), null);
-    KeyboardShortcut CTRL_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
-    KeyboardShortcut ALT_OR_OPTION_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, ALT_DOWN_MASK), null);
-    KeyboardShortcut META_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, META_DOWN_MASK), null);
-    ShortcutSet INSERT_ENTER_SHORTCUT = new CustomShortcutSet(CTRL_ENTER, SHIFT_ENTER, META_ENTER, ALT_OR_OPTION_ENTER);
+    KeyboardShortcut SHIFT_ENTER =
+        new KeyboardShortcut(getKeyStroke(VK_ENTER, SHIFT_DOWN_MASK), null);
+    KeyboardShortcut CTRL_ENTER =
+        new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
+    KeyboardShortcut ALT_OR_OPTION_ENTER =
+        new KeyboardShortcut(getKeyStroke(VK_ENTER, ALT_DOWN_MASK), null);
+    KeyboardShortcut META_ENTER =
+        new KeyboardShortcut(getKeyStroke(VK_ENTER, META_DOWN_MASK), null);
+    ShortcutSet INSERT_ENTER_SHORTCUT =
+        new CustomShortcutSet(CTRL_ENTER, SHIFT_ENTER, META_ENTER, ALT_OR_OPTION_ENTER);
     AnAction insertEnterAction =
         new DumbAwareAction() {
           @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -1,9 +1,10 @@
 package com.sourcegraph.cody;
 
-import static com.intellij.openapi.util.SystemInfoRt.isMac;
 import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
+import static java.awt.event.InputEvent.ALT_DOWN_MASK;
 import static java.awt.event.InputEvent.CTRL_DOWN_MASK;
 import static java.awt.event.InputEvent.META_DOWN_MASK;
+import static java.awt.event.InputEvent.SHIFT_DOWN_MASK;
 import static java.awt.event.KeyEvent.VK_ENTER;
 import static javax.swing.KeyStroke.getKeyStroke;
 
@@ -449,12 +450,25 @@ class CodyToolWindowContent implements UpdatableChat {
     promptInput.setLineWrap(true);
     promptInput.setWrapStyleWord(true);
     promptInput.requestFocusInWindow();
-    KeyboardShortcut CTRL_ENTER =
-        new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
-    KeyboardShortcut META_ENTER =
-        new KeyboardShortcut(getKeyStroke(VK_ENTER, META_DOWN_MASK), null);
-    ShortcutSet DEFAULT_SUBMIT_ACTION_SHORTCUT =
-        isMac ? new CustomShortcutSet(CTRL_ENTER, META_ENTER) : new CustomShortcutSet(CTRL_ENTER);
+
+    /* Insert Enter on Shift+Enter, Ctrl+Enter, Alt/Option+Enter, and Meta+Enter */
+    KeyboardShortcut SHIFT_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, SHIFT_DOWN_MASK), null);
+    KeyboardShortcut CTRL_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, CTRL_DOWN_MASK), null);
+    KeyboardShortcut ALT_OR_OPTION_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, ALT_DOWN_MASK), null);
+    KeyboardShortcut META_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, META_DOWN_MASK), null);
+    ShortcutSet INSERT_ENTER_SHORTCUT = new CustomShortcutSet(CTRL_ENTER, SHIFT_ENTER, META_ENTER, ALT_OR_OPTION_ENTER);
+    AnAction insertEnterAction =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            promptInput.insert("\n", promptInput.getCaretPosition());
+          }
+        };
+    insertEnterAction.registerCustomShortcutSet(INSERT_ENTER_SHORTCUT, promptInput);
+
+    /* Submit on enter */
+    KeyboardShortcut JUST_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, 0), null);
+    ShortcutSet DEFAULT_SUBMIT_ACTION_SHORTCUT = new CustomShortcutSet(JUST_ENTER);
     AnAction sendMessageAction =
         new DumbAwareAction() {
           @Override
@@ -463,6 +477,7 @@ class CodyToolWindowContent implements UpdatableChat {
           }
         };
     sendMessageAction.registerCustomShortcutSet(DEFAULT_SUBMIT_ACTION_SHORTCUT, promptInput);
+
     return promptInput;
   }
 


### PR DESCRIPTION
Previous state:
- Inserts return char on ⏎
- Sends message on ⌃⏎ and ⌘⏎

New state:
- Sends message on ⏎
- Inserts a return char for ⌘⏎, ⇧⏎, ⌃⏎, and ⌥⏎.

Why change this?
- ChatGPT sends on ⏎
- Cody in VS Code sends on ⏎
- For me (@vdavid), a long-term IntelliJ user, sending on ⏎ comes naturally
- Other insiders were confused by this as well

Caveat:
- line breaks are not displayed in the sent messages. This was a pre-existing condition, not a regression. Created issue: https://github.com/sourcegraph/sourcegraph/issues/54330

## Test plan

Tested in this Loom: https://www.loom.com/share/9bd6fb2b5f7743dfa266cb74b76b1a7e