### PR TITLE
cody web: fix 404 errors when loading /cody

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -83,6 +83,8 @@ const (
 	routeOwn                     = "own"
 	routeAppComingSoon           = "app-coming-soon"
 	routeAppAuthCallback         = "app-auth-callback"
+	routeCody                    = "cody"
+	routeCodyChat                = "cody-chat"
 	routeGetCody                 = "get-cody"
 
 	routeSearchStream  = "search.stream"
@@ -184,6 +186,8 @@ func newRouter() *mux.Router {
 	r.Path("/app/auth/callback").Methods("GET").Name(routeAppAuthCallback)
 	r.Path("/ping-from-self-hosted").Methods("GET", "OPTIONS").Name(uirouter.RoutePingFromSelfHosted)
 	r.Path("/get-cody").Methods("GET").Name(routeGetCody)
+	r.Path("/cody").Methods("GET").Name(routeCody)
+	r.Path("/cody/{chatID}").Methods("GET").Name(routeCodyChat)
 
 	// 🚨 SECURITY: The embed route is used to serve embeddable content (via an iframe) to 3rd party sites.
 	// Any changes to the embedding route could have security implications. Please consult the security team
@@ -300,6 +304,8 @@ func initRouter(db database.DB, enterpriseJobs jobutil.EnterpriseJobs, router *m
 	router.Get(routeAppComingSoon).Handler(brandedNoIndex("Coming soon"))
 	router.Get(routeAppAuthCallback).Handler(brandedNoIndex("Auth callback"))
 	router.Get(uirouter.RoutePingFromSelfHosted).Handler(handler(db, servePingFromSelfHosted))
+	router.Get(routeCody).Handler(brandedNoIndex("Cody"))
+	router.Get(routeCodyChat).Handler(brandedNoIndex("Cody"))
 	router.Get(routeGetCody).Handler(brandedNoIndex("Cody"))
 
 	// 🚨 SECURITY: The embed route is used to serve embeddable content (via an iframe) to 3rd party sites.


### PR DESCRIPTION
This has been bugging me for a while. The 404 errors come from the backend before the frontend takes over.

You could see `frontend` also logging errors:

```
[frontend] t=2023-07-03T08:50:34+0000 lvl=eror msg="ui HTTP handler error response" method=GET request_uri=/cody/MjAyMy0wNy0wM1QwNzo0MzowMS4xODNa status_code=404 error="repo not found: name=\"cody/MjAyMy0wNy0wM1QwNzo0MzowMS4xODNa\"" error_id=wt7u7W trace=
```

That means for every `/cody` requests we'd try to find a repository.

This here fixes the error by defining 2 routes:

- `/cody`
- `/cody/{chatID}`

And handling them correctly.

## Before

https://github.com/sourcegraph/sourcegraph/assets/1185253/468abf97-9ae5-47f2-9744-145b6bff3184

## After

https://github.com/sourcegraph/sourcegraph/assets/1185253/ea2a62d8-8a31-41be-a88c-5cc788262296



## Test plan

- `sg start`
- Then load `sourcegraph.test:3443/cody`
- Then hard-reload the URL I've been redirected to
