### PR TITLE
ci: introduce a bazel-do runtype to run user given bazel commands only

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -47,6 +47,7 @@ const (
 	// Special test branches
 
 	BackendIntegrationTests // run backend tests that are used on main
+	BazelDo                 // run a specific bazel command
 
 	// None is a no-op, add all run types above this type.
 	None
@@ -178,6 +179,10 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "backend-integration/",
 		}
+	case BazelDo:
+		return &RunTypeMatcher{
+			Branch: "bazel-do/",
+		}
 	}
 
 	return nil
@@ -226,6 +231,8 @@ func (t RunType) String() string {
 
 	case BackendIntegrationTests:
 		return "Backend integration tests"
+	case BazelDo:
+		return "Bazel command"
 	}
 	return ""
 }

--- a/doc/dev/background-information/bazel/cookbook.md
+++ b/doc/dev/background-information/bazel/cookbook.md
@@ -1,0 +1,36 @@
+# Bazel cookbook
+
+The `bazel` command is very powerful, and it can be used both locally and in CI. The goal of this page is list useful recipes that you might need during your development journey.
+
+## Testing 
+
+### Making sure a test isn't flaky anymore
+
+The only way of ensuring that a test isn't flaky anymore is to run it many times in a row, and to observe no failures. You can easily
+do this with Bazel, with the `--runs_per_test=N` flag: 
+
+```
+# Target will be tested three times in parallel.
+bazel test //lib/gitservice/... --runs_per_test=3
+```
+
+Some tests, particularly integration tests, are not designed to be run concurrently (which they should), so we need to run them one after the other with the 
+`--local_test_jobs` flag:
+
+```
+# Target will be tested three times in serial.
+bazel test //lib/gitservice/... --runs_per_test=3 --local_test_jobs=1
+```
+
+If you really want to make sure your test is not flaky anymore, you'll want to really raise the number of runs, which might not be practical to do locally. Why 
+not leverage our beefy CI agents for that purpose? 
+
+You can use the `bazel-do` CI runtype to ask the CI to run a single bazel command and report back: 
+
+- Commit all your changes 
+- Create a new branch prefixed with `bazel-do` 
+  - ex `bazel-do/jh/flaky-foobar`
+- Amend your last commit or create an empty one that contains in the commit description a new line starting with `!bazel [my-command]`:
+  - ex: `!bazel test //lib/gitservice/... --runs_per_test=50` 
+- Git push that branch 
+- Run `sg ci status --web` to open the build page in your browser or `sg ci status --wait` to wait for the results in your terminal.

