### PR TITLE
bzl: fix build tags / disable cgo for server+prom 

### DIFF
--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -19,6 +19,11 @@ go_library(
 go_binary(
     name = "server",
     embed = [":server_lib"],
+    gotags = [
+        "netgo",
+        "dist",
+    ],
+    pure = "on",
     visibility = ["//visibility:public"],
     x_defs = {
         "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",

--- a/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
+++ b/docker-images/prometheus/cmd/prom-wrapper/BUILD.bazel
@@ -46,6 +46,7 @@ go_binary(
         "netgo",
         "dist",
     ],
+    pure = "on",
     static = "on",
     visibility = ["//visibility:public"],
     x_defs = {

--- a/enterprise/cmd/server/BUILD.bazel
+++ b/enterprise/cmd/server/BUILD.bazel
@@ -20,6 +20,11 @@ go_library(
 go_binary(
     name = "server",
     embed = [":server_lib"],
+    gotags = [
+        "netgo",
+        "dist",
+    ],
+    pure = "on",
     visibility = ["//visibility:public"],
     x_defs = {
         "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",


### PR DESCRIPTION
As a follow-up to https://sourcegraph.slack.com/archives/C04MYFW01NV/p1687904137730639 where @unknwon spotted a failure in the pure-docker test suite, I was ablet to root-cause the issues down to the prom-wrapper binary being built with `netgo` but with `cgo` enabled, which led to a weird case, where it still tried to nslookup with cgo and segfaulted. 

- 56c03276dd02f4873ec013f046d0453af456d816 fixes prom-wrapper 
- 7d6f928179d39bbed16f71bfa57b5a4d3e413100 conservatively disable cgo + enable netgo on the server, even if no issues have been observed so far. We might want to revisit this after the release. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Prom-wrapper QA: https://buildkite.com/sourcegraph/deploy-sourcegraph-docker/builds/13756
- CI (integration tests covered the server changes) 