### PR TITLE
executors: Handle single job and not needing to run the safe git command

### DIFF
--- a/enterprise/cmd/batcheshelper/main.go
+++ b/enterprise/cmd/batcheshelper/main.go
@@ -164,7 +164,6 @@ func getPreviouslyExecutedStep(path string, previousStep int) (execution.AfterSt
 
 func getAddSafe() (bool, error) {
 	addSafeString := os.Getenv("EXECUTOR_ADD_SAFE")
-	fmt.Println("EXECUTOR_ADD_SAFE:", addSafeString)
 	// Default to true for backwards compatibility.
 	if addSafeString == "" {
 		return true, nil

--- a/enterprise/cmd/batcheshelper/main.go
+++ b/enterprise/cmd/batcheshelper/main.go
@@ -78,7 +78,11 @@ func doMain() error {
 	case "pre":
 		return run.Pre(ctx, logger, arguments.step, executionInput, previousResult, wd, *workspaceFilesPath)
 	case "post":
-		return run.Post(ctx, logger, &util.RealCmdRunner{}, arguments.step, executionInput, previousResult, wd, *workspaceFilesPath)
+		addSafe, err := getAddSafe()
+		if err != nil {
+			return err
+		}
+		return run.Post(ctx, logger, &util.RealCmdRunner{}, arguments.step, executionInput, previousResult, wd, *workspaceFilesPath, addSafe)
 	default:
 		return errors.Newf("invalid mode %q", arguments.mode)
 	}
@@ -156,4 +160,18 @@ func getPreviouslyExecutedStep(path string, previousStep int) (execution.AfterSt
 		}
 	}
 	return execution.AfterStepResult{}, nil
+}
+
+func getAddSafe() (bool, error) {
+	addSafeString := os.Getenv("EXECUTOR_ADD_SAFE")
+	fmt.Println("EXECUTOR_ADD_SAFE:", addSafeString)
+	// Default to true for backwards compatibility.
+	if addSafeString == "" {
+		return true, nil
+	}
+	addSafe, err := strconv.ParseBool(addSafeString)
+	if err != nil {
+		return false, errors.Wrap(err, "parsing EXECUTOR_ADD_SAFE boolean")
+	}
+	return addSafe, nil
 }

--- a/enterprise/cmd/batcheshelper/run/post.go
+++ b/enterprise/cmd/batcheshelper/run/post.go
@@ -31,10 +31,14 @@ func Post(
 	previousResult execution.AfterStepResult,
 	workingDirectory string,
 	workspaceFilesPath string,
+	addSafe bool,
 ) error {
-	// Sometimes the files belong to different users. Mark the repository directory as safe.
-	if _, err := runner.Git(ctx, "", "config", "--global", "--add", "safe.directory", "/job/repository"); err != nil {
-		return errors.Wrap(err, "failed to mark repository directory as safe")
+	if addSafe {
+		fmt.Println("Adding safe files to git")
+		// Sometimes the files belong to different users. Mark the repository directory as safe.
+		if _, err := runner.Git(ctx, "", "config", "--global", "--add", "safe.directory", "/job/repository"); err != nil {
+			return errors.Wrap(err, "failed to mark repository directory as safe")
+		}
 	}
 
 	// Generate the diff.

--- a/enterprise/cmd/batcheshelper/run/post.go
+++ b/enterprise/cmd/batcheshelper/run/post.go
@@ -34,7 +34,6 @@ func Post(
 	addSafe bool,
 ) error {
 	if addSafe {
-		fmt.Println("Adding safe files to git")
 		// Sometimes the files belong to different users. Mark the repository directory as safe.
 		if _, err := runner.Git(ctx, "", "config", "--global", "--add", "safe.directory", "/job/repository"); err != nil {
 			return errors.Wrap(err, "failed to mark repository directory as safe")

--- a/enterprise/cmd/batcheshelper/run/post_test.go
+++ b/enterprise/cmd/batcheshelper/run/post_test.go
@@ -235,7 +235,7 @@ func TestPost(t *testing.T) {
 				test.mockFunc(runner)
 			}
 
-			err = run.Post(context.Background(), logger, runner, test.step, test.executionInput, test.previousResult, dir, workspaceFilesDir)
+			err = run.Post(context.Background(), logger, runner, test.step, test.executionInput, test.previousResult, dir, workspaceFilesDir, true)
 
 			if test.expectedErr != nil {
 				require.Error(t, err)

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -623,6 +623,13 @@ func NewKubernetesSingleJob(
 
 	for stepIndex, step := range specs {
 		jobEnvs := newEnvVars(step.Env)
+		// Single job does not need to add the git directory as safe since the user is the same across all containers.
+		// This is a work around until we have a more elegant solution for dealing with the multi-job and different users.
+		// e.g. Executor is run as sourcegraph user and batcheshelper is run as root.
+		jobEnvs = append(jobEnvs, corev1.EnvVar{
+			Name:  "EXECUTOR_ADD_SAFE",
+			Value: "false",
+		})
 
 		nextIndexCommand := fmt.Sprintf("if [ \"$(%s /job/skip.json %s)\" != \"skip\" ]; then ", filepath.Join(KubernetesJobMountPath, "nextIndex.sh"), step.Key)
 		stepInitContainers[stepIndex+1] = corev1.Container{

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
@@ -737,9 +737,11 @@ func TestNewKubernetesSingleJob(t *testing.T) {
 		"if [ \"$(/job/nextIndex.sh /job/skip.json my.container.0)\" != \"skip\" ]; then echo; hello;  fi",
 		job.Spec.Template.Spec.InitContainers[1].Args[0],
 	)
-	require.Len(t, job.Spec.Template.Spec.InitContainers[1].Env, 1)
+	require.Len(t, job.Spec.Template.Spec.InitContainers[1].Env, 2)
 	assert.Equal(t, "FOO", job.Spec.Template.Spec.InitContainers[1].Env[0].Name)
 	assert.Equal(t, "bar", job.Spec.Template.Spec.InitContainers[1].Env[0].Value)
+	assert.Equal(t, "EXECUTOR_ADD_SAFE", job.Spec.Template.Spec.InitContainers[1].Env[1].Name)
+	assert.Equal(t, "false", job.Spec.Template.Spec.InitContainers[1].Env[1].Value)
 	require.Len(t, job.Spec.Template.Spec.InitContainers[1].VolumeMounts, 1)
 	assert.Equal(t, "job-data", job.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].Name)
 	assert.Equal(t, "/job", job.Spec.Template.Spec.InitContainers[1].VolumeMounts[0].MountPath)
@@ -755,9 +757,11 @@ func TestNewKubernetesSingleJob(t *testing.T) {
 		"if [ \"$(/job/nextIndex.sh /job/skip.json my.container.1)\" != \"skip\" ]; then echo; world;  fi",
 		job.Spec.Template.Spec.InitContainers[2].Args[0],
 	)
-	require.Len(t, job.Spec.Template.Spec.InitContainers[2].Env, 1)
+	require.Len(t, job.Spec.Template.Spec.InitContainers[2].Env, 2)
 	assert.Equal(t, "FOO", job.Spec.Template.Spec.InitContainers[2].Env[0].Name)
 	assert.Equal(t, "baz", job.Spec.Template.Spec.InitContainers[2].Env[0].Value)
+	assert.Equal(t, "EXECUTOR_ADD_SAFE", job.Spec.Template.Spec.InitContainers[1].Env[1].Name)
+	assert.Equal(t, "false", job.Spec.Template.Spec.InitContainers[1].Env[1].Value)
 	require.Len(t, job.Spec.Template.Spec.InitContainers[2].VolumeMounts, 1)
 	assert.Equal(t, "job-data", job.Spec.Template.Spec.InitContainers[2].VolumeMounts[0].Name)
 	assert.Equal(t, "/job", job.Spec.Template.Spec.InitContainers[2].VolumeMounts[0].MountPath)

--- a/enterprise/cmd/executor/kubernetes/batches/executor-batches.Deployment.yml
+++ b/enterprise/cmd/executor/kubernetes/batches/executor-batches.Deployment.yml
@@ -64,6 +64,8 @@ spec:
             # Check executor-batches.Role.yml to ensure the correct rules are enabled.
 #            - name: KUBERNETES_SINGLE_JOB_POD
 #              value: "true"
+#            - name: "KUBERNETES_SINGLE_JOB_STEP_IMAGE"
+#              value: "batcheshelper:candidate"
             # Check executor-batches.Role.yml to ensure the correct rules are enabled.
 #            - name: KUBERNETES_JOB_VOLUME_TYPE
 #              value: "pvc"


### PR DESCRIPTION
When running a single job, do not need to add the directory as safe.

## Test plan

Updated tests and ran locally.