### PR TITLE
doc/admin: Clarify importance of all accessible orgs for ADO

### DIFF
--- a/doc/admin/external_service/azuredevops.md
+++ b/doc/admin/external_service/azuredevops.md
@@ -2,17 +2,31 @@
 
 Site admins can sync Git repositories hosted on [Azure DevOps](https://dev.azure.com) with Sourcegraph so that users can search and navigate the repositories.
 
-To connect Azure DevOps to Sourcegraph, create a personal access token from your user settings page. Ensure that you select the following scopes:
+To connect Azure DevOps to Sourcegraph, create a personal access token from your user settings page by following the below steps:
 
-- Code (Read)
-- Project and Team
-- User Profile
+1. Navigate to the `Personal Access Tokens` page from the user settings.
 
-Additionally, under the `Organization` menu, select `All accessible organizations` to allow access to all organizations. This is required to be able to sync repositories from multiple organizations. Alternatively, site admins may also create a unique user that has access to only the selective organizations that they would like to sync with Sourcegraph.
+![Visit the Personal Access Tokens page](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/config/azure-devops-personal-access-token-step-1.png)
+
+2. Click on `New Token`.
+
+![Click on New Token](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/config/azure-devops-personal-access-token-step-2.png)
+
+3.. Under the `Organization` menu, select `All accessible organizations` to allow access to all organizations. This is required to be able to perform connection checks from the code host page and to sync repositories from multiple organizations. Alternatively, site admins may also create a unique user that has access to only the selective organizations that they would like to sync with Sourcegraph. However the token being created **must** have access to `All accessible organizations` as shown below.
+
+![Select All accessible organizations](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/config/azure-devops-personal-access-token-step-3.png)
+
+4. Select the following scopes:
+
+   - Code (Read)
+   - Project and Team
+   - User Profile
+
+Next, configure the code host connection by following the next steps:
 
 1. Go to **Site admin > Manage code hosts > Add repositories**.
-2. Select **Azure DevOps**.
-3. Provide a [configuration](#configuration) for the Azure DevOps code host connection. Here is an example configuration:
+1. Select **Azure DevOps**.
+1. Provide a [configuration](#configuration) for the Azure DevOps code host connection. Here is an example configuration:
 
    ```json
    {
@@ -24,7 +38,7 @@ Additionally, under the `Organization` menu, select `All accessible organization
    }
    ```
 
-4. Press **Add repositories**.
+1. Select **Add repositories**.
 
 ## Repository syncing
 

--- a/doc/admin/external_service/azuredevops.md
+++ b/doc/admin/external_service/azuredevops.md
@@ -12,7 +12,7 @@ To connect Azure DevOps to Sourcegraph, create a personal access token from your
 
 ![Click on New Token](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/config/azure-devops-personal-access-token-step-2.png)
 
-3.. Under the `Organization` menu, select `All accessible organizations` to allow access to all organizations. This is required to be able to perform connection checks from the code host page and to sync repositories from multiple organizations. Alternatively, site admins may also create a unique user that has access to only the selective organizations that they would like to sync with Sourcegraph. However the token being created **must** have access to `All accessible organizations` as shown below.
+3. Under the `Organization` menu, select `All accessible organizations` to allow access to all organizations. This is required to be able to perform connection checks from the code host page and to sync repositories from multiple organizations. Alternatively, site admins may also create a unique user that has access to only the selective organizations that they would like to sync with Sourcegraph. However the token being created **must** have access to `All accessible organizations` as shown below.
 
 ![Select All accessible organizations](https://storage.googleapis.com/sourcegraph-assets/docs/images/admin/config/azure-devops-personal-access-token-step-3.png)
 


### PR DESCRIPTION
Add screenshots to make this obvious.

Doc page now looks like: 
(Note first screenshot is bit too large and needs another highlight around the icon in the menu bar, I'm reuploading the image to the assets bucket as soon as the current one is deletd by tech-ops, as I don't have permissions, but for the time being this should work)

<img width="1506" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/2682729/03e4c117-cd9c-4133-9192-1a5dd7abecf4">


## Test plan

Doc change only.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
