### PR TITLE
bzl: port go compiler directives linter from sg lint to nogo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -314,10 +314,10 @@ nogo(
             "//dev/linters/depguard",
             "//dev/linters/exportloopref",
             "//dev/linters/forbidigo",
+            "//dev/linters/gocheckcompilerdirectives",
             "//dev/linters/gocritic",
             "//dev/linters/ineffassign",
             "//dev/linters/unparam",
-            "//dev/linters/gocheckcompilerdirectives",
         ] + STATIC_CHECK_ANALYZERS,
     }),
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -317,6 +317,7 @@ nogo(
             "//dev/linters/gocritic",
             "//dev/linters/ineffassign",
             "//dev/linters/unparam",
+            "//dev/linters/gocheckcompilerdirectives",
         ] + STATIC_CHECK_ANALYZERS,
     }),
 )

--- a/dev/linters/go.mod
+++ b/dev/linters/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	4d63.com/gocheckcompilerdirectives v1.2.1 // indirect
 	github.com/go-toolsmith/astfmt v1.1.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/dev/linters/go.sum
+++ b/dev/linters/go.sum
@@ -1,3 +1,5 @@
+4d63.com/gocheckcompilerdirectives v1.2.1 h1:AHcMYuw56NPjq/2y615IGg2kYkBdTvOaojYCBcRE7MA=
+4d63.com/gocheckcompilerdirectives v1.2.1/go.mod h1:yjDJSxmDTtIHHCqX0ufRYZDL6vQtMG7tJdKVeWwsqvs=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/OpenPeeDeeP/depguard/v2 v2.0.1 h1:yr9ZswukmNxl/hmJHEoLEjCF1d+f2pQrC0m1jzVljAE=
 github.com/OpenPeeDeeP/depguard/v2 v2.0.1/go.mod h1:gwSk4XDpowOuQSsMWNK5F7+C3kMz7QIexKRkD/GL4GU=

--- a/dev/linters/gocheckcompilerdirectives/BUILD.bazel
+++ b/dev/linters/gocheckcompilerdirectives/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "gocheckcompilerdirectives",
+    srcs = ["gocheckcompilerdirectives.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/gocheckcompilerdirectives",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_4d63_gocheckcompilerdirectives//checkcompilerdirectives:go_default_library",
+    ],
+)

--- a/dev/linters/gocheckcompilerdirectives/gocheckcompilerdirectives.go
+++ b/dev/linters/gocheckcompilerdirectives/gocheckcompilerdirectives.go
@@ -1,0 +1,8 @@
+package gocheckcompilerdirectives
+
+import (
+	"4d63.com/gocheckcompilerdirectives/checkcompilerdirectives"
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
+)
+
+var Analyzer = nolint.Wrap(checkcompilerdirectives.Analyzer())

--- a/dev/sg/internal/generate/golang/golang.go
+++ b/dev/sg/internal/generate/golang/golang.go
@@ -149,7 +149,7 @@ func runGoGenerate(ctx context.Context, args []string, progressBar bool, verbosi
 
 	// If no packages are given, go for everything except doc/cli/references.
 	// We cut down on the number of files we have to generate by looking for a
-	// go:generate directive by hand first.
+	// "go:generate" directive by hand first.
 	paths, err := FindFilesWithGenerate(wd)
 	if err != nil {
 		return err

--- a/dev/sg/linters/go_checks.go
+++ b/dev/sg/linters/go_checks.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	goFmt          = runScript("Go format", "dev/check/gofmt.sh")
 	goDBConnImport = runScript("Go pkg/database/dbconn", "dev/check/go-dbconn-import.sh")
 )
 

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -35,7 +35,6 @@ var Targets = []Target{
 		Name:        "go",
 		Description: "Check go code for linting errors, forbidden imports, generated files, etc",
 		Checks: []*linter{
-			goFmt,
 			goGenerateLinter,
 			goDBConnImport,
 			goEnterpriseImport,

--- a/linter_deps.bzl
+++ b/linter_deps.bzl
@@ -175,3 +175,10 @@ def linter_dependencies():
     version = "v0.0.0-20230312165513-e84e2d14e3b8",
     sum = "h1:VuJo4Mt0EVPychre4fNlDWDuE5AjXtPJpRUWqZDQhaI=",
   )
+
+  go_repository(
+    name ="com_4d63_gocheckcompilerdirectives",
+    importpath = "4d63.com/gocheckcompilerdirectives",
+    version = "v1.2.1",
+    sum = "h1:AHcMYuw56NPjq/2y615IGg2kYkBdTvOaojYCBcRE7MA=",
+  )


### PR DESCRIPTION
This removes the linter that checks for incorrectly formatted `go:generate` directives from `sg lint` and replace it with a proper linter handled by `nogo`. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested + CI 