### PR TITLE
[gitlab] Fix GitLab internal project visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed an embeddings job scheduler bug where if we cannot resolve one of the repositories or its default branch then all repositories submitted will not have their respective embeddings job enqueued. Embeddings job scheduler will now continue to schedule jobs for subsequent repositories in the submitted repositories set. [#54701](https://github.com/sourcegraph/sourcegraph/pull/54701)
+- GitLab internal project visibility is handled more reliably. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
 
 ## 5.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Experimental support for Azure OpenAI for the completions and embeddings provider has been added. [#55178](https://github.com/sourcegraph/sourcegraph/pull/55178)
+- Added a feature flag for alternate GitLab project visibility resolution. This may solve some weird cases with not being able to see GitLab internal projects. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
+  - To use this feature flag, create a Boolean feature flag named "gitLabProjectVisibilityExperimental" and set the value to True.
 
 ### Changed
 
@@ -28,7 +30,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed an issue where GitHub Apps could not be set up using Firefox. [#55305](https://github.com/sourcegraph/sourcegraph/pull/55305)
-- GitLab internal project visibility is handled more reliably. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed an issue where GitHub Apps could not be set up using Firefox. [#55305](https://github.com/sourcegraph/sourcegraph/pull/55305)
+- GitLab internal project visibility is handled more reliably. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
 
 ### Removed
 
@@ -80,7 +81,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed an embeddings job scheduler bug where if we cannot resolve one of the repositories or its default branch then all repositories submitted will not have their respective embeddings job enqueued. Embeddings job scheduler will now continue to schedule jobs for subsequent repositories in the submitted repositories set. [#54701](https://github.com/sourcegraph/sourcegraph/pull/54701)
-- GitLab internal project visibility is handled more reliably. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
 
 ## 5.1.2
 

--- a/internal/authz/providers/gitlab/BUILD.bazel
+++ b/internal/authz/providers/gitlab/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/extsvc",
         "//internal/extsvc/auth",
         "//internal/extsvc/gitlab",
+        "//internal/featureflag",
         "//internal/httpcli",
         "//internal/licensing",
         "//internal/types",

--- a/internal/authz/providers/gitlab/BUILD.bazel
+++ b/internal/authz/providers/gitlab/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//internal/extsvc",
         "//internal/extsvc/auth",
         "//internal/extsvc/gitlab",
+        "//internal/featureflag",
         "//internal/oauthutil",
         "//internal/rcache",
         "//internal/types",

--- a/internal/authz/providers/gitlab/oauth_test.go
+++ b/internal/authz/providers/gitlab/oauth_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -64,81 +65,164 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		}
 	})
 
-	// The OAuthProvider uses the gitlab.Client under the hood,
-	// which uses rcache, a caching layer that uses Redis.
-	// We need to clear the cache before we run the tests
-	rcache.SetupForTest(t)
+	t.Run("feature flag disabled", func(t *testing.T) {
+		// The OAuthProvider uses the gitlab.Client under the hood,
+		// which uses rcache, a caching layer that uses Redis.
+		// We need to clear the cache before we run the tests
+		rcache.SetupForTest(t)
 
-	p := newOAuthProvider(
-		OAuthProviderOp{
-			BaseURL: mustURL(t, "https://gitlab.com"),
-			Token:   "admin_token",
-			DB:      database.NewMockDB(),
-		},
-		&mockDoer{
-			do: func(r *http.Request) (*http.Response, error) {
-				visibility := r.URL.Query().Get("visibility")
-				if visibility != "private" && visibility != "internal" {
-					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
-				}
-				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
-				if r.URL.String() != want {
-					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
-				}
-
-				want = "Bearer my_access_token"
-				got := r.Header.Get("Authorization")
-				if got != want {
-					return nil, errors.Errorf("HTTP Authorization: want %q but got %q", want, got)
-				}
-
-				body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
-				if visibility == "internal" {
-					body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
-				}
-				return &http.Response{
-					Status:     http.StatusText(http.StatusOK),
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
-				}, nil
+		p := newOAuthProvider(
+			OAuthProviderOp{
+				BaseURL: mustURL(t, "https://gitlab.com"),
+				Token:   "admin_token",
+				DB:      database.NewMockDB(),
 			},
-		},
-	)
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					visibility := r.URL.Query().Get("visibility")
+					if visibility != "private" && visibility != "internal" {
+						return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+					}
+					want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
+					if r.URL.String() != want {
+						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
+					}
 
-	gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
-		return &oauthutil.OAuthContext{
-			ClientID:     "client",
-			ClientSecret: "client_sec",
-			Endpoint: oauth2.Endpoint{
-				AuthURL:  "url/oauth/authorize",
-				TokenURL: "url/oauth/token",
+					want = "Bearer my_access_token"
+					got := r.Header.Get("Authorization")
+					if got != want {
+						return nil, errors.Errorf("HTTP Authorization: want %q but got %q", want, got)
+					}
+
+					body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
+					if visibility == "internal" {
+						body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
+					}
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
 			},
-			Scopes: []string{"read_user"},
+		)
+
+		gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
+			return &oauthutil.OAuthContext{
+				ClientID:     "client",
+				ClientSecret: "client_sec",
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  "url/oauth/authorize",
+					TokenURL: "url/oauth/token",
+				},
+				Scopes: []string{"read_user"},
+			}
 		}
-	}
-	defer func() { gitlab.MockGetOAuthContext = nil }()
+		defer func() { gitlab.MockGetOAuthContext = nil }()
 
-	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
-	repoIDs, err := p.FetchUserPerms(context.Background(),
-		&extsvc.Account{
-			AccountSpec: extsvc.AccountSpec{
-				ServiceType: extsvc.TypeGitLab,
-				ServiceID:   "https://gitlab.com/",
+		authData := json.RawMessage(`{"access_token": "my_access_token"}`)
+		repoIDs, err := p.FetchUserPerms(context.Background(),
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: extsvc.TypeGitLab,
+					ServiceID:   "https://gitlab.com/",
+				},
+				AccountData: extsvc.AccountData{
+					AuthData: extsvc.NewUnencryptedData(authData),
+				},
 			},
-			AccountData: extsvc.AccountData{
-				AuthData: extsvc.NewUnencryptedData(authData),
-			},
-		},
-		authz.FetchPermsOptions{},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
+			authz.FetchPermsOptions{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
-		t.Fatal(diff)
-	}
+		expRepoIDs := []extsvc.RepoID{"1", "2", "3", "4"}
+		if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("feature flag enabled", func(t *testing.T) {
+		// The OAuthProvider uses the gitlab.Client under the hood,
+		// which uses rcache, a caching layer that uses Redis.
+		// We need to clear the cache before we run the tests
+		rcache.SetupForTest(t)
+		ctx := context.Background()
+		flags := map[string]bool{"gitLabProjectVisibilityExperimental": true}
+		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+
+		p := newOAuthProvider(
+			OAuthProviderOp{
+				BaseURL: mustURL(t, "https://gitlab.com"),
+				Token:   "admin_token",
+				DB:      database.NewMockDB(),
+			},
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					visibility := r.URL.Query().Get("visibility")
+					if visibility != "private" && visibility != "internal" {
+						return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+					}
+					want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
+					if r.URL.String() != want {
+						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
+					}
+
+					want = "Bearer my_access_token"
+					got := r.Header.Get("Authorization")
+					if got != want {
+						return nil, errors.Errorf("HTTP Authorization: want %q but got %q", want, got)
+					}
+
+					body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
+					if visibility == "internal" {
+						body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
+					}
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
+			},
+		)
+
+		gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
+			return &oauthutil.OAuthContext{
+				ClientID:     "client",
+				ClientSecret: "client_sec",
+				Endpoint: oauth2.Endpoint{
+					AuthURL:  "url/oauth/authorize",
+					TokenURL: "url/oauth/token",
+				},
+				Scopes: []string{"read_user"},
+			}
+		}
+		defer func() { gitlab.MockGetOAuthContext = nil }()
+
+		authData := json.RawMessage(`{"access_token": "my_access_token"}`)
+		repoIDs, err := p.FetchUserPerms(ctx,
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: extsvc.TypeGitLab,
+					ServiceID:   "https://gitlab.com/",
+				},
+				AccountData: extsvc.AccountData{
+					AuthData: extsvc.NewUnencryptedData(authData),
+				},
+			},
+			authz.FetchPermsOptions{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
+		if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }
 
 func TestOAuthProvider_FetchRepoPerms(t *testing.T) {

--- a/internal/authz/providers/gitlab/oauth_test.go
+++ b/internal/authz/providers/gitlab/oauth_test.go
@@ -81,7 +81,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				if visibility != "private" && visibility != "internal" {
 					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
 				}
-				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
+				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -92,9 +92,9 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 					return nil, errors.Errorf("HTTP Authorization: want %q but got %q", want, got)
 				}
 
-				body := `[{"id": 1}, {"id": 2}]`
+				body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
 				if visibility == "internal" {
-					body = `[{"id": 3}]`
+					body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
 				}
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),

--- a/internal/authz/providers/gitlab/sudo.go
+++ b/internal/authz/providers/gitlab/sudo.go
@@ -220,8 +220,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 // whether to discard.
 func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
 	q := make(url.Values)
-	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
-	q.Add("per_page", "100")        // 100 is the maximum page size
+	q.Add("per_page", "100") // 100 is the maximum page size
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
@@ -243,7 +242,9 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUs
 			}
 
 			for _, p := range projects {
-				projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
+				if p.DefaultBranch != "" {
+					projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
+				}
 			}
 
 			if next == nil {

--- a/internal/authz/providers/gitlab/sudo.go
+++ b/internal/authz/providers/gitlab/sudo.go
@@ -242,7 +242,8 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUs
 			}
 
 			for _, p := range projects {
-				if p.DefaultBranch != "" {
+				// Only append the project if the user can see the contents of the project.
+				if p.ContentsVisible() {
 					projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
 				}
 			}

--- a/internal/authz/providers/gitlab/sudo.go
+++ b/internal/authz/providers/gitlab/sudo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -219,8 +220,13 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 // It may return partial but valid results in case of error, and it is up to callers to decide
 // whether to discard.
 func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
+	flags := featureflag.FromContext(ctx)
+	experimentalVisibility := flags.GetBoolOr("gitLabProjectVisibilityExperimental", false)
 	q := make(url.Values)
 	q.Add("per_page", "100") // 100 is the maximum page size
+	if !experimentalVisibility {
+		q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
+	}
 
 	// 100 matches the maximum page size, thus a good default to avoid multiple allocations
 	// when appending the first 100 results to the slice.
@@ -242,10 +248,13 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUs
 			}
 
 			for _, p := range projects {
-				// Only append the project if the user can see the contents of the project.
-				if p.ContentsVisible() {
-					projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
+				if experimentalVisibility && !p.ContentsVisible() {
+					// If feature flag is enabled and user cannot see the contents
+					// of the project, skip the project
+					continue
 				}
+
+				projectIDs = append(projectIDs, extsvc.RepoID(strconv.Itoa(p.ID)))
 			}
 
 			if next == nil {

--- a/internal/authz/providers/gitlab/sudo.go
+++ b/internal/authz/providers/gitlab/sudo.go
@@ -222,6 +222,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
 	flags := featureflag.FromContext(ctx)
 	experimentalVisibility := flags.GetBoolOr("gitLabProjectVisibilityExperimental", false)
+
 	q := make(url.Values)
 	q.Add("per_page", "100") // 100 is the maximum page size
 	if !experimentalVisibility {

--- a/internal/authz/providers/gitlab/sudo_test.go
+++ b/internal/authz/providers/gitlab/sudo_test.go
@@ -274,7 +274,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				if visibility != "private" && visibility != "internal" {
 					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
 				}
-				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
+				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
 				if r.URL.String() != want {
 					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
 				}
@@ -291,9 +291,9 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 					return nil, errors.Errorf("HTTP Sudo: want %q but got %q", want, got)
 				}
 
-				body := `[{"id": 1}, {"id": 2}]`
+				body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
 				if visibility == "internal" {
-					body = `[{"id": 3}]`
+					body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
 				}
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),

--- a/internal/authz/providers/gitlab/sudo_test.go
+++ b/internal/authz/providers/gitlab/sudo_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -258,73 +259,148 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		}
 	})
 
