### PR TITLE
debugging logs and hack fix

### DIFF
--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -44,6 +44,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
     }
 
     const objectType = maybeObjectType || 'tree'
+    console.log('!!!! maybeObjectType = ', maybeObjectType, ' !!!!!')
     const mode = getModeFromPath(filePath)
 
     // Redirect OpenGrok-style line number hashes (#123, #123-321) to query parameter (?L123, ?L123-321)

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -18,7 +18,7 @@ const RepositoryFileTreePage = lazyComponent(() => import('./RepositoryFileTreeP
 //
 // This splat should be used for all routes inside of `RepoContainer`.
 export const repoSplat =
-    '/:repo_one?/:repo_two?/:repo_three?/:repo_four?/:repo_five?/:repo_six?/:repo_seven?/:repo_eight?/:repo_nine?/:repo_ten?'
+    '/:repo_one?/:repo_two?/:repo_three?/:repo_four?/:repo_five?/:repo_six?/:repo_seven?/:repo_eight?/:repo_nine?/:repo_ten?/:repo_eleven?/:repo_twelve?/:repo_thirteen?/:repo_fourteen?/:repo_fifteen?'
 
 const routeToObjectType = {
     [repoSplat + '/-/blob/*']: 'blob',

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"net/url"
 	"os"
@@ -237,8 +238,9 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 	Recursive bool
 }) (*GitTreeEntryResolver, error) {
 	treeEntry, err := r.path(ctx, args.Path, func(stat fs.FileInfo) error {
+		fmt.Println("CALLED TREE")
 		if !stat.Mode().IsDir() {
-			return errors.Errorf("not a directory: %q", args.Path)
+			return errors.Errorf("not a directory, Tree: %q", args.Path)
 		}
 
 		return nil
@@ -249,6 +251,7 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 
 	// Note: args.Recursive is deprecated
 	if treeEntry != nil {
+		fmt.Println("RECURSED")
 		treeEntry.isRecursive = args.Recursive
 	}
 	return treeEntry, nil

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"net/url"
 	"os"
@@ -433,6 +434,7 @@ func (r *GitTreeEntryResolver) OwnershipStats(ctx context.Context) (OwnershipSta
 }
 
 func (r *GitTreeEntryResolver) parent(ctx context.Context) (*GitTreeEntryResolver, error) {
+	fmt.Println("CALLED PARENT")
 	if r.IsRoot() {
 		return nil, nil
 	}
@@ -440,7 +442,7 @@ func (r *GitTreeEntryResolver) parent(ctx context.Context) (*GitTreeEntryResolve
 	parentPath := path.Dir(r.Path())
 	return r.commit.path(ctx, parentPath, func(stat fs.FileInfo) error {
 		if !stat.Mode().IsDir() {
-			return errors.Errorf("not a directory: %q", parentPath)
+			return errors.Errorf("not a directory, parent: %q", parentPath)
 		}
 		return nil
 	})


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/54389

This is a debugging branch for long repo name slugs looping and freezing browser tabs when a file blob is evaluated as a FileTree. No real fix here just console.logs and prints

A hacky fix is included by making a match group on the repo name splats longer but I dont think this is great solution

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
