### PR TITLE
bzl: avoid ui/assets/* dep on CHANGELOG.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ pnpm-debug.log
 /ui/assets/*.br
 /ui/assets/*.gz
 /ui/assets/stats-*
-/ui/assets/enterprise/
 
 *.json.actual
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -325,7 +325,7 @@ exports_files([
     "go.mod",
     # Used for when copy_to_directory might reference an empty filegroup
     # under certain conditions. See //ui/assets/...
-    "CHANGELOG.md",
+    "CONTRIBUTING.md",
 ])
 
 # stamp_tags(

--- a/dev/backcompat/patches/ui_assets.patch
+++ b/dev/backcompat/patches/ui_assets.patch
@@ -1,13 +1,42 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index b0957560b9..9bc63273e8 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -325,7 +325,7 @@ exports_files([
+     "go.mod",
+     # Used for when copy_to_directory might reference an empty filegroup
+     # under certain conditions. See //ui/assets/...
+-    "CHANGELOG.md",
++    "CONTRIBUTING.md",
+ ])
+
+ # stamp_tags(
 diff --git a/ui/assets/enterprise/BUILD.bazel b/ui/assets/enterprise/BUILD.bazel
-index 180a828683..e5f019d83e 100644
+index 180a828683..c3a34519ad 100644
 --- a/ui/assets/enterprise/BUILD.bazel
 +++ b/ui/assets/enterprise/BUILD.bazel
-@@ -17,8 +17,6 @@ copy_to_directory(
+@@ -16,9 +16,7 @@ go_library(
+ copy_to_directory(
      name = "copy_bundle",
      srcs = [
-         "//:CHANGELOG.md",
+-        "//:CHANGELOG.md",
 -        "//client/browser:integration-assets",
 -        "//client/web:bundle-enterprise",
++        "//:CONTRIBUTING.md",
+         "//ui/assets/img",
+     ],
+     out = "dist",
+diff --git a/ui/assets/oss/BUILD.bazel b/ui/assets/oss/BUILD.bazel
+index 8fa2db0f75..82b18e25a8 100644
+--- a/ui/assets/oss/BUILD.bazel
++++ b/ui/assets/oss/BUILD.bazel
+@@ -16,8 +16,7 @@ go_library(
+ copy_to_directory(
+     name = "copy_bundle",
+     srcs = [
+-        "//:CHANGELOG.md",
+-        "//client/web:bundle",
++        "//:CONTRIBUTING.md",
          "//ui/assets/img",
      ],
      out = "dist",
@@ -23,18 +52,6 @@ index 0936b92a8c..c395c54bf2 100644
  var assetsFS embed.FS
  var afs fs.FS = assetsFS
 
-diff --git a/ui/assets/oss/BUILD.bazel b/ui/assets/oss/BUILD.bazel
-index 8fa2db0f75..9752602daf 100644
---- a/ui/assets/oss/BUILD.bazel
-+++ b/ui/assets/oss/BUILD.bazel
-@@ -17,7 +17,6 @@ copy_to_directory(
-     name = "copy_bundle",
-     srcs = [
-         "//:CHANGELOG.md",
--        "//client/web:bundle",
-         "//ui/assets/img",
-     ],
-     out = "dist",
 diff --git a/ui/assets/oss/assets.go b/ui/assets/oss/assets.go
 index ea4012cee1..3444294b9a 100644
 --- a/ui/assets/oss/assets.go

--- a/ui/assets/enterprise/BUILD.bazel
+++ b/ui/assets/enterprise/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
 copy_to_directory(
     name = "copy_bundle",
     srcs = [
-        "//:CHANGELOG.md",
+        "//:CONTRIBUTING.md",
         "//client/browser:integration-assets",
         "//client/web:bundle-enterprise",
         "//ui/assets/img",

--- a/ui/assets/oss/BUILD.bazel
+++ b/ui/assets/oss/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
 copy_to_directory(
     name = "copy_bundle",
     srcs = [
-        "//:CHANGELOG.md",
+        "//:CONTRIBUTING.md",
         "//client/web:bundle",
         "//ui/assets/img",
     ],


### PR DESCRIPTION
Because we at least need one file to be present or the embed won't work, this replaces CHANGELOG.md by CONTRIBUTING.md as a placeholder. This will prevent PRs updating the changelog from invalidating the cache for nothing for these slow targets. 

Follow-up to https://github.com/sourcegraph/devx-support/issues/39

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 