### PR TITLE
Revert "zoekt: update to sourcegraph/zoekt@b9e6d9433e2e4438be6727ac3f1ae0a00e283220"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -513,7 +513,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e
+	github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2066,8 +2066,8 @@ github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3 h1:6PgJPdhDHRGs
 github.com/sourcegraph/scip v0.2.4-0.20230613194658-b62733841bc3/go.mod h1:ymcTuv+6D5OEZB/84TRPQvUpDK7v7zXnWBJl79hb7ns=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e h1:lxhAkz9gafw1DD0+XcnXXK4Hh3yujyhHNH4cY53pb+E=
-github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
+github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a h1:zFLcZUQ74dCV/oIiQT3+db8kFPstAnvFDm7pd+tjZ+8=
+github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#54037

Test Plan: CI 

@keegancsmith @stefanhengl this broke `sg start` and only it because: 

- the automated PR doesn't bump deps.bzl, so bazel runs with the old version. 
- there is still code referencing the deleted funcs, see https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/httpapi/search.go?L130

