### PR TITLE
web: fix code-intel layout in Safari

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/EmptyPoliciesList.module.scss
@@ -18,6 +18,7 @@
 
 .content-expanded {
     grid-template-columns: 1fr [docs] min-content [divider] 1fr [cta];
+    grid-auto-rows: minmax(min-content, max-content);
 }
 
 .divider {


### PR DESCRIPTION
## Context

Fixing the Safari layout issue [reported](https://sourcegraph.slack.com/archives/C01NKL6V7E2/p1687980195563189) by the customer.

![image](https://github.com/sourcegraph/sourcegraph/assets/3846380/26069c76-03d9-4702-a9a5-6b862536c5bb)

## Test plan

1. In Safari, navigate to [https://sourcegraph.test:3443/site-admin/code-graph/configuration](https://sourcegraph.test:3443/site-admin/code-graph/configuration) and ensure that UI is OK.

<img width="941" alt="Screenshot 2023-06-30 at 14 36 25" src="https://github.com/sourcegraph/sourcegraph/assets/3846380/9253ebf8-1b03-4f2c-a7f1-4221be174e04">

