### PR TITLE
cody-gateway: do not enable dotcom actor sources if no token is set

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/source.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/source.go
@@ -66,6 +66,11 @@ func NewSources(sources ...Source) *Sources {
 	return &Sources{sources: sources}
 }
 
+// Add appends sources to the set.
+func (s *Sources) Add(sources ...Source) { s.sources = append(s.sources, sources...) }
+
+// Get attempts to retrieve an actor from any source that can provide it.
+// It returns the first non-ErrNotFromSource error encountered.
 func (s *Sources) Get(ctx context.Context, token string) (_ *Actor, err error) {
 	var span trace.Span
 	ctx, span = tracer.Start(ctx, "Sources.Get")

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -72,7 +72,8 @@ func (c *Config) Load() {
 	c.DiagnosticsSecret = c.Get("CODY_GATEWAY_DIAGNOSTICS_SECRET", "", "Secret for accessing diagnostics - "+
 		"should be used as 'Authorization: Bearer $secret' header when accessing diagnostics endpoints.")
 
-	c.Dotcom.AccessToken = c.Get("CODY_GATEWAY_DOTCOM_ACCESS_TOKEN", "", "The Sourcegraph.com access token to be used.")
+	c.Dotcom.AccessToken = c.GetOptional("CODY_GATEWAY_DOTCOM_ACCESS_TOKEN",
+		"The Sourcegraph.com access token to be used. If not provided, dotcom-based actor sources will be disabled.")
 	c.Dotcom.URL = c.Get("CODY_GATEWAY_DOTCOM_API_URL", "https://sourcegraph.com/.api/graphql", "Custom override for the dotcom API endpoint")
 	c.Dotcom.InternalMode = c.GetBool("CODY_GATEWAY_DOTCOM_INTERNAL_MODE", "false", "Only allow tokens associated with active internal and dev licenses to be used.") ||
 		c.GetBool("CODY_GATEWAY_DOTCOM_DEV_LICENSES_ONLY", "false", "DEPRECATED, use CODY_GATEWAY_DOTCOM_INTERNAL_MODE")

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -300,11 +300,12 @@ commands:
     checkBinary: .bin/cody-gateway
     env:
       CODY_GATEWAY_ANTHROPIC_ACCESS_TOKEN: foobar
-      CODY_GATEWAY_DOTCOM_ACCESS_TOKEN: foobar
+      # Set in override if you want to test local Cody Gateway: https://docs.sourcegraph.com/dev/how-to/cody_gateway
+      CODY_GATEWAY_DOTCOM_ACCESS_TOKEN: ""
       CODY_GATEWAY_DOTCOM_API_URL: https://sourcegraph.test:3443/.api/graphql
       CODY_GATEWAY_ALLOW_ANONYMOUS: true
       CODY_GATEWAY_DIAGNOSTICS_SECRET: sekret
-      SRC_LOG_LEVEL: dbug
+      SRC_LOG_LEVEL: info
     watch:
       - lib
       - internal


### PR DESCRIPTION
These actor sources require additional setup to function (https://docs.sourcegraph.com/dev/how-to/cody_gateway) - if you don't care (dev-private points to the managed dev instance by default) this is just error noise on the dotcom run set, so unless a dotcom token is set we disable these sources entirely.

```
 [   cody-gateway] ERROR cody-gateway.sourcesSync goroutine/periodic.go:395 operation.error {"TraceId": "f243edc2964770e6a886e4d95c09baa3", "SpanId": "fca7eb444071c1c0", "count": 1, "elapsed": 0.022313334, "error": "failed to sync dotcom-product-subscriptions: failed to list subscriptions from dotcom: returned error 401 Unauthorized: Invalid access token."}
```

## Test plan

With new defaults:

```
[   cody-gateway] WARN cody-gateway shared/main.go:96 CODY_GATEWAY_DOTCOM_ACCESS_TOKEN is not set, dotcom-based actor sources are disabled
```

Add `sg.config.overwrite.yaml` with token:

```
[   cody-gateway] INFO cody-gateway shared/main.go:79 dotcom-based actor sources are enabled
```
