### PR TITLE
Setup: Fix local repositories UI overflow problem

### DIFF
--- a/client/web/src/enterprise/app/settings/local-repositories/LocalRepositoriesTab.module.scss
+++ b/client/web/src/enterprise/app/settings/local-repositories/LocalRepositoriesTab.module.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    min-width: 0;
 }
 
 .header-actions {
@@ -23,14 +24,16 @@
     list-style: none;
 
     &--sub-list {
-        margin-top: 1.25rem;
-        margin-left: 1.5rem;
+        padding-top: 1.25rem;
+        padding-left: 1.5rem;
         gap: 0.75rem;
     }
 }
 
 .list-item {
+    max-width: 100%;
     display: flex;
+    gap: 0.5rem;
     border-bottom: 1px solid var(--border-color);
     padding-bottom: 1rem;
 
@@ -54,6 +57,7 @@
         display: flex;
         column-gap: 0.5rem;
         flex: 1;
+        min-width: 0;
     }
 
     &-content {
@@ -61,7 +65,7 @@
         flex-wrap: wrap;
         column-gap: 0.5rem;
         row-gap: 0.25rem;
-        flex-grow: 1;
+        min-width: 0;
     }
 
     &-directory-content {
@@ -83,6 +87,9 @@
 
     &-name {
         margin-bottom: 0;
+        text-align: left;
+        min-width: 0;
+        overflow-wrap: break-word;
     }
 
     &-icon {
@@ -100,10 +107,13 @@
         text-align: left;
         color: var(--text-muted);
         font-weight: normal;
+        min-width: 0;
+        overflow-wrap: break-word;
     }
 
     &-action {
         align-self: flex-start;
         flex-grow: 0;
+        margin-left: auto;
     }
 }

--- a/client/web/src/enterprise/app/settings/local-repositories/LocalRepositoriesTab.tsx
+++ b/client/web/src/enterprise/app/settings/local-repositories/LocalRepositoriesTab.tsx
@@ -203,10 +203,13 @@ interface RepositoryItemProps {
 const RepositoryItem: FC<RepositoryItemProps> = ({ service, repository, onDelete }) => (
     <li className={styles.listItem}>
         <span className={styles.listItemContent}>
-            <Icon aria-hidden={true} svgPath={mdiGit} inline={false} className={styles.listItemIcon} />
-            <Text weight="bold" className={styles.listItemName}>
-                {repository.name}
-            </Text>
+            <div className={styles.listItemDirectoryPath}>
+                <Icon aria-hidden={true} svgPath={mdiGit} inline={false} className={styles.listItemIcon} />
+                <Text weight="bold" className={styles.listItemName}>
+                    {repository.name}
+                </Text>
+            </div>
+
             <Text size="small" className={styles.listItemDescription}>
                 {repository.path}
             </Text>

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.module.scss
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.module.scss
@@ -2,6 +2,7 @@
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    max-width: 100%;
 }
 
 .content {
@@ -9,6 +10,7 @@
     background: radial-gradient(116.94% 133.26% at 52.08% 100%, #6112a3 0.41%, #270741 54.04%, #1e0632 94.78%);
     align-self: baseline;
     position: relative;
+    max-width: 100%;
 }
 
 .footer {

--- a/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.module.scss
+++ b/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.module.scss
@@ -6,9 +6,9 @@
 
 .description,
 .local-repositories {
-    flex-grow: 1;
+    flex-basis: 50%;
     flex-shrink: 0;
-    flex-basis: 24rem;
+    flex-grow: 0;
 }
 
 .description {


### PR DESCRIPTION

| Setting page | Setup flow |
| ---------- | ---------- |
| <img width="1041" alt="Screenshot 2023-06-28 at 12 15 43" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/3624b630-e6ba-4d79-ab4d-a33b9fd86a7a"> | <img width="1052" alt="Screenshot 2023-06-28 at 12 24 39" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/9e4a86e8-48aa-4ea4-a43c-15d7ec4c8c56"> |

## Test plan
- Check that local repositories UI works properly (shows wrapped names of repositories and their filenames) 
- Check local repositories UI in the setup flow and on the setting page

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
