### PR TITLE
bzl: build //client/web:bundle in isolation first

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -147,6 +147,14 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 
 	// Test commands
 	bazelTestCmds := []bk.StepOpt{}
+
+	// bazel build //client/web:bundle is very resource hungry and often crashes when ran along other targets
+	// so we run it first to avoid failing builds midway.
+	cmds = append(cmds,
+		bazelAnnouncef("bazel build //client/web:bundle"),
+		bk.Cmd(bazelCmd("build //client/web:bundle")),
+	)
+
 	for _, target := range targets {
 		cmd := bazelCmd(fmt.Sprintf("test %s", target))
 		bazelTestCmds = append(bazelTestCmds,


### PR DESCRIPTION
This moves the `//client/web:bundle` target to be built first, in isolation. Dependending on how Bazel schedules things, we've observed a few OOM crashes when building it since yesterday. 

This should bring more stability, until @valerybugakov modularizes the frontend and we can say goodbye to this huge target once for all :) 

It won't affect PRs with no client changes, because caching, PRs with client code might be a tad slower, but it's always better than crashing and retrying. 


## Test plan

<img width="1186" alt="CleanShot 2023-06-30 at 14 22 34@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/68ea7671-6f01-432b-8767-52307b77362f">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
