### PR TITLE
Add file loader for woff2 fonts

### DIFF
--- a/client/web/dev/esbuild/build.ts
+++ b/client/web/dev/esbuild/build.ts
@@ -86,6 +86,7 @@ export const BUILD_OPTIONS: esbuild.BuildOptions = {
     loader: {
         '.yaml': 'text',
         '.ttf': 'file',
+        '.woff2': 'file',
         '.png': 'file',
     },
     target: 'esnext',


### PR DESCRIPTION
Follow up for https://github.com/sourcegraph/sourcegraph/pull/53962

In https://github.com/sourcegraph/sourcegraph/pull/53962 we added woff2 font, but we don't have any loader in esbuild for `.woff2` files. This pr simply adds it. 

## Test plan
CI is green

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
