### PR TITLE
deploy: correct blobstore endpoint in sourcegraph/server image (fix 'main' CI)

### DIFF
--- a/internal/conf/deploy/endpoints.go
+++ b/internal/conf/deploy/endpoints.go
@@ -10,7 +10,7 @@ func BlobstoreDefaultEndpoint() string {
 	if IsApp() {
 		return "http://127.0.0.1:49000"
 	}
-	if IsSingleBinary() {
+	if IsSingleBinary() || IsDeployTypeSingleDockerContainer(Type()) {
 		return "http://127.0.0.1:9000"
 	}
 	return "http://blobstore:9000"
@@ -21,7 +21,7 @@ func BlobstoreHostPort() (string, string) {
 	if IsApp() {
 		return "127.0.0.1", "49000"
 	}
-	if env.InsecureDev || IsSingleBinary() {
+	if env.InsecureDev || IsSingleBinary() || IsDeployTypeSingleDockerContainer(Type()) {
 		return "127.0.0.1", "9000"
 	}
 	return "", "9000"


### PR DESCRIPTION
We still use `sourcegraph/server` to run our integration tests in our CI pipelines (yuck) and in my change #54466 I failed to realize that `IsSingleBinary()` and `IsDeployTypeSingleDockerContainer(Type())` report different things.

This fixes the issue, and likely fixes `main` on our CI pipelines. If not, then both this change and the other should be reverted.

## Test plan

CI