### PR TITLE
JetBrains: show editor context recipe actions when cody app is available

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - fix logging to use JetBrains api + other minor fixes [#54579](https://github.com/sourcegraph/sourcegraph/pull/54579)
+- Enable editor recipe context menu items when working with Cody app only when Cody app is running [#54583](https://github.com/sourcegraph/sourcegraph/pull/54583)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/DownloadCodyAppAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/DownloadCodyAppAction.java
@@ -1,0 +1,42 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.localapp.LocalAppManager;
+import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
+import org.jetbrains.annotations.NotNull;
+
+public class DownloadCodyAppAction extends DumbAwareAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    BrowserUtil.browse("https://about.sourcegraph.com/app");
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      hideAction(e);
+      return;
+    }
+    if (LocalAppManager.isPlatformSupported()
+        && ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.LOCAL_APP) {
+      if (!LocalAppManager.isLocalAppInstalled()) {
+        showAction(e);
+        return;
+      }
+    }
+    hideAction(e);
+  }
+
+  private static void showAction(@NotNull AnActionEvent e) {
+    e.getPresentation().setEnabledAndVisible(true);
+  }
+
+  private static void hideAction(@NotNull AnActionEvent e) {
+    e.getPresentation().setEnabledAndVisible(false);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeDetailedAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class ExplainCodeDetailedAction extends BaseRecipeAction {
+public class ExplainCodeDetailedAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ExplainCodeHighLevelAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class ExplainCodeHighLevelAction extends BaseRecipeAction {
+public class ExplainCodeHighLevelAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/FindCodeSmellsAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class FindCodeSmellsAction extends BaseRecipeAction {
+public class FindCodeSmellsAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateDocStringAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class GenerateDocStringAction extends BaseRecipeAction {
+public class GenerateDocStringAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/GenerateUnitTestAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class GenerateUnitTestAction extends BaseRecipeAction {
+public class GenerateUnitTestAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/ImproveVariableNamesAction.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
-public class ImproveVariableNamesAction extends BaseRecipeAction {
+public class ImproveVariableNamesAction extends SimpleRecipeAction {
 
   @Override
   protected PromptProvider getPromptProvider() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/RunCodyAppAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/RunCodyAppAction.java
@@ -1,0 +1,41 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.localapp.LocalAppManager;
+import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.SettingsComponent;
+import org.jetbrains.annotations.NotNull;
+
+public class RunCodyAppAction extends DumbAwareAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    LocalAppManager.runLocalApp();
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      hideAction(e);
+      return;
+    }
+    if (LocalAppManager.isPlatformSupported()
+        && ConfigUtil.getInstanceType(project) == SettingsComponent.InstanceType.LOCAL_APP) {
+      if (LocalAppManager.isLocalAppInstalled() && !LocalAppManager.isLocalAppRunning()) {
+        showAction(e);
+        return;
+      }
+    }
+    hideAction(e);
+  }
+
+  private static void showAction(@NotNull AnActionEvent e) {
+    e.getPresentation().setEnabledAndVisible(true);
+  }
+
+  private static void hideAction(@NotNull AnActionEvent e) {
+    e.getPresentation().setEnabledAndVisible(false);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
@@ -1,0 +1,35 @@
+package com.sourcegraph.cody.recipes;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.UpdatableChat;
+import com.sourcegraph.cody.UpdatableChatHolderService;
+import com.sourcegraph.telemetry.GraphQlLogger;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class SimpleRecipeAction extends BaseRecipeAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) {
+      return;
+    }
+    UpdatableChatHolderService updatableChatHolderService =
+        project.getService(UpdatableChatHolderService.class);
+    UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
+    executeRecipeWithPromptProvider(updatableChat, project);
+  }
+
+  public void executeRecipeWithPromptProvider(UpdatableChat updatableChat, Project project) {
+    GraphQlLogger.logCodyEvents(project, this.getActionComponentName(), "clicked");
+    RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
+    ActionUtil.runIfCodeSelected(
+        updatableChat,
+        project,
+        (editorSelection) -> recipeRunner.runRecipe(this.getPromptProvider(), editorSelection));
+  }
+
+  protected abstract PromptProvider getPromptProvider();
+
+  protected abstract String getActionComponentName();
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.recipes;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.UpdatableChat;
 import com.sourcegraph.cody.UpdatableChatHolderService;
@@ -10,7 +9,7 @@ import com.sourcegraph.cody.ui.SelectOptionManager;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import org.jetbrains.annotations.NotNull;
 
-public class TranslateToLanguageAction extends DumbAwareAction {
+public class TranslateToLanguageAction extends BaseRecipeAction {
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
 

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -137,6 +137,18 @@
         </action>
 
         <action
+            id="cody.downloadAndInstallCodyAction"
+            class="com.sourcegraph.cody.recipes.DownloadCodyAppAction"
+            text="Download Cody App"
+            icon="/icons/codyLogoSm.svg" />
+
+        <action
+            id="cody.runCodyAppAction"
+            class="com.sourcegraph.cody.recipes.RunCodyAppAction"
+            text="Run Cody App"
+            icon="/icons/codyLogoSm.svg" />
+
+        <action
             id="cody.recipe.explainCodeHighLevel"
             class="com.sourcegraph.cody.recipes.ExplainCodeHighLevelAction"
             text="Explain Code at a High Level"
@@ -185,6 +197,8 @@
 
         <group id="CodyEditorActions" icon="/icons/codyLogoSm.svg" popup="true" text="Cody"
                searchable="false">
+            <reference ref="cody.downloadAndInstallCodyAction"/>
+            <reference ref="cody.runCodyAppAction"/>
             <reference ref="cody.recipe.explainCodeDetailed"/>
             <reference ref="cody.recipe.explainCodeHighLevel"/>
             <reference ref="cody.recipe.findCodeSmells"/>


### PR DESCRIPTION
Enable editor context menu actions when configured to use Cody local app only when the cody app is up and running, otherwise show actions to download or run the cody app
## Test plan
- When the chat is not displayed because Cody app is not installed or not running and you're configured to use Cody app then recipe actions should be disabled and appropriate action should be shown  
![Screenshot 2023-07-04 at 15 19 04](https://github.com/sourcegraph/sourcegraph/assets/7345368/aa664fa3-5ba6-4e1e-b596-d862915bf3e5)

![Screenshot 2023-07-04 at 15 01 00](https://github.com/sourcegraph/sourcegraph/assets/7345368/3a999462-3a84-4342-998e-87ff226f37fd)
![Screenshot 2023-07-04 at 15 01 26](https://github.com/sourcegraph/sourcegraph/assets/7345368/3a66eac7-a65b-4647-a15a-b75f0c0a44ba)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
