### PR TITLE
gitserver: Fix arguments to `ClientForRepo` in `BatchLog`

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -122,6 +122,15 @@ func (c *testGitserverConns) ClientForRepo(userAgent string, repo api.RepoName) 
 	return c.clientFunc(conn), nil
 }
 
+func (c *testGitserverConns) ClientForAddr(addr string) (proto.GitserverServiceClient, error) {
+	conn, err := c.conns.ConnForAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.clientFunc(conn), nil
+}
+
 func (c *testGitserverConns) ConnForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
 	return c.conns.ConnForRepo(userAgent, repo)
 }
@@ -185,7 +194,10 @@ type GitserverConns struct {
 }
 
 func (g *GitserverConns) ConnForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
-	addr := g.AddrForRepo(userAgent, repo)
+	return g.ConnForAddr(g.AddrForRepo(userAgent, repo))
+}
+
+func (g *GitserverConns) ConnForAddr(addr string) (*grpc.ClientConn, error) {
 	ce, ok := g.grpcConns[addr]
 	if !ok {
 		return nil, errors.Newf("no gRPC connection found for address %q", addr)
@@ -224,6 +236,14 @@ func (a *atomicGitServerConns) AddrForRepo(userAgent string, repo api.RepoName) 
 
 func (a *atomicGitServerConns) ClientForRepo(userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error) {
 	conn, err := a.get().ConnForRepo(userAgent, repo)
+	if err != nil {
+		return nil, err
+	}
+	return proto.NewGitserverServiceClient(conn), nil
+}
+
+func (a *atomicGitServerConns) ClientForAddr(addr string) (proto.GitserverServiceClient, error) {
+	conn, err := a.get().ConnForAddr(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -122,15 +122,6 @@ func (c *testGitserverConns) ClientForRepo(userAgent string, repo api.RepoName) 
 	return c.clientFunc(conn), nil
 }
 
-func (c *testGitserverConns) ClientForAddr(addr string) (proto.GitserverServiceClient, error) {
-	conn, err := c.conns.ConnForAddr(addr)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.clientFunc(conn), nil
-}
-
 func (c *testGitserverConns) ConnForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
 	return c.conns.ConnForRepo(userAgent, repo)
 }
@@ -194,10 +185,7 @@ type GitserverConns struct {
 }
 
 func (g *GitserverConns) ConnForRepo(userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
-	return g.ConnForAddr(g.AddrForRepo(userAgent, repo))
-}
-
-func (g *GitserverConns) ConnForAddr(addr string) (*grpc.ClientConn, error) {
+	addr := g.AddrForRepo(userAgent, repo)
 	ce, ok := g.grpcConns[addr]
 	if !ok {
 		return nil, errors.Newf("no gRPC connection found for address %q", addr)
@@ -236,14 +224,6 @@ func (a *atomicGitServerConns) AddrForRepo(userAgent string, repo api.RepoName) 
 
 func (a *atomicGitServerConns) ClientForRepo(userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error) {
 	conn, err := a.get().ConnForRepo(userAgent, repo)
-	if err != nil {
-		return nil, err
-	}
-	return proto.NewGitserverServiceClient(conn), nil
-}
-
-func (a *atomicGitServerConns) ClientForAddr(addr string) (proto.GitserverServiceClient, error) {
-	conn, err := a.get().ConnForAddr(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -976,10 +976,15 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 	ctx, _, endObservation := c.operations.batchLog.With(ctx, &err, observation.Args{Attrs: opts.Attrs()})
 	defer endObservation(1, observation.Args{})
 
+	type clientAndError struct {
+		client  proto.GitserverServiceClient
+		dialErr error // non-nil if there was an error dialing the client
+	}
+
 	// Make a request to a single gitserver shard and feed the results to the user-supplied
 	// callback. This function is invoked multiple times (and concurrently) in the loops below
 	// this function definition.
-	performLogRequestToShard := func(ctx context.Context, addr string, client proto.GitserverServiceClient, repoCommits []api.RepoCommit) (err error) {
+	performLogRequestToShard := func(ctx context.Context, addr string, grpcClient clientAndError, repoCommits []api.RepoCommit) (err error) {
 		var numProcessed int
 		repoNames := repoNamesFromRepoCommits(repoCommits)
 
@@ -1006,6 +1011,11 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 		var response protocol.BatchLogResponse
 
 		if internalgrpc.IsGRPCEnabled(ctx) {
+			client, err := grpcClient.client, grpcClient.dialErr
+			if err != nil {
+				return err
+			}
+
 			resp, err := client.BatchLog(ctx, request.ToProto())
 			if err != nil {
 				return err
@@ -1104,13 +1114,15 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 
 		client, err := c.ClientForRepo(repoCommits[0].Repo)
 		if err != nil {
-			return errors.Wrapf(err, "getting gRPC client for repository %q", repoCommits[0].Repo)
+			err = errors.Wrapf(err, "getting gRPC client for repository %q", repoCommits[0].Repo)
 		}
+
+		ce := clientAndError{client: client, dialErr: err}
 
 		g.Go(func() (err error) {
 			defer sem.Release(1)
 
-			return performLogRequestToShard(ctx, addr, client, repoCommits)
+			return performLogRequestToShard(ctx, addr, ce, repoCommits)
 		})
 	}
 
@@ -1755,4 +1767,9 @@ func readResponseBody(body io.Reader) string {
 	// strings.TrimSpace, see attached screenshots in this pull request:
 	// https://github.com/sourcegraph/sourcegraph/pull/39358.
 	return strings.TrimSpace(string(content))
+}
+
+type clientAndError struct {
+	client proto.GitserverServiceClient
+	err    error
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1104,7 +1104,7 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 
 		client, err := c.ClientForRepo(repoCommits[0].Repo)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "getting gRPC client for repository %q", repoCommits[0].Repo)
 		}
 
 		g.Go(func() (err error) {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1008,6 +1008,8 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 		var response protocol.BatchLogResponse
 
 		if internalgrpc.IsGRPCEnabled(ctx) {
+			// Each of the repo names belong to the same shard - look up the address
+			// of the target gitserver shard from any one of them.
 			client, err := c.ClientForRepo(api.RepoName(repoNames[0]))
 			if err != nil {
 				return err

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -1009,7 +1009,7 @@ func (c *clientImplementor) BatchLog(ctx context.Context, opts BatchLogOptions, 
 		var response protocol.BatchLogResponse
 
 		if internalgrpc.IsGRPCEnabled(ctx) {
-			client, err := c.ClientForRepo(repoName)
+			client, err := c.ClientForRepo(api.RepoName(repoNames[0]))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Discovered locally when trying to request commits for multiple repos. In the gRPC branch of `ClientForRepo` we pass `repoName`, which was constructed with an explicit note that it's ONLY used for tracing (called in the `do` method). This messes up the calculation for an address and we end up not reaching out to any relevant shards.

This method is constructed in such a way that each set of repo names belong to the same gitserver shard, so we can take the first item from the set to calculate the repository name.

**Note**: This may cause partial code intelligence result sets when there are multiple repositories in the same shard per page of results.

## Test plan

Tested locally.