-	// The OAuthProvider uses the gitlab.Client under the hood,
-	// which uses rcache, a caching layer that uses Redis.
-	// We need to clear the cache before we run the tests
-	rcache.SetupForTest(t)
+	t.Run("feature flag disabled", func(t *testing.T) {
+		// The OAuthProvider uses the gitlab.Client under the hood,
+		// which uses rcache, a caching layer that uses Redis.
+		// We need to clear the cache before we run the tests
+		rcache.SetupForTest(t)
 
-	p := newSudoProvider(
-		SudoProviderOp{
-			BaseURL:   mustURL(t, "https://gitlab.com"),
-			SudoToken: "admin_token",
-		},
-		&mockDoer{
-			do: func(r *http.Request) (*http.Response, error) {
-				visibility := r.URL.Query().Get("visibility")
-				if visibility != "private" && visibility != "internal" {
-					return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
-				}
-				want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
-				if r.URL.String() != want {
-					return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
-				}
-
-				want = "admin_token"
-				got := r.Header.Get("Private-Token")
-				if got != want {
-					return nil, errors.Errorf("HTTP Private-Token: want %q but got %q", want, got)
-				}
-
-				want = "999"
-				got = r.Header.Get("Sudo")
-				if got != want {
-					return nil, errors.Errorf("HTTP Sudo: want %q but got %q", want, got)
-				}
-
-				body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
-				if visibility == "internal" {
-					body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
-				}
-				return &http.Response{
-					Status:     http.StatusText(http.StatusOK),
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
-				}, nil
+		p := newSudoProvider(
+			SudoProviderOp{
+				BaseURL:   mustURL(t, "https://gitlab.com"),
+				SudoToken: "admin_token",
 			},
-		},
-	)
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					visibility := r.URL.Query().Get("visibility")
+					if visibility != "private" && visibility != "internal" {
+						return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+					}
+					want := fmt.Sprintf("https://gitlab.com/api/v4/projects?min_access_level=20&per_page=100&visibility=%s", visibility)
+					if r.URL.String() != want {
+						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
+					}
 
-	accountData := json.RawMessage(`{"id": 999}`)
-	repoIDs, err := p.FetchUserPerms(context.Background(),
-		&extsvc.Account{
-			AccountSpec: extsvc.AccountSpec{
-				ServiceType: "gitlab",
-				ServiceID:   "https://gitlab.com/",
-			},
-			AccountData: extsvc.AccountData{
-				Data: extsvc.NewUnencryptedData(accountData),
-			},
-		},
-		authz.FetchPermsOptions{},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
+					want = "admin_token"
+					got := r.Header.Get("Private-Token")
+					if got != want {
+						return nil, errors.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+					}
 
-	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
-		t.Fatal(diff)
-	}
+					want = "999"
+					got = r.Header.Get("Sudo")
+					if got != want {
+						return nil, errors.Errorf("HTTP Sudo: want %q but got %q", want, got)
+					}
+
+					body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
+					if visibility == "internal" {
+						body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
+					}
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
+			},
+		)
+
+		accountData := json.RawMessage(`{"id": 999}`)
+		repoIDs, err := p.FetchUserPerms(context.Background(),
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: "gitlab",
+					ServiceID:   "https://gitlab.com/",
+				},
+				AccountData: extsvc.AccountData{
+					Data: extsvc.NewUnencryptedData(accountData),
+				},
+			},
+			authz.FetchPermsOptions{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expRepoIDs := []extsvc.RepoID{"1", "2", "3", "4"}
+		if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("feature flag enabled", func(t *testing.T) {
+		// The OAuthProvider uses the gitlab.Client under the hood,
+		// which uses rcache, a caching layer that uses Redis.
+		// We need to clear the cache before we run the tests
+		rcache.SetupForTest(t)
+		ctx := context.Background()
+		flags := map[string]bool{"gitLabProjectVisibilityExperimental": true}
+		ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+
+		p := newSudoProvider(
+			SudoProviderOp{
+				BaseURL:   mustURL(t, "https://gitlab.com"),
+				SudoToken: "admin_token",
+			},
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					visibility := r.URL.Query().Get("visibility")
+					if visibility != "private" && visibility != "internal" {
+						return nil, errors.Errorf("URL visibility: want private or internal, got %s", visibility)
+					}
+					want := fmt.Sprintf("https://gitlab.com/api/v4/projects?per_page=100&visibility=%s", visibility)
+					if r.URL.String() != want {
+						return nil, errors.Errorf("URL: want %q but got %q", want, r.URL)
+					}
+
+					want = "admin_token"
+					got := r.Header.Get("Private-Token")
+					if got != want {
+						return nil, errors.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+					}
+
+					want = "999"
+					got = r.Header.Get("Sudo")
+					if got != want {
+						return nil, errors.Errorf("HTTP Sudo: want %q but got %q", want, got)
+					}
+
+					body := `[{"id": 1, "default_branch": "main"}, {"id": 2, "default_branch": "main"}]`
+					if visibility == "internal" {
+						body = `[{"id": 3, "default_branch": "main"}, {"id": 4}]`
+					}
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
+			},
+		)
+
+		accountData := json.RawMessage(`{"id": 999}`)
+		repoIDs, err := p.FetchUserPerms(ctx,
+			&extsvc.Account{
+				AccountSpec: extsvc.AccountSpec{
+					ServiceType: "gitlab",
+					ServiceID:   "https://gitlab.com/",
+				},
+				AccountData: extsvc.AccountData{
+					Data: extsvc.NewUnencryptedData(accountData),
+				},
+			},
+			authz.FetchPermsOptions{},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
+		if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }
 
 func TestSudoProvider_FetchRepoPerms(t *testing.T) {

--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -34,6 +34,7 @@ type Project struct {
 	StarCount         int            `json:"star_count"`
 	ForksCount        int            `json:"forks_count"`
 	EmptyRepo         bool           `json:"empty_repo"`
+	DefaultBranch     string         `json:"default_branch"`
 }
 
 type ProjectCommon struct {

--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -76,6 +76,14 @@ func (p Project) RequiresAuthentication() bool {
 	return p.Visibility == "private" || p.Visibility == "internal"
 }
 
+// ContentsVisible reports whether or not the repository contents of this project is visible to the user.
+// Repo content visibility is determined by checking whether or not the default branch of the project
+// was returned in the JSON response. If no default branch is returned it means that either the
+// project has no repository initialised, or the user cannot see the contents of the repository.
+func (p *Project) ContentsVisible() bool {
+	return p.DefaultBranch != ""
+}
+
 func idCacheKey(id int) string                                  { return "1:" + strconv.Itoa(id) }
 func pathWithNamespaceCacheKey(pathWithNamespace string) string { return "1:" + pathWithNamespace }
 

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -111,10 +111,11 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 							HTTPURLToRepo:     "https://gitlab.com/gitlab-org/gitaly.git",
 							SSHURLToRepo:      "git@gitlab.com:gitlab-org/gitaly.git",
 						},
-						Visibility: "",
-						Archived:   false,
-						StarCount:  168,
-						ForksCount: 76,
+						Visibility:    "",
+						Archived:      false,
+						StarCount:     168,
+						ForksCount:    76,
+						DefaultBranch: "master",
 					},
 				}
 
@@ -210,7 +211,6 @@ func TestGitLabSource_makeRepo(t *testing.T) {
 	for _, test := range tests {
 		test.name = "GitLabSource_makeRepo_" + test.name
 		t.Run(test.name, func(t *testing.T) {
-
 			s, err := newGitLabSource(logtest.Scoped(t), &svc, test.schema, nil)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/repos/testdata/gitlab-repos.json
+++ b/internal/repos/testdata/gitlab-repos.json
@@ -7,7 +7,8 @@
     "http_url_to_repo": "https://gitlab.com/gitlab-org/gitaly.git",
     "ssh_url_to_repo": "git@gitlab.com:gitlab-org/gitaly.git",
     "visibility": "public",
-    "archived": false
+    "archived": false,
+    "default_branch": "main"
   },
   {
     "id": 2,
@@ -17,7 +18,8 @@
     "http_url_to_repo": "https://gitlab.com/gitlab-org/gitaly-2.git",
     "ssh_url_to_repo": "git@gitlab.com:gitlab-org/gitaly-2.git",
     "visibility": "internal",
-    "archived": false
+    "archived": false,
+    "default_branch": "main"
   },
   {
     "id": 3,
@@ -27,6 +29,7 @@
     "http_url_to_repo": "https://gitlab.com/gitlab-org/gitaly-3.git",
     "ssh_url_to_repo": "git@gitlab.com:gitlab-org/gitaly-3.git",
     "visibility": "private",
-    "archived": false
+    "archived": false,
+    "default_branch": "main"
   }
 ]

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_path-pattern
@@ -32,7 +32,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -68,7 +69,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -104,7 +106,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   }
  ]

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_simple
@@ -32,7 +32,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -68,7 +69,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -104,7 +106,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   }
  ]

