### PR TITLE
remove displayed duplicated files from "read" section

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Don't display doubled messages about the error when trying to load context [#54345](https://github.com/sourcegraph/sourcegraph/pull/54345)
 - Now handling Null error messages in error logging properly [#54351](https://github.com/sourcegraph/sourcegraph/pull/54351)
 - Made sidebar refresh work for non-internal builds [#54348](https://github.com/sourcegraph/sourcegraph/pull/54358)
+- Don't display duplicated files in the "Read" section in the chat [#54363](https://github.com/sourcegraph/sourcegraph/pull/54363)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ContextFilesMessage.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ContextFilesMessage.java
@@ -11,6 +11,7 @@ import com.sourcegraph.cody.ui.AccordionSection;
 import java.awt.*;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.swing.border.EmptyBorder;
@@ -23,12 +24,12 @@ public class ContextFilesMessage extends MessagePanel {
 
     JBInsets margin =
         JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN));
-    List<String> contextFileNames =
+    Set<String> contextFileNames =
         contextMessages.stream()
             .map(ContextMessage::getFile)
             .filter(Objects::nonNull)
             .map(ContextFile::getFileName)
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
 
     AccordionSection accordionSection =
         new AccordionSection("Read " + contextFileNames.size() + " files");


### PR DESCRIPTION
Remove displayed duplicated file from "read" section in the chat

before: (duplicated readme.md entry)
![Screenshot 2023-06-28 at 15 02 22](https://github.com/sourcegraph/sourcegraph/assets/7345368/a57bc155-7e7e-4baa-a7bc-c1b7077d3004)
now: no duplicates
![Screenshot 2023-06-28 at 15 04 58](https://github.com/sourcegraph/sourcegraph/assets/7345368/fa40fe91-3004-4929-871f-e43742648766)


## Test plan
- No duplicated entries should appear in the "Read" files section in chat

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
