### PR TITLE
gateway: Add endpoints to read limits

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/actor/limits.go
+++ b/enterprise/cmd/cody-gateway/internal/actor/limits.go
@@ -105,6 +105,10 @@ func (l *concurrencyLimiter) TryAcquire(ctx context.Context) (func(context.Conte
 	return l.nextLimiter.TryAcquire(ctx)
 }
 
+func (l *concurrencyLimiter) Usage(ctx context.Context) (int, time.Time, error) {
+	return l.nextLimiter.Usage(ctx)
+}
+
 type ErrConcurrencyLimitExceeded struct {
 	feature    codygateway.Feature
 	limit      int
@@ -147,4 +151,8 @@ func (u updateOnErrorLimiter) TryAcquire(ctx context.Context) (func(context.Cont
 		u.actor.Update(ctx) // TODO: run this in goroutine+background context maybe?
 	}
 	return commit, err
+}
+
+func (u updateOnErrorLimiter) Usage(ctx context.Context) (int, time.Time, error) {
+	return u.nextLimiter.Usage(ctx)
 }

--- a/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//enterprise/cmd/cody-gateway/internal/events",
         "//enterprise/cmd/cody-gateway/internal/httpapi/completions",
         "//enterprise/cmd/cody-gateway/internal/httpapi/embeddings",
+        "//enterprise/cmd/cody-gateway/internal/httpapi/featurelimiter",
         "//enterprise/cmd/cody-gateway/internal/httpapi/requestlogger",
         "//enterprise/cmd/cody-gateway/internal/limiter",
         "//enterprise/cmd/cody-gateway/internal/notify",

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -88,7 +88,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 	return featurelimiter.Handle(
 		baseLogger,
 		eventLogger,
-		limiter.NewPrefixRedisStore("rate_limit:", rs),
+		rs,
 		rateLimitNotifier,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			act := actor.FromContext(r.Context())

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -37,7 +37,7 @@ func NewHandler(
 	return featurelimiter.HandleFeature(
 		baseLogger,
 		eventLogger,
-		limiter.NewPrefixRedisStore("rate_limit:", rs),
+		rs,
 		rateLimitNotifier,
 		codygateway.FeatureEmbeddings,
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/completions"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/embeddings"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/featurelimiter"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/httpapi/requestlogger"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/cody-gateway/internal/notify"
@@ -30,6 +31,8 @@ type Config struct {
 }
 
 func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisStore, authr *auth.Authenticator, config *Config) http.Handler {
+	// Add a prefix to the store for globally unique keys and simpler pruning.
+	rs = limiter.NewPrefixRedisStore("rate_limit:", rs)
 	r := mux.NewRouter()
 
 	// V1 service routes
@@ -110,6 +113,19 @@ func NewHandler(logger log.Logger, eventLogger events.Logger, rs limiter.RedisSt
 			),
 		)
 	}
+
+	// Register a route where actors can retrieve their current rate limit state.
+	v1router.Path("/limits").Methods(http.MethodGet).Handler(
+		instrumentation.HTTPMiddleware("v1.limits",
+			authr.Middleware(
+				requestlogger.Middleware(
+					logger,
+					featurelimiter.ListLimitsHandler(logger, eventLogger, rs),
+				),
+			),
+			otelhttp.WithPublicEndpoint(),
+		),
+	)
 
 	return r
 }

--- a/internal/codygateway/types.go
+++ b/internal/codygateway/types.go
@@ -8,6 +8,13 @@ import (
 
 type Feature string
 
+var AllFeatures = []Feature{
+	FeatureCodeCompletions,
+	FeatureChatCompletions,
+	FeatureEmbeddings,
+}
+
+// NOTE: When you add a new feature here, make sure to add it to the slice above as well.
 const (
 	FeatureCodeCompletions Feature = Feature(types.CompletionsFeatureCode)
 	FeatureChatCompletions Feature = Feature(types.CompletionsFeatureChat)


### PR DESCRIPTION
This PR adds a basic endpoint that enumerates the configured limits and the current rate limit data. The main purpose of it is debugging, as we don't have direct read access to redis, but we may want to build some UI features off of this later, too.

## Test plan

Verified things work manually.