### PR TITLE
own: remove forgotten "Own" references in favor of "Code ownership".

### DIFF
--- a/client/web/src/enterprise/own/OwnPage.tsx
+++ b/client/web/src/enterprise/own/OwnPage.tsx
@@ -17,7 +17,7 @@ import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
 
 /**
- * A page explaining how to use Sourcegraph Own.
+ * A page explaining how to use Code ownership.
  */
 export const OwnPage: React.FunctionComponent<{}> = () => {
     const allowAutoplay = !useReducedMotion()
@@ -28,8 +28,8 @@ export const OwnPage: React.FunctionComponent<{}> = () => {
             <PageHeader description="Track and update code ownership across your entire codebase." className="mb-3">
                 <H1 as="h2" className="d-flex align-items-center">
                     <Icon svgPath={mdiAccount} aria-hidden={true} />
-                    <span className="ml-2">Own</span>
-                    <ProductStatusBadge status="experimental" className="ml-2" />
+                    <span className="ml-2">Code ownership</span>
+                    <ProductStatusBadge status="beta" className="ml-2" />
                 </H1>
             </PageHeader>
 
@@ -55,10 +55,10 @@ export const OwnPage: React.FunctionComponent<{}> = () => {
                     <div className="col-12 col-md-5">
                         <H2 as="h3">Evergreen code ownership data for your entire codebase</H2>
                         <Text>
-                            CODEOWNERS alone is not enough. Own makes it easy to find the owner of any file within your
-                            codebase.
+                            CODEOWNERS alone is not enough. Code ownership makes it easy to find the owner of any file
+                            within your codebase.
                         </Text>
-                        <H3 as="h4">Use Own to…</H3>
+                        <H3 as="h4">Use code ownership to…</H3>
                         <ul>
                             <li>Search for vulnerable code and reach out to the owner in seconds</li>
                             <li>Find who to ask about unfamiliar code</li>
@@ -66,8 +66,8 @@ export const OwnPage: React.FunctionComponent<{}> = () => {
                         </ul>
                         <Text>Ingest ownership data from CODEOWNERS files, or from an existing ownership system.</Text>
                         <Text>
-                            Own is currently an experimental feature and is getting smarter fast. We’d love your
-                            feedback. You can turn it on using the documentation below, or{' '}
+                            Code ownership is in a beta and is getting smarter fast. We’d love your feedback. You can
+                            turn it on using the documentation below, or{' '}
                             <Link to="https://about.sourcegraph.com/demo">contact us</Link> to get a demo and learn more
                             about our roadmap.
                         </Text>

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -31,7 +31,7 @@ export const OwnAnalyticsPage: FC = () => {
         <>
             {loading && <LoadingSpinner />}
             {error && <ErrorAlert prefix="Error finding out if own analytics are enabled" error={error} />}
-            <AnalyticsPageTitle>Own</AnalyticsPageTitle>
+            <AnalyticsPageTitle>Code ownership</AnalyticsPageTitle>
             {enabled ? <OwnAnalyticsPanel /> : <OwnEnableAnalytics />}
         </>
     )
@@ -80,7 +80,7 @@ const OwnAnalyticsPanel: FC = () => {
     return (
         <>
             {loading && <LoadingSpinner />}
-            {error && <ErrorAlert prefix="Error getting own analytics" error={error} />}
+            {error && <ErrorAlert prefix="Error getting code ownership analytics" error={error} />}
             {!loading && !error && (
                 <>
                     {/* TODO(#52826): If only partial data is available - make that clear to the user. */}
@@ -122,7 +122,7 @@ const OwnAnalyticsPanel: FC = () => {
 
 const OwnEnableAnalytics: FC = () => (
     <Alert variant="info">
-        Analytics is not enabled, please <Link to="/site-admin/own-signal-page">enable Own analytics</Link> job first to
-        see Own stats.
+        Analytics is not enabled, please <Link to="/site-admin/own-signal-page">enable code ownership analytics</Link>{' '}
+        job first to see code ownership stats.
     </Alert>
 )

--- a/client/web/src/enterprise/own/admin-ui/OwnStatusPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnStatusPage.tsx
@@ -50,11 +50,11 @@ export const OwnStatusPage: FC = () => {
         <div>
             <span className={styles.topHeader}>
                 <div>
-                    <PageTitle title="Own Signals Configuration" />
+                    <PageTitle title="Code ownership signals configuration" />
                     <PageHeader
                         headingElement="h2"
-                        path={[{ text: 'Own Signals Configuration' }]}
-                        description="List of Own inference signal indexers and their configurations. All repositories are included by default."
+                        path={[{ text: 'Code ownership signals configuration' }]}
+                        description="List of code ownership inference signal indexers and their configurations. All repositories are included by default."
                         className="mb-3"
                     />
                     {saveError && <ErrorAlert error={saveError} />}
@@ -100,7 +100,7 @@ export const OwnStatusPage: FC = () => {
 
             <Container className={styles.root}>
                 {loading && <LoadingSpinner />}
-                {error && <ErrorAlert prefix="Error fetching Own signal configurations" error={error} />}
+                {error && <ErrorAlert prefix="Error fetching code ownership signal configurations" error={error} />}
                 {!loading &&
                     localData &&
                     !error &&

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -175,7 +175,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     const searchNavBarItems = useMemo(() => {
         const items: (NavDropdownItem | false)[] = [
             !!showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
-            ownEnabled && { path: EnterprisePageRoutes.Own, content: 'Own' },
+            ownEnabled && { path: EnterprisePageRoutes.Own, content: 'Code ownership' },
             codySearchEnabled && {
                 path: EnterprisePageRoutes.CodySearch,
                 content: (

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -51,7 +51,7 @@ export const analyticsGroup: SiteAdminSideBarGroup = {
             to: '/site-admin/analytics/extensions',
         },
         {
-            label: 'Own',
+            label: 'Code ownership',
             to: '/site-admin/analytics/own',
         },
         {

--- a/doc/own/codeowners_format.md
+++ b/doc/own/codeowners_format.md
@@ -51,7 +51,7 @@ To configure ownership in Sourcegraph, you have two options:
 
 > Use this approach if you prefer versioned ownership data.
 
-You can simply commit a `CODEOWNERS` file at any of the following locations for it to be picked up automatically by Own:
+You can simply commit a `CODEOWNERS` file at any of the following locations for it to be picked up automatically by code ownership:
 
 ```
 CODEOWNERS

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -79,7 +79,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [Background information](dev/background-information/index.md)
   - [Contributing](dev/contributing.md)
 - [Dotcom](dotcom/index.md)
-- [Own (beta)](own/index.md)
+- [Code ownership (beta)](own/index.md)
   - [The CODEOWNERS format](own/codeowners_format.md)
   - [CODEOWNERS ingestion](own/codeowners_ingestion.md)
   - [Assigned ownership](own/assigned_ownership.md)


### PR DESCRIPTION
Test plan:
Local sg run and visual checks.

### Screenshots
| Before | After |
| :-- | :-- |
| <img width="472" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/4570e5c3-a898-4b0a-b1a2-086cf4294301"> | <img width="472" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/15605998-e994-45b0-aec7-5a604620f17f"> |
| <img width="472" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/a61320d8-7323-4d10-9d0d-52c6aeca593d"> | <img width="472" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/94846361/0c4eb1eb-750f-43bb-9c7c-cf8ddf269500"> | 
