### PR TITLE
dotcom/productsubscription: allow SA to do license key lookup

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -153,7 +153,7 @@ func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscript
 
 func (r ProductSubscriptionLicensingResolver) ProductLicenses(ctx context.Context, args *graphqlbackend.ProductLicensesArgs) (graphqlbackend.ProductLicenseConnection, error) {
 	// 🚨 SECURITY: Only site admins may list product licenses.
-	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
+	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This is required for upcoming Cloud automation: https://github.com/sourcegraph/controller/pull/805

Currently we can't do the lookup:

```
ERROR mi2.instance.check.enforce.Enforce.cody mi2/instance.go:511 error encountered {"TraceId": "03e4d62c01a89c6a62e5d2e8f1cb6df6", "SpanId": "98bf6654fdf74de6", "environment": "prod", "instance": "src-96ed006bb45d673944e4", "error": "GetEmbeddingsIndexerToken: getSubscription: GetProductSubscriptionByLicense: input: dotcom.productLicenses must be site admin"}
```

## Test plan

unit tests on the `serviceAccountOrSiteAdmin` helper