### PR TITLE
codeintel: Add symbols method to syntect client

### DIFF
--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -270,3 +270,50 @@ func New(syntectServer string) *Client {
 		httpClient:    httpcli.InternalClient,
 	}
 }
+
+type symbolsResponse struct {
+	Scip      string
+	Plaintext bool
+}
+
+type SymbolsQuery struct {
+	FileName string `json:"filename"`
+	Content  string `json:"content"`
+}
+
+// SymbolsResponse represents a response to a symbols query.
+type SymbolsResponse struct {
+	Scip      string `json:"scip"`
+	Plaintext bool   `json:"plaintext"`
+}
+
+func (c *Client) Symbols(ctx context.Context, q *SymbolsQuery) (*SymbolsResponse, error) {
+	serialized, err := json.Marshal(q)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to encode query")
+	}
+	body := bytes.NewReader(serialized)
+
+	req, err := http.NewRequest("POST", c.url("/symbols"), body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to perform symbols request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Newf("unexpected status code %d", resp.StatusCode)
+	}
+
+	var r SymbolsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, errors.Wrap(err, "failed to decode symbols response")
+	}
+
+	return &r, nil
+}


### PR DESCRIPTION
Pulled from #51690. This adds a new client method we'll use to provide precise Cody context.

## Test plan

Tested locally.