### PR TITLE
JetBrains: Register some recipes as context menu actions in editor

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added recipes to editor context menu [#54430](https://github.com/sourcegraph/sourcegraph/pull/54430)
+
 ### Changed
 
 ### Deprecated

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -138,7 +138,8 @@ class CodyToolWindowContent implements UpdatableChat {
         e -> new TranslateToLanguageAction().executeAction(project));
     JButton gitHistoryButton = createRecipeButton("Summarize recent code changes");
     gitHistoryButton.addActionListener(
-        e -> new SummarizeRecentChangesRecipe(project, this, recipeRunner).summarizeRecentChanges());
+        e ->
+            new SummarizeRecentChangesRecipe(project, this, recipeRunner).summarizeRecentChanges());
     JButton findCodeSmellsButton = createRecipeButton("Smell code");
     findCodeSmellsButton.addActionListener(
         e -> new FindCodeSmellsAction().executeRecipeWithPromptProvider(this, project));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -120,53 +120,28 @@ class CodyToolWindowContent implements UpdatableChat {
     RecipeRunner recipeRunner = new RecipeRunner(this.project, this);
     JButton explainCodeDetailedButton = createRecipeButton("Explain selected code (detailed)");
     explainCodeDetailedButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:explain-code-detailed", "clicked");
-          new ExplainCodeDetailedAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new ExplainCodeDetailedAction().executeRecipeWithPromptProvider(this, project));
     JButton explainCodeHighLevelButton = createRecipeButton("Explain selected code (high level)");
     explainCodeHighLevelButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:explain-code-high-level", "clicked");
-          new ExplainCodeHighLevelAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new ExplainCodeHighLevelAction().executeRecipeWithPromptProvider(this, project));
     JButton generateUnitTestButton = createRecipeButton("Generate a unit test");
     generateUnitTestButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:generate-unit-test", "clicked");
-          new GenerateUnitTestAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new GenerateUnitTestAction().executeRecipeWithPromptProvider(this, project));
     JButton generateDocstringButton = createRecipeButton("Generate a docstring");
     generateDocstringButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:generate-docstring", "clicked");
-          new GenerateDocStringAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new GenerateDocStringAction().executeRecipeWithPromptProvider(this, project));
     JButton improveVariableNamesButton = createRecipeButton("Improve variable names");
     improveVariableNamesButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:improve-variable-names", "clicked");
-          new ImproveVariableNamesAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new ImproveVariableNamesAction().executeRecipeWithPromptProvider(this, project));
     JButton translateToLanguageButton = createRecipeButton("Translate to different language");
     translateToLanguageButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvent(this.project, "recipe:translate-to-language", "clicked");
-          new TranslateToLanguageAction().executeAction(project);
-        });
+        e -> new TranslateToLanguageAction().executeAction(project));
     JButton gitHistoryButton = createRecipeButton("Summarize recent code changes");
     gitHistoryButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvent(
-              this.project, "recipe:summarize-recent-code-changes", "clicked");
-          new SummarizeRecentChangesRecipe(project, this, recipeRunner).summarizeRecentChanges();
-        });
+        e -> new SummarizeRecentChangesRecipe(project, this, recipeRunner).summarizeRecentChanges());
     JButton findCodeSmellsButton = createRecipeButton("Smell code");
     findCodeSmellsButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:smell-code", "clicked");
-          new FindCodeSmellsAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new FindCodeSmellsAction().executeRecipeWithPromptProvider(this, project));
     // JButton fixupButton = createWideButton("Fixup code from inline instructions");
     // fixupButton.addActionListener(e -> recipeRunner.runFixup());
     // JButton contextSearchButton = createWideButton("Codebase context search");
@@ -175,10 +150,7 @@ class CodyToolWindowContent implements UpdatableChat {
     // releaseNotesButton.addActionListener(e -> recipeRunner.runReleaseNotes());
     JButton optimizeCodeButton = createRecipeButton("Optimize code");
     optimizeCodeButton.addActionListener(
-        e -> {
-          GraphQlLogger.logCodyEvents(this.project, "recipe:optimize-code", "clicked");
-          new OptimizeCodeAction().executeRecipeWithPromptProvider(this, project);
-        });
+        e -> new OptimizeCodeAction().executeRecipeWithPromptProvider(this, project));
     recipesPanel.add(explainCodeDetailedButton);
     recipesPanel.add(explainCodeHighLevelButton);
     recipesPanel.add(generateUnitTestButton);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ActionUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ActionUtil.java