--- a/internal/repos/testdata/golden/GitLabSource_makeRepo_ssh
+++ b/internal/repos/testdata/golden/GitLabSource_makeRepo_ssh
@@ -32,7 +32,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -68,7 +69,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   },
   {
@@ -104,7 +106,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   }
  ]

--- a/internal/repos/testdata/sources/GITLAB/TestGitlabSource_ListRepos
+++ b/internal/repos/testdata/sources/GITLAB/TestGitlabSource_ListRepos
@@ -32,7 +32,8 @@
     "archived": false,
     "star_count": 0,
     "forks_count": 0,
-    "empty_repo": false
+    "empty_repo": false,
+    "default_branch": "main"
    }
   }
  ]

--- a/internal/repos/testdata/sources/TestGitlabSource_ListRepos.yaml
+++ b/internal/repos/testdata/sources/TestGitlabSource_ListRepos.yaml
@@ -1,63 +1,63 @@
 ---
 version: 1
 interactions:
-  - request:
-      body: ""
-      form: {}
-      headers:
-        Cache-Control:
-          - max-age=0
-        Content-Type:
-          - application/json; charset=utf-8
-      url: https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?per_page=100
-      method: GET
-    response:
-      body: '[{"id":371312,"description":null,"name":"non-empty-repo","name_with_namespace":"small-test-group
+- request:
+    body: ""
+    form: {}
+    headers:
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?per_page=100
+    method: GET
+  response:
+    body: '[{"id":371312,"description":null,"name":"non-empty-repo","name_with_namespace":"small-test-group
       / non-empty-repo","path":"non-empty-repo","path_with_namespace":"small-test-group/non-empty-repo","created_at":"2023-03-27T16:42:38.858Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.sgdev.org:small-test-group/non-empty-repo.git","http_url_to_repo":"https://gitlab.sgdev.org/small-test-group/non-empty-repo.git","web_url":"https://gitlab.sgdev.org/small-test-group/non-empty-repo","readme_url":"https://gitlab.sgdev.org/small-test-group/non-empty-repo/-/blob/main/README.md","avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2023-03-27T16:42:38.858Z","namespace":{"id":560490,"name":"small-test-group","path":"small-test-group","kind":"group","full_path":"small-test-group","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.sgdev.org/groups/small-test-group"},"_links":{"self":"https://gitlab.sgdev.org/api/v4/projects/371312","issues":"https://gitlab.sgdev.org/api/v4/projects/371312/issues","merge_requests":"https://gitlab.sgdev.org/api/v4/projects/371312/merge_requests","repo_branches":"https://gitlab.sgdev.org/api/v4/projects/371312/repository/branches","labels":"https://gitlab.sgdev.org/api/v4/projects/371312/labels","events":"https://gitlab.sgdev.org/api/v4/projects/371312/events","members":"https://gitlab.sgdev.org/api/v4/projects/371312/members","cluster_agents":"https://gitlab.sgdev.org/api/v4/projects/371312/cluster_agents"},"packages_enabled":true,"empty_repo":false,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2023-03-28T16:42:38.908Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":false,"service_desk_enabled":false,"service_desk_address":null,"can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"disabled","security_and_compliance_access_level":"private","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":1,"import_url":null,"import_type":null,"import_status":"none","open_issues_count":0,"ci_default_git_depth":20,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_opt_in_jwt":false,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","ci_config_path":null,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"repository_storage":"default","keep_latest_artifact":true,"runner_token_expiration_interval":null,"requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":true,"compliance_frameworks":[]},{"id":371311,"description":null,"name":"empty-repo","name_with_namespace":"small-test-group
       / empty-repo","path":"empty-repo","path_with_namespace":"small-test-group/empty-repo","created_at":"2023-03-27T16:42:20.257Z","default_branch":"main","tag_list":[],"topics":[],"ssh_url_to_repo":"git@gitlab.sgdev.org:small-test-group/empty-repo.git","http_url_to_repo":"https://gitlab.sgdev.org/small-test-group/empty-repo.git","web_url":"https://gitlab.sgdev.org/small-test-group/empty-repo","readme_url":null,"avatar_url":null,"forks_count":0,"star_count":0,"last_activity_at":"2023-03-27T16:42:20.257Z","namespace":{"id":560490,"name":"small-test-group","path":"small-test-group","kind":"group","full_path":"small-test-group","parent_id":null,"avatar_url":null,"web_url":"https://gitlab.sgdev.org/groups/small-test-group"},"_links":{"self":"https://gitlab.sgdev.org/api/v4/projects/371311","issues":"https://gitlab.sgdev.org/api/v4/projects/371311/issues","merge_requests":"https://gitlab.sgdev.org/api/v4/projects/371311/merge_requests","repo_branches":"https://gitlab.sgdev.org/api/v4/projects/371311/repository/branches","labels":"https://gitlab.sgdev.org/api/v4/projects/371311/labels","events":"https://gitlab.sgdev.org/api/v4/projects/371311/events","members":"https://gitlab.sgdev.org/api/v4/projects/371311/members","cluster_agents":"https://gitlab.sgdev.org/api/v4/projects/371311/cluster_agents"},"packages_enabled":true,"empty_repo":true,"archived":false,"visibility":"private","resolve_outdated_diff_discussions":false,"container_expiration_policy":{"cadence":"1d","enabled":false,"keep_n":10,"older_than":"90d","name_regex":".*","name_regex_keep":null,"next_run_at":"2023-03-28T16:42:20.276Z"},"issues_enabled":true,"merge_requests_enabled":true,"wiki_enabled":true,"jobs_enabled":true,"snippets_enabled":true,"container_registry_enabled":false,"service_desk_enabled":false,"service_desk_address":null,"can_create_merge_request_in":true,"issues_access_level":"enabled","repository_access_level":"enabled","merge_requests_access_level":"enabled","forking_access_level":"enabled","wiki_access_level":"enabled","builds_access_level":"enabled","snippets_access_level":"enabled","pages_access_level":"private","operations_access_level":"enabled","analytics_access_level":"enabled","container_registry_access_level":"disabled","security_and_compliance_access_level":"private","emails_disabled":null,"shared_runners_enabled":true,"lfs_enabled":true,"creator_id":1,"import_url":null,"import_type":null,"import_status":"none","open_issues_count":0,"ci_default_git_depth":20,"ci_forward_deployment_enabled":true,"ci_job_token_scope_enabled":false,"ci_separated_caches":true,"ci_opt_in_jwt":false,"ci_allow_fork_pipelines_to_run_in_parent_project":true,"public_jobs":true,"build_timeout":3600,"auto_cancel_pending_pipelines":"enabled","ci_config_path":null,"shared_with_groups":[],"only_allow_merge_if_pipeline_succeeds":false,"allow_merge_on_skipped_pipeline":null,"restrict_user_defined_variables":false,"request_access_enabled":true,"only_allow_merge_if_all_discussions_are_resolved":false,"remove_source_branch_after_merge":true,"printing_merge_request_link_enabled":true,"merge_method":"merge","squash_option":"default_off","enforce_auth_checks_on_uploads":true,"suggestion_commit_message":null,"merge_commit_template":null,"squash_commit_template":null,"auto_devops_enabled":true,"auto_devops_deploy_strategy":"continuous","autoclose_referenced_issues":true,"repository_storage":"default","keep_latest_artifact":true,"runner_token_expiration_interval":null,"requirements_enabled":false,"requirements_access_level":"enabled","security_and_compliance_enabled":true,"compliance_frameworks":[]}]'
