### PR TITLE
App - make App check for new repos faster

### DIFF
--- a/internal/conf/confdefaults/confdefaults.go
+++ b/internal/conf/confdefaults/confdefaults.go
@@ -93,6 +93,7 @@ var App = conftypes.RawUnified{
 		"structuralSearch": "disabled"
 	},
 	"cody.enabled": true,
+	"repoListUpdateInterval": 0,
 	"completions": {
 		"enabled": true,
 		"provider": "sourcegraph"

--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//internal/codeintel/dependencies",
         "//internal/conf",
         "//internal/conf/conftypes",
+        "//internal/conf/deploy",
         "//internal/conf/reposource",
         "//internal/database",
         "//internal/database/basestore",

--- a/internal/repos/conf.go
+++ b/internal/repos/conf.go
@@ -13,8 +13,6 @@ import (
 //
 // - 15 seconds for app deployments (to speed up adding repos during setup)
 // - 1 minute otherwise
-//
-// The returned duration is in minutes.
 func ConfRepoListUpdateInterval() time.Duration {
 	v := conf.Get().RepoListUpdateInterval
 	if v == 0 { //  default to 1 minute

--- a/internal/repos/conf.go
+++ b/internal/repos/conf.go
@@ -4,11 +4,23 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 )
 
+// ConfRepoListUpdateInterval returns the repository list update interval.
+//
+// If the RepoListUpdateInterval site configuration setting is 0, it defaults to:
+//
+// - 15 seconds for app deployments (to speed up adding repos during setup)
+// - 1 minute otherwise
+//
+// The returned duration is in minutes.
 func ConfRepoListUpdateInterval() time.Duration {
 	v := conf.Get().RepoListUpdateInterval
 	if v == 0 { //  default to 1 minute
+		if deploy.IsApp() {
+			return time.Second * 15 // 15 seconds for app deployments
+		}
 		v = 1
 	}
 	return time.Duration(v) * time.Minute


### PR DESCRIPTION
External services are only scanned for new repos at a set interval currently the minimum time between checks is 1 min.  This overrides that min for App and allows it to check every 15 seconds.   This allows new repos to be added more quickly during the setup flow instead of having a wait potentially for 1 min before they are discovered and synced.
## Test plan
`sg start app` add a local repo ensure repo is added and cloned.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
