### PR TITLE
Schedule embeddings jobs will not roll back transaction on read errors

### DIFF
--- a/internal/embeddings/background/repo/mocks_temp.go
+++ b/internal/embeddings/background/repo/mocks_temp.go
@@ -80,7 +80,7 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		CreateRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc{
-			defaultHook: func(context.Context, api.RepoID, api.CommitID) (r0 int, r1 error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID, string) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -153,7 +153,7 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 			},
 		},
 		CreateRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc{
-			defaultHook: func(context.Context, api.RepoID, api.CommitID) (int, error) {
+			defaultHook: func(context.Context, api.RepoID, api.CommitID, string) (int, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CreateRepoEmbeddingJob")
 			},
 		},
@@ -482,24 +482,24 @@ func (c RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall) Results() []interf
 // when the CreateRepoEmbeddingJob method of the parent
 // MockRepoEmbeddingJobsStore instance is invoked.
 type RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc struct {
-	defaultHook func(context.Context, api.RepoID, api.CommitID) (int, error)
-	hooks       []func(context.Context, api.RepoID, api.CommitID) (int, error)
+	defaultHook func(context.Context, api.RepoID, api.CommitID, string) (int, error)
+	hooks       []func(context.Context, api.RepoID, api.CommitID, string) (int, error)
 	history     []RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateRepoEmbeddingJob delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockRepoEmbeddingJobsStore) CreateRepoEmbeddingJob(v0 context.Context, v1 api.RepoID, v2 api.CommitID) (int, error) {
-	r0, r1 := m.CreateRepoEmbeddingJobFunc.nextHook()(v0, v1, v2)
-	m.CreateRepoEmbeddingJobFunc.appendCall(RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall{v0, v1, v2, r0, r1})
+func (m *MockRepoEmbeddingJobsStore) CreateRepoEmbeddingJob(v0 context.Context, v1 api.RepoID, v2 api.CommitID, v3 string) (int, error) {
+	r0, r1 := m.CreateRepoEmbeddingJobFunc.nextHook()(v0, v1, v2, v3)
+	m.CreateRepoEmbeddingJobFunc.appendCall(RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall{v0, v1, v2, v3, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
 // CreateRepoEmbeddingJob method of the parent MockRepoEmbeddingJobsStore
 // instance is invoked and the hook queue is empty.
-func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID) (int, error)) {
+func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) SetDefaultHook(hook func(context.Context, api.RepoID, api.CommitID, string) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -508,7 +508,7 @@ func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) SetDefaultHook(hook f
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID) (int, error)) {
+func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) PushHook(hook func(context.Context, api.RepoID, api.CommitID, string) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -517,19 +517,19 @@ func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) PushHook(hook func(co
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID) (int, error) {
+	f.SetDefaultHook(func(context.Context, api.RepoID, api.CommitID, string) (int, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, api.RepoID, api.CommitID) (int, error) {
+	f.PushHook(func(context.Context, api.RepoID, api.CommitID, string) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) nextHook() func(context.Context, api.RepoID, api.CommitID) (int, error) {
+func (f *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc) nextHook() func(context.Context, api.RepoID, api.CommitID, string) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -573,6 +573,9 @@ type RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall struct {
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
 	Arg2 api.CommitID
+	// Arg3 is the value of the 4th argument passed to this method
+	// invocation.
+	Arg3 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -584,7 +587,7 @@ type RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this

--- a/internal/embeddings/background/repo/store.go
+++ b/internal/embeddings/background/repo/store.go
@@ -99,7 +99,7 @@ type RepoEmbeddingJobsStore interface {
 	Exec(ctx context.Context, query *sqlf.Query) error
 	Done(err error) error
 
-	CreateRepoEmbeddingJob(ctx context.Context, repoID api.RepoID, revision api.CommitID) (int, error)
+	CreateRepoEmbeddingJob(ctx context.Context, repoID api.RepoID, revision api.CommitID, state string) (int, error)
 	GetLastCompletedRepoEmbeddingJob(ctx context.Context, repoID api.RepoID) (*RepoEmbeddingJob, error)
 	GetLastRepoEmbeddingJobForRevision(ctx context.Context, repoID api.RepoID, revision api.CommitID) (*RepoEmbeddingJob, error)
 	ListRepoEmbeddingJobs(ctx context.Context, args ListOpts) ([]*RepoEmbeddingJob, error)
@@ -245,10 +245,10 @@ func (s *repoEmbeddingJobsStore) Transact(ctx context.Context) (RepoEmbeddingJob
 	return &repoEmbeddingJobsStore{Store: tx}, nil
 }
 
-const createRepoEmbeddingJobFmtStr = `INSERT INTO repo_embedding_jobs (repo_id, revision) VALUES (%s, %s) RETURNING id`
+const createRepoEmbeddingJobFmtStr = `INSERT INTO repo_embedding_jobs (repo_id, revision, state) VALUES (%s, %s, %s) RETURNING id`
 
-func (s *repoEmbeddingJobsStore) CreateRepoEmbeddingJob(ctx context.Context, repoID api.RepoID, revision api.CommitID) (int, error) {
-	q := sqlf.Sprintf(createRepoEmbeddingJobFmtStr, repoID, revision)
+func (s *repoEmbeddingJobsStore) CreateRepoEmbeddingJob(ctx context.Context, repoID api.RepoID, revision api.CommitID, state string) (int, error) {
+	q := sqlf.Sprintf(createRepoEmbeddingJobFmtStr, repoID, revision, state)
 	id, _, err := basestore.ScanFirstInt(s.Query(ctx, q))
 	return id, err
 }

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -45,13 +45,13 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	require.Equal(t, exists, false)
 
 	// Create three repo embedding jobs.
-	id1, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "deadbeef")
+	id1, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "deadbeef", "queued")
 	require.NoError(t, err)
 
-	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
+	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee", "queued")
 	require.NoError(t, err)
 
-	id3, err := store.CreateRepoEmbeddingJob(ctx, createdRepo2.ID, "tea")
+	id3, err := store.CreateRepoEmbeddingJob(ctx, createdRepo2.ID, "tea", "queued")
 	require.NoError(t, err)
 
 	count, err := store.CountRepoEmbeddingJobs(ctx, ListOpts{})
@@ -155,10 +155,10 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 	store := NewRepoEmbeddingJobsStore(db)
 
 	// Create two repo embedding jobs.
-	id1, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "deadbeef")
+	id1, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "deadbeef", "queued")
 	require.NoError(t, err)
 
-	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
+	id2, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee", "queued")
 	require.NoError(t, err)
 
 	// Cancel the first one.
@@ -187,7 +187,7 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 	require.Error(t, err)
 
 	// Attempting to cancel a completed job should fail
-	id3, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "avocado")
+	id3, err := store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "avocado", "queued")
 	require.NoError(t, err)
 
 	setJobState(t, ctx, store, id3, "completed")
@@ -231,7 +231,7 @@ func TestGetEmbeddableRepos(t *testing.T) {
 	require.Equal(t, 2, len(repos))
 
 	// Create and queue an embedding job for the first repo.
-	_, err = store.CreateRepoEmbeddingJob(ctx, firstRepo.ID, "coffee")
+	_, err = store.CreateRepoEmbeddingJob(ctx, firstRepo.ID, "coffee", "queued")
 	require.NoError(t, err)
 
 	// Only the second repo should be embeddable, since the first was recently queued

--- a/internal/embeddings/schedule_test.go
+++ b/internal/embeddings/schedule_test.go
@@ -29,7 +29,7 @@ func TestScheduleRepositoriesForEmbedding(t *testing.T) {
 
 	// Create a repo embedding job.
 	store := repo.NewRepoEmbeddingJobsStore(db)
-	_, err = store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
+	_, err = store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee", "queued")
 	require.NoError(t, err)
 
 	gitserverClient := gitserver.NewMockClient()
@@ -49,4 +49,43 @@ func TestScheduleRepositoriesForEmbedding(t *testing.T) {
 	count, err = store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
+}
+
+func TestScheduleRepositoriesForEmbeddingFailedState(t *testing.T) {
+	t.Parallel()
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	repoStore := db.Repos()
+
+	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
+	err := repoStore.Create(ctx, createdRepo0)
+	require.NoError(t, err)
+
+	createdRepo1 := &types.Repo{Name: "github.com/sourcegraph/zoekt", URI: "github.com/sourcegraph/zoekt", ExternalRepo: api.ExternalRepoSpec{}}
+	err = repoStore.Create(ctx, createdRepo1)
+	require.NoError(t, err)
+
+	// Create a repo embedding job.
+	store := repo.NewRepoEmbeddingJobsStore(db)
+
+	gitserverClient := gitserver.NewMockClient()
+	gitserverClient.GetDefaultBranchFunc.PushReturn("", "sgrevision", nil)
+	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "zoektrevision", nil)
+
+	repoNames := []api.RepoName{"github.com/sourcegraph/sourcegraph", "github.com/sourcegraph/zoekt"}
+	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+
+	pattern := "github.com/sourcegraph/sourcegraph"
+	first := 10
+	jobs, err := store.ListRepoEmbeddingJobs(ctx, repo.ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}, Query: &pattern})
+	require.Equal(t, "failed", jobs[0].State)
+
+	pattern = "github.com/sourcegraph/zoekt"
+	jobs, err = store.ListRepoEmbeddingJobs(ctx, repo.ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}, Query: &pattern})
+	require.Equal(t, "queued", jobs[0].State)
 }


### PR DESCRIPTION
When a set of repositories are to be scheduled for embeddings (via graphql or a policy) an error with a single repository can cause the entire set of embeddings jobs to be rolled back. The specific error that occurred for a recent customer issue ([slack discussion](https://sourcegraph.slack.com/archives/C053L1AQ0BC/p1688671109829779)) was due to one of the [repos being empty](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/embeddings/schedule.go?L36-42) and causing all 500 repos matched by a policy to not be enqueued for embeddings jobs. Not only do all repos have their embeddings jobs rolled back but additionally the logging will only report one problematic repo before exiting the scheduling logic which makes it so that the log does not capture all of the problematic repos in one attempt.

We should instead allow read errors (e.g. reading sql or fetching information from gitserver) to be handled but not prevent the entire batch of jobs to be rolled back. This will allow a policy to be partially impactful across the repositories it is concerned with. Especially given that an empty repo won't have any need to be enqueued for an embeddings job.

This PR changes the error handling so that repos that cannot complete an embeddings job will still be enqueued with a `failed` state so that site admin pages can still display which individual repos are problematic. When a repo is enqueued with a `failed` state we do not roll back the transaction so that successful embeddings jobs are still created with a `queued` state.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
