### PR TITLE
cody-gateway/events: do not let bufferedLogger.Stop time out

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/events/buffered.go
+++ b/enterprise/cmd/cody-gateway/internal/events/buffered.go
@@ -155,8 +155,9 @@ func (l *BufferedLogger) Stop() {
 			log.Duration("elapsed", time.Since(start)))
 
 	// We may lose some events, but it won't be a lot since traffic should
-	// already be routing to new instances when work is stopping.
-	case <-time.After(10 * time.Second):
+	// already be routing to new instances when work is stopping, and the deadline
+	// is already very long.
+	case <-time.After(2 * time.Minute):
 		l.log.Error("failed to shut down within shutdown deadline",
 			log.Error(errors.Newf("unflushed events: %d", len(l.bufferC)))) // real error for Sentry
 	}


### PR DESCRIPTION
We want to make sure we ~never drop anything, so let's just allow buffered events logger to work for longer to process all events.

## Test plan

n/a
