### PR TITLE
sg: add ci bazel helper command to run bazel commands in CI 

### DIFF
--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -109,6 +109,7 @@ go_library(
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_github//github",
         "@com_github_google_go_github_v41//github",
+        "@com_github_google_uuid//:uuid",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_keegancsmith_sqlf//:sqlf",

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -313,6 +313,7 @@ sg ci build --help
 					return err
 				}
 
+                                 // give buildkite some time to kick off the build so that we can find it later on
 				time.Sleep(10 * time.Second)
 				client, err := bk.NewClient(cmd.Context, std.Out)
 				if err != nil {

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/gen2brain/beeep"
+	"github.com/google/uuid"
 	"github.com/grafana/regexp"
 	"github.com/urfave/cli/v2"
 
@@ -222,7 +223,7 @@ sg ci build --help
 				return errors.New("target is not a branch")
 			}
 
-			message, err := run.TrimResult(run.GitCmd("show", "--format=%s\\n%b"))
+			message, err := run.TrimResult(run.GitCmd("show", "--format=%B"))
 			if err != nil {
 				return err
 			}
@@ -261,129 +262,261 @@ sg ci build --help
 				return errors.Newf("unsupported format type: %q", cmd.String("format"))
 			}
 		},
-	}, {
-		Name:    "status",
-		Aliases: []string{"st"},
-		Usage:   "Get the status of the CI run associated with the currently checked out branch",
-		Flags: append(ciTargetFlags,
-			&cli.BoolFlag{
-				Name:  "wait",
-				Usage: "Wait by blocking until the build is finished",
+	},
+		{
+			Name:      "bazel",
+			Usage:     "Fires a CI build running a given bazel command",
+			ArgsUsage: "[--web|--wait] [test|build] <bazel flags> <target1> <target2> ...",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  "wait",
+					Usage: "Wait until build completion and then print logs for the Bazel command",
+					Value: false,
+				},
+				&cli.BoolFlag{
+					Name:  "web",
+					Usage: "Print the web URL for the build and return immediately",
+					Value: false,
+				},
 			},
-			&cli.BoolFlag{
-				Name:    "web",
-				Aliases: []string{"view", "w"},
-				Usage:   "Open build page in web browser (--view is DEPRECATED and will be removed in the future)",
-			}),
-		Action: func(cmd *cli.Context) error {
-			client, err := bk.NewClient(cmd.Context, std.Out)
-			if err != nil {
-				return err
-			}
-			target, err := getBuildTarget(cmd)
-			if err != nil {
-				return err
-			}
+			Action: func(cmd *cli.Context) error {
+				args := cmd.Args().Slice()
 
-			// Just support main pipeline for now
-			build, err := target.GetBuild(cmd.Context, client)
-			if err != nil {
-				return err
-			}
-
-			// Print a high level overview, and jump into a browser
-			printBuildOverview(build)
-			if cmd.Bool("view") {
-				if err := open.URL(*build.WebURL); err != nil {
-					std.Out.WriteWarningf("failed to open build in browser: %s", err)
-				}
-			}
-
-			// If we are waiting and unfinished, poll for a build
-			if cmd.Bool("wait") && build.FinishedAt == nil {
-				if build.Branch == nil {
-					return errors.Newf("build %d not associated with a branch", *build.Number)
+				out, err := run.GitCmd("diff", "--cached")
+				if err != nil {
+					return err
 				}
 
-				pending := std.Out.Pending(output.Styledf(output.StylePending, "Waiting for %d jobs...", len(build.Jobs)))
-				err := statusTicker(cmd.Context, func() (bool, error) {
-					// get the next update for this specific build
-					build, err = client.GetBuildByNumber(cmd.Context, target.pipeline, strconv.Itoa(*build.Number))
-					if err != nil {
-						return false, errors.Newf("failed to get most recent build for branch %q: %w", *build.Branch, err)
+				if out != "" {
+					return errors.New("You have staged changes, aborting.")
+				}
+
+				branch := fmt.Sprintf("bazel-do/%s", uuid.NewString())
+				_, err = run.GitCmd("checkout", "-b", branch)
+				if err != nil {
+					return err
+				}
+				_, err = run.GitCmd("commit", "--allow-empty", "-m", fmt.Sprintf("!bazel %s", strings.Join(args, " ")))
+				if err != nil {
+					return err
+				}
+				_, err = run.GitCmd("push", "origin", branch)
+				if err != nil {
+					return err
+				}
+				_, err = run.GitCmd("checkout", "-")
+				if err != nil {
+					return err
+				}
+				_, err = run.GitCmd("branch", "-D", branch)
+				if err != nil {
+					return err
+				}
+
+				time.Sleep(10 * time.Second)
+				client, err := bk.NewClient(cmd.Context, std.Out)
+				if err != nil {
+					return err
+				}
+				build, err := client.GetMostRecentBuild(cmd.Context, "sourcegraph", branch)
+				if err != nil {
+					return err
+				}
+
+				if cmd.Bool("web") {
+					if err := open.URL(*build.WebURL); err != nil {
+						std.Out.WriteWarningf("failed to open build in browser: %s", err)
 					}
+				}
 
-					// Check if all jobs are finished
-					finishedJobs := 0
-					for _, job := range build.Jobs {
-						if job.State != nil {
-							if *job.State == "failed" && !job.SoftFailed {
-								// If a job has failed, return immediately, we don't have to wait until all
-								// steps are completed.
-								return true, nil
-							}
-							if *job.State == "passed" || job.SoftFailed {
-								finishedJobs++
+				if cmd.Bool("wait") {
+					pending := std.Out.Pending(output.Styledf(output.StylePending, "Waiting for %d jobs...", len(build.Jobs)))
+					err = statusTicker(cmd.Context, func() (bool, error) {
+						// get the next update for this specific build
+						build, err = client.GetBuildByNumber(cmd.Context, "sourcegraph", strconv.Itoa(*build.Number))
+						if err != nil {
+							return false, errors.Newf("failed to get most recent build for branch %q: %w", *build.Branch, err)
+						}
+
+						// Check if all jobs are finished
+						finishedJobs := 0
+						for _, job := range build.Jobs {
+							if job.State != nil {
+								if *job.State == "failed" && !job.SoftFailed {
+									// If a job has failed, return immediately, we don't have to wait until all
+									// steps are completed.
+									return true, nil
+								}
+								if *job.State == "passed" || job.SoftFailed {
+									finishedJobs++
+								}
 							}
 						}
+
+						// once started, poll for status
+						if build.StartedAt != nil {
+							pending.Updatef("Waiting for %d out of %d jobs... (elapsed: %v)",
+								len(build.Jobs)-finishedJobs, len(build.Jobs), time.Since(build.StartedAt.Time))
+						}
+
+						if build.FinishedAt == nil {
+							// No failure yet, we can keep waiting.
+							return false, nil
+						}
+						return true, nil
+					})
+
+					std.Out.WriteLine(output.Styledf(output.StylePending, "Fetching logs for %s ...",
+						*build.WebURL))
+					options := bk.ExportLogsOpts{
+						JobStepKey: "bazel-do",
+					}
+					logs, err := client.ExportLogs(cmd.Context, "sourcegraph", *build.Number, options)
+					if err != nil {
+						return err
+					}
+					if len(logs) == 0 {
+						std.Out.WriteLine(output.Line("", output.StyleSuggestion,
+							fmt.Sprintf("No logs found matching the given parameters (job: %q, state: %q).", options.JobQuery, options.State)))
+						return nil
 					}
 
-					// once started, poll for status
-					if build.StartedAt != nil {
-						pending.Updatef("Waiting for %d out of %d jobs... (elapsed: %v)",
-							len(build.Jobs)-finishedJobs, len(build.Jobs), time.Since(build.StartedAt.Time))
+					for _, entry := range logs {
+						std.Out.Write(*entry.Content)
 					}
 
-					if build.FinishedAt == nil {
-						// No failure yet, we can keep waiting.
-						return false, nil
+					pending.Destroy()
+					if err != nil {
+						return err
 					}
-					return true, nil
-				})
-				pending.Destroy()
-				if err != nil {
-					return err
 				}
-			}
-
-			// lets get annotations (if any) for the build
-			var annotations bk.JobAnnotations
-			annotations, err = client.GetJobAnnotationsByBuildNumber(cmd.Context, "sourcegraph", strconv.Itoa(*build.Number))
-			if err != nil {
-				return errors.Newf("failed to get annotations for build %d: %w", *build.Number, err)
-			}
-
-			// render resutls
-			failed := printBuildResults(build, annotations, cmd.Bool("wait"))
-
-			// If we're not on a specific branch and not asking for a specific build,
-			// warn if build commit is not your local copy - we are building an
-			// unknown revision.
-			if !target.fromFlag && target.targetType == buildTargetTypeBranch {
-				commit, err := run.GitCmd("rev-parse", "HEAD")
-				if err != nil {
-					return err
-				}
-				commit = strings.TrimSpace(commit)
-				if commit != *build.Commit {
-					std.Out.WriteLine(output.Linef("⚠️", output.StyleSuggestion,
-						"The currently checked out commit %q does not match the commit of the build found, %q.\nHave you pushed your most recent changes yet?",
-						commit, *build.Commit))
-				}
-			}
-
-			if failed {
-				std.Out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion,
-					"Some jobs have failed - try using 'sg ci logs' to see what went wrong, or go to the build page: %s", *build.WebURL))
-			}
-
-			return nil
+				std.Out.WriteLine(output.Styledf(output.StyleBold, "Build URL: %s", *build.WebURL))
+				return nil
+			},
 		},
-	}, {
-		Name:      "build",
-		ArgsUsage: "[runtype] <argument>",
-		Usage:     "Manually request a build for the currently checked out commit and branch (e.g. to trigger builds on forks or with special run types)",
-		Description: fmt.Sprintf(`
+		{
+			Name:    "status",
+			Aliases: []string{"st"},
+			Usage:   "Get the status of the CI run associated with the currently checked out branch",
+			Flags: append(ciTargetFlags,
+				&cli.BoolFlag{
+					Name:  "wait",
+					Usage: "Wait by blocking until the build is finished",
+				},
+				&cli.BoolFlag{
+					Name:    "web",
+					Aliases: []string{"view", "w"},
+					Usage:   "Open build page in web browser (--view is DEPRECATED and will be removed in the future)",
+				}),
+			Action: func(cmd *cli.Context) error {
+				client, err := bk.NewClient(cmd.Context, std.Out)
+				if err != nil {
+					return err
+				}
+				target, err := getBuildTarget(cmd)
+				if err != nil {
+					return err
+				}
+
+				// Just support main pipeline for now
+				build, err := target.GetBuild(cmd.Context, client)
+				if err != nil {
+					return err
+				}
+
+				// Print a high level overview, and jump into a browser
+				printBuildOverview(build)
+				if cmd.Bool("view") {
+					if err := open.URL(*build.WebURL); err != nil {
+						std.Out.WriteWarningf("failed to open build in browser: %s", err)
+					}
+				}
+
+				// If we are waiting and unfinished, poll for a build
+				if cmd.Bool("wait") && build.FinishedAt == nil {
+					if build.Branch == nil {
+						return errors.Newf("build %d not associated with a branch", *build.Number)
+					}
+
+					pending := std.Out.Pending(output.Styledf(output.StylePending, "Waiting for %d jobs...", len(build.Jobs)))
+					err := statusTicker(cmd.Context, func() (bool, error) {
+						// get the next update for this specific build
+						build, err = client.GetBuildByNumber(cmd.Context, target.pipeline, strconv.Itoa(*build.Number))
+						if err != nil {
+							return false, errors.Newf("failed to get most recent build for branch %q: %w", *build.Branch, err)
+						}
+
+						// Check if all jobs are finished
+						finishedJobs := 0
+						for _, job := range build.Jobs {
+							if job.State != nil {
+								if *job.State == "failed" && !job.SoftFailed {
+									// If a job has failed, return immediately, we don't have to wait until all
+									// steps are completed.
+									return true, nil
+								}
+								if *job.State == "passed" || job.SoftFailed {
+									finishedJobs++
+								}
+							}
+						}
+
+						// once started, poll for status
+						if build.StartedAt != nil {
+							pending.Updatef("Waiting for %d out of %d jobs... (elapsed: %v)",
+								len(build.Jobs)-finishedJobs, len(build.Jobs), time.Since(build.StartedAt.Time))
+						}
+
+						if build.FinishedAt == nil {
+							// No failure yet, we can keep waiting.
+							return false, nil
+						}
+						return true, nil
+					})
+					pending.Destroy()
+					if err != nil {
+						return err
+					}
+				}
+
+				// lets get annotations (if any) for the build
+				var annotations bk.JobAnnotations
+				annotations, err = client.GetJobAnnotationsByBuildNumber(cmd.Context, "sourcegraph", strconv.Itoa(*build.Number))
+				if err != nil {
+					return errors.Newf("failed to get annotations for build %d: %w", *build.Number, err)
+				}
+
+				// render resutls
+				failed := printBuildResults(build, annotations, cmd.Bool("wait"))
+
+				// If we're not on a specific branch and not asking for a specific build,
+				// warn if build commit is not your local copy - we are building an
+				// unknown revision.
+				if !target.fromFlag && target.targetType == buildTargetTypeBranch {
+					commit, err := run.GitCmd("rev-parse", "HEAD")
+					if err != nil {
+						return err
+					}
+					commit = strings.TrimSpace(commit)
+					if commit != *build.Commit {
+						std.Out.WriteLine(output.Linef("⚠️", output.StyleSuggestion,
+							"The currently checked out commit %q does not match the commit of the build found, %q.\nHave you pushed your most recent changes yet?",
+							commit, *build.Commit))
+					}
+				}
+
+				if failed {
+					std.Out.WriteLine(output.Linef(output.EmojiLightbulb, output.StyleSuggestion,
+						"Some jobs have failed - try using 'sg ci logs' to see what went wrong, or go to the build page: %s", *build.WebURL))
+				}
+
+				return nil
+			},
+		}, {
+			Name:      "build",
+			ArgsUsage: "[runtype] <argument>",
+			Usage:     "Manually request a build for the currently checked out commit and branch (e.g. to trigger builds on forks or with special run types)",
+			Description: fmt.Sprintf(`
 Reference to all pipeline run types can be found at: https://docs.sourcegraph.com/dev/background-information/ci/reference
 
 Optionally provide a run type to build with.
@@ -399,8 +532,8 @@ Supported run types when providing an argument for 'sg ci build [runtype]':
 
 For run types that require branch arguments, you will be prompted for an argument, or you
 can provide it directly (for example, 'sg ci build [runtype] <argument>').`,
-			strings.Join(getAllowedBuildTypeArgs(), "\n* ")),
-		UsageText: `
+				strings.Join(getAllowedBuildTypeArgs(), "\n* ")),
+			UsageText: `
 # Start a main-dry-run build
 sg ci build main-dry-run
 
@@ -413,338 +546,338 @@ sg ci build docker-images-patch-notest prometheus
 # Publish all images without testing
 sg ci build docker-images-candidates-notest
 `,
-		BashComplete: completions.CompleteOptions(getAllowedBuildTypeArgs),
-		Flags: []cli.Flag{
-			&ciPipelineFlag,
-			&cli.StringFlag{
-				Name:    "commit",
-				Aliases: []string{"c"},
-				Usage:   "`commit` from the current branch to build (defaults to current commit)",
+			BashComplete: completions.CompleteOptions(getAllowedBuildTypeArgs),
+			Flags: []cli.Flag{
+				&ciPipelineFlag,
+				&cli.StringFlag{
+					Name:    "commit",
+					Aliases: []string{"c"},
+					Usage:   "`commit` from the current branch to build (defaults to current commit)",
+				},
 			},
-		},
-		Action: func(cmd *cli.Context) error {
-			ctx := cmd.Context
-			client, err := bk.NewClient(ctx, std.Out)
-			if err != nil {
-				return err
-			}
-
-			branch, err := run.TrimResult(run.GitCmd("branch", "--show-current"))
-			if err != nil {
-				return err
-			}
-			commit := cmd.String("commit")
-			if commit == "" {
-				commit, err = run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
+			Action: func(cmd *cli.Context) error {
+				ctx := cmd.Context
+				client, err := bk.NewClient(ctx, std.Out)
 				if err != nil {
 					return err
 				}
-			}
 
-			// 🚨 SECURITY: We do a simple check to see if commit is in origin, this is
-			// non blocking but we ask for confirmation to double check that the user
-			// is aware that potentially unknown code is going to get run on our infra.
-			if !repo.HasCommit(ctx, commit) {
-				std.Out.WriteLine(output.Linef(output.EmojiWarning, output.StyleReset,
-					"Commit %q not found in in local 'origin/' branches - you might be triggering a build for a fork. Make sure all code has been reviewed before continuing.",
-					commit))
-				response, err := open.Prompt("Continue? (yes/no)")
+				branch, err := run.TrimResult(run.GitCmd("branch", "--show-current"))
 				if err != nil {
 					return err
 				}
-				if response != "yes" {
-					return errors.New("Cancelling request.")
+				commit := cmd.String("commit")
+				if commit == "" {
+					commit, err = run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
+					if err != nil {
+						return err
+					}
 				}
-				branch = fmt.Sprintf("_manually_triggered_external/%s", commit)
-			}
 
-			var rt runtype.RunType
-			if cmd.NArg() == 0 {
-				rt = runtype.PullRequest
-			} else {
-				rt = runtype.Compute("", fmt.Sprintf("%s/%s", cmd.Args().First(), branch), nil)
-				// If a special runtype is not detected then the argument was invalid
-				if rt == runtype.PullRequest {
-					std.Out.WriteFailuref("Unsupported runtype %q", cmd.Args().First())
-					std.Out.Writef("Supported runtypes:\n\n\t%s\n\nSee 'sg ci docs' to learn more.", strings.Join(getAllowedBuildTypeArgs(), ", "))
-					return exit.NewEmptyExitErr(1)
+				// 🚨 SECURITY: We do a simple check to see if commit is in origin, this is
+				// non blocking but we ask for confirmation to double check that the user
+				// is aware that potentially unknown code is going to get run on our infra.
+				if !repo.HasCommit(ctx, commit) {
+					std.Out.WriteLine(output.Linef(output.EmojiWarning, output.StyleReset,
+						"Commit %q not found in in local 'origin/' branches - you might be triggering a build for a fork. Make sure all code has been reviewed before continuing.",
+						commit))
+					response, err := open.Prompt("Continue? (yes/no)")
+					if err != nil {
+						return err
+					}
+					if response != "yes" {
+						return errors.New("Cancelling request.")
+					}
+					branch = fmt.Sprintf("_manually_triggered_external/%s", commit)
 				}
-			}
-			if rt != runtype.PullRequest {
-				m := rt.Matcher()
-				if m.BranchArgumentRequired {
-					var branchArg string
-					if cmd.NArg() >= 2 {
-						branchArg = cmd.Args().Get(1)
-					} else {
-						std.Out.Write("This run type requires a branch path argument.")
-						branchArg, err = open.Prompt("Enter your argument input:")
+
+				var rt runtype.RunType
+				if cmd.NArg() == 0 {
+					rt = runtype.PullRequest
+				} else {
+					rt = runtype.Compute("", fmt.Sprintf("%s/%s", cmd.Args().First(), branch), nil)
+					// If a special runtype is not detected then the argument was invalid
+					if rt == runtype.PullRequest {
+						std.Out.WriteFailuref("Unsupported runtype %q", cmd.Args().First())
+						std.Out.Writef("Supported runtypes:\n\n\t%s\n\nSee 'sg ci docs' to learn more.", strings.Join(getAllowedBuildTypeArgs(), ", "))
+						return exit.NewEmptyExitErr(1)
+					}
+				}
+				if rt != runtype.PullRequest {
+					m := rt.Matcher()
+					if m.BranchArgumentRequired {
+						var branchArg string
+						if cmd.NArg() >= 2 {
+							branchArg = cmd.Args().Get(1)
+						} else {
+							std.Out.Write("This run type requires a branch path argument.")
+							branchArg, err = open.Prompt("Enter your argument input:")
+							if err != nil {
+								return err
+							}
+						}
+						branch = fmt.Sprintf("%s/%s", branchArg, branch)
+					}
+
+					branch = fmt.Sprintf("%s%s", rt.Matcher().Branch, branch)
+					block := std.Out.Block(output.Line("", output.StylePending, fmt.Sprintf("Pushing %s to %s...", commit, branch)))
+					gitOutput, err := run.GitCmd("push", "origin", fmt.Sprintf("%s:refs/heads/%s", commit, branch), "--force")
+					if err != nil {
+						return err
+					}
+					block.WriteLine(output.Line("", output.StyleSuggestion, strings.TrimSpace(gitOutput)))
+					block.Close()
+				}
+
+				var (
+					pipeline = ciPipelineFlag.Get(cmd)
+					build    *buildkite.Build
+				)
+				if rt != runtype.PullRequest {
+					pollTicker := time.NewTicker(5 * time.Second)
+					std.Out.WriteLine(output.Styledf(output.StylePending, "Polling for build for branch %s at %s...", branch, commit))
+					for i := 0; i < 30; i++ {
+						// attempt to fetch the new build - it might take some time for the hooks so we will
+						// retry up to 30 times (roughly 30 seconds)
+						if build != nil && build.Commit != nil && *build.Commit == commit {
+							break
+						}
+						<-pollTicker.C
+						build, err = client.GetMostRecentBuild(ctx, pipeline, branch)
 						if err != nil {
-							return err
+							return errors.Wrap(err, "GetMostRecentBuild")
 						}
 					}
-					branch = fmt.Sprintf("%s/%s", branchArg, branch)
-				}
-
-				branch = fmt.Sprintf("%s%s", rt.Matcher().Branch, branch)
-				block := std.Out.Block(output.Line("", output.StylePending, fmt.Sprintf("Pushing %s to %s...", commit, branch)))
-				gitOutput, err := run.GitCmd("push", "origin", fmt.Sprintf("%s:refs/heads/%s", commit, branch), "--force")
-				if err != nil {
-					return err
-				}
-				block.WriteLine(output.Line("", output.StyleSuggestion, strings.TrimSpace(gitOutput)))
-				block.Close()
-			}
-
-			var (
-				pipeline = ciPipelineFlag.Get(cmd)
-				build    *buildkite.Build
-			)
-			if rt != runtype.PullRequest {
-				pollTicker := time.NewTicker(5 * time.Second)
-				std.Out.WriteLine(output.Styledf(output.StylePending, "Polling for build for branch %s at %s...", branch, commit))
-				for i := 0; i < 30; i++ {
-					// attempt to fetch the new build - it might take some time for the hooks so we will
-					// retry up to 30 times (roughly 30 seconds)
-					if build != nil && build.Commit != nil && *build.Commit == commit {
-						break
-					}
-					<-pollTicker.C
-					build, err = client.GetMostRecentBuild(ctx, pipeline, branch)
+				} else {
+					std.Out.WriteLine(output.Styledf(output.StylePending, "Requesting build for branch %q at %q...", branch, commit))
+					build, err = client.TriggerBuild(ctx, pipeline, branch, commit)
 					if err != nil {
-						return errors.Wrap(err, "GetMostRecentBuild")
+						return errors.Newf("failed to trigger build for branch %q at %q: %w", branch, commit, err)
 					}
 				}
-			} else {
-				std.Out.WriteLine(output.Styledf(output.StylePending, "Requesting build for branch %q at %q...", branch, commit))
-				build, err = client.TriggerBuild(ctx, pipeline, branch, commit)
-				if err != nil {
-					return errors.Newf("failed to trigger build for branch %q at %q: %w", branch, commit, err)
-				}
-			}
 
-			std.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Created build: %s", *build.WebURL))
-			return nil
-		},
-	}, {
-		Name:  "logs",
-		Usage: "Get logs from CI builds (e.g. to grep locally)",
-		Description: `Get logs from CI builds, and output them in stdout or push them to Loki. By default only gets failed jobs - to change this, use the '--state' flag.
+				std.Out.WriteLine(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Created build: %s", *build.WebURL))
+				return nil
+			},
+		}, {
+			Name:  "logs",
+			Usage: "Get logs from CI builds (e.g. to grep locally)",
+			Description: `Get logs from CI builds, and output them in stdout or push them to Loki. By default only gets failed jobs - to change this, use the '--state' flag.
 
 The '--job' flag can be used to narrow down the logs returned - you can provide either the ID, or part of the name of the job you want to see logs for.
 
 To send logs to a Loki instance, you can provide --out=http://127.0.0.1:3100 after spinning up an instance with 'sg run loki grafana'.
 From there, you can start exploring logs with the Grafana explore panel.
 `,
-		Flags: append(ciTargetFlags,
-			&cli.StringFlag{
-				Name:    "job",
-				Aliases: []string{"j"},
-				Usage:   "ID or name of the job to export logs for",
-			},
-			&cli.StringFlag{
-				Name:    "state",
-				Aliases: []string{"s"},
-				Usage:   "Job `state` to export logs for (provide an empty value for all states)",
-				Value:   "failed",
-			},
-			&cli.StringFlag{
-				Name:    "out",
-				Aliases: []string{"o"},
-				Usage: fmt.Sprintf("Output `format`: one of [%s], or a URL pointing to a Loki instance, such as %s",
-					strings.Join([]string{ciLogsOutTerminal, ciLogsOutSimple, ciLogsOutJSON}, "|"), loki.DefaultLokiURL),
-				Value: ciLogsOutTerminal,
-			},
-			&cli.StringFlag{
-				Name:  "overwrite-state",
-				Usage: "`state` to overwrite the job state metadata",
-			},
-		),
-		Action: func(cmd *cli.Context) error {
-			ctx := cmd.Context
-			client, err := bk.NewClient(ctx, std.Out)
-			if err != nil {
-				return err
-			}
-
-			target, err := getBuildTarget(cmd)
-			if err != nil {
-				return err
-			}
-
-			build, err := target.GetBuild(ctx, client)
-			if err != nil {
-				return err
-			}
-			std.Out.WriteLine(output.Styledf(output.StylePending, "Fetching logs for %s ...",
-				*build.WebURL))
-
-			options := bk.ExportLogsOpts{
-				JobQuery: cmd.String("job"),
-				State:    cmd.String("state"),
-			}
-			logs, err := client.ExportLogs(ctx, "sourcegraph", *build.Number, options)
-			if err != nil {
-				return err
-			}
-			if len(logs) == 0 {
-				std.Out.WriteLine(output.Line("", output.StyleSuggestion,
-					fmt.Sprintf("No logs found matching the given parameters (job: %q, state: %q).", options.JobQuery, options.State)))
-				return nil
-			}
-
-			logsOut := cmd.String("out")
-			switch logsOut {
-			case ciLogsOutTerminal, ciLogsOutSimple:
-				// Buildkite's timestamp thingo causes log lines to not render in terminal
-				bkTimestamp := regexp.MustCompile(`\x1b_bk;t=\d{13}\x07`) // \x1b is ESC, \x07 is BEL
-				for _, log := range logs {
-					block := std.Out.Block(output.Linef(output.EmojiInfo, output.StyleUnderline, "%s",
-						*log.JobMeta.Name))
-					content := bkTimestamp.ReplaceAllString(*log.Content, "")
-					if logsOut == ciLogsOutSimple {
-						content = bk.CleanANSI(content)
-					}
-					block.Write(content)
-					block.Close()
-				}
-				std.Out.WriteLine(output.Styledf(output.StyleSuccess, "Found and output logs for %d jobs.", len(logs)))
-
-			case ciLogsOutJSON:
-				for _, log := range logs {
-					if logsOut != "" {
-						failed := logsOut
-						log.JobMeta.State = &failed
-					}
-					stream, err := loki.NewStreamFromJobLogs(log)
-					if err != nil {
-						return errors.Newf("build %d job %s: NewStreamFromJobLogs: %s", log.JobMeta.Build, log.JobMeta.Job, err)
-					}
-					b, err := json.MarshalIndent(stream, "", "\t")
-					if err != nil {
-						return errors.Newf("build %d job %s: Marshal: %s", log.JobMeta.Build, log.JobMeta.Job, err)
-					}
-					std.Out.Write(string(b))
-				}
-
-			default:
-				lokiURL, err := url.Parse(logsOut)
+			Flags: append(ciTargetFlags,
+				&cli.StringFlag{
+					Name:    "job",
+					Aliases: []string{"j"},
+					Usage:   "ID or name of the job to export logs for",
+				},
+				&cli.StringFlag{
+					Name:    "state",
+					Aliases: []string{"s"},
+					Usage:   "Job `state` to export logs for (provide an empty value for all states)",
+					Value:   "failed",
+				},
+				&cli.StringFlag{
+					Name:    "out",
+					Aliases: []string{"o"},
+					Usage: fmt.Sprintf("Output `format`: one of [%s], or a URL pointing to a Loki instance, such as %s",
+						strings.Join([]string{ciLogsOutTerminal, ciLogsOutSimple, ciLogsOutJSON}, "|"), loki.DefaultLokiURL),
+					Value: ciLogsOutTerminal,
+				},
+				&cli.StringFlag{
+					Name:  "overwrite-state",
+					Usage: "`state` to overwrite the job state metadata",
+				},
+			),
+			Action: func(cmd *cli.Context) error {
+				ctx := cmd.Context
+				client, err := bk.NewClient(ctx, std.Out)
 				if err != nil {
-					return errors.Newf("invalid Loki target: %w", err)
+					return err
 				}
-				lokiClient := loki.NewLokiClient(lokiURL)
-				std.Out.WriteLine(output.Styledf(output.StylePending, "Pushing to Loki instance at %q", lokiURL.Host))
 
-				var (
-					pushedEntries int
-					pushedStreams int
-					pushErrs      []string
-					pending       = std.Out.Pending(output.Styled(output.StylePending, "Processing logs..."))
-				)
-				for i, log := range logs {
-					job := log.JobMeta.Job
-					if log.JobMeta.Label != nil {
-						job = fmt.Sprintf("%q (%s)", *log.JobMeta.Label, log.JobMeta.Job)
+				target, err := getBuildTarget(cmd)
+				if err != nil {
+					return err
+				}
+
+				build, err := target.GetBuild(ctx, client)
+				if err != nil {
+					return err
+				}
+				std.Out.WriteLine(output.Styledf(output.StylePending, "Fetching logs for %s ...",
+					*build.WebURL))
+
+				options := bk.ExportLogsOpts{
+					JobQuery: cmd.String("job"),
+					State:    cmd.String("state"),
+				}
+				logs, err := client.ExportLogs(ctx, "sourcegraph", *build.Number, options)
+				if err != nil {
+					return err
+				}
+				if len(logs) == 0 {
+					std.Out.WriteLine(output.Line("", output.StyleSuggestion,
+						fmt.Sprintf("No logs found matching the given parameters (job: %q, state: %q).", options.JobQuery, options.State)))
+					return nil
+				}
+
+				logsOut := cmd.String("out")
+				switch logsOut {
+				case ciLogsOutTerminal, ciLogsOutSimple:
+					// Buildkite's timestamp thingo causes log lines to not render in terminal
+					bkTimestamp := regexp.MustCompile(`\x1b_bk;t=\d{13}\x07`) // \x1b is ESC, \x07 is BEL
+					for _, log := range logs {
+						block := std.Out.Block(output.Linef(output.EmojiInfo, output.StyleUnderline, "%s",
+							*log.JobMeta.Name))
+						content := bkTimestamp.ReplaceAllString(*log.Content, "")
+						if logsOut == ciLogsOutSimple {
+							content = bk.CleanANSI(content)
+						}
+						block.Write(content)
+						block.Close()
 					}
-					overwriteState := cmd.String("overwrite-state")
-					if overwriteState != "" {
-						failed := overwriteState
-						log.JobMeta.State = &failed
+					std.Out.WriteLine(output.Styledf(output.StyleSuccess, "Found and output logs for %d jobs.", len(logs)))
+
+				case ciLogsOutJSON:
+					for _, log := range logs {
+						if logsOut != "" {
+							failed := logsOut
+							log.JobMeta.State = &failed
+						}
+						stream, err := loki.NewStreamFromJobLogs(log)
+						if err != nil {
+							return errors.Newf("build %d job %s: NewStreamFromJobLogs: %s", log.JobMeta.Build, log.JobMeta.Job, err)
+						}
+						b, err := json.MarshalIndent(stream, "", "\t")
+						if err != nil {
+							return errors.Newf("build %d job %s: Marshal: %s", log.JobMeta.Build, log.JobMeta.Job, err)
+						}
+						std.Out.Write(string(b))
 					}
 
-					pending.Updatef("Processing build %d job %s (%d/%d)...",
-						log.JobMeta.Build, job, i, len(logs))
-					stream, err := loki.NewStreamFromJobLogs(log)
+				default:
+					lokiURL, err := url.Parse(logsOut)
 					if err != nil {
-						pushErrs = append(pushErrs, fmt.Sprintf("build %d job %s: %s",
-							log.JobMeta.Build, job, err))
-						continue
+						return errors.Newf("invalid Loki target: %w", err)
+					}
+					lokiClient := loki.NewLokiClient(lokiURL)
+					std.Out.WriteLine(output.Styledf(output.StylePending, "Pushing to Loki instance at %q", lokiURL.Host))
+
+					var (
+						pushedEntries int
+						pushedStreams int
+						pushErrs      []string
+						pending       = std.Out.Pending(output.Styled(output.StylePending, "Processing logs..."))
+					)
+					for i, log := range logs {
+						job := log.JobMeta.Job
+						if log.JobMeta.Label != nil {
+							job = fmt.Sprintf("%q (%s)", *log.JobMeta.Label, log.JobMeta.Job)
+						}
+						overwriteState := cmd.String("overwrite-state")
+						if overwriteState != "" {
+							failed := overwriteState
+							log.JobMeta.State = &failed
+						}
+
+						pending.Updatef("Processing build %d job %s (%d/%d)...",
+							log.JobMeta.Build, job, i, len(logs))
+						stream, err := loki.NewStreamFromJobLogs(log)
+						if err != nil {
+							pushErrs = append(pushErrs, fmt.Sprintf("build %d job %s: %s",
+								log.JobMeta.Build, job, err))
+							continue
+						}
+
+						// Set buildkite metadata if available
+						if ciBranch := os.Getenv("BUILDKITE_BRANCH"); ciBranch != "" {
+							stream.Stream.Branch = ciBranch
+						}
+						if ciQueue := os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE"); ciQueue != "" {
+							stream.Stream.Queue = ciQueue
+						}
+
+						err = lokiClient.PushStreams(ctx, []*loki.Stream{stream})
+						if err != nil {
+							pushErrs = append(pushErrs, fmt.Sprintf("build %d job %q: %s",
+								log.JobMeta.Build, job, err))
+							continue
+						}
+
+						pushedEntries += len(stream.Values)
+						pushedStreams += 1
 					}
 
-					// Set buildkite metadata if available
-					if ciBranch := os.Getenv("BUILDKITE_BRANCH"); ciBranch != "" {
-						stream.Stream.Branch = ciBranch
-					}
-					if ciQueue := os.Getenv("BUILDKITE_AGENT_META_DATA_QUEUE"); ciQueue != "" {
-						stream.Stream.Queue = ciQueue
-					}
-
-					err = lokiClient.PushStreams(ctx, []*loki.Stream{stream})
-					if err != nil {
-						pushErrs = append(pushErrs, fmt.Sprintf("build %d job %q: %s",
-							log.JobMeta.Build, job, err))
-						continue
+					if pushedEntries > 0 {
+						pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess,
+							"Pushed %d entries from %d streams to Loki", pushedEntries, pushedStreams))
+					} else {
+						pending.Destroy()
 					}
 
-					pushedEntries += len(stream.Values)
-					pushedStreams += 1
+					if pushErrs != nil {
+						failedStreams := len(logs) - pushedStreams
+						std.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning,
+							"Failed to push %d streams: \n - %s", failedStreams, strings.Join(pushErrs, "\n - ")))
+						if failedStreams == len(logs) {
+							return errors.New("failed to push all logs")
+						}
+					}
 				}
 
-				if pushedEntries > 0 {
-					pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess,
-						"Pushed %d entries from %d streams to Loki", pushedEntries, pushedStreams))
-				} else {
-					pending.Destroy()
-				}
-
-				if pushErrs != nil {
-					failedStreams := len(logs) - pushedStreams
-					std.Out.WriteLine(output.Linef(output.EmojiFailure, output.StyleWarning,
-						"Failed to push %d streams: \n - %s", failedStreams, strings.Join(pushErrs, "\n - ")))
-					if failedStreams == len(logs) {
-						return errors.New("failed to push all logs")
-					}
-				}
-			}
-
-			return nil
-		},
-	}, {
-		Name:        "docs",
-		Usage:       "Render reference documentation for build pipeline types",
-		Description: "An online version of the rendered documentation is also available in https://docs.sourcegraph.com/dev/background-information/ci/reference.",
-		Action: func(ctx *cli.Context) error {
-			cmd := exec.Command("go", "run", "./enterprise/dev/ci/gen-pipeline.go", "-docs")
-			out, err := run.InRoot(cmd)
-			if err != nil {
-				return err
-			}
-			return std.Out.WriteMarkdown(out)
-		},
-	}, {
-		Name:      "open",
-		ArgsUsage: "[pipeline]",
-		Usage:     "Open Sourcegraph's Buildkite page in browser",
-		Action: func(ctx *cli.Context) error {
-			buildkiteURL := fmt.Sprintf("https://buildkite.com/%s", bk.BuildkiteOrg)
-			args := ctx.Args().Slice()
-			if len(args) > 0 && args[0] != "" {
-				pipeline := args[0]
-				buildkiteURL += fmt.Sprintf("/%s", pipeline)
-			}
-			return open.URL(buildkiteURL)
-		},
-	}, {
-		Name:      "search-failures",
-		ArgsUsage: "[text to search for]",
-		Usage:     "Open Sourcegraph's CI failures Grafana logs page in browser",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "step",
-				Usage: "Filter by step name (--step STEP_NAME will translate to '.*STEP_NAME.*')",
+				return nil
 			},
-		},
-		Action: func(ctx *cli.Context) error {
-			text := "TODO"
-			stepName := ctx.String("step")
+		}, {
+			Name:        "docs",
+			Usage:       "Render reference documentation for build pipeline types",
+			Description: "An online version of the rendered documentation is also available in https://docs.sourcegraph.com/dev/background-information/ci/reference.",
+			Action: func(ctx *cli.Context) error {
+				cmd := exec.Command("go", "run", "./enterprise/dev/ci/gen-pipeline.go", "-docs")
+				out, err := run.InRoot(cmd)
+				if err != nil {
+					return err
+				}
+				return std.Out.WriteMarkdown(out)
+			},
+		}, {
+			Name:      "open",
+			ArgsUsage: "[pipeline]",
+			Usage:     "Open Sourcegraph's Buildkite page in browser",
+			Action: func(ctx *cli.Context) error {
+				buildkiteURL := fmt.Sprintf("https://buildkite.com/%s", bk.BuildkiteOrg)
+				args := ctx.Args().Slice()
+				if len(args) > 0 && args[0] != "" {
+					pipeline := args[0]
+					buildkiteURL += fmt.Sprintf("/%s", pipeline)
+				}
+				return open.URL(buildkiteURL)
+			},
+		}, {
+			Name:      "search-failures",
+			ArgsUsage: "[text to search for]",
+			Usage:     "Open Sourcegraph's CI failures Grafana logs page in browser",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "step",
+					Usage: "Filter by step name (--step STEP_NAME will translate to '.*STEP_NAME.*')",
+				},
+			},
+			Action: func(ctx *cli.Context) error {
+				text := "TODO"
+				stepName := ctx.String("step")
 
-			if ctx.Args().Len() > 0 {
-				text = ctx.Args().Slice()[0]
-			}
-			grafanaURL := buildGrafanaURL(text, stepName)
-			return open.URL(grafanaURL)
-		},
-	}},
+				if ctx.Args().Len() > 0 {
+					text = ctx.Args().Slice()[0]
+				}
+				grafanaURL := buildGrafanaURL(text, stepName)
+				return open.URL(grafanaURL)
+			},
+		}},
 }
 
 func buildGrafanaURL(text string, stepName string) string {
@@ -921,7 +1054,7 @@ func statusTicker(ctx context.Context, f func() (bool, error)) error {
 		return nil
 	}
 	// Not finished, start ticking ...
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(20 * time.Second)
 	for {
 		select {
 		case <-ticker.C:

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -266,7 +266,7 @@ sg ci build --help
 		{
 			Name:      "bazel",
 			Usage:     "Fires a CI build running a given bazel command",
-			ArgsUsage: "[--web|--wait] [test|build] <bazel flags> <target1> <target2> ...",
+			ArgsUsage: "[--web|--wait] [test|build] <target1> <target2> ... <bazel flags>",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "wait",

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -216,6 +216,18 @@ Flags:
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 * `--format="<value>"`: Output format for the preview (one of 'markdown', 'json', or 'yaml') (default: markdown)
 
+### sg ci bazel
+
+Fires a CI build running a given bazel command.
+
+Arguments: `[--web|--wait] [test|build] <target1> <target2> ... <bazel flags>`
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--wait`: Wait until build completion and then print logs for the Bazel command
+* `--web`: Print the web URL for the build and return immediately
+
 ### sg ci status
 
 Get the status of the CI run associated with the currently checked out branch.

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -110,9 +110,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		var bzlCmd string
 		scanner := bufio.NewScanner(strings.NewReader(env["CI_COMMIT_MESSAGE"]))
 		for scanner.Scan() {
-			line := scanner.Text()
+			line := strings.TrimSpace(scanner.Text())
 			if strings.HasPrefix(line, "!bazel") {
-				bzlCmd = strings.TrimPrefix(line, "!bazel")
+				bzlCmd = strings.TrimSpace(strings.TrimPrefix(line, "!bazel"))
 
 				// sanitize the input
 				if err := verifyBazelCommand(bzlCmd); err != nil {
@@ -126,6 +126,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 						bk.Cmd(bazelCmd(bzlCmd)),
 					)
 				})
+				break
 			}
 		}
 


### PR DESCRIPTION
This is the companion PR to https://github.com/sourcegraph/sourcegraph/pull/54576 that streamline working with the `bazel-do/...` branches. 

It creates a new branch, with a unique name, adds an empty commit with the bazel command in the commit messages and pushes it. 

It support the `--wait` and `--web` flags, as usual. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + https://buildkite.com/sourcegraph/sourcegraph/builds/232650#0189219a-4365-43eb-8035-6bce05d087b2 


