### PR TITLE
JetBrains: log telemetry events twice if not on dotcom instance

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- telemetry is now being sent to both the current instance & dotcom (unless the current instance is dotcom, then just that) [#54347](https://github.com/sourcegraph/sourcegraph/pull/54347)
+
 ### Security
 
 ## [3.0.0]

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -6,7 +6,9 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.api.GraphQlClient;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -63,38 +65,66 @@ public class GraphQlLogger {
     return eventParameters;
   }
 
-  // This could be exposed later (as public), but currently, we don't use it externally.
-  private static void logEvent(
-      @NotNull Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
-    String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
-    String accessToken = ConfigUtil.getProjectAccessToken(project);
-    String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
+  private static void callGraphQlService(
+      @Nullable Consumer<Integer> callback,
+      @NotNull String instanceUrl,
+      @Nullable String accessToken,
+      @Nullable String requestHeaders,
+      @NotNull String query,
+      @NotNull JsonObject variables) {
     new Thread(
             () -> {
-              String query =
-                  "mutation LogEvents($events: [Event!]) {"
-                      + "    logEvents(events: $events) { "
-                      + "        alwaysNil"
-                      + "    }"
-                      + "}";
-
-              JsonArray events = new JsonArray();
-              events.add(event.toJson());
-              JsonObject variables = new JsonObject();
-              variables.add("events", events);
-
               try {
                 int responseStatusCode =
                     GraphQlClient.callGraphQLService(
-                            instanceUrl, accessToken, customRequestHeaders, query, variables)
+                            instanceUrl, accessToken, requestHeaders, query, variables)
                         .getStatusCode();
-                if (callback != null) {
-                  callback.accept(responseStatusCode);
-                }
+                Optional.ofNullable(callback).ifPresent(c -> c.accept(responseStatusCode));
               } catch (IOException e) {
                 logger.info(e);
               }
             })
         .start();
+  }
+
+  private static void logDotcomEvent(
+      @Nullable Consumer<Integer> callback, @NotNull String query, @NotNull JsonObject variables) {
+    System.out.println("logDotcomEvent");
+    String instanceUrl = ConfigUtil.DOTCOM_URL;
+    callGraphQlService(callback, instanceUrl, null, null, query, variables);
+  }
+
+  private static void logInstanceEvent(
+      @Nullable Consumer<Integer> callback,
+      @NotNull String query,
+      @NotNull JsonObject variables,
+      @NotNull Project project) {
+    System.out.println("logInstanceEvent");
+    String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+    String accessToken = ConfigUtil.getProjectAccessToken(project);
+    String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
+    callGraphQlService(callback, instanceUrl, accessToken, customRequestHeaders, query, variables);
+  }
+
+  // This could be exposed later (as public), but currently, we don't use it externally.
+  private static void logEvent(
+      @NotNull Project project, @NotNull Event event, @Nullable Consumer<Integer> callback) {
+    String query =
+        "mutation LogEvents($events: [Event!]) {"
+            + "    logEvents(events: $events) { "
+            + "        alwaysNil"
+            + "    }"
+            + "}";
+    JsonArray events = new JsonArray();
+    events.add(event.toJson());
+    JsonObject variables = new JsonObject();
+    variables.add("events", events);
+    SettingsComponent.InstanceType instanceType = ConfigUtil.getInstanceType(project);
+    logDotcomEvent(callback, query, variables); // always log events to dotcom
+    if (instanceType != SettingsComponent.InstanceType.DOTCOM // also log to the instance separately
+        // but only if its url is actually different from dotcom
+        && !ConfigUtil.getSourcegraphUrl(project).equals(ConfigUtil.DOTCOM_URL)) {
+      logInstanceEvent(callback, query, variables, project);
+    }
   }
 }


### PR DESCRIPTION
Fixes #54314 

Telemetry events should now be sent to both the current instance and to dotcom (unless the current instance is dotcom, or it's configured as an enterprise instance that's actually just dotcom).

## Test plan
- Green CI
- You can check the logs when a telemetry event should be sent to verify the behaviour.
