### PR TITLE
docs/executors: specify feature flag for native k8s deployment

### DIFF
--- a/doc/admin/executors/deploy_executors_kubernetes.md
+++ b/doc/admin/executors/deploy_executors_kubernetes.md
@@ -14,6 +14,9 @@
 
 ## Requirements
 
+### Feature flag
+To instruct Sourcegraph to use Kubernetes-deployed executors, you will need to enable the `native-ssbc-execution` [feature flag](./native_execution.md#enable).
+
 ### RBAC Roles
 
 Executors interact with the Kubernetes API to handle jobs. The following are the RBAC Roles needed to run Executors on


### PR DESCRIPTION
Makes it explicit to set this flag in the deployment docs for native Kubernetes executors.

## Test plan
`sg run docsite`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
