### PR TITLE
[Backport 5.1] Update prometheus tools

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -36,7 +36,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:2e7c1efa275df630d33121a53cbd40758fbdd4fa1fa5a31d256f8d2891e87c7e",
+        digest = "sha256:8c43c861026ff3706849bf56d22ef2a1714f76e739fb2cd9f89b78abeec39bd2",
         image = "us.gcr.io/sourcegraph-dev/wolfi-server-base",
     )
 
@@ -54,7 +54,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:b51ae2b70cd7cd7883e8057d69a74c959fd5f03d723538908ea8f47a0a322e02",
+        digest = "sha256:df37c2ab0fac3e0215b19f51cf993971a71db9fb4db1230070e937d7842f154b",
         image = "us.gcr.io/sourcegraph-dev/wolfi-postgres-exporter-base",
     )
 
@@ -150,7 +150,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:9f7149d05afad6e3581a7a4bc13c60cad5d314bab7307e1dcd47d1c6bb42c497",
+        digest = "sha256:85b5b0f1cf4df378ac007b846a84fde3a5b00696394bfa2dbc6ca0118ba31999",
         image = "us.gcr.io/sourcegraph-dev/wolfi-node-exporter-base",
     )
 

--- a/wolfi-images/batcheshelper.yaml
+++ b/wolfi-images/batcheshelper.yaml
@@ -7,6 +7,6 @@ contents:
     - mailcap
 
     ## batcheshelper packages
-    - 'git>=2.38.1'
+    - 'git'
 
 # MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023

--- a/wolfi-images/node-exporter.yaml
+++ b/wolfi-images/node-exporter.yaml
@@ -3,6 +3,6 @@ include: ./sourcegraph-base.yaml
 contents:
   packages:
     ## node-exporter-specific packages
-    - 'prometheus-node-exporter=1.5.0-r3' # IMPORTANT: Pinned version for managed updates
+    - 'prometheus-node-exporter=1.6.0-r1' # IMPORTANT: Pinned version for managed updates
 
 # MANUAL REBUILD: Wed Jun 14 15:27:52 BST 2023

--- a/wolfi-images/postgres-exporter.yaml
+++ b/wolfi-images/postgres-exporter.yaml
@@ -3,7 +3,7 @@ include: ./sourcegraph-base.yaml
 contents:
   packages:
     ## postgres-exporter packages
-    - 'prometheus-postgres-exporter=0.12.0-r1' # IMPORTANT: Pinned version for managed updates
+    - 'prometheus-postgres-exporter=0.13.1-r0' # IMPORTANT: Pinned version for managed updates
 
 accounts:
   groups:

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -22,7 +22,7 @@ contents:
     - posix-libc-utils # Adds locale, used by server postgres init scripts
     - postgresql-12
     - postgresql-12-contrib
-    - prometheus-postgres-exporter=0.12.0-r1 # IMPORTANT: Pinned version for managed updates
+    - prometheus-postgres-exporter=0.13.1-r0 # IMPORTANT: Pinned version for managed updates
     - prometheus-alertmanager
     - python3
     - posix-libc-utils # Locales


### PR DESCRIPTION
Backport of https://github.com/sourcegraph/sourcegraph/pull/54533 to 5.1

Update postgres-exporter and node-exporter to latest versions.

The current version of postgres-exporter seems to cause a [non-critical error](https://sourcegraph.slack.com/archives/C02E4HE42BX/p1688168678260469?thread_ts=1688063676.565389&cid=C02E4HE42BX) which is fixed in 0.12.1, so also backporting. 

TODO:
- [x] Update deps_oci with new image hashes once CI runs.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- CI
- Testing on S2