### PR TITLE
search: match lang specific files everywhere

### DIFF
--- a/internal/search/query/BUILD.bazel
+++ b/internal/search/query/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     timeout = "short",
     srcs = [
         "date_format_test.go",
+        "helpers_test.go",
         "mapper_test.go",
         "parser_test.go",
         "predicate_test.go",
@@ -58,6 +59,7 @@ go_test(
         "//lib/errors",
         "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//require",

--- a/internal/search/query/helpers.go
+++ b/internal/search/query/helpers.go
@@ -56,7 +56,7 @@ func LangToFileRegexp(lang string) string {
 		patterns[i] = regexp.QuoteMeta(e) + "$"
 	}
 	for _, filename := range filenamesFromLanguage[lang] {
-		patterns = append(patterns, "(?:^|/)"+regexp.QuoteMeta(filename)+"$")
+		patterns = append(patterns, "(^|/)"+regexp.QuoteMeta(filename)+"$")
 	}
 	return UnionRegExps(patterns)
 }

--- a/internal/search/query/helpers.go
+++ b/internal/search/query/helpers.go
@@ -56,7 +56,7 @@ func LangToFileRegexp(lang string) string {
 		patterns[i] = regexp.QuoteMeta(e) + "$"
 	}
 	for _, filename := range filenamesFromLanguage[lang] {
-		patterns = append(patterns, "^"+regexp.QuoteMeta(filename)+"$")
+		patterns = append(patterns, "(?:^|/)"+regexp.QuoteMeta(filename)+"$")
 	}
 	return UnionRegExps(patterns)
 }

--- a/internal/search/query/helpers_test.go
+++ b/internal/search/query/helpers_test.go
@@ -1,0 +1,74 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+)
+
+func TestLangToFileRegexp(t *testing.T) {
+	cases := []struct {
+		lang        string
+		matches     []string
+		doesntMatch []string
+	}{
+		{
+			lang: "Starlark",
+			matches: []string{
+				// BUILD.bazel
+				"BUILD.bazel",
+				"/BUILD.bazel",
+				"/a/BUILD.bazel",
+				"/a/BUILD",
+				"/a/b/BUILD.bazel",
+				// *.bzl
+				"/a/b/foo.bzl",
+			},
+			doesntMatch: []string{
+				"aBUILD.bazel",
+				"aBUILD.bazelb",
+				"a/BUILD.bazel/b",
+				"BUILD.bazel/b",
+				"aBUILDb",
+				"BUILDb",
+				// lowercase
+				"build.bazel",
+				"build",
+			},
+		},
+		{
+			lang: "Dockerfile",
+			matches: []string{
+				"Dockerfile",
+				"a/Dockerfile",
+				"/a/b/Dockerfile",
+			},
+			doesntMatch: []string{
+				"notaDockerfile",
+				"a/Dockerfile/b",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.lang, func(t *testing.T) {
+			pattern := LangToFileRegexp(c.lang)
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, m := range c.matches {
+				if !re.MatchString(m) {
+					t.Errorf("expected %q to match %q", pattern, m)
+				}
+			}
+
+			for _, m := range c.doesntMatch {
+				if re.MatchString(m) {
+					t.Errorf("expected %q to not match %q", pattern, m)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes a bug where we only match certain files, such as Dockerfile or BUILD.bazel, at root level when the user searches via the "lang:" filter EG "r:sourcegraph$ lang:bazel"

Background:
For some languages, linguist, and consequently go-enry, specifies files that don't match the language's extensions.

For example, for Starlark (alias of bazel), linguist lists the extensions .bzl and .star and a couple of special files such as `BUILD.bazel`. Note that ".bazel" is not listed as extension of Starlark.

However, our regexp pattern for the special files matches only files at root level.

This changes the regexp to be more permissive.

Cons:
- On the search page we now highlight a leading "/" for the new matches which is suboptimal. 

![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/59cd3cbd-3743-4445-a635-d27688519da0)


Test plan:
added unit test
