### PR TITLE
cody-gateway: hardcode notification thresholds per actor source

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/notify/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/notify/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//internal/codygateway",
         "//internal/redispool",
+        "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_slack_go_slack//:slack",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",

--- a/enterprise/cmd/cody-gateway/shared/config.go
+++ b/enterprise/cmd/cody-gateway/shared/config.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -119,12 +118,6 @@ func (c *Config) Load() {
 	c.ActorConcurrencyLimit.Percentage = float32(c.GetPercent("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_PERCENTAGE", "50", "The percentage of daily rate limit to be allowed as concurrent requests limit from an actor.")) / 100
 	c.ActorConcurrencyLimit.Interval = c.GetInterval("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_INTERVAL", "10s", "The interval at which to check the concurrent requests limit from an actor.")
 
-	thresholds := c.Get("CODY_GATEWAY_ACTOR_RATE_LIMIT_NOTIFY_THRESHOLDS", "90,95,100", "The comma-separated list of the percentage of the rate limit usage to trigger an notification.")
-	c.ActorRateLimitNotify.Thresholds = make([]int, 0, len(thresholds))
-	for _, str := range strings.Split(thresholds, ",") {
-		threshold, _ := strconv.ParseInt(strings.TrimSpace(str), 10, 64)
-		c.ActorRateLimitNotify.Thresholds = append(c.ActorRateLimitNotify.Thresholds, int(threshold))
-	}
 	c.ActorRateLimitNotify.SlackWebhookURL = c.Get("CODY_GATEWAY_ACTOR_RATE_LIMIT_NOTIFY_SLACK_WEBHOOK_URL", "", "The Slack webhook URL to send notifications to.")
 }
 
@@ -144,12 +137,6 @@ func (c *Config) Validate() error {
 
 	if len(c.AllowedEmbeddingsModels) == 0 {
 		c.AddError(errors.New("must provide allowed models for embeddings generation"))
-	}
-
-	for _, threshold := range c.ActorRateLimitNotify.Thresholds {
-		if threshold <= 0 || threshold > 100 {
-			c.AddError(errors.Errorf("threshold out of range %d, should be (0, 100]", threshold))
-		}
 	}
 
 	return nil

--- a/enterprise/cmd/cody-gateway/shared/main.go
+++ b/enterprise/cmd/cody-gateway/shared/main.go
@@ -110,7 +110,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			// Detailed notifications for product subscriptions.
 			codygateway.ActorSourceProductSubscription: []int{90, 95, 100},
 			// No notifications for individual dotcom users - this can get quite
-			// spammy./
+			// spammy.
 			codygateway.ActorSourceDotcomUser: []int{},
 		},
 		config.ActorRateLimitNotify.SlackWebhookURL,

--- a/internal/codygateway/types.go
+++ b/internal/codygateway/types.go
@@ -50,10 +50,6 @@ type ActorConcurrencyLimitConfig struct {
 // ActorRateLimitNotifyConfig is the configuration for the rate limit
 // notifications of an actor.
 type ActorRateLimitNotifyConfig struct {
-	// Thresholds is a list of the percentages of the rate limit usage to trigger a
-	// notification. Each threshold will only trigger the notification once during
-	// the same rate limit window.
-	Thresholds []int
 	// SlackWebhookURL is the URL of the Slack webhook to send the alerts to.
 	SlackWebhookURL string
 }


### PR DESCRIPTION
As App usage of Gateway ramps up, we are expecting a _lot_ of actors to hit their rate limits. This is already causing a lot of noise in the channel. This change retains the previous notification thresholds for product subscriptions, but disables them entirely for other actor sources for now.

Env-based config is probably too brittle for this granularity so I think we should just hardcode it.

Thread: https://sourcegraph.slack.com/archives/C05BWKQB0R1/p1687904578368609

## Test plan

Unit tests