### PR TITLE
JetBrains: unstable codegen support

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added recipes to editor context menu [#54430](https://github.com/sourcegraph/sourcegraph/pull/54430)
 - Figure out default repository when no files are opened in the editor [#54476](https://github.com/sourcegraph/sourcegraph/pull/54476)
+- Added `unstable-codegen` completions support [#54435](https://github.com/sourcegraph/sourcegraph/pull/54435)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/api/GraphQlClient.java
@@ -8,13 +8,15 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -30,7 +32,11 @@ public class GraphQlClient {
       throws IOException {
     HttpPost request =
         createRequest(instanceUrl, accessToken, customRequestHeaders, query, variables);
-    try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+    try (CloseableHttpClient client =
+        HttpClients.custom()
+            .setDefaultRequestConfig(
+                RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+            .build()) {
       CloseableHttpResponse httpResponse = client.execute(request);
       GraphQlResponse response =
           new GraphQlResponse(getStatusCode(httpResponse), getResponseBody(httpResponse));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CodyCompletionsManager.java
@@ -85,7 +85,7 @@ public class CodyCompletionsManager {
             200,
             0.6,
             0.1);
-    TextDocument textDocument = new IntelliJTextDocument(editor);
+    TextDocument textDocument = new IntelliJTextDocument(editor, project);
     CompletionDocumentContext documentCompletionContext = textDocument.getCompletionContext(offset);
     if (documentCompletionContext.isCompletionTriggerValid()) {
       Callable<CompletableFuture<Void>> callable =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsProviderType.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/CompletionsProviderType.java
@@ -1,0 +1,22 @@
+package com.sourcegraph.cody.completions;
+
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+public enum CompletionsProviderType {
+  ANTHROPIC,
+  UNSTABLE_CODEGEN;
+
+  public static final CompletionsProviderType DEFAULT_COMPLETIONS_PROVIDER_TYPE = ANTHROPIC;
+
+  @NotNull
+  public static Optional<CompletionsProviderType> optionalValueOf(@NotNull String name) {
+    String normalizedName = name.trim().toUpperCase().replace('-', '_');
+    try {
+      return Optional.of(CompletionsProviderType.valueOf(normalizedName));
+    } catch (IllegalArgumentException e) {
+      System.err.println("Cody: Error: Invalid completions provider type: " + name);
+      return Optional.empty();
+    }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtil.java
@@ -1,0 +1,82 @@
+package com.sourcegraph.cody.completions;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class UnstableCodegenLanguageUtil {
+  private static final Map<String, String> fileExtensionToModelLanguageId =
+      new HashMap<>() {
+        {
+          put(".js", "javascript");
+          put(".jsx", "javascript");
+          put(".java", "java");
+          put(".py", "python");
+          put(".cpp", "cpp");
+          put(".apex", "apex");
+          put(".ts", "typescript");
+          put(".kt", "kotlin");
+          put(".cls", "apex");
+          put(".scss", "css");
+          put(".css", "css");
+          put(".html", "html");
+          put(".cs", "c-sharp");
+          put(".php", "php");
+          put(".sql", "sql");
+          put(".rs", "rust");
+          put(".rlib", "rust");
+          put(".vue", "vue");
+          put(".rb", "ruby");
+          put(".swift", "swift");
+          put(".dart", "dart");
+          put(".sh", "shell");
+          put(".lua", "lua");
+          put(".go", "go");
+        }
+      };
+
+  public static String getModelLanguageId(
+      @Nullable String intelliJLanguageId, @NotNull String fileName) {
+    String fileExtension = "." + StringUtils.substringAfterLast(fileName, ".");
+    String languageIdBasedOnExtension =
+        fileExtensionToModelLanguageId.getOrDefault(fileExtension, "");
+    String languageIdBasedOnIntelliJ =
+        Optional.ofNullable(intelliJLanguageId).map(String::toLowerCase).orElse("");
+    boolean intelliJLanguageIdIsSupported =
+        fileExtensionToModelLanguageId.containsValue(languageIdBasedOnIntelliJ);
+    if (!languageIdBasedOnExtension.isEmpty()
+        && !languageIdBasedOnIntelliJ.isEmpty()
+        && !languageIdBasedOnExtension.equals(languageIdBasedOnIntelliJ)) {
+      System.err.println( // logging the mismatch to make debugging easier
+          "Cody: Completion: Detected mismatch between the code language detected by IntelliJ vs based on extension. "
+              + "IntelliJ detected: "
+              + languageIdBasedOnIntelliJ
+              + " and extension-based detection: "
+              + languageIdBasedOnExtension);
+      if (intelliJLanguageIdIsSupported) {
+        System.err.println(
+            "Cody: IntelliJ detected language is supported by `unstable-codegen`, so it takes priority.");
+      }
+    }
+    String fileExtensionFallback = StringUtils.stripStart(fileExtension, ".");
+    if (intelliJLanguageIdIsSupported) {
+      // if the languageId returned from IntelliJ is supported, that takes priority
+      return languageIdBasedOnIntelliJ;
+    } else if (!languageIdBasedOnExtension.isEmpty()) {
+      // otherwise, if a supported language based on extension was found, we pick that
+      return languageIdBasedOnExtension;
+    } else if (!languageIdBasedOnIntelliJ.isEmpty()) {
+      // otherwise, we pick whatever we got from IntelliJ anyway, if it's not empty
+      return languageIdBasedOnIntelliJ;
+    } else if (!fileExtensionFallback.isEmpty()) {
+      // otherwise, we try to return the file extension (with no leading dot)
+      return fileExtensionFallback;
+    } else {
+      // if the file doesn't even have an extension, we've run out of options
+      return "no-known-extension-detected";
+    }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtil.java
@@ -38,6 +38,7 @@ public class UnstableCodegenLanguageUtil {
         }
       };
 
+  @NotNull
   public static String getModelLanguageId(
       @Nullable String intelliJLanguageId, @NotNull String fileName) {
     String fileExtension = "." + StringUtils.substringAfterLast(fileName, ".");

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/CodyCompletionItemProvider.java
@@ -297,14 +297,9 @@ public class CodyCompletionItemProvider extends InlineCompletionItemProvider {
               endpoint ->
                   (CompletionProvider)
                       new UnstableCodegenEndOfLineCompletionProvider(
-                          completionsClient,
-                          promptChars,
-                          responseTokens,
                           snippets,
                           prefix,
                           suffix,
-                          injectPrefix,
-                          defaultN,
                           document.fileName(),
                           endpoint,
                           document.getLanguageId()))

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -109,7 +111,11 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
           httpPost.setHeader("Accept", "application/json");
           httpPost.setEntity(params);
 
-          try (CloseableHttpClient client = HttpClients.createDefault()) {
+          try (CloseableHttpClient client =
+              HttpClients.custom()
+                  .setDefaultRequestConfig(
+                      RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+                  .build()) {
             CloseableHttpResponse response = client.execute(httpPost);
             int responseCode = response.getStatusLine().getStatusCode();
             if (responseCode != 200) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -29,37 +29,34 @@ import org.jetbrains.annotations.Nullable;
 
 /** This is a rough implementation loosely translating unstable-codegen.ts */
 public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvider {
-  private final String fileName;
-  private final String completionsEndpoint;
-  private final String languageId;
+  @NotNull private final String fileName;
+  @NotNull private final String completionsEndpoint;
+  @Nullable private final String intelliJLanguageId;
 
   public UnstableCodegenEndOfLineCompletionProvider(
-      SourcegraphNodeCompletionsClient completionsClient,
-      int promptChars,
-      int responseTokens,
-      List<ReferenceSnippet> snippets,
-      String prefix,
-      String suffix,
-      String injectPrefix,
-      int defaultN,
-      String fileName,
+      @NotNull List<ReferenceSnippet> snippets,
+      @NotNull String prefix,
+      @NotNull String suffix,
+      @NotNull String fileName,
       @NotNull String completionsEndpoint,
-      @Nullable String languageId) {
+      @Nullable String intelliJLanguageId) {
     super(
-        completionsClient,
-        promptChars,
-        responseTokens,
+        null, // unused
+        -1, // unused
+        -1,
         snippets,
         prefix,
         suffix,
-        injectPrefix,
-        defaultN);
+        "", // unused
+        -1 // unused
+        );
     this.fileName = fileName;
     this.completionsEndpoint = completionsEndpoint;
-    this.languageId = languageId;
+    this.intelliJLanguageId = intelliJLanguageId;
   }
 
   @Override
+  @NotNull
   protected List<Message> createPromptPrefix() {
     // it seems it's not necessary for unstable-codegen for now
     return Collections.emptyList();
@@ -74,7 +71,8 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
       params.put(
           "lang_prefix",
           "<|"
-              + UnstableCodegenLanguageUtil.getModelLanguageId(this.languageId, this.fileName)
+              + UnstableCodegenLanguageUtil.getModelLanguageId(
+                  this.intelliJLanguageId, this.fileName)
               + "|>");
       params.put("prefix", this.prefix);
       params.put("suffix", this.suffix);
@@ -97,8 +95,9 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
   }
 
   @Override
+  @NotNull
   public CompletableFuture<List<Completion>> generateCompletions(
-      CancellationToken token, Optional<Integer> n) {
+      @NotNull CancellationToken token, @NotNull Optional<Integer> n) {
     return CompletableFuture.supplyAsync(
         () -> {
           StringEntity params = getParams();
@@ -156,7 +155,8 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
         });
   }
 
-  private String postProcess(String content) {
+  @NotNull
+  private String postProcess(@NotNull String content) {
     if (content.contains("\n")) {
       return content.substring(0, content.indexOf('\n')).trim();
     } else return content.trim();
@@ -169,7 +169,9 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
     return number;
   }
 
-  private Context prepareContext(List<ReferenceSnippet> snippets, String fileName) {
+  @NotNull
+  private Context prepareContext(
+      @NotNull List<ReferenceSnippet> snippets, @NotNull String fileName) {
     List<Window> windows = new ArrayList<>();
 
     double similarity = 0.5;
@@ -181,58 +183,58 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
     return new Context(fileName, windows);
   }
 
-  class Context {
-    private String currentFilePath;
-    private List<Window> windows;
+  static class Context {
+    @NotNull private String currentFilePath;
+    @NotNull private List<Window> windows;
 
-    public Context(String currentFilePath, List<Window> windows) {
+    public Context(@NotNull String currentFilePath, @NotNull List<Window> windows) {
       this.currentFilePath = currentFilePath;
       this.windows = windows;
     }
 
-    public String getCurrentFilePath() {
+    public @NotNull String getCurrentFilePath() {
       return currentFilePath;
     }
 
-    public void setCurrentFilePath(String currentFilePath) {
+    public void setCurrentFilePath(@NotNull String currentFilePath) {
       this.currentFilePath = currentFilePath;
     }
 
-    public List<Window> getWindows() {
+    public @NotNull List<Window> getWindows() {
       return windows;
     }
 
-    public void setWindows(List<Window> windows) {
+    public void setWindows(@NotNull List<Window> windows) {
       this.windows = windows;
     }
 
     // getters and setters
   }
 
-  class Window {
-    private String filePath;
-    private String text;
+  static class Window {
+    @NotNull private String filePath;
+    @NotNull private String text;
     private double similarity;
 
-    public Window(String filePath, String text, double similarity) {
+    public Window(@NotNull String filePath, @NotNull String text, double similarity) {
       this.filePath = filePath;
       this.text = text;
       this.similarity = similarity;
     }
 
-    public String getFilePath() {
+    public @NotNull String getFilePath() {
       return filePath;
     }
 
-    public void setFilePath(String filePath) {
+    public void setFilePath(@NotNull String filePath) {
       this.filePath = filePath;
     }
 
-    public String getText() {
+    public @NotNull String getText() {
       return text;
     }
 
-    public void setText(String text) {
+    public void setText(@NotNull String text) {
       this.text = text;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -1,13 +1,36 @@
 package com.sourcegraph.cody.completions.prompt_library;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sourcegraph.cody.api.Message;
+import com.sourcegraph.cody.completions.UnstableCodegenLanguageUtil;
 import com.sourcegraph.cody.vscode.CancellationToken;
 import com.sourcegraph.cody.vscode.Completion;
+import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
+import java.util.*;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class UnstableCodegenEndOfLineCompletionProvider extends EndOfLineCompletionProvider {
+/** This is a rough implementation loosely translating unstable-codegen.ts */
+public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvider {
+  private final String fileName;
+  private final String completionsEndpoint;
+  private final String languageId;
+
   public UnstableCodegenEndOfLineCompletionProvider(
       SourcegraphNodeCompletionsClient completionsClient,
       int promptChars,
@@ -16,7 +39,10 @@ public class UnstableCodegenEndOfLineCompletionProvider extends EndOfLineComplet
       String prefix,
       String suffix,
       String injectPrefix,
-      int defaultN) {
+      int defaultN,
+      String fileName,
+      @NotNull String completionsEndpoint,
+      @Nullable String languageId) {
     super(
         completionsClient,
         promptChars,
@@ -26,20 +52,190 @@ public class UnstableCodegenEndOfLineCompletionProvider extends EndOfLineComplet
         suffix,
         injectPrefix,
         defaultN);
+    this.fileName = fileName;
+    this.completionsEndpoint = completionsEndpoint;
+    this.languageId = languageId;
   }
 
   @Override
   protected List<Message> createPromptPrefix() {
-    System.err.println("UnstableCodegenEndOfLineCompletionProvider.createPromptPrefix");
-    // TODO: implement
-    return List.of();
+    // it seems it's not necessary for unstable-codegen for now
+    return Collections.emptyList();
+  }
+
+  @Nullable
+  private StringEntity getParams() {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      Map<String, Object> params = new HashMap<>();
+      params.put("debug_ext_path", "cody");
+      params.put(
+          "lang_prefix",
+          "<|"
+              + UnstableCodegenLanguageUtil.getModelLanguageId(this.languageId, this.fileName)
+              + "|>");
+      params.put("prefix", this.prefix);
+      params.put("suffix", this.suffix);
+      params.put("top_p", 0.95);
+      params.put("temperature", 0.2);
+      params.put("max_tokens", 40);
+      params.put("batch_size", makeEven(4));
+      params.put("context", mapper.writeValueAsString(prepareContext(snippets, fileName)));
+      params.put("completion_type", "automatic");
+
+      StringEntity result = new StringEntity(mapper.writeValueAsString(params));
+      result.setContentType("application/json");
+      result.setContentEncoding("UTF-8");
+
+      return result;
+    } catch (JsonProcessingException | UnsupportedEncodingException e) {
+      e.printStackTrace();
+      return null;
+    }
   }
 
   @Override
   public CompletableFuture<List<Completion>> generateCompletions(
       CancellationToken token, Optional<Integer> n) {
-    System.err.println("UnstableCodegenEndOfLineCompletionProvider.generateCompletions");
-    // TODO: implement
-    return CompletableFuture.completedFuture(List.of());
+    return CompletableFuture.supplyAsync(
+        () -> {
+          StringEntity params = getParams();
+          if (params == null) {
+            System.err.println("Cody: Could not create params for unstable-codegen");
+            return Collections.emptyList();
+          }
+          HttpPost httpPost = new HttpPost(completionsEndpoint);
+          httpPost.setHeader("Content-Type", "application/json");
+          httpPost.setHeader("Accept", "application/json");
+          httpPost.setEntity(params);
+
+          try (CloseableHttpClient client = HttpClients.createDefault()) {
+            CloseableHttpResponse response = client.execute(httpPost);
+            int responseCode = response.getStatusLine().getStatusCode();
+            if (responseCode != 200) {
+              System.err.println(
+                  "Cody: `unstable-codegen` completion provider returned non-200 response code: "
+                      + responseCode);
+              return Collections.emptyList();
+            }
+            HttpEntity responseEntity = response.getEntity();
+
+            if (responseEntity != null) {
+              String responseString = EntityUtils.toString(responseEntity);
+              ObjectMapper mapper = new ObjectMapper();
+              JsonNode rootNode = mapper.readTree(responseString);
+              JsonNode completionsNode = rootNode.get("completions");
+
+              List<String> completions = new ArrayList<>();
+              for (JsonNode completionNode : completionsNode) {
+                String completion = completionNode.get("completion").asText();
+                completions.add(completion);
+              }
+
+              return completions.stream()
+                  .map(this::postProcess)
+                  .map(
+                      c -> new Completion(prefix, Collections.emptyList(), this.postProcess(c), ""))
+                  .collect(Collectors.toList());
+            }
+          } catch (ConnectException e) {
+            System.err.println(
+                "Cody: Could not connect to the 'unstable-codegen' completion provider");
+            return Collections.emptyList();
+          } catch (Exception e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+          }
+          return Collections.emptyList();
+        });
+  }
+
+  private String postProcess(String content) {
+    if (content.contains("\n")) {
+      return content.substring(0, content.indexOf('\n')).trim();
+    } else return content.trim();
+  }
+
+  private int makeEven(int number) {
+    if (number % 2 == 1) {
+      return number + 1;
+    }
+    return number;
+  }
+
+  private Context prepareContext(List<ReferenceSnippet> snippets, String fileName) {
+    List<Window> windows = new ArrayList<>();
+
+    double similarity = 0.5;
+    for (ReferenceSnippet snippet : snippets) {
+      similarity *= 0.99;
+      windows.add(new Window(snippet.filename, snippet.jaccard.text, similarity));
+    }
+
+    return new Context(fileName, windows);
+  }
+
+  class Context {
+    private String currentFilePath;
+    private List<Window> windows;
+
+    public Context(String currentFilePath, List<Window> windows) {
+      this.currentFilePath = currentFilePath;
+      this.windows = windows;
+    }
+
+    public String getCurrentFilePath() {
+      return currentFilePath;
+    }
+
+    public void setCurrentFilePath(String currentFilePath) {
+      this.currentFilePath = currentFilePath;
+    }
+
+    public List<Window> getWindows() {
+      return windows;
+    }
+
+    public void setWindows(List<Window> windows) {
+      this.windows = windows;
+    }
+
+    // getters and setters
+  }
+
+  class Window {
+    private String filePath;
+    private String text;
+    private double similarity;
+
+    public Window(String filePath, String text, double similarity) {
+      this.filePath = filePath;
+      this.text = text;
+      this.similarity = similarity;
+    }
+
+    public String getFilePath() {
+      return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+      this.filePath = filePath;
+    }
+
+    public String getText() {
+      return text;
+    }
+
+    public void setText(String text) {
+      this.text = text;
+    }
+
+    public double getSimilarity() {
+      return similarity;
+    }
+
+    public void setSimilarity(double similarity) {
+      this.similarity = similarity;
+    }
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -1,0 +1,45 @@
+package com.sourcegraph.cody.completions.prompt_library;
+
+import com.sourcegraph.cody.api.Message;
+import com.sourcegraph.cody.vscode.CancellationToken;
+import com.sourcegraph.cody.vscode.Completion;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class UnstableCodegenEndOfLineCompletionProvider extends EndOfLineCompletionProvider {
+  public UnstableCodegenEndOfLineCompletionProvider(
+      SourcegraphNodeCompletionsClient completionsClient,
+      int promptChars,
+      int responseTokens,
+      List<ReferenceSnippet> snippets,
+      String prefix,
+      String suffix,
+      String injectPrefix,
+      int defaultN) {
+    super(
+        completionsClient,
+        promptChars,
+        responseTokens,
+        snippets,
+        prefix,
+        suffix,
+        injectPrefix,
+        defaultN);
+  }
+
+  @Override
+  protected List<Message> createPromptPrefix() {
+    System.err.println("UnstableCodegenEndOfLineCompletionProvider.createPromptPrefix");
+    // TODO: implement
+    return List.of();
+  }
+
+  @Override
+  public CompletableFuture<List<Completion>> generateCompletions(
+      CancellationToken token, Optional<Integer> n) {
+    System.err.println("UnstableCodegenEndOfLineCompletionProvider.generateCompletions");
+    // TODO: implement
+    return CompletableFuture.completedFuture(List.of());
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -80,7 +80,7 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
       params.put("temperature", 0.2);
       params.put("max_tokens", 40);
       params.put("batch_size", makeEven(4));
-      params.put("context", mapper.writeValueAsString(prepareContext(snippets, fileName)));
+      params.put("context", ""); // mapper.writeValueAsString(prepareContext(snippets, fileName)));
       params.put("completion_type", "automatic");
 
       StringEntity result = new StringEntity(mapper.writeValueAsString(params));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/completions/prompt_library/UnstableCodegenEndOfLineCompletionProvider.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.completions.prompt_library;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -80,7 +81,7 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
       params.put("temperature", 0.2);
       params.put("max_tokens", 40);
       params.put("batch_size", makeEven(4));
-      params.put("context", ""); // mapper.writeValueAsString(prepareContext(snippets, fileName)));
+      params.put("context", mapper.writeValueAsString(prepareContext(snippets, fileName)));
       params.put("completion_type", "automatic");
 
       StringEntity result = new StringEntity(mapper.writeValueAsString(params));
@@ -184,7 +185,10 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
   }
 
   static class Context {
-    @NotNull private String currentFilePath;
+    @JsonProperty("current_file_path")
+    @NotNull
+    private String currentFilePath;
+
     @NotNull private List<Window> windows;
 
     public Context(@NotNull String currentFilePath, @NotNull List<Window> windows) {
@@ -212,7 +216,10 @@ public class UnstableCodegenEndOfLineCompletionProvider extends CompletionProvid
   }
 
   static class Window {
-    @NotNull private String filePath;
+    @JsonProperty("file_path")
+    @NotNull
+    private String filePath;
+
     @NotNull private String text;
     private double similarity;
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -11,9 +11,11 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -84,7 +86,11 @@ public class LocalAppManager {
   @NotNull
   private static Optional<String> getRunningAppVersion() {
     // TODO: do this asynchronously
-    try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+    try (CloseableHttpClient httpClient =
+        HttpClients.custom()
+            .setDefaultRequestConfig(
+                RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+            .build()) {
       HttpGet request = new HttpGet(getLocalAppUrl() + "/__version");
       HttpResponse response = httpClient.execute(request);
       int statusCode = response.getStatusLine().getStatusCode();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/IntelliJTextDocument.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/IntelliJTextDocument.java
@@ -1,22 +1,30 @@
 package com.sourcegraph.cody.vscode;
 
+import com.intellij.lang.Language;
+import com.intellij.lang.LanguageUtil;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.completions.CompletionDocumentContext;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.Optional;
+import org.jetbrains.annotations.Nullable;
 
 /** Implementation of vscode.TextDocument backed by IntelliJ's Editor. */
 public class IntelliJTextDocument implements TextDocument {
   public final Editor editor;
   public VirtualFile file;
+  public Language language;
 
-  public IntelliJTextDocument(Editor editor) {
+  public IntelliJTextDocument(Editor editor, Project project) {
     this.editor = editor;
-    this.file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+    Document document = editor.getDocument();
+    this.file = FileDocumentManager.getInstance().getFile(document);
+    this.language = LanguageUtil.getLanguageForPsi(project, file);
   }
 
   @Override
@@ -62,5 +70,11 @@ public class IntelliJTextDocument implements TextDocument {
     int lineStartOffset = document.getLineStartOffset(line);
     String sameLinePrefix = document.getText(TextRange.create(lineStartOffset, offset));
     return new CompletionDocumentContext(sameLinePrefix, sameLineSuffix);
+  }
+
+  @Override
+  @Nullable
+  public String getLanguageId() {
+    return Optional.ofNullable(this.language).map(Language::getID).orElse(null);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/TextDocument.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/TextDocument.java
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.vscode;
 
 import com.sourcegraph.cody.completions.CompletionDocumentContext;
 import java.net.URI;
+import org.jetbrains.annotations.Nullable;
 
 public interface TextDocument {
   URI uri();
@@ -17,4 +18,7 @@ public interface TextDocument {
   Position positionAt(int offset);
 
   CompletionDocumentContext getCompletionContext(int offset);
+
+  @Nullable
+  String getLanguageId();
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -1,16 +1,42 @@
 package com.sourcegraph.config;
 
+import com.sourcegraph.cody.completions.CompletionsProviderType;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.Properties;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class UserLevelConfig {
+  /**
+   * Overrides the provider used for generating code completions. Only supported values at the
+   * moment are 'anthropic' (default) or 'unstable-codegen'.
+   */
+  @NotNull
+  public static CompletionsProviderType getCompletionsProviderType() {
+    Properties properties = readProperties();
+    String key = "cody.completions.advanced.provider";
+    return Optional.ofNullable(properties.getProperty(key, null))
+        .flatMap(CompletionsProviderType::optionalValueOf)
+        .orElse(CompletionsProviderType.DEFAULT_COMPLETIONS_PROVIDER_TYPE);
+  }
+
+  /**
+   * Overrides the server endpoint used for generating code completions. This is only supported with
+   * the `unstable-codegen` provider right now.
+   */
+  @Nullable
+  public static String getCompletionsProviderUrl() {
+    Properties properties = readProperties();
+    String key = "cody.completions.advanced.serverEndpoint";
+    return properties.getProperty(key, null);
+  }
+
   @Nullable
   public static String getDefaultBranchName() {
     Properties properties = readProperties();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -31,7 +31,7 @@ public class UserLevelConfig {
    * the `unstable-codegen` provider right now.
    */
   @Nullable
-  public static String getCompletionsProviderUrl() {
+  public static String getCompletionsServerEndpoint() {
     Properties properties = readProperties();
     String key = "cody.completions.advanced.serverEndpoint";
     return properties.getProperty(key, null);

--- a/client/jetbrains/src/test/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtilTest.java
+++ b/client/jetbrains/src/test/java/com/sourcegraph/cody/completions/UnstableCodegenLanguageUtilTest.java
@@ -1,0 +1,44 @@
+package com.sourcegraph.cody.completions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class UnstableCodegenLanguageUtilTest {
+
+  @Test
+  public void extensionUsedIfIntelliJLanguageIdUndefined() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId(null, "foo.js");
+    assertEquals("javascript", languageId);
+  }
+
+  @Test
+  public void intellijLanguageIdTakesPriorityIfExtensionUknown() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId("JAVA", "foo.unknown");
+    assertEquals("java", languageId);
+  }
+
+  @Test
+  public void intellijLanguageIdTakesPriorityIfSupported() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId("JAVA", "foo.js");
+    assertEquals("java", languageId);
+  }
+
+  @Test
+  public void extensionLanguageIdTakesPriorityIfIntelliJUnsupported() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId("something", "foo.js");
+    assertEquals("javascript", languageId);
+  }
+
+  @Test
+  public void unsupportedExtensionUsedIfThereAreNoAlternatives() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId(null, "foo.unknown");
+    assertEquals("unknown", languageId);
+  }
+
+  @Test
+  public void fallbackReturnedWhenExtensionAndLanguageIdCantBeDetermined() {
+    String languageId = UnstableCodegenLanguageUtil.getModelLanguageId(null, "foo");
+    assertEquals("no-known-extension-detected", languageId);
+  }
+}


### PR DESCRIPTION
Fixes #53973

given the following `~/sourcegraph-jetbrains.properties`:
```props
cody.completions.advanced.provider = unstable-codegen
cody.completions.advanced.serverEndpoint = http://localhost:3001/batch
```
when running a mock server with:
```bash
cd client/cody && pnpm ts-node ./scripts/mock-server.ts
```

You will be able to get the mock completion with the plugin (screenshot below).

<img width="417" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/18601388/d2a4fd4c-7eca-4893-81e2-5cfd62250b7d">

## Test plan
- included some unit tests for `languageId` detection
- test against the mock server (as described)
- test against the live backend



