### PR TITLE
cody-gateway: downgrade OTEL errors to debug

### DIFF
--- a/enterprise/cmd/cody-gateway/shared/tracing.go
+++ b/enterprise/cmd/cody-gateway/shared/tracing.go
@@ -30,7 +30,7 @@ func maybeEnableTracing(ctx context.Context, logger log.Logger, config TraceConf
 	policy.SetTracePolicy(config.Policy)
 	otel.SetTextMapPropagator(oteldefaults.Propagator())
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		logger.Warn("OpenTelemetry error", log.Error(err))
+		logger.Debug("OpenTelemetry error", log.Error(err))
 	}))
 
 	// Initialize exporter


### PR DESCRIPTION
In Sourcegraph we use debug-level for this error handler by default as well. Reduces error noise in local dev.

## Test plan

n/a

