### PR TITLE
bzl: bump backcompat to target 5.1.0

### DIFF
--- a/dev/backcompat/flakes.bzl
+++ b/dev/backcompat/flakes.bzl
@@ -23,5 +23,6 @@ FLAKES = {
             "prefix": "Test",
             "reason": "Shifting constraints on table; ranking is experimental"
         },
-    ]
+    ],
+    "5.1.0": []
 }

--- a/dev/backcompat/patches/BUILD.bazel
+++ b/dev/backcompat/patches/BUILD.bazel
@@ -1,4 +1,5 @@
 exports_files([
     # See https://sourcegraph.com/search?q=context:global+dev/backcompat/patches/back_compat_migrations.patch+repo:github.com/sourcegraph/sourcegraph+lang:Go&patternType=standard&sm=0&groupBy=repo
     "back_compat_migrations.patch",  # git diff ci/backcompat-v5.0.0 ..HEAD -- migrations/ > migrations/back_compat_migrations.patch
+    "ui_assets.patch",  # manually created patch, removes all refs to //client so we don't depend on it
 ])

--- a/dev/backcompat/patches/ui_assets.patch
+++ b/dev/backcompat/patches/ui_assets.patch
@@ -1,0 +1,49 @@
+diff --git a/ui/assets/enterprise/BUILD.bazel b/ui/assets/enterprise/BUILD.bazel
+index 180a828683..e5f019d83e 100644
+--- a/ui/assets/enterprise/BUILD.bazel
++++ b/ui/assets/enterprise/BUILD.bazel
+@@ -17,8 +17,6 @@ copy_to_directory(
+     name = "copy_bundle",
+     srcs = [
+         "//:CHANGELOG.md",
+-        "//client/browser:integration-assets",
+-        "//client/web:bundle-enterprise",
+         "//ui/assets/img",
+     ],
+     out = "dist",
+diff --git a/ui/assets/enterprise/assets.go b/ui/assets/enterprise/assets.go
+index 0936b92a8c..c395c54bf2 100644
+--- a/ui/assets/enterprise/assets.go
++++ b/ui/assets/enterprise/assets.go
+@@ -12,7 +12,6 @@ import (
+ 	"github.com/sourcegraph/sourcegraph/ui/assets"
+ )
+
+-//go:embed *
+ var assetsFS embed.FS
+ var afs fs.FS = assetsFS
+
+diff --git a/ui/assets/oss/BUILD.bazel b/ui/assets/oss/BUILD.bazel
+index 8fa2db0f75..9752602daf 100644
+--- a/ui/assets/oss/BUILD.bazel
++++ b/ui/assets/oss/BUILD.bazel
+@@ -17,7 +17,6 @@ copy_to_directory(
+     name = "copy_bundle",
+     srcs = [
+         "//:CHANGELOG.md",
+-        "//client/web:bundle",
+         "//ui/assets/img",
+     ],
+     out = "dist",
+diff --git a/ui/assets/oss/assets.go b/ui/assets/oss/assets.go
+index ea4012cee1..3444294b9a 100644
+--- a/ui/assets/oss/assets.go
++++ b/ui/assets/oss/assets.go
+@@ -12,7 +12,6 @@ import (
+ 	"github.com/sourcegraph/sourcegraph/ui/assets"
+ )
+
+-//go:embed *
+ var assetsFS embed.FS
+ var afs fs.FS = assetsFS
+

--- a/dev/backcompat/test_release_version.bzl
+++ b/dev/backcompat/test_release_version.bzl
@@ -7,7 +7,7 @@ See https://docs.sourcegraph.com/dev/background-information/sql/migrations
 """
 
 # Defines which version we target with the backward compatibility tests.
-MINIMUM_UPGRADEABLE_VERSION = "5.0.0"
+MINIMUM_UPGRADEABLE_VERSION = "5.1.0"
 
 # Defines a reproducible reference to clone Sourcegraph at to run those tests.
-MINIMUM_UPGRADEABLE_VERSION_REF = "196e8d2884a8c20a4c4a22e2c03faff08a329a30"
+MINIMUM_UPGRADEABLE_VERSION_REF = "a3c3bd2f845857cad7e6c65a1edf06a04ce36751"

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -23,6 +23,8 @@ func BazelOperations() []operations.Operation {
 		"@sourcegraph_back_compat//internal/...",
 		"@sourcegraph_back_compat//enterprise/cmd/...",
 		"@sourcegraph_back_compat//enterprise/internal/...",
+		"-@sourcegraph_back_compat//cmd/migrator/...",
+		"-@sourcegraph_back_compat//enterprise/cmd/migrator/...",
 	))
 	return ops
 }
@@ -167,10 +169,10 @@ func bazelBackCompatTest(targets ...string) func(*bk.Pipeline) {
 
 		// Generate a patch that backports the migration from the new code into the old one.
 		// Ignore space is because of https://github.com/bazelbuild/bazel/issues/17376
-		bk.Cmd("git diff --ignore-space-at-eol origin/ci/backcompat-v5.0.0..HEAD -- migrations/ > dev/backcompat/patches/back_compat_migrations.patch"),
+		bk.Cmd("git diff --ignore-space-at-eol v5.1.0..HEAD -- migrations/ > dev/backcompat/patches/back_compat_migrations.patch"),
 	}
 
-	bazelCmd := bazelCmd(fmt.Sprintf("test %s", strings.Join(targets, " ")))
+	bazelCmd := bazelCmd(fmt.Sprintf("test --test_tag_filters=go -- %s ", strings.Join(targets, " ")))
 	cmds = append(
 		cmds,
 		bk.Cmd(bazelCmd),


### PR DESCRIPTION
This PR moves the target release for back compat tests to 5.1 and fixes the various issues that arose. 

- We don't need to handle otel breaking updates, as 5.1 and HEAD are on the same version
- We now need to explicitly remove `/client/*` as we're properly targeting the `v5.1.0` tag and it doesn't contain my crude patches anymore 
- Bumped pinned back compat scip deps, as it frequently breaks due to having a lot of API changes across time 
- Added a new patch, to handle the consequences of having removed the client tree: previous release didn't have the refactored ui/assets explicit oss/enterprise targets and thus didn't explicitly depend on the client. Now we do, so it needed some patching to make the build working. 
- The buildkite command itself now substracts a few steps that are not playing very well with the backcompat approach, I'm not sure to understand why, the the `//cmd/migrator:schema_descriptions` `genrule` doesn't like very much being built in a different place. I suspect that's because the tree is one folder below, but it's harder to patch this than it is to simply remove it from the test targets entirely. 
- And finally, the buildkite command also filters things to only run go tests. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + local fun 