### PR TITLE
executors: Be able to paginate over secrets

### DIFF
--- a/client/web/src/enterprise/executors/secrets/backend.ts
+++ b/client/web/src/enterprise/executors/secrets/backend.ts
@@ -217,7 +217,6 @@ export const globalExecutorSecretsConnectionFactory = (
         },
         options: {
             useURL: true,
-            fetchPolicy: 'no-cache',
         },
         getConnection: result => {
             const { executorSecrets } = dataOrThrowErrors(result)


### PR DESCRIPTION
Executor secrets could not be paginated over. Removing the fetch policy (`no-cache`) made it so that the `previousResult` would not be `{}`.

With the `no-cache`, `previousResult` would be empty, causing an error to be thrown since there are no `nodes` on the result.

## Test plan

Tested manually.


https://github.com/sourcegraph/sourcegraph/assets/38407415/f6722b4a-a298-409b-9ce0-fd0453454358

