### PR TITLE
JetBrains: preserve new lines in the human chat message

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Preserve new lines in the human chat message [#54417](https://github.com/sourcegraph/sourcegraph/pull/54417)
+
 ### Security
 
 ## [3.0.2]

--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.21.0")
     testImplementation(platform("org.junit:junit-bom:5.7.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.assertj:assertj-core:3.24.2")
 }
 
 spotless {
@@ -174,4 +175,8 @@ tasks {
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -41,6 +41,7 @@ import com.sourcegraph.cody.chat.ChatMessage;
 import com.sourcegraph.cody.chat.ChatUIConstants;
 import com.sourcegraph.cody.chat.ContentWithGradientBorder;
 import com.sourcegraph.cody.chat.ContextFilesMessage;
+import com.sourcegraph.cody.chat.HumanMessageToMarkdownTextTransformer;
 import com.sourcegraph.cody.chat.Interaction;
 import com.sourcegraph.cody.chat.Transcript;
 import com.sourcegraph.cody.context.ContextGetter;
@@ -600,7 +601,8 @@ class CodyToolWindowContent implements UpdatableChat {
   }
 
   private void sendMessage(@NotNull Project project) {
-    String messageText = promptInput.getText();
+    String messageText =
+        new HumanMessageToMarkdownTextTransformer(promptInput.getText()).transform();
     promptInput.setText("");
     sendMessage(project, ChatMessage.createHumanMessage(messageText, messageText), "");
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/HumanMessageToMarkdownTextTransformer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/HumanMessageToMarkdownTextTransformer.java
@@ -1,0 +1,17 @@
+package com.sourcegraph.cody.chat;
+
+import org.jetbrains.annotations.NotNull;
+
+public class HumanMessageToMarkdownTextTransformer {
+  private @NotNull final String humanMessageText;
+
+  private static final String SPACE = " ";
+
+  public HumanMessageToMarkdownTextTransformer(@NotNull String humanMessageText) {
+    this.humanMessageText = humanMessageText;
+  }
+
+  public String transform() {
+    return humanMessageText.replace("\n", "<br />");
+  }
+}

--- a/client/jetbrains/src/test/java/URLBuilderTest.java
+++ b/client/jetbrains/src/test/java/URLBuilderTest.java
@@ -11,7 +11,7 @@ public class URLBuilderTest {
 
   @Test
   @Disabled(
-      "This test tries to access intellij state which is not present in the unit test environment.")
+      "This test tries to access IntelliJ state which is not present in the unit test environment.")
   public void testBuildCommitUrl_AllValid() {
     String remoteUrl = "https://github.com/sourcegraph/sourcegraph-jetbrains.git";
 

--- a/client/jetbrains/src/test/java/URLBuilderTest.java
+++ b/client/jetbrains/src/test/java/URLBuilderTest.java
@@ -2,6 +2,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.sourcegraph.website.URLBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -9,6 +10,8 @@ import org.junit.jupiter.params.provider.EmptySource;
 public class URLBuilderTest {
 
   @Test
+  @Disabled(
+      "This test tries to access intellij state which is not present in the unit test environment.")
   public void testBuildCommitUrl_AllValid() {
     String remoteUrl = "https://github.com/sourcegraph/sourcegraph-jetbrains.git";
 

--- a/client/jetbrains/src/test/java/com/sourcegraph/cody/chat/HumanMessageToMarkdownTextTransformerTest.java
+++ b/client/jetbrains/src/test/java/com/sourcegraph/cody/chat/HumanMessageToMarkdownTextTransformerTest.java
@@ -1,0 +1,77 @@
+package com.sourcegraph.cody.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.commonmark.node.HtmlInline;
+import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.Text;
+import org.commonmark.parser.Parser;
+import org.junit.jupiter.api.Test;
+
+public class HumanMessageToMarkdownTextTransformerTest {
+  @Test
+  public void shouldTransformNewLinesToMarkdownNewLines() {
+    // given
+    HumanMessageToMarkdownTextTransformer transformer =
+        new HumanMessageToMarkdownTextTransformer("foo\nbar");
+
+    // when
+    String result = transformer.transform();
+
+    // then
+    Node rootMarkdownNode = readMarkdown(result);
+    Paragraph firstParagraph = (Paragraph) rootMarkdownNode.getFirstChild();
+    Text textInFirstParagraph = (Text) firstParagraph.getFirstChild();
+    assertThat(textInFirstParagraph.getLiteral()).isEqualTo("foo");
+    Paragraph secondParagraph = (Paragraph) rootMarkdownNode.getLastChild();
+    Text textInSecondParagraph = (Text) secondParagraph.getLastChild();
+    assertThat(textInSecondParagraph.getLiteral()).isEqualTo("bar");
+  }
+
+  @Test
+  public void shouldNotSplitTextToNewLineInMarkdownWhenThereIsNoNewLine() {
+    // given
+    HumanMessageToMarkdownTextTransformer transformer =
+        new HumanMessageToMarkdownTextTransformer("foo bar");
+
+    // when
+    String result = transformer.transform();
+
+    // then
+    Node rootMarkdownNode = readMarkdown(result);
+    Paragraph firstParagraph = (Paragraph) rootMarkdownNode.getFirstChild();
+    Text textInFirstParagraph = (Text) firstParagraph.getFirstChild();
+    assertThat(textInFirstParagraph.getLiteral()).isEqualTo("foo bar");
+    Paragraph secondParagraph = (Paragraph) rootMarkdownNode.getLastChild();
+    // there are no new nodes, first and last child is the same node
+    assertThat(firstParagraph == secondParagraph).isTrue();
+  }
+
+  @Test
+  public void shouldAddDoubledMarkdownLines() {
+    // given
+    HumanMessageToMarkdownTextTransformer transformer =
+        new HumanMessageToMarkdownTextTransformer("foo\n\nbar");
+
+    // when
+    String result = transformer.transform();
+
+    // then
+    Node rootMarkdownNode = readMarkdown(result);
+    Paragraph firstParagraph = (Paragraph) rootMarkdownNode.getFirstChild();
+    Text textInFirstParagraph = (Text) firstParagraph.getFirstChild();
+    assertThat(textInFirstParagraph.getLiteral()).isEqualTo("foo");
+    HtmlInline firstNewLine = (HtmlInline) textInFirstParagraph.getNext();
+    assertThat(firstNewLine.getLiteral()).isEqualTo("<br />");
+    HtmlInline secondNewLine = (HtmlInline) firstNewLine.getNext();
+    assertThat(secondNewLine.getLiteral()).isEqualTo("<br />");
+    Text textInLastParagraph = (Text) secondNewLine.getNext();
+    assertThat(textInLastParagraph.getLiteral()).isEqualTo("bar");
+  }
+
+  private Node readMarkdown(String result) {
+    return Parser.builder().build().parse(result);
+  }
+}


### PR DESCRIPTION
When sending a message with new lines they're preserved in the chat message

Added AssertJ assertions to the unit tests to have better error messages on failed tests, and unit tests are now enabled on CI

## Test plan
- Send a message with new line and the message should be displayed with new line in the chat

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
before:

https://github.com/sourcegraph/sourcegraph/assets/7345368/b19bc261-5346-4567-9882-445495c41c96

after:

https://github.com/sourcegraph/sourcegraph/assets/7345368/8e8b2a53-457e-4355-8c19-cc5b149ed671

