### PR TITLE
dev/release: also bump images and update chart versions in nested directories

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -828,9 +828,9 @@ cc @${release.captainGitHubUsername}
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
                         edits: [
-                            `for i in charts/*; do sg ops update-images -kind helm -pin-tag ${release.version.version} $i/.; done`,
-                            `${sed} -i 's/appVersion:.*/appVersion: "${release.version.version}"/g' charts/*/Chart.yaml`,
-                            `${sed} -i 's/version:.*/version: "${release.version.version}"/g' charts/*/Chart.yaml`,
+                            `find charts -name values.yaml -exec bash -c 'for file in "$1"; do path=$(echo $file | sed "s|/[^/]*$||"); sg ops update-images -kind helm -pin-tag ${release.version.version} $path; done' none {} \\;`,
+                            `find charts -name Chart.yaml | xargs ${sed} -i 's/appVersion:.*/appVersion: "${release.version.version}"/g'`,
+                            `find charts -name Chart.yaml | xargs ${sed} -i 's/version:.*/version: "${release.version.version}"/g'`,
                             './scripts/helm-docs.sh',
                         ],
                         ...prBodyAndDraftState([]),


### PR DESCRIPTION
The changes in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/279 introduced a new directory structure, which broke the release procedure for our helm charts, because the glob patterns used by the image and chart version update commands didn't match all directories with charts any longer.

This PR rewrites the commands to match any directories with `values.yaml` and `Chart.yaml` files respectively.

## TODO
The commands were tested in isolation, but I'm not sure how to test this properly with an appropriate `pnpm` command.

## Test plan
TBD

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