--- a/doc/dev/background-information/bazel/index.md
+++ b/doc/dev/background-information/bazel/index.md
@@ -15,6 +15,7 @@ Sourcegraph uses [Bazel](https://bazel.build) as its build system. Reach out on 
   - [Bazel and container images](./containers.md)
 - **How-tos**
   - [Writing a server integration test](./server_integration_tests.md)
+  - [Cookbook](./cookbook.md)
 
 ---
 

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -359,3 +359,12 @@ Base pipeline (more steps might be included based on branch changes):
 - **Publish candidate images**: Push candidate Images
 - **End-to-end tests**: Executors E2E
 - **Publish images**: executor-vm, alpine-3.14, codeinsights-db, codeintel-db, postgres-12-alpine, prometheus-gcp, Push final images
+
+### Bazel command
+
+The run type for branches matching `bazel-do/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build bazel-do
+```

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -253,6 +253,7 @@ Supported run types when providing an argument for 'sg ci build [runtype]':
 * docker-images-patch-notest - Patch image without testing
 * executor-patch-notest - Build executor without testing
 * backend-integration - Backend integration tests
+* bazel-do - Bazel command
 
 For run types that require branch arguments, you will be prompted for an argument, or you
 can provide it directly (for example, 'sg ci build [runtype] <argument>').

--- a/enterprise/dev/ci/gen-pipeline.go
+++ b/enterprise/dev/ci/gen-pipeline.go
@@ -180,7 +180,7 @@ func renderPipelineDocs(logger log.Logger, w io.Writer) {
 
 			// Don't generate a preview for more complicated branch types, since we don't
 			// know what arguments to provide as a sample in advance.
-			if m.BranchArgumentRequired {
+			if m.BranchArgumentRequired || rt.Is(runtype.BazelDo) {
 				continue
 			}
 

--- a/enterprise/dev/ci/internal/ci/BUILD.bazel
+++ b/enterprise/dev/ci/internal/ci/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -25,4 +26,10 @@ go_library(
         "@com_github_masterminds_semver//:semver",
         "@com_github_sourcegraph_log//:log",
     ],
+)
+
+go_test(
+    name = "ci_test",
+    srcs = ["bazel_operations_test.go"],
+    embed = [":ci"],
 )

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -508,10 +508,19 @@ func verifyBazelCommand(command string) error {
 		return errors.New("unauthorized input for bazel command: '|'")
 	}
 	if strings.Contains(command, "$") {
-		return errors.New("unauthorized input for bazel command: '|'")
+		return errors.New("unauthorized input for bazel command: '$'")
 	}
 	if strings.Contains(command, "`") {
 		return errors.New("unauthorized input for bazel command: '`'")
+	}
+	if strings.Contains(command, ">") {
+		return errors.New("unauthorized input for bazel command: '>'")
+	}
+	if strings.Contains(command, "<") {
+		return errors.New("unauthorized input for bazel command: '<'")
+	}
+	if strings.Contains(command, "(") {
+		return errors.New("unauthorized input for bazel command: '('")
 	}
 
 	// check for command and targets

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -507,6 +507,12 @@ func verifyBazelCommand(command string) error {
 	if strings.Contains(command, "|") {
 		return errors.New("unauthorized input for bazel command: '|'")
 	}
+	if strings.Contains(command, "$") {
+		return errors.New("unauthorized input for bazel command: '|'")
+	}
+	if strings.Contains(command, "`") {
+		return errors.New("unauthorized input for bazel command: '`'")
+	}
 
 	// check for command and targets
 	strs := strings.Split(command, " ")

--- a/enterprise/dev/ci/internal/ci/bazel_operations_test.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations_test.go
@@ -1,19 +1,43 @@
 package ci
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestVerifyBazelCommand(t *testing.T) {
 	tests := []struct {
 		cmd       string
 		wantError bool
 	}{
+		// normal commands
 		{"test //foobar/...", false},
-		{"test //foobar/... --runs_per_test=20", false},
+		{"test //foobar/... -//foobar/baz", false},
+		{"test //foobar/... --runs_per_test=10", false},
+		{"test //foobar/... --runs_per_test=10 --test_timeout=30", false},
+		{"build //foobar/... -//foobar/baz --runs_per_test=10 --test_timeout=30", false},
+
+		// invalid commands
+		{"test --runs_per_test=10", true},
+		{"build --nobuild", true},
+
+		// forbidden commands
+		{"run //foobar/...", true},
+		{"query //foobar/...", true},
+		{"query //foobar/... --output=build", true},
+		{"cquery //foobar/...", true},
+		{"cquery //foobar/... --output=files", true},
+
+		// shell escapes
 		{"test //foobar/...; curl", true},
 		{"test //foobar/...& curl", true},
 		{"test //foobar/...&& curl", true},
 		{"test //foobar/...|| curl", true},
-		{"run //foobar/...", true},
+
+		// forbidden flags
+		{"test //foobar/... --shell_executable", true},
+		{"test //foobar/... -//foobar/baz --shell_executable", true},
+		{"test //foobar/... --runs_per_test=20 --shell_executable", true},
+		{"test //foobar/... --shell_executable --runs_per_test=20 ", true},
 	}
 
 	for _, test := range tests {

--- a/enterprise/dev/ci/internal/ci/bazel_operations_test.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations_test.go
@@ -1,0 +1,28 @@
+package ci
+
+import "testing"
+
+func TestVerifyBazelCommand(t *testing.T) {
+	tests := []struct {
+		cmd       string
+		wantError bool
+	}{
+		{"test //foobar/...", false},
+		{"test //foobar/... --runs_per_test=20", false},
+		{"test //foobar/...; curl", true},
+		{"test //foobar/...& curl", true},
+		{"test //foobar/...&& curl", true},
+		{"test //foobar/...|| curl", true},
+		{"run //foobar/...", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.cmd, func(t *testing.T) {
+			err := verifyBazelCommand(test.cmd)
+			if (test.wantError && err == nil) || (!test.wantError && err != nil) {
+				t.Log(err)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/enterprise/dev/ci/internal/ci/bazel_operations_test.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations_test.go
@@ -32,6 +32,10 @@ func TestVerifyBazelCommand(t *testing.T) {
 		{"test //foobar/...& curl", true},
 		{"test //foobar/...&& curl", true},
 		{"test //foobar/...|| curl", true},
+		{"test //foobar/$(foo)", true},
+		{"test //foobar/... $(foo)", true},
+		{"test //foobar/`foo`)", true},
+		{"test //foobar/... `foo`", true},
 
 		// forbidden flags
 		{"test //foobar/... --shell_executable", true},

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -95,7 +95,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	ops := operations.NewSet()
 
 	if op, err := exposeBuildMetadata(c); err == nil {
-		ops.Merge(operations.NewNamedSet("Metadata", op))
+		if !c.RunType.Is(runtype.BazelDo) {
+			// Skip meta for bazel-do
+			ops.Merge(operations.NewNamedSet("Metadata", op))
+		}
 	}
 
 	// This statement outlines the pipeline steps for each CI case.
@@ -113,6 +116,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 				ops.Append(func(pipeline *bk.Pipeline) {
 					pipeline.AddStep(":bazel::desktop_computer: bazel "+bzCmd,
+						bk.Key("bazel-do"),
 						bk.Agent("queue", "bazel"),
 						bk.Cmd(bazelCmd(bzCmd)),
 					)


### PR DESCRIPTION
This introduces the `bazel-do` runtype, which provides a `bazel-do/[name]` branch scheme, where you can pass in the commit description a bazel command to be run. 

Diagnosing flaky tests, or simply testing something in CI can a bit cumbersome if you don't know your way around the pipeline. This PR fixes that by providing a way to set-up a build for your branch that will run a single bazel command and nothing else. 

Classic use cases can be: 

- diagnosing a flaky test
- just testing something and you want the faster builds from the CI 
- ensuring that your new code builds remotely without having to wait for the whole build. 

How to use: create a `bazel-do/my-thing` branch and put `!bazel test //something` in the last commit description. 

I plan to follow up with a `bazel ci bazel test //foobar` that will create the branch and the commit for you, as a convenience. 

Security: only Sourcegraph teammates can build this, and it only triggers on branch named `bazel-do`. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Did a few manual tests in CI, they worked perfectly. 


