### PR TITLE
App - add os and arch info during startup log message

### DIFF
--- a/internal/singleprogram/singleprogram.go
+++ b/internal/singleprogram/singleprogram.go
@@ -28,7 +28,7 @@ type CleanupFunc func() error
 
 func Init(logger log.Logger) CleanupFunc {
 	if deploy.IsApp() {
-		fmt.Fprintln(os.Stderr, "✱ Sourcegraph App version:", version.Version())
+		fmt.Fprintln(os.Stderr, "✱ Sourcegraph App version:", version.Version(), runtime.GOOS, runtime.GOARCH)
 	}
 
 	// TODO(sqs) TODO(single-binary): see the env.HackClearEnvironCache docstring, we should be able to remove this


### PR DESCRIPTION
Write the os and arch in addition to the version number at startup, this information is useful when debugging startup issues. 
## Test plan
`sg start app` view output
```
✱ Sourcegraph App version: 0.0.0+dev darwin arm64
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
