### PR TITLE
JetBrains: Rename plugin to "Cody AI by Sourcegraph"

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/Icons.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/Icons.java
@@ -5,5 +5,6 @@ import javax.swing.*;
 
 public interface Icons {
   Icon SourcegraphLogo = IconLoader.getIcon("/icons/sourcegraphLogo.svg", Icons.class);
+  Icon CodyLogo = IconLoader.getIcon("/icons/codyLogo.svg", Icons.class);
   Icon GearPlain = IconLoader.getIcon("/icons/gearPlain.svg", Icons.class);
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -142,7 +142,6 @@ public class CodyAgent implements Disposable {
 
   private static String agentBinaryName() {
     String os = SystemInfoRt.isMac ? "macos" : SystemInfoRt.isWindows ? "windows" : "linux";
-    @SuppressWarnings("MissingRecentApi")
     String arch = CpuArch.isArm64() ? "arm64" : "x64";
     return "agent-" + os + "-" + arch + binarySuffix();
   }
@@ -164,7 +163,7 @@ public class CodyAgent implements Disposable {
   private static File agentBinary() throws CodyAgentException {
     Path pluginPath = agentDirectory();
     if (pluginPath == null) {
-      throw new CodyAgentException("Sourcegraph plugin path not found");
+      throw new CodyAgentException("Cody AI by Sourcegraph plugin path not found");
     }
     Path binarySource = pluginPath.resolve("agent").resolve(agentBinaryName());
     if (!Files.isRegularFile(binarySource)) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
@@ -17,8 +17,8 @@ public class BrowserErrorNotification {
   public static void show(Project project, URI uri) {
     Notification notification =
         new Notification(
-            "Sourcegraph errors",
-            "Sourcegraph",
+            "Cody AI by Sourcegraph errors",
+            "Cody AI by Sourcegraph",
             "Opening an external browser is not supported. You can still copy the URL to your clipboard and open it manually.",
             NotificationType.WARNING);
     AnAction copyUrlAction =
@@ -36,7 +36,7 @@ public class BrowserErrorNotification {
             notification.expire();
           }
         };
-    notification.setIcon(Icons.SourcegraphLogo);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(copyUrlAction);
     notification.addAction(dismissAction);
     Notifications.Bus.notify(notification);

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
@@ -14,7 +14,7 @@ public class ErrorNotification {
   public static void show(Project project, String errorMessage) {
     Notification notification =
         new Notification(
-            "Sourcegraph errors", "Sourcegraph", errorMessage, NotificationType.WARNING);
+            "Cody AI by Sourcegraph errors", "Cody AI by Sourcegraph", errorMessage, NotificationType.WARNING);
     AnAction dismissAction =
         new DumbAwareAction("Dismiss") {
           @Override
@@ -22,7 +22,7 @@ public class ErrorNotification {
             notification.expire();
           }
         };
-    notification.setIcon(Icons.SourcegraphLogo);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(dismissAction);
     Notifications.Bus.notify(notification);
     notification.notify(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -13,8 +13,8 @@ import org.jetbrains.annotations.Nullable;
 @State(
     name = "ApplicationConfig",
     storages = {@Storage("sourcegraph.xml")})
-public class SourcegraphApplicationService
-    implements PersistentStateComponent<SourcegraphApplicationService>, SourcegraphService {
+public class CodyApplicationService
+    implements PersistentStateComponent<CodyApplicationService>, CodyService {
   @Nullable public String instanceType;
   @Nullable public String url;
 
@@ -41,8 +41,8 @@ public class SourcegraphApplicationService
   // about an update
 
   @NotNull
-  public static SourcegraphApplicationService getInstance() {
-    return ApplicationManager.getApplication().getService(SourcegraphApplicationService.class);
+  public static CodyApplicationService getInstance() {
+    return ApplicationManager.getApplication().getService(CodyApplicationService.class);
   }
 
   @Nullable
@@ -139,12 +139,12 @@ public class SourcegraphApplicationService
   }
 
   @Nullable
-  public SourcegraphApplicationService getState() {
+  public CodyApplicationService getState() {
     return this;
   }
 
   @Override
-  public void loadState(@NotNull SourcegraphApplicationService settings) {
+  public void loadState(@NotNull CodyApplicationService settings) {
     this.instanceType = settings.instanceType;
     this.url = settings.url;
     this.accessToken = settings.accessToken;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
@@ -11,8 +11,8 @@ import org.jetbrains.annotations.Nullable;
 @State(
     name = "Config",
     storages = {@Storage("sourcegraph.xml")})
-public class SourcegraphProjectService
-    implements PersistentStateComponent<SourcegraphProjectService>, SourcegraphService {
+public class CodyProjectService
+    implements PersistentStateComponent<CodyProjectService>, CodyService {
   @Nullable public String instanceType;
   @Nullable public String url;
 
@@ -82,12 +82,12 @@ public class SourcegraphProjectService
 
   @Nullable
   @Override
-  public SourcegraphProjectService getState() {
+  public CodyProjectService getState() {
     return this;
   }
 
   @Override
-  public void loadState(@NotNull SourcegraphProjectService settings) {
+  public void loadState(@NotNull CodyProjectService settings) {
     this.instanceType = settings.instanceType;
     this.url = settings.url;
     this.accessToken = settings.accessToken;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyService.java
@@ -5,10 +5,10 @@ import com.sourcegraph.find.Search;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public interface SourcegraphService {
+public interface CodyService {
   @NotNull
-  static SourcegraphProjectService getInstance(@NotNull Project project) {
-    return project.getService(SourcegraphProjectService.class);
+  static CodyProjectService getInstance(@NotNull Project project) {
+    return project.getService(CodyProjectService.class);
   }
 
   @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -174,7 +174,7 @@ public class ConfigUtil {
 
   public static void setLastSearch(@NotNull Project project, @NotNull Search lastSearch) {
     // Project level
-    SourcegraphProjectService settings = getProjectLevelConfig(project);
+    CodyProjectService settings = getProjectLevelConfig(project);
     settings.lastSearchQuery = lastSearch.getQuery() != null ? lastSearch.getQuery() : "";
     settings.lastSearchCaseSensitive = lastSearch.isCaseSensitive();
     settings.lastSearchPatternType =
@@ -242,26 +242,26 @@ public class ConfigUtil {
   }
 
   public static void setAuthenticationFailedLastTime(boolean value) {
-    SourcegraphApplicationService.getInstance().authenticationFailedLastTime = value;
+    CodyApplicationService.getInstance().authenticationFailedLastTime = value;
   }
 
   public static String getLastUpdateNotificationPluginVersion() {
-    return SourcegraphApplicationService.getInstance().getLastUpdateNotificationPluginVersion();
+    return CodyApplicationService.getInstance().getLastUpdateNotificationPluginVersion();
   }
 
   public static void setLastUpdateNotificationPluginVersionToCurrent() {
-    SourcegraphApplicationService.getInstance().lastUpdateNotificationPluginVersion =
+    CodyApplicationService.getInstance().lastUpdateNotificationPluginVersion =
         getPluginVersion();
   }
 
   @NotNull
-  private static SourcegraphApplicationService getApplicationLevelConfig() {
-    return Objects.requireNonNull(SourcegraphApplicationService.getInstance());
+  private static CodyApplicationService getApplicationLevelConfig() {
+    return Objects.requireNonNull(CodyApplicationService.getInstance());
   }
 
   @NotNull
-  private static SourcegraphProjectService getProjectLevelConfig(@NotNull Project project) {
-    return Objects.requireNonNull(SourcegraphService.getInstance(project));
+  private static CodyProjectService getProjectLevelConfig(@NotNull Project project) {
+    return Objects.requireNonNull(CodyService.getInstance(project));
   }
 
   @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -49,8 +49,8 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     // Display notification
     Notification notification =
         new Notification(
-            "Sourcegraph access",
-            "Sourcegraph",
+            "Cody AI by Sourcegraph: server access",
+            "Cody AI by Sourcegraph",
             "A custom Sourcegraph URL is not set for this project. You can only access public repos. Do you want to set your custom URL?",
             NotificationType.INFORMATION);
     AnAction setUrlAction = new OpenPluginSettingsAction("Set URL");
@@ -69,7 +69,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             ConfigUtil.setUrlNotificationDismissed(true);
           }
         };
-    notification.setIcon(Icons.SourcegraphLogo);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(setUrlAction);
     notification.addAction(cancelAction);
     notification.addAction(neverShowAgainAction);
@@ -83,8 +83,8 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
     Notification notification =
         new Notification(
-            "Sourcegraph plugin updates",
-            "Sourcegraph",
+            "Cody AI by Sourcegraph plugin updates",
+            "Cody AI by Sourcegraph",
             "Access the new plugin and try out code search with the shortcut "
                 + altSShortcutText
                 + "! Learn more about the plugin’s functionality in our blog post.",
@@ -106,7 +106,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             BrowserOpener.openInBrowser(project, whatsNewUrl);
           }
         };
-    notification.setIcon(Icons.SourcegraphLogo);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(openAction);
     notification.addAction(learnMoreAction);
     Notifications.Bus.notify(notification);
@@ -122,8 +122,8 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             + " It is not possible to use Sourcegraph API and Cody without it.";
     Notification notification =
         new Notification(
-            "Sourcegraph access", "Sourcegraph", content, NotificationType.INFORMATION);
-    notification.setIcon(Icons.SourcegraphLogo);
+            "Cody AI by Sourcegraph: server access", "Sourcegraph", content, NotificationType.INFORMATION);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(new OpenPluginSettingsAction("Set Access Token"));
     notification.addAction(dumbAwareAction("Do Not Set", notification::expire));
     notification.addAction(

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
@@ -7,7 +7,7 @@ public interface PluginSettingChangeActionNotifier {
 
   Topic<PluginSettingChangeActionNotifier> TOPIC =
       Topic.create(
-          "Sourcegraph plugin settings have changed", PluginSettingChangeActionNotifier.class);
+          "Cody AI by Sourcegraph plugin settings have changed", PluginSettingChangeActionNotifier.class);
 
   void beforeAction(@NotNull PluginSettingChangeContext context);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -115,11 +115,10 @@ public class SettingsChangeListener implements Disposable {
     String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
     Notification notification =
         new Notification(
-            "Sourcegraph access",
-            "Sourcegraph authentication success",
-            "Your Sourcegraph account has been connected to the Sourcegraph plugin. Press "
-                + altSShortcutText
-                + " to open Sourcegraph.",
+            "Cody AI by Sourcegraph: server access",
+            "Cody AI by Sourcegraph: auth success",
+            "Your Sourcegraph account has been connected to the Sourcegraph plugin. "
+                + "Open the Cody sidebar, or press " + altSShortcutText + " to open Sourcegraph.",
             NotificationType.INFORMATION);
     AnAction dismissAction =
         new DumbAwareAction("Dismiss") {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -175,17 +175,17 @@ public class SettingsComponent {
     codyAppRadioButton.setActionCommand(InstanceType.LOCAL_APP.name());
     codyAppRadioButton.addActionListener(actionListener);
     codyAppRadioButton.setEnabled(isLocalAppInstalled && isLocalAppAccessTokenConfigured);
-    JRadioButton sourcegraphDotComRadioButton = new JRadioButton("Use sourcegraph.com");
-    sourcegraphDotComRadioButton.setMnemonic(KeyEvent.VK_C);
-    sourcegraphDotComRadioButton.setActionCommand(InstanceType.DOTCOM.name());
-    sourcegraphDotComRadioButton.addActionListener(actionListener);
+    JRadioButton dotcomRadioButton = new JRadioButton("Use sourcegraph.com");
+    dotcomRadioButton.setMnemonic(KeyEvent.VK_C);
+    dotcomRadioButton.setActionCommand(InstanceType.DOTCOM.name());
+    dotcomRadioButton.addActionListener(actionListener);
     JRadioButton enterpriseInstanceRadioButton = new JRadioButton("Use an enterprise instance");
     enterpriseInstanceRadioButton.setMnemonic(KeyEvent.VK_E);
     enterpriseInstanceRadioButton.setActionCommand(InstanceType.ENTERPRISE.name());
     enterpriseInstanceRadioButton.addActionListener(actionListener);
     instanceTypeButtonGroup = new ButtonGroup();
     instanceTypeButtonGroup.add(codyAppRadioButton);
-    instanceTypeButtonGroup.add(sourcegraphDotComRadioButton);
+    instanceTypeButtonGroup.add(dotcomRadioButton);
     instanceTypeButtonGroup.add(enterpriseInstanceRadioButton);
 
     // Assemble the three main panels String platformName =
@@ -193,16 +193,16 @@ public class SettingsComponent {
         Optional.ofNullable(System.getProperty("os.name")).orElse("Your platform");
     String codyAppCommentText =
         isLocalAppPlatformSupported
-            ? "Use Sourcegraph through the locally installed Cody App."
+            ? "Use Sourcegraph through Cody App."
             : platformName
-                + " is not yet supported by the local Cody App. Keep an eye on future updates!";
+                + " is not yet supported by the Cody App. Keep an eye on future updates!";
     JBLabel codyAppComment =
         new JBLabel(codyAppCommentText, UIUtil.ComponentStyle.SMALL, UIUtil.FontColor.BRIGHTER);
     codyAppComment.setBorder(JBUI.Borders.emptyLeft(20));
     boolean shouldShowInstallLocalAppLink = !isLocalAppInstalled && isLocalAppPlatformSupported;
     JLabel installLocalAppComment =
         new JBLabel(
-            "The local Cody App wasn't detected on this system, it seems it hasn't been installed yet.",
+            "Cody App wasn't detected on this system, it seems it hasn't been installed yet.",
             UIUtil.ComponentStyle.SMALL,
             UIUtil.FontColor.BRIGHTER);
     installLocalAppComment.setVisible(shouldShowInstallLocalAppLink);
@@ -217,7 +217,7 @@ public class SettingsComponent {
     runLocalAppLink.setBorder(JBUI.Borders.emptyLeft(20));
     JLabel runLocalAppComment =
         new JBLabel(
-            "The local Cody App seems to be installed, but it's not running, currently.",
+            "Cody App seems to be installed, but it's not running, currently.",
             UIUtil.ComponentStyle.SMALL,
             UIUtil.FontColor.BRIGHTER);
     runLocalAppComment.setVisible(shouldShowRunLocalAppLink);
@@ -245,14 +245,14 @@ public class SettingsComponent {
     dotComPanelContent.setBorder(IdeBorderFactory.createEmptyBorder(JBUI.insets(1, 30, 0, 0)));
     JPanel dotComPanel =
         FormBuilder.createFormBuilder()
-            .addComponent(sourcegraphDotComRadioButton, 1)
+            .addComponent(dotcomRadioButton, 1)
             .addComponent(dotComComment, 2)
             .addComponent(dotComPanelContent, 1)
             .getPanel();
     JPanel enterprisePanelContent =
         FormBuilder.createFormBuilder()
             .addLabeledComponent(urlLabel, urlTextField, 1)
-            .addTooltip("If your company uses a private Sourcegraph instance, set its URL here")
+            .addTooltip("If your company uses a Sourcegraph enterprise instance, set its URL here")
             .addLabeledComponent(accessTokenLabel, enterpriseAccessTokenTextField, 1)
             .addComponentToRightColumn(userDocsLinkComment, 1)
             .addComponentToRightColumn(enterpriseAccessTokenLinkComment, 1)
@@ -281,7 +281,7 @@ public class SettingsComponent {
           String[] pairs = customRequestHeadersTextField.getText().split(",");
           if (pairs.length % 2 != 0) {
             return new ValidationInfo(
-                "Must be a comma-separated list of pairs", customRequestHeadersTextField);
+                "Must be a comma-separated list of string pairs", customRequestHeadersTextField);
           }
 
           for (int i = 0; i < pairs.length; i += 2) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -19,7 +19,7 @@ public class SettingsConfigurable implements Configurable {
   @Nls(capitalization = Nls.Capitalization.Title)
   @Override
   public String getDisplayName() {
-    return "Sourcegraph";
+    return "Cody AI by Sourcegraph";
   }
 
   @Override
@@ -69,8 +69,8 @@ public class SettingsConfigurable implements Configurable {
     PluginSettingChangeActionNotifier publisher =
         bus.syncPublisher(PluginSettingChangeActionNotifier.TOPIC);
 
-    SourcegraphApplicationService aSettings = SourcegraphApplicationService.getInstance();
-    SourcegraphProjectService pSettings = SourcegraphService.getInstance(project);
+    CodyApplicationService aSettings = CodyApplicationService.getInstance();
+    CodyProjectService pSettings = CodyService.getInstance(project);
 
     boolean oldCodyCompletionsEnabled = ConfigUtil.areCodyCompletionsEnabled();
     String oldUrl = ConfigUtil.getSourcegraphUrl(project);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -105,8 +105,8 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
   private void showNoBrowserErrorNotification() {
     Notification notification =
         new Notification(
-            "Sourcegraph errors",
-            "Sourcegraph",
+            "Cody AI by Sourcegraph errors",
+            "Cody AI by Sourcegraph",
             "Your IDE doesn't support JCEF. You won't be able to use \"Find with Sourcegraph\". If you believe this is an error, please raise this at support@sourcegraph.com, specifying your OS and IDE version.",
             NotificationType.ERROR);
     AnAction copyEmailAddressAction =
@@ -125,7 +125,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
             notification.expire();
           }
         };
-    notification.setIcon(Icons.SourcegraphLogo);
+    notification.setIcon(Icons.CodyLogo);
     notification.addAction(copyEmailAddressAction);
     notification.addAction(dismissAction);
     Notifications.Bus.notify(notification);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -164,7 +164,7 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
     final Editor editor;
 
     SimpleEditorFileAction(String text, FileActionBase action, Editor editor) {
-      super(text, text, Icons.SourcegraphLogo);
+      super(text, text, Icons.CodyLogo);
       this.action = action;
       this.editor = editor;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -68,7 +68,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
       emptyText.appendLine(
           "Make sure your Sourcegraph URL and access token are correct to use search.");
       emptyText.appendLine(
-          "Click here to configure your Sourcegraph settings.",
+          "Click here to configure your Cody AI by Sourcegraph settings.",
           new SimpleTextAttributes(STYLE_PLAIN, JBUI.CurrentTheme.Link.Foreground.ENABLED),
           __ ->
               ShowSettingsUtil.getInstance()
@@ -88,7 +88,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
           "If you believe this is a bug, please raise this at support@sourcegraph.com,");
       //noinspection DialogTitleCapitalization
       emptyText.appendLine(
-          "mentioning the above error message and your plugin and Sourcegraph version.");
+          "mentioning the above error message and your Cody plugin and Cody App or Sourcegraph server version.");
       emptyText.appendLine("Sorry for the inconvenience.");
 
     } else if (connectionAndAuthState == ConnectionAndAuthState.LOADING) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
@@ -20,8 +20,8 @@ public class CopyAction extends FileActionBase {
     // Display notification
     Notification notification =
         new Notification(
-            "Sourcegraph URL sharing",
-            "Sourcegraph",
+            "Cody AI by Sourcegraph: URL sharing",
+            "Cody AI by Sourcegraph",
             "File URL copied to clipboard: " + urlWithoutUtm,
             NotificationType.INFORMATION);
     Notifications.Bus.notify(notification);

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -94,7 +94,7 @@ public class URLBuilder {
       @NotNull String productName,
       @NotNull String productVersion) {
     if (sourcegraphBase.equals("")) {
-      throw new RuntimeException("Missing sourcegraph URI for commit uri.");
+      throw new RuntimeException("Missing Sourcegraph URI for commit uri.");
     } else if (revisionNumber.equals("")) {
       throw new RuntimeException("Missing revision number for commit uri.");
     } else if (remoteUrl.equals("")) {

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>com.sourcegraph.jetbrains</id>
-    <name>Sourcegraph</name>
+    <name>Cody AI by Sourcegraph</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
 
     <!--
@@ -18,20 +18,20 @@
     <depends optional="true" config-file="plugin-perforce.xml">PerforceDirectPlugin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <projectService serviceImplementation="com.sourcegraph.config.SourcegraphProjectService"/>
+        <projectService serviceImplementation="com.sourcegraph.config.CodyProjectService"/>
         <projectService serviceImplementation="com.sourcegraph.config.SettingsChangeListener"/>
-        <applicationService serviceImplementation="com.sourcegraph.config.SourcegraphApplicationService"/>
+        <applicationService serviceImplementation="com.sourcegraph.config.CodyApplicationService"/>
         <projectConfigurable
             parentId="tools"
             instance="com.sourcegraph.config.SettingsConfigurable"
             id="com.sourcegraph.config.SettingsConfigurable"
-            displayName="Sourcegraph"
+            displayName="Cody AI by Sourcegraph"
             nonDefaultProject="false"
         />
-        <notificationGroup id="Sourcegraph access" displayType="BALLOON"/>
-        <notificationGroup id="Sourcegraph errors" displayType="BALLOON"/>
-        <notificationGroup id="Sourcegraph URL sharing" displayType="BALLOON"/>
-        <notificationGroup id="Sourcegraph plugin updates" displayType="STICKY_BALLOON"/>
+        <notificationGroup id="Cody AI by Sourcegraph: server access" displayType="BALLOON"/>
+        <notificationGroup id="Cody AI by Sourcegraph errors" displayType="BALLOON"/>
+        <notificationGroup id="Cody AI by Sourcegraph: URL sharing" displayType="BALLOON"/>
+        <notificationGroup id="Cody AI by Sourcegraph plugin updates" displayType="STICKY_BALLOON"/>
         <projectService id="sourcegraph.findService" serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity implementation="com.sourcegraph.telemetry.PostStartupActivity"/>
         <postStartupActivity implementation="com.sourcegraph.config.NotificationActivity"/>
@@ -43,7 +43,6 @@
             anchor="left"
             secondary="false"
             factoryClass="com.sourcegraph.cody.CodyToolWindowFactory"/>
-        <notificationGroup id="Cody Sourcegraph access" displayType="BALLOON"/>
         <projectService serviceImplementation="com.sourcegraph.cody.agent.CodyAgent"/>
 
 
@@ -142,7 +141,7 @@
             <reference ref="cody.refreshCodyAppDetection"/>
         </group>
 
-        <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Sourcegraph"
+        <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Cody AI by Sourcegraph"
                searchable="false">
             <reference ref="sourcegraph.openFindPopup"/>
             <reference ref="sourcegraph.searchSelection"/>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/54336

- Renamed the plugin
- Changed the icon at almost all places (where it made sense)
- Renamed some classes where it made sense
- Made sure the labels that used to say Sourcegraph now say Cody AI by Sourcegraph, where it made sense

## Test plan

Check if the icons and labels look and feel good.