### PR TITLE
App: fix blobstore port for sg start app

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1440,6 +1440,8 @@ commandsets:
       DISABLE_CODE_INSIGHTS: true
       SOURCEGRAPH_APP: 1
       EXTSVC_CONFIG_ALLOW_EDITS: true
+      PRECISE_CODE_INTEL_UPLOAD_AWS_ENDPOINT: http://localhost:49000
+      EMBEDDINGS_UPLOAD_AWS_ENDPOINT: http://localhost:49000
 
   cody-gateway:
     checks:


### PR DESCRIPTION
Blobstore port for `sg start app` was incorrect because `SetDefaultEnv` does not overwrite existing values and `sg` set a default for blobstore to `9000`
## Test plan
`sg start app` - no errors about blobstore or code intel lsif uploads.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
