### PR TITLE
Cody Inline Chat: Add "Collapse All Comments"

### DIFF
--- a/client/cody/CHANGELOG.md
+++ b/client/cody/CHANGELOG.md
@@ -11,7 +11,8 @@ Starting from `0.2.0`, Cody is using `major.EVEN_NUMBER.patch` for release versi
 - Added support for server-side token limits to Chat. [pull/54488](https://github.com/sourcegraph/sourcegraph/pull/54488)
 - Add "Find code smells" recipe to editor context menu and command pallette [pull/54432](https://github.com/sourcegraph/sourcegraph/pull/54432)
 - Add a typewriter effect to Cody's responses to mimic typing in characters rather than varying chunks [pull/54522](https://github.com/sourcegraph/sourcegraph/pull/54522)
-- Add suggested recipes to the new chat welcome message. (pull/54277)(https://github.com/sourcegraph/sourcegraph/pull/54277)
+- Add suggested recipes to the new chat welcome message. [pull/54277](https://github.com/sourcegraph/sourcegraph/pull/54277)
+- Added the option to collapse all inline chats from within the inline chat window. [pull/54675](https://github.com/sourcegraph/sourcegraph/pull/54675)
 
 ### Fixed
 

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -384,6 +384,14 @@
         "icon": "$(sync~spin)"
       },
       {
+        "command": "cody.comment.collapse-all",
+        "title": "Collapse All Comments",
+        "category": "Cody Inline Chat",
+        "when": "cody.activated && config.cody.inlineChat.enabled",
+        "enablement": "!commentThreadIsEmpty",
+        "icon": "$(collapse-all)"
+      },
+      {
         "command": "cody.inline.new",
         "title": "Start a new Thread (Ctrl+Shift+C)",
         "category": "Cody Inline Chat",
@@ -554,6 +562,10 @@
         },
         {
           "command": "cody.comment.load",
+          "when": "false"
+        },
+        {
+          "command": "cody.comment.collapse-all",
           "when": "false"
         },
         {
@@ -743,6 +755,11 @@
           "command": "cody.comment.load",
           "group": "inline@2",
           "when": "cody.activated && commentController =~ /^cody-inline/ && cody.reply.pending && config.cody.inlineChat.enabled"
+        },
+        {
+          "command": "cody.comment.collapse-all",
+          "group": "inline@3",
+          "when": "cody.activated && commentController =~ /^cody-inline/ && config.cody.inlineChat.enabled"
         }
       ],
       "view/item/context": [

--- a/client/cody/package.json
+++ b/client/cody/package.json
@@ -369,7 +369,7 @@
       },
       {
         "command": "cody.comment.delete",
-        "title": "Remove Comment",
+        "title": "Remove Inline Chat",
         "category": "Cody Inline Chat",
         "when": "cody.activated && config.cody.inlineChat.enabled",
         "enablement": "!commentThreadIsEmpty",
@@ -385,7 +385,7 @@
       },
       {
         "command": "cody.comment.collapse-all",
-        "title": "Collapse All Comments",
+        "title": "Collapse All Inline Chats",
         "category": "Cody Inline Chat",
         "when": "cody.activated && config.cody.inlineChat.enabled",
         "enablement": "!commentThreadIsEmpty",

--- a/client/cody/src/main.ts
+++ b/client/cody/src/main.ts
@@ -177,6 +177,9 @@ const register = async (
         vscode.commands.registerCommand('cody.comment.delete', (thread: vscode.CommentThread) => {
             commentController.delete(thread)
         }),
+        vscode.commands.registerCommand('cody.comment.collapse-all', () =>
+            vscode.commands.executeCommand('workbench.action.collapseAllComments')
+        ),
         vscode.commands.registerCommand('cody.inline.new', () =>
             vscode.commands.executeCommand('workbench.action.addComment')
         ),


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/assets/9516420/f2c2dd46-6afa-4c65-8daa-2fc286b1552d

Adds a "Collapse All Comments" option to the inline chat header

## Test plan

Tested locally in VS Code.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
