### PR TITLE
app: resolve port :9000 conflicts (change to :49000)

### DIFF
--- a/cmd/blobstore/shared/BUILD.bazel
+++ b/cmd/blobstore/shared/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//cmd/blobstore/internal/blobstore",
         "//internal/actor",
         "//internal/conf",
+        "//internal/conf/deploy",
         "//internal/debugserver",
         "//internal/env",
         "//internal/goroutine",

--- a/cmd/blobstore/shared/shared.go
+++ b/cmd/blobstore/shared/shared.go
@@ -18,15 +18,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/blobstore/internal/blobstore"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
-
-const port = "9000"
 
 func shutdownOnSignal(ctx context.Context, server *http.Server) error {
 	// Listen for shutdown signals. When we receive one attempt to clean up,
@@ -75,10 +73,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, config *Con
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 
-	host := ""
-	if env.InsecureDev {
-		host = "127.0.0.1"
-	}
+	host, port := deploy.BlobstoreHostPort()
 	addr := net.JoinHostPort(host, port)
 	server := &http.Server{
 		ReadTimeout:  75 * time.Second,

--- a/cmd/server/shared/BUILD.bazel
+++ b/cmd/server/shared/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//cmd/server/internal/goreman",
         "//cmd/server/shared/assets",
+        "//internal/conf/deploy",
         "//internal/database/postgresdsn",
         "//internal/env",
         "//internal/hostname",

--- a/cmd/server/shared/blobstore.go
+++ b/cmd/server/shared/blobstore.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 
 	sglog "github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 )
 
 func maybeBlobstore(logger sglog.Logger) []string {
@@ -14,7 +16,7 @@ func maybeBlobstore(logger sglog.Logger) []string {
 	}
 
 	// Point at local blobstore endpoint.
-	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://127.0.0.1:9000")
+	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", deploy.BlobstoreDefaultEndpoint())
 	SetDefaultEnv("PRECISE_CODE_INTEL_UPLOAD_BACKEND", "blobstore")
 
 	// cmd/server-specific blobstore env vars

--- a/enterprise/internal/codeintel/shared/lsifuploadstore/BUILD.bazel
+++ b/enterprise/internal/codeintel/shared/lsifuploadstore/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/shared/lsifuploadstore",
     visibility = ["//enterprise:__subpackages__"],
     deps = [
+        "//internal/conf/deploy",
         "//internal/env",
         "//internal/observation",
         "//internal/uploadstore",

--- a/enterprise/internal/codeintel/shared/lsifuploadstore/config.go
+++ b/enterprise/internal/codeintel/shared/lsifuploadstore/config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -40,7 +41,7 @@ func (c *Config) Load() {
 
 	if c.Backend == "blobstore" || c.Backend == "s3" {
 		c.S3Region = c.Get("PRECISE_CODE_INTEL_UPLOAD_AWS_REGION", "us-east-1", "The target AWS region.")
-		c.S3Endpoint = c.Get("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://blobstore:9000", "The target AWS endpoint.")
+		c.S3Endpoint = c.Get("PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", deploy.BlobstoreDefaultEndpoint(), "The target AWS endpoint.")
 		c.S3UsePathStyle = c.GetBool("PRECISE_CODE_INTEL_UPLOAD_AWS_USE_PATH_STYLE", "false", "Whether to use path calling (vs subdomain calling).")
 		ec2RoleCredentials := c.GetBool("PRECISE_CODE_INTEL_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS", "false", "Whether to use the EC2 metadata API, or use the provided static credentials.")
 

--- a/enterprise/internal/embeddings/BUILD.bazel
+++ b/enterprise/internal/embeddings/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//internal/api",
         "//internal/codeintel/types",
         "//internal/conf/conftypes",
+        "//internal/conf/deploy",
         "//internal/database",
         "//internal/endpoint",
         "//internal/env",

--- a/enterprise/internal/embeddings/uploadstore.go
+++ b/enterprise/internal/embeddings/uploadstore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
@@ -41,7 +42,7 @@ func (c *EmbeddingsUploadStoreConfig) Load() {
 
 	if c.Backend == "blobstore" || c.Backend == "s3" {
 		c.S3Region = c.Get("EMBEDDINGS_UPLOAD_AWS_REGION", "us-east-1", "The target AWS region.")
-		c.S3Endpoint = c.Get("EMBEDDINGS_UPLOAD_AWS_ENDPOINT", "http://blobstore:9000", "The target AWS endpoint.")
+		c.S3Endpoint = c.Get("EMBEDDINGS_UPLOAD_AWS_ENDPOINT", deploy.BlobstoreDefaultEndpoint(), "The target AWS endpoint.")
 		c.S3UsePathStyle = c.GetBool("EMBEDDINGS_UPLOAD_AWS_USE_PATH_STYLE", "false", "Whether to use path calling (vs subdomain calling).")
 		ec2RoleCredentials := c.GetBool("EMBEDDINGS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS", "false", "Whether to use the EC2 metadata API, or use the provided static credentials.")
 

--- a/internal/conf/deploy/BUILD.bazel
+++ b/internal/conf/deploy/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "deploy",
-    srcs = ["deploytype.go"],
+    srcs = [
+        "deploytype.go",
+        "endpoints.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/conf/deploy",
     visibility = ["//:__subpackages__"],
+    deps = ["//internal/env"],
 )

--- a/internal/conf/deploy/endpoints.go
+++ b/internal/conf/deploy/endpoints.go
@@ -1,0 +1,28 @@
+package deploy
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+// BlobstoreEndpoint returns the default blobstore endpoint that should be used for this deployment
+// type.
+func BlobstoreDefaultEndpoint() string {
+	if IsApp() {
+		return "http://127.0.0.1:49000"
+	}
+	if IsSingleBinary() {
+		return "http://127.0.0.1:9000"
+	}
+	return "http://blobstore:9000"
+}
+
+// BlobstoreHostPort returns the host/port that should be listened on for this deployment type.
+func BlobstoreHostPort() (string, string) {
+	if IsApp() {
+		return "127.0.0.1", "49000"
+	}
+	if env.InsecureDev || IsSingleBinary() {
+		return "127.0.0.1", "9000"
+	}
+	return "", "9000"
+}

--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -52,7 +52,7 @@ func Init(logger log.Logger) CleanupFunc {
 
 	setDefaultEnv(logger, "SYMBOLS_URL", "http://127.0.0.1:3184")
 	setDefaultEnv(logger, "SEARCHER_URL", "http://127.0.0.1:3181")
-	setDefaultEnv(logger, "BLOBSTORE_URL", "http://127.0.0.1:9000")
+	setDefaultEnv(logger, "BLOBSTORE_URL", deploy.BlobstoreDefaultEndpoint())
 	setDefaultEnv(logger, "EMBEDDINGS_URL", "http://127.0.0.1:9991")
 
 	// The syntax-highlighter might not be running, but this is a better default than an internal
@@ -69,9 +69,9 @@ func Init(logger log.Logger) CleanupFunc {
 	// setDefaultEnv(logger, "JAEGER_SERVER_URL", "http://localhost:16686")
 
 	// Use blobstore on localhost.
-	setDefaultEnv(logger, "PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", "http://localhost:9000")
+	setDefaultEnv(logger, "PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT", deploy.BlobstoreDefaultEndpoint())
 	setDefaultEnv(logger, "PRECISE_CODE_INTEL_UPLOAD_BACKEND", "blobstore")
-	setDefaultEnv(logger, "EMBEDDINGS_UPLOAD_AWS_ENDPOINT", "http://localhost:9000")
+	setDefaultEnv(logger, "EMBEDDINGS_UPLOAD_AWS_ENDPOINT", deploy.BlobstoreDefaultEndpoint())
 
 	// Need to override this because without a host (eg ":3080") it listens only on localhost, which
 	// is not accessible from the containers


### PR DESCRIPTION
Apparently VS Code's Python support uses port 9000, so as long as we use it most VS Code Python devs can't run the app due to the port conflict with our services.

This PR switches the app's blobstore to listen on `:49000` instead of `:9000`. My thinking for now is that we can centralize all "default endpoint" and "what host/port should I listen on?" into the `deploy` package, and for now just change ports to have a `4` in front of them to reduce the change of conflicts.

Later, once we have them centralized in the `deploy` package we can easily modify that code to pick an unavailable port.

This also binds blobstore to `127.0.0.1` (more secure), previously it was bound to `localhost`.

## Test plan

To test this I did the following:

1. [x] Methodically searched our codebase for `9000` and vetted each instance, to ensure I didn't miss anything.
2. [x] Tested with `sg start app` and confirmed `sudo lsof -i -P | grep LISTEN | grep :9000` reported nothing while `sudo lsof -i -P | grep LISTEN | grep :49000` did.
3. [x] Created an app build with `./enterprise/dev/app/build.sh` and tested it:
    * [x] Confirmed embeddings generation (which get stored in blobstore) still works through the setup wizard
4. [x] Confirmed `sg start enterprise-codeintel` starts and runs
