### PR TITLE
Autocomplete: Check for additional completion providers when sending logs

### DIFF
--- a/client/cody/src/completions/logger.ts
+++ b/client/cody/src/completions/logger.ts
@@ -137,6 +137,12 @@ const otherCompletionProviders = [
     'GitHub.copilot-nightly',
     'TabNine.tabnine-vscode',
     'TabNine.tabnine-vscode-self-hosted-updater',
+    'AmazonWebServices.aws-toolkit-vscode', // Includes CodeWhisperer
+    'Codeium.codeium',
+    'Codeium.codeium-enterprise-updater',
+    'CodeComplete.codecomplete-vscode',
+    'Venthe.fauxpilot',
+    'TabbyML.vscode-tabby',
 ]
 function otherCompletionProviderEnabled(): boolean {
     return !!otherCompletionProviders.find(id => vscode.extensions.getExtension(id)?.isActive)


### PR DESCRIPTION
Follow up to #54172 to check for additional completion providers when sending logs.

## Test plan

Logs should now show that another completion provider is enabled when AWS CodeWhisperer, Codeium, CodeComplete, Fauxpilot, or Tabby are enabled.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
