### PR TITLE
silence errors when redis is reporting key does not exist

### DIFF
--- a/enterprise/cmd/worker/internal/executors/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/executors/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/observation",
         "//internal/rcache",
         "//lib/errors",
+        "@com_github_gomodule_redigo//redis",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promhttp",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
When App was running and there were no executor queues there was a constant flow of errors being logged 

```
ERROR multiqueue-cache-cleaner.multiqueue.cachecleaner.metrics executors/multiqueue_cache_cleaner.go:95 Failed to get cache size {"queue": "codeintel", "error": "redigo: nil returned"}
ERROR executors.multiqueue-cache-cleaner goroutine/periodic.go:95 An error occurred in a background task {"handler": "executors.multiqueue-cache-cleaner", "error": "multiqueue.cachecleaner: redigo: nil returned"}
```
Redis reporting that the key does not exist should not throw an error but behave like the value is 0.
## Test plan
existing unit tests pass
`sg start app` errors no longer present
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
