### PR TITLE
Tracing: remove LazyPrintf

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -304,9 +304,6 @@ func (s *Server) repoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	tr, ctx := trace.New(ctx, "repoLookup", args.String())
 	defer func() {
 		s.Logger.Debug("repoLookup", log.String("result", fmt.Sprint(result)), log.Error(err))
-		if result != nil {
-			tr.LazyPrintf("result: %s", result)
-		}
 		tr.SetError(err)
 		tr.Finish()
 	}()

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -146,7 +146,6 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	tr, ctx = trace.New(ctx, "search", fmt.Sprintf("%s@%s", p.Repo, p.Commit))
 	defer tr.Finish()
 
-	tr.LazyPrintf("%s", p.Pattern)
 	tr.SetAttributes(
 		attribute.String("repo", string(p.Repo)),
 		attribute.String("url", p.URL),
@@ -179,10 +178,12 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 				code = "500"
 			}
 		}
-		tr.LazyPrintf("code=%s matches=%d limitHit=%v", code, sender.SentCount(), sender.LimitHit())
 		metricRequestTotal.WithLabelValues(code).Inc()
-		tr.AddEvent("matches", attribute.Int("matches.len", sender.SentCount()))
-		tr.SetAttributes(attribute.Bool("limitHit", sender.LimitHit()))
+		tr.AddEvent("done",
+			attribute.String("code", code),
+			attribute.Int("matches.len", sender.SentCount()),
+			attribute.Bool("limitHit", sender.LimitHit()),
+		)
 		s.Log.Debug("search request",
 			log.String("repo", string(p.Repo)),
 			log.String("commit", string(p.Commit)),

--- a/internal/search/client/BUILD.bazel
+++ b/internal/search/client/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -121,7 +121,7 @@ func (s *searchClient) Plan(
 		if err != nil {
 			return "", err
 		}
-		tr.LazyPrintf("substitute query %s for context %s", sc.Query, context)
+		tr.AddEvent("substituted context filter with query", attribute.String("query", sc.Query), attribute.String("context", context))
 		return sc.Query, nil
 	})
 
@@ -133,7 +133,7 @@ func (s *searchClient) Plan(
 	if err != nil {
 		return nil, &QueryError{Query: searchQuery, Err: err}
 	}
-	tr.LazyPrintf("parsing done")
+	tr.AddEvent("parsing done")
 
 	inputs := &search.Inputs{
 		Plan:                   plan,
@@ -148,7 +148,7 @@ func (s *searchClient) Plan(
 		SanitizeSearchPatterns: sanitizeSearchPatterns(ctx, s.db, s.logger), // Experimental: check site config to see if search sanitization is enabled
 	}
 
-	tr.LazyPrintf("Parsed query: %s", inputs.Query)
+	tr.AddEvent("parsed query", attribute.Stringer("query", inputs.Query))
 
 	return inputs, nil
 }

--- a/internal/search/job/jobutil/limit.go
+++ b/internal/search/job/jobutil/limit.go
@@ -38,7 +38,7 @@ func (l *LimitJob) Run(ctx context.Context, clients job.RuntimeClients, s stream
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	s = newLimitStream(l.limit, s, func() {
-		tr.LazyPrintf("limit hit, canceling child context")
+		tr.AddEvent("limit hit, canceling child context")
 		cancel()
 	})
 

--- a/internal/search/searchcontexts/BUILD.bazel
+++ b/internal/search/searchcontexts/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/types",
         "//lib/errors",
         "@com_github_inconshreveable_log15//:log15",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
     ],

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -2,6 +2,7 @@ package searchcontexts
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -57,7 +58,7 @@ func ParseSearchContextSpec(searchContextSpec string) ParsedSearchContextSpec {
 func ResolveSearchContextSpec(ctx context.Context, db database.DB, searchContextSpec string) (sc *types.SearchContext, err error) {
 	tr, ctx := trace.New(ctx, "ResolveSearchContextSpec", searchContextSpec)
 	defer func() {
-		tr.LazyPrintf("context: %+v", sc)
+		tr.AddEvent("resolved search context", attribute.String("searchContext", fmt.Sprintf("%+v", sc)))
 		tr.SetErrorIfNotContext(err)
 		tr.Finish()
 	}()

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -763,7 +763,7 @@ func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB
 		if a := actor.FromContext(ctx); a.IsAuthenticated() {
 			userID = a.UID
 		} else {
-			tr.LazyPrintf("skipping private repo resolution for unauthed user")
+			tr.AddEvent("skipping private repo resolution for unauthed user")
 			return nil
 		}
 	}
@@ -785,7 +785,7 @@ func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB
 
 	if err != nil {
 		logger.Error("doResults: failed to list user private repos", log.Error(err), log.Int32("user-id", userID))
-		tr.LazyPrintf("error resolving user private repos: %v", err)
+		tr.AddEvent("error resolving user private repos", trace.Error(err))
 	}
 	return userPrivateRepos
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -2,7 +2,6 @@ package trace
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -39,17 +38,6 @@ func (t *Trace) SetAttributes(attributes ...attribute.KeyValue) {
 // accepts attributes for simplicity, and for ease of adapting to nettrace.
 func (t *Trace) AddEvent(name string, attributes ...attribute.KeyValue) {
 	t.oteltraceSpan.AddEvent(name, oteltrace.WithAttributes(attributes...))
-}
-
-// LazyPrintf evaluates its arguments with fmt.Sprintf each time the
-// /debug/requests page is rendered. Any memory referenced by a will be
-// pinned until the trace is finished and later discarded.
-func (t *Trace) LazyPrintf(format string, a ...any) {
-	t.oteltraceSpan.AddEvent("LazyPrintf", oteltrace.WithAttributes(
-		attribute.Stringer("message", stringerFunc(func() string {
-			return fmt.Sprintf(format, a...)
-		})),
-	))
 }
 
 // SetError declares that this trace and span resulted in an error.


### PR DESCRIPTION
This removes the `LazyPrintf` method on `trace.Trace`. This method existed because of `x/net/trace`, but now we can just use `AddEvent` instead. It's not quite as ergonomic, but it provides more readable span events (they're not named `LazyPrintf`) and helps discourage adding massive payloads to a span.

This is another step towards standardization on OpenTelemetry.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/54563

## Test plan

CI. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
