### PR TITLE
JetBrains: display more informative message when no context found

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Use smaller Cody logo in toolbar and editor context menu [#54481](https://github.com/sourcegraph/sourcegraph/pull/54481)
 - Sourcegraph link sharing and opening file in browser actions are disabled when working with Cody app [#54473](https://github.com/sourcegraph/sourcegraph/pull/54473)
+- Display more informative message when no context has been found [#54480](https://github.com/sourcegraph/sourcegraph/pull/54480)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -64,6 +64,7 @@ import com.sourcegraph.cody.ui.HtmlViewer;
 import com.sourcegraph.cody.ui.RoundedJBTextArea;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
+import com.sourcegraph.config.SettingsComponent.InstanceType;
 import com.sourcegraph.config.SettingsConfigurable;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import com.sourcegraph.vcs.RepoUtil;
@@ -603,9 +604,20 @@ class CodyToolWindowContent implements UpdatableChat {
   public void displayUsedContext(@NotNull List<ContextMessage> contextMessages) {
     // Use context
     if (contextMessages.size() == 0) {
+      InstanceType instanceType = ConfigUtil.getInstanceType(project);
+
+      String report = "I found no context for your request.";
+      String ask =
+          instanceType == InstanceType.ENTERPRISE
+              ? "Please ensure this repository is added to your Sourcegraph Enterprise instance and that your access token and custom request headers are set up correctly."
+              : (instanceType == InstanceType.LOCAL_APP
+                  ? "Please ensure this repository is configured in Cody App."
+                  : (instanceType == InstanceType.DOTCOM
+                      ? "As your current server setting is Sourcegraph.com, please ensure this repository is public and indexed on Sourcegraph.com and that your access token is valid."
+                      : ""));
+      String resolution = "I will try to answer without context.";
       this.addMessageToChat(
-          ChatMessage.createAssistantMessage(
-              "No context found for your request. Please ensure this repository is configured in Cody App or Sourcegraph Enterprise and verify the connection in Settings. I will try to answer without context"));
+          ChatMessage.createAssistantMessage(report + " " + ask + " " + resolution));
     } else {
 
       ContextFilesMessage contextFilesMessage = new ContextFilesMessage(contextMessages);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -605,7 +605,7 @@ class CodyToolWindowContent implements UpdatableChat {
     if (contextMessages.size() == 0) {
       this.addMessageToChat(
           ChatMessage.createAssistantMessage(
-              "I didn't find any context for your ask. I'll try to answer without further context."));
+              "No context found for your request. Please ensure this repository is configured in Cody App or Sourcegraph Enterprise and verify the connection in Settings. I will try to answer without context"));
     } else {
 
       ContextFilesMessage contextFilesMessage = new ContextFilesMessage(contextMessages);


### PR DESCRIPTION
When no context found for user query we will display more informative message that can help user fix his problems with context

## Test plan
- Configure Cody to use dotcom but open project which is not indexed by dotcom and ask Cody something. Cody should respond with
>
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/0f7ab8a0-0073-4756-b2e1-79149ccf1def)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
