### PR TITLE
JetBrains: disable link sharing when working with Cody app

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 - Use smaller Cody logo in toolbar and editor context menu [#54481](https://github.com/sourcegraph/sourcegraph/pull/54481)
+- Sourcegraph link sharing and opening file in browser actions are disabled when working with Cody app [#54473](https://github.com/sourcegraph/sourcegraph/pull/54473)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
@@ -3,8 +3,11 @@ package com.sourcegraph.website;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
+import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
 import java.awt.datatransfer.StringSelection;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,5 +28,16 @@ public class CopyAction extends FileActionBase {
             "File URL copied to clipboard: " + urlWithoutUtm,
             NotificationType.INFORMATION);
     Notifications.Bus.notify(notification);
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    e.getPresentation()
+        .setEnabled(
+            ConfigUtil.getInstanceType(project) != SettingsComponent.InstanceType.LOCAL_APP);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
@@ -3,11 +3,8 @@ package com.sourcegraph.website;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
-import com.sourcegraph.config.ConfigUtil;
-import com.sourcegraph.config.SettingsComponent;
 import java.awt.datatransfer.StringSelection;
 import org.jetbrains.annotations.NotNull;
 
@@ -28,16 +25,5 @@ public class CopyAction extends FileActionBase {
             "File URL copied to clipboard: " + urlWithoutUtm,
             NotificationType.INFORMATION);
     Notifications.Bus.notify(notification);
-  }
-
-  @Override
-  public void update(@NotNull AnActionEvent e) {
-    Project project = e.getProject();
-    if (project == null) {
-      return;
-    }
-    e.getPresentation()
-        .setEnabled(
-            ConfigUtil.getInstanceType(project) != SettingsComponent.InstanceType.LOCAL_APP);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -10,6 +10,8 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.common.ErrorNotification;
+import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
 import com.sourcegraph.find.PreviewContent;
 import com.sourcegraph.find.SourcegraphVirtualFile;
 import com.sourcegraph.vcs.RepoInfo;
@@ -126,5 +128,16 @@ public abstract class FileActionBase extends DumbAwareAction {
     SelectionModel sel = editor.getSelectionModel();
     VisualPosition position = sel.getSelectionEndPosition();
     return position != null ? editor.visualToLogicalPosition(position) : null;
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    e.getPresentation()
+        .setEnabled(
+            ConfigUtil.getInstanceType(project) != SettingsComponent.InstanceType.LOCAL_APP);
   }
 }


### PR DESCRIPTION
closes: #54332 
## Test plan
- When Cody App is selected as the instance type link opening and sharing options on Sourcegraph should not be available to run


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


Uploading Screen Recording 2023-06-30 at 09.43.15.mov…


