### PR TITLE
App - update welcome text around embeddings

### DIFF
--- a/client/web/src/enterprise/app/setup/components/AppSetupProgressBar.tsx
+++ b/client/web/src/enterprise/app/setup/components/AppSetupProgressBar.tsx
@@ -63,7 +63,7 @@ export const AppSetupProgressBar: FC<AppSetupProgressBarProps> = props => {
             <div className={styles.description}>
                 {hasDetails && (
                     <>
-                        <span>Generating embeddings for {data.embeddingsSetupProgress.currentRepository}</span>
+                        <span>Building the code graph for {data.embeddingsSetupProgress.currentRepository}</span>
                         <Text size="small" className={styles.percent}>
                             {data.embeddingsSetupProgress.currentRepositoryFilesProcessed} /{' '}
                             {data.embeddingsSetupProgress.currentRepositoryTotalFilesToProcess}
@@ -73,7 +73,7 @@ export const AppSetupProgressBar: FC<AppSetupProgressBarProps> = props => {
 
                 {!hasDetails && (
                     <>
-                        <span>Generating repositories embeddings</span>
+                        <span>Building the code graph</span>
                         <Text size="small" className={styles.percent}>
                             Loading files <LoadingSpinner />
                         </Text>

--- a/client/web/src/enterprise/app/setup/steps/AppAllSetSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppAllSetSetupStep.tsx
@@ -24,11 +24,11 @@ export const AppAllSetSetupStep: FC<StepComponentProps> = ({ className }) => {
 
                 <div className={styles.descriptionContent}>
                     <Text className={styles.descriptionText}>
-                        Once embeddings are finished being generated, you can specify Cody’s context and start asking
+                        Once the code graph is finished being generated, you can specify Cody’s context and start asking
                         questions in the Cody Chat.
                     </Text>
 
-                    <Tooltip content={!isProgressFinished ? 'Embeddings are still being generated' : ''}>
+                    <Tooltip content={!isProgressFinished ? 'The code graph is still being generated' : ''}>
                         <Button
                             size="lg"
                             variant="primary"

--- a/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppLocalRepositoriesSetupStep.tsx
@@ -66,13 +66,13 @@ export const AddLocalRepositoriesSetupPage: FC<StepComponentProps> = ({ classNam
                     >
                         embeddings
                     </Link>
-                    , which help Cody generate more accurate answers about your code.
+                    , which helps Cody build the code graph and generate more accurate answers about your code.
                 </Text>
 
                 <Tooltip
                     content={
                         repositories.length > MAX_NUMBER_OF_REPOSITORIES
-                            ? `Select fewer repositories, Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos`
+                            ? `Select fewer repositories, Currently Cody supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repositories`
                             : repositories.length === 0
                             ? 'Select at least one repository to continue'
                             : undefined
@@ -133,7 +133,7 @@ const PathsPickerActions: FC<PathsPickerActionsProps> = props => {
 
     return (
         <Tooltip
-            content={disabled ? `Right now Cody only supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repos` : ''}
+            content={disabled ? `Currently Cody supports a maximum of ${MAX_NUMBER_OF_REPOSITORIES} repositories` : ''}
         >
             <Button variant="primary" disabled={disabled} className={className} onClick={handleClickCallPathPicker}>
                 <Icon svgPath={mdiGit} aria-hidden={true} /> Add a repository


### PR DESCRIPTION
Updates the welcome text around embeddings to align to building the code graph terminology.

resolves https://github.com/sourcegraph/sourcegraph/issues/54339

## Test plan
`sg start app` 👀 

<img width="1052" alt="Screenshot 2023-06-29 at 10 58 06 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/b6b651b7-2c90-48b8-8818-1a1c91bf32af">
<img width="1052" alt="Screenshot 2023-06-29 at 11 00 58 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/85df175c-a867-463b-9162-22579b854d7a">
<img width="1052" alt="Screenshot 2023-06-29 at 11 14 27 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/d4fa3f1a-6b98-4fcf-b605-c7b85857bb5d">
<img width="1052" alt="Screenshot 2023-06-29 at 11 14 47 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/c41240e0-faf8-4a6a-b47b-7638692c7f1e">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
