### PR TITLE
App - add manual check for updates

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -25,6 +25,10 @@ fn create_system_tray_menu() -> SystemTrayMenu {
         .add_item(
             CustomMenuItem::new("settings".to_string(), "Settings").accelerator("CmdOrCtrl+,"),
         )
+        .add_item(CustomMenuItem::new(
+            "update".to_string(),
+            "Check for updates",
+        ))
         .add_submenu(troubleshooting_menu)
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(CustomMenuItem::new(
@@ -54,6 +58,7 @@ pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
                 shell::open(&app.shell_scope(), "https://about.sourcegraph.com", None).unwrap()
             }
             "restart" => app.restart(),
+            "update" => app.trigger_global("tauri://update", None),
             "quit" => app.exit(0),
             _ => {}
         }


### PR DESCRIPTION
Adds a check for updates to the system tray so users can manually check for updates.  Tauri itself only checks during app start.
## Test plan
set dev version to `2023.6.25`  in tauri.dev.conf.json
`sg start app` no when prompted for update
Use the manual check option in system tray and see update prompt.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
