### PR TITLE
build: update to Aspect CLI 5.5.4

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,2 +1,2 @@
 BAZELISK_BASE_URL=https://github.com/aspect-build/aspect-cli/releases/download
-USE_BAZEL_VERSION=aspect/5.5.2
+USE_BAZEL_VERSION=aspect/5.5.4


### PR DESCRIPTION
Suppresses the incorrect syntax error warning span when running `bazel configure`

https://github.com/aspect-build/aspect-cli/releases/tag/5.5.4

# Test Plan

Ran `bazel configure` locally and observed no more spam from treesitter
