### PR TITLE
Fix Cody Sidebar Resize Flicker

### DIFF
--- a/client/web/src/cody/sidebar/Provider.tsx
+++ b/client/web/src/cody/sidebar/Provider.tsx
@@ -70,3 +70,5 @@ export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> 
 export const useCodySidebar = (): CodySidebarStore => useContext(CodySidebarContext) as CodySidebarStore
 
 export const CODY_SIDEBAR_SIZES = { default: 350, max: 1200, min: 250 }
+
+export { useSidebarSize }

--- a/client/web/src/cody/sidebar/Provider.tsx
+++ b/client/web/src/cody/sidebar/Provider.tsx
@@ -9,7 +9,6 @@ import { useSidebarSize } from './useSidebarSize'
 interface CodySidebarStore extends CodyChatStore {
     readonly isSidebarOpen: boolean
     readonly inputNeedsFocus: boolean
-    readonly sidebarSize: number
     setIsSidebarOpen: (isOpen: boolean) => void
     setFocusProvided: () => void
     setSidebarSize: (size: number) => void
@@ -19,7 +18,6 @@ const CodySidebarContext = React.createContext<CodySidebarStore | null>({
     ...codyChatStoreMock,
     isSidebarOpen: false,
     inputNeedsFocus: false,
-    sidebarSize: 0,
     setSidebarSize: () => {},
     setIsSidebarOpen: () => {},
     setFocusProvided: () => {},
@@ -32,7 +30,7 @@ interface ICodySidebarStoreProviderProps {
 export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> = ({ children }) => {
     const [isSidebarOpen, setIsSidebarOpenState] = useTemporarySetting('cody.showSidebar', false)
     const [inputNeedsFocus, setInputNeedsFocus] = useState(false)
-    const { sidebarSize, setSidebarSize } = useSidebarSize()
+    const { setSidebarSize } = useSidebarSize()
 
     const setFocusProvided = useCallback(() => {
         setInputNeedsFocus(false)
@@ -55,12 +53,11 @@ export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> 
             ...codyChatStore,
             isSidebarOpen: isSidebarOpen ?? false,
             inputNeedsFocus,
-            sidebarSize: isSidebarOpen ? sidebarSize : 0,
             setIsSidebarOpen,
             setFocusProvided,
             setSidebarSize,
         }),
-        [codyChatStore, isSidebarOpen, sidebarSize, setIsSidebarOpen, setFocusProvided, setSidebarSize, inputNeedsFocus]
+        [codyChatStore, isSidebarOpen, setIsSidebarOpen, setFocusProvided, setSidebarSize, inputNeedsFocus]
     )
 
     // dirty fix because CodyRecipesWidget is rendered inside a different React DOM tree.
@@ -71,3 +68,5 @@ export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> 
 }
 
 export const useCodySidebar = (): CodySidebarStore => useContext(CodySidebarContext) as CodySidebarStore
+
+export const CODY_SIDEBAR_SIZES = { default: 350, max: 1200, min: 250 }

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -34,7 +34,7 @@ import { BatchChangesProps } from '../batches'
 import { CodeIntelligenceProps } from '../codeintel'
 import { RepoContainerEditor } from '../cody/components/RepoContainerEditor'
 import { CodySidebar } from '../cody/sidebar'
-import { useCodySidebar, CODY_SIDEBAR_SIZES } from '../cody/sidebar/Provider'
+import { useCodySidebar, useSidebarSize, CODY_SIDEBAR_SIZES } from '../cody/sidebar/Provider'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
@@ -155,10 +155,13 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     const {
         isSidebarOpen: isCodySidebarOpen,
         setIsSidebarOpen: setIsCodySidebarOpen,
-        setSidebarSize: setCodySidebarSize,
         scope,
         setEditorScope,
     } = useCodySidebar()
+
+    const { sidebarSize, setSidebarSize: setCodySidebarSize } = useSidebarSize()
+
+    const codySidebarSize = useMemo(() => sidebarSize, [isCodySidebarOpen])
 
     useEffect(() => {
         const activeEditor = scope.editor.getActiveTextEditor()
@@ -499,7 +502,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         ariaLabel="Cody sidebar"
                         maxSize={CODY_SIDEBAR_SIZES.max}
                         minSize={CODY_SIDEBAR_SIZES.min}
-                        defaultSize={CODY_SIDEBAR_SIZES.default}
+                        defaultSize={codySidebarSize || CODY_SIDEBAR_SIZES.default}
                         storageKey="size-cache-cody-sidebar"
                         onResize={setCodySidebarSize}
                     >

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -34,7 +34,7 @@ import { BatchChangesProps } from '../batches'
 import { CodeIntelligenceProps } from '../codeintel'
 import { RepoContainerEditor } from '../cody/components/RepoContainerEditor'
 import { CodySidebar } from '../cody/sidebar'
-import { useCodySidebar } from '../cody/sidebar/Provider'
+import { useCodySidebar, CODY_SIDEBAR_SIZES } from '../cody/sidebar/Provider'
 import { BreadcrumbSetters, BreadcrumbsProps } from '../components/Breadcrumbs'
 import { RouteError } from '../components/ErrorBoundary'
 import { HeroPage } from '../components/HeroPage'
@@ -68,8 +68,6 @@ import { repoSettingsAreaPath } from './settings/routes'
 import styles from './RepoContainer.module.scss'
 
 const RepoSettingsArea = lazyComponent(() => import('./settings/RepoSettingsArea'), 'RepoSettingsArea')
-
-const CODY_SIDEBAR_SIZES = { default: 350, max: 1200, min: 250 }
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -155,7 +153,6 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     )
 
     const {
-        sidebarSize: codySidebarSize,
         isSidebarOpen: isCodySidebarOpen,
         setIsSidebarOpen: setIsCodySidebarOpen,
         setSidebarSize: setCodySidebarSize,
@@ -502,7 +499,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         ariaLabel="Cody sidebar"
                         maxSize={CODY_SIDEBAR_SIZES.max}
                         minSize={CODY_SIDEBAR_SIZES.min}
-                        defaultSize={codySidebarSize || CODY_SIDEBAR_SIZES.default}
+                        defaultSize={CODY_SIDEBAR_SIZES.default}
                         storageKey="size-cache-cody-sidebar"
                         onResize={setCodySidebarSize}
                     >

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -161,7 +161,9 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
 
     const { sidebarSize, setSidebarSize: setCodySidebarSize } = useSidebarSize()
 
+    /* eslint-disable react-hooks/exhaustive-deps */
     const codySidebarSize = useMemo(() => sidebarSize, [isCodySidebarOpen])
+    /* eslint-enable react-hooks/exhaustive-deps */
 
     useEffect(() => {
         const activeEditor = scope.editor.getActiveTextEditor()


### PR DESCRIPTION
Bug report: https://sourcegraph.slack.com/archives/C03CSAER9LK/p1687966684496949

The issue was the whole sidebar store getting updated due to resize. 
## Test plan
- resize cody sidebar