### PR TITLE
search: update zoekt with removal of RepositoryRankRequest

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -238,7 +238,6 @@ func RegisterInternalServices(
 	}
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))
-	m.Get(apirouter.RepoRank).Handler(trace.Route(handler(indexer.serveRepoRank)))
 	m.Get(apirouter.DocumentRanks).Handler(trace.Route(handler(indexer.serveDocumentRanks)))
 	m.Get(apirouter.UpdateIndexStatus).Handler(trace.Route(handler(indexer.handleIndexStatusUpdate)))
 

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -117,21 +117,6 @@ func (s *searchIndexerGRPCServer) List(ctx context.Context, r *proto.ListRequest
 	return &response, nil
 }
 
-func (s *searchIndexerGRPCServer) RepositoryRank(ctx context.Context, request *proto.RepositoryRankRequest) (*proto.RepositoryRankResponse, error) {
-	ranks, err := s.server.Ranking.GetRepoRank(ctx, api.RepoName(request.Repository))
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-
-		return nil, err
-	}
-
-	return &proto.RepositoryRankResponse{
-		Rank: ranks,
-	}, nil
-}
-
 func (s *searchIndexerGRPCServer) DocumentRanks(ctx context.Context, request *proto.DocumentRanksRequest) (*proto.DocumentRanksResponse, error) {
 	ranks, err := s.server.Ranking.GetDocumentRanks(ctx, api.RepoName(request.Repository))
 	if err != nil {
@@ -474,10 +459,6 @@ var metricGetVersion = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_search_get_version_total",
 	Help: "The total number of times we poll gitserver for the version of a indexable branch.",
 })
-
-func (h *searchIndexerServer) serveRepoRank(w http.ResponseWriter, r *http.Request) error {
-	return serveRank(h.Ranking.GetRepoRank, w, r)
-}
 
 func (h *searchIndexerServer) serveDocumentRanks(w http.ResponseWriter, r *http.Request) error {
 	return serveRank(h.Ranking.GetDocumentRanks, w, r)

--- a/deps.bzl
+++ b/deps.bzl
@@ -6310,8 +6310,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:zFLcZUQ74dCV/oIiQT3+db8kFPstAnvFDm7pd+tjZ+8=",
-        version = "v0.0.0-20230620185637-63241cb1b17a",
+        sum = "h1:lxhAkz9gafw1DD0+XcnXXK4Hh3yujyhHNH4cY53pb+E=",
+        version = "v0.0.0-20230628123617-b9e6d9433e2e",
     )
 
     go_repository(

--- a/deps.bzl
+++ b/deps.bzl
@@ -6310,8 +6310,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:lxhAkz9gafw1DD0+XcnXXK4Hh3yujyhHNH4cY53pb+E=",
-        version = "v0.0.0-20230628123617-b9e6d9433e2e",
+        sum = "h1:R47B3db8T7o6/STiPywibnrD+kZvlAXp5W5N0S+dSvg=",
+        version = "v0.0.0-20230629101834-7643f3b313a2",
     )
 
     go_repository(

--- a/dev/backcompat/defs.bzl
+++ b/dev/backcompat/defs.bzl
@@ -45,13 +45,16 @@ PATCH_GO_TEST_CMDS = [
 # Join all individual go test patches into a single shell snippet.
 PATCH_ALL_GO_TESTS_CMD = "\n".join(PATCH_GO_TEST_CMDS)
 
-# Replaces all occurences of @com_github_sourcegraph_(scip|conc) by @back_compat_com_github_sourcegraph_(scip|conc).
+# Replaces all occurences of @com_github_sourcegraph_(scip|conc) and zoekt by @back_compat_com_github_sourcegraph_(scip|conc).
+# We need to do this, because the backcompat share the same deps as the current HEAD, so we need to handle deviations manually here.
+# It's annoying, but that's how we get cached back compat tests.
 PATCH_BUILD_FIXES_CMD = """_sed_binary="sed"
 if [ "$(uname)" == "Darwin" ]; then
     _sed_binary="gsed"
 fi
 find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_conc|@back_compat_com_github_sourcegraph_conc|g' {} +
 find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_scip|@back_compat_com_github_sourcegraph_scip|g' {} +
+find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_zoekt|@back_compat_com_github_sourcegraph_zoekt|g' {} +
 """
 
 def back_compat_defs():
@@ -100,6 +103,14 @@ def back_compat_defs():
         "github.com/sourcegraph/conc",
         sum = "h1:96VpOCAtXDCQ8Oycz0ftHqdPyMi8w12ltN4L2noYg7s=", # Need to be manually updated when bumping the back compat release target.
         version = "v0.2.0", # Need to be manually updated when bumping the back compat release target.
+    )
+
+    go_repository(
+        name = "back_compat_com_github_sourcegraph_zoekt",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/sourcegraph/zoekt",
+        sum = "h1:zFLcZUQ74dCV/oIiQT3+db8kFPstAnvFDm7pd+tjZ+8=",
+        version = "v0.0.0-20230620185637-63241cb1b17a",
     )
 
 

--- a/go.mod
+++ b/go.mod
@@ -513,7 +513,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a
+	github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -513,7 +513,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e
+	github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2066,8 +2066,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e h1:lxhAkz9gafw1DD0+XcnXXK4Hh3yujyhHNH4cY53pb+E=
-github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
+github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2 h1:R47B3db8T7o6/STiPywibnrD+kZvlAXp5W5N0S+dSvg=
+github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2/go.mod h1:tulqNTjuUDxIO3W80Ipbe6drMJJdcJdQPyKwAwo9cmw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -2066,8 +2066,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a h1:zFLcZUQ74dCV/oIiQT3+db8kFPstAnvFDm7pd+tjZ+8=
-github.com/sourcegraph/zoekt v0.0.0-20230620185637-63241cb1b17a/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
+github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e h1:lxhAkz9gafw1DD0+XcnXXK4Hh3yujyhHNH4cY53pb+E=
+github.com/sourcegraph/zoekt v0.0.0-20230628123617-b9e6d9433e2e/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -181,6 +181,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		attribute.Int("stats.files_loaded", statsAgg.FilesLoaded),
 		attribute.Int("stats.files_skipped", statsAgg.FilesSkipped),
 		attribute.Int("stats.match_count", statsAgg.MatchCount),
+		attribute.Int("stats.ngram_lookups", statsAgg.NgramLookups),
 		attribute.Int("stats.ngram_matches", statsAgg.NgramMatches),
 		attribute.Int("stats.shard_files_considered", statsAgg.ShardFilesConsidered),
 		attribute.Int("stats.shards_scanned", statsAgg.ShardsScanned),


### PR DESCRIPTION
This endpoint was unused which was why it was removed in Zoekt. The changes from Zoekt included in this dep bump:

- https://github.com/sourcegraph/zoekt/commit/1686b50d50 indexserver: remove unused GetRepoRank
- https://github.com/sourcegraph/zoekt/commit/7078a585a9 shards: populate RepoList.Stats.Repos
- https://github.com/sourcegraph/zoekt/commit/b9e6d9433e zoekt-indexserver: Check stderr for git fetch
- https://github.com/sourcegraph/zoekt/commit/93f7b0c983 matchtree: capture Stats before pruning
- https://github.com/sourcegraph/zoekt/commit/7643f3b313 matchiter: capture metric NgramLookups

Test Plan: CI

