### PR TITLE
sveltekit-prototyp: Properly use kit's "streaming promises" feature

### DIFF
--- a/client/web-sveltekit/src/lib/utils.ts
+++ b/client/web-sveltekit/src/lib/utils.ts
@@ -8,9 +8,14 @@ export type LoadingData<D, E> =
     | { loading: false; data: null; error: E }
 
 /**
- * Converts a promise to a readable store which emits loading and error data.
- * This is useful in loader functions to prevent SvelteKit from waiting for the
- * promise to resolve before rendering the page.
+ * Converts a promise to a readable store which emits data, loading and error states.
+ * Sometimes load functions return deferred promises and the data needs to be
+ * "post processed" in code (i.e. not using {#await}).
+ * Usually when working with async data one has to be careful with outdated data.
+ * If the load function has been called again we don't want to process the
+ * previous data anymore.
+ * Using a (reactive) store makes that simpler since Svelte will automatically unsubscribe
+ * when the store changes.
  */
 export function asStore<T, E = Error>(promise: Promise<T>): Readable<LoadingData<T, E>> {
     const { subscribe, set } = writable<LoadingData<T, E>>({ loading: true })

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.svelte
@@ -4,6 +4,7 @@
     import { page } from '$app/stores'
     import Icon from '$lib/Icon.svelte'
     import FileTree from '$lib/repo/FileTree.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
@@ -13,7 +14,7 @@
         return arr[arr.length - 1]
     }
 
-    $: treeOrError = data.treeEntries
+    $: treeOrError = asStore(data.treeEntries.deferred)
     let showSidebar = true
 </script>
 

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+layout.ts
@@ -4,14 +4,13 @@ import { catchError } from 'rxjs/operators'
 
 import { asError, isErrorLike, type ErrorLike } from '$lib/common'
 import { fetchTreeEntries } from '$lib/loader/repo'
