### PR TITLE
App/Insights: provide fallback for Intl.ListFormat

### DIFF
--- a/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
@@ -22,7 +22,7 @@ declare namespace Intl {
 const LIST_FORMATTER = (() => {
     try {
         return new Intl.ListFormat('en', { style: 'long', type: 'conjunction' })
-    } catch (e) {
+    } catch {
         return {
             format(items: string[]) {
                 return items.join(', ')

--- a/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
@@ -19,7 +19,17 @@ declare namespace Intl {
     }
 }
 
-const LIST_FORMATTER = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' })
+const LIST_FORMATTER = (() => {
+    try {
+        return new Intl.ListFormat('en', { style: 'long', type: 'conjunction' })
+    } catch (e) {
+        return {
+            format(items: string[]) {
+                return items.join(', ')
+            },
+        }
+    }
+})()
 
 const INTERVALS = [
     { type: 'years', inMinutes: 60 * 24 * 7 * 5 * 12 },


### PR DESCRIPTION
On some browsers Intl.ListFormat does not exist and causes the page to error.  This appears to be an issue on some linux versions and older macos versions.

resolves https://github.com/sourcegraph/sourcegraph/issues/54301

## Test plan
`sg start enterprise-codeinsights` - ensure that creation screen units display correctly
`sg start app` ensure embeddings jobs load

open dev tools and set int.ListFormat to null
verify app and code insights still loads and display a comma separated list such as `One year, two months`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
