### PR TITLE
env: add MustGetBytes

### DIFF
--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -105,7 +105,7 @@ If you would like to allow your Sourcegraph instance to control the creation and
 
 ### Environment variables for the `embeddings` service
 
-- `EMBEDDINGS_CACHE_SIZE`: The maximum size of the in-memory cache (in bytes) that holds the embeddings for commonly-searched repos. If embeddings for a repo are larger than this size, the repo will not be held in the cache and must be re-fetched for each embeddings search. Defaults to `6442450944` (6 GiB).
+- `EMBEDDINGS_CACHE_SIZE`: The maximum size of the in-memory cache that holds the embeddings for commonly-searched repos. If embeddings for a repo are larger than this size, the repo will not be held in the cache and must be re-fetched for each embeddings search. Defaults to `6GiB`.
 
 ### Incremental embeddings
 

--- a/enterprise/cmd/embeddings/shared/config.go
+++ b/enterprise/cmd/embeddings/shared/config.go
@@ -40,8 +40,5 @@ func (c *Config) Validate() error {
 	var errs error
 	errs = errors.Append(errs, c.BaseConfig.Validate())
 	errs = errors.Append(errs, c.EmbeddingsUploadStoreConfig.Validate())
-	if c.EmbeddingsCacheSize < 0 {
-		errs = errors.Append(errs, errors.New("embeddings cache size cannot be negative"))
-	}
 	return errs
 }

--- a/enterprise/cmd/embeddings/shared/config.go
+++ b/enterprise/cmd/embeddings/shared/config.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"net/url"
-	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -10,14 +9,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 
-const defaultEmbeddingsCacheSize = 6 * 1024 * 1024 * 1024 // 6 GiB
+const defaultEmbeddingsCacheSize = "6GiB"
 
 type Config struct {
 	env.BaseConfig
 
 	EmbeddingsUploadStoreConfig *emb.EmbeddingsUploadStoreConfig
 
-	EmbeddingsCacheSize int64
+	EmbeddingsCacheSize uint64
 
 	WeaviateURL *url.URL
 }
@@ -34,7 +33,7 @@ func (c *Config) Load() {
 		}
 	}
 
-	c.EmbeddingsCacheSize = int64(c.GetInt("EMBEDDINGS_CACHE_SIZE", strconv.Itoa(defaultEmbeddingsCacheSize), "The size of the in-memory cache for embeddings indexes"))
+	c.EmbeddingsCacheSize = env.MustGetBytes("EMBEDDINGS_CACHE_SIZE", defaultEmbeddingsCacheSize, "The size of the in-memory cache for embeddings indexes")
 }
 
 func (c *Config) Validate() error {

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -57,12 +57,12 @@ var (
 type embeddingsIndexCache struct {
 	mu                 sync.Mutex
 	cache              *lru.Cache[embeddings.RepoEmbeddingIndexName, repoEmbeddingIndexCacheEntry]
-	maxSizeBytes       int64
-	remainingSizeBytes int64
+	maxSizeBytes       uint64
+	remainingSizeBytes uint64
 }
 
 // newEmbeddingsIndexCache creates a cache with reasonable settings for an embeddings cache
-func newEmbeddingsIndexCache(maxSizeBytes int64) (_ *embeddingsIndexCache, err error) {
+func newEmbeddingsIndexCache(maxSizeBytes uint64) (_ *embeddingsIndexCache, err error) {
 	c := &embeddingsIndexCache{
 		maxSizeBytes:       maxSizeBytes,
 		remainingSizeBytes: maxSizeBytes,
@@ -125,7 +125,7 @@ func NewCachedEmbeddingIndexGetter(
 	repoStore database.RepoStore,
 	repoEmbeddingJobStore repo.RepoEmbeddingJobsStore,
 	downloadRepoEmbeddingIndex downloadRepoEmbeddingIndexFn,
-	cacheSizeBytes int64,
+	cacheSizeBytes uint64,
 ) (*CachedEmbeddingIndexGetter, error) {
 	cache, err := newEmbeddingsIndexCache(cacheSizeBytes)
 	if err != nil {

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
@@ -46,7 +46,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 				}, nil
 			}
 		},
-		int64(cacheSize),
+		uint64(cacheSize),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/embeddings/types.go
+++ b/internal/embeddings/types.go
@@ -20,8 +20,8 @@ func (index *EmbeddingIndex) Row(n int) []int8 {
 	return index.Embeddings[n*index.ColumnDimension : (n+1)*index.ColumnDimension]
 }
 
-func (index *EmbeddingIndex) EstimateSize() int64 {
-	return int64(len(index.Embeddings) + len(index.RowMetadata)*(16+8+8) + len(index.Ranks)*4)
+func (index *EmbeddingIndex) EstimateSize() uint64 {
+	return uint64(len(index.Embeddings) + len(index.RowMetadata)*(16+8+8) + len(index.Ranks)*4)
 }
 
 // Filter removes all files from the index that are in the set and updates the ranks
@@ -71,7 +71,7 @@ type RepoEmbeddingIndex struct {
 	TextIndex       EmbeddingIndex
 }
 
-func (i *RepoEmbeddingIndex) EstimateSize() int64 {
+func (i *RepoEmbeddingIndex) EstimateSize() uint64 {
 	return i.CodeIndex.EstimateSize() + i.TextIndex.EstimateSize()
 }
 

--- a/internal/env/BUILD.bazel
+++ b/internal/env/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//lib/errors",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_inconshreveable_log15//:log15",
     ],
 )

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/inconshreveable/log15"
 )
 
@@ -133,6 +134,16 @@ func Get(name, defaultValue, description string) string {
 	env[name] = e
 
 	return value
+}
+
+// MustGetBytes is similar to Get but ensures that the value is a valid byte size (as defined by go-humanize)
+func MustGetBytes(name string, defaultValue string, description string) uint64 {
+	s := Get(name, defaultValue, description)
+	n, err := humanize.ParseBytes(s)
+	if err != nil {
+		panic(fmt.Sprintf("parsing environment variable %q. Expected valid time.Duration, got %q", name, s))
+	}
+	return n
 }
 
 // MustGetDuration is similar to Get but ensures that the value is a valid time.Duration.


### PR DESCRIPTION
This adds `env.MustGetBytes` that parses an environment variable with `go-humanize` and updates the `EMBEDDINGS_CACHE_SIZE` env var to use that. This is easier to read than a big blob of numbers, and easier to configure for admins. `go-humanize` supports numbers without a label and interprets it as bytes, just like we did before.

## Test plan

Check out the `go-humanize` tests for exactly what is accepted. Tested that a couple of env vars work as expected (in particular, just a plain number like this option used to use exclusively)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
