### PR TITLE
JetBrains: Remove Sourcegraph CLI's environment variable overrides

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Removed
 
+- Sourcegraph CLI's SRC_ENDPOINT and SRC_ACCESS_TOKEN env variables overrides for the local config got removed [#54369](https://github.com/sourcegraph/sourcegraph/pull/54369)
+
 ### Fixed
 
 - telemetry is now being sent to both the current instance & dotcom (unless the current instance is dotcom, then just that) [#54347](https://github.com/sourcegraph/sourcegraph/pull/54347)

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -114,7 +114,6 @@ The plugin works with all JetBrains IDEs, including:
   - If you use Sourcegraph.com, using an access token is optional (and only necessary to use Cody).
   - The configuration for an access token to use with Sourcegraph.com & a private instance is separate,
     you can switch between them on the fly.
-  - You can override the access token with the `SRC_ACCESS_TOKEN` environment variable.
   - See our [user docs](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token) for a video guide on how to
     create an access token.
 - **Custom request headers**: Any custom headers to send with every request to Sourcegraph.

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -250,15 +250,13 @@ public class CodyCompletionsManager {
   private CompletionsService completionsService(@NotNull Editor editor) {
     Optional<Project> project = Optional.ofNullable(editor.getProject());
     String instanceUrl =
-        Optional.ofNullable(System.getenv("SRC_ENDPOINT"))
-            .or(() -> project.map(ConfigUtil::getSourcegraphUrl))
+        project
+            .map(ConfigUtil::getSourcegraphUrl)
             .map(url -> url.endsWith("/") ? url : url + "/")
             .orElse(ConfigUtil.DOTCOM_URL);
     Optional<String> accessToken =
-        Optional.ofNullable(System.getenv("SRC_ACCESS_TOKEN"))
-            .or(
-                () ->
-                    project.flatMap(p -> Optional.ofNullable(ConfigUtil.getProjectAccessToken(p))))
+        project
+            .flatMap(p -> Optional.ofNullable(ConfigUtil.getProjectAccessToken(p)))
             .filter(StringUtils::isNotEmpty);
     if (accessToken.isEmpty() && !ConfigUtil.isAccessTokenNotificationDismissed()) {
       NotificationActivity.notifyAboutSourcegraphAccessToken(Optional.of(instanceUrl));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -110,7 +110,6 @@ public class LocalAppManager {
   }
 
   public static void runLocalApp() {
-    System.out.println("Running local Cody app...");
     getLocalAppPaths()
         .filter(paths -> !isLocalAppRunning()) // only run the app if it's not already running
         .ifPresent(

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -89,10 +89,7 @@ public class CodyApplicationService
     // configuring enterpriseAccessToken overrides the deprecated accessToken field
     String configuredEnterpriseAccessToken =
         StringUtils.isEmpty(enterpriseAccessToken) ? accessToken : enterpriseAccessToken;
-    // defaulting to SRC_ACCESS_TOKEN env if nothing else was configured
-    return configuredEnterpriseAccessToken == null
-        ? System.getenv("SRC_ACCESS_TOKEN")
-        : configuredEnterpriseAccessToken;
+    return configuredEnterpriseAccessToken;
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
@@ -45,9 +45,6 @@ public class CodyProjectService
   @Override
   @Nullable
   public String getDotComAccessToken() {
-    if (dotComAccessToken == null) {
-      return System.getenv("SRC_ACCESS_TOKEN");
-    }
     return dotComAccessToken;
   }
 
@@ -110,10 +107,7 @@ public class CodyProjectService
     // configuring enterpriseAccessToken overrides the deprecated accessToken field
     String configuredEnterpriseAccessToken =
         StringUtils.isEmpty(enterpriseAccessToken) ? accessToken : enterpriseAccessToken;
-    // defaulting to SRC_ACCESS_TOKEN env if nothing else was configured
-    return configuredEnterpriseAccessToken == null
-        ? System.getenv("SRC_ACCESS_TOKEN")
-        : configuredEnterpriseAccessToken;
+    return configuredEnterpriseAccessToken;
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -89,7 +89,6 @@ public class GraphQlLogger {
 
   private static void logDotcomEvent(
       @Nullable Consumer<Integer> callback, @NotNull String query, @NotNull JsonObject variables) {
-    System.out.println("logDotcomEvent");
     String instanceUrl = ConfigUtil.DOTCOM_URL;
     callGraphQlService(callback, instanceUrl, null, null, query, variables);
   }
@@ -99,7 +98,6 @@ public class GraphQlLogger {
       @NotNull String query,
       @NotNull JsonObject variables,
       @NotNull Project project) {
-    System.out.println("logInstanceEvent");
     String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
     String accessToken = ConfigUtil.getProjectAccessToken(project);
     String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);


### PR DESCRIPTION
This removes the (hidden) overrides for the `instanceUrl` and `accessToken` with the `SRC_ENDPOINT` and `SRC_ACCESS_TOKEN` environment variables.
We had these to be able to quickly reuse the settings from [Sourcegraph CLI](https://docs.sourcegraph.com/cli) (as the CLI is configured with those).
I think we shouldn't rely on it anymore, since it may provide uneccessary complexity with debugging stuff for users who might have had the CLI on their machines before.

If we do want to reuse the values from these variables, it should probably be via another instance switch (next to the local app, dotcom and enterprise) instead of somewhat implicitly.

Note: I also removed some debug logs that don't seem necessary anymore.

## Test plan
- Having a configured Sourcegraph CLI locally shouldn't override the Cody plugin's local config.
