### PR TITLE
Embeddings: remove extra retries

### DIFF
--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -69,7 +69,7 @@ func embedQueries(queries []string, siteConfigPath string) error {
 		if err != nil {
 			return err
 		}
-		v, err := c.GetEmbeddingsWithRetries(ctx, []string{query}, 0)
+		v, err := c.GetEmbeddings(ctx, []string{query})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get embeddings for query %s", query)
 		}

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -172,7 +172,7 @@ func getQueryEmbedding(ctx context.Context, query string) ([]float32, string, er
 		return nil, "", errors.Wrap(err, "getting embeddings client")
 	}
 
-	floatQuery, err := client.GetEmbeddingsWithRetries(ctx, []string{query}, queryEmbeddingRetries)
+	floatQuery, err := client.GetEmbeddings(ctx, []string{query})
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting query embedding")
 	}

--- a/enterprise/internal/embeddings/embed/client/client.go
+++ b/enterprise/internal/embeddings/embed/client/client.go
@@ -6,8 +6,8 @@ import (
 )
 
 type EmbeddingsClient interface {
-	// GetEmbeddingsWithRetries returns embeddings for the given texts.
-	GetEmbeddingsWithRetries(ctx context.Context, texts []string, maxRetries int) ([]float32, error)
+	// GetEmbeddings returns embeddings for the given texts.
+	GetEmbeddings(ctx context.Context, texts []string) ([]float32, error)
 	// GetDimensions returns the dimensionality of the embedding space.
 	GetDimensions() (int, error)
 	// GetModelIdentifier returns the identifier of the model used to generate embeddings. The format is

--- a/enterprise/internal/embeddings/embed/client/openai/client_test.go
+++ b/enterprise/internal/embeddings/embed/client/openai/client_test.go
@@ -16,7 +16,7 @@ func TestOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
 		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
 		invalidTexts := []string{"a", ""} // empty string is invalid
-		_, err := client.GetEmbeddingsWithRetries(context.Background(), invalidTexts, 10)
+		_, err := client.GetEmbeddings(context.Background(), invalidTexts)
 		require.ErrorContains(t, err, "empty string")
 	})
 
@@ -67,7 +67,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		resp, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err)
 		var expected []float32
 		{
@@ -119,7 +119,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		_, err := client.GetEmbeddingsWithRetries(context.Background(), []string{"a", "b"}, 0)
+		_, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
 		require.Error(t, err, "expected request to error on failed retry")
 	})
 }

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -185,7 +185,7 @@ func embedFiles(
 			index.Ranks = append(index.Ranks, float32(repoPathRanks.Paths[chunk.FileName]))
 		}
 
-		batchEmbeddings, err := client.GetEmbeddingsWithRetries(ctx, batchChunks, getEmbeddingsMaxRetries)
+		batchEmbeddings, err := client.GetEmbeddings(ctx, batchChunks)
 		if err != nil {
 			return errors.Wrap(err, "error while getting embeddings")
 		}

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -298,7 +298,7 @@ func (c *mockEmbeddingsClient) GetModelIdentifier() string {
 	return "mock/some-model"
 }
 
-func (c *mockEmbeddingsClient) GetEmbeddingsWithRetries(_ context.Context, texts []string, _ int) ([]float32, error) {
+func (c *mockEmbeddingsClient) GetEmbeddings(_ context.Context, texts []string) ([]float32, error) {
 	dimensions, err := c.GetDimensions()
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/embeddings/embed/embed_test.go
+++ b/enterprise/internal/embeddings/embed/embed_test.go
@@ -280,7 +280,7 @@ type misbehavingEmbeddingsClient struct {
 	returnedDimsPerInput int
 }
 
-func (c *misbehavingEmbeddingsClient) GetEmbeddingsWithRetries(_ context.Context, texts []string, _ int) ([]float32, error) {
+func (c *misbehavingEmbeddingsClient) GetEmbeddings(_ context.Context, texts []string) ([]float32, error) {
 	return make([]float32, len(texts)*c.returnedDimsPerInput), nil
 }
 


### PR DESCRIPTION
Retries are handled automatically by the underlying HTTP client. With this extra layer, we were retrying 5x more times, up to 1600 times. Let's leave retrying to the HTTP layer to reduce complexity in the embeddings clients.

## Test plan

Tested that retries were, in fact, handled in the HTTP layer for intermittent errors. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
