### PR TITLE
Cody: Do not flicker error messages when aborting during context fetching

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,7 +10,7 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
-- Prevents errors from being displayed for a cancelled requests. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+- Prevents errors from being displayed for a cancelled requests. [pull/54429](https://github.com/sourcegraph/sourcegraph/pull/54429)
 
 ### Changed
 

--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -10,6 +10,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Fixed
 
+- Prevents errors from being displayed for a cancelled requests. [pull/](https://github.com/sourcegraph/sourcegraph/pull/)
+
 ### Changed
 
 ## [0.4.2]

--- a/client/cody/src/chat/ChatViewProvider.ts
+++ b/client/cody/src/chat/ChatViewProvider.ts
@@ -361,7 +361,8 @@ export class ChatViewProvider implements vscode.WebviewViewProvider, vscode.Disp
             onError: (err, statusCode) => {
                 // TODO notify the multiplexer of the error
                 debug('ChatViewProvider:onError', err)
-                if (err === 'aborted') {
+
+                if (isAbortError(err)) {
                     return
                 }
                 // Display error message as assistant response
@@ -931,4 +932,8 @@ export async function getCodebaseContext(
         undefined,
         getRerankWithLog(chatClient)
     )
+}
+
+function isAbortError(error: string): boolean {
+    return error === 'aborted' || error === 'socket hang up'
 }


### PR DESCRIPTION
Closes #54427

During context fetching if we abort the request before we ever got a response from the server, we get a message with the text `socket hang up` in addition to the `aborted` error when responses are always streaming in.

With the recent changes from me to properly bubble up context fetching errors, these messages became visible in some unintended ways:

![image](https://github.com/sourcegraph/sourcegraph/assets/458591/ddecda63-c494-49f9-b57e-326a53c54e85)
 
This PR fixes the issue by handling both `abort` and `socket hang up` messages.

## Test plan

- tested locally with both indexed and unindexed repos. Just send a message and press abort.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
