### PR TITLE
App - remove embeddings policy warning during setup

### DIFF
--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -113,7 +113,8 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({ authenticatedUser
                     .
                 </DismissibleAlert>
             )}
-            {showNoEmbeddingPoliciesAlert && authenticatedUser?.siteAdmin && (
+            {/*Sourcegraph app creates a global policy during setup but this alert is flashing during connection to dotcom account */}
+            {showNoEmbeddingPoliciesAlert && authenticatedUser?.siteAdmin && !isSourcegraphApp && (
                 <DismissibleAlert
                     key="no-embeddings-policies-alert"
                     partialStorageKey="no-embeddings-policies-alert"

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -113,7 +113,7 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({ authenticatedUser
                     .
                 </DismissibleAlert>
             )}
-            {/*Sourcegraph app creates a global policy during setup but this alert is flashing during connection to dotcom account */}
+            {/* Sourcegraph app creates a global policy during setup but this alert is flashing during connection to dotcom account */}
             {showNoEmbeddingPoliciesAlert && authenticatedUser?.siteAdmin && !isSourcegraphApp && (
                 <DismissibleAlert
                     key="no-embeddings-policies-alert"


### PR DESCRIPTION
When returning from dotcom connection the page would display a red warning regarding cody being enabled but without a global embeddings policy.

In app the policy gets auto created after the users adds repos.  This disables the warning on app.

resolves https://github.com/sourcegraph/sourcegraph/issues/54495
## Test plan
Made release build
verified no red flash

https://github.com/sourcegraph/sourcegraph/assets/6098507/7e526eea-b16a-4908-a94a-05075b868080


https://github.com/sourcegraph/sourcegraph/assets/6098507/784bbc90-8fac-4b8c-8030-dbcdbd2b85dd



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
