### PR TITLE
Add redirect option to external auth signup component

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -47,7 +47,10 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     const isRequestAccessAllowed = checkRequestAccessAllowed(props.context)
 
     if (authenticatedUser) {
-        const returnTo = getReturnTo(location)
+        let returnTo = getReturnTo(location)
+        if (context.sourcegraphDotComMode && returnTo === '/search') {
+            returnTo = '/get-cody'
+        }
         return <Navigate to={returnTo} replace={true} />
     }
 

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -81,9 +81,6 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 return response.text().then(text => Promise.reject(new Error(text)))
             }
 
-            // Redirect page to `/get-cody`, post signup.
-            window.location.replace('get-cody')
-
             return Promise.resolve()
         })
 

--- a/client/web/src/auth/components/ExternalsAuth.tsx
+++ b/client/web/src/auth/components/ExternalsAuth.tsx
@@ -17,6 +17,7 @@ interface ExternalsAuthProps {
     withCenteredText?: boolean
     ctaClassName?: string
     iconClassName?: string
+    redirect?: string
 }
 
 const GitlabColorIcon: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({ className }) => (
@@ -58,6 +59,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
     withCenteredText,
     ctaClassName,
     iconClassName,
+    redirect,
 }) => {
     // Since this component is only intended for use on Sourcegraph.com, it's OK to hardcode
     // GitHub and GitLab auth providers here as they are the only ones used on Sourcegraph.com.
@@ -77,7 +79,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
                 <Link
                     // Use absolute URL to force full-page reload (because the auth routes are
                     // handled by the backend router, not the frontend router).
-                    to={`${window.location.origin}${githubProvider.authenticationURL}`}
+                    to={`${window.location.origin}${githubProvider.authenticationURL}` + redirect ? `&redirect=${redirect}` : ''}
                     className={classNames(
                         'text-decoration-none',
                         withCenteredText && 'd-flex justify-content-center',

--- a/client/web/src/auth/components/ExternalsAuth.tsx
+++ b/client/web/src/auth/components/ExternalsAuth.tsx
@@ -79,7 +79,11 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
                 <Link
                     // Use absolute URL to force full-page reload (because the auth routes are
                     // handled by the backend router, not the frontend router).
-                    to={`${window.location.origin}${githubProvider.authenticationURL}` + redirect ? `&redirect=${redirect}` : ''}
+                    to={
+                        `${window.location.origin}${githubProvider.authenticationURL}` + redirect
+                            ? `&redirect=${redirect}`
+                            : ''
+                    }
                     className={classNames(
                         'text-decoration-none',
                         withCenteredText && 'd-flex justify-content-center',

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -46,56 +46,56 @@ const codyPlatformCardItems = (
     icon: string | JSX.Element
     illustration: { dark: string; light: string }
 }[] => [
-    {
-        title: 'Knows your code',
-        description:
-            'Cody knows about your codebase and can use that knowledge to explain, generate, and improve your code.',
-        icon: mdiCodeBracesBox,
-        illustration: {
-            dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-dark.png',
-            light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-light.png',
+        {
+            title: 'Knows your code',
+            description:
+                'Cody knows about your codebase and can use that knowledge to explain, generate, and improve your code.',
+            icon: mdiCodeBracesBox,
+            illustration: {
+                dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-dark.png',
+                light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-light.png',
+            },
         },
-    },
-    {
-        title: 'More powerful in your IDE',
-        description: (
-            <>
-                The extensions combine an LLM with the context of your code to help you generate and fix code more
-                accurately. <Link to="/help/cody#get-cody">View supported IDEs</Link>.
-            </>
-        ),
-        icon: <IDEIcon />,
-        illustration: {
-            dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-dark.png',
-            light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-light.png',
+        {
+            title: 'More powerful in your IDE',
+            description: (
+                <>
+                    The extensions combine an LLM with the context of your code to help you generate and fix code more
+                    accurately. <Link to="/help/cody#get-cody">View supported IDEs</Link>.
+                </>
+            ),
+            icon: <IDEIcon />,
+            illustration: {
+                dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-dark.png',
+                light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-light.png',
+            },
         },
-    },
-    ...(isSourcegraphDotCom
-        ? [
-              {
-                  title: 'Try it on sourcegraph.com',
-                  description:
-                      'Cody explains, generates, convert code, and more within the context of public repositories.',
-                  icon: mdiGit,
-                  illustration: {
-                      dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
-                      light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
-                  },
-              },
-          ]
-        : [
-              {
-                  title: 'Recipes accelerate your flow',
-                  description:
-                      'Cody explains, generates, convert code, and more within the context of your repositories.',
-                  icon: mdiGit,
-                  illustration: {
-                      dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
-                      light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
-                  },
-              },
-          ]),
-]
+        ...(isSourcegraphDotCom
+            ? [
+                {
+                    title: 'Try it on sourcegraph.com',
+                    description:
+                        'Cody explains, generates, convert code, and more within the context of public repositories.',
+                    icon: mdiGit,
+                    illustration: {
+                        dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
+                        light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
+                    },
+                },
+            ]
+            : [
+                {
+                    title: 'Recipes accelerate your flow',
+                    description:
+                        'Cody explains, generates, convert code, and more within the context of your repositories.',
+                    icon: mdiGit,
+                    illustration: {
+                        dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
+                        light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
+                    },
+                },
+            ]),
+    ]
 
 export interface CodyMarketingPageProps {
     isSourcegraphDotCom: boolean
@@ -164,6 +164,7 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                                 onClick={onClickCTAButton}
                                 ctaClassName={styles.authButton}
                                 iconClassName={styles.buttonIcon}
+                                redirect="/get-cody"
                             />
                         </div>
                         <Link to="https://sourcegraph.com/sign-up?showEmail=true">Or, continue with email</Link>

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -46,56 +46,56 @@ const codyPlatformCardItems = (
     icon: string | JSX.Element
     illustration: { dark: string; light: string }
 }[] => [
-        {
-            title: 'Knows your code',
-            description:
-                'Cody knows about your codebase and can use that knowledge to explain, generate, and improve your code.',
-            icon: mdiCodeBracesBox,
-            illustration: {
-                dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-dark.png',
-                light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-light.png',
-            },
+    {
+        title: 'Knows your code',
+        description:
+            'Cody knows about your codebase and can use that knowledge to explain, generate, and improve your code.',
+        icon: mdiCodeBracesBox,
+        illustration: {
+            dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-dark.png',
+            light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-knows-your-code-illustration-light.png',
         },
-        {
-            title: 'More powerful in your IDE',
-            description: (
-                <>
-                    The extensions combine an LLM with the context of your code to help you generate and fix code more
-                    accurately. <Link to="/help/cody#get-cody">View supported IDEs</Link>.
-                </>
-            ),
-            icon: <IDEIcon />,
-            illustration: {
-                dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-dark.png',
-                light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-light.png',
-            },
+    },
+    {
+        title: 'More powerful in your IDE',
+        description: (
+            <>
+                The extensions combine an LLM with the context of your code to help you generate and fix code more
+                accurately. <Link to="/help/cody#get-cody">View supported IDEs</Link>.
+            </>
+        ),
+        icon: <IDEIcon />,
+        illustration: {
+            dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-dark.png',
+            light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-vs-code-illustration-light.png',
         },
-        ...(isSourcegraphDotCom
-            ? [
-                {
-                    title: 'Try it on sourcegraph.com',
-                    description:
-                        'Cody explains, generates, convert code, and more within the context of public repositories.',
-                    icon: mdiGit,
-                    illustration: {
-                        dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
-                        light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
-                    },
-                },
-            ]
-            : [
-                {
-                    title: 'Recipes accelerate your flow',
-                    description:
-                        'Cody explains, generates, convert code, and more within the context of your repositories.',
-                    icon: mdiGit,
-                    illustration: {
-                        dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
-                        light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
-                    },
-                },
-            ]),
-    ]
+    },
+    ...(isSourcegraphDotCom
+        ? [
+              {
+                  title: 'Try it on sourcegraph.com',
+                  description:
+                      'Cody explains, generates, convert code, and more within the context of public repositories.',
+                  icon: mdiGit,
+                  illustration: {
+                      dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
+                      light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
+                  },
+              },
+          ]
+        : [
+              {
+                  title: 'Recipes accelerate your flow',
+                  description:
+                      'Cody explains, generates, convert code, and more within the context of your repositories.',
+                  icon: mdiGit,
+                  illustration: {
+                      dark: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-dark.png',
+                      light: 'https://storage.googleapis.com/sourcegraph-assets/app-images/cody-com-illustration-light.png',
+                  },
+              },
+          ]),
+]
 
 export interface CodyMarketingPageProps {
     isSourcegraphDotCom: boolean

--- a/client/web/src/get-cody/GetCodyPage.module.scss
+++ b/client/web/src/get-cody/GetCodyPage.module.scss
@@ -1,6 +1,6 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
-@font-face{
+@font-face {
     font-family: 'Source Sans 3 VF';
     font-weight: 200 900;
     font-style: normal;
@@ -14,7 +14,8 @@
     height: fit-content;
     width: 100%;
     position: relative;
-    font-family: 'Source Sans 3 VF', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: 'Source Sans 3 VF', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+        Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 
     .page {
         max-width: 1360px;


### PR DESCRIPTION
Adds a `redirect` option to the `ExternalsAuth` component which can be used to specify a redirect page after a user signs-up successfully from specific locations.

## Test plan



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
