### PR TITLE
Cody VSCE: Fix customHeaders never being passed through

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Fixed `cody.customHeaders` never being passed through. [pull/54354](https://github.com/sourcegraph/sourcegraph/pull/54354)
+
 ### Changed
 
 ## [0.4.0]

--- a/client/cody/src/services/AuthProvider.ts
+++ b/client/cody/src/services/AuthProvider.ts
@@ -188,7 +188,7 @@ export class AuthProvider {
     public async auth(
         uri: string,
         token: string | null,
-        customHeaders = {}
+        customHeaders?: {} | null
     ): Promise<{ authStatus: AuthStatus; isLoggedIn: boolean } | null> {
         const endpoint = formatURL(uri) || ''
         const config = {


### PR DESCRIPTION
This fixes `cody.customHeaders` so it's used instead of ignored. Reported by an Enterprise user who can no longer log into their instance, because the custom header isn't being passed.

After:

```
--> POST /.api/graphql?CurrentUser HTTP/1.1
--> Content-Type: application/json; charset=utf-8
--> Authorization: token a test token
--> Accept: */*
--> Content-Length: 89
--> User-Agent: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
--> Accept-Encoding: gzip,deflate
--> Connection: close
--> Host: localhost:3000
```

Before:

```
--> POST /.api/graphql?CurrentUser HTTP/1.1
--> x-test: test-test-test
--> Content-Type: application/json; charset=utf-8
--> Authorization: token a test token
--> Accept: */*
--> Content-Length: 89
--> User-Agent: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
--> Accept-Encoding: gzip,deflate
--> Connection: close
--> Host: localhost:3000
```

## Test plan

- Set a custom header
- Run a local echo server (`npx http-echo-server 3000`)
- Sign in to server and observe headers
- Debug in VS Code and observe headers