### PR TITLE
JetBrains: load first repository from the project if no file open

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added recipes to editor context menu [#54430](https://github.com/sourcegraph/sourcegraph/pull/54430)
+- Figure out default repository when no files are opened in the editor [#54476](https://github.com/sourcegraph/sourcegraph/pull/54476)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -697,7 +697,7 @@ class CodyToolWindowContent implements UpdatableChat {
     VirtualFile fileFromTheRepository =
         currentFile != null
             ? currentFile
-            : RepoUtil.getRootFileFromFirstRepository(project).orElse(null);
+            : RepoUtil.getRootFileFromFirstGitRepository(project).orElse(null);
     if (fileFromTheRepository == null) {
       return null;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -694,13 +694,17 @@ class CodyToolWindowContent implements UpdatableChat {
 
   @Nullable
   private static String getRepoName(@NotNull Project project, @Nullable VirtualFile currentFile) {
-    if (currentFile == null) {
+    VirtualFile fileFromTheRepository =
+        currentFile != null
+            ? currentFile
+            : RepoUtil.getRootFileFromFirstRepository(project).orElse(null);
+    if (fileFromTheRepository == null) {
       return null;
     }
     try {
-      return RepoUtil.getRemoteRepoUrlWithoutScheme(project, currentFile);
+      return RepoUtil.getRemoteRepoUrlWithoutScheme(project, fileFromTheRepository);
     } catch (Exception e) {
-      return RepoUtil.getSimpleRepositoryName(project, currentFile);
+      return RepoUtil.getSimpleRepositoryName(project, fileFromTheRepository);
     }
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -12,6 +12,7 @@ import git4idea.repo.GitRepository;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.perforce.perforce.PerforceAuthenticationException;
@@ -181,5 +182,11 @@ public class RepoUtil {
     }
 
     return VCSType.UNKNOWN;
+  }
+
+  public static Optional<VirtualFile> getRootFileFromFirstRepository(@NotNull Project project) {
+    Optional<Repository> firstFoundRepository =
+        VcsRepositoryManager.getInstance(project).getRepositories().stream().findFirst();
+    return firstFoundRepository.map(Repository::getRoot);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcsUtil.VcsUtil;
 import com.sourcegraph.common.ErrorNotification;
 import com.sourcegraph.config.ConfigUtil;
+import git4idea.GitVcs;
 import git4idea.repo.GitRepository;
 import java.io.File;
 import java.net.MalformedURLException;
@@ -184,9 +185,11 @@ public class RepoUtil {
     return VCSType.UNKNOWN;
   }
 
-  public static Optional<VirtualFile> getRootFileFromFirstRepository(@NotNull Project project) {
+  public static Optional<VirtualFile> getRootFileFromFirstGitRepository(@NotNull Project project) {
     Optional<Repository> firstFoundRepository =
-        VcsRepositoryManager.getInstance(project).getRepositories().stream().findFirst();
+        VcsRepositoryManager.getInstance(project).getRepositories().stream()
+            .filter(it -> it.getVcs().getName().equals(GitVcs.NAME))
+            .findFirst();
     return firstFoundRepository.map(Repository::getRoot);
   }
 }


### PR DESCRIPTION
Load first repository from the project when no file is opened in the editor

closes #54346 

## Test plan
- Open project with a git repository, close all files opened in the editor and ask Cody about the project, context should be provided because the repository should be selected from the first git repository available in the project

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


https://github.com/sourcegraph/sourcegraph/assets/7345368/f92d854e-b0c4-4ec9-9246-fce5a5669bd0

