### PR TITLE
bzl: re-enable code-intel-qa (only on main)

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -13,10 +13,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/internal/ci/operations"
 )
 
-func BazelOperations() []operations.Operation {
+func BazelOperations(isMain bool) []operations.Operation {
 	ops := []operations.Operation{}
 	ops = append(ops, bazelConfigure())
-	ops = append(ops, bazelTest("//...", "//client/web:test"))
+	if isMain {
+		ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test"))
+	} else {
+		ops = append(ops, bazelTest("//...", "//client/web:test"))
+	}
 	ops = append(ops, bazelBackCompatTest(
 		"@sourcegraph_back_compat//cmd/...",
 		"@sourcegraph_back_compat//lib/...",

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -28,6 +28,7 @@ type CoreTestOperationsOptions struct {
 	// for addWebAppOSSBuild
 	CacheBundleSize      bool
 	CreateBundleSizeDiff bool
+	IsMainBranch         bool
 }
 
 // CoreTestOperations is a core set of tests that should be run in most CI cases. More
@@ -43,7 +44,7 @@ type CoreTestOperationsOptions struct {
 func CoreTestOperations(diff changed.Diff, opts CoreTestOperationsOptions) *operations.Set {
 	// Base set
 	ops := operations.NewSet()
-	ops.Append(BazelOperations()...)
+	ops.Append(BazelOperations(opts.IsMainBranch)...)
 
 	// Simple, fast-ish linter checks
 	linterOps := operations.NewNamedSet("Linters and static analysis")

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -275,6 +275,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			MinimumUpgradeableVersion: minimumUpgradeableVersion,
 			ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
 			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun),
+			IsMainBranch:              true,
 		}))
 
 		// Publish candidate images to dev registry

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -117,6 +117,7 @@ server_integration_test(
         "SOURCEGRAPH_LICENSE_GENERATION_KEY",
         "SOURCEGRAPH_LICENSE_KEY",
     ],
+    flaky = True,
     port = "7082",
     runner_src = ":codeintel_integration_test.sh",
     tags = [


### PR DESCRIPTION
Re-enable code-intel-qa, marked as flaky, on `main` branch only. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 