### PR TITLE
cody admin: update estimated time to finish

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useState, useEffect } from 'react'
 
 import classNames from 'classnames'
 
@@ -100,12 +100,13 @@ const RepoEmbeddingJobExecutionInfo: FC<
     >
 > = ({ state, cancel, finishedAt, queuedAt, startedAt, failureMessage, stats }) => {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-    const estimatedFinish = calculateEstimatedFinish(
-        startedAt,
-        stats.filesScheduled,
-        stats.filesEmbedded,
-        stats.filesSkipped
-    )
+
+    const [estimatedFinish, setEstimatedFinish] = useState<Date | null>(null)
+    useEffect(() => {
+        setEstimatedFinish(
+            calculateEstimatedFinish(startedAt, stats.filesScheduled, stats.filesEmbedded, stats.filesSkipped)
+        )
+    }, [startedAt, stats.filesScheduled, stats.filesEmbedded, stats.filesSkipped])
 
     return (
         <>


### PR DESCRIPTION
With this change we update the estimate of "time to finish" on **Cody > Embeddings Jobs** without requiring the user to refresh the page.

The video runs 15x faster. Previously, the reported files changes, but not the "Expected time to finish"

https://github.com/sourcegraph/sourcegraph/assets/26413131/d0bca405-8a2d-4260-990b-202b8fb44fc4






### Test plan
Visual inspection