@@ -1,0 +1,28 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.chat.ChatMessage;
+import com.sourcegraph.cody.editor.EditorContext;
+import com.sourcegraph.cody.editor.EditorContextGetter;
+import java.util.function.Consumer;
+import org.jetbrains.annotations.NotNull;
+
+public class ActionUtil {
+
+  public static void runIfCodeSelected(
+      @NotNull UpdatableChat updatableChat,
+      @NotNull Project project,
+      @NotNull Consumer<String> runIfCodeSelected) {
+    EditorContext editorContext = EditorContextGetter.getEditorContext(project);
+    String editorSelection = editorContext.getSelection();
+    if (editorSelection == null) {
+      updatableChat.activateChatTab();
+      updatableChat.addMessageToChat(
+          ChatMessage.createAssistantMessage(
+              "No code selected. Please select some code and try again."));
+      return;
+    }
+    runIfCodeSelected.accept(editorSelection);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/BaseRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/BaseRecipeAction.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.UpdatableChat;
 import com.sourcegraph.cody.UpdatableChatHolderService;
+import com.sourcegraph.telemetry.GraphQlLogger;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class BaseRecipeAction extends DumbAwareAction {
@@ -21,6 +22,7 @@ public abstract class BaseRecipeAction extends DumbAwareAction {
   }
 
   public void executeRecipeWithPromptProvider(UpdatableChat updatableChat, Project project) {
+    GraphQlLogger.logCodyEvents(project, this.getActionComponentName(), "clicked");
     RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
     ActionUtil.runIfCodeSelected(
         updatableChat,
@@ -29,4 +31,6 @@ public abstract class BaseRecipeAction extends DumbAwareAction {
   }
 
   protected abstract PromptProvider getPromptProvider();
+
+  protected abstract String getActionComponentName();
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/BaseRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/BaseRecipeAction.java
@@ -1,0 +1,32 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.UpdatableChatHolderService;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class BaseRecipeAction extends DumbAwareAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    UpdatableChatHolderService updatableChatHolderService =
+        project.getService(UpdatableChatHolderService.class);
+    UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
+    executeRecipeWithPromptProvider(updatableChat, project);
+  }
+
+  public void executeRecipeWithPromptProvider(UpdatableChat updatableChat, Project project) {
+    RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
+    ActionUtil.runIfCodeSelected(
+        updatableChat,
+        project,
+        (editorSelection) -> recipeRunner.runRecipe(this.getPromptProvider(), editorSelection));
+  }
+
+  protected abstract PromptProvider getPromptProvider();
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
@@ -6,4 +6,9 @@ public class ExplainCodeDetailedAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new ExplainCodeDetailedPromptProvider();
   }
+
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:explain-code-detailed";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class ExplainCodeDetailedAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new ExplainCodeDetailedPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class ExplainCodeHighLevelAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new ExplainCodeHighLevelPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
@@ -7,8 +7,8 @@ public class ExplainCodeHighLevelAction extends BaseRecipeAction {
     return new ExplainCodeHighLevelPromptProvider();
   }
 
-    @Override
-    protected String getActionComponentName() {
-        return "recipe:explain-code-high-level";
-    }
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:explain-code-high-level";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
@@ -6,4 +6,9 @@ public class ExplainCodeHighLevelAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new ExplainCodeHighLevelPromptProvider();
   }
+
+    @Override
+    protected String getActionComponentName() {
+        return "recipe:explain-code-high-level";
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
@@ -1,13 +1,14 @@
 package com.sourcegraph.cody.recipes;
 
-/**
- * This action is intentionally not registered in the plugin.xml file. It is used only as a recipe,
- * it's not available in the context menu.
- */
 public class FindCodeSmellsAction extends BaseRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {
     return new FindCodeSmellsPromptProvider();
+  }
+
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:find-code-smells";
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
@@ -1,0 +1,13 @@
+package com.sourcegraph.cody.recipes;
+
+/**
+ * This action is intentionally not registered in the plugin.xml file. It is used only as a recipe,
+ * it's not available in the context menu.
+ */
+public class FindCodeSmellsAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new FindCodeSmellsPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
@@ -7,8 +7,8 @@ public class GenerateDocStringAction extends BaseRecipeAction {
     return new GenerateDocStringPromptProvider();
   }
 
-    @Override
-    protected String getActionComponentName() {
-        return "recipe:generate-docstring";
-    }
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:generate-docstring";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
@@ -6,4 +6,9 @@ public class GenerateDocStringAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new GenerateDocStringPromptProvider();
   }
+
+    @Override
+    protected String getActionComponentName() {
+        return "recipe:generate-docstring";
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class GenerateDocStringAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new GenerateDocStringPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
@@ -7,8 +7,8 @@ public class GenerateUnitTestAction extends BaseRecipeAction {
     return new GenerateUnitTestPromptProvider();
   }
 
-    @Override
-    protected String getActionComponentName() {
-        return "recipe:generate-unit-test";
-    }
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:generate-unit-test";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class GenerateUnitTestAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new GenerateUnitTestPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
@@ -6,4 +6,9 @@ public class GenerateUnitTestAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new GenerateUnitTestPromptProvider();
   }
+
+    @Override
+    protected String getActionComponentName() {
+        return "recipe:generate-unit-test";
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class ImproveVariableNamesAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new ImproveVariableNamesPromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
@@ -6,4 +6,9 @@ public class ImproveVariableNamesAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new ImproveVariableNamesPromptProvider();
   }
+
+    @Override
+    protected String getActionComponentName() {
+        return "recipe:improve-variable-names";
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
@@ -7,8 +7,8 @@ public class ImproveVariableNamesAction extends BaseRecipeAction {
     return new ImproveVariableNamesPromptProvider();
   }
 
-    @Override
-    protected String getActionComponentName() {
-        return "recipe:improve-variable-names";
-    }
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:improve-variable-names";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
@@ -6,4 +6,9 @@ public class OptimizeCodeAction extends BaseRecipeAction {
   protected PromptProvider getPromptProvider() {
     return new OptimizeCodePromptProvider();
   }
+
+    @Override
+    protected String getActionComponentName() {
+        return "recipe:optimize-code";
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.recipes;
+
+public class OptimizeCodeAction extends BaseRecipeAction {
+
+  @Override
+  protected PromptProvider getPromptProvider() {
+    return new OptimizeCodePromptProvider();
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/OptimizeCodeAction.java
@@ -7,8 +7,8 @@ public class OptimizeCodeAction extends BaseRecipeAction {
     return new OptimizeCodePromptProvider();
   }
 
-    @Override
-    protected String getActionComponentName() {
-        return "recipe:optimize-code";
-    }
+  @Override
+  protected String getActionComponentName() {
+    return "recipe:optimize-code";
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SummarizeRecentChangesRecipe.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SummarizeRecentChangesRecipe.java
@@ -14,6 +14,7 @@ import com.sourcegraph.cody.vcs.Last5ItemsFromCurrentFileFilterOption;
 import com.sourcegraph.cody.vcs.VcsCommitsMetadataLoader;
 import com.sourcegraph.cody.vcs.VcsFilter;
 import com.sourcegraph.cody.vcs.VcsLogFilterOptionsRegistry;
+import com.sourcegraph.telemetry.GraphQlLogger;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.lang.ArrayUtils;
@@ -34,6 +35,7 @@ public class SummarizeRecentChangesRecipe {
   }
 
   public void summarizeRecentChanges() {
+    GraphQlLogger.logCodyEvent(this.project, "recipe:summarize-recent-code-changes", "clicked");
     if (!this.isAnyVcsEnabled()) {
       chat.activateChatTab();
       chat.addMessageToChat(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
@@ -1,0 +1,45 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.UpdatableChatHolderService;
+import com.sourcegraph.cody.prompts.SupportedLanguages;
+import com.sourcegraph.cody.ui.SelectOptionManager;
+import com.sourcegraph.telemetry.GraphQlLogger;
+import org.jetbrains.annotations.NotNull;
+
+public class TranslateToLanguageAction extends DumbAwareAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    executeAction(project);
+  }
+
+  public void executeAction(Project project) {
+    UpdatableChatHolderService updatableChatHolderService =
+        project.getService(UpdatableChatHolderService.class);
+    UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
+    RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
+    ActionUtil.runIfCodeSelected(
+        updatableChat,
+        project,
+        (editorSelection) -> {
+          SelectOptionManager selectOptionManager = SelectOptionManager.getInstance(project);
+          selectOptionManager.show(
+              project,
+              SupportedLanguages.LANGUAGE_NAMES,
+              (selectedLanguage) -> {
+                GraphQlLogger.logCodyEvent(project, "recipe:translate-to-language", "executed");
+                recipeRunner.runRecipe(
+                    new TranslateToLanguagePromptProvider(new Language(selectedLanguage)),
+                    editorSelection);
+              });
+        });
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
@@ -22,6 +22,7 @@ public class TranslateToLanguageAction extends DumbAwareAction {
   }
 
   public void executeAction(Project project) {
+    GraphQlLogger.logCodyEvent(project, "recipe:translate-to-language", "clicked");
     UpdatableChatHolderService updatableChatHolderService =
         project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -37,7 +37,7 @@ public class GraphQlLogger {
   }
 
   public static void logCodyEvents(
-      @NotNull Project project, @NotNull String componentName, @NotNull String[] actions) {
+      @NotNull Project project, @NotNull String componentName, String... actions) {
     for (String action : actions) {
       logCodyEvent(project, componentName, action);
     }

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -136,12 +136,65 @@
                 class="com.sourcegraph.cody.chat.RefreshCodyAppDetection">
         </action>
 
+        <action
+            id="cody.recipe.explainCodeHighLevel"
+            class="com.sourcegraph.cody.recipes.ExplainCodeHighLevelAction"
+            text="Explain Code at a High Level"
+            icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.explainCodeDetailed"
+            class="com.sourcegraph.cody.recipes.ExplainCodeDetailedAction"
+            text="Explain Code in Detail"
+            icon="/icons/codyLogo.svg" />
+        <action
+            id="cody.recipe.generateDocString"
+            class="com.sourcegraph.cody.recipes.GenerateDocStringAction"
+            text="Generate Docstring"
+            icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.generateUnitTest"
+            class="com.sourcegraph.cody.recipes.GenerateUnitTestAction"
+            text="Generate Unit Test"
+            icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.improveVariableNames"
+            class="com.sourcegraph.cody.recipes.ImproveVariableNamesAction"
+            text="Improve Variable Names"
+            icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.optimizeCode"
+            class="com.sourcegraph.cody.recipes.OptimizeCodeAction"
+            text="Optimize Code"
+            icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.translateToLanguage"
+            class="com.sourcegraph.cody.recipes.TranslateToLanguageAction"
+            text="Translate to Language"
+            icon="/icons/codyLogo.svg" />
+
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>
             <reference ref="cody.refreshCodyAppDetection"/>
         </group>
 
-        <group id="SourcegraphEditor" icon="/icons/codyLogo.svg" popup="true" text="Cody AI by Sourcegraph"
+        <group id="CodyEditorActions" icon="/icons/codyLogo.svg" popup="true" text="Cody"
+               searchable="false">
+            <reference ref="cody.recipe.explainCodeHighLevel"/>
+            <reference ref="cody.recipe.explainCodeDetailed"/>
+            <reference ref="cody.recipe.generateDocString"/>
+            <reference ref="cody.recipe.generateUnitTest"/>
+            <reference ref="cody.recipe.improveVariableNames"/>
+            <reference ref="cody.recipe.optimizeCode"/>
+            <reference ref="cody.recipe.translateToLanguage"/>
+            <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+        </group>
+
+        <group id="SourcegraphEditor" icon="/icons/sourcegraphLogo.svg" popup="true" text="Sourcegraph"
                searchable="false">
             <reference ref="sourcegraph.openFindPopup"/>
             <reference ref="sourcegraph.searchSelection"/>

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -147,6 +147,13 @@
             class="com.sourcegraph.cody.recipes.ExplainCodeDetailedAction"
             text="Explain Code in Detail"
             icon="/icons/codyLogo.svg" />
+
+        <action
+            id="cody.recipe.findCodeSmells"
+            class="com.sourcegraph.cody.recipes.FindCodeSmellsAction"
+            text="Find Code Smells"
+            icon="/icons/codyLogo.svg" />
+
         <action
             id="cody.recipe.generateDocString"
             class="com.sourcegraph.cody.recipes.GenerateDocStringAction"
@@ -184,8 +191,9 @@
 
         <group id="CodyEditorActions" icon="/icons/codyLogo.svg" popup="true" text="Cody"
                searchable="false">
-            <reference ref="cody.recipe.explainCodeHighLevel"/>
             <reference ref="cody.recipe.explainCodeDetailed"/>
+            <reference ref="cody.recipe.explainCodeHighLevel"/>
+            <reference ref="cody.recipe.findCodeSmells"/>
             <reference ref="cody.recipe.generateDocString"/>
             <reference ref="cody.recipe.generateUnitTest"/>
             <reference ref="cody.recipe.improveVariableNames"/>


### PR DESCRIPTION
Some recipes are now available as a context menu items in the editor

## Test plan
- Open editor, select some code and execute all the actions available under the "Cody" menu element
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/b89d2d70-e975-497f-b537-22f962ae1b9c)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