-import { asStore } from '$lib/utils'
 import { requestGraphQL } from '$lib/web'
 
 import type { LayoutLoad } from './$types'
 
 export const load: LayoutLoad = ({ parent, params }) => ({
-    treeEntries: asStore(
-        parent().then(({ resolvedRevision, repoName, revision }) =>
+    treeEntries: {
+        deferred: parent().then(({ resolvedRevision, repoName, revision }) =>
             !isErrorLike(resolvedRevision)
                 ? fetchTreeEntries({
                       repoName,
@@ -24,6 +23,6 @@ export const load: LayoutLoad = ({ parent, params }) => ({
                       .pipe(catchError((error): [ErrorLike] => [asError(error)]))
                       .toPromise()
                 : null
-        )
-    ),
+        ),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+page.svelte
@@ -5,13 +5,14 @@
     import { isErrorLike } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: treeOrError = data.treeEntries
-    $: commits = data.commits
+    $: treeOrError = asStore(data.treeEntries.deferred)
+    $: commits = asStore(data.commits.deferred)
 </script>
 
 <div class="content">

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/+page.ts
@@ -1,12 +1,11 @@
 import { fetchCommits } from '$lib/loader/commits'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ parent }) => ({
-    commits: asStore(
-        parent()
+    commits: {
+        deferred: parent()
             .then(({ resolvedRevision }) => fetchCommits(resolvedRevision, true))
-            .then(result => result?.nodes.slice(0, 5) ?? [])
-    ),
+            .then(result => result?.nodes.slice(0, 5) ?? []),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.svelte
@@ -3,6 +3,7 @@
     import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
     import type { BlobFileFields } from '$lib/graphql-operations'
     import HeaderAction from '$lib/repo/HeaderAction.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
     import FormatAction from './FormatAction.svelte'
@@ -10,8 +11,8 @@
 
     export let data: PageData
 
-    $: blob = data.blob
-    $: highlights = data.highlights
+    $: blob = asStore(data.blob.deferred)
+    $: highlights = asStore(data.highlights.deferred)
     $: loading = $blob.loading
     let blobData: BlobFileFields
     $: if (!$blob.loading && $blob.data) {

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/blob/[...path]/+page.ts
@@ -2,7 +2,6 @@ import { map } from 'rxjs/operators'
 
 import { fetchHighlight, fetchBlobPlaintext } from '$lib/loader/blob'
 import { parseRepoRevision } from '$lib/shared'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
@@ -10,17 +9,17 @@ export const load: PageLoad = ({ params }) => {
     const { repoName, revision } = parseRepoRevision(params.repo)
 
     return {
-        blob: asStore(
-            fetchBlobPlaintext({
+        blob: {
+            deferred: fetchBlobPlaintext({
                 filePath: params.path,
                 repoName,
                 revision: revision ?? '',
-            }).toPromise()
-        ),
-        highlights: asStore(
-            fetchHighlight({ filePath: params.path, repoName, revision: revision ?? '' })
+            }).toPromise(),
+        },
+        highlights: {
+            deferred: fetchHighlight({ filePath: params.path, repoName, revision: revision ?? '' })
                 .pipe(map(highlight => highlight?.lsif))
-                .toPromise()
-        ),
+                .toPromise(),
+        },
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/tree/[...path]/+page.svelte
@@ -4,12 +4,13 @@
     import { page } from '$app/stores'
     import { isErrorLike } from '$lib/common'
     import Icon from '$lib/Icon.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: treeDataStatus = data.treeEntries
+    $: treeDataStatus = asStore(data.treeEntries.deferred)
     $: treeOrError = (!$treeDataStatus.loading && $treeDataStatus.data) || null
     $: entries = treeOrError && !isErrorLike(treeOrError) ? treeOrError.entries : []
 </script>

--- a/client/web-sveltekit/src/routes/[...repo]/(code)/-/tree/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/(code)/-/tree/[...path]/+page.ts
@@ -2,14 +2,13 @@ import { catchError } from 'rxjs/operators'
 
 import { asError, isErrorLike, type ErrorLike } from '$lib/common'
 import { fetchTreeEntries } from '$lib/loader/repo'
-import { asStore } from '$lib/utils'
 import { requestGraphQL } from '$lib/web'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ params, parent }) => ({
-    treeEntries: asStore(
-        parent().then(({ resolvedRevision, revision, repoName }) =>
+    treeEntries: {
+        deferred: parent().then(({ resolvedRevision, revision, repoName }) =>
             !isErrorLike(resolvedRevision)
                 ? fetchTreeEntries({
                       repoName,
@@ -22,6 +21,6 @@ export const load: PageLoad = ({ params, parent }) => ({
                       .pipe(catchError((error): [ErrorLike] => [asError(error)]))
                       .toPromise()
                 : null
-        )
-    ),
+        ),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.svelte
@@ -1,19 +1,20 @@
 <script lang="ts">
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: branchesData = data.branches
-    $: defaultBranch = !$branchesData.loading && $branchesData.data ? $branchesData.data.defaultBranch : null
-    $: activeBranches = !$branchesData.loading && $branchesData.data ? $branchesData.data.activeBranches : null
+    $: branches = asStore(data.branches.deferred)
+    $: defaultBranch = !$branches.loading && $branches.data ? $branches.data.defaultBranch : null
+    $: activeBranches = !$branches.loading && $branches.data ? $branches.data.activeBranches : null
 </script>
 
-{#if $branchesData.loading}
+{#if $branches.loading}
     <LoadingSpinner />
-{:else if $branchesData.data}
+{:else if $branches.data}
     {#if defaultBranch}
         <table class="mb-3">
             <thead><tr><th colspan="3">Default branch</th></tr></thead>

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/+page.ts
@@ -1,15 +1,14 @@
 import { isErrorLike } from '$lib/common'
 import { queryGitBranchesOverview } from '$lib/loader/repo'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ parent }) => ({
-    branches: asStore(
-        parent().then(({ resolvedRevision }) =>
+    branches: {
+        deferred: parent().then(({ resolvedRevision }) =>
             isErrorLike(resolvedRevision)
                 ? null
                 : queryGitBranchesOverview({ repo: resolvedRevision.repo.id, first: 10 }).toPromise()
-        )
-    ),
+        ),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/all/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/all/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: branches = data.branches
+    $: branches = asStore(data.branches.deferred)
     $: nodes = !$branches.loading && $branches.data ? $branches.data.nodes : null
     $: total = !$branches.loading && $branches.data ? $branches.data.totalCount : null
 </script>

--- a/client/web-sveltekit/src/routes/[...repo]/-/branches/all/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/-/branches/all/+page.ts
@@ -1,13 +1,12 @@
 import { isErrorLike } from '$lib/common'
 import { GitRefType } from '$lib/graphql-operations'
 import { queryGitReferences } from '$lib/loader/repo'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ parent }) => ({
-    branches: asStore(
-        parent().then(({ resolvedRevision }) =>
+    branches: {
+        deferred: parent().then(({ resolvedRevision }) =>
             isErrorLike(resolvedRevision)
                 ? null
                 : queryGitReferences({
@@ -15,6 +14,6 @@ export const load: PageLoad = ({ parent }) => ({
                       type: GitRefType.GIT_BRANCH,
                       first: 20,
                   }).toPromise()
-        )
-    ),
+        ),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
     import Commit from '$lib/Commit.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
     import FileDiff from './FileDiff.svelte'
 
     export let data: PageData
 
-    $: ({ commit, diff } = data)
+    $: commit = asStore(data.commit.deferred)
+    $: diff = asStore(data.diff.deferred)
 </script>
 
 <section>

--- a/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commit/[...revspec]/+page.ts
@@ -1,6 +1,5 @@
 import { isErrorLike } from '$lib/common'
 import { fetchRepoCommit, queryRepositoryComparisonFileDiffs } from '$lib/loader/commits'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
@@ -20,9 +19,11 @@ export const load: PageLoad = ({ parent, params }) => {
     })
 
     return {
-        commit: asStore(commit.then(result => result?.commit ?? null)),
-        diff: asStore(
-            commit.then(result => {
+        commit: {
+            deferred: commit.then(result => result?.commit ?? null),
+        },
+        diff: {
+            deferred: commit.then(result => {
                 if (!result?.commit?.oid || !result?.commit.parents[0]?.oid) {
                     return null
                 }
@@ -34,7 +35,7 @@ export const load: PageLoad = ({ parent, params }) => {
                     first: null,
                     after: null,
                 }).toPromise()
-            })
-        ),
+            }),
+        },
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import Commit from '$lib/Commit.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: commits = data.commits
+    $: commits = asStore(data.commits.deferred)
 </script>
 
 <section>

--- a/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/-/commits/+page.ts
@@ -1,12 +1,11 @@
 import { fetchCommits } from '$lib/loader/commits'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ parent }) => ({
-    commits: asStore(
-        parent()
+    commits: {
+        deferred: parent()
             .then(({ resolvedRevision }) => fetchCommits(resolvedRevision))
-            .then(result => result?.nodes ?? [])
-    ),
+            .then(result => result?.nodes ?? []),
+    },
 })

--- a/client/web-sveltekit/src/routes/[...repo]/-/tags/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo]/-/tags/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import GitReference from '$lib/repo/GitReference.svelte'
+    import { asStore } from '$lib/utils'
 
     import type { PageData } from './$types'
 
     export let data: PageData
 
-    $: tags = data.tags
+    $: tags = asStore(data.tags.deferred)
     $: nodes = !$tags.loading && $tags.data ? $tags.data.nodes : null
     $: total = !$tags.loading && $tags.data ? $tags.data.totalCount : null
 </script>

--- a/client/web-sveltekit/src/routes/[...repo]/-/tags/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo]/-/tags/+page.ts
@@ -1,13 +1,12 @@
 import { isErrorLike } from '$lib/common'
 import { GitRefType } from '$lib/graphql-operations'
 import { queryGitReferences } from '$lib/loader/repo'
-import { asStore } from '$lib/utils'
 
 import type { PageLoad } from './$types'
 
 export const load: PageLoad = ({ parent }) => ({
-    tags: asStore(
-        parent().then(({ resolvedRevision }) =>
+    tags: {
+        deferred: parent().then(({ resolvedRevision }) =>
             isErrorLike(resolvedRevision)
                 ? null
                 : queryGitReferences({
@@ -15,6 +14,6 @@ export const load: PageLoad = ({ parent }) => ({
                       type: GitRefType.GIT_TAG,
                       first: 20,
                   }).toPromise()
-        )
-    ),
+        ),
+    },
 })


### PR DESCRIPTION
tl;dr: A little bit of housekeeping to (eventually) make use of streaming promises and to be less unconventional.

Context: Top-level promises returned by `load` functions are automatically resolved and the resolved values are passed to pages. This is not practical for big or slow-loading data. The workaround I've used so far was to return a store from the load functions instead. However this won't work if we ever decide to use server side rendering (can't serialize a store).
Recently SvelteKit has added support for streaming promises: https://kit.svelte.dev/docs/load#streaming-with-promises

To make (eventually) use of this and still get benefits from using a store we can simply return the (nested) promise from the load function and instantiate the store inside the component.

Note: SvelteKit doesn't merge nested objects from `load` functions. If we did something like `return {deferred: {dataA: ...}}` in a *layout* file and `return {deferred: {dataB: ...}}` in a `page` file, the page wouldn't have access to `dataA` unless the page load function explicitly "forwards" it. To avoid accidental override I decided to go the other direction: have unique toplevel names with a `deferred` sub-property. I guess we'll see whether or not that's a good approach.

## Test plan

TypeScript is happy