### PR TITLE
ci: enable client integration tests

### DIFF
--- a/client/completions-review-tool/tsconfig.json
+++ b/client/completions-review-tool/tsconfig.json
@@ -7,8 +7,6 @@
     "rootDir": ".",
     "outDir": "./out",
     "baseUrl": "./src",
-    // Remix takes care of building everything in `remix build`.
-    // "noEmit": true,
   },
   "include": ["globals.d.ts", "remix.env.d.ts", "**/*.ts", "**/*.tsx", "*.js"],
 }

--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -119,7 +119,6 @@ mocha_test(
     flaky = True,
     is_percy_enabled = True,
     tags = [
-        "manual",
         "no-sandbox",
         "requires-network",
     ],


### PR DESCRIPTION
## Context

- Re-enables client integration tests in Bazel
- Removes comment from the `tsconfig.json` file, which resulted in a warning when running `bazel configure`

## Test plan

CI 
