### PR TITLE
uploadstore: add method to list all keys

### DIFF
--- a/internal/embeddings/BUILD.bazel
+++ b/internal/embeddings/BUILD.bazel
@@ -79,6 +79,7 @@ go_test(
         "//internal/types",
         "//internal/uploadstore",
         "//lib/errors",
+        "//lib/iterator",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 type noOpUploadStore struct{}
@@ -28,6 +29,10 @@ func (s *noOpUploadStore) Init(ctx context.Context) error {
 }
 
 func (s *noOpUploadStore) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (s *noOpUploadStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
 	return nil, nil
 }
 
@@ -78,6 +83,15 @@ func (s *mockUploadStore) Get(ctx context.Context, key string) (io.ReadCloser, e
 		return nil, errors.Newf("file %s not found", key)
 	}
 	return io.NopCloser(bytes.NewReader(file)), nil
+}
+
+func (s *mockUploadStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
+	var names []string
+	for k := range s.files {
+		names = append(names, k)
+	}
+
+	return iterator.From[string](names), nil
 }
 
 func (s *mockUploadStore) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {

--- a/internal/uploadstore/BUILD.bazel
+++ b/internal/uploadstore/BUILD.bazel
@@ -61,5 +61,6 @@ go_test(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_inconshreveable_log15//:log15",
         "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//iterator",
     ],
 )

--- a/internal/uploadstore/BUILD.bazel
+++ b/internal/uploadstore/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/metrics",
         "//internal/observation",
         "//lib/errors",
+        "//lib/iterator",
         "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
         "@com_github_aws_aws_sdk_go_v2_credentials//:credentials",

--- a/internal/uploadstore/lazy_client.go
+++ b/internal/uploadstore/lazy_client.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sync"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 type lazyStore struct {
@@ -29,6 +31,14 @@ func (s *lazyStore) Get(ctx context.Context, key string) (io.ReadCloser, error) 
 	}
 
 	return s.store.Get(ctx, key)
+}
+
+func (s *lazyStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
+	if err := s.initOnce(ctx); err != nil {
+		return nil, err
+	}
+
+	return s.store.List(ctx)
 }
 
 func (s *lazyStore) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {

--- a/internal/uploadstore/mocks/BUILD.bazel
+++ b/internal/uploadstore/mocks/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["mocks_temp.go"],
     importpath = "github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks",
     visibility = ["//:__subpackages__"],
-    deps = ["//internal/uploadstore"],
+    deps = [
+        "//internal/uploadstore",
+        "//lib/iterator",
+    ],
 )

--- a/internal/uploadstore/mocks/mocks_temp.go
+++ b/internal/uploadstore/mocks/mocks_temp.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	uploadstore "github.com/sourcegraph/sourcegraph/internal/uploadstore"
+	iterator "github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 // MockStore is a mock implementation of the Store interface (from the
@@ -34,6 +35,9 @@ type MockStore struct {
 	// InitFunc is an instance of a mock function object controlling the
 	// behavior of the method Init.
 	InitFunc *StoreInitFunc
+	// ListFunc is an instance of a mock function object controlling the
+	// behavior of the method List.
+	ListFunc *StoreListFunc
 	// UploadFunc is an instance of a mock function object controlling the
 	// behavior of the method Upload.
 	UploadFunc *StoreUploadFunc
@@ -65,6 +69,11 @@ func NewMockStore() *MockStore {
 		},
 		InitFunc: &StoreInitFunc{
 			defaultHook: func(context.Context) (r0 error) {
+				return
+			},
+		},
+		ListFunc: &StoreListFunc{
+			defaultHook: func(context.Context) (r0 *iterator.Iterator[string], r1 error) {
 				return
 			},
 		},
@@ -105,6 +114,11 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.Init")
 			},
 		},
