### PR TITLE
soap: fix missing display name

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/sourcegraphoperator/provider.go
@@ -55,7 +55,8 @@ func (p *provider) Config() schema.AuthProviders {
 	// non-Sourcegraph employees.
 	return schema.AuthProviders{
 		Openidconnect: &schema.OpenIDConnectAuthProvider{
-			ConfigID: auth.SourcegraphOperatorProviderType,
+			ConfigID:    auth.SourcegraphOperatorProviderType,
+			DisplayName: "Sourcegraph Operators",
 		},
 	}
 }


### PR DESCRIPTION
regression from

https://github.com/sourcegraph/sourcegraph/pull/50586/files#diff-ee8e8b3d80266a31a0ea0102394d4434f42c692b4a787b9446d54846fd7167c4L237-R248

auth providers are populated from context.window

before

https://github.com/sourcegraph/sourcegraph/blob/bc2293827bcb6dda6c41ff1b24fadd2e92ede6dd/cmd/frontend/internal/app/jscontext/jscontext.go#L236-L251

after

https://github.com/sourcegraph/sourcegraph/blob/e2d4e003e0ddc51b8f103ee811a7387f5739a7b1/cmd/frontend/internal/app/jscontext/jscontext.go#L248-L265

it now gets the display name from common config, which relies on Provider.Config


https://github.com/sourcegraph/sourcegraph/blob/e2d4e003e0ddc51b8f103ee811a7387f5739a7b1/internal/auth/providers/providers.go#L192-L223




## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

see above

before

![CleanShot 2023-07-05 at 15 42 01](https://github.com/sourcegraph/sourcegraph/assets/8373004/22bca9bf-1b57-4da5-ae55-eea5bc42ee54)

after

![CleanShot 2023-07-05 at 15 40 40](https://github.com/sourcegraph/sourcegraph/assets/8373004/6a867ff0-92ca-4d9d-9908-88e56c9f687e)
