### PR TITLE
sg: remove extra semaphore release

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -184,7 +184,6 @@ func (c *cmdRunner) runAndWatch(ctx context.Context, cmd Command, reload <-chan 
 				} else if cmd.Install == "" && cmd.InstallFunc != "" {
 					fn, ok := installFuncs[cmd.InstallFunc]
 					if !ok {
-						c.installSemaphore.Release(1)
 						return "", errors.Newf("no install func with name %q found", cmd.InstallFunc)
 					}
 					return "", fn(ctx, makeEnvMap(c.parentEnv, cmd.Env))


### PR DESCRIPTION
This removes an extra `semaphore.Release` (it's already deferred in that function) that was causing a panic locally in `sg` and misleading me on the underlying cause.

## Test plan

This no longer panics on error.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
