### PR TITLE
web: drop repo splat in favor of the repo name

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -355,6 +355,9 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         repoName,
     }
 
+    // must exactly match how the revision was encoded in the URL
+    const repoNameAndRevision = `${repoName}${typeof rawRevision === 'string' ? `@${rawRevision}` : ''}`
+
     return (
         <>
             {focusCodyShortcut?.keybindings.map((keybinding, index) => (
@@ -452,7 +455,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                             {repoContainerRoutes.map(({ path, render, condition = () => true }) => (
                                 <Route
                                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                    path={repoName + path}
+                                    path={repoNameAndRevision + path}
                                     errorElement={<RouteError />}
                                     element={
                                         /**
@@ -469,14 +472,14 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                                 />
                             ))}
                             <Route
-                                path={repoName + repoSettingsAreaPath}
+                                path={repoNameAndRevision + repoSettingsAreaPath}
                                 errorElement={<RouteError />}
                                 // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
                                 element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
                             />
                             <Route
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                path="*"
+                                path={repoNameAndRevision + '/*'}
                                 errorElement={<RouteError />}
                                 element={
                                     isEmptyRepo ? (

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -60,7 +60,6 @@ import {
     RepoRevisionContainerContext,
     RepoRevisionContainerRoute,
 } from './RepoRevisionContainer'
-import { repoSplat } from './repoRevisionContainerRoutes'
 import { RepoSettingsAreaRoute } from './settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
 import { repoSettingsAreaPath } from './settings/routes'
@@ -453,7 +452,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                             {repoContainerRoutes.map(({ path, render, condition = () => true }) => (
                                 <Route
                                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                    path={repoSplat + path}
+                                    path={repoName + path}
                                     errorElement={<RouteError />}
                                     element={
                                         /**
@@ -470,7 +469,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                                 />
                             ))}
                             <Route
-                                path={repoSplat + repoSettingsAreaPath}
+                                path={repoName + repoSettingsAreaPath}
                                 errorElement={<RouteError />}
                                 // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
                                 element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -209,11 +209,7 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                 {routes.map(
                     ({ path, render, condition = () => true }) =>
                         condition(repoRevisionContainerContext) && (
-                            <Route
-                                key="hardcoded-key"
-                                path={repoName + path}
-                                element={render(repoRevisionContainerContext)}
-                            />
+                            <Route key="hardcoded-key" path={path} element={render(repoRevisionContainerContext)} />
                         )
                 )}
             </Routes>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -209,7 +209,11 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                 {routes.map(
                     ({ path, render, condition = () => true }) =>
                         condition(repoRevisionContainerContext) && (
-                            <Route key="hardcoded-key" path={path} element={render(repoRevisionContainerContext)} />
+                            <Route
+                                key="hardcoded-key"
+                                path={repoName + path}
+                                element={render(repoRevisionContainerContext)}
+                            />
                         )
                 )}
             </Routes>

--- a/client/web/src/repo/repoRevisionContainerRoutes.tsx
+++ b/client/web/src/repo/repoRevisionContainerRoutes.tsx
@@ -7,28 +7,11 @@ import { RepoRevisionContainerRoute } from './RepoRevisionContainer'
 const RepositoryCommitsPage = lazyComponent(() => import('./commits/RepositoryCommitsPage'), 'RepositoryCommitsPage')
 const RepositoryFileTreePage = lazyComponent(() => import('./RepositoryFileTreePage'), 'RepositoryFileTreePage')
 
-// Work around the issue that react router can not match nested splats when the URL contains spaces
-// by expanding the repo matcher to an optional path of up to 10 segments.
-//
-// We don't rely on the route param names anyway and use `parseBrowserRepoURL`
-// instead to parse the repo name.
-//
-// More info about the issue
-// https://github.com/remix-run/react-router/pull/10028
-//
-// This splat should be used for all routes inside of `RepoContainer`.
-export const repoSplat =
-    '/:repo_one?/:repo_two?/:repo_three?/:repo_four?/:repo_five?/:repo_six?/:repo_seven?/:repo_eight?/:repo_nine?/:repo_ten?'
-
 const routeToObjectType = {
-    [repoSplat + '/-/blob/*']: 'blob',
-    [repoSplat + '/-/tree/*']: 'tree',
+    '/-/blob/*': 'blob',
+    '/-/tree/*': 'tree',
     ['*']: undefined,
 } as const
-
-export const commitsPath = repoSplat + '/-/commits/*'
-
-export const changelistsPath = repoSplat + '/-/changelists/*'
 
 export function createRepoRevisionContainerRoutes(
     PageComponent: typeof RepositoryFileTreePage
@@ -43,12 +26,12 @@ export function createRepoRevisionContainerRoutes(
             ),
         })),
         {
-            path: commitsPath,
+            path: '/-/commits/*',
             render: ({ revision, repo, ...context }) =>
                 repo ? <RepositoryCommitsPage {...context} repo={repo} revision={revision} /> : <LoadingSpinner />,
         },
         {
-            path: changelistsPath,
+            path: '/-/changelists/*',
             render: ({ revision, repo, ...context }) =>
                 repo ? <RepositoryCommitsPage {...context} repo={repo} revision={revision} /> : <LoadingSpinner />,
         },


### PR DESCRIPTION
## Context

- Testing an alternative solution to https://github.com/sourcegraph/sourcegraph/issues/54389
- The `works with spaces in the repository name` client integration test failed when we tried this approach half a year ago. This problem was either fixed in react-router, or the removal of the compat router helped.
- Closes https://github.com/sourcegraph/sourcegraph/issues/54389

## Test plan

CI
