### PR TITLE
JetBrains: Handle embedding checking response == null

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/embeddings/EmbeddingsSearcher.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/embeddings/EmbeddingsSearcher.java
@@ -186,7 +186,7 @@ public class EmbeddingsSearcher {
       try {
         JsonObject body = response.getBodyAsJson();
         JsonObject data = body.getAsJsonObject("data");
-        if (data.get("repository").isJsonNull()) { // Embedding does not exist
+        if (data == null || data.get("repository").isJsonNull()) { // Embedding does not exist
           return null;
         }
         JsonObject repository = data.getAsJsonObject("repository");


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/54472

Sourcegraph 5.0.5 responded with null data to this request, which we didn't expect, but we do now.
## Test plan

Tested it with 5.0.5 locally. [1-min Loom](https://www.loom.com/share/0d5d3b35ae6a48c7894e88d5a39a22ce?sid=d58d4f22-5eda-4a30-b850-41b9470707bc)