### PR TITLE
[Backport 5.1] bzl: update deps.bzl (go.mod update was not reflected) (#54521)

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6295,8 +6295,8 @@ def go_dependencies():
         ],
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/scip",
-        sum = "h1:6PgJPdhDHRGskCu7+NxodNtX1z8umdC40QvoQt4FsP8=",
-        version = "v0.2.4-0.20230613194658-b62733841bc3",
+        sum = "h1:o+eq0cjVV3B5ngIBF04Lv3GwttKOuYFF5NTcfXWXzfA=",
+        version = "v0.3.1-0.20230627154934-45df7f6d33fc",
     )
 
     go_repository(


### PR DESCRIPTION
In 2f7ae0988f5 @efritz updated `scip` in `go.mod`, but he forgot to run `bazel run :gazelle-update-repos`. This PR fixes this.

@efritz it's really easy to miss this, I'll try finding a quick fix so it doesn't happen anymore 🙏

Backport 59a7bafd321cdd344f5954e0e22f12df10870bdd from https://github.com/sourcegraph/sourcegraph/pull/54521

## Test plan

CI