-      headers:
-        Cache-Control:
-          - max-age=0, private, must-revalidate
-        Cf-Cache-Status:
-          - DYNAMIC
-        Cf-Ray:
-          - 7ae91adb4d3c54d9-YYZ
-        Content-Type:
-          - application/json
-        Date:
-          - Mon, 27 Mar 2023 16:45:38 GMT
-        Etag:
-          - W/"96bb02a883518ed8d978149109e34915"
-        Link:
-          - <https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?id=small-test-group&include_ancestor_groups=false&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=100&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
-            rel="first", <https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?id=small-test-group&include_ancestor_groups=false&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=100&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
-            rel="last"
-        Server:
-          - cloudflare
-        Vary:
-          - Origin
-        Via:
-          - 1.1 google
-        X-Content-Type-Options:
-          - nosniff
-        X-Frame-Options:
-          - SAMEORIGIN
-        X-Next-Page:
-          - ""
-        X-Page:
-          - "1"
-        X-Per-Page:
-          - "100"
-        X-Prev-Page:
-          - ""
-        X-Request-Id:
-          - 01GWHZC19A7QQ3K4KH3PJ8QYKB
-        X-Runtime:
-          - "0.122058"
-        X-Total:
-          - "2"
-        X-Total-Pages:
-          - "1"
-      status: 200 OK
-      code: 200
-      duration: ""
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 7ed3a0bd4e813e9a-CPT
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 27 Jul 2023 08:49:14 GMT
+      Etag:
+      - W/"96bb02a883518ed8d978149109e34915"
+      Link:
+      - <https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?id=small-test-group&include_ancestor_groups=false&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=100&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
+        rel="first", <https://gitlab.sgdev.org/api/v4/groups/small-test-group/projects?id=small-test-group&include_ancestor_groups=false&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=100&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
+        rel="last"
+      Server:
+      - cloudflare
+      Vary:
+      - Origin
+      Via:
+      - 1.1 google
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "100"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 01H6B8KCR76PSW27NQHR9ZK0TC
+      X-Runtime:
+      - "0.184716"
+      X-Total:
+      - "2"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
Original Slack thread [here](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1687969384430849)

## Before this PR

We use a `min_access_level=20`  check on GitLab project queries, because `access_level` 10 is GUEST, and users with GUEST access cannot see repo contents, so we don't want to give access to those repos on Sourcegraph
HOWEVER, for Internal repos on GitLab, users can see the contents of the repo depending on how the repo is configured, regardless of their access level. So this puts us in a conundrum. If we have `min_access_level=20`, users can't see repos they should be able to see, but if we remove it, users can see repos they shouldn't be able to see

## After this PR

Adds a feature flag named "gitLabProjectVisibilityExperimental". When set to true:

@indradhanush  and I diffed some responses from the GitLab API, depending on whether or not you are part of the GitLab group or not, whether the project is visible or not, etc. etc. and there is a common field:
`default_branch` is only visible in the project API response if the user is able to see the contents of the project. If they cannot see the contents of the project, they cannot see the default branch of the project.
So by removing `min_access_level=20` and checking for the presence of `default_branch` on the returned project list, we can determine whether or not the user should be able to see the repo contents or not

## Test plan

VCR tests should be updated

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
