### PR TITLE
Remove some outdated cody config disclaimers

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -8,9 +8,6 @@ Cody reads relevant code files to increase the accuracy and quality of the respo
 
 ### Embeddings
 
-> NOTE: Enterprise Cloud customers should reach out to their Sourcegraph representative to enable embeddings.
-> See [Enabling Cody Enterprise: Cody on Sourcegraph Cloud](./enabling_cody_enterprise.md#cody-on-sourcegraph-cloud)
-
 Embeddings are a semantic representation of text that allow us to create a search index over an entire codebase. The process of creating embeddings involves us splitting the entire codebase into searchable chunks and sending them to the external service specified in the site config for embedding. The final embedding index is stored in a managed object storage service.
 
 Embeddings for relevant code files must be enabled for each repository that you'd like Cody to have context on.
@@ -22,8 +19,6 @@ Embeddings for relevant code files must be enabled for each repository that you'
 > embeddings will be enabled for all repositories by default.
 
 Embeddings are automatically enabled and configured once [Cody is enabled](../quickstart.md). You can also [use third-party embeddings provider directly](#using-a-third-party-embeddings-provider-directly) for embeddings.
-
-> NOTE: Unless both completions and embeddings are configured, the `/site-admin/cody` page will not be available.
 
 Embeddings will not be generated for any repo unless an admin takes action. There are two ways to do this.
 

--- a/doc/cody/explanations/cody_gateway.md
+++ b/doc/cody/explanations/cody_gateway.md
@@ -12,7 +12,7 @@ Reach out your account manager for more details about Sourcegraph Cody Gateway a
 
 > WARNING: Sourcegraph Cody Gateway access must be included in your Sourcegraph Enterprise subscription plan first - reach out to your account manager for more details.
 >
-> If you are a [Sourcegraph Cloud](../../cloud/index.md) customer, please reach out to your account manager to enable Cody.
+> If you are a [Sourcegraph Cloud](../../cloud/index.md) customer, Cody is enabled by default on your instance starting with Sourcegraph 5.1.
 
 <span class="virtual-br"></span>
 

--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -24,6 +24,8 @@ There are two steps required to enable Cody on your enterprise instance:
 This requires site-admin privileges.
 
 1. First, configure your desired LLM provider:
+    > NOTE: If you are a Sourcegraph Cloud customer, skip to (3).
+
     - Recommended: [Using Sourcegraph Cody Gateway](./cody_gateway.md#using-cody-gateway-in-sourcegraph-enterprise)
     - [Using a third-party LLM provider directly](#using-a-third-party-llm-provider-directly)
 2. Go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:


### PR DESCRIPTION
Cody will be on by default for cloud from 5.1, and cody.enabled is the single source of truth. This fixes some confusing wording in our docs.

## Test plan

just docs
