### PR TITLE
packages: skip duplicates when extracting

### DIFF
--- a/cmd/gitserver/server/vcs_syncer_go_modules.go
+++ b/cmd/gitserver/server/vcs_syncer_go_modules.go
@@ -81,7 +81,7 @@ func (s *goModulesSyncer) Download(ctx context.Context, dir string, dep reposour
 // valid according to modzip.CheckZip or that are potentially malicious.
 func unzip(mod module.Version, zipBytes []byte, workDir string) error {
 	zipFile := path.Join(workDir, "mod.zip")
-	err := os.WriteFile(zipFile, zipBytes, 0666)
+	err := os.WriteFile(zipFile, zipBytes, 0o666)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create go module zip file %q", zipFile)
 	}
@@ -106,7 +106,8 @@ func unzip(mod module.Version, zipBytes []byte, workDir string) error {
 
 	br := bytes.NewReader(zipBytes)
 	err = unpack.Zip(br, int64(br.Len()), workDir, unpack.Opts{
-		SkipInvalid: true,
+		SkipInvalid:    true,
+		SkipDuplicates: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			malicious := isPotentiallyMaliciousFilepathInArchive(path, workDir)
 			_, ok := valid[path]

--- a/cmd/gitserver/server/vcs_syncer_jvm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_jvm_packages.go
@@ -129,12 +129,13 @@ func unzipJarFile(jarPath, destination string) (err error) {
 
 	zipFile, err := os.ReadFile(jarPath)
 	if err != nil {
-		errors.Wrap(err, "bad jvm package")
+		return errors.Wrap(err, "bad jvm package")
 	}
 
 	r := bytes.NewReader(zipFile)
 	opts := unpack.Opts{
-		SkipInvalid: true,
+		SkipInvalid:    true,
+		SkipDuplicates: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 

--- a/cmd/gitserver/server/vcs_syncer_npm_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_npm_packages.go
@@ -128,7 +128,8 @@ func decompressTgz(tgz io.Reader, destination string) error {
 	logger := log.Scoped("decompressTgz", "Decompress a tarball at tgzPath, putting the files under destination.")
 
 	err := unpack.Tgz(tgz, destination, unpack.Opts{
-		SkipInvalid: true,
+		SkipInvalid:    true,
+		SkipDuplicates: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 

--- a/cmd/gitserver/server/vcs_syncer_python_packages.go
+++ b/cmd/gitserver/server/vcs_syncer_python_packages.go
@@ -92,7 +92,8 @@ func unpackPythonPackage(pkg io.Reader, packageURL, reposDir, workDir string) er
 	filename := path.Base(u.Path)
 
 	opts := unpack.Opts{
-		SkipInvalid: true,
+		SkipInvalid:    true,
+		SkipDuplicates: true,
 		Filter: func(path string, file fs.FileInfo) bool {
 			size := file.Size()
 


### PR DESCRIPTION
Many dependency archives include duplicate files, we should set the flag to skip em to reduce some errors :fist_oncoming: 

## Test plan

N/A flipping a switch that is already tested and proven 
