### PR TITLE
JetBrains: show stop generating button while receiving the response

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added embeddings status in footer [#54575](https://github.com/sourcegraph/sourcegraph/pull/54575)
 - Added currently opened file name in footer [#54610](https://github.com/sourcegraph/sourcegraph/pull/54610)
 - Auto-growing prompt input [#53594](https://github.com/sourcegraph/sourcegraph/pull/53594)
+- Added "stop generating" button [#54710](https://github.com/sourcegraph/sourcegraph/pull/54710)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -217,12 +217,13 @@ class CodyToolWindowContent implements UpdatableChat {
     layeredPane.setLayout(new BorderLayout());
     // Add a button to the south of the main panel
     JButton button = new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
+    stopGeneratingButtonPanel = new JPanel();
     button.addActionListener(
         e -> {
           cancellationToken.abort();
-          finishMessageProcessing();
+          stopGeneratingButtonPanel.setVisible(false);
+          sendButton.setEnabled(true);
         });
-    stopGeneratingButtonPanel = new JPanel();
     stopGeneratingButtonPanel.add(button);
     stopGeneratingButtonPanel.setOpaque(false);
     stopGeneratingButtonPanel.setVisible(false);
@@ -464,7 +465,6 @@ class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
-              stopGeneratingButtonPanel.setVisible(true);
               transcript.addAssistantResponse(message);
               if (messagesPanel.getComponentCount() > 0) {
                 JPanel lastBubblePanel =
@@ -567,7 +567,8 @@ class CodyToolWindowContent implements UpdatableChat {
                       CodyAgent.getClient(project),
                       CodyAgent.getInitializedServer(project),
                       humanMessage,
-                      this);
+                      this,
+                      cancellationToken);
                 } catch (Exception e) {
                   logger.error("Error sending message '" + humanMessage + "' to chat", e);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -4,6 +4,7 @@ import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
 import static java.awt.event.KeyEvent.VK_ENTER;
 import static javax.swing.KeyStroke.getKeyStroke;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -21,6 +22,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.ui.components.JBTextArea;
+import com.intellij.util.IconUtil;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.cody.agent.CodyAgent;
@@ -55,6 +57,7 @@ import com.sourcegraph.cody.recipes.SummarizeRecentChangesRecipe;
 import com.sourcegraph.cody.recipes.TranslateToLanguageAction;
 import com.sourcegraph.cody.ui.AutoGrowingTextArea;
 import com.sourcegraph.cody.ui.HtmlViewer;
+import com.sourcegraph.cody.vscode.CancellationToken;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
 import com.sourcegraph.config.SettingsComponent.InstanceType;
@@ -76,6 +79,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
+import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
@@ -94,6 +98,8 @@ class CodyToolWindowContent implements UpdatableChat {
   private final @NotNull JBTextArea promptInput;
   private final @NotNull JButton sendButton;
   private final @NotNull Project project;
+  private @NotNull volatile CancellationToken cancellationToken = new CancellationToken();
+  private final JPanel stopGeneratingButtonPanel;
   private boolean needScrollingDown = true;
   private @NotNull Transcript transcript = new Transcript();
   private boolean isChatVisible = false;
@@ -159,6 +165,7 @@ class CodyToolWindowContent implements UpdatableChat {
             messagesPanel,
             JBScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
             JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    chatPanel.setBorder(BorderFactory.createEmptyBorder());
 
     // Scroll all the way down after each message
     AdjustmentListener scrollAdjustmentListener =
@@ -204,8 +211,26 @@ class CodyToolWindowContent implements UpdatableChat {
     // Main content panel
     contentPanel.setLayout(new BorderLayout(0, 0));
     contentPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
-    contentPanel.add(chatPanel, BorderLayout.CENTER);
+
+    // Create a layered pane and add the main panel and button to it
+    JLayeredPane layeredPane = new JLayeredPane();
+    layeredPane.setLayout(new BorderLayout());
+    // Add a button to the south of the main panel
+    JButton button = new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
+    button.addActionListener(
+        e -> {
+          cancellationToken.abort();
+          finishMessageProcessing();
+        });
+    stopGeneratingButtonPanel = new JPanel();
+    stopGeneratingButtonPanel.add(button);
+    stopGeneratingButtonPanel.setOpaque(false);
+    stopGeneratingButtonPanel.setVisible(false);
+    layeredPane.add(chatPanel, BorderLayout.CENTER);
+    layeredPane.add(stopGeneratingButtonPanel, BorderLayout.SOUTH, JLayeredPane.POPUP_LAYER);
+    contentPanel.add(layeredPane, BorderLayout.CENTER);
     contentPanel.add(lowerPanel, BorderLayout.SOUTH);
+
     tabbedPane.addChangeListener(e -> this.focusPromptInput());
 
     JPanel appNotInstalledPanel = createAppNotInstalledPanel();
@@ -439,25 +464,41 @@ class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
+              stopGeneratingButtonPanel.setVisible(true);
               transcript.addAssistantResponse(message);
               if (messagesPanel.getComponentCount() > 0) {
                 JPanel lastBubblePanel =
                     (JPanel) messagesPanel.getComponent(messagesPanel.getComponentCount() - 1);
-                ChatBubble lastBubble = (ChatBubble) lastBubblePanel.getComponent(0);
-                lastBubble.updateText(message);
-                messagesPanel.revalidate();
-                messagesPanel.repaint();
+                Component component = lastBubblePanel.getComponent(0);
+                if (component instanceof ChatBubble) {
+                  ChatBubble lastBubble = (ChatBubble) component;
+                  lastBubble.updateText(message);
+                  messagesPanel.revalidate();
+                  messagesPanel.repaint();
+                }
               }
             });
   }
 
   private void startMessageProcessing() {
-    ApplicationManager.getApplication().invokeLater(() -> sendButton.setEnabled(false));
+    cancellationToken.abort();
+    cancellationToken = new CancellationToken();
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              stopGeneratingButtonPanel.setVisible(true);
+              sendButton.setEnabled(false);
+            });
   }
 
   @Override
   public void finishMessageProcessing() {
-    ApplicationManager.getApplication().invokeLater(() -> sendButton.setEnabled(true));
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              stopGeneratingButtonPanel.setVisible(false);
+              sendButton.setEnabled(true);
+            });
   }
 
   @Override
