### PR TITLE
Tracing: replace `family` and `title` with `name`

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -73,7 +73,7 @@ func (s *repos) Get(ctx context.Context, repo api.RepoID) (_ *types.Repo, err er
 		return Mocks.Repos.Get(ctx, repo)
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "Get", repo, &err)
+	ctx, done := startTrace(ctx, "Get", repo, &err)
 	defer done()
 
 	return s.store.Get(ctx, repo)
@@ -86,7 +86,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 		return Mocks.Repos.GetByName(ctx, name)
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "GetByName", name, &err)
+	ctx, done := startTrace(ctx, "GetByName", name, &err)
 	defer done()
 
 	repo, err := s.store.GetByName(ctx, name)
@@ -135,7 +135,7 @@ var metricIsRepoCloneable = promauto.NewCounterVec(prometheus.CounterOpts{
 // repo-updater when in sourcegraph.com mode. It's possible that the repo has
 // been renamed on the code host in which case a different name may be returned.
 func (s *repos) add(ctx context.Context, name api.RepoName) (addedName api.RepoName, err error) {
-	ctx, done := startTrace(ctx, "Repos", "Add", name, &err)
+	ctx, done := startTrace(ctx, "Add", name, &err)
 	defer done()
 
 	// Avoid hitting repo-updater (and incurring a hit against our GitHub/etc. API rate
@@ -178,7 +178,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 		return Mocks.Repos.List(ctx, opt)
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "List", opt, &err)
+	ctx, done := startTrace(ctx, "List", opt, &err)
 	defer func() {
 		if err == nil {
 			if tr := trace.TraceFromContext(ctx); tr != nil {
@@ -197,7 +197,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 // The intended call site for this is the logic which assigns repositories to
 // zoekt shards.
 func (s *repos) ListIndexable(ctx context.Context) (repos []types.MinimalRepo, err error) {
-	ctx, done := startTrace(ctx, "Repos", "ListIndexable", nil, &err)
+	ctx, done := startTrace(ctx, "ListIndexable", nil, &err)
 	defer func() {
 		if err == nil {
 			if tr := trace.TraceFromContext(ctx); tr != nil {
@@ -221,7 +221,7 @@ func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api
 		return Mocks.Repos.GetInventory(ctx, repo, commitID)
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "GetInventory", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
+	ctx, done := startTrace(ctx, "GetInventory", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
 	defer done()
 
 	// Cap GetInventory operation to some reasonable time.
@@ -259,7 +259,7 @@ func (s *repos) DeleteRepositoryFromDisk(ctx context.Context, repoID api.RepoID)
 		return errors.Wrap(err, fmt.Sprintf("error while fetching repo with ID %d", repoID))
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "DeleteRepositoryFromDisk", repoID, &err)
+	ctx, done := startTrace(ctx, "DeleteRepositoryFromDisk", repoID, &err)
 	defer done()
 
 	err = s.gitserverClient.Remove(ctx, repo.Name)
@@ -272,7 +272,7 @@ func (s *repos) RequestRepositoryClone(ctx context.Context, repoID api.RepoID) (
 		return errors.Wrap(err, fmt.Sprintf("error while fetching repo with ID %d", repoID))
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "RequestRepositoryClone", repoID, &err)
+	ctx, done := startTrace(ctx, "RequestRepositoryClone", repoID, &err)
 	defer done()
 
 	resp, err := s.gitserverClient.RequestRepoClone(ctx, repo.Name)
@@ -299,14 +299,14 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 		return Mocks.Repos.ResolveRev(ctx, repo, rev)
 	}
 
-	ctx, done := startTrace(ctx, "Repos", "ResolveRev", map[string]any{"repo": repo.Name, "rev": rev}, &err)
+	ctx, done := startTrace(ctx, "ResolveRev", map[string]any{"repo": repo.Name, "rev": rev}, &err)
 	defer done()
 
 	return s.gitserverClient.ResolveRevision(ctx, repo.Name, rev, gitserver.ResolveRevisionOptions{})
 }
 
 func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.CommitID) (res *gitdomain.Commit, err error) {
-	ctx, done := startTrace(ctx, "Repos", "GetCommit", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
+	ctx, done := startTrace(ctx, "GetCommit", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
 	defer done()
 
 	s.logger.Debug("GetCommit", log.String("repo", string(repo.Name)), log.String("commitID", string(commitID)))

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -31,7 +31,7 @@ func startTrace(ctx context.Context, server, method string, arg any, err *error)
 	name := server + "." + method
 	requestGauge.WithLabelValues(name).Inc()
 
-	tr, ctx := trace.DeprecatedNew(ctx, server, method,
+	tr, ctx := trace.New(ctx, server, method,
 		attribute.String("argument", fmt.Sprintf("%#v", arg)),
 		attribute.Int("userID", int(actor.FromContext(ctx).UID)),
 	)

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -31,7 +31,7 @@ func startTrace(ctx context.Context, server, method string, arg any, err *error)
 	name := server + "." + method
 	requestGauge.WithLabelValues(name).Inc()
 
-	tr, ctx := trace.New(ctx, server, method,
+	tr, ctx := trace.DeprecatedNew(ctx, server, method,
 		attribute.String("argument", fmt.Sprintf("%#v", arg)),
 		attribute.Int("userID", int(actor.FromContext(ctx).UID)),
 	)

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -27,11 +27,11 @@ var requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Current number of requests running for a method.",
 }, []string{"method"})
 
-func startTrace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) { //nolint:unparam // unparam complains that `server` always has same value across call-sites, but that's OK
-	name := server + "." + method
+func startTrace(ctx context.Context, method string, arg any, err *error) (context.Context, func()) { //nolint:unparam // unparam complains that `server` always has same value across call-sites, but that's OK
+	name := "Repos." + method
 	requestGauge.WithLabelValues(name).Inc()
 
-	tr, ctx := trace.DeprecatedNew(ctx, server, method,
+	tr, ctx := trace.New(ctx, name,
 		attribute.String("argument", fmt.Sprintf("%#v", arg)),
 		attribute.Int("userID", int(actor.FromContext(ctx).UID)),
 	)

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -100,7 +100,7 @@ func linksForRepository(
 	db database.DB,
 	repo *types.Repo,
 ) (phabRepo *types.PhabricatorRepo, links *protocol.RepoLinks, serviceType string) {
-	tr, ctx := trace.DeprecatedNew(ctx, "externallink", "linksForRepository",
+	tr, ctx := trace.New(ctx, "linksForRepository",
 		attribute.String("repo", string(repo.Name)),
 		attribute.Stringer("externalRepo", repo.ExternalRepo))
 	defer tr.Finish()

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -100,7 +100,7 @@ func linksForRepository(
 	db database.DB,
 	repo *types.Repo,
 ) (phabRepo *types.PhabricatorRepo, links *protocol.RepoLinks, serviceType string) {
-	tr, ctx := trace.New(ctx, "externallink", "linksForRepository",
+	tr, ctx := trace.DeprecatedNew(ctx, "externallink", "linksForRepository",
 		attribute.String("repo", string(repo.Name)),
 		attribute.Stringer("externalRepo", repo.ExternalRepo))
 	defer tr.Finish()

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -101,7 +101,7 @@ func linksForRepository(
 	repo *types.Repo,
 ) (phabRepo *types.PhabricatorRepo, links *protocol.RepoLinks, serviceType string) {
 	tr, ctx := trace.New(ctx, "linksForRepository",
-		attribute.String("repo", string(repo.Name)),
+		repo.Name.Attr(),
 		attribute.Stringer("externalRepo", repo.ExternalRepo))
 	defer tr.Finish()
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -279,7 +279,7 @@ func (r *GitCommitResolver) Path(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) path(ctx context.Context, path string, validate func(fs.FileInfo) error) (_ *GitTreeEntryResolver, err error) {
-	tr, ctx := trace.New(ctx, "GitCommitResolver", "path",
+	tr, ctx := trace.DeprecatedNew(ctx, "GitCommitResolver", "path",
 		attribute.String("path", path))
 	defer tr.FinishWithErr(&err)
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -279,8 +279,7 @@ func (r *GitCommitResolver) Path(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) path(ctx context.Context, path string, validate func(fs.FileInfo) error) (_ *GitTreeEntryResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "GitCommitResolver", "path",
-		attribute.String("path", path))
+	tr, ctx := trace.New(ctx, "GitCommitResolver.path", attribute.String("path", path))
 	defer tr.FinishWithErr(&err)
 
 	stat, err := r.gitserverClient.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.gitRepo, api.CommitID(r.oid), path)

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -42,7 +42,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 }
 
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi fs.FileInfo) bool) (_ []*GitTreeEntryResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "GitTreeEntryResolver", "entries")
+	tr, ctx := trace.New(ctx, "GitTreeEntryResolver.entries")
 	defer tr.FinishWithErr(&err)
 
 	entries, err := r.gitserverClient.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), r.Path(), r.isRecursive || args.Recursive)

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -42,7 +42,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 }
 
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi fs.FileInfo) bool) (_ []*GitTreeEntryResolver, err error) {
-	tr, ctx := trace.New(ctx, "GitTreeEntryResolver", "entries")
+	tr, ctx := trace.DeprecatedNew(ctx, "GitTreeEntryResolver", "entries")
 	defer tr.FinishWithErr(&err)
 
 	entries, err := r.gitserverClient.ReadDir(ctx, authz.DefaultSubRepoPermsChecker, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), r.Path(), r.isRecursive || args.Recursive)

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -197,7 +197,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
-	tr, ctx := trace.New(ctx, "GitTreeEntryResolver", "url")
+	tr, ctx := trace.DeprecatedNew(ctx, "GitTreeEntryResolver", "url")
 	defer tr.Finish()
 
 	if submodule := r.Submodule(); submodule != nil {
@@ -294,7 +294,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 }
 
 func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (_ string, err error) {
-	tr, ctx := trace.New(ctx, "gitTreeEntry", "cloneURLToRepoName")
+	tr, ctx := trace.DeprecatedNew(ctx, "gitTreeEntry", "cloneURLToRepoName")
 	defer tr.FinishWithErr(&err)
 
 	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, db, cloneURL)

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -197,7 +197,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
-	tr, ctx := trace.DeprecatedNew(ctx, "GitTreeEntryResolver", "url")
+	tr, ctx := trace.New(ctx, "GitTreeEntryResolver.url")
 	defer tr.Finish()
 
 	if submodule := r.Submodule(); submodule != nil {
@@ -294,7 +294,7 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 }
 
 func cloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (_ string, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "gitTreeEntry", "cloneURLToRepoName")
+	tr, ctx := trace.New(ctx, "cloneURLToRepoName")
 	defer tr.FinishWithErr(&err)
 
 	repoName, err := cloneurls.RepoSourceCloneURLToRepoName(ctx, db, cloneURL)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -242,7 +242,7 @@ type RepositoryCommitArgs struct {
 }
 
 func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitArgs) (_ *GitCommitResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "Commit",
+	tr, ctx := trace.New(ctx, "RepositoryResolver.Commit",
 		attribute.String("commit", args.Rev))
 	defer tr.FinishWithErr(&err)
 
@@ -267,7 +267,7 @@ type RepositoryChangelistArgs struct {
 }
 
 func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryChangelistArgs) (_ *PerforceChangelistResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "Changelist",
+	tr, ctx := trace.New(ctx, "RepositoryResolver.Changelist",
 		attribute.String("changelist", args.CID))
 	defer tr.FinishWithErr(&err)
 
@@ -314,7 +314,7 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 }
 
 func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (_ *GitCommitResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "FirstEverCommit")
+	tr, ctx := trace.New(ctx, "RepositoryResolver.FirstEverCommit")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := r.repo(ctx)

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -242,7 +242,7 @@ type RepositoryCommitArgs struct {
 }
 
 func (r *RepositoryResolver) Commit(ctx context.Context, args *RepositoryCommitArgs) (_ *GitCommitResolver, err error) {
-	tr, ctx := trace.New(ctx, "RepositoryResolver", "Commit",
+	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "Commit",
 		attribute.String("commit", args.Rev))
 	defer tr.FinishWithErr(&err)
 
@@ -267,7 +267,7 @@ type RepositoryChangelistArgs struct {
 }
 
 func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryChangelistArgs) (_ *PerforceChangelistResolver, err error) {
-	tr, ctx := trace.New(ctx, "RepositoryResolver", "Changelist",
+	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "Changelist",
 		attribute.String("changelist", args.CID))
 	defer tr.FinishWithErr(&err)
 
@@ -314,7 +314,7 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 }
 
 func (r *RepositoryResolver) FirstEverCommit(ctx context.Context) (_ *GitCommitResolver, err error) {
-	tr, ctx := trace.New(ctx, "RepositoryResolver", "FirstEverCommit")
+	tr, ctx := trace.DeprecatedNew(ctx, "RepositoryResolver", "FirstEverCommit")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := r.repo(ctx)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -192,7 +192,7 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
-	tr, _ := trace.DeprecatedNew(ctx, "DynamicFilters", "", attribute.String("resolver", "SearchResultsResolver"))
+	tr, _ := trace.New(ctx, "DynamicFilters", attribute.String("resolver", "SearchResultsResolver"))
 	defer tr.Finish()
 
 	var filters streaming.SearchFilters
@@ -235,7 +235,7 @@ func (sf *searchFilterResolver) Kind() string {
 // blameFileMatch blames the specified file match to produce the time at which
 // the first line match inside of it was authored.
 func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.FileMatch) (t time.Time, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "SearchResultsResolver", "blameFileMatch")
+	tr, ctx := trace.New(ctx, "SearchResultsResolver.blameFileMatch")
 	defer tr.FinishWithErr(&err)
 
 	// Blame the first line match.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -192,7 +192,7 @@ func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
 }
 
 func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFilterResolver {
-	tr, _ := trace.New(ctx, "DynamicFilters", "", attribute.String("resolver", "SearchResultsResolver"))
+	tr, _ := trace.DeprecatedNew(ctx, "DynamicFilters", "", attribute.String("resolver", "SearchResultsResolver"))
 	defer tr.Finish()
 
 	var filters streaming.SearchFilters
@@ -235,7 +235,7 @@ func (sf *searchFilterResolver) Kind() string {
 // blameFileMatch blames the specified file match to produce the time at which
 // the first line match inside of it was authored.
 func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.FileMatch) (t time.Time, err error) {
-	tr, ctx := trace.New(ctx, "SearchResultsResolver", "blameFileMatch")
+	tr, ctx := trace.DeprecatedNew(ctx, "SearchResultsResolver", "blameFileMatch")
 	defer tr.FinishWithErr(&err)
 
 	// Blame the first line match.

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -45,7 +45,7 @@ func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 
 // Deprecated: in the GraphQL API
 func (r *settingsCascade) Merged(ctx context.Context) (_ *configurationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Merged", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "Merged", "")
 	defer tr.FinishWithErr(&err)
 
 	var messages []string

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -45,7 +45,7 @@ func (r *settingsCascade) Final(ctx context.Context) (string, error) {
 
 // Deprecated: in the GraphQL API
 func (r *settingsCascade) Merged(ctx context.Context) (_ *configurationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Merged", "")
+	tr, ctx := trace.New(ctx, "SettingsCascade.Merged")
 	defer tr.FinishWithErr(&err)
 
 	var messages []string

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -40,7 +40,7 @@ func serveRepoLanding(db database.DB) func(http.ResponseWriter, *http.Request) e
 }
 
 func serveDefLanding(w http.ResponseWriter, r *http.Request) (err error) {
-	tr, ctx := trace.DeprecatedNew(r.Context(), "serveDefLanding", "")
+	tr, ctx := trace.New(r.Context(), "serveDefLanding")
 	defer tr.FinishWithErr(&err)
 	r = r.WithContext(ctx)
 

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -40,7 +40,7 @@ func serveRepoLanding(db database.DB) func(http.ResponseWriter, *http.Request) e
 }
 
 func serveDefLanding(w http.ResponseWriter, r *http.Request) (err error) {
-	tr, ctx := trace.New(r.Context(), "serveDefLanding", "")
+	tr, ctx := trace.DeprecatedNew(r.Context(), "serveDefLanding", "")
 	defer tr.FinishWithErr(&err)
 	r = r.WithContext(ctx)
 

--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -36,7 +36,7 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 			w.WriteHeader(404)
 			return
 		}
-		tr, ctx := trace.DeprecatedNew(r.Context(), "blame.Stream", "")
+		tr, ctx := trace.New(r.Context(), "blame.Stream")
 		defer tr.Finish()
 		r = r.WithContext(ctx)
 

--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -36,7 +36,7 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 			w.WriteHeader(404)
 			return
 		}
-		tr, ctx := trace.New(r.Context(), "blame.Stream", "")
+		tr, ctx := trace.DeprecatedNew(r.Context(), "blame.Stream", "")
 		defer tr.Finish()
 		r = r.WithContext(ctx)
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -59,7 +59,7 @@ type streamHandler struct {
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	tr, ctx := trace.DeprecatedNew(r.Context(), "search.ServeStream", "")
+	tr, ctx := trace.New(r.Context(), "search.ServeStream")
 	defer tr.Finish()
 	r = r.WithContext(ctx)
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -59,7 +59,7 @@ type streamHandler struct {
 }
 
 func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	tr, ctx := trace.New(r.Context(), "search.ServeStream", "")
+	tr, ctx := trace.DeprecatedNew(r.Context(), "search.ServeStream", "")
 	defer tr.Finish()
 	r = r.WithContext(ctx)
 

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -34,7 +34,7 @@ const (
 
 // List lists extensions on the remote registry matching the query (or all if the query is empty).
 func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "registry", "List",
+	tr, ctx := trace.New(ctx, "registry.List",
 		attribute.Stringer("registry", registry),
 		attribute.String("query", query))
 	defer func() {

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -34,7 +34,7 @@ const (
 
 // List lists extensions on the remote registry matching the query (or all if the query is empty).
 func List(ctx context.Context, registry *url.URL, query string) (xs []*Extension, err error) {
-	tr, ctx := trace.New(ctx, "registry", "List",
+	tr, ctx := trace.DeprecatedNew(ctx, "registry", "List",
 		attribute.Stringer("registry", registry),
 		attribute.String("query", query))
 	defer func() {

--- a/cmd/gitserver/server/run.go
+++ b/cmd/gitserver/server/run.go
@@ -50,7 +50,7 @@ func runCommand(ctx context.Context, cmd wrexec.Cmder) (exitCode int, err error)
 	}
 	runCommandMockMu.RUnlock()
 
-	tr, _ := trace.DeprecatedNew(ctx, "gitserver", "runCommand",
+	tr, _ := trace.New(ctx, "runCommand",
 		attribute.String("path", cmd.Unwrap().Path),
 		attribute.StringSlice("args", cmd.Unwrap().Args),
 		attribute.String("dir", cmd.Unwrap().Dir))

--- a/cmd/gitserver/server/run.go
+++ b/cmd/gitserver/server/run.go
@@ -50,7 +50,7 @@ func runCommand(ctx context.Context, cmd wrexec.Cmder) (exitCode int, err error)
 	}
 	runCommandMockMu.RUnlock()
 
-	tr, _ := trace.New(ctx, "gitserver", "runCommand",
+	tr, _ := trace.DeprecatedNew(ctx, "gitserver", "runCommand",
 		attribute.String("path", cmd.Unwrap().Path),
 		attribute.StringSlice("args", cmd.Unwrap().Args),
 		attribute.String("dir", cmd.Unwrap().Dir))

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -105,7 +105,7 @@ func init() {
 // command *without* a context.
 func runCommandGraceful(ctx context.Context, logger log.Logger, cmd wrexec.Cmder) (exitCode int, err error) {
 	c := cmd.Unwrap()
-	tr, ctx := trace.DeprecatedNew(ctx, "gitserver", "runCommandGraceful",
+	tr, ctx := trace.New(ctx, "runCommandGraceful",
 		attribute.String("path", c.Path),
 		attribute.StringSlice("args", c.Args),
 		attribute.String("dir", c.Dir))
@@ -479,7 +479,7 @@ func (s *Server) Handler() http.Handler {
 	getObjectFunc := gitdomain.GetObjectFunc(func(ctx context.Context, repo api.RepoName, objectName string) (_ *gitdomain.GitObject, err error) {
 		// Tracing is server concern, so add it here. Once generics lands we should be
 		// able to create some simple wrappers
-		tr, ctx := trace.DeprecatedNew(ctx, "git", "GetObject",
+		tr, ctx := trace.New(ctx, "GetObject",
 			attribute.String("objectName", objectName))
 		defer tr.FinishWithErr(&err)
 
@@ -1140,7 +1140,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	logger := s.Logger.Scoped("handleSearch", "http handler for search")
-	tr, ctx := trace.DeprecatedNew(r.Context(), "search", "")
+	tr, ctx := trace.New(r.Context(), "handleSearch")
 	defer tr.Finish()
 
 	// Decode the request
@@ -1619,7 +1619,7 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 		args := strings.Join(req.Args, " ")
 
 		var tr *trace.Trace
-		tr, ctx = trace.DeprecatedNew(ctx, "exec."+cmd, string(req.Repo))
+		tr, ctx = trace.New(ctx, "exec."+cmd, attribute.String("repo", string(req.Repo)))
 		tr.SetAttributes(
 			attribute.String("args", args),
 			attribute.String("ensure_revision", req.EnsureRevision),
@@ -1891,7 +1891,7 @@ func (s *Server) p4Exec(ctx context.Context, logger log.Logger, req *protocol.P4
 		args := strings.Join(req.Args, " ")
 
 		var tr *trace.Trace
-		tr, ctx = trace.DeprecatedNew(ctx, "p4exec."+cmd, req.P4Port)
+		tr, ctx = trace.New(ctx, "p4exec."+cmd, attribute.String("port", req.P4Port))
 		tr.SetAttributes(attribute.String("args", args))
 		logger = logger.WithTrace(trace.Context(ctx))
 
@@ -2553,8 +2553,7 @@ func honeySampleRate(cmd string, actor *actor.Actor) uint {
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, revspec string) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "server", "doRepoUpdate",
-		attribute.String("repo", string(repo)))
+	tr, ctx := trace.New(ctx, "doRepoUpdate", attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)
 
 	s.repoUpdateLocksMu.Lock()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -105,7 +105,7 @@ func init() {
 // command *without* a context.
 func runCommandGraceful(ctx context.Context, logger log.Logger, cmd wrexec.Cmder) (exitCode int, err error) {
 	c := cmd.Unwrap()
-	tr, ctx := trace.New(ctx, "gitserver", "runCommandGraceful",
+	tr, ctx := trace.DeprecatedNew(ctx, "gitserver", "runCommandGraceful",
 		attribute.String("path", c.Path),
 		attribute.StringSlice("args", c.Args),
 		attribute.String("dir", c.Dir))
@@ -479,7 +479,7 @@ func (s *Server) Handler() http.Handler {
 	getObjectFunc := gitdomain.GetObjectFunc(func(ctx context.Context, repo api.RepoName, objectName string) (_ *gitdomain.GitObject, err error) {
 		// Tracing is server concern, so add it here. Once generics lands we should be
 		// able to create some simple wrappers
-		tr, ctx := trace.New(ctx, "git", "GetObject",
+		tr, ctx := trace.DeprecatedNew(ctx, "git", "GetObject",
 			attribute.String("objectName", objectName))
 		defer tr.FinishWithErr(&err)
 
@@ -1140,7 +1140,7 @@ func (s *Server) handleArchive(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	logger := s.Logger.Scoped("handleSearch", "http handler for search")
-	tr, ctx := trace.New(r.Context(), "search", "")
+	tr, ctx := trace.DeprecatedNew(r.Context(), "search", "")
 	defer tr.Finish()
 
 	// Decode the request
@@ -1619,7 +1619,7 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 		args := strings.Join(req.Args, " ")
 
 		var tr *trace.Trace
-		tr, ctx = trace.New(ctx, "exec."+cmd, string(req.Repo))
+		tr, ctx = trace.DeprecatedNew(ctx, "exec."+cmd, string(req.Repo))
 		tr.SetAttributes(
 			attribute.String("args", args),
 			attribute.String("ensure_revision", req.EnsureRevision),
@@ -1891,7 +1891,7 @@ func (s *Server) p4Exec(ctx context.Context, logger log.Logger, req *protocol.P4
 		args := strings.Join(req.Args, " ")
 
 		var tr *trace.Trace
-		tr, ctx = trace.New(ctx, "p4exec."+cmd, req.P4Port)
+		tr, ctx = trace.DeprecatedNew(ctx, "p4exec."+cmd, req.P4Port)
 		tr.SetAttributes(attribute.String("args", args))
 		logger = logger.WithTrace(trace.Context(ctx))
 
@@ -2553,7 +2553,7 @@ func honeySampleRate(cmd string, actor *actor.Actor) uint {
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, revspec string) (err error) {
-	tr, ctx := trace.New(ctx, "server", "doRepoUpdate",
+	tr, ctx := trace.DeprecatedNew(ctx, "server", "doRepoUpdate",
 		attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1225,7 +1225,7 @@ func (s *Server) searchWithObservability(ctx context.Context, tr *trace.Trace, a
 	defer searchRunning.Dec()
 
 	tr.SetAttributes(
-		attribute.String("repo", string(args.Repo)),
+		args.Repo.Attr(),
 		attribute.Bool("include_diff", args.IncludeDiff),
 		attribute.String("query", args.Query.String()),
 		attribute.Int("limit", args.Limit),
@@ -1619,7 +1619,7 @@ func (s *Server) exec(ctx context.Context, logger log.Logger, req *protocol.Exec
 		args := strings.Join(req.Args, " ")
 
 		var tr *trace.Trace
-		tr, ctx = trace.New(ctx, "exec."+cmd, attribute.String("repo", string(req.Repo)))
+		tr, ctx = trace.New(ctx, "exec."+cmd, req.Repo.Attr())
 		tr.SetAttributes(
 			attribute.String("args", args),
 			attribute.String("ensure_revision", req.EnsureRevision),
@@ -2553,7 +2553,7 @@ func honeySampleRate(cmd string, actor *actor.Actor) uint {
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName, revspec string) (err error) {
-	tr, ctx := trace.New(ctx, "doRepoUpdate", attribute.String("repo", string(repo)))
+	tr, ctx := trace.New(ctx, "doRepoUpdate", repo.Attr())
 	defer tr.FinishWithErr(&err)
 
 	s.repoUpdateLocksMu.Lock()

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -315,7 +315,7 @@ func (gs *GRPCServer) Search(req *proto.SearchRequest, ss proto.GitserverService
 		})
 	}
 
-	tr, ctx := trace.New(ss.Context(), "search", "")
+	tr, ctx := trace.DeprecatedNew(ss.Context(), "search", "")
 	defer tr.Finish()
 
 	limitHit, err := gs.Server.searchWithObservability(ctx, tr, args, onMatch)

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -315,7 +315,7 @@ func (gs *GRPCServer) Search(req *proto.SearchRequest, ss proto.GitserverService
 		})
 	}
 
-	tr, ctx := trace.DeprecatedNew(ss.Context(), "search", "")
+	tr, ctx := trace.New(ss.Context(), "search")
 	defer tr.Finish()
 
 	limitHit, err := gs.Server.searchWithObservability(ctx, tr, args, onMatch)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -118,7 +118,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
-	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", req.String())
+	tr, ctx := trace.DeprecatedNew(ctx, "enqueueRepoUpdate", req.String())
 	defer func() {
 		s.Logger.Debug("enqueueRepoUpdate", log.Object("http", log.Int("status", httpStatus), log.String("resp", fmt.Sprint(resp)), log.Error(err)))
 		if resp != nil {
@@ -301,7 +301,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tr, ctx := trace.New(ctx, "repoLookup", args.String())
+	tr, ctx := trace.DeprecatedNew(ctx, "repoLookup", args.String())
 	defer func() {
 		s.Logger.Debug("repoLookup", log.String("result", fmt.Sprint(result)), log.Error(err))
 		tr.SetError(err)

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -118,7 +118,7 @@ func (s *Server) handleEnqueueRepoUpdate(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) enqueueRepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp *protocol.RepoUpdateResponse, httpStatus int, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "enqueueRepoUpdate", req.String())
+	tr, ctx := trace.New(ctx, "enqueueRepoUpdate", attribute.Stringer("req", req))
 	defer func() {
 		s.Logger.Debug("enqueueRepoUpdate", log.Object("http", log.Int("status", httpStatus), log.String("resp", fmt.Sprint(resp)), log.Error(err)))
 		if resp != nil {
@@ -301,7 +301,7 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tr, ctx := trace.DeprecatedNew(ctx, "repoLookup", args.String())
+	tr, ctx := trace.New(ctx, "repoLookup", attribute.Stringer("args", &args))
 	defer func() {
 		s.Logger.Debug("repoLookup", log.String("result", fmt.Sprint(result)), log.Error(err))
 		tr.SetError(err)

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -144,8 +144,8 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	var tr *trace.Trace
 	tr, ctx = trace.New(ctx, "search",
 		p.Repo.Attr(),
+		p.Commit.Attr(),
 		attribute.String("url", p.URL),
-		attribute.String("commit", string(p.Commit)),
 		attribute.String("pattern", p.Pattern),
 		attribute.Bool("isRegExp", p.IsRegExp),
 		attribute.StringSlice("languages", p.Languages),

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -14,7 +14,6 @@ package search
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"math"
 	"net"
 	"net/http"
@@ -143,7 +142,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	defer metricRunning.Dec()
 
 	var tr *trace.Trace
-	tr, ctx = trace.DeprecatedNew(ctx, "search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
+	tr, ctx = trace.New(ctx, "search", attribute.String("repo", string(p.Repo)), attribute.String("commit", string(p.Commit)))
 	defer tr.Finish()
 
 	tr.SetAttributes(

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -143,7 +143,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	defer metricRunning.Dec()
 
 	var tr *trace.Trace
-	tr, ctx = trace.New(ctx, "search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
+	tr, ctx = trace.DeprecatedNew(ctx, "search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
 	defer tr.Finish()
 
 	tr.SetAttributes(

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -142,11 +142,8 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	defer metricRunning.Dec()
 
 	var tr *trace.Trace
-	tr, ctx = trace.New(ctx, "search", attribute.String("repo", string(p.Repo)), attribute.String("commit", string(p.Commit)))
-	defer tr.Finish()
-
-	tr.SetAttributes(
-		attribute.String("repo", string(p.Repo)),
+	tr, ctx = trace.New(ctx, "search",
+		p.Repo.Attr(),
 		attribute.String("url", p.URL),
 		attribute.String("commit", string(p.Commit)),
 		attribute.String("pattern", p.Pattern),
@@ -158,8 +155,8 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		attribute.Int("limit", p.Limit),
 		attribute.Bool("patternMatchesContent", p.PatternMatchesContent),
 		attribute.Bool("patternMatchesPath", p.PatternMatchesPath),
-		attribute.String("select", p.Select),
-	)
+		attribute.String("select", p.Select))
+	defer tr.Finish()
 	defer func(start time.Time) {
 		code := "200"
 		// We often have canceled and timed out requests. We do not want to

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -261,7 +261,7 @@ func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *zipFile, limit in
 
 // regexSearch concurrently searches files in zr looking for matches using rg.
 func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool, sender matchSender) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "search", "RegexSearch")
+	tr, ctx := trace.New(ctx, "regexSearch")
 	defer tr.FinishWithErr(&err)
 
 	if rg.re != nil {

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -261,7 +261,7 @@ func regexSearchBatch(ctx context.Context, rg *readerGrep, zf *zipFile, limit in
 
 // regexSearch concurrently searches files in zr looking for matches using rg.
 func regexSearch(ctx context.Context, rg *readerGrep, zf *zipFile, patternMatchesContent, patternMatchesPaths bool, isPatternNegated bool, sender matchSender) (err error) {
-	tr, ctx := trace.New(ctx, "search", "RegexSearch")
+	tr, ctx := trace.DeprecatedNew(ctx, "search", "RegexSearch")
 	defer tr.FinishWithErr(&err)
 
 	if rg.re != nil {

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -396,7 +396,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 		return mockStructuralSearch(ctx, inputType, paths, extensionHint, pattern, rule, languages, repo, sender)
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "searcher", "StructuralSearch",
+	tr, ctx := trace.New(ctx, "structuralSearch",
 		attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -396,7 +396,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 		return mockStructuralSearch(ctx, inputType, paths, extensionHint, pattern, rule, languages, repo, sender)
 	}
 
-	tr, ctx := trace.New(ctx, "searcher", "StructuralSearch",
+	tr, ctx := trace.DeprecatedNew(ctx, "searcher", "StructuralSearch",
 		attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)
 

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -396,8 +396,7 @@ func structuralSearch(ctx context.Context, inputType comby.Input, paths filePatt
 		return mockStructuralSearch(ctx, inputType, paths, extensionHint, pattern, rule, languages, repo, sender)
 	}
 
-	tr, ctx := trace.New(ctx, "structuralSearch",
-		attribute.String("repo", string(repo)))
+	tr, ctx := trace.New(ctx, "structuralSearch", repo.Attr())
 	defer tr.FinishWithErr(&err)
 
 	// Cap the number of forked processes to limit the size of zip contents being mapped to memory. Resolving #7133 could help to lift this restriction.

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -142,7 +142,7 @@ func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.Co
 }
 
 func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (path string, err error) {
-	tr, ctx := trace.New(ctx, "ArchiveStore", "PrepareZipPaths")
+	tr, ctx := trace.DeprecatedNew(ctx, "ArchiveStore", "PrepareZipPaths")
 	defer tr.FinishWithErr(&err)
 
 	var cacheHit bool
@@ -227,7 +227,7 @@ func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit a
 // not populate the in-memory cache. You should probably be calling
 // prepareZip.
 func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitID, filter *searchableFilter, paths []string) (rc io.ReadCloser, err error) {
-	tr, ctx := trace.New(ctx, "ArchiveStore", "fetch",
+	tr, ctx := trace.DeprecatedNew(ctx, "ArchiveStore", "fetch",
 		attribute.String("repo", string(repo)),
 		attribute.String("commit", string(commit)))
 

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -142,7 +142,7 @@ func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.Co
 }
 
 func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (path string, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "ArchiveStore", "PrepareZipPaths")
+	tr, ctx := trace.New(ctx, "ArchiveStore.PrepareZipPaths")
 	defer tr.FinishWithErr(&err)
 
 	var cacheHit bool
@@ -227,7 +227,7 @@ func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit a
 // not populate the in-memory cache. You should probably be calling
 // prepareZip.
 func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitID, filter *searchableFilter, paths []string) (rc io.ReadCloser, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "ArchiveStore", "fetch",
+	tr, ctx := trace.New(ctx, "ArchiveStore.fetch",
 		attribute.String("repo", string(repo)),
 		attribute.String("commit", string(commit)))
 

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -228,7 +228,7 @@ func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit a
 // prepareZip.
 func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitID, filter *searchableFilter, paths []string) (rc io.ReadCloser, err error) {
 	tr, ctx := trace.New(ctx, "ArchiveStore.fetch",
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(commit)))
 
 	metricFetchQueueSize.Inc()

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -229,7 +229,7 @@ func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit a
 func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitID, filter *searchableFilter, paths []string) (rc io.ReadCloser, err error) {
 	tr, ctx := trace.New(ctx, "ArchiveStore.fetch",
 		repo.Attr(),
-		attribute.String("commit", string(commit)))
+		commit.Attr())
 
 	metricFetchQueueSize.Inc()
 	ctx, releaseFetchLimiter, err := s.fetchLimiter.Acquire(ctx) // Acquire concurrent fetches semaphore

--- a/cmd/symbols/fetcher/repository_fetcher.go
+++ b/cmd/symbols/fetcher/repository_fetcher.go
@@ -61,7 +61,7 @@ func (f *repositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo api
 
 func (f *repositoryFetcher) fetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string, callback func(request ParseRequest)) (err error) {
 	ctx, trace, endObservation := f.operations.fetchRepositoryArchive.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commitID", string(commit)),
 		attribute.Int("paths", len(paths)),
 	}})

--- a/cmd/symbols/fetcher/repository_fetcher.go
+++ b/cmd/symbols/fetcher/repository_fetcher.go
@@ -62,7 +62,7 @@ func (f *repositoryFetcher) FetchRepositoryArchive(ctx context.Context, repo api
 func (f *repositoryFetcher) fetchRepositoryArchive(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string, callback func(request ParseRequest)) (err error) {
 	ctx, trace, endObservation := f.operations.fetchRepositoryArchive.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commitID", string(commit)),
+		commit.Attr(),
 		attribute.Int("paths", len(paths)),
 	}})
 	defer endObservation(1, observation.Args{})

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -56,7 +56,7 @@ func NewClient(observationCtx *observation.Context) GitserverClient {
 
 func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (_ io.ReadCloser, err error) {
 	ctx, _, endObservation := c.operations.fetchTar.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(commit)),
 		attribute.Int("paths", len(paths)),
 	}})
@@ -79,7 +79,7 @@ func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commi
 
 func (c *gitserverClient) GitDiff(ctx context.Context, repo api.RepoName, commitA, commitB api.CommitID) (_ Changes, err error) {
 	ctx, _, endObservation := c.operations.gitDiff.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commitA", string(commitA)),
 		attribute.String("commitB", string(commitB)),
 	}})

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -57,7 +57,7 @@ func NewClient(observationCtx *observation.Context) GitserverClient {
 func (c *gitserverClient) FetchTar(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (_ io.ReadCloser, err error) {
 	ctx, _, endObservation := c.operations.fetchTar.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.Int("paths", len(paths)),
 	}})
 	defer endObservation(1, observation.Args{})

--- a/cmd/symbols/internal/api/search_sqlite.go
+++ b/cmd/symbols/internal/api/search_sqlite.go
@@ -29,7 +29,7 @@ func MakeSqliteSearchFunc(observationCtx *observation.Context, cachedDatabaseWri
 	return func(ctx context.Context, args search.SymbolsParameters) (results []result.Symbol, err error) {
 		ctx, trace, endObservation := operations.Search.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 			args.Repo.Attr(),
-			attribute.String("commitID", string(args.CommitID)),
+			args.CommitID.Attr(),
 			attribute.String("query", args.Query),
 			attribute.Bool("isRegExp", args.IsRegExp),
 			attribute.Bool("isCaseSensitive", args.IsCaseSensitive),

--- a/cmd/symbols/internal/api/search_sqlite.go
+++ b/cmd/symbols/internal/api/search_sqlite.go
@@ -28,7 +28,7 @@ func MakeSqliteSearchFunc(observationCtx *observation.Context, cachedDatabaseWri
 
 	return func(ctx context.Context, args search.SymbolsParameters) (results []result.Symbol, err error) {
 		ctx, trace, endObservation := operations.Search.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-			attribute.String("repo", string(args.Repo)),
+			args.Repo.Attr(),
 			attribute.String("commitID", string(args.CommitID)),
 			attribute.String("query", args.Query),
 			attribute.Bool("isRegExp", args.IsRegExp),

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -59,7 +59,7 @@ func NewParser(
 func (p *parser) Parse(ctx context.Context, args search.SymbolsParameters, paths []string) (_ <-chan SymbolOrError, err error) {
 	ctx, _, endObservation := p.operations.parse.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		args.Repo.Attr(),
-		attribute.String("commitID", string(args.CommitID)),
+		args.CommitID.Attr(),
 		attribute.Int("paths", len(paths)),
 		attribute.StringSlice("paths", paths),
 	}})

--- a/cmd/symbols/parser/parser.go
+++ b/cmd/symbols/parser/parser.go
@@ -58,7 +58,7 @@ func NewParser(
 
 func (p *parser) Parse(ctx context.Context, args search.SymbolsParameters, paths []string) (_ <-chan SymbolOrError, err error) {
 	ctx, _, endObservation := p.operations.parse.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(args.Repo)),
+		args.Repo.Attr(),
 		attribute.String("commitID", string(args.CommitID)),
 		attribute.Int("paths", len(paths)),
 		attribute.StringSlice("paths", paths),

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -29,7 +29,7 @@ func searchRepoEmbeddingIndexes(
 	getQueryEmbedding getQueryEmbeddingFn,
 	weaviate *weaviateClient,
 ) (_ *embeddings.EmbeddingCombinedSearchResults, err error) {
-	tr, ctx := trace.New(ctx, "searchRepoEmbeddingIndexes", "", params.Attrs()...)
+	tr, ctx := trace.DeprecatedNew(ctx, "searchRepoEmbeddingIndexes", "", params.Attrs()...)
 	defer tr.FinishWithErr(&err)
 
 	floatQuery, queryModel, err := getQueryEmbedding(ctx, params.Query)
@@ -48,7 +48,7 @@ func searchRepoEmbeddingIndexes(
 	}
 
 	searchRepo := func(repoID api.RepoID, repoName api.RepoName) (codeResults, textResults []embeddings.EmbeddingSearchResult, err error) {
-		tr, ctx := trace.New(ctx, "searchRepo", "",
+		tr, ctx := trace.DeprecatedNew(ctx, "searchRepo", "",
 			attribute.String("repoName", string(repoName)),
 		)
 		defer tr.FinishWithErr(&err)

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -29,7 +29,7 @@ func searchRepoEmbeddingIndexes(
 	getQueryEmbedding getQueryEmbeddingFn,
 	weaviate *weaviateClient,
 ) (_ *embeddings.EmbeddingCombinedSearchResults, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "searchRepoEmbeddingIndexes", "", params.Attrs()...)
+	tr, ctx := trace.New(ctx, "searchRepoEmbeddingIndexes", params.Attrs()...)
 	defer tr.FinishWithErr(&err)
 
 	floatQuery, queryModel, err := getQueryEmbedding(ctx, params.Query)
@@ -48,7 +48,7 @@ func searchRepoEmbeddingIndexes(
 	}
 
 	searchRepo := func(repoID api.RepoID, repoName api.RepoName) (codeResults, textResults []embeddings.EmbeddingSearchResult, err error) {
-		tr, ctx := trace.DeprecatedNew(ctx, "searchRepo", "",
+		tr, ctx := trace.New(ctx, "searchRepo",
 			attribute.String("repoName", string(repoName)),
 		)
 		defer tr.FinishWithErr(&err)

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
@@ -60,7 +60,7 @@ func newMiddleware(ossDB database.DB, authPrefix string, isAPIHandler bool, next
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, _ := trace.New(r.Context(), traceFamily, "Middleware.Handle")
+		span, _ := trace.DeprecatedNew(r.Context(), traceFamily, "Middleware.Handle")
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 		span.Finish()
 		if strings.HasPrefix(r.URL.Path, authPrefix+"/") {

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware.go
@@ -55,12 +55,11 @@ func newMiddleware(ossDB database.DB, authPrefix string, isAPIHandler bool, next
 	db := edb.NewEnterpriseDB(ossDB)
 	ghAppState := rcache.NewWithTTL("github_app_state", cacheTTLSeconds)
 	handler := newServeMux(db, authPrefix, ghAppState)
-	traceFamily := "githubapp"
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, _ := trace.DeprecatedNew(r.Context(), traceFamily, "Middleware.Handle")
+		span, _ := trace.New(r.Context(), "githubapp")
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 		span.Finish()
 		if strings.HasPrefix(r.URL.Path, authPrefix+"/") {

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -34,7 +34,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, ctx := trace.DeprecatedNew(r.Context(), traceFamily, "Middleware.Handle")
+		span, ctx := trace.New(r.Context(), traceFamily+".Middleware.Handle")
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 
 		// Delegate to the auth flow handler

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -34,7 +34,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, ctx := trace.New(r.Context(), traceFamily+".Middleware.Handle")
+		span, ctx := trace.New(r.Context(), traceFamily)
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 
 		// Delegate to the auth flow handler

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -34,7 +34,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, ctx := trace.New(r.Context(), traceFamily, "Middleware.Handle")
+		span, ctx := trace.DeprecatedNew(r.Context(), traceFamily, "Middleware.Handle")
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 
 		// Delegate to the auth flow handler

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -34,7 +34,7 @@ func NewMiddleware(db database.DB, serviceType, authPrefix string, isAPIHandler 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This span should be manually finished before delegating to the next handler or
 		// redirecting.
-		span, ctx := trace.New(r.Context(), traceFamily)
+		span, ctx := trace.New(r.Context(), traceFamily+".middleware")
 		span.SetAttributes(attribute.Bool("isAPIHandler", isAPIHandler))
 
 		// Delegate to the auth flow handler

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -39,7 +39,7 @@ type SessionIssuerHelper interface {
 
 func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, sessionKey string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		span, ctx := trace.DeprecatedNew(r.Context(), "oauth.SessionIssuer", "Handle")
+		span, ctx := trace.New(r.Context(), "oauth.SessionIssuer")
 		defer span.Finish()
 
 		// Scopes logger to family from trace.New

--- a/enterprise/cmd/frontend/internal/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/session.go
@@ -39,7 +39,7 @@ type SessionIssuerHelper interface {
 
 func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, sessionKey string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		span, ctx := trace.New(r.Context(), "oauth.SessionIssuer", "Handle")
+		span, ctx := trace.DeprecatedNew(r.Context(), "oauth.SessionIssuer", "Handle")
 		defer span.Finish()
 
 		// Scopes logger to family from trace.New

--- a/enterprise/cmd/frontend/internal/batches/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 
@@ -417,7 +418,7 @@ func (r *Resolver) batchSpecWorkspaceByID(ctx context.Context, gqlID graphql.ID)
 }
 
 func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.CreateBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, _ := trace.DeprecatedNew(ctx, "Resolver.CreateBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
+	tr, _ := trace.New(ctx, "Resolver.CreateBatchChange", attribute.String("BatchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
@@ -447,7 +448,7 @@ func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.C
 }
 
 func (r *Resolver) ApplyBatchChange(ctx context.Context, args *graphqlbackend.ApplyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ApplyBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.ApplyBatchChange", attribute.String("BatchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
@@ -550,7 +551,7 @@ func (r *Resolver) applyOrCreateBatchChange(ctx context.Context, args *graphqlba
 }
 
 func (r *Resolver) CreateBatchSpec(ctx context.Context, args *graphqlbackend.CreateBatchSpecArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "CreateBatchSpec", fmt.Sprintf("Resolver.CreateBatchSpec %s, Spec %q", args.Namespace, args.BatchSpec))
+	tr, ctx := trace.New(ctx, "CreateBatchSpec", attribute.String("namespace", string(args.Namespace)), attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -417,7 +417,7 @@ func (r *Resolver) batchSpecWorkspaceByID(ctx context.Context, gqlID graphql.ID)
 }
 
 func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.CreateBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, _ := trace.New(ctx, "Resolver.CreateBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
+	tr, _ := trace.DeprecatedNew(ctx, "Resolver.CreateBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
@@ -447,7 +447,7 @@ func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.C
 }
 
 func (r *Resolver) ApplyBatchChange(ctx context.Context, args *graphqlbackend.ApplyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.ApplyBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ApplyBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := rbac.CheckCurrentUserHasPermission(ctx, r.store.DatabaseDB(), rbac.BatchChangesWritePermission); err != nil {
@@ -550,7 +550,7 @@ func (r *Resolver) applyOrCreateBatchChange(ctx context.Context, args *graphqlba
 }
 
 func (r *Resolver) CreateBatchSpec(ctx context.Context, args *graphqlbackend.CreateBatchSpecArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "CreateBatchSpec", fmt.Sprintf("Resolver.CreateBatchSpec %s, Spec %q", args.Namespace, args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "CreateBatchSpec", fmt.Sprintf("Resolver.CreateBatchSpec %s, Spec %q", args.Namespace, args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -605,7 +605,7 @@ func (r *Resolver) CreateBatchSpec(ctx context.Context, args *graphqlbackend.Cre
 }
 
 func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend.CreateChangesetSpecArgs) (_ graphqlbackend.ChangesetSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetSpec", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetSpec", "")
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -634,7 +634,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 }
 
 func (r *Resolver) CreateChangesetSpecs(ctx context.Context, args *graphqlbackend.CreateChangesetSpecsArgs) (_ []graphqlbackend.ChangesetSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetSpecs", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetSpecs", "")
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -672,7 +672,7 @@ func (r *Resolver) CreateChangesetSpecs(ctx context.Context, args *graphqlbacken
 }
 
 func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.MoveBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.MoveBatchChange", fmt.Sprintf("BatchChange %s", args.BatchChange))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.MoveBatchChange", fmt.Sprintf("BatchChange %s", args.BatchChange))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -718,7 +718,7 @@ func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.Mov
 }
 
 func (r *Resolver) DeleteBatchChange(ctx context.Context, args *graphqlbackend.DeleteBatchChangeArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.DeleteBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DeleteBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -994,7 +994,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 }
 
 func (r *Resolver) CloseBatchChange(ctx context.Context, args *graphqlbackend.CloseBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CloseBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CloseBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1030,7 +1030,7 @@ func (r *Resolver) CloseBatchChange(ctx context.Context, args *graphqlbackend.Cl
 }
 
 func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncChangesetArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.SyncChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.SyncChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1055,7 +1055,7 @@ func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncC
 }
 
 func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.ReenqueueChangesetArgs) (_ graphqlbackend.ChangesetResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.ReenqueueChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReenqueueChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1085,7 +1085,7 @@ func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.
 }
 
 func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graphqlbackend.CreateBatchChangesCredentialArgs) (_ graphqlbackend.BatchChangesCredentialResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateBatchChangesCredential", fmt.Sprintf("%q (%q)", args.ExternalServiceKind, args.ExternalServiceURL))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateBatchChangesCredential", fmt.Sprintf("%q (%q)", args.ExternalServiceKind, args.ExternalServiceURL))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1255,7 +1255,7 @@ func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, exter
 }
 
 func (r *Resolver) DeleteBatchChangesCredential(ctx context.Context, args *graphqlbackend.DeleteBatchChangesCredentialArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.DeleteBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DeleteBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1312,7 +1312,7 @@ func (r *Resolver) deleteBatchChangesSiteCredential(ctx context.Context, credent
 }
 
 func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.DetachChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.DetachChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DetachChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1348,7 +1348,7 @@ func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.De
 }
 
 func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbackend.CreateChangesetCommentsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetComments", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetComments", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1393,7 +1393,7 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 }
 
 func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend.ReenqueueChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.ReenqueueChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReenqueueChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1429,7 +1429,7 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 }
 
 func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.MergeChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.MergeChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.MergeChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1468,7 +1468,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 }
 
 func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.CloseChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CloseChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CloseChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1506,7 +1506,7 @@ func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.Clo
 }
 
 func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.PublishChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.PublishChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.PublishChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1539,7 +1539,7 @@ func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.P
 }
 
 func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatchSpecArgs) (_ graphqlbackend.BatchSpecConnectionResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.BatchSpecs", fmt.Sprintf("First: %d, After: %v", args.First, args.After))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.BatchSpecs", fmt.Sprintf("First: %d, After: %v", args.First, args.After))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1584,7 +1584,7 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 }
 
 func (r *Resolver) CreateEmptyBatchChange(ctx context.Context, args *graphqlbackend.CreateEmptyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateEmptyBatchChange", fmt.Sprintf("Namespace: %+v", args.Namespace))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateEmptyBatchChange", fmt.Sprintf("Namespace: %+v", args.Namespace))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1619,7 +1619,7 @@ func (r *Resolver) CreateEmptyBatchChange(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) UpsertEmptyBatchChange(ctx context.Context, args *graphqlbackend.UpsertEmptyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.UpsertEmptyBatchChange", fmt.Sprintf("Namespace: %s", args.Namespace))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.UpsertEmptyBatchChange", fmt.Sprintf("Namespace: %s", args.Namespace))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1650,7 +1650,7 @@ func (r *Resolver) UpsertEmptyBatchChange(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlbackend.CreateBatchSpecFromRawArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CreateBatchSpecFromRaw", fmt.Sprintf("Namespace: %+v", args.Namespace))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateBatchSpecFromRaw", fmt.Sprintf("Namespace: %+v", args.Namespace))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -1690,7 +1690,7 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.ExecuteBatchSpecArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.ExecuteBatchSpec", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ExecuteBatchSpec", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1728,7 +1728,7 @@ func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.Ex
 }
 
 func (r *Resolver) CancelBatchSpecExecution(ctx context.Context, args *graphqlbackend.CancelBatchSpecExecutionArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CancelBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CancelBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1756,7 +1756,7 @@ func (r *Resolver) CancelBatchSpecExecution(ctx context.Context, args *graphqlba
 }
 
 func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecWorkspaceExecutionArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.RetryBatchSpecWorkspaceExecution", fmt.Sprintf("Workspaces: %+v", args.BatchSpecWorkspaces))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.RetryBatchSpecWorkspaceExecution", fmt.Sprintf("Workspaces: %+v", args.BatchSpecWorkspaces))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1796,7 +1796,7 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 }
 
 func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbackend.ReplaceBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.ReplaceBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReplaceBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1837,7 +1837,7 @@ func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbacke
 }
 
 func (r *Resolver) UpsertBatchSpecInput(ctx context.Context, args *graphqlbackend.UpsertBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.UpsertBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.UpsertBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -1886,7 +1886,7 @@ func (r *Resolver) CancelBatchSpecWorkspaceExecution(ctx context.Context, args *
 }
 
 func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecExecutionArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.RetryBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.RetryBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1984,7 +1984,7 @@ func (r *Resolver) batchSpecWorkspaceFileByID(ctx context.Context, gqlID graphql
 }
 
 func (r *Resolver) AvailableBulkOperations(ctx context.Context, args *graphqlbackend.AvailableBulkOperationsArgs) (availableBulkOperations []string, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.AvailableBulkOperations", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.AvailableBulkOperations", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -2024,7 +2024,7 @@ func (r *Resolver) AvailableBulkOperations(ctx context.Context, args *graphqlbac
 }
 
 func (r *Resolver) CheckBatchChangesCredential(ctx context.Context, args *graphqlbackend.CheckBatchChangesCredentialArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CheckBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CheckBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
 	defer tr.FinishWithErr(&err)
 
 	cred, err := r.batchChangesCredentialByID(ctx, args.BatchChangesCredential)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolver.go
@@ -606,7 +606,7 @@ func (r *Resolver) CreateBatchSpec(ctx context.Context, args *graphqlbackend.Cre
 }
 
 func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend.CreateChangesetSpecArgs) (_ graphqlbackend.ChangesetSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetSpec", "")
+	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetSpec")
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -635,7 +635,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 }
 
 func (r *Resolver) CreateChangesetSpecs(ctx context.Context, args *graphqlbackend.CreateChangesetSpecsArgs) (_ []graphqlbackend.ChangesetSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetSpecs", "")
+	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetSpecs")
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -673,7 +673,7 @@ func (r *Resolver) CreateChangesetSpecs(ctx context.Context, args *graphqlbacken
 }
 
 func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.MoveBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.MoveBatchChange", fmt.Sprintf("BatchChange %s", args.BatchChange))
+	tr, ctx := trace.New(ctx, "Resolver.MoveBatchChange", attribute.String("batchChange", string(args.BatchChange)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -719,7 +719,7 @@ func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.Mov
 }
 
 func (r *Resolver) DeleteBatchChange(ctx context.Context, args *graphqlbackend.DeleteBatchChangeArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DeleteBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
+	tr, ctx := trace.New(ctx, "Resolver.DeleteBatchChange", attribute.String("batchChange", string(args.BatchChange)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -995,7 +995,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 }
 
 func (r *Resolver) CloseBatchChange(ctx context.Context, args *graphqlbackend.CloseBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CloseBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
+	tr, ctx := trace.New(ctx, "Resolver.CloseBatchChange", attribute.String("batchChange", string(args.BatchChange)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1031,7 +1031,7 @@ func (r *Resolver) CloseBatchChange(ctx context.Context, args *graphqlbackend.Cl
 }
 
 func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncChangesetArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.SyncChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
+	tr, ctx := trace.New(ctx, "Resolver.SyncChangeset", attribute.String("changeset", string(args.Changeset)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1056,7 +1056,7 @@ func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncC
 }
 
 func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.ReenqueueChangesetArgs) (_ graphqlbackend.ChangesetResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReenqueueChangeset", fmt.Sprintf("Changeset: %q", args.Changeset))
+	tr, ctx := trace.New(ctx, "Resolver.ReenqueueChangeset", attribute.String("changeset", string(args.Changeset)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1086,7 +1086,10 @@ func (r *Resolver) ReenqueueChangeset(ctx context.Context, args *graphqlbackend.
 }
 
 func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graphqlbackend.CreateBatchChangesCredentialArgs) (_ graphqlbackend.BatchChangesCredentialResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateBatchChangesCredential", fmt.Sprintf("%q (%q)", args.ExternalServiceKind, args.ExternalServiceURL))
+	tr, ctx := trace.New(ctx, "Resolver.CreateBatchChangesCredential",
+		attribute.String("externalServiceKind", args.ExternalServiceKind),
+		attribute.String("externalServiceURL", args.ExternalServiceURL),
+	)
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1256,7 +1259,7 @@ func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, exter
 }
 
 func (r *Resolver) DeleteBatchChangesCredential(ctx context.Context, args *graphqlbackend.DeleteBatchChangesCredentialArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DeleteBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
+	tr, ctx := trace.New(ctx, "Resolver.DeleteBatchChangesCredential", attribute.String("credential", string(args.BatchChangesCredential)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1313,7 +1316,9 @@ func (r *Resolver) deleteBatchChangesSiteCredential(ctx context.Context, credent
 }
 
 func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.DetachChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.DetachChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.DetachChangesets",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1349,7 +1354,9 @@ func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.De
 }
 
 func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbackend.CreateChangesetCommentsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateChangesetComments", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.CreateChangesetComments",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1394,7 +1401,9 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 }
 
 func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend.ReenqueueChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReenqueueChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.ReenqueueChangesets",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1430,7 +1439,9 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 }
 
 func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.MergeChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.MergeChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.MergeChangesets",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1469,7 +1480,9 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 }
 
 func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.CloseChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CloseChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.CloseChangesets",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1507,7 +1520,9 @@ func (r *Resolver) CloseChangesets(ctx context.Context, args *graphqlbackend.Clo
 }
 
 func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.PublishChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.PublishChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.PublishChangesets",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1540,7 +1555,9 @@ func (r *Resolver) PublishChangesets(ctx context.Context, args *graphqlbackend.P
 }
 
 func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatchSpecArgs) (_ graphqlbackend.BatchSpecConnectionResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.BatchSpecs", fmt.Sprintf("First: %d, After: %v", args.First, args.After))
+	tr, ctx := trace.New(ctx, "Resolver.BatchSpecs",
+		attribute.Int("first", int(args.First)),
+		attribute.String("after", fmt.Sprintf("%v", args.After)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1585,7 +1602,8 @@ func (r *Resolver) BatchSpecs(ctx context.Context, args *graphqlbackend.ListBatc
 }
 
 func (r *Resolver) CreateEmptyBatchChange(ctx context.Context, args *graphqlbackend.CreateEmptyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateEmptyBatchChange", fmt.Sprintf("Namespace: %+v", args.Namespace))
+	tr, ctx := trace.New(ctx, "Resolver.CreateEmptyBatchChange",
+		attribute.String("namespace", string(args.Namespace)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1620,7 +1638,8 @@ func (r *Resolver) CreateEmptyBatchChange(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) UpsertEmptyBatchChange(ctx context.Context, args *graphqlbackend.UpsertEmptyBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.UpsertEmptyBatchChange", fmt.Sprintf("Namespace: %s", args.Namespace))
+	tr, ctx := trace.New(ctx, "Resolver.UpsertEmptyBatchChange",
+		attribute.String("namespace", string(args.Namespace)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1651,7 +1670,8 @@ func (r *Resolver) UpsertEmptyBatchChange(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlbackend.CreateBatchSpecFromRawArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CreateBatchSpecFromRaw", fmt.Sprintf("Namespace: %+v", args.Namespace))
+	tr, ctx := trace.New(ctx, "Resolver.CreateBatchSpecFromRaw",
+		attribute.String("namespace", string(args.Namespace)))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -1691,7 +1711,8 @@ func (r *Resolver) CreateBatchSpecFromRaw(ctx context.Context, args *graphqlback
 }
 
 func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.ExecuteBatchSpecArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ExecuteBatchSpec", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.ExecuteBatchSpec",
+		attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
 		return nil, err
@@ -1729,7 +1750,8 @@ func (r *Resolver) ExecuteBatchSpec(ctx context.Context, args *graphqlbackend.Ex
 }
 
 func (r *Resolver) CancelBatchSpecExecution(ctx context.Context, args *graphqlbackend.CancelBatchSpecExecutionArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CancelBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.CancelBatchSpecExecution",
+		attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1757,7 +1779,8 @@ func (r *Resolver) CancelBatchSpecExecution(ctx context.Context, args *graphqlba
 }
 
 func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecWorkspaceExecutionArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.RetryBatchSpecWorkspaceExecution", fmt.Sprintf("Workspaces: %+v", args.BatchSpecWorkspaces))
+	tr, ctx := trace.New(ctx, "Resolver.RetryBatchSpecWorkspaceExecution",
+		attribute.String("workspaces", fmt.Sprintf("%+v", args.BatchSpecWorkspaces)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1797,7 +1820,8 @@ func (r *Resolver) RetryBatchSpecWorkspaceExecution(ctx context.Context, args *g
 }
 
 func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbackend.ReplaceBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.ReplaceBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.ReplaceBatchSpecInput",
+		attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1838,7 +1862,7 @@ func (r *Resolver) ReplaceBatchSpecInput(ctx context.Context, args *graphqlbacke
 }
 
 func (r *Resolver) UpsertBatchSpecInput(ctx context.Context, args *graphqlbackend.UpsertBatchSpecInputArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.UpsertBatchSpecInput", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.UpsertBatchSpecInput", attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := batchChangesCreateAccess(ctx, r.store.DatabaseDB()); err != nil {
@@ -1887,7 +1911,7 @@ func (r *Resolver) CancelBatchSpecWorkspaceExecution(ctx context.Context, args *
 }
 
 func (r *Resolver) RetryBatchSpecExecution(ctx context.Context, args *graphqlbackend.RetryBatchSpecExecutionArgs) (_ graphqlbackend.BatchSpecResolver, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.RetryBatchSpecExecution", fmt.Sprintf("BatchSpec: %+v", args.BatchSpec))
+	tr, ctx := trace.New(ctx, "Resolver.RetryBatchSpecExecution", attribute.String("batchSpec", string(args.BatchSpec)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -1985,7 +2009,9 @@ func (r *Resolver) batchSpecWorkspaceFileByID(ctx context.Context, gqlID graphql
 }
 
 func (r *Resolver) AvailableBulkOperations(ctx context.Context, args *graphqlbackend.AvailableBulkOperationsArgs) (availableBulkOperations []string, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.AvailableBulkOperations", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	tr, ctx := trace.New(ctx, "Resolver.AvailableBulkOperations",
+		attribute.String("batchChange", string(args.BatchChange)),
+		attribute.Int("changesets.len", len(args.Changesets)))
 	defer tr.FinishWithErr(&err)
 
 	if err := enterprise.BatchChangesEnabledForUser(ctx, r.store.DatabaseDB()); err != nil {
@@ -2025,7 +2051,8 @@ func (r *Resolver) AvailableBulkOperations(ctx context.Context, args *graphqlbac
 }
 
 func (r *Resolver) CheckBatchChangesCredential(ctx context.Context, args *graphqlbackend.CheckBatchChangesCredentialArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolver.CheckBatchChangesCredential", fmt.Sprintf("Credential: %q", args.BatchChangesCredential))
+	tr, ctx := trace.New(ctx, "Resolver.CheckBatchChangesCredential",
+		attribute.String("credential", string(args.BatchChangesCredential)))
 	defer tr.FinishWithErr(&err)
 
 	cred, err := r.batchChangesCredentialByID(ctx, args.BatchChangesCredential)

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -55,7 +55,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "compute.ServeStream", args.Query)
+	tr, ctx := trace.New(ctx, "compute.ServeStream", attribute.String("query", args.Query))
 	defer tr.FinishWithErr(&err)
 
 	eventWriter, err := streamhttp.NewWriter(w)

--- a/enterprise/cmd/frontend/internal/compute/streaming/stream.go
+++ b/enterprise/cmd/frontend/internal/compute/streaming/stream.go
@@ -55,7 +55,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tr, ctx := trace.New(ctx, "compute.ServeStream", args.Query)
+	tr, ctx := trace.DeprecatedNew(ctx, "compute.ServeStream", args.Query)
 	defer tr.FinishWithErr(&err)
 
 	eventWriter, err := streamhttp.NewWriter(w)

--- a/enterprise/cmd/frontend/internal/context/resolvers/context.go
+++ b/enterprise/cmd/frontend/internal/context/resolvers/context.go
@@ -61,7 +61,7 @@ func (r *Resolver) GetCodyContext(ctx context.Context, args graphqlbackend.GetCo
 		return nil, err
 	}
 
-	tr, ctx := trace.New(ctx, "resolveChunks", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "resolveChunks", "")
 	defer tr.FinishWithErr(&err)
 
 	return iter.MapErr(fileChunks, func(fileChunk *codycontext.FileChunkContext) (graphqlbackend.ContextResultResolver, error) {

--- a/enterprise/cmd/frontend/internal/context/resolvers/context.go
+++ b/enterprise/cmd/frontend/internal/context/resolvers/context.go
@@ -61,7 +61,7 @@ func (r *Resolver) GetCodyContext(ctx context.Context, args graphqlbackend.GetCo
 		return nil, err
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "resolveChunks", "")
+	tr, ctx := trace.New(ctx, "resolveChunks")
 	defer tr.FinishWithErr(&err)
 
 	return iter.MapErr(fileChunks, func(fileChunk *codycontext.FileChunkContext) (graphqlbackend.ContextResultResolver, error) {

--- a/enterprise/cmd/frontend/internal/guardrails/dotcom/dotcom.go
+++ b/enterprise/cmd/frontend/internal/guardrails/dotcom/dotcom.go
@@ -49,7 +49,7 @@ func (tc *tracedClient) MakeRequest(
 	req *graphql.Request,
 	resp *graphql.Response,
 ) error {
-	span, ctx := trace.New(ctx, "DotComGraphQL", req.OpName)
+	span, ctx := trace.DeprecatedNew(ctx, "DotComGraphQL", req.OpName)
 
 	err := tc.c.MakeRequest(ctx, req, resp)
 

--- a/enterprise/cmd/frontend/internal/guardrails/dotcom/dotcom.go
+++ b/enterprise/cmd/frontend/internal/guardrails/dotcom/dotcom.go
@@ -49,7 +49,7 @@ func (tc *tracedClient) MakeRequest(
 	req *graphql.Request,
 	resp *graphql.Response,
 ) error {
-	span, ctx := trace.DeprecatedNew(ctx, "DotComGraphQL", req.OpName)
+	span, ctx := trace.New(ctx, "DotComGraphQL."+req.OpName)
 
 	err := tc.c.MakeRequest(ctx, req, resp)
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -711,7 +711,7 @@ func (s *PermsSyncer) saveUserPermsForAccount(ctx context.Context, userID int32,
 
 func (s *PermsSyncer) observe(ctx context.Context, family, title string) (context.Context, func(requestType, int32, *error)) {
 	began := s.clock()
-	tr, ctx := trace.New(ctx, family, title)
+	tr, ctx := trace.DeprecatedNew(ctx, family, title)
 
 	return ctx, func(typ requestType, id int32, err *error) {
 		defer tr.Finish()

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -80,7 +80,7 @@ func NewPermsSyncer(
 // When `noPerms` is true, the method will use partial results to update permissions
 // tables even when error occurs.
 func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPerms bool, fetchOpts authz.FetchPermsOptions) (result *database.SetPermissionsResult, providerStates database.CodeHostStatusesSet, err error) {
-	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms", "")
+	ctx, save := s.observe(ctx, "PermsSyncer.syncRepoPerms")
 	defer save(requestTypeRepo, int32(repoID), &err)
 
 	repo, err := s.reposStore.RepoStore().Get(ctx, repoID)
@@ -257,7 +257,7 @@ func (s *PermsSyncer) syncRepoPerms(ctx context.Context, repoID api.RepoID, noPe
 // the method will use partial results to update permissions tables even when error occurs.
 func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms bool, fetchOpts authz.FetchPermsOptions) (*database.SetPermissionsResult, database.CodeHostStatusesSet, error) {
 	var err error
-	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms", "")
+	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms")
 	defer save(requestTypeUser, userID, &err)
 
 	user, err := s.db.Users().GetByID(ctx, userID)
@@ -709,9 +709,9 @@ func (s *PermsSyncer) saveUserPermsForAccount(ctx context.Context, userID int32,
 	return stats, nil
 }
 
-func (s *PermsSyncer) observe(ctx context.Context, family, title string) (context.Context, func(requestType, int32, *error)) {
+func (s *PermsSyncer) observe(ctx context.Context, name string) (context.Context, func(requestType, int32, *error)) {
 	began := s.clock()
-	tr, ctx := trace.DeprecatedNew(ctx, family, title)
+	tr, ctx := trace.New(ctx, name)
 
 	return ctx, func(typ requestType, id int32, err *error) {
 		defer tr.Finish()

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -83,7 +83,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 		return nil, nil
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "bitbucket.authz.provider.FetchAccount", "")
+	tr, ctx := trace.New(ctx, "bitbucket.authz.provider.FetchAccount")
 	defer func() {
 		tr.SetAttributes(
 			attribute.String("user.name", user.Username),

--- a/enterprise/internal/authz/bitbucketserver/provider.go
+++ b/enterprise/internal/authz/bitbucketserver/provider.go
@@ -83,7 +83,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 		return nil, nil
 	}
 
-	tr, ctx := trace.New(ctx, "bitbucket.authz.provider.FetchAccount", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "bitbucket.authz.provider.FetchAccount", "")
 	defer func() {
 		tr.SetAttributes(
 			attribute.String("user.name", user.Username),

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -85,7 +85,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 		return nil, nil
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "perforce.authz.provider.FetchAccount", "")
+	tr, ctx := trace.New(ctx, "perforce.authz.provider.FetchAccount")
 	defer func() {
 		tr.SetAttributes(
 			attribute.String("user.name", user.Username),

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -85,7 +85,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 		return nil, nil
 	}
 
-	tr, ctx := trace.New(ctx, "perforce.authz.provider.FetchAccount", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "perforce.authz.provider.FetchAccount", "")
 	defer func() {
 		tr.SetAttributes(
 			attribute.String("user.name", user.Username),

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gobwas/glob"
 	"github.com/grafana/regexp"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 
@@ -89,7 +90,7 @@ type workspaceResolver struct {
 }
 
 func (wr *workspaceResolver) ResolveWorkspacesForBatchSpec(ctx context.Context, batchSpec *batcheslib.BatchSpec) (workspaces []*RepoWorkspace, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.ResolveWorkspacesForBatchSpec", "")
+	tr, ctx := trace.New(ctx, "workspaceResolver.ResolveWorkspacesForBatchSpec")
 	defer tr.FinishWithErr(&err)
 
 	// First, find all repositories that match the batch spec `on` definitions.
@@ -230,7 +231,7 @@ var ErrMalformedOnQueryOrRepository = batcheslib.NewValidationError(errors.New("
 
 // resolveRepositoriesOn resolves a single on: entry in a batch spec.
 func (wr *workspaceResolver) resolveRepositoriesOn(ctx context.Context, on *batcheslib.OnQueryOrRepository) (_ []*RepoRevision, _ onlib.RepositoryRuleType, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoriesOn", "")
+	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoriesOn")
 	defer tr.FinishWithErr(&err)
 
 	if on.RepositoriesMatchingQuery != "" {
@@ -270,7 +271,7 @@ func (wr *workspaceResolver) resolveRepositoriesOn(ctx context.Context, on *batc
 }
 
 func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoryName", "")
+	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoryName")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := wr.store.Repos().GetByName(ctx, api.RepoName(name))
@@ -288,7 +289,7 @@ func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name str
 }
 
 func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context, name, branch string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoryNameAndBranch", "")
+	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoryNameAndBranch")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := wr.store.Repos().GetByName(ctx, api.RepoName(name))
@@ -313,7 +314,7 @@ func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context,
 }
 
 func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Context, query string) (_ []*RepoRevision, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositorySearch", "")
+	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositorySearch")
 	defer tr.FinishWithErr(&err)
 
 	query = setDefaultQueryCount(query)
@@ -426,7 +427,7 @@ func (wr *workspaceResolver) runSearch(ctx context.Context, query string, onMatc
 }
 
 func repoToRepoRevisionWithDefaultBranch(ctx context.Context, gitserverClient gitserver.Client, repo *types.Repo, fileMatches []string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repoToRepoRevision", "")
+	tr, ctx := trace.New(ctx, "repoToRepoRevision")
 	defer tr.FinishWithErr(&err)
 
 	branch, commit, err := gitserverClient.GetDefaultBranch(ctx, repo.Name, false)
@@ -446,8 +447,7 @@ func repoToRepoRevisionWithDefaultBranch(ctx context.Context, gitserverClient gi
 const batchIgnoreFilePath = ".batchignore"
 
 func hasBatchIgnoreFile(ctx context.Context, gitserverClient gitserver.Client, r *RepoRevision) (_ bool, err error) {
-	traceTitle := fmt.Sprintf("RepoID: %q", r.Repo.ID)
-	tr, ctx := trace.DeprecatedNew(ctx, "hasBatchIgnoreFile", traceTitle)
+	tr, ctx := trace.New(ctx, "hasBatchIgnoreFile", attribute.Int("repoID", int(r.Repo.ID)))
 	defer tr.FinishWithErr(&err)
 
 	stat, err := gitserverClient.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.Repo.Name, r.Commit, batchIgnoreFilePath)

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -89,7 +89,7 @@ type workspaceResolver struct {
 }
 
 func (wr *workspaceResolver) ResolveWorkspacesForBatchSpec(ctx context.Context, batchSpec *batcheslib.BatchSpec) (workspaces []*RepoWorkspace, err error) {
-	tr, ctx := trace.New(ctx, "workspaceResolver.ResolveWorkspacesForBatchSpec", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.ResolveWorkspacesForBatchSpec", "")
 	defer tr.FinishWithErr(&err)
 
 	// First, find all repositories that match the batch spec `on` definitions.
@@ -230,7 +230,7 @@ var ErrMalformedOnQueryOrRepository = batcheslib.NewValidationError(errors.New("
 
 // resolveRepositoriesOn resolves a single on: entry in a batch spec.
 func (wr *workspaceResolver) resolveRepositoriesOn(ctx context.Context, on *batcheslib.OnQueryOrRepository) (_ []*RepoRevision, _ onlib.RepositoryRuleType, err error) {
-	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoriesOn", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoriesOn", "")
 	defer tr.FinishWithErr(&err)
 
 	if on.RepositoriesMatchingQuery != "" {
@@ -270,7 +270,7 @@ func (wr *workspaceResolver) resolveRepositoriesOn(ctx context.Context, on *batc
 }
 
 func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoryName", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoryName", "")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := wr.store.Repos().GetByName(ctx, api.RepoName(name))
@@ -288,7 +288,7 @@ func (wr *workspaceResolver) resolveRepositoryName(ctx context.Context, name str
 }
 
 func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context, name, branch string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositoryNameAndBranch", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositoryNameAndBranch", "")
 	defer tr.FinishWithErr(&err)
 
 	repo, err := wr.store.Repos().GetByName(ctx, api.RepoName(name))
@@ -313,7 +313,7 @@ func (wr *workspaceResolver) resolveRepositoryNameAndBranch(ctx context.Context,
 }
 
 func (wr *workspaceResolver) resolveRepositoriesMatchingQuery(ctx context.Context, query string) (_ []*RepoRevision, err error) {
-	tr, ctx := trace.New(ctx, "workspaceResolver.resolveRepositorySearch", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "workspaceResolver.resolveRepositorySearch", "")
 	defer tr.FinishWithErr(&err)
 
 	query = setDefaultQueryCount(query)
@@ -426,7 +426,7 @@ func (wr *workspaceResolver) runSearch(ctx context.Context, query string, onMatc
 }
 
 func repoToRepoRevisionWithDefaultBranch(ctx context.Context, gitserverClient gitserver.Client, repo *types.Repo, fileMatches []string) (_ *RepoRevision, err error) {
-	tr, ctx := trace.New(ctx, "repoToRepoRevision", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repoToRepoRevision", "")
 	defer tr.FinishWithErr(&err)
 
 	branch, commit, err := gitserverClient.GetDefaultBranch(ctx, repo.Name, false)
@@ -447,7 +447,7 @@ const batchIgnoreFilePath = ".batchignore"
 
 func hasBatchIgnoreFile(ctx context.Context, gitserverClient gitserver.Client, r *RepoRevision) (_ bool, err error) {
 	traceTitle := fmt.Sprintf("RepoID: %q", r.Repo.ID)
-	tr, ctx := trace.New(ctx, "hasBatchIgnoreFile", traceTitle)
+	tr, ctx := trace.DeprecatedNew(ctx, "hasBatchIgnoreFile", traceTitle)
 	defer tr.FinishWithErr(&err)
 
 	stat, err := gitserverClient.Stat(ctx, authz.DefaultSubRepoPermsChecker, r.Repo.Name, r.Commit, batchIgnoreFilePath)

--- a/enterprise/internal/completions/httpapi/BUILD.bazel
+++ b/enterprise/internal/completions/httpapi/BUILD.bazel
@@ -28,5 +28,6 @@ go_library(
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/enterprise/internal/completions/httpapi/observability.go
+++ b/enterprise/internal/completions/httpapi/observability.go
@@ -21,7 +21,7 @@ func Trace(ctx context.Context, family, model string) *traceBuilder {
 	// is we need to somehow make it cleaner to access fields from the
 	// request.
 
-	tr, ctx := trace.New(ctx, "completions."+family, model)
+	tr, ctx := trace.DeprecatedNew(ctx, "completions."+family, model)
 	var ev honey.Event
 	if honey.Enabled() {
 		ev = honey.NewEvent("completions")

--- a/enterprise/internal/completions/httpapi/observability.go
+++ b/enterprise/internal/completions/httpapi/observability.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/requestclient"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // Trace is a convenience helper around instrumenting our handlers and
@@ -21,7 +22,7 @@ func Trace(ctx context.Context, family, model string) *traceBuilder {
 	// is we need to somehow make it cleaner to access fields from the
 	// request.
 
-	tr, ctx := trace.DeprecatedNew(ctx, "completions."+family, model)
+	tr, ctx := trace.New(ctx, "completions."+family, attribute.String("model", model))
 	var ev honey.Event
 	if honey.Enabled() {
 		ev = honey.NewEvent("completions")

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1786,7 +1786,7 @@ WHERE perms.repo_id IN
 
 func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...attribute.KeyValue)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
 	began := s.clock()
-	tr, ctx := trace.New(ctx, "database.PermsStore."+family, title)
+	tr, ctx := trace.DeprecatedNew(ctx, "database.PermsStore."+family, title)
 
 	return ctx, func(err *error, attrs ...attribute.KeyValue) {
 		now := s.clock()

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -234,7 +234,7 @@ func (s *permsStore) Done(err error) error {
 }
 
 func (s *permsStore) LoadUserPermissions(ctx context.Context, userID int32) (p []authz.Permission, err error) {
-	ctx, save := s.observe(ctx, "LoadUserPermissions", "")
+	ctx, save := s.observe(ctx, "LoadUserPermissions")
 	defer func() {
 		tracingFields := []attribute.KeyValue{}
 		for _, perm := range p {
@@ -257,7 +257,7 @@ WHERE user_external_account_id = %s;
 
 	q := sqlf.Sprintf(format, accountID)
 
-	ctx, save := s.observe(ctx, "FetchReposByExternalAccount", "")
+	ctx, save := s.observe(ctx, "FetchReposByExternalAccount")
 	defer func() {
 		save(&err)
 	}()
@@ -266,7 +266,7 @@ WHERE user_external_account_id = %s;
 }
 
 func (s *permsStore) LoadRepoPermissions(ctx context.Context, repoID int32) (p []authz.Permission, err error) {
-	ctx, save := s.observe(ctx, "LoadRepoPermissions", "")
+	ctx, save := s.observe(ctx, "LoadRepoPermissions")
 	defer func() {
 		tracingFields := []attribute.KeyValue{}
 		for _, perm := range p {
@@ -367,7 +367,7 @@ func (s *permsStore) SetRepoPerms(ctx context.Context, repoID int32, userIDs []a
 //
 // So one repo {id:2} was removed and one was added {id:233} to the user
 func (s *permsStore) setUserRepoPermissions(ctx context.Context, p []authz.Permission, entity authz.PermissionEntity, source authz.PermsSource, replacePerms bool) (_ *database.SetPermissionsResult, err error) {
-	ctx, save := s.observe(ctx, "setUserRepoPermissions", "")
+	ctx, save := s.observe(ctx, "setUserRepoPermissions")
 	defer func() {
 		f := []attribute.KeyValue{}
 		for _, permission := range p {
@@ -701,7 +701,7 @@ DO UPDATE SET
 }
 
 func (s *permsStore) LoadUserPendingPermissions(ctx context.Context, p *authz.UserPendingPermissions) (err error) {
-	ctx, save := s.observe(ctx, "LoadUserPendingPermissions", "")
+	ctx, save := s.observe(ctx, "LoadUserPendingPermissions")
 	defer func() { save(&err, p.Attrs()...) }()
 
 	id, ids, updatedAt, err := s.loadUserPendingPermissions(ctx, p, "")
@@ -716,7 +716,7 @@ func (s *permsStore) LoadUserPendingPermissions(ctx context.Context, p *authz.Us
 }
 
 func (s *permsStore) SetRepoPendingPermissions(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) (err error) {
-	ctx, save := s.observe(ctx, "SetRepoPendingPermissions", "")
+	ctx, save := s.observe(ctx, "SetRepoPendingPermissions")
 	defer func() { save(&err, append(p.Attrs(), accounts.TracingFields()...)...) }()
 
 	var txs *permsStore
@@ -823,7 +823,7 @@ func (s *permsStore) SetRepoPendingPermissions(ctx context.Context, accounts *ex
 }
 
 func (s *permsStore) loadUserPendingPermissionsIDs(ctx context.Context, q *sqlf.Query) (ids []int64, err error) {
-	ctx, save := s.observe(ctx, "loadUserPendingPermissionsIDs", "")
+	ctx, save := s.observe(ctx, "loadUserPendingPermissionsIDs")
 	defer func() {
 		save(&err,
 			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
@@ -841,7 +841,7 @@ var scanBindIDs = basestore.NewMapScanner(func(s dbutil.Scanner) (bindID string,
 })
 
 func (s *permsStore) loadExistingUserPendingPermissionsBatch(ctx context.Context, q *sqlf.Query) (bindIDsToIDs map[string]int64, err error) {
-	ctx, save := s.observe(ctx, "loadExistingUserPendingPermissionsBatch", "")
+	ctx, save := s.observe(ctx, "loadExistingUserPendingPermissionsBatch")
 	defer func() {
 		save(&err,
 			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
@@ -960,7 +960,7 @@ AND object_type = %s
 }
 
 func (s *permsStore) GrantPendingPermissions(ctx context.Context, p *authz.UserGrantPermissions) (err error) {
-	ctx, save := s.observe(ctx, "GrantPendingPermissions", "")
+	ctx, save := s.observe(ctx, "GrantPendingPermissions")
 	defer func() { save(&err, p.Attrs()...) }()
 
 	var txs *permsStore
@@ -1178,7 +1178,7 @@ AND bind_id = %s
 }
 
 func (s *permsStore) ListPendingUsers(ctx context.Context, serviceType, serviceID string) (bindIDs []string, err error) {
-	ctx, save := s.observe(ctx, "ListPendingUsers", "")
+	ctx, save := s.observe(ctx, "ListPendingUsers")
 	defer save(&err)
 
 	q := sqlf.Sprintf(`
@@ -1216,7 +1216,7 @@ AND service_id = %s
 }
 
 func (s *permsStore) DeleteAllUserPermissions(ctx context.Context, userID int32) (err error) {
-	ctx, save := s.observe(ctx, "DeleteAllUserPermissions", "")
+	ctx, save := s.observe(ctx, "DeleteAllUserPermissions")
 
 	var txs *permsStore
 	if s.InTransaction() {
@@ -1245,7 +1245,7 @@ func (s *permsStore) DeleteAllUserPermissions(ctx context.Context, userID int32)
 }
 
 func (s *permsStore) DeleteAllUserPendingPermissions(ctx context.Context, accounts *extsvc.Accounts) (err error) {
-	ctx, save := s.observe(ctx, "DeleteAllUserPendingPermissions", "")
+	ctx, save := s.observe(ctx, "DeleteAllUserPendingPermissions")
 	defer func() { save(&err, accounts.TracingFields()...) }()
 
 	// NOTE: Practically, we don't need to clean up "repo_pending_permissions" table because the value of "id" column
@@ -1268,7 +1268,7 @@ AND bind_id IN (%s)`,
 }
 
 func (s *permsStore) execute(ctx context.Context, q *sqlf.Query, vs ...any) (err error) {
-	ctx, save := s.observe(ctx, "execute", "")
+	ctx, save := s.observe(ctx, "execute")
 	defer func() { save(&err, attribute.String("q", q.Query(sqlf.PostgresBindVar))) }()
 
 	var rows *sql.Rows
@@ -1343,7 +1343,7 @@ AND bind_id = %s
 		p.Type,
 		p.BindID,
 	)
-	ctx, save := s.observe(ctx, "load", "")
+	ctx, save := s.observe(ctx, "load")
 	defer func() {
 		save(&err,
 			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
@@ -1389,7 +1389,7 @@ AND permission = %s
 		p.RepoID,
 		p.Perm.String(),
 	)
-	ctx, save := s.observe(ctx, "load", "")
+	ctx, save := s.observe(ctx, "load")
 	defer func() {
 		save(&err,
 			attribute.String("Query.Query", q.Query(sqlf.PostgresBindVar)),
@@ -1427,7 +1427,7 @@ var scanUserIDsByExternalAccounts = basestore.NewMapScanner(func(s dbutil.Scanne
 })
 
 func (s *permsStore) GetUserIDsByExternalAccounts(ctx context.Context, accounts *extsvc.Accounts) (_ map[string]authz.UserIDWithExternalAccountID, err error) {
-	ctx, save := s.observe(ctx, "ListUsersByExternalAccounts", "")
+	ctx, save := s.observe(ctx, "ListUsersByExternalAccounts")
 	defer func() { save(&err, accounts.TracingFields()...) }()
 
 	items := make([]*sqlf.Query, len(accounts.AccountIDs))
@@ -1784,9 +1784,9 @@ WHERE perms.repo_id IN
 	return m, nil
 }
 
-func (s *permsStore) observe(ctx context.Context, family, title string) (context.Context, func(*error, ...attribute.KeyValue)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
+func (s *permsStore) observe(ctx context.Context, family string) (context.Context, func(*error, ...attribute.KeyValue)) { //nolint:unparam // unparam complains that `title` always has same value across call-sites, but that's OK
 	began := s.clock()
-	tr, ctx := trace.DeprecatedNew(ctx, "database.PermsStore."+family, title)
+	tr, ctx := trace.New(ctx, "database.PermsStore."+family)
 
 	return ctx, func(err *error, attrs ...attribute.KeyValue) {
 		now := s.clock()

--- a/enterprise/internal/insights/background/queryrunner/search.go
+++ b/enterprise/internal/insights/background/queryrunner/search.go
@@ -22,7 +22,7 @@ import (
 
 func GetSearchHandlers() map[types.GenerationMethod]InsightsHandler {
 	searchStream := func(ctx context.Context, query string) (*streaming.TabulationResult, error) {
-		tr, ctx := trace.New(ctx, "CodeInsightsSearch", "searchStream")
+		tr, ctx := trace.DeprecatedNew(ctx, "CodeInsightsSearch", "searchStream")
 		defer tr.Finish()
 
 		decoder, streamResults := streaming.TabulationDecoder()
@@ -36,7 +36,7 @@ func GetSearchHandlers() map[types.GenerationMethod]InsightsHandler {
 
 	computeSearchStream := func(ctx context.Context, query string) (*streaming.ComputeTabulationResult, error) {
 		decoder, streamResults := streaming.MatchContextComputeDecoder()
-		tr, ctx := trace.New(ctx, "CodeInsightsSearch", "computeMatchContextSearchStream")
+		tr, ctx := trace.DeprecatedNew(ctx, "CodeInsightsSearch", "computeMatchContextSearchStream")
 		defer tr.Finish()
 
 		err := streaming.ComputeMatchContextStream(ctx, query, decoder)

--- a/enterprise/internal/insights/background/queryrunner/search.go
+++ b/enterprise/internal/insights/background/queryrunner/search.go
@@ -22,7 +22,7 @@ import (
 
 func GetSearchHandlers() map[types.GenerationMethod]InsightsHandler {
 	searchStream := func(ctx context.Context, query string) (*streaming.TabulationResult, error) {
-		tr, ctx := trace.DeprecatedNew(ctx, "CodeInsightsSearch", "searchStream")
+		tr, ctx := trace.New(ctx, "CodeInsightsSearch.searchStream")
 		defer tr.Finish()
 
 		decoder, streamResults := streaming.TabulationDecoder()
@@ -36,7 +36,7 @@ func GetSearchHandlers() map[types.GenerationMethod]InsightsHandler {
 
 	computeSearchStream := func(ctx context.Context, query string) (*streaming.ComputeTabulationResult, error) {
 		decoder, streamResults := streaming.MatchContextComputeDecoder()
-		tr, ctx := trace.DeprecatedNew(ctx, "CodeInsightsSearch", "computeMatchContextSearchStream")
+		tr, ctx := trace.New(ctx, "CodeInsightsSearch.computeMatchContextSearchStream")
 		defer tr.Finish()
 
 		err := streaming.ComputeMatchContextStream(ctx, query, decoder)

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -24,7 +24,7 @@ type Opts struct {
 // Search calls the streaming search endpoint and uses decoder to decode the
 // response body.
 func Search(ctx context.Context, query string, patternType *string, decoder streamhttp.FrontendStreamDecoder) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "insights", "StreamSearch",
+	tr, ctx := trace.New(ctx, "insights.StreamSearch",
 		attribute.String("query", query))
 	defer tr.FinishWithErr(&err)
 
@@ -59,7 +59,7 @@ func Search(ctx context.Context, query string, patternType *string, decoder stre
 }
 
 func genericComputeStream(ctx context.Context, handler func(io.Reader) error, query, operation string) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, operation, "")
+	tr, ctx := trace.New(ctx, operation)
 	defer tr.FinishWithErr(&err)
 
 	req, err := client.NewComputeStreamRequest(internalapi.Client.URL+"/.internal", query)

--- a/enterprise/internal/insights/query/streaming/search.go
+++ b/enterprise/internal/insights/query/streaming/search.go
@@ -24,7 +24,7 @@ type Opts struct {
 // Search calls the streaming search endpoint and uses decoder to decode the
 // response body.
 func Search(ctx context.Context, query string, patternType *string, decoder streamhttp.FrontendStreamDecoder) (err error) {
-	tr, ctx := trace.New(ctx, "insights", "StreamSearch",
+	tr, ctx := trace.DeprecatedNew(ctx, "insights", "StreamSearch",
 		attribute.String("query", query))
 	defer tr.FinishWithErr(&err)
 
@@ -59,7 +59,7 @@ func Search(ctx context.Context, query string, patternType *string, decoder stre
 }
 
 func genericComputeStream(ctx context.Context, handler func(io.Reader) error, query, operation string) (err error) {
-	tr, ctx := trace.New(ctx, operation, "")
+	tr, ctx := trace.DeprecatedNew(ctx, operation, "")
 	defer tr.FinishWithErr(&err)
 
 	req, err := client.NewComputeStreamRequest(internalapi.Client.URL+"/.internal", query)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -47,7 +47,7 @@ func UndeletedRepoName(name RepoName) RepoName {
 type CommitID string
 
 func (c CommitID) Attr() attribute.KeyValue {
-	attribute.String("commitID", string(c))
+	return attribute.String("commitID", string(c))
 }
 
 // Short returns the SHA-1 commit hash truncated to 7 characters

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -46,6 +46,10 @@ func UndeletedRepoName(name RepoName) RepoName {
 // CommitID is the 40-character SHA-1 hash for a Git commit.
 type CommitID string
 
+func (c CommitID) Attr() attribute.KeyValue {
+	attribute.String("commitID", string(c))
+}
+
 // Short returns the SHA-1 commit hash truncated to 7 characters
 func (c CommitID) Short() string {
 	if len(c) >= 7 {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -23,12 +23,16 @@ type RepoID int32
 // Previously, this was called RepoURI.
 type RepoName string
 
-// RepoHashedName is the hashed name of a repo
-type RepoHashedName string
+func (r RepoName) Attr() attribute.KeyValue {
+	return attribute.String("repo", string(r))
+}
 
 func (r RepoName) Equal(o RepoName) bool {
 	return strings.EqualFold(string(r), string(o))
 }
+
+// RepoHashedName is the hashed name of a repo
+type RepoHashedName string
 
 var deletedRegex = lazyregexp.New("DELETED-[0-9]+\\.[0-9]+-")
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -84,7 +84,7 @@ func (rc *RepoCommit) FromProto(p *proto.RepoCommit) {
 
 func (rc RepoCommit) Attrs() []attribute.KeyValue {
 	return []attribute.KeyValue{
-		attribute.String("repo", string(rc.Repo)),
+		rc.Repo.Attr(),
 		attribute.String("commitID", string(rc.CommitID)),
 	}
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -85,7 +85,7 @@ func (rc *RepoCommit) FromProto(p *proto.RepoCommit) {
 func (rc RepoCommit) Attrs() []attribute.KeyValue {
 	return []attribute.KeyValue{
 		rc.Repo.Attr(),
-		attribute.String("commitID", string(rc.CommitID)),
+		rc.CommitID.Attr(),
 	}
 }
 

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -24,7 +24,7 @@ import (
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
 func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "RepoSourceCloneURLToRepoName", "", attribute.String("cloneURL", cloneURL))
+	tr, ctx := trace.New(ctx, "RepoSourceCloneURLToRepoName", attribute.String("cloneURL", cloneURL))
 	defer tr.FinishWithErr(&err)
 
 	if repoName := reposource.CustomCloneURLToRepoName(cloneURL); repoName != "" {
@@ -104,7 +104,7 @@ func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL 
 }
 
 func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (_ api.RepoName, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "cloneurls", "getRepoNameFromService",
+	tr, ctx := trace.New(ctx, "getRepoNameFromService",
 		attribute.Int64("externalService.ID", svc.ID),
 		attribute.String("externalService.Kind", svc.Kind))
 	defer tr.FinishWithErr(&err)

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -24,7 +24,7 @@ import (
 // error if a matching code host could not be found. This function does not actually check the code
 // host to see if the repository actually exists.
 func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL string) (repoName api.RepoName, err error) {
-	tr, ctx := trace.New(ctx, "RepoSourceCloneURLToRepoName", "", attribute.String("cloneURL", cloneURL))
+	tr, ctx := trace.DeprecatedNew(ctx, "RepoSourceCloneURLToRepoName", "", attribute.String("cloneURL", cloneURL))
 	defer tr.FinishWithErr(&err)
 
 	if repoName := reposource.CustomCloneURLToRepoName(cloneURL); repoName != "" {
@@ -104,7 +104,7 @@ func RepoSourceCloneURLToRepoName(ctx context.Context, db database.DB, cloneURL 
 }
 
 func getRepoNameFromService(ctx context.Context, cloneURL string, svc *types.ExternalService) (_ api.RepoName, err error) {
-	tr, ctx := trace.New(ctx, "cloneurls", "getRepoNameFromService",
+	tr, ctx := trace.DeprecatedNew(ctx, "cloneurls", "getRepoNameFromService",
 		attribute.Int64("externalService.ID", svc.ID),
 		attribute.String("externalService.Kind", svc.Kind))
 	defer tr.FinishWithErr(&err)

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -86,7 +86,7 @@ func newService(
 // is invoked and the resulting index jobs are combined into a flattened list.
 func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ *shared.InferenceResult, err error) {
 	ctx, _, endObservation := s.operations.inferIndexJobs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", commit),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -136,7 +136,7 @@ func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit,
 // invoked and the resulting index job hints are combined into a flattened list.
 func (s *Service) InferIndexJobHints(ctx context.Context, repo api.RepoName, commit, overrideScript string) (_ []config.IndexJobHint, err error) {
 	ctx, _, endObservation := s.operations.inferIndexJobHints.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", commit),
 	}})
 	defer endObservation(1, observation.Args{})

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -73,7 +73,7 @@ func NewRootResolver(
 func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.GitBlobLSIFDataArgs) (_ resolverstubs.GitBlobLSIFDataResolver, err error) {
 	ctx, _, endObservation := r.operations.gitBlobLsifData.WithErrors(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repoID", int(args.Repo.ID)),
-		attribute.String("commit", string(args.Commit)),
+		args.Commit.Attr(),
 		attribute.String("path", args.Path),
 		attribute.Bool("exactPath", args.ExactPath),
 		attribute.String("toolName", args.ToolName),

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -204,7 +204,7 @@ func SetupCmdWithPipes(ctx context.Context, args Args) (cmd *exec.Cmd, stdin io.
 
 // Matches returns all matches in all files for which comby finds matches.
 func Matches(ctx context.Context, args Args) (_ []*FileMatch, err error) {
-	tr, ctx := trace.New(ctx, "comby", "matches")
+	tr, ctx := trace.DeprecatedNew(ctx, "comby", "matches")
 	defer tr.FinishWithErr(&err)
 
 	args.ResultKind = MatchOnly
@@ -221,7 +221,7 @@ func Matches(ctx context.Context, args Args) (_ []*FileMatch, err error) {
 
 // Replacements performs in-place replacement for match and rewrite template.
 func Replacements(ctx context.Context, args Args) (_ []*FileReplacement, err error) {
-	tr, ctx := trace.New(ctx, "comby", "replacements")
+	tr, ctx := trace.DeprecatedNew(ctx, "comby", "replacements")
 	defer tr.FinishWithErr(&err)
 
 	results, err := Run(ctx, args, toFileReplacement)
@@ -238,7 +238,7 @@ func Replacements(ctx context.Context, args Args) (_ []*FileReplacement, err err
 // Outputs performs substitution of all variables captured in a match
 // pattern in a rewrite template and outputs the result, newline-sparated.
 func Outputs(ctx context.Context, args Args) (_ string, err error) {
-	tr, ctx := trace.New(ctx, "comby", "outputs")
+	tr, ctx := trace.DeprecatedNew(ctx, "comby", "outputs")
 	defer tr.FinishWithErr(&err)
 
 	results, err := Run(ctx, args, toOutput)

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -204,7 +204,7 @@ func SetupCmdWithPipes(ctx context.Context, args Args) (cmd *exec.Cmd, stdin io.
 
 // Matches returns all matches in all files for which comby finds matches.
 func Matches(ctx context.Context, args Args) (_ []*FileMatch, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "comby", "matches")
+	tr, ctx := trace.New(ctx, "comby.Matches")
 	defer tr.FinishWithErr(&err)
 
 	args.ResultKind = MatchOnly
@@ -221,7 +221,7 @@ func Matches(ctx context.Context, args Args) (_ []*FileMatch, err error) {
 
 // Replacements performs in-place replacement for match and rewrite template.
 func Replacements(ctx context.Context, args Args) (_ []*FileReplacement, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "comby", "replacements")
+	tr, ctx := trace.New(ctx, "comby.Replacements")
 	defer tr.FinishWithErr(&err)
 
 	results, err := Run(ctx, args, toFileReplacement)
@@ -238,7 +238,7 @@ func Replacements(ctx context.Context, args Args) (_ []*FileReplacement, err err
 // Outputs performs substitution of all variables captured in a match
 // pattern in a rewrite template and outputs the result, newline-sparated.
 func Outputs(ctx context.Context, args Args) (_ string, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "comby", "outputs")
+	tr, ctx := trace.New(ctx, "comby.Outputs")
 	defer tr.FinishWithErr(&err)
 
 	results, err := Run(ctx, args, toOutput)

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -426,7 +426,7 @@ type ExternalAccountsListOptions struct {
 }
 
 func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.Account, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "UserExternalAccountsStore.List", "")
+	tr, ctx := trace.New(ctx, "UserExternalAccountsStore.List")
 	defer func() {
 		if err != nil {
 			tr.SetError(err)
@@ -446,7 +446,7 @@ func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccoun
 }
 
 func (s *userExternalAccountsStore) ListForUsers(ctx context.Context, userIDs []int32) (userToAccts map[int32][]*extsvc.Account, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "UserExternalAccountsStore.ListForUsers", "")
+	tr, ctx := trace.New(ctx, "UserExternalAccountsStore.ListForUsers")
 	var count int
 	defer func() {
 		if err != nil {

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -426,7 +426,7 @@ type ExternalAccountsListOptions struct {
 }
 
 func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccountsListOptions) (acct []*extsvc.Account, err error) {
-	tr, ctx := trace.New(ctx, "UserExternalAccountsStore.List", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "UserExternalAccountsStore.List", "")
 	defer func() {
 		if err != nil {
 			tr.SetError(err)
@@ -446,7 +446,7 @@ func (s *userExternalAccountsStore) List(ctx context.Context, opt ExternalAccoun
 }
 
 func (s *userExternalAccountsStore) ListForUsers(ctx context.Context, userIDs []int32) (userToAccts map[int32][]*extsvc.Account, err error) {
-	tr, ctx := trace.New(ctx, "UserExternalAccountsStore.ListForUsers", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "UserExternalAccountsStore.ListForUsers", "")
 	var count int
 	defer func() {
 		if err != nil {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1334,7 +1334,7 @@ ORDER BY es.id, essj.finished_at DESC
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) (_ []*types.ExternalService, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "externalServiceStore", "List")
+	tr, ctx := trace.New(ctx, "externalServiceStore.List")
 	defer tr.FinishWithErr(&err)
 
 	if opt.OrderByDirection != "ASC" {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1429,7 +1429,7 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 }
 
 func (e *externalServiceStore) ListRepos(ctx context.Context, opt ExternalServiceReposListOptions) (_ []*types.ExternalServiceRepo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "externalServiceStore", "ListRepos")
+	tr, ctx := trace.New(ctx, "externalServiceStore.ListRepos")
 	defer tr.FinishWithErr(&err)
 
 	predicate := sqlf.Sprintf("TRUE")

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1334,7 +1334,7 @@ ORDER BY es.id, essj.finished_at DESC
 }
 
 func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) (_ []*types.ExternalService, err error) {
-	tr, ctx := trace.New(ctx, "externalServiceStore", "List")
+	tr, ctx := trace.DeprecatedNew(ctx, "externalServiceStore", "List")
 	defer tr.FinishWithErr(&err)
 
 	if opt.OrderByDirection != "ASC" {
@@ -1429,7 +1429,7 @@ func (e *externalServiceStore) List(ctx context.Context, opt ExternalServicesLis
 }
 
 func (e *externalServiceStore) ListRepos(ctx context.Context, opt ExternalServiceReposListOptions) (_ []*types.ExternalServiceRepo, err error) {
-	tr, ctx := trace.New(ctx, "externalServiceStore", "ListRepos")
+	tr, ctx := trace.DeprecatedNew(ctx, "externalServiceStore", "ListRepos")
 	defer tr.FinishWithErr(&err)
 
 	predicate := sqlf.Sprintf("TRUE")

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -125,7 +125,7 @@ func (s *repoStore) Transact(ctx context.Context) (RepoStore, error) {
 // Get finds and returns the repo with the given repository ID from the database.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.Get", "")
+	tr, ctx := trace.New(ctx, "repos.Get")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -194,7 +194,7 @@ func logPrivateRepoAccessGranted(ctx context.Context, db DB, ids []api.RepoID) {
 //
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *types.Repo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByName", "")
+	tr, ctx := trace.New(ctx, "repos.GetByName")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -233,7 +233,7 @@ func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *t
 // RepoHashedName is the repository hashed name.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.RepoHashedName) (_ *types.Repo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByHashedName", "")
+	tr, ctx := trace.New(ctx, "repos.GetByHashedName")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -255,7 +255,7 @@ func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.Repo
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
 func (s *repoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) (_ []*types.Repo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByIDs", "")
+	tr, ctx := trace.New(ctx, "repos.GetByIDs")
 	defer tr.FinishWithErr(&err)
 
 	// listRepos will return a list of all repos if we pass in an empty ID list,
@@ -283,7 +283,7 @@ func (s *repoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 }
 
 func (s *repoStore) GetRepoDescriptionsByIDs(ctx context.Context, ids ...api.RepoID) (_ map[api.RepoID]string, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetRepoDescriptionsByIDs", "")
+	tr, ctx := trace.New(ctx, "repos.GetRepoDescriptionsByIDs")
 	defer tr.FinishWithErr(&err)
 
 	opts := ReposListOptions{
@@ -310,7 +310,7 @@ func (s *repoStore) GetRepoDescriptionsByIDs(ctx context.Context, ids ...api.Rep
 }
 
 func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.Count", "")
+	tr, ctx := trace.New(ctx, "repos.Count")
 	defer tr.FinishWithErr(&err)
 
 	opt.Select = []string{"COUNT(*)"}
@@ -327,7 +327,7 @@ func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 // Metadata returns repo metadata used to decorate search results. The returned slice may be smaller than the
 // number of IDs given if a repo with the given ID does not exist.
 func (s *repoStore) Metadata(ctx context.Context, ids ...api.RepoID) (_ []*types.SearchedRepo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.Metadata", "")
+	tr, ctx := trace.New(ctx, "repos.Metadata")
 	defer tr.FinishWithErr(&err)
 
 	opts := ReposListOptions{
@@ -797,7 +797,7 @@ const (
 // This will not return any repositories from external services that are not present in the Sourcegraph repository.
 // Matching is done with fuzzy matching, i.e. "query" will match any repo name that matches the regexp `q.*u.*e.*r.*y`
 func (s *repoStore) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.List", "")
+	tr, ctx := trace.New(ctx, "repos.List")
 	defer tr.FinishWithErr(&err)
 
 	if len(opt.OrderBy) == 0 {
@@ -809,7 +809,7 @@ func (s *repoStore) List(ctx context.Context, opt ReposListOptions) (results []*
 
 // StreamMinimalRepos calls the given callback for each of the repositories names and ids that match the given options.
 func (s *repoStore) StreamMinimalRepos(ctx context.Context, opt ReposListOptions, cb func(*types.MinimalRepo)) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.StreamMinimalRepos", "")
+	tr, ctx := trace.New(ctx, "repos.StreamMinimalRepos")
 	defer tr.FinishWithErr(&err)
 
 	opt.Select = minimalRepoColumns
@@ -1289,7 +1289,7 @@ type ListSourcegraphDotComIndexableReposOptions struct {
 const listSourcegraphDotComIndexableReposMinStars = 5
 
 func (s *repoStore) ListSourcegraphDotComIndexableRepos(ctx context.Context, opts ListSourcegraphDotComIndexableReposOptions) (results []types.MinimalRepo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.ListIndexable", "")
+	tr, ctx := trace.New(ctx, "repos.ListIndexable")
 	defer tr.FinishWithErr(&err)
 
 	var joins, where []*sqlf.Query
@@ -1367,7 +1367,7 @@ ORDER BY stars DESC NULLS LAST
 // Create inserts repos and their sources, respectively in the repo and external_service_repos table.
 // Associated external services must already exist.
 func (s *repoStore) Create(ctx context.Context, repos ...*types.Repo) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repos.Create", "")
+	tr, ctx := trace.New(ctx, "repos.Create")
 	defer tr.FinishWithErr(&err)
 
 	records := make([]*repoRecord, 0, len(repos))

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -125,7 +125,7 @@ func (s *repoStore) Transact(ctx context.Context) (RepoStore, error) {
 // Get finds and returns the repo with the given repository ID from the database.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) Get(ctx context.Context, id api.RepoID) (_ *types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "repos.Get", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.Get", "")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -194,7 +194,7 @@ func logPrivateRepoAccessGranted(ctx context.Context, db DB, ids []api.RepoID) {
 //
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "repos.GetByName", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByName", "")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -233,7 +233,7 @@ func (s *repoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (_ *t
 // RepoHashedName is the repository hashed name.
 // When a repo isn't found or has been blocked, an error is returned.
 func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.RepoHashedName) (_ *types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "repos.GetByHashedName", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByHashedName", "")
 	defer tr.FinishWithErr(&err)
 
 	repos, err := s.listRepos(ctx, tr, ReposListOptions{
@@ -255,7 +255,7 @@ func (s *repoStore) GetByHashedName(ctx context.Context, repoHashedName api.Repo
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
 func (s *repoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) (_ []*types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "repos.GetByIDs", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetByIDs", "")
 	defer tr.FinishWithErr(&err)
 
 	// listRepos will return a list of all repos if we pass in an empty ID list,
@@ -283,7 +283,7 @@ func (s *repoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 }
 
 func (s *repoStore) GetRepoDescriptionsByIDs(ctx context.Context, ids ...api.RepoID) (_ map[api.RepoID]string, err error) {
-	tr, ctx := trace.New(ctx, "repos.GetRepoDescriptionsByIDs", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.GetRepoDescriptionsByIDs", "")
 	defer tr.FinishWithErr(&err)
 
 	opts := ReposListOptions{
@@ -310,7 +310,7 @@ func (s *repoStore) GetRepoDescriptionsByIDs(ctx context.Context, ids ...api.Rep
 }
 
 func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
-	tr, ctx := trace.New(ctx, "repos.Count", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.Count", "")
 	defer tr.FinishWithErr(&err)
 
 	opt.Select = []string{"COUNT(*)"}
@@ -327,7 +327,7 @@ func (s *repoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 // Metadata returns repo metadata used to decorate search results. The returned slice may be smaller than the
 // number of IDs given if a repo with the given ID does not exist.
 func (s *repoStore) Metadata(ctx context.Context, ids ...api.RepoID) (_ []*types.SearchedRepo, err error) {
-	tr, ctx := trace.New(ctx, "repos.Metadata", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.Metadata", "")
 	defer tr.FinishWithErr(&err)
 
 	opts := ReposListOptions{
@@ -797,7 +797,7 @@ const (
 // This will not return any repositories from external services that are not present in the Sourcegraph repository.
 // Matching is done with fuzzy matching, i.e. "query" will match any repo name that matches the regexp `q.*u.*e.*r.*y`
 func (s *repoStore) List(ctx context.Context, opt ReposListOptions) (results []*types.Repo, err error) {
-	tr, ctx := trace.New(ctx, "repos.List", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.List", "")
 	defer tr.FinishWithErr(&err)
 
 	if len(opt.OrderBy) == 0 {
@@ -809,7 +809,7 @@ func (s *repoStore) List(ctx context.Context, opt ReposListOptions) (results []*
 
 // StreamMinimalRepos calls the given callback for each of the repositories names and ids that match the given options.
 func (s *repoStore) StreamMinimalRepos(ctx context.Context, opt ReposListOptions, cb func(*types.MinimalRepo)) (err error) {
-	tr, ctx := trace.New(ctx, "repos.StreamMinimalRepos", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.StreamMinimalRepos", "")
 	defer tr.FinishWithErr(&err)
 
 	opt.Select = minimalRepoColumns
@@ -1289,7 +1289,7 @@ type ListSourcegraphDotComIndexableReposOptions struct {
 const listSourcegraphDotComIndexableReposMinStars = 5
 
 func (s *repoStore) ListSourcegraphDotComIndexableRepos(ctx context.Context, opts ListSourcegraphDotComIndexableReposOptions) (results []types.MinimalRepo, err error) {
-	tr, ctx := trace.New(ctx, "repos.ListIndexable", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.ListIndexable", "")
 	defer tr.FinishWithErr(&err)
 
 	var joins, where []*sqlf.Query
@@ -1367,7 +1367,7 @@ ORDER BY stars DESC NULLS LAST
 // Create inserts repos and their sources, respectively in the repo and external_service_repos table.
 // Associated external services must already exist.
 func (s *repoStore) Create(ctx context.Context, repos ...*types.Repo) (err error) {
-	tr, ctx := trace.New(ctx, "repos.Create", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "repos.Create", "")
 	defer tr.FinishWithErr(&err)
 
 	records := make([]*repoRecord, 0, len(repos))

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2380,7 +2380,7 @@ func TestParseIncludePattern(t *testing.T) {
 		`\s`: {regexp: `\s`},
 	}
 
-	tr, _ := trace.DeprecatedNew(context.Background(), "", "")
+	tr, _ := trace.New(context.Background(), "")
 	defer tr.Finish()
 
 	for pattern, want := range tests {

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -2380,7 +2380,7 @@ func TestParseIncludePattern(t *testing.T) {
 		`\s`: {regexp: `\s`},
 	}
 
-	tr, _ := trace.New(context.Background(), "", "")
+	tr, _ := trace.DeprecatedNew(context.Background(), "", "")
 	defer tr.Finish()
 
 	for pattern, want := range tests {

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -71,7 +71,7 @@ func (s *savedSearchStore) IsEmpty(ctx context.Context) (bool, error) {
 // user is an admin. It is the callers responsibility to ensure that only users
 // with the proper permissions can access the returned saved searches.
 func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.SavedQuerySpecAndConfig, err error) {
-	tr, ctx := trace.New(ctx, "database.SavedSearches.ListAll", "",
+	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.ListAll", "",
 		attribute.Int("count", len(savedSearches)),
 	)
 	defer tr.FinishWithErr(&err)
@@ -319,7 +319,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 		return nil, errors.New("newSavedSearch.ID must be zero")
 	}
 
-	tr, ctx := trace.New(ctx, "database.SavedSearches.Create", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Create", "")
 	defer tr.FinishWithErr(&err)
 
 	savedQuery = &types.SavedSearch{
@@ -358,7 +358,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 // user is an admin. It is the callers responsibility to ensure the user has
 // proper permissions to perform the update.
 func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedSearch) (savedQuery *types.SavedSearch, err error) {
-	tr, ctx := trace.New(ctx, "database.SavedSearches.Update", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Update", "")
 	defer tr.FinishWithErr(&err)
 
 	savedQuery = &types.SavedSearch{
@@ -395,7 +395,7 @@ func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedS
 // user is an admin. It is the callers responsibility to ensure the user has
 // proper permissions to perform the delete.
 func (s *savedSearchStore) Delete(ctx context.Context, id int32) (err error) {
-	tr, ctx := trace.New(ctx, "database.SavedSearches.Delete", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Delete", "")
 	defer tr.FinishWithErr(&err)
 	_, err = s.Handle().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
 	return err

--- a/internal/database/saved_searches.go
+++ b/internal/database/saved_searches.go
@@ -71,7 +71,7 @@ func (s *savedSearchStore) IsEmpty(ctx context.Context) (bool, error) {
 // user is an admin. It is the callers responsibility to ensure that only users
 // with the proper permissions can access the returned saved searches.
 func (s *savedSearchStore) ListAll(ctx context.Context) (savedSearches []api.SavedQuerySpecAndConfig, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.ListAll", "",
+	tr, ctx := trace.New(ctx, "database.SavedSearches.ListAll",
 		attribute.Int("count", len(savedSearches)),
 	)
 	defer tr.FinishWithErr(&err)
@@ -319,7 +319,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 		return nil, errors.New("newSavedSearch.ID must be zero")
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Create", "")
+	tr, ctx := trace.New(ctx, "database.SavedSearches.Create")
 	defer tr.FinishWithErr(&err)
 
 	savedQuery = &types.SavedSearch{
@@ -358,7 +358,7 @@ func (s *savedSearchStore) Create(ctx context.Context, newSavedSearch *types.Sav
 // user is an admin. It is the callers responsibility to ensure the user has
 // proper permissions to perform the update.
 func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedSearch) (savedQuery *types.SavedSearch, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Update", "")
+	tr, ctx := trace.New(ctx, "database.SavedSearches.Update")
 	defer tr.FinishWithErr(&err)
 
 	savedQuery = &types.SavedSearch{
@@ -395,7 +395,7 @@ func (s *savedSearchStore) Update(ctx context.Context, savedSearch *types.SavedS
 // user is an admin. It is the callers responsibility to ensure the user has
 // proper permissions to perform the delete.
 func (s *savedSearchStore) Delete(ctx context.Context, id int32) (err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.SavedSearches.Delete", "")
+	tr, ctx := trace.New(ctx, "database.SavedSearches.Delete")
 	defer tr.FinishWithErr(&err)
 	_, err = s.Handle().ExecContext(ctx, `DELETE FROM saved_searches WHERE ID=$1`, id)
 	return err

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -149,7 +149,7 @@ func (o *settingsStore) GetLatestSchemaSettings(ctx context.Context, subject api
 // 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
 // responsible for ensuring this or that the response never makes it to a user.
 func (o *settingsStore) ListAll(ctx context.Context, impreciseSubstring string) (_ []*api.Settings, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.Settings.ListAll", "")
+	tr, ctx := trace.New(ctx, "database.Settings.ListAll")
 	defer tr.FinishWithErr(&err)
 
 	q := sqlf.Sprintf(`

--- a/internal/database/settings.go
+++ b/internal/database/settings.go
@@ -149,7 +149,7 @@ func (o *settingsStore) GetLatestSchemaSettings(ctx context.Context, subject api
 // 🚨 SECURITY: This method does NOT verify the user is an admin. The caller is
 // responsible for ensuring this or that the response never makes it to a user.
 func (o *settingsStore) ListAll(ctx context.Context, impreciseSubstring string) (_ []*api.Settings, err error) {
-	tr, ctx := trace.New(ctx, "database.Settings.ListAll", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "database.Settings.ListAll", "")
 	defer tr.FinishWithErr(&err)
 
 	q := sqlf.Sprintf(`

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/sourcegraph/log"
@@ -1063,7 +1064,7 @@ type UsersListOptions struct {
 }
 
 func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types.User, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.Users.List", fmt.Sprintf("%+v", opt))
+	tr, ctx := trace.New(ctx, "database.Users.List", attribute.String("opt", fmt.Sprintf("%+v", opt)))
 	defer tr.FinishWithErr(&err)
 
 	if opt == nil {
@@ -1077,7 +1078,7 @@ func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types
 
 // ListForSCIM lists users along with their email addresses and SCIM ExternalID.
 func (u *userStore) ListForSCIM(ctx context.Context, opt *UsersListOptions) (_ []*types.UserForSCIM, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "database.Users.ListForSCIM", fmt.Sprintf("%+v", opt))
+	tr, ctx := trace.New(ctx, "database.Users.ListForSCIM", attribute.String("opt", fmt.Sprintf("%+v", opt)))
 	defer tr.FinishWithErr(&err)
 
 	if opt == nil {

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1063,7 +1063,7 @@ type UsersListOptions struct {
 }
 
 func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types.User, err error) {
-	tr, ctx := trace.New(ctx, "database.Users.List", fmt.Sprintf("%+v", opt))
+	tr, ctx := trace.DeprecatedNew(ctx, "database.Users.List", fmt.Sprintf("%+v", opt))
 	defer tr.FinishWithErr(&err)
 
 	if opt == nil {
@@ -1077,7 +1077,7 @@ func (u *userStore) List(ctx context.Context, opt *UsersListOptions) (_ []*types
 
 // ListForSCIM lists users along with their email addresses and SCIM ExternalID.
 func (u *userStore) ListForSCIM(ctx context.Context, opt *UsersListOptions) (_ []*types.UserForSCIM, err error) {
-	tr, ctx := trace.New(ctx, "database.Users.ListForSCIM", fmt.Sprintf("%+v", opt))
+	tr, ctx := trace.DeprecatedNew(ctx, "database.Users.ListForSCIM", fmt.Sprintf("%+v", opt))
 	defer tr.FinishWithErr(&err)
 
 	if opt == nil {

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -111,7 +111,7 @@ func UpdateRepoEmbeddingIndex(
 }
 
 func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "DownloadRepoEmbeddingIndex", "", attribute.String("key", key))
+	tr, ctx := trace.New(ctx, "DownloadRepoEmbeddingIndex", attribute.String("key", key))
 	defer tr.FinishWithErr(&err)
 
 	dec, err := newDecoder(ctx, uploadStore, key)

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -111,7 +111,7 @@ func UpdateRepoEmbeddingIndex(
 }
 
 func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
-	tr, ctx := trace.New(ctx, "DownloadRepoEmbeddingIndex", "", attribute.String("key", key))
+	tr, ctx := trace.DeprecatedNew(ctx, "DownloadRepoEmbeddingIndex", "", attribute.String("key", key))
 	defer tr.FinishWithErr(&err)
 
 	dec, err := newDecoder(ctx, uploadStore, key)

--- a/internal/encryption/helpers.go
+++ b/internal/encryption/helpers.go
@@ -20,14 +20,14 @@ func MaybeEncrypt(ctx context.Context, key Key, data string) (_, keyIdent string
 		return data, "", nil
 	}
 
-	tr, trCtx := trace.New(ctx, "key", "Encrypt")
+	tr, trCtx := trace.DeprecatedNew(ctx, "key", "Encrypt")
 	encrypted, err := key.Encrypt(trCtx, []byte(data))
 	tr.FinishWithErr(&err)
 	if err != nil {
 		return "", "", err
 	}
 
-	tr, trCtx = trace.New(ctx, "key", "Version")
+	tr, trCtx = trace.DeprecatedNew(ctx, "key", "Version")
 	version, err := key.Version(trCtx)
 	tr.FinishWithErr(&err)
 	if err != nil {
@@ -50,11 +50,11 @@ func MaybeDecrypt(ctx context.Context, key Key, data, keyIdent string) (string, 
 		return data, errors.Errorf("key mismatch: value is encrypted but no encryption key available in site-config")
 	}
 
-	tr, innerCtx := trace.New(ctx, "key", "Decrypt")
+	tr, innerCtx := trace.DeprecatedNew(ctx, "key", "Decrypt")
 	decrypted, err := key.Decrypt(innerCtx, []byte(data))
 	tr.FinishWithErr(&err)
 	if err != nil {
-		tr, innerCtx = trace.New(ctx, "key", "Version")
+		tr, innerCtx = trace.DeprecatedNew(ctx, "key", "Version")
 		version, versionErr := key.Version(innerCtx)
 		tr.FinishWithErr(&versionErr)
 		if versionErr == nil && keyIdent != version.JSON() {

--- a/internal/encryption/helpers.go
+++ b/internal/encryption/helpers.go
@@ -20,14 +20,14 @@ func MaybeEncrypt(ctx context.Context, key Key, data string) (_, keyIdent string
 		return data, "", nil
 	}
 
-	tr, trCtx := trace.DeprecatedNew(ctx, "key", "Encrypt")
+	tr, trCtx := trace.New(ctx, "key.Encrypt")
 	encrypted, err := key.Encrypt(trCtx, []byte(data))
 	tr.FinishWithErr(&err)
 	if err != nil {
 		return "", "", err
 	}
 
-	tr, trCtx = trace.DeprecatedNew(ctx, "key", "Version")
+	tr, trCtx = trace.New(ctx, "key.Version")
 	version, err := key.Version(trCtx)
 	tr.FinishWithErr(&err)
 	if err != nil {
@@ -50,11 +50,11 @@ func MaybeDecrypt(ctx context.Context, key Key, data, keyIdent string) (string, 
 		return data, errors.Errorf("key mismatch: value is encrypted but no encryption key available in site-config")
 	}
 
-	tr, innerCtx := trace.DeprecatedNew(ctx, "key", "Decrypt")
+	tr, innerCtx := trace.New(ctx, "key.Decrypt")
 	decrypted, err := key.Decrypt(innerCtx, []byte(data))
 	tr.FinishWithErr(&err)
 	if err != nil {
-		tr, innerCtx = trace.DeprecatedNew(ctx, "key", "Version")
+		tr, innerCtx = trace.New(ctx, "key.Version")
 		version, versionErr := key.Version(innerCtx)
 		tr.FinishWithErr(&versionErr)
 		if versionErr == nil && keyIdent != version.JSON() {

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -210,7 +210,7 @@ func (c *client) reqPage(ctx context.Context, url string, results any) (*PageTok
 }
 
 func (c *client) do(ctx context.Context, req *http.Request, result any) (code int, err error) {
-	tr, ctx := trace.New(ctx, "Bitbucket Cloud", "do")
+	tr, ctx := trace.DeprecatedNew(ctx, "Bitbucket Cloud", "do")
 	defer tr.FinishWithErr(&err)
 	req = req.WithContext(ctx)
 

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -210,7 +210,7 @@ func (c *client) reqPage(ctx context.Context, url string, results any) (*PageTok
 }
 
 func (c *client) do(ctx context.Context, req *http.Request, result any) (code int, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Bitbucket Cloud", "do")
+	tr, ctx := trace.New(ctx, "BitbucketCloud.do")
 	defer tr.FinishWithErr(&err)
 	req = req.WithContext(ctx)
 

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -975,7 +975,7 @@ func (c *Client) send(ctx context.Context, method, path string, qry url.Values, 
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (_ *http.Response, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Bitbucket Server", "do")
+	tr, ctx := trace.New(ctx, "BitbucketServer.do")
 	defer tr.FinishWithErr(&err)
 	req = req.WithContext(ctx)
 

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -975,7 +975,7 @@ func (c *Client) send(ctx context.Context, method, path string, qry url.Values, 
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request, result any) (_ *http.Response, err error) {
-	tr, ctx := trace.New(ctx, "Bitbucket Server", "do")
+	tr, ctx := trace.DeprecatedNew(ctx, "Bitbucket Server", "do")
 	defer tr.FinishWithErr(&err)
 	req = req.WithContext(ctx)
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1595,7 +1595,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 
 	var resp *http.Response
 
-	tr, ctx := trace.New(ctx, "GitHub", "",
+	tr, ctx := trace.DeprecatedNew(ctx, "GitHub", "",
 		attribute.Stringer("url", req.URL))
 	defer func() {
 		if resp != nil {

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1595,7 +1595,7 @@ func doRequest(ctx context.Context, logger log.Logger, apiURL *url.URL, auther a
 
 	var resp *http.Response
 
-	tr, ctx := trace.DeprecatedNew(ctx, "GitHub", "",
+	tr, ctx := trace.New(ctx, "GitHub",
 		attribute.Stringer("url", req.URL))
 	defer func() {
 		if resp != nil {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -252,7 +252,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	var resp *http.Response
 
-	tr, ctx := trace.New(ctx, "GitLab", "",
+	tr, ctx := trace.DeprecatedNew(ctx, "GitLab", "",
 		attribute.Stringer("url", req.URL))
 	defer func() {
 		if resp != nil {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -252,7 +252,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result any) (respons
 func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	var resp *http.Response
 
-	tr, ctx := trace.DeprecatedNew(ctx, "GitLab", "",
+	tr, ctx := trace.New(ctx, "GitLab",
 		attribute.Stringer("url", req.URL))
 	defer func() {
 		if resp != nil {

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -142,7 +142,7 @@ func (client *HTTPClient) makeGetRequest(ctx context.Context, doer httpcli.Doer,
 	}
 
 	do := func() (_ *http.Response, err error) {
-		tr, ctx := trace.New(ctx, "npm", "")
+		tr, ctx := trace.DeprecatedNew(ctx, "npm", "")
 		defer tr.FinishWithErr(&err)
 		req = req.WithContext(ctx)
 

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -142,7 +142,7 @@ func (client *HTTPClient) makeGetRequest(ctx context.Context, doer httpcli.Doer,
 	}
 
 	do := func() (_ *http.Response, err error) {
-		tr, ctx := trace.DeprecatedNew(ctx, "npm", "")
+		tr, ctx := trace.New(ctx, "npm")
 		defer tr.FinishWithErr(&err)
 		req = req.WithContext(ctx)
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -584,7 +584,7 @@ func (e badRequestError) BadRequest() bool { return true }
 func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	ctx, _, endObservation := c.execOp.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(c.repo)),
+		c.repo.Attr(),
 		attribute.StringSlice("args", c.args[1:]),
 	}})
 	done := func() {
@@ -753,7 +753,7 @@ func isRevisionNotFound(err string) bool {
 
 func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchRequest, onMatches func([]protocol.CommitMatch)) (limitHit bool, err error) {
 	ctx, _, endObservation := c.operations.search.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(args.Repo)),
+		args.Repo.Attr(),
 		attribute.Stringer("query", args.Query),
 		attribute.Bool("diff", args.IncludeDiff),
 		attribute.Int("limit", args.Limit),
@@ -1575,7 +1575,7 @@ func (c *clientImplementor) do(ctx context.Context, repoForTracing api.RepoName,
 	}
 
 	ctx, trLogger, endObservation := c.operations.do.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repoForTracing)),
+		repoForTracing.Attr(),
 		attribute.String("method", method),
 		attribute.String("path", parsedURL.Path),
 	}})

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -407,7 +407,7 @@ func (c *clientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 func (c *clientImplementor) ReadDir(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string, recurse bool) (_ []fs.FileInfo, err error) {
 	ctx, _, endObservation := c.operations.readDir.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.String("path", path),
 		attribute.Bool("recurse", recurse),
 	}})
@@ -497,7 +497,7 @@ func (oid objectInfo) OID() gitdomain.OID { return gitdomain.OID(oid) }
 // no attempt to follow the link.
 func (c *clientImplementor) lStat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (_ fs.FileInfo, err error) {
 	ctx, _, endObservation := c.operations.lstat.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.String("path", path),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1374,7 +1374,7 @@ func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoNam
 func (c *clientImplementor) ReadFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) (_ []byte, err error) {
 	ctx, _, endObservation := c.operations.readFile.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.String("name", name),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1399,7 +1399,7 @@ func (c *clientImplementor) NewFileReader(ctx context.Context, checker authz.Sub
 	// TODO: this does not capture the lifetime of the request since we return a reader
 	ctx, _, endObservation := c.operations.newFileReader.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.String("name", name),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1536,7 +1536,7 @@ func (br *blobReader) convertError(err error) error {
 // Stat returns a FileInfo describing the named file at commit.
 func (c *clientImplementor) Stat(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string) (_ fs.FileInfo, err error) {
 	ctx, _, endObservation := c.operations.stat.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("commit", string(commit)),
+		commit.Attr(),
 		attribute.String("path", path),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1641,7 +1641,7 @@ func (c *clientImplementor) getCommit(ctx context.Context, checker authz.SubRepo
 func (c *clientImplementor) GetCommit(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (_ *gitdomain.Commit, err error) {
 	ctx, _, endObservation := c.operations.getCommit.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		repo.Attr(),
-		attribute.String("commit", string(id)),
+		id.Attr(),
 		attribute.Bool("noEnsureRevision", opt.NoEnsureRevision),
 	}})
 	defer endObservation(1, observation.Args{})

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -406,7 +406,7 @@ func (c *clientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 // ReadDir reads the contents of the named directory at commit.
 func (c *clientImplementor) ReadDir(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, path string, recurse bool) (_ []fs.FileInfo, err error) {
 	ctx, _, endObservation := c.operations.readDir.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(commit)),
 		attribute.String("path", path),
 		attribute.Bool("recurse", recurse),
@@ -742,7 +742,7 @@ type Hunk struct {
 func (c *clientImplementor) StreamBlameFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, path string, opt *BlameOptions) (_ HunkReader, err error) {
 	ctx, _, endObservation := c.operations.streamBlameFile.With(ctx, &err, observation.Args{
 		Attrs: append([]attribute.KeyValue{
-			attribute.String("repo", string(repo)),
+			repo.Attr(),
 			attribute.String("path", path),
 		}, opt.Attrs()...),
 	})
@@ -797,7 +797,7 @@ func streamBlameFileCmd(ctx context.Context, checker authz.SubRepoPermissionChec
 func (c *clientImplementor) BlameFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, path string, opt *BlameOptions) (_ []*Hunk, err error) {
 	ctx, _, endObservation := c.operations.blameFile.With(ctx, &err, observation.Args{
 		Attrs: append([]attribute.KeyValue{
-			attribute.String("repo", string(repo)),
+			repo.Attr(),
 			attribute.String("path", path),
 		}, opt.Attrs()...),
 	})
@@ -990,7 +990,7 @@ func (c *clientImplementor) ResolveRevision(ctx context.Context, repo api.RepoNa
 	resolveRevisionCounter.WithLabelValues(labelEnsureRevisionValue).Inc()
 
 	ctx, _, endObservation := c.operations.resolveRevision.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("spec", spec),
 		attribute.Bool("noEnsureRevision", opt.NoEnsureRevision),
 	}})
@@ -1207,7 +1207,7 @@ func parseDirectoryChildren(dirnames, paths []string) map[string][]string {
 // ListTags returns a list of all tags in the repository. If commitObjs is non-empty, only all tags pointing at those commits are returned.
 func (c *clientImplementor) ListTags(ctx context.Context, repo api.RepoName, commitObjs ...string) (_ []*gitdomain.Tag, err error) {
 	ctx, _, endObservation := c.operations.listTags.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.StringSlice("commitObjs", commitObjs),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1339,7 +1339,7 @@ func RevListArgs(givenCommit string) []string {
 // revspecs).
 func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoName, left, right string) (_ *gitdomain.BehindAhead, err error) {
 	ctx, _, endObservation := c.operations.getBehindAhead.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("left", left),
 		attribute.String("right", right),
 	}})
@@ -1373,7 +1373,7 @@ func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoNam
 // file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
 func (c *clientImplementor) ReadFile(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) (_ []byte, err error) {
 	ctx, _, endObservation := c.operations.readFile.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(commit)),
 		attribute.String("name", name),
 	}})
@@ -1398,7 +1398,7 @@ func (c *clientImplementor) ReadFile(ctx context.Context, checker authz.SubRepoP
 func (c *clientImplementor) NewFileReader(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit api.CommitID, name string) (_ io.ReadCloser, err error) {
 	// TODO: this does not capture the lifetime of the request since we return a reader
 	ctx, _, endObservation := c.operations.newFileReader.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(commit)),
 		attribute.String("name", name),
 	}})
@@ -1640,7 +1640,7 @@ func (c *clientImplementor) getCommit(ctx context.Context, checker authz.SubRepo
 // the repository or if the commit must be fetched from the remote.
 func (c *clientImplementor) GetCommit(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, id api.CommitID, opt ResolveRevisionOptions) (_ *gitdomain.Commit, err error) {
 	ctx, _, endObservation := c.operations.getCommit.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("commit", string(id)),
 		attribute.Bool("noEnsureRevision", opt.NoEnsureRevision),
 	}})
@@ -1653,7 +1653,7 @@ func (c *clientImplementor) GetCommit(ctx context.Context, checker authz.SubRepo
 func (c *clientImplementor) Commits(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, opt CommitsOptions) (_ []*gitdomain.Commit, err error) {
 	opt = addNameOnly(opt, checker)
 	ctx, _, endObservation := c.operations.commits.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("opts", fmt.Sprintf("%#v", opt)),
 	}})
 	defer endObservation(1, observation.Args{})
@@ -1771,7 +1771,7 @@ func parseCommitsUniqueToBranch(lines []string) (_ map[string]time.Time, err err
 // contains a commit past a specified date.
 func (c *clientImplementor) HasCommitAfter(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, date string, revspec string) (_ bool, err error) {
 	ctx, _, endObservation := c.operations.hasCommitAfter.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 		attribute.String("date", date),
 		attribute.String("revSpec", revspec),
 	}})
@@ -2014,7 +2014,7 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 // FirstEverCommit returns the first commit ever made to the repository.
 func (c *clientImplementor) FirstEverCommit(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName) (_ *gitdomain.Commit, err error) {
 	ctx, _, endObservation := c.operations.firstEverCommit.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -2509,7 +2509,7 @@ func (c *clientImplementor) ArchiveReader(
 	// TODO: this does not capture the lifetime of the request because we return a reader
 	ctx, _, endObservation := c.operations.archiveReader.With(ctx, &err, observation.Args{
 		Attrs: append(
-			[]attribute.KeyValue{attribute.String("repo", string(repo))},
+			[]attribute.KeyValue{repo.Attr()},
 			options.Attrs()...,
 		),
 	})
@@ -2718,7 +2718,7 @@ func (f branchFilter) add(list []string) {
 func (c *clientImplementor) ListBranches(ctx context.Context, repo api.RepoName, opt BranchesOptions) (_ []*gitdomain.Branch, err error) {
 	ctx, _, endObservation := c.operations.listBranches.With(ctx, &err, observation.Args{
 		Attrs: append(
-			[]attribute.KeyValue{attribute.String("repo", string(repo))},
+			[]attribute.KeyValue{repo.Attr()},
 			opt.Attrs()...,
 		),
 	})
@@ -2796,7 +2796,7 @@ func (p byteSlices) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 // ListRefs returns a list of all refs in the repository.
 func (c *clientImplementor) ListRefs(ctx context.Context, repo api.RepoName) (_ []gitdomain.Ref, err error) {
 	ctx, _, endObservation := c.operations.listRefs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
-		attribute.String("repo", string(repo)),
+		repo.Attr(),
 	}})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/gitserver/proxy.go
+++ b/internal/gitserver/proxy.go
@@ -37,8 +37,8 @@ type ReverseProxy struct {
 // to gitserver. The director must rewrite the request to the correct gitserver address, which
 // should be obtained via a gitserver client's AddrForRepo method.
 func (p *ReverseProxy) ServeHTTP(repo api.RepoName, method, op string, director func(req *http.Request), res http.ResponseWriter, req *http.Request) {
-	tr, _ := trace.DeprecatedNew(req.Context(), "ReverseProxy", "ServeHTTP",
-		attribute.String("repo", string(repo)),
+	tr, _ := trace.New(req.Context(), "ReverseProxy.ServeHTTP",
+		repo.Attr(),
 		attribute.String("method", method),
 		attribute.String("op", op))
 	defer tr.Finish()

--- a/internal/gitserver/proxy.go
+++ b/internal/gitserver/proxy.go
@@ -37,7 +37,7 @@ type ReverseProxy struct {
 // to gitserver. The director must rewrite the request to the correct gitserver address, which
 // should be obtained via a gitserver client's AddrForRepo method.
 func (p *ReverseProxy) ServeHTTP(repo api.RepoName, method, op string, director func(req *http.Request), res http.ResponseWriter, req *http.Request) {
-	tr, _ := trace.New(req.Context(), "ReverseProxy", "ServeHTTP",
+	tr, _ := trace.DeprecatedNew(req.Context(), "ReverseProxy", "ServeHTTP",
 		attribute.String("repo", string(repo)),
 		attribute.String("method", method),
 		attribute.String("op", op))

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -176,7 +176,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 	// Normalize filetype
 	q.Filetype = languages.NormalizeLanguage(q.Filetype)
 
-	tr, ctx := trace.DeprecatedNew(ctx, "gosyntect", "Highlight",
+	tr, ctx := trace.New(ctx, "gosyntect.Highlight",
 		attribute.String("filepath", q.Filepath),
 		attribute.String("theme", q.Theme),
 		attribute.Bool("css", q.CSS))

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -176,7 +176,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 	// Normalize filetype
 	q.Filetype = languages.NormalizeLanguage(q.Filetype)
 
-	tr, ctx := trace.New(ctx, "gosyntect", "Highlight",
+	tr, ctx := trace.DeprecatedNew(ctx, "gosyntect", "Highlight",
 		attribute.String("filepath", q.Filepath),
 		attribute.String("theme", q.Theme),
 		attribute.Bool("css", q.CSS))

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -83,7 +83,7 @@ func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func (t *externalTransport) update(ctx context.Context, config *schema.TlsExternal) *http.Transport {
 	// No function calls here use the context further
-	tr, _ := trace.DeprecatedNew(ctx, "externalTransport", "update")
+	tr, _ := trace.New(ctx, "externalTransport.update")
 	defer tr.Finish()
 
 	t.mu.Lock()

--- a/internal/httpcli/external.go
+++ b/internal/httpcli/external.go
@@ -83,7 +83,7 @@ func (t *externalTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func (t *externalTransport) update(ctx context.Context, config *schema.TlsExternal) *http.Transport {
 	// No function calls here use the context further
-	tr, _ := trace.New(ctx, "externalTransport", "update")
+	tr, _ := trace.DeprecatedNew(ctx, "externalTransport", "update")
 	defer tr.Finish()
 
 	t.mu.Lock()

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -322,7 +322,7 @@ func (op *Operation) startTrace(ctx context.Context) (*trace.Trace, context.Cont
 		return nil, ctx
 	}
 
-	tr, ctx := op.context.Tracer.New(ctx, op.kebabName, "")
+	tr, ctx := op.context.Tracer.New(ctx, op.kebabName)
 	return tr, ctx
 }
 

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -208,7 +208,7 @@ func (s *store) trace(ctx context.Context, family string) (*trace.Trace, context
 	if txctx == nil {
 		txctx = ctx
 	}
-	tr, txctx := s.Tracer.New(txctx, family, "")
+	tr, txctx := s.Tracer.New(txctx, family)
 	ctx = trace.CopyContext(ctx, txctx)
 	return tr, ctx
 }

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -291,7 +291,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 
 	logger.Debug("SyncRepo started")
 
-	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", string(name))
+	tr, ctx := trace.DeprecatedNew(ctx, "Syncer.SyncRepo", string(name))
 	defer tr.Finish()
 
 	repo, err = s.Store.RepoStore().GetByName(ctx, name)
@@ -879,7 +879,7 @@ func (s *Syncer) observeSync(
 	family, title string,
 ) (context.Context, func(*types.ExternalService, error)) {
 	began := s.Now()
-	tr, ctx := trace.New(ctx, family, title)
+	tr, ctx := trace.DeprecatedNew(ctx, family, title)
 
 	return ctx, func(svc *types.ExternalService, err error) {
 		var owner string

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -292,7 +292,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 
 	logger.Debug("SyncRepo started")
 
-	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", attribute.String("repo", string(name)))
+	tr, ctx := trace.New(ctx, "Syncer.SyncRepo", name.Attr())
 	defer tr.Finish()
 
 	repo, err = s.Store.RepoStore().GetByName(ctx, name)

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -127,7 +127,7 @@ func (c *Client) RepoLookup(
 		return MockRepoLookup(args)
 	}
 
-	tr, ctx := trace.New(ctx, "repoupdater", "RepoLookup",
+	tr, ctx := trace.DeprecatedNew(ctx, "repoupdater", "RepoLookup",
 		attribute.String("repo", string(args.Repo)))
 	defer func() {
 		if result != nil {
@@ -442,7 +442,7 @@ func (c *Client) httpPost(ctx context.Context, method string, payload any) (resp
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
-	tr, ctx := trace.New(ctx, "repoupdater", "do")
+	tr, ctx := trace.DeprecatedNew(ctx, "repoupdater", "do")
 	defer tr.FinishWithErr(&err)
 
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -127,7 +127,7 @@ func (c *Client) RepoLookup(
 		return MockRepoLookup(args)
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "repoupdater", "RepoLookup",
+	tr, ctx := trace.New(ctx, "repoupdater.RepoLookup",
 		attribute.String("repo", string(args.Repo)))
 	defer func() {
 		if result != nil {
@@ -442,7 +442,7 @@ func (c *Client) httpPost(ctx context.Context, method string, payload any) (resp
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "repoupdater", "do")
+	tr, ctx := trace.New(ctx, "repoupdater.do")
 	defer tr.FinishWithErr(&err)
 
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -128,7 +128,7 @@ func (c *Client) RepoLookup(
 	}
 
 	tr, ctx := trace.New(ctx, "repoupdater.RepoLookup",
-		attribute.String("repo", string(args.Repo)))
+		args.Repo.Attr())
 	defer func() {
 		if result != nil {
 			tr.SetAttributes(attribute.Bool("found", result.Repo != nil))

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -71,7 +71,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		event.AddAttributes(attrs)
 	}
 
-	tr, ctx := trace.New(ctx, "zoekt."+cat, qStr, attrs...)
+	tr, ctx := trace.DeprecatedNew(ctx, "zoekt."+cat, qStr, attrs...)
 	defer func() {
 		tr.SetErrorIfNotContext(err)
 		tr.Finish()
@@ -232,7 +232,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListO
 
 	qStr := queryString(q)
 
-	tr, ctx := trace.New(ctx, "zoekt", cat, attrs...)
+	tr, ctx := trace.DeprecatedNew(ctx, "zoekt", cat, attrs...)
 	tr.SetAttributes(
 		attribute.Stringer("opts", opts),
 		attribute.String("query", qStr),

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -97,7 +97,7 @@ func (s *searchClient) Plan(
 	searchMode search.Mode,
 	protocol search.Protocol,
 ) (_ *search.Inputs, err error) {
-	tr, ctx := trace.New(ctx, "NewSearchInputs", searchQuery)
+	tr, ctx := trace.DeprecatedNew(ctx, "NewSearchInputs", searchQuery)
 	defer tr.FinishWithErr(&err)
 
 	searchType, err := detectSearchType(version, patternType)
@@ -159,7 +159,7 @@ func (s *searchClient) Execute(
 	stream streaming.Sender,
 	inputs *search.Inputs,
 ) (_ *search.Alert, err error) {
-	tr, ctx := trace.New(ctx, "Execute", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "Execute", "")
 	defer tr.FinishWithErr(&err)
 
 	planJob, err := jobutil.NewPlanJob(inputs, inputs.Plan, s.enterpriseJobs)

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -97,7 +97,7 @@ func (s *searchClient) Plan(
 	searchMode search.Mode,
 	protocol search.Protocol,
 ) (_ *search.Inputs, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "NewSearchInputs", searchQuery)
+	tr, ctx := trace.New(ctx, "NewSearchInputs", attribute.String("query", searchQuery))
 	defer tr.FinishWithErr(&err)
 
 	searchType, err := detectSearchType(version, patternType)
@@ -159,7 +159,7 @@ func (s *searchClient) Execute(
 	stream streaming.Sender,
 	inputs *search.Inputs,
 ) (_ *search.Alert, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Execute", "")
+	tr, ctx := trace.New(ctx, "Execute")
 	defer tr.FinishWithErr(&err)
 
 	planJob, err := jobutil.NewPlanJob(inputs, inputs.Plan, s.enterpriseJobs)

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -70,7 +70,7 @@ func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
 // only be called after a search result is performed, because it relies on the
 // invariant that query and pattern error checking has already been performed.
 func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, duration time.Duration) {
-	tr, ctx := trace.DeprecatedNew(ctx, "LogSearchDuration", "")
+	tr, ctx := trace.New(ctx, "LogSearchDuration")
 	defer tr.Finish()
 
 	var types []string

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -70,7 +70,7 @@ func (l *LogJob) MapChildren(fn job.MapFunc) job.Job {
 // only be called after a search result is performed, because it relies on the
 // invariant that query and pattern error checking has already been performed.
 func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, duration time.Duration) {
-	tr, ctx := trace.New(ctx, "LogSearchDuration", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "LogSearchDuration", "")
 	defer tr.Finish()
 
 	var types []string

--- a/internal/search/job/observe.go
+++ b/internal/search/job/observe.go
@@ -14,7 +14,7 @@ import (
 type finishSpanFunc func(*search.Alert, error)
 
 func StartSpan(ctx context.Context, stream streaming.Sender, job Job) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
-	tr, ctx := trace.DeprecatedNew(ctx, job.Name(), "")
+	tr, ctx := trace.New(ctx, job.Name())
 	tr.SetAttributes(job.Attributes(VerbosityMax)...)
 
 	observingStream := newObservingStream(tr, stream)

--- a/internal/search/job/observe.go
+++ b/internal/search/job/observe.go
@@ -14,7 +14,7 @@ import (
 type finishSpanFunc func(*search.Alert, error)
 
 func StartSpan(ctx context.Context, stream streaming.Sender, job Job) (*trace.Trace, context.Context, streaming.Sender, finishSpanFunc) {
-	tr, ctx := trace.New(ctx, job.Name(), "")
+	tr, ctx := trace.DeprecatedNew(ctx, job.Name(), "")
 	tr.SetAttributes(job.Attributes(VerbosityMax)...)
 
 	observingStream := newObservingStream(tr, stream)

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -116,7 +116,7 @@ func (r *Resolver) Iterator(ctx context.Context, opts search.RepoOptions) *itera
 }
 
 func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolved, errs error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "searchrepos.Resolve", op.String())
+	tr, ctx := trace.New(ctx, "searchrepos.Resolve", attribute.Stringer("opts", &op))
 	defer tr.FinishWithErr(&errs)
 
 	excludePatterns := op.MinusRepoFilters
@@ -532,7 +532,7 @@ func (r *Resolver) filterRepoHasFileContent(
 	_ int,
 	err error,
 ) {
-	tr, ctx := trace.DeprecatedNew(ctx, "Resolve.FilterHasFileContent", "")
+	tr, ctx := trace.New(ctx, "Resolve.FilterHasFileContent")
 	tr.SetAttributes(attribute.Int("inputRevCount", len(repoRevs)))
 	defer func() {
 		tr.SetError(err)
@@ -756,7 +756,7 @@ func (r *Resolver) repoHasFileContentAtCommit(ctx context.Context, repo types.Mi
 // computeExcludedRepos computes the ExcludedRepos that the given RepoOptions would not match. This is
 // used to show in the search UI what repos are excluded precisely.
 func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOptions) (ex ExcludedRepos, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "searchrepos.Excluded", op.String())
+	tr, ctx := trace.New(ctx, "searchrepos.Excluded", attribute.Stringer("opts", &op))
 	defer func() {
 		tr.SetAttributes(
 			attribute.Int("excludedForks", ex.Forks),

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -116,7 +116,7 @@ func (r *Resolver) Iterator(ctx context.Context, opts search.RepoOptions) *itera
 }
 
 func (r *Resolver) Resolve(ctx context.Context, op search.RepoOptions) (_ Resolved, errs error) {
-	tr, ctx := trace.New(ctx, "searchrepos.Resolve", op.String())
+	tr, ctx := trace.DeprecatedNew(ctx, "searchrepos.Resolve", op.String())
 	defer tr.FinishWithErr(&errs)
 
 	excludePatterns := op.MinusRepoFilters
@@ -532,7 +532,7 @@ func (r *Resolver) filterRepoHasFileContent(
 	_ int,
 	err error,
 ) {
-	tr, ctx := trace.New(ctx, "Resolve.FilterHasFileContent", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "Resolve.FilterHasFileContent", "")
 	tr.SetAttributes(attribute.Int("inputRevCount", len(repoRevs)))
 	defer func() {
 		tr.SetError(err)
@@ -756,7 +756,7 @@ func (r *Resolver) repoHasFileContentAtCommit(ctx context.Context, repo types.Mi
 // computeExcludedRepos computes the ExcludedRepos that the given RepoOptions would not match. This is
 // used to show in the search UI what repos are excluded precisely.
 func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOptions) (ex ExcludedRepos, err error) {
-	tr, ctx := trace.New(ctx, "searchrepos.Excluded", op.String())
+	tr, ctx := trace.DeprecatedNew(ctx, "searchrepos.Excluded", op.String())
 	defer func() {
 		tr.SetAttributes(
 			attribute.Int("excludedForks", ex.Forks),

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -57,7 +57,7 @@ func ParseSearchContextSpec(searchContextSpec string) ParsedSearchContextSpec {
 }
 
 func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContextSpec string) (sc *types.SearchContext, err error) {
-	tr, ctx := trace.New(ctx, "ResolveSearchContextSpec", searchContextSpec)
+	tr, ctx := trace.DeprecatedNew(ctx, "ResolveSearchContextSpec", searchContextSpec)
 	defer func() {
 		tr.AddEvent("resolved search context", attribute.String("searchContext", fmt.Sprintf("%+v", sc)))
 		tr.SetErrorIfNotContext(err)

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -57,7 +57,7 @@ func ParseSearchContextSpec(searchContextSpec string) ParsedSearchContextSpec {
 }
 
 func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContextSpec string) (sc *types.SearchContext, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "ResolveSearchContextSpec", searchContextSpec)
+	tr, ctx := trace.New(ctx, "ResolveSearchContextSpec", attribute.String("searchContextSpec", searchContextSpec))
 	defer func() {
 		tr.AddEvent("resolved search context", attribute.String("searchContext", fmt.Sprintf("%+v", sc)))
 		tr.SetErrorIfNotContext(err)

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"time"

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -45,7 +45,7 @@ func Search(
 		return MockSearch(ctx, repo, repoID, commit, p, fetchTimeout, onMatches)
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo, commit))
+	tr, ctx := trace.New(ctx, "searcher.client", repo.Attr(), commit.Attr())
 	defer tr.FinishWithErr(&err)
 
 	r := protocol.Request{
@@ -122,7 +122,7 @@ func Search(
 }
 
 func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*protocol.FileMatch)) (_ bool, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "searcher", "textSearchStream")
+	tr, ctx := trace.New(ctx, "searcher.textSearchStream")
 	defer tr.FinishWithErr(&err)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, bytes.NewReader(body))

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -45,7 +45,7 @@ func Search(
 		return MockSearch(ctx, repo, repoID, commit, p, fetchTimeout, onMatches)
 	}
 
-	tr, ctx := trace.New(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo, commit))
+	tr, ctx := trace.DeprecatedNew(ctx, "searcher.client", fmt.Sprintf("%s@%s", repo, commit))
 	defer tr.FinishWithErr(&err)
 
 	r := protocol.Request{
@@ -122,7 +122,7 @@ func Search(
 }
 
 func textSearchStream(ctx context.Context, url string, body []byte, cb func([]*protocol.FileMatch)) (_ bool, err error) {
-	tr, ctx := trace.New(ctx, "searcher", "textSearchStream")
+	tr, ctx := trace.DeprecatedNew(ctx, "searcher", "textSearchStream")
 	defer tr.FinishWithErr(&err)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, bytes.NewReader(body))

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -113,7 +113,7 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.SearcherURLs, clients.SearcherGRPCConnectionCache, repo, repo.Name, rev, s.Indexed, s.PatternInfo, fetchTimeout, stream)
 					if err != nil {
 						tr.SetAttributes(
-							attribute.String("repo", string(repo.Name)),
+							repo.Name.Attr(),
 							trace.Error(err),
 							attribute.Bool("timeout", errcode.IsTimeout(err)),
 							attribute.Bool("temporary", errcode.IsTemporary(err)))

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -88,7 +88,7 @@ func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
 func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
 	inputRev := repoRevs.Revs[0]
-	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "searchInRepo",
+	tr, ctx := trace.New(ctx, "symbols.searchInRepo",
 		attribute.String("repo", string(repoRevs.Repo.Name)),
 		attribute.String("rev", inputRev))
 	defer tr.FinishWithErr(&err)

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -88,7 +88,7 @@ func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
 func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
 	inputRev := repoRevs.Revs[0]
-	tr, ctx := trace.New(ctx, "symbols", "searchInRepo",
+	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "searchInRepo",
 		attribute.String("repo", string(repoRevs.Repo.Name)),
 		attribute.String("rev", inputRev))
 	defer tr.FinishWithErr(&err)

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -101,7 +101,7 @@ func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, pat
 	if err != nil {
 		return nil, err
 	}
-	tr.SetAttributes(attribute.String("commit", string(commitID)))
+	tr.SetAttributes(commitID.Attr())
 
 	symbols, err := backend.Symbols.ListTags(ctx, search.SymbolsParameters{
 		Repo:            repoRevs.Repo.Name,

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -56,7 +56,7 @@ func (s *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 				},
 			})
 			if err != nil {
-				tr.SetAttributes(attribute.String("repo", string(repoRevs.Repo.Name)), trace.Error(err))
+				tr.SetAttributes(repoRevs.Repo.Name.Attr(), trace.Error(err))
 			}
 			return err
 		})
@@ -89,7 +89,7 @@ func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 func searchInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
 	inputRev := repoRevs.Revs[0]
 	tr, ctx := trace.New(ctx, "symbols.searchInRepo",
-		attribute.String("repo", string(repoRevs.Repo.Name)),
+		repoRevs.Repo.Name.Attr(),
 		attribute.String("rev", inputRev))
 	defer tr.FinishWithErr(&err)
 

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -224,7 +224,7 @@ func PartitionRepos(
 		return &IndexedRepoRevs{}, repos, nil
 	}
 
-	tr, ctx := trace.DeprecatedNew(ctx, "PartitionRepos", string(typ))
+	tr, ctx := trace.New(ctx, "PartitionRepos", attribute.String("type", string(typ)))
 	defer tr.FinishWithErr(&err)
 
 	// Only include indexes with symbol information if a symbol request.
@@ -755,7 +755,7 @@ func (t *GlobalTextSearchJob) MapChildren(job.MapFunc) job.Job { return t }
 // only the repos directly added by the user. Otherwise it's all repos the user has
 // access to on all connected code hosts / external services.
 func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
-	tr, ctx := trace.DeprecatedNew(ctx, "privateReposForActor", "")
+	tr, ctx := trace.New(ctx, "privateReposForActor")
 	defer tr.Finish()
 
 	userID := int32(0)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -224,7 +224,7 @@ func PartitionRepos(
 		return &IndexedRepoRevs{}, repos, nil
 	}
 
-	tr, ctx := trace.New(ctx, "PartitionRepos", string(typ))
+	tr, ctx := trace.DeprecatedNew(ctx, "PartitionRepos", string(typ))
 	defer tr.FinishWithErr(&err)
 
 	// Only include indexes with symbol information if a symbol request.
@@ -755,7 +755,7 @@ func (t *GlobalTextSearchJob) MapChildren(job.MapFunc) job.Job { return t }
 // only the repos directly added by the user. Otherwise it's all repos the user has
 // access to on all connected code hosts / external services.
 func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
-	tr, ctx := trace.New(ctx, "privateReposForActor", "")
+	tr, ctx := trace.DeprecatedNew(ctx, "privateReposForActor", "")
 	defer tr.Finish()
 
 	userID := int32(0)

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -718,7 +718,7 @@ func TestContextWithoutDeadline(t *testing.T) {
 	ctxWithDeadline, cancelWithDeadline := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelWithDeadline()
 
-	tr, ctxWithDeadline := trace.DeprecatedNew(ctxWithDeadline, "", "")
+	tr, ctxWithDeadline := trace.New(ctxWithDeadline, "")
 
 	if _, ok := ctxWithDeadline.Deadline(); !ok {
 		t.Fatal("expected context to have deadline")

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -718,7 +718,7 @@ func TestContextWithoutDeadline(t *testing.T) {
 	ctxWithDeadline, cancelWithDeadline := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelWithDeadline()
 
-	tr, ctxWithDeadline := trace.New(ctxWithDeadline, "", "")
+	tr, ctxWithDeadline := trace.DeprecatedNew(ctxWithDeadline, "", "")
 
 	if _, ok := ctxWithDeadline.Deadline(); !ok {
 		t.Fatal("expected context to have deadline")

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -371,7 +371,7 @@ func CookieMiddlewareWithCSRFSafety(
 }
 
 func authenticateByCookie(logger log.Logger, db database.DB, r *http.Request, w http.ResponseWriter) context.Context {
-	span, ctx := trace.DeprecatedNew(r.Context(), "session", "authenticateByCookie")
+	span, ctx := trace.New(r.Context(), "session.authenticateByCookie")
 	defer span.Finish()
 	logger = trace.Logger(ctx, logger)
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -371,7 +371,7 @@ func CookieMiddlewareWithCSRFSafety(
 }
 
 func authenticateByCookie(logger log.Logger, db database.DB, r *http.Request, w http.ResponseWriter) context.Context {
-	span, ctx := trace.New(r.Context(), "session", "authenticateByCookie")
+	span, ctx := trace.DeprecatedNew(r.Context(), "session", "authenticateByCookie")
 	defer span.Finish()
 	logger = trace.Logger(ctx, logger)
 

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -72,7 +72,7 @@ func (s *service) UserFromContext(ctx context.Context) (*schema.Settings, error)
 }
 
 func (s *service) ForSubject(ctx context.Context, subject api.SettingsSubject) (_ *schema.Settings, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "settings", "ForSubject")
+	tr, ctx := trace.New(ctx, "settings.ForSubject")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -72,7 +72,7 @@ func (s *service) UserFromContext(ctx context.Context) (*schema.Settings, error)
 }
 
 func (s *service) ForSubject(ctx context.Context, subject api.SettingsSubject) (_ *schema.Settings, err error) {
-	tr, ctx := trace.New(ctx, "settings", "ForSubject")
+	tr, ctx := trace.DeprecatedNew(ctx, "settings", "ForSubject")
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -172,7 +172,7 @@ func (c *Client) listLanguageMappingsJSON(ctx context.Context, repository api.Re
 
 // Search performs a symbol search on the symbols service.
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
-	tr, ctx := trace.New(ctx, "symbols", "Search",
+	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "Search",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.CommitID)))
 	defer tr.FinishWithErr(&err)
@@ -272,7 +272,7 @@ func (c *Client) searchJSON(ctx context.Context, args search.SymbolsParameters) 
 }
 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
-	tr, ctx := trace.New(ctx, "symbols", "LocalCodeIntel",
+	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "LocalCodeIntel",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
@@ -337,7 +337,7 @@ func (c *Client) localCodeIntelJSON(ctx context.Context, args types.RepoCommitPa
 }
 
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
-	tr, ctx := trace.New(ctx, "squirrel", "SymbolInfo",
+	tr, ctx := trace.DeprecatedNew(ctx, "squirrel", "SymbolInfo",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
@@ -442,7 +442,7 @@ func (c *Client) httpPost(
 	repo api.RepoName,
 	payload any,
 ) (resp *http.Response, err error) {
-	tr, ctx := trace.New(ctx, "symbols", "httpPost",
+	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "httpPost",
 		attribute.String("method", method),
 		attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -172,7 +172,7 @@ func (c *Client) listLanguageMappingsJSON(ctx context.Context, repository api.Re
 
 // Search performs a symbol search on the symbols service.
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "Search",
+	tr, ctx := trace.New(ctx, "symbols.Search",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.CommitID)))
 	defer tr.FinishWithErr(&err)
@@ -272,7 +272,7 @@ func (c *Client) searchJSON(ctx context.Context, args search.SymbolsParameters) 
 }
 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "LocalCodeIntel",
+	tr, ctx := trace.New(ctx, "symbols.LocalCodeIntel",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
@@ -337,7 +337,7 @@ func (c *Client) localCodeIntelJSON(ctx context.Context, args types.RepoCommitPa
 }
 
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "squirrel", "SymbolInfo",
+	tr, ctx := trace.New(ctx, "squirrel.SymbolInfo",
 		attribute.String("repo", string(args.Repo)),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
@@ -442,7 +442,7 @@ func (c *Client) httpPost(
 	repo api.RepoName,
 	payload any,
 ) (resp *http.Response, err error) {
-	tr, ctx := trace.DeprecatedNew(ctx, "symbols", "httpPost",
+	tr, ctx := trace.New(ctx, "symbols.httpPost",
 		attribute.String("method", method),
 		attribute.String("repo", string(repo)))
 	defer tr.FinishWithErr(&err)

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -173,7 +173,7 @@ func (c *Client) listLanguageMappingsJSON(ctx context.Context, repository api.Re
 // Search performs a symbol search on the symbols service.
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
 	tr, ctx := trace.New(ctx, "symbols.Search",
-		attribute.String("repo", string(args.Repo)),
+		args.Repo.Attr(),
 		attribute.String("commitID", string(args.CommitID)))
 	defer tr.FinishWithErr(&err)
 
@@ -273,7 +273,7 @@ func (c *Client) searchJSON(ctx context.Context, args search.SymbolsParameters) 
 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
 	tr, ctx := trace.New(ctx, "symbols.LocalCodeIntel",
-		attribute.String("repo", string(args.Repo)),
+		attribute.String("repo", args.Repo),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
 
@@ -338,7 +338,7 @@ func (c *Client) localCodeIntelJSON(ctx context.Context, args types.RepoCommitPa
 
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
 	tr, ctx := trace.New(ctx, "squirrel.SymbolInfo",
-		attribute.String("repo", string(args.Repo)),
+		attribute.String("repo", args.Repo),
 		attribute.String("commitID", string(args.Commit)))
 	defer tr.FinishWithErr(&err)
 
@@ -444,7 +444,7 @@ func (c *Client) httpPost(
 ) (resp *http.Response, err error) {
 	tr, ctx := trace.New(ctx, "symbols.httpPost",
 		attribute.String("method", method),
-		attribute.String("repo", string(repo)))
+		repo.Attr())
 	defer tr.FinishWithErr(&err)
 
 	symbolsURL, err := c.url(repo)

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -174,7 +174,7 @@ func (c *Client) listLanguageMappingsJSON(ctx context.Context, repository api.Re
 func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (symbols result.Symbols, err error) {
 	tr, ctx := trace.New(ctx, "symbols.Search",
 		args.Repo.Attr(),
-		attribute.String("commitID", string(args.CommitID)))
+		args.CommitID.Attr())
 	defer tr.FinishWithErr(&err)
 
 	var response search.SymbolsResponse
@@ -274,7 +274,7 @@ func (c *Client) searchJSON(ctx context.Context, args search.SymbolsParameters) 
 func (c *Client) LocalCodeIntel(ctx context.Context, args types.RepoCommitPath) (result *types.LocalCodeIntelPayload, err error) {
 	tr, ctx := trace.New(ctx, "symbols.LocalCodeIntel",
 		attribute.String("repo", args.Repo),
-		attribute.String("commitID", string(args.Commit)))
+		attribute.String("commitID", args.Commit))
 	defer tr.FinishWithErr(&err)
 
 	if internalgrpc.IsGRPCEnabled(ctx) {
@@ -339,7 +339,7 @@ func (c *Client) localCodeIntelJSON(ctx context.Context, args types.RepoCommitPa
 func (c *Client) SymbolInfo(ctx context.Context, args types.RepoCommitPathPoint) (result *types.SymbolInfo, err error) {
 	tr, ctx := trace.New(ctx, "squirrel.SymbolInfo",
 		attribute.String("repo", args.Repo),
-		attribute.String("commitID", string(args.Commit)))
+		attribute.String("commitID", args.Commit))
 	defer tr.FinishWithErr(&err)
 
 	if internalgrpc.IsGRPCEnabled(ctx) {

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -15,8 +15,8 @@ import (
 func Logger(ctx context.Context, l log.Logger) log.Logger {
 	// Attach details about internal/trace
 	if t := TraceFromContext(ctx); t != nil {
-		if t.family != "" {
-			l = l.With(log.String("trace.family", t.family))
+		if t.name != "" {
+			l = l.With(log.String("trace.family", t.name))
 		}
 	}
 	// Attach any trace (WithTrace no-ops if empty trace is provided)

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -9,8 +9,6 @@ import (
 // Logger will set the TraceContext on l if ctx has one. This is an expanded
 // convenience function around l.WithTrace for the common case.
 //
-// If you already set the family manually on the logger scope, then you might
-// want to use trace.Context(ctx) instead.
 func Logger(ctx context.Context, l log.Logger) log.Logger {
 	// Attach any trace (WithTrace no-ops if empty trace is provided)
 	return l.WithTrace(Context(ctx))

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -6,19 +6,12 @@ import (
 	"github.com/sourcegraph/log"
 )
 
-// Logger will set the TraceContext on l if ctx has one, and also assign the trace
-// family as a scope if a trace family is found. This is an expanded convenience function
-// around l.WithTrace for the common case.
+// Logger will set the TraceContext on l if ctx has one. This is an expanded
+// convenience function around l.WithTrace for the common case.
 //
-// If you already set the family manually on the logger scope, then you might want to use
-// trace.Context(ctx) instead.
+// If you already set the family manually on the logger scope, then you might
+// want to use trace.Context(ctx) instead.
 func Logger(ctx context.Context, l log.Logger) log.Logger {
-	// Attach details about internal/trace
-	if t := TraceFromContext(ctx); t != nil {
-		if t.name != "" {
-			l = l.With(log.String("trace.family", t.name))
-		}
-	}
 	// Attach any trace (WithTrace no-ops if empty trace is provided)
 	return l.WithTrace(Context(ctx))
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -15,7 +15,7 @@ import (
 // golang.org/x/net/trace.Trace, applying its various API functions to both
 // underlying trace types. Use New to construct one.
 type Trace struct {
-	family string
+	name string
 
 	// oteltraceSpan is always set.
 	oteltraceSpan oteltrace.Span

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -21,8 +21,8 @@ type Trace struct {
 	oteltraceSpan oteltrace.Span
 }
 
-// New returns a new Trace with the specified family and title.
-func New(ctx context.Context, family, title string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
+// DeprecatedNew returns a new Trace with the specified family and title.
+func DeprecatedNew(ctx context.Context, family, title string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
 	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
 	return tr.New(ctx, family, title, attrs...)
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -21,13 +21,6 @@ type Trace struct {
 	oteltraceSpan oteltrace.Span
 }
 
-// DeprecatedNew returns a new Trace with the specified family and title.
-// DEPRECATED: use New instead.
-func DeprecatedNew(ctx context.Context, family, title string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
-	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
-	return tr.New(ctx, family, title, attrs...)
-}
-
 // New returns a new Trace with the specified name.
 // For tips on naming, see the OpenTelemetry Span documentation:
 // https://opentelemetry.io/docs/specs/otel/trace/api/#span

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -22,9 +22,16 @@ type Trace struct {
 }
 
 // DeprecatedNew returns a new Trace with the specified family and title.
+// DEPRECATED: use New instead.
 func DeprecatedNew(ctx context.Context, family, title string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
 	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
 	return tr.New(ctx, family, title, attrs...)
+}
+
+// New returns a new Trace with the specified name.
+func New(ctx context.Context, name string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
+	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
+	return tr.New(ctx, name, "", attrs...)
 }
 
 // SetAttributes sets kv as attributes of the Span.

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -26,7 +26,7 @@ type Trace struct {
 // https://opentelemetry.io/docs/specs/otel/trace/api/#span
 func New(ctx context.Context, name string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
 	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
-	return tr.New(ctx, name, "", attrs...)
+	return tr.New(ctx, name, attrs...)
 }
 
 // SetAttributes sets kv as attributes of the Span.

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -29,6 +29,8 @@ func DeprecatedNew(ctx context.Context, family, title string, attrs ...attribute
 }
 
 // New returns a new Trace with the specified name.
+// For tips on naming, see the OpenTelemetry Span documentation:
+// https://opentelemetry.io/docs/specs/otel/trace/api/#span
 func New(ctx context.Context, name string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
 	tr := Tracer{TracerProvider: otel.GetTracerProvider()}
 	return tr.New(ctx, name, "", attrs...)

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -15,8 +15,6 @@ import (
 // golang.org/x/net/trace.Trace, applying its various API functions to both
 // underlying trace types. Use New to construct one.
 type Trace struct {
-	name string
-
 	// oteltraceSpan is always set.
 	oteltraceSpan oteltrace.Span
 }

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -28,11 +28,11 @@ func (t Tracer) New(ctx context.Context, name string, attrs ...attribute.KeyValu
 
 	// Set up the split trace.
 	trace := &Trace{
-		family:        name,
+		name:          name,
 		oteltraceSpan: otelSpan,
 	}
 	if parent := TraceFromContext(ctx); parent != nil {
-		trace.family = parent.family + " > " + name
+		trace.name = parent.name + " > " + name
 	}
 	return trace, contextWithTrace(ctx, trace)
 }

--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -26,13 +26,6 @@ func (t Tracer) New(ctx context.Context, name string, attrs ...attribute.KeyValu
 		Tracer("sourcegraph/internal/trace").
 		Start(ctx, name, oteltrace.WithAttributes(attrs...))
 
-	// Set up the split trace.
-	trace := &Trace{
-		name:          name,
-		oteltraceSpan: otelSpan,
-	}
-	if parent := TraceFromContext(ctx); parent != nil {
-		trace.name = parent.name + " > " + name
-	}
+	trace := &Trace{oteltraceSpan: otelSpan}
 	return trace, contextWithTrace(ctx, trace)
 }

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -310,11 +310,10 @@ func (w *Worker[T]) dequeueAndHandle() (dequeued bool, err error) {
 	}
 
 	// Create context and span based on the root context
-	workerSpan, workerCtxWithSpan := trace.DeprecatedNew(
+	workerSpan, workerCtxWithSpan := trace.New(
 		// TODO tail-based sampling once its a thing, until then, we can configure on a per-job basis
 		policy.WithShouldTrace(w.rootCtx, w.options.Metrics.traceSampler(record)),
 		w.options.Name,
-		"",
 	)
 	handleCtx, cancel := context.WithCancel(workerCtxWithSpan)
 	processLog := trace.Logger(workerCtxWithSpan, w.options.Metrics.logger)

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -310,7 +310,7 @@ func (w *Worker[T]) dequeueAndHandle() (dequeued bool, err error) {
 	}
 
 	// Create context and span based on the root context
-	workerSpan, workerCtxWithSpan := trace.New(
+	workerSpan, workerCtxWithSpan := trace.DeprecatedNew(
 		// TODO tail-based sampling once its a thing, until then, we can configure on a per-job basis
 		policy.WithShouldTrace(w.rootCtx, w.options.Metrics.traceSampler(record)),
 		w.options.Name,


### PR DESCRIPTION
This removes the "title" argument to `trace.New()`. This was previously only displayed as an attribute on the span, which is confusing since people would often use a span name for this argument since it is called "title." OpenTelemetry does not have the concept of a family and title (these are from `x/net/trace`, which is no longer used), so this is another step towards reconciling our tracing package with OpenTelemetry.

Basically, I went through all uses of `trace.New()` and either named the span `family.title`, removed the title in the case it was an empty string, or converted the title to a set of more structured attributes.

Now, `trace.New()` only takes a context, a span name, and an optional set of attributes.

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
