### PR TITLE
backcompat: fixes to better handle file movement

### DIFF
--- a/dev/backcompat/defs.bzl
+++ b/dev/backcompat/defs.bzl
@@ -32,7 +32,10 @@ PATCH_GO_TEST = """_sed_binary="sed"
 if [ "$(uname)" == "Darwin" ]; then
     _sed_binary="gsed"
 fi
-$_sed_binary -i "s/func {}/func _{}/g" {}/*.go
+
+if [ -a "{}" ]; then
+    $_sed_binary -i "s/func {}/func _{}/g" {}/*.go
+fi
 """
 
 # Assemble go test patches, based on the currently defined version.

--- a/dev/backcompat/defs.bzl
+++ b/dev/backcompat/defs.bzl
@@ -41,7 +41,7 @@ fi
 # Assemble go test patches, based on the currently defined version.
 # See //dev/backcompat:test_release_version.bzl for the version definition.
 PATCH_GO_TEST_CMDS = [
-    PATCH_GO_TEST.format(test["prefix"], test["prefix"], test["path"], test["prefix"], test["reason"])
+    PATCH_GO_TEST.format(test["path"], test["prefix"], test["prefix"], test["path"])
     for test in FLAKES[MINIMUM_UPGRADEABLE_VERSION]
 ]
 

--- a/dev/backcompat/flakes.bzl
+++ b/dev/backcompat/flakes.bzl
@@ -19,7 +19,7 @@ FLAKES = {
             "reason": "Shifting constraints on table; ranking is experimental",
         },
         {
-            "path": "internal/codeintel/ranking/internal/store",
+            "path": "enterprise/internal/codeintel/ranking/internal/store",
             "prefix": "Test",
             "reason": "Shifting constraints on table; ranking is experimental",
         },


### PR DESCRIPTION
* Add a test to the sed command to only perform sed on files that exist
* Update the format args used - it had more args that formating place holders
* Set flakes path for ranking tests
## Test plan
Green CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
