### PR TITLE
ci: drop metadata step

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -15,14 +15,12 @@ For a higher-level overview, please refer to the [continuous integration docs](h
 The default run type.
 
 - Pipeline for `Go` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Client` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
@@ -31,90 +29,76 @@ The default run type.
   - **Pipeline setup**: Trigger async
 
 - Pipeline for `GraphQL` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Unit and integration tests for the Cody VS Code extension, E2E tests for the Cody VS Code extension, Stylelint (all)
 
 - Pipeline for `DatabaseSchema` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `Docs` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Dockerfiles` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `ExecutorVMImage` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `CIScripts` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `Terraform` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `SVG` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `Shell` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
 
 - Pipeline for `DockerImages` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `WolfiPackages` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `WolfiBaseImages` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
 
 - Pipeline for `Protobuf` changes:
-  - **Metadata**: Pipeline metadata
   - Ensure buildfiles are up to date
   - Tests
   - BackCompat Tests
@@ -131,7 +115,6 @@ sg ci build wolfi
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 
 ### Release branch nightly healthcheck build
 
@@ -139,7 +122,6 @@ The run type for environment including `{"RELEASE_NIGHTLY":"true"}`.
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - Trigger 5.1 release branch healthcheck build
 - Trigger 5.0 release branch healthcheck build
 
@@ -194,7 +176,6 @@ The run type for tags starting with `v`.
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
 - Ensure buildfiles are up to date
@@ -212,7 +193,6 @@ The run type for branches matching `^[0-9]+\.[0-9]+$` (regexp match).
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
 - Ensure buildfiles are up to date
@@ -263,7 +243,6 @@ The run type for branches matching `main` (exact match).
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary
 - Ensure buildfiles are up to date
@@ -286,7 +265,6 @@ sg ci build main-dry-run
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary
 - Ensure buildfiles are up to date
@@ -348,7 +326,6 @@ sg ci build backend-integration
 
 Base pipeline (more steps might be included based on branch changes):
 
-- **Metadata**: Pipeline metadata
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images
 - Ensure buildfiles are up to date

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -1,7 +1,6 @@
 package ci
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1025,34 +1024,4 @@ func publishExecutorDockerMirror(c Config) operations.Operation {
 
 		pipeline.AddStep(":packer: :white_check_mark: Publish docker registry mirror image", stepOpts...)
 	}
-}
-
-func exposeBuildMetadata(c Config) (operations.Operation, error) {
-	overview := struct {
-		RunType      string       `json:"RunType"`
-		Version      string       `json:"Version"`
-		Diff         string       `json:"Diff"`
-		MessageFlags MessageFlags `json:"MessageFlags"`
-	}{
-		RunType:      c.RunType.String(),
-		Diff:         c.Diff.String(),
-		MessageFlags: c.MessageFlags,
-	}
-	data, err := json.Marshal(&overview)
-	if err != nil {
-		return nil, err
-	}
-
-	return func(p *bk.Pipeline) {
-		p.AddStep(":memo::pipeline: Pipeline metadata",
-			bk.SoftFail(),
-			bk.Env("BUILD_METADATA", string(data)),
-			bk.AnnotatedCmd("dev/ci/gen-metadata-annotation.sh", bk.AnnotatedCmdOpts{
-				Annotations: &bk.AnnotationOpts{
-					Type:         bk.AnnotationTypeInfo,
-					IncludeNames: false,
-				},
-			}),
-		)
-	}, nil
 }

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -94,13 +94,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	// Set up operations that add steps to a pipeline.
 	ops := operations.NewSet()
 
-	if op, err := exposeBuildMetadata(c); err == nil {
-		if !c.RunType.Is(runtype.BazelDo) {
-			// Skip meta for bazel-do
-			ops.Merge(operations.NewNamedSet("Metadata", op))
-		}
-	}
-
 	// This statement outlines the pipeline steps for each CI case.
 	//
 	// PERF: Try to order steps such that slower steps are first.


### PR DESCRIPTION
The metadata step is for the dev-infra team usage, but we don't use it much these days. Because it's still about 1m 1m30 per build, we're better without it.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 