### PR TITLE
Read repository name form http/https remotes

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Made sidebar refresh work for non-internal builds [#54348](https://github.com/sourcegraph/sourcegraph/pull/54358)
 - Don't display duplicated files in the "Read" section in the chat [#54363](https://github.com/sourcegraph/sourcegraph/pull/54363)
 - Repositories without configured git remotes are now available for Cody [#54370](https://github.com/sourcegraph/sourcegraph/pull/54370)
+- Repositories with http/https remotes are now available for Cody [#54372](https://github.com/sourcegraph/sourcegraph/pull/54372)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -10,6 +10,9 @@ import com.sourcegraph.common.ErrorNotification;
 import com.sourcegraph.config.ConfigUtil;
 import git4idea.repo.GitRepository;
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.perforce.perforce.PerforceAuthenticationException;
@@ -96,9 +99,16 @@ public class RepoUtil {
   public static @NotNull String getRemoteRepoUrlWithoutScheme(
       @NotNull Project project, @NotNull VirtualFile file) throws Exception {
     String remoteUrl = getRemoteRepoUrl(project, file);
-    return remoteUrl
-        .substring(remoteUrl.indexOf('@') + 1)
-        .replaceFirst(":", "/")
+    String repoName;
+      try {
+          URL url = new URL(remoteUrl);
+          repoName = url.getHost() + url.getPath();
+      } catch (MalformedURLException e) {
+          repoName = remoteUrl
+              .substring(remoteUrl.indexOf('@') + 1)
+              .replaceFirst(":", "/");
+      }
+    return repoName
         .replaceFirst(".git$", "");
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -12,7 +12,6 @@ import git4idea.repo.GitRepository;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.perforce.perforce.PerforceAuthenticationException;
@@ -100,16 +99,13 @@ public class RepoUtil {
       @NotNull Project project, @NotNull VirtualFile file) throws Exception {
     String remoteUrl = getRemoteRepoUrl(project, file);
     String repoName;
-      try {
-          URL url = new URL(remoteUrl);
-          repoName = url.getHost() + url.getPath();
-      } catch (MalformedURLException e) {
-          repoName = remoteUrl
-              .substring(remoteUrl.indexOf('@') + 1)
-              .replaceFirst(":", "/");
-      }
-    return repoName
-        .replaceFirst(".git$", "");
+    try {
+      URL url = new URL(remoteUrl);
+      repoName = url.getHost() + url.getPath();
+    } catch (MalformedURLException e) {
+      repoName = remoteUrl.substring(remoteUrl.indexOf('@') + 1).replaceFirst(":", "/");
+    }
+    return repoName.replaceFirst(".git$", "");
   }
 
   // Returned format: git@github.com:sourcegraph/sourcegraph.git


### PR DESCRIPTION
This fixes the problem when user has git repository configured with https remote instead of ssh

This solves one of the problem why context was not available for some users https://github.com/sourcegraph/sourcegraph/issues/54353 

## Test plan
- Context from git repositories with different remotes than ssh should be correctly read from Cody app 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
