### PR TITLE
Cody: Add find code smells recipe to context menus

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -8,6 +8,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 
 ### Added
 
+- Add "Find code smells" recipe to editor context menu and command pallette [pull/54432](https://github.com/sourcegraph/sourcegraph/pull/54432)
+
 ### Fixed
 
 ### Changed

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -283,6 +283,11 @@
         "title": "Codebase Context Search"
       },
       {
+        "command": "cody.recipe.find-code-smells",
+        "category": "Ask Cody",
+        "title": "Find Code Smells"
+      },
+      {
         "command": "cody.test.token",
         "category": "Cody",
         "title": "Set Access Token"
@@ -532,6 +537,10 @@
           "when": "cody.activated && editorHasSelection"
         },
         {
+          "command": "cody.recipe.find-code-smells",
+          "when": "cody.activated && editorHasSelection"
+        },
+        {
           "command": "cody.test.token",
           "when": "false"
         },
@@ -650,6 +659,10 @@
         },
         {
           "command": "cody.recipe.fixup",
+          "when": "cody.activated"
+        },
+        {
+          "command": "cody.recipe.find-code-smells",
           "when": "cody.activated"
         },
         {


### PR DESCRIPTION
This pr adds "find code smells" recipe to editor context menu and to command pallette as it wasn't previously added when the recipe was added to the recipes section in the chat, according to the conversation with @vdavid 
## Test plan
- Find code smells recipe should be available in command pallette and in the editor context menu

![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/60ffdfd7-4b7f-4c81-93ee-3c27b4c23686)
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/cafa2d7d-1573-41f4-99dd-8c4e20613f2a)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
