### PR TITLE
uploads: Simplify code for streaming indexes

### DIFF
--- a/internal/codeintel/uploads/internal/background/processor/BUILD.bazel
+++ b/internal/codeintel/uploads/internal/background/processor/BUILD.bazel
@@ -40,7 +40,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/internal/codeintel/uploads/internal/background/processor/scip_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip_test.go
@@ -63,6 +63,7 @@ func implCorrelateSCIP(t *testing.T, testIndexPath string, indexSizeLimit int64)
 		return nil
 	})
 	require.NoError(t, err)
+	packageData.Normalize()
 	packages := packageData.Packages
 	packageReferences := packageData.PackageReferences
 	if err != nil {

--- a/internal/codeintel/uploads/internal/background/processor/scip_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip_test.go
@@ -50,17 +50,21 @@ func implCorrelateSCIP(t *testing.T, testIndexPath string, indexSizeLimit int64)
 	}
 
 	// Correlate and consume channels from returned object
-	correlatedSCIPData, err := correlateSCIP(ctx, log.NoOp(), testReader(), "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
+	scipDataStream, err := prepareSCIPDataStream(ctx, testReader(), "", func(ctx context.Context, dirnames []string) (map[string][]string, error) {
 		return scipDirectoryChildren, nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error processing SCIP: %s", err)
 	}
 	var documents []lsifstore.ProcessedSCIPDocument
-	for document := range correlatedSCIPData.Documents {
-		documents = append(documents, document)
-	}
-	packages, packageReferences, err := readPackageAndPackageReferences(ctx, correlatedSCIPData)
+	packageData := lsifstore.ProcessedPackageData{}
+	err = scipDataStream.DocumentIterator.VisitAllDocuments(ctx, log.NoOp(), &packageData, func(d lsifstore.ProcessedSCIPDocument) error {
+		documents = append(documents, d)
+		return nil
+	})
+	require.NoError(t, err)
+	packages := packageData.Packages
+	packageReferences := packageData.PackageReferences
 	if err != nil {
 		t.Fatalf("unexpected error reading processed SCIP: %s", err)
 	}
@@ -73,7 +77,7 @@ func implCorrelateSCIP(t *testing.T, testIndexPath string, indexSizeLimit int64)
 		ToolArguments:        nil,
 		ProtocolVersion:      0,
 	}
-	if diff := cmp.Diff(expectedMetadata, correlatedSCIPData.Metadata); diff != "" {
+	if diff := cmp.Diff(expectedMetadata, scipDataStream.Metadata); diff != "" {
 		t.Fatalf("unexpected metadata (-want +got):\n%s", diff)
 	}
 

--- a/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
+++ b/internal/codeintel/uploads/internal/lsifstore/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//lib/errors",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_protobuf//proto",

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -223,6 +223,21 @@ type Package struct {
 	Version string
 }
 
+func (pi *Package) LessThan(pj *Package) bool {
+	if pi.Scheme == pj.Scheme {
+		if pi.Manager == pj.Manager {
+			if pi.Name == pj.Name {
+				return pi.Version < pj.Version
+			}
+
+			return pi.Name < pj.Name
+		}
+
+		return pi.Manager < pj.Manager
+	}
+	return pi.Scheme < pj.Scheme
+}
+
 // PackageReferences pairs a package name/version with a dump that depends on it.
 type PackageReference struct {
 	Package


### PR DESCRIPTION
Previously, we had a bunch of channels and goroutines, which
aren't necessary, since the invoking goroutine anyways processes
the documents one-by-one and writes them into the database

## Test plan

Covered by existing tests