### PR TITLE
Don't display message with internal error when unable to load context

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - telemetry is now being sent to both the current instance & dotcom (unless the current instance is dotcom, then just that) [#54347](https://github.com/sourcegraph/sourcegraph/pull/54347)
+- Don't display doubled messages about the error when trying to load context [#54345](https://github.com/sourcegraph/sourcegraph/pull/54345)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -687,11 +687,12 @@ class CodyToolWindowContent implements UpdatableChat {
                     ConfigUtil.getCustomRequestHeaders(project))
                 .getContextMessages(humanMessage.getText(), 8, 2, true);
       } catch (IOException e) {
-        this.addMessageToChat(
-            ChatMessage.createAssistantMessage(
-                "I didn't get a correct response. This is what I encountered while trying to get some context for your ask: \""
-                    + e.getMessage()
-                    + "\". I'll try to answer without further context."));
+        logger.warn(
+            "Unable to load context for message: "
+                + humanMessage.getText()
+                + ", in repo: "
+                + repoName,
+            e);
       }
     }
     return contextMessages;


### PR DESCRIPTION
Internal error message is printed out to the logs instead of being displayed as a message

## Test plan
Steps to reproduce:
- Have Cody App selected as the server instance
- Have the Cody App running when you start the IDE
- Quit the Cody App
- Send another message in the chat
- Get these:
- I didn't find any context for your ask. I'll try to answer without further context.
- I'm sorry, I can't connect to the server. Please make sure that the server is running and try again.

No message with internal error should be shown to the user
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/4886d6d1-bd00-421f-95ed-64e9461c8465)

