### PR TITLE
App - open doc links in settings in new windows

### DIFF
--- a/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
+++ b/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
@@ -100,7 +100,10 @@ export const CodyConfigurationPage: FC<CodyConfigurationPageProps> = ({
                 description={
                     <>
                         Rules that control keeping embeddings up-to-date. See the{' '}
-                        <Link to="/help/cody/explanations/policies">documentation</Link> for more details.
+                        <Link target="_blank" to="/help/cody/explanations/policies">
+                            documentation
+                        </Link>{' '}
+                        for more details.
                     </>
                 }
                 actions={

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -413,7 +413,10 @@ class SiteAdminConfigurationContent extends React.Component<Props, State> {
                     description={
                         <>
                             View and edit the Sourcegraph site configuration. See{' '}
-                            <Link to="/help/admin/config/site_config">documentation</Link> for more information.
+                            <Link target="_blank" to="/help/admin/config/site_config">
+                                documentation
+                            </Link>{' '}
+                            for more information.
                         </>
                     }
                     className="mb-3"


### PR DESCRIPTION
Some docs links in the settings section navigated away from settings. It would be best to open these in a new window so the user can view them without losing their place in settings.  This also resolves an issue in app where allowing it to link out to the documentation.

resolves https://github.com/sourcegraph/app/issues/24
## Test plan
`sg start app` validated that links open to correct page in a new window.
`sg start` validated that links open in new tab
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
