### PR TITLE
sg: silence most bazel output for docsite

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -404,7 +404,7 @@ commands:
 
   docsite:
     description: Docsite instance serving the docs
-    cmd: bazel run //doc:serve
+    cmd: bazel run --noshow_progress --noshow_loading_progress //doc:serve
 
   syntax-highlighter:
     ignoreStdout: true


### PR DESCRIPTION
Supresses noisy outputs from `sg run docsite` 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Before 

<img width="1044" alt="CleanShot 2023-07-06 at 18 55 54@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/3fffe3c1-565b-4b15-8db6-6471e87f72b8">


After 

<img width="1016" alt="CleanShot 2023-07-06 at 18 56 12@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/35cf9b54-6d5c-434f-ae73-3b2ae0673b12">
