### PR TITLE
fix Bitbucket Cloud exclude regex to make it work with AJV.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Known issues
 
-There is an issue with Sourcegraph instances configured to use explicit permissions using permissions.userMapping in Site configuration, where repository permissions are not enforced. Customers using the explicit permissions API are advised to upgrade to v5.1.1 directly.
+- There is an issue with Sourcegraph instances configured to use explicit permissions using permissions.userMapping in Site configuration, where repository permissions are not enforced. Customers using the explicit permissions API are advised to upgrade to v5.1.1 directly.
+- There is an issue with creating and updating existing Bitbucket.org (Cloud) code host connections due to problem with JSON schema validation which prevents the JSON editor from loading and surfaces as an error in the UI.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Fixed validation of Bitbucket Cloud configuration in site-admin create/update form. [#54494](https://github.com/sourcegraph/sourcegraph/pull/54494)
 
 ### Removed
 

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -142,6 +142,13 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			wantErr: "<nil>",
 		},
 		{
+			name:    "1 error - Bitbucket.org",
+			kind:    extsvc.KindBitbucketCloud,
+			// Invalid UUID, using + instead of -
+			config:  `{"url": "https://bitbucket.org", "username": "ceo", "appPassword": "abc", "exclude": [{"uuid":"{fceb73c7+cef6-4abe-956d-e471281126bd}"}]}`,
+			wantErr: `exclude.0.uuid: Does not match pattern '^\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}$'`,
+		},
+		{
 			name:    "1 error",
 			kind:    extsvc.KindGitHub,
 			config:  `{"repositoryQuery": ["none"], "token": "fake"}`,

--- a/schema/BUILD.bazel
+++ b/schema/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
@@ -93,4 +94,16 @@ js_library(
 npm_package(
     name = "schema_pkg",
     srcs = ["package.json"],
+)
+
+go_test(
+    name = "schema_test",
+    srcs = ["validation_test.go"],
+    embed = [":schema"],
+    deps = [
+        "//internal/jsonc",
+        "//lib/errors",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_xeipuuv_gojsonschema//:gojsonschema",
+    ],
 )

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -107,7 +107,7 @@
           "uuid": {
             "description": "The UUID of a Bitbucket Cloud repo (as returned by the Bitbucket Cloud's API) to exclude from mirroring.",
             "type": "string",
-            "pattern": "^\\{[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}\\}$"
+            "pattern": "^\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\}$"
           },
           "pattern": {
             "description": "Regular expression which matches against the name of a Bitbucket Cloud repo.",

--- a/schema/validation_test.go
+++ b/schema/validation_test.go
@@ -1,0 +1,108 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var testSchemaWithUUIDValidation string = `
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "test.schema.json#",
+  "allowComments": true,
+  "type": "object",
+  "properties": {
+    "uuid-escaped": {
+      "description": "UUID -- with escaping of -",
+      "type": "string",
+      "pattern": "^\\{[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}\\}$"
+    },
+    "uuid-unescaped": {
+      "description": "UUID -- without escaping of - ",
+      "type": "string",
+      "pattern": "^\\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\}$"
+    }
+  }
+}
+`
+
+func TestSchemaValidationUUID(t *testing.T) {
+	// This test validates that both regexes in the pattern behave the same way, with `\\-` or `-`.
+	//
+	// It's part of https://github.com/sourcegraph/sourcegraph/pull/54494, which fixes a regression for customers.
+	//
+	// This test should serve as an anti-regression-regression test, to make sure that we don't break something else.
+
+	t.Run("valid input", func(t *testing.T) {
+		input := `
+{
+	"uuid-escaped": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+	"uuid-unescaped": "{fceb73c7-cef6-4abe-956d-e471281126bd}",
+}
+`
+		if err := validateAgainstSchema(t, input, testSchemaWithUUIDValidation); err != nil {
+			t.Fatalf("err should be nil, but is not: %s", err)
+		}
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		input := `
+{
+	"uuid-escaped": "{fceb73c7+cef6-4abe-956d-e471281126bd}",
+	"uuid-unescaped": "{fceb73c7+cef6-4abe-956d-e471281126bd}",
+}
+`
+		err := validateAgainstSchema(t, input, testSchemaWithUUIDValidation)
+		if err == nil {
+			t.Fatal("expected err to not be nil, but is nil")
+		}
+
+		wantErr := `2 errors occurred:
+	* uuid-escaped: Does not match pattern '^\{[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}\}$'
+	* uuid-unescaped: Does not match pattern '^\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}$'`
+
+		if diff := cmp.Diff(err.Error(), wantErr); diff != "" {
+			t.Fatalf("wrong error message: %s", diff)
+		}
+	})
+
+}
+
+// validateAgainstSchema does roughly what we do in
+// `database.MakeValidateExternalServiceConfigFunc`, using same libraries.
+//
+// This is for testing our assumptions about schemas and how they work.
+func validateAgainstSchema(t *testing.T, input, schema string) error {
+	sl := gojsonschema.NewSchemaLoader()
+	sc, err := sl.Compile(gojsonschema.NewStringLoader(testSchemaWithUUIDValidation))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	normalized, err := jsonc.Parse(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := sc.Validate(gojsonschema.NewBytesLoader(normalized))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var errs error
+	for _, err := range res.Errors() {
+		errString := err.String()
+		// Remove `(root): ` from error formatting since these errors are
+		// presented to users.
+		errString = strings.TrimPrefix(errString, "(root): ")
+		errs = errors.Append(errs, errors.New(errString))
+	}
+
+	return errs
+}


### PR DESCRIPTION
### The problem
The regular expression used in matching the exclusion by UUID in Bitbucket.org (Cloud) code host connection was unsupported by [AJV](https://ajv.js.org/), which was added for validation purposes in https://github.com/sourcegraph/sourcegraph/pull/52012.

The problem surfaced in an ugly way as an uncaught error that prevented the loading of create/edit code host UI for Bitbucket Cloud, which schema contained the invalid regex.

The issue was reported in Slack: https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1688132947851839.

### Customer impact

Customers using Bitbucket.org (Cloud) are unable to create new or edit existing code host connections.

### What is changed

AJV JSON schema validator treated the escaped `-` sign as invalid. Removing the escaping from it fixed the problem.

Test plan:
Local sg run and verify that Bitbucket Cloud code hosts can be created and updated using UUID excludes, changes are stored in the DB, and UI validation with AJV works.
