### PR TITLE
link "Get Cody for Enterprise" to Cody pricing, not demo page

### DIFF
--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -311,7 +311,7 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                         </Text>
                         <div className={styles.ctaButtonWrapper}>
                             <Link
-                                to="https://about.sourcegraph.com/demo"
+                                to="https://about.sourcegraph.com/cody/pricing"
                                 className={classNames('text-decoration-none', styles.getCodyEnterpriseButton)}
                             >
                                 Get Cody for Enterprise


### PR DESCRIPTION
This page actually describes what you get. The demo page currently shows a Code Search video.

This page is pending merge at https://github.com/sourcegraph/about/pull/6344. The link does not currently work, but it will by the time this is deployed.



## Test plan

n/a