### PR TITLE
sg: add --legacy to run command

### DIFF
--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -164,6 +164,7 @@ Flags:
 
 * `--describe`: Print details about selected run target
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
+* `--legacy`: Force run to pick the non-bazel variant of the command
 
 ## sg ci
 


### PR DESCRIPTION
@efritz noticed that `sg run frontend` always pick the Bazel variant, which at the moment triggers a bundle build, which is really really slow. 

This was not how it was when we first introduced the Bazel variants of the commands, but I missed the consequences of refactoring how we handle the assets a while ago, which created this situation. 

This PR provides a bandage, which I hope will be ok with you @efritz while we fix the root cause for this. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + locally tested. 