### PR TITLE
JetBrains: show currently opened file name in footer

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added embeddings status in footer [#54575](https://github.com/sourcegraph/sourcegraph/pull/54575)
+- Added currently opened file name in footer [#54610](https://github.com/sourcegraph/sourcegraph/pull/54610)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/CurrentlyOpenFileListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/CurrentlyOpenFileListener.java
@@ -8,12 +8,12 @@ import com.sourcegraph.common.ProjectFileUtils;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
-public class CurrentlyOpenedFileListener implements FileEditorManagerListener {
+public class CurrentlyOpenFileListener implements FileEditorManagerListener {
 
   private final @NotNull Project project;
   private final @NotNull EmbeddingStatusView embeddingStatusView;
 
-  public CurrentlyOpenedFileListener(
+  public CurrentlyOpenFileListener(
       @NotNull Project project, @NotNull EmbeddingStatusView embeddingStatusView) {
     this.project = project;
     this.embeddingStatusView = embeddingStatusView;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/CurrentlyOpenedFileListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/CurrentlyOpenedFileListener.java
@@ -1,0 +1,32 @@
+package com.sourcegraph.cody.context;
+
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.sourcegraph.common.ProjectFileUtils;
+import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
+
+public class CurrentlyOpenedFileListener implements FileEditorManagerListener {
+
+  private final @NotNull Project project;
+  private final @NotNull EmbeddingStatusView embeddingStatusView;
+
+  public CurrentlyOpenedFileListener(
+      @NotNull Project project, @NotNull EmbeddingStatusView embeddingStatusView) {
+    this.project = project;
+    this.embeddingStatusView = embeddingStatusView;
+  }
+
+  @Override
+  public void selectionChanged(@NotNull FileEditorManagerEvent event) {
+    VirtualFile newFile = event.getNewFile();
+    String openedFileName = Optional.ofNullable(newFile).map(VirtualFile::getName).orElse("");
+    String relativeFilePath = null;
+    if (newFile != null) {
+      relativeFilePath = ProjectFileUtils.getRelativePathToProjectRoot(project, newFile);
+    }
+    embeddingStatusView.setOpenedFileName(openedFileName, relativeFilePath);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -62,7 +62,7 @@ public class EmbeddingStatusView extends JPanel {
         .connect()
         .subscribe(
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
-            new CurrentlyOpenedFileListener(project, this));
+            new CurrentlyOpenFileListener(project, this));
   }
 
   private void updateViewBasedOnStatus() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -3,11 +3,13 @@ package com.sourcegraph.cody.context;
 import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.ColorUtil;
 import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.components.JBLabel;
 import com.intellij.util.concurrency.EdtExecutorService;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
@@ -15,41 +17,52 @@ import com.sourcegraph.cody.context.embeddings.EmbeddingsStatusLoader;
 import com.sourcegraph.cody.editor.EditorUtil;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.vcs.RepoUtil;
-import java.awt.BorderLayout;
+import java.awt.FlowLayout;
 import java.util.concurrent.TimeUnit;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.JPanel;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class EmbeddingStatusView extends JPanel {
 
   private final @NotNull SimpleColoredComponent embeddingStatusContent;
+  private final @NotNull JBLabel openedFileContent;
   private final @NotNull Project project;
   private @NotNull EmbeddingStatus embeddingStatus;
 
   public EmbeddingStatusView(@NotNull Project project) {
     super();
     this.project = project;
-    this.setLayout(new BorderLayout());
+    this.setLayout(new FlowLayout(FlowLayout.LEFT));
     Border topBorder =
         BorderFactory.createMatteBorder(
             1, 0, 0, 0, ColorUtil.brighter(UIUtil.getPanelBackground(), 3));
     this.setBorder(topBorder);
-    JPanel innerPanel = new JPanel();
-    innerPanel.setLayout(new BorderLayout());
+    Box innerPanel = Box.createHorizontalBox();
     embeddingStatusContent = new SimpleColoredComponent();
+    openedFileContent = new JBLabel();
     embeddingStatus = new EmbeddingStatusNotAvailableYet();
     updateViewBasedOnStatus();
-    innerPanel.add(embeddingStatusContent, BorderLayout.CENTER);
+    innerPanel.add(embeddingStatusContent);
+    innerPanel.add(Box.createHorizontalStrut(5));
+    innerPanel.add(openedFileContent);
     innerPanel.setBorder(new EmptyBorder(JBUI.insets(TEXT_MARGIN, TEXT_MARGIN, 0, TEXT_MARGIN)));
-    this.add(innerPanel, BorderLayout.CENTER);
+    this.add(innerPanel);
 
     EdtExecutorService.getScheduledExecutorInstance()
         .scheduleWithFixedDelay(this::updateEmbeddingStatusView, 1, 10, TimeUnit.SECONDS);
+    project
+        .getMessageBus()
+        .connect()
+        .subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            new CurrentlyOpenedFileListener(project, this));
   }
 
   private void updateViewBasedOnStatus() {
@@ -103,5 +116,10 @@ public class EmbeddingStatusView extends JPanel {
                         }
                       });
             });
+  }
+
+  public void setOpenedFileName(@NotNull String fileName, @Nullable String filePath) {
+    openedFileContent.setText(fileName);
+    openedFileContent.setToolTipText(filePath);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/ProjectFileUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/ProjectFileUtils.java
@@ -1,0 +1,23 @@
+package com.sourcegraph.common;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.io.File;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ProjectFileUtils {
+
+  public static @Nullable String getRelativePathToProjectRoot(
+      @NotNull Project project, @NotNull VirtualFile file) {
+    VirtualFile rootForFile = ProjectFileIndex.getInstance(project).getContentRootForFile(file);
+    if (rootForFile != null) {
+      return new File(rootForFile.getPath())
+          .toURI()
+          .relativize(new File(file.getPath()).toURI())
+          .getPath();
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Shows currently opened file name in Cody footer

## Test plan
- Open some files in the editor and see that the file name is being displayed in the footer
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/c8db8edb-31fe-4897-b724-d7d0881ca50a)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
