### PR TITLE
source: fix username input validation

### DIFF
--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -303,7 +303,7 @@ exports[`SignUpPage renders sign up page (server) 1`] = `
                   id="username"
                   maxlength="255"
                   name="username"
-                  pattern="^\\\\w(?:\\\\w|[.-](?=\\\\w))*-?$"
+                  pattern="^\\\\w(?:\\\\w|[.\\\\-](?=\\\\w))*-?$"
                   placeholder=" "
                   required=""
                   spellcheck="false"

--- a/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
+++ b/client/web/src/site-admin/init/__snapshots__/SiteInitPage.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`SiteInitPage normal 1`] = `
                   id="username"
                   maxlength="255"
                   name="username"
-                  pattern="^\\\\w(?:\\\\w|[.-](?=\\\\w))*-?$"
+                  pattern="^\\\\w(?:\\\\w|[.\\\\-](?=\\\\w))*-?$"
                   placeholder=" "
                   required=""
                   spellcheck="false"

--- a/client/web/src/user/index.ts
+++ b/client/web/src/user/index.ts
@@ -1,7 +1,8 @@
 /**
  * Regular expression to identify valid username.
  */
-export const VALID_USERNAME_REGEXP = /^\w(?:\w|[.-](?=\w))*-?$/.source
+// eslint-disable-next-line no-useless-escape
+export const VALID_USERNAME_REGEXP = /^\w(?:\w|[.\-](?=\w))*-?$/.source
 
 /** Maximum allowed length for a username. */
 export const USERNAME_MAX_LENGTH = 255


### PR DESCRIPTION
Closes #54702

I'm still trying to figure out when this started happening or why it started happening. However, according to the error message it looks like there's an invalid character within the character class (usually denoted by the [] brackets)

![image](https://github.com/sourcegraph/sourcegraph/assets/25608335/00833274-d919-408a-959a-c46735cb8b4c)

In the given regular expression `/^\w(?:\w|[.-](?=\w))*-?$/`, the invalid character class is [.-]. Escaping the hyphen character within the character class `[.\-]` fixes the error.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Spin up a fresh instance of Sourcegraph, entering the username and password shouldn't trigger the error in the console anymore.

![CleanShot 2023-07-07 at 12 16 25@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/f621a1ee-b320-4d92-95f8-7d46a033e6c4)
