### PR TITLE
embeddings (experimental): add header to chunks with repo name and file path

### DIFF
--- a/enterprise/internal/embeddings/embed/BUILD.bazel
+++ b/enterprise/internal/embeddings/embed/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "embed.go",
         "files.go",
         "iface.go",
+        "metadata_header.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/internal/embeddings/embed",
     visibility = ["//enterprise:__subpackages__"],
@@ -34,6 +35,7 @@ go_test(
     srcs = [
         "embed_test.go",
         "files_test.go",
+        "metadata_header_test.go",
         "mocks_test.go",
     ],
     embed = [":embed"],

--- a/enterprise/internal/embeddings/embed/embed.go
+++ b/enterprise/internal/embeddings/embed/embed.go
@@ -97,7 +97,7 @@ func EmbedRepo(
 		reportProgress(&stats)
 	}
 
-	codeIndex, codeIndexStats, err := embedFiles(ctx, codeFileNames, client, contextService, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxCodeEmbeddings, ranks, reportCodeProgress)
+	codeIndex, codeIndexStats, err := embedFiles(ctx, opts.RepoName, codeFileNames, client, contextService, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxCodeEmbeddings, ranks, reportCodeProgress)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -108,7 +108,7 @@ func EmbedRepo(
 		reportProgress(&stats)
 	}
 
-	textIndex, textIndexStats, err := embedFiles(ctx, textFileNames, client, contextService, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxTextEmbeddings, ranks, reportTextProgress)
+	textIndex, textIndexStats, err := embedFiles(ctx, opts.RepoName, textFileNames, client, contextService, opts.ExcludePatterns, opts.SplitOptions, readLister, opts.MaxTextEmbeddings, ranks, reportTextProgress)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -143,6 +143,7 @@ type EmbedRepoOpts struct {
 // the embeddings and metadata about the chunks the embeddings correspond to.
 func embedFiles(
 	ctx context.Context,
+	repoName api.RepoName,
 	files []FileEntry,
 	client client.EmbeddingsClient,
 	contextService ContextService,
@@ -176,7 +177,7 @@ func embedFiles(
 
 		batchChunks := make([]string, len(batch))
 		for idx, chunk := range batch {
-			batchChunks[idx] = chunk.Content
+			batchChunks[idx] = addMetadataHeader(chunk.Content, string(repoName), chunk.FileName)
 			index.RowMetadata = append(index.RowMetadata, embeddings.RepoEmbeddingRowMetadata{FileName: chunk.FileName, StartLine: chunk.StartLine, EndLine: chunk.EndLine})
 
 			// Unknown documents have rank 0. Zoekt is a bit smarter about this, assigning 0

--- a/enterprise/internal/embeddings/embed/metadata_header.go
+++ b/enterprise/internal/embeddings/embed/metadata_header.go
@@ -1,0 +1,56 @@
+package embed
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+var commentLinePrefix = map[string]string{
+	"py":       "#",
+	"pl":       "#",
+	"rb":       "#",
+	"r":        "#",
+	"exs":      "#",
+	"ex":       "#",
+	"jl":       "#",
+	"sh":       "#",
+	"yml":      "#",
+	"yaml":     "#",
+	"sql":      "--",
+	"hs":       "--",
+	"lua":      "--",
+	"md":       "<!--",
+	"markdown": "<!--",
+	"html":     "<!--",
+	"ml":       "(*",
+	"mli":      "(*",
+	"lisp":     ";;",
+	"el":       ";;",
+	"clj":      ";;",
+	"m":        "%",
+	"erl":      "%",
+	"txt":      "",
+}
+
+var commentLineSuffix = map[string]string{
+	"md":       "-->",
+	"markdown": "-->",
+	"html":     "-->",
+	"ml":       "*)",
+	"mli":      "*)",
+}
+
+func getMetadataHeader(repoName, filePath string) string {
+	extension := strings.ToLower(strings.TrimPrefix(path.Ext(filePath), "."))
+	prefix, prefixOk := commentLinePrefix[extension]
+	if !prefixOk {
+		prefix = "//"
+	}
+	suffix := commentLineSuffix[extension]
+	return strings.TrimSpace(fmt.Sprintf("%s %s %s %s", prefix, repoName, filePath, suffix))
+}
+
+func addMetadataHeader(code string, repoName string, filePath string) string {
+	return getMetadataHeader(repoName, filePath) + "\n" + code
+}

--- a/enterprise/internal/embeddings/embed/metadata_header_test.go
+++ b/enterprise/internal/embeddings/embed/metadata_header_test.go
@@ -1,0 +1,43 @@
+package embed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddMetadataHeader(t *testing.T) {
+	tests := []struct {
+		code         string
+		fileName     string
+		expectedCode string
+	}{
+		{
+			code:         "a line of code",
+			fileName:     "some/file.go",
+			expectedCode: "// github.com/sourcegraph/sourcegraph some/file.go\na line of code",
+		},
+		{
+			code:         "a line of html",
+			fileName:     "some/file.html",
+			expectedCode: "<!-- github.com/sourcegraph/sourcegraph some/file.html -->\na line of html",
+		},
+		{
+			code:         "a line of text",
+			fileName:     "some/extensionless/file",
+			expectedCode: "// github.com/sourcegraph/sourcegraph some/extensionless/file\na line of text",
+		},
+		{
+			code:         "a line of text",
+			fileName:     "some/text/file.txt",
+			expectedCode: "github.com/sourcegraph/sourcegraph some/text/file.txt\na line of text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			codeWithHeader := addMetadataHeader(tt.code, "github.com/sourcegraph/sourcegraph", tt.fileName)
+			require.Equal(t, tt.expectedCode, codeWithHeader)
+		})
+	}
+}


### PR DESCRIPTION
According to the embeddings evaluation suite, the retrieval performance is greatly improved if we include a comment header for each embeddable chunk. The comment header contains the repo name and the file path of the chunk.

I generated an HTML report comparing the production embeddings search vs. the local embeddings search with added comment headers (on the Sourcegraph repo): https://drive.google.com/file/d/1sBs2JB40CduKM6cVNuxSKf0kNIKjGFtJ/view?usp=sharing

Please inspect the above report and check whether the new local rankings make more sense compared to production.

This is an experimental feature, and we have to be sure it will be a net positive before merging. It doesn't make sense to merge it behind a feature flag because turning it on/off would require re-embedding all indexes.

## Test plan

* Unit testing and manual inspection of production vs. local results.