### PR TITLE
Update prometheus tools

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,7 +52,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:2e7c1efa275df630d33121a53cbd40758fbdd4fa1fa5a31d256f8d2891e87c7e",
+        digest = "sha256:8c43c861026ff3706849bf56d22ef2a1714f76e739fb2cd9f89b78abeec39bd2",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
@@ -70,7 +70,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:21fe5b8ada61899c7f5afeb3fa36078471d555d0d4237c66d87c105770d868b2",
+        digest = "sha256:df37c2ab0fac3e0215b19f51cf993971a71db9fb4db1230070e937d7842f154b",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
@@ -167,7 +167,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:958a60217909ab5986cd5e116151a7f5ba96cf4cb0a7c25843ccbc0b6d1440c2",
+        digest = "sha256:85b5b0f1cf4df378ac007b846a84fde3a5b00696394bfa2dbc6ca0118ba31999",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 

--- a/wolfi-images/batcheshelper.yaml
+++ b/wolfi-images/batcheshelper.yaml
@@ -7,6 +7,6 @@ contents:
     - mailcap
 
     ## batcheshelper packages
-    - 'git>=2.38.1'
+    - 'git'
 
 # MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -10,7 +10,7 @@ contents:
     - ca-certificates
     - git
     - maven
-    - openjdk-11=11.0.20.4-r0 # TODO(will): Temporarily pinned to avoid bad signature
+    - openjdk-11
     - openjdk-11-default-jvm
     - python3
     - py3-pip

--- a/wolfi-images/node-exporter.yaml
+++ b/wolfi-images/node-exporter.yaml
@@ -3,6 +3,6 @@ include: ./sourcegraph-base.yaml
 contents:
   packages:
     ## node-exporter-specific packages
-    - 'prometheus-node-exporter=1.5.0-r3' # IMPORTANT: Pinned version for managed updates
+    - 'prometheus-node-exporter=1.6.0-r1' # IMPORTANT: Pinned version for managed updates
 
 # MANUAL REBUILD: Thu Jun 22 13:43:35 BST 2023

--- a/wolfi-images/postgres-exporter.yaml
+++ b/wolfi-images/postgres-exporter.yaml
@@ -3,7 +3,7 @@ include: ./sourcegraph-base.yaml
 contents:
   packages:
     ## postgres-exporter packages
-    - 'prometheus-postgres-exporter=0.12.0-r1' # IMPORTANT: Pinned version for managed updates
+    - 'prometheus-postgres-exporter=0.13.1-r0' # IMPORTANT: Pinned version for managed updates
 
 accounts:
   groups:

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -22,7 +22,7 @@ contents:
     - posix-libc-utils # Adds locale, used by server postgres init scripts
     - postgresql-12
     - postgresql-12-contrib
-    - prometheus-postgres-exporter=0.12.0-r1 # IMPORTANT: Pinned version for managed updates
+    - prometheus-postgres-exporter=0.13.1-r0 # IMPORTANT: Pinned version for managed updates
     - prometheus-alertmanager
     - python3
     - posix-libc-utils # Locales


### PR DESCRIPTION
Update postgres-exporter and node-exporter to latest versions.

The current version of postgres-exporter seems to cause a [non-critical error](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1688168678260469?thread_ts=1688063676.565389&cid=C02E4HE42BX) which is fixed in 0.12.1, so also backporting. 

TODO:
- [x] Update deps_oci with new image hashes once CI runs.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- CI
- Testing on S2