### PR TITLE
bzl: update deps.bzl (go.mod update was not reflected)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -383,7 +383,6 @@ load("@container_structure_test//:repositories.bzl", "container_structure_test_r
 
 container_structure_test_register_toolchain(name = "cst")
 
-
 load("//dev:tool_deps.bzl", "tool_deps")
 
 tool_deps()

--- a/deps.bzl
+++ b/deps.bzl
@@ -6302,8 +6302,8 @@ def go_dependencies():
         ],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/scip",
-        sum = "h1:6PgJPdhDHRGskCu7+NxodNtX1z8umdC40QvoQt4FsP8=",
-        version = "v0.2.4-0.20230613194658-b62733841bc3",
+        sum = "h1:o+eq0cjVV3B5ngIBF04Lv3GwttKOuYFF5NTcfXWXzfA=",
+        version = "v0.3.1-0.20230627154934-45df7f6d33fc",
     )
 
     go_repository(


### PR DESCRIPTION
In 2f7ae0988f5 @efritz updated `scip` in `go.mod`, but he forgot to run `bazel run :gazelle-update-repos`. This PR fixes this. 

@efritz it's really easy to miss this, I'll try finding a quick fix so it doesn't happen anymore 🙏 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 