### PR TITLE
sg generate: fix typo and add missing newline

### DIFF
--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -65,7 +65,7 @@ func generateProtoRunner(ctx context.Context, args []string) *generate.Report {
 
 	// Don't run buf gen if no .proto files changed or not in CI
 	if !strings.Contains(string(out), ".proto") {
-		return &generate.Report{Output: "No .proto files changed or not in CI. Skippping buf gen."}
+		return &generate.Report{Output: "No .proto files changed or not in CI. Skipping buf gen.\n"}
 	}
 	// Run buf gen by default
 	return proto.Generate(ctx, verbose)


### PR DESCRIPTION
Title says it: when running `sg generate` the early-exit message didn't contain the newline at the end that every other `report.Output` has. I figured it's easier and more consistent to add it here now instead of checking whether `report.Output` has a trailing newline etc.

Also fixes a typo. Two P.

## Before
![before](https://github.com/sourcegraph/sourcegraph/assets/1185253/8c819055-8403-47df-bab8-1bb420f27be9)

## After

![after](https://github.com/sourcegraph/sourcegraph/assets/1185253/7cfe6972-1d96-41f1-a3ce-0a414dcb5973)


## Test plan

Tested manually, see screenshots