+		ListFunc: &StoreListFunc{
+			defaultHook: func(context.Context) (*iterator.Iterator[string], error) {
+				panic("unexpected invocation of MockStore.List")
+			},
+		},
 		UploadFunc: &StoreUploadFunc{
 			defaultHook: func(context.Context, string, io.Reader) (int64, error) {
 				panic("unexpected invocation of MockStore.Upload")
@@ -131,6 +145,9 @@ func NewMockStoreFrom(i uploadstore.Store) *MockStore {
 		},
 		InitFunc: &StoreInitFunc{
 			defaultHook: i.Init,
+		},
+		ListFunc: &StoreListFunc{
+			defaultHook: i.List,
 		},
 		UploadFunc: &StoreUploadFunc{
 			defaultHook: i.Upload,
@@ -672,6 +689,110 @@ func (c StoreInitFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreInitFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
+}
+
+// StoreListFunc describes the behavior when the List method of the parent
+// MockStore instance is invoked.
+type StoreListFunc struct {
+	defaultHook func(context.Context) (*iterator.Iterator[string], error)
+	hooks       []func(context.Context) (*iterator.Iterator[string], error)
+	history     []StoreListFuncCall
+	mutex       sync.Mutex
+}
+
+// List delegates to the next hook function in the queue and stores the
+// parameter and result values of this invocation.
+func (m *MockStore) List(v0 context.Context) (*iterator.Iterator[string], error) {
+	r0, r1 := m.ListFunc.nextHook()(v0)
+	m.ListFunc.appendCall(StoreListFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the List method of the
+// parent MockStore instance is invoked and the hook queue is empty.
+func (f *StoreListFunc) SetDefaultHook(hook func(context.Context) (*iterator.Iterator[string], error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// List method of the parent MockStore instance invokes the hook at the
+// front of the queue and discards it. After the queue is empty, the default
+// hook function is invoked for any future action.
+func (f *StoreListFunc) PushHook(hook func(context.Context) (*iterator.Iterator[string], error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreListFunc) SetDefaultReturn(r0 *iterator.Iterator[string], r1 error) {
+	f.SetDefaultHook(func(context.Context) (*iterator.Iterator[string], error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreListFunc) PushReturn(r0 *iterator.Iterator[string], r1 error) {
+	f.PushHook(func(context.Context) (*iterator.Iterator[string], error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreListFunc) nextHook() func(context.Context) (*iterator.Iterator[string], error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreListFunc) appendCall(r0 StoreListFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreListFuncCall objects describing the
+// invocations of this function.
+func (f *StoreListFunc) History() []StoreListFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreListFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreListFuncCall is an object that describes an invocation of method
+// List on an instance of MockStore.
+type StoreListFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 *iterator.Iterator[string]
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreListFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreListFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreUploadFunc describes the behavior when the Upload method of the

--- a/internal/uploadstore/observability.go
+++ b/internal/uploadstore/observability.go
@@ -13,6 +13,7 @@ type Operations struct {
 	Compose       *observation.Operation
 	Delete        *observation.Operation
 	ExpireObjects *observation.Operation
+	List		  *observation.Operation
 }
 
 func NewOperations(observationCtx *observation.Context, domain, storeName string) *Operations {
@@ -37,5 +38,6 @@ func NewOperations(observationCtx *observation.Context, domain, storeName string
 		Compose:       op("Compose"),
 		Delete:        op("Delete"),
 		ExpireObjects: op("ExpireObjects"),
+		List:          op("List"),
 	}
 }

--- a/internal/uploadstore/observability.go
+++ b/internal/uploadstore/observability.go
@@ -13,7 +13,7 @@ type Operations struct {
 	Compose       *observation.Operation
 	Delete        *observation.Operation
 	ExpireObjects *observation.Operation
-	List		  *observation.Operation
+	List          *observation.Operation
 }
 
 func NewOperations(observationCtx *observation.Context, domain, storeName string) *Operations {

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 type s3Store struct {
@@ -83,6 +84,33 @@ const maxZeroReads = 3
 // errNoDownloadProgress is returned from Get after multiple connection reset errors occur
 // in a row.
 var errNoDownloadProgress = errors.New("no download progress")
+
+func (s *s3Store) List(ctx context.Context) (*iterator.Iterator[string], error) {
+	// We wrap the client's paginator and just return the keys.
+	paginator := s.client.NewListObjectsV2Paginator(&s3.ListObjectsV2Input{Bucket: &s.bucket})
+
+	next := func() ([]string, error) {
+		if !paginator.HasMorePages() {
+			return nil, nil
+		}
+
+		nextPage, err := paginator.NextPage(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		keys := make([]string, 0, len(nextPage.Contents))
+		for _, c := range nextPage.Contents {
+			if c.Key != nil {
+				keys = append(keys, *c.Key)
+			}
+		}
+
+		return keys, nil
+	}
+
+	return iterator.New[string](next), nil
+}
 
 func (s *s3Store) Get(ctx context.Context, key string) (_ io.ReadCloser, err error) {
 	ctx, _, endObservation := s.operations.Get.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -94,7 +94,7 @@ func (s *s3Store) List(ctx context.Context) (*iterator.Iterator[string], error) 
 			return nil, nil
 		}
 
-		nextPage, err := paginator.NextPage(context.Background())
+		nextPage, err := paginator.NextPage(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/uploadstore/store.go
+++ b/internal/uploadstore/store.go
@@ -33,7 +33,7 @@ type Store interface {
 	// the age of the object exceeds the given max age.
 	ExpireObjects(ctx context.Context, prefix string, maxAge time.Duration) error
 
-	// List returns an iterator over the keys.
+	// List returns an iterator over all keys.
 	List(ctx context.Context) (*iterator.Iterator[string], error)
 }
 

--- a/internal/uploadstore/store.go
+++ b/internal/uploadstore/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 // Store is an expiring key/value store backed by a managed blob store.
@@ -31,6 +32,9 @@ type Store interface {
 	// ExpireObjects iterates all objects with the given prefix and deletes them when
 	// the age of the object exceeds the given max age.
 	ExpireObjects(ctx context.Context, prefix string, maxAge time.Duration) error
+
+	// List returns an iterator over the keys.
+	List(ctx context.Context) (*iterator.Iterator[string], error)
 }
 
 var storeConstructors = map[string]func(ctx context.Context, config Config, operations *Operations) (Store, error){


### PR DESCRIPTION
This adds the method `Store.List(ctx context.Context) (iterator, err)` to the upload store.

**Why?**
Long-term we want to surface more information about the available embeddings to the user. Currently we rely on embeddings jobs which provide an indirect representation of the state of the embeddings store. As a first step we have to have a unified way (GCS, S3) to find out which embeddings we actually have (-> this PR)

Once we can list all keys, we can, for example, create a background job that keeps a db table up-to-date which we can use to:

- quickly filter repos by their embeddings in the site-admin UI.
- list embeddings (not just jobs) and their metadata.
  
## Test plan
- new unit tests
- manual testing
  - I created a bucket on GCS and configured my local instance to use that bucket. Then I updated the embeddings worker to list all exisiting embeddings at the end of an embeddings job. I ran a couple of embeddings jobs and verified that the logs made sense.
