### PR TITLE
Chore: remove redundant err check

### DIFF
--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -79,10 +79,6 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return err
 	}
 
-	if err != nil {
-		return err
-	}
-
 	weaviate := newWeaviateClient(
 		logger,
 		config.WeaviateURL,


### PR DESCRIPTION
Just removing a redundant error check that my linter was complaining about.

## Test plan

It builds.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