@@ -466,6 +507,8 @@ class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
+              cancellationToken.abort();
+              stopGeneratingButtonPanel.setVisible(false);
               sendButton.setEnabled(true);
               messagesPanel.removeAll();
               addWelcomeMessage();
@@ -548,7 +591,7 @@ class CodyToolWindowContent implements UpdatableChat {
                         TruncationUtils.MAX_AVAILABLE_PROMPT_LENGTH);
 
                 try {
-                  chat.sendMessageWithoutAgent(prompt, responsePrefix, this);
+                  chat.sendMessageWithoutAgent(prompt, responsePrefix, this, cancellationToken);
                 } catch (Exception e) {
                   logger.error("Error sending message '" + humanMessage + "' to chat", e);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -212,10 +212,8 @@ class CodyToolWindowContent implements UpdatableChat {
     contentPanel.setLayout(new BorderLayout(0, 0));
     contentPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
 
-    // Create a layered pane and add the main panel and button to it
     JLayeredPane layeredPane = new JLayeredPane();
     layeredPane.setLayout(new BorderLayout());
-    // Add a button to the south of the main panel
     JButton button = new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
     stopGeneratingButtonPanel = new JPanel();
     button.addActionListener(
@@ -229,6 +227,7 @@ class CodyToolWindowContent implements UpdatableChat {
     stopGeneratingButtonPanel.setVisible(false);
     layeredPane.add(chatPanel, BorderLayout.CENTER);
     layeredPane.add(stopGeneratingButtonPanel, BorderLayout.SOUTH, JLayeredPane.POPUP_LAYER);
+
     contentPanel.add(layeredPane, BorderLayout.CENTER);
     contentPanel.add(lowerPanel, BorderLayout.SOUTH);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
@@ -56,7 +56,7 @@ public class CompletionsService {
       @NotNull CompletionsInput input,
       @NotNull CompletionsCallbacks cb,
       @NotNull Endpoint endpoint,
-      CancellationToken token) {
+      @NotNull CancellationToken cancellationToken) {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(Speaker.class, new SpeakerLowercaseSerializer())
@@ -65,7 +65,8 @@ public class CompletionsService {
     String body = gson.toJsonTree(input).getAsJsonObject().toString();
 
     SSEClient sseClient =
-        new SSEClient(instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint, token);
+        new SSEClient(
+            instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint, cancellationToken);
     sseClient.start();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.sourcegraph.api.GraphQlClient;
-
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 
@@ -64,8 +63,7 @@ public class CompletionsService {
     String body = gson.toJsonTree(input).getAsJsonObject().toString();
 
     SSEClient sseClient =
-        new SSEClient(
-            instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint);
+        new SSEClient(instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint);
     sseClient.start();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CompletionsService.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.sourcegraph.api.GraphQlClient;
-import com.sourcegraph.cody.vscode.CancellationToken;
+
 import java.io.IOException;
 import org.jetbrains.annotations.NotNull;
 
@@ -55,8 +55,7 @@ public class CompletionsService {
   public void streamCompletion(
       @NotNull CompletionsInput input,
       @NotNull CompletionsCallbacks cb,
-      @NotNull Endpoint endpoint,
-      @NotNull CancellationToken cancellationToken) {
+      @NotNull Endpoint endpoint) {
     Gson gson =
         new GsonBuilder()
             .registerTypeAdapter(Speaker.class, new SpeakerLowercaseSerializer())
@@ -66,7 +65,7 @@ public class CompletionsService {
 
     SSEClient sseClient =
         new SSEClient(
-            instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint, cancellationToken);
+            instanceUrl + endpoint.urlPath, accessToken, body, cb, endpoint);
     sseClient.start();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
@@ -35,8 +35,7 @@ public class SourcegraphNodeCompletionsClient {
             params.topK,
             params.topP),
         callbacks,
-        CompletionsService.Endpoint.Code
-    );
+        CompletionsService.Endpoint.Code);
     return callbacks.promise;
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
@@ -35,8 +35,8 @@ public class SourcegraphNodeCompletionsClient {
             params.topK,
             params.topP),
         callbacks,
-        CompletionsService.Endpoint.Code,
-        this.token);
+        CompletionsService.Endpoint.Code
+    );
     return callbacks.promise;
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -38,21 +38,22 @@ public class Chat {
       @NotNull CancellationToken cancellationToken) {
     completionsService.streamCompletion(
         new CompletionsInput(prompt, 0.5f, null, 1000, -1, -1),
-        new ChatUpdaterCallbacks(chat, prefix),
-        CompletionsService.Endpoint.Stream,
-        cancellationToken);
+        new ChatUpdaterCallbacks(chat, cancellationToken, prefix),
+        CompletionsService.Endpoint.Stream
+    );
   }
 
   public void sendMessageViaAgent(
       @NotNull CodyAgentClient client,
       @NotNull CompletableFuture<CodyAgentServer> codyAgentServer,
       @NotNull ChatMessage humanMessage,
-      @NotNull UpdatableChat chat)
+      @NotNull UpdatableChat chat,
+      @NotNull CancellationToken cancellationToken)
       throws ExecutionException, InterruptedException {
     final AtomicBoolean isFirstMessage = new AtomicBoolean(false);
     client.onChatUpdateMessageInProgress =
         (agentChatMessage) -> {
-          if (agentChatMessage.text == null) {
+          if (agentChatMessage.text == null || cancellationToken.isCancelled()) {
             return;
           }
 
@@ -88,6 +89,9 @@ public class Chat {
                         .setHumanChatInput(humanMessage.getText())),
             CodyAgent.executorService)
         .get();
+    // TODO we need to move this finishMessageProcessing to be executed when the whole message
+    // processing is finished to make "stop generating" works. Ideally we need a signal from agent
+    // that it finished processing the message so we can call this method.
     chat.finishMessageProcessing();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -32,12 +32,15 @@ public class Chat {
   }
 
   public void sendMessageWithoutAgent(
-      @NotNull List<Message> prompt, @Nullable String prefix, @NotNull UpdatableChat chat) {
+      @NotNull List<Message> prompt,
+      @Nullable String prefix,
+      @NotNull UpdatableChat chat,
+      @NotNull CancellationToken cancellationToken) {
     completionsService.streamCompletion(
         new CompletionsInput(prompt, 0.5f, null, 1000, -1, -1),
         new ChatUpdaterCallbacks(chat, prefix),
         CompletionsService.Endpoint.Stream,
-        new CancellationToken());
+        cancellationToken);
   }
 
   public void sendMessageViaAgent(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -39,8 +39,7 @@ public class Chat {
     completionsService.streamCompletion(
         new CompletionsInput(prompt, 0.5f, null, 1000, -1, -1),
         new ChatUpdaterCallbacks(chat, cancellationToken, prefix),
-        CompletionsService.Endpoint.Stream
-    );
+        CompletionsService.Endpoint.Stream);
   }
 
   public void sendMessageViaAgent(


### PR DESCRIPTION
Show stop generating button when response from Cody is being processed

## Test plan
- Talk to Cody and stop generating the response by clicking at the button
- Execute some recipes and stop generating by clicking at the button
- Reset current conversation while receiving the response should also stop generate response
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
