### PR TITLE
redirect batchers notifications to the Code Search team

### DIFF
--- a/.github/workflows/batches-notify.yml
+++ b/.github/workflows/batches-notify.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           body: |
-            Hey, @sourcegraph/batchers (@eseliger @courier-new @adeola-ak @BolajiOlajide @st0nebraker @malomarrec @chrispine @danielmarquespt) - we have been mentioned. Let's take a look.
+            Hey, @sourcegraph/code-search - Batch Changes has been mentioned. Let's take a look.


### PR DESCRIPTION

## Test plan

Comment on an issue including `batch` or `team/batchers` in the text and look for a notification to @sourcegraph/code-search 