### PR TITLE
DB table for file contents

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -628,6 +628,15 @@
       "CycleOption": "NO"
     },
     {
+      "Name": "embedding_plugin_files_id_seq",
+      "TypeName": "integer",
+      "StartValue": 1,
+      "MinimumValue": 1,
+      "MaximumValue": 2147483647,
+      "Increment": 1,
+      "CycleOption": "NO"
+    },
+    {
       "Name": "event_logs_export_allowlist_id_seq",
       "TypeName": "integer",
       "StartValue": 1,
@@ -10151,6 +10160,78 @@
           "ConstraintDefinition": "FOREIGN KEY (thread_id) REFERENCES discussion_threads(id) ON DELETE CASCADE"
         }
       ],
+      "Triggers": []
+    },
+    {
+      "Name": "embedding_plugin_files",
+      "Comment": "",
+      "Columns": [
+        {
+          "Name": "contents",
+          "Index": 3,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "embedding_plugin_id",
+          "Index": 4,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "file_path",
+          "Index": 2,
+          "TypeName": "text",
+          "IsNullable": false,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "id",
+          "Index": 1,
+          "TypeName": "integer",
+          "IsNullable": false,
+          "Default": "nextval('embedding_plugin_files_id_seq'::regclass)",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        }
+      ],
+      "Indexes": [
+        {
+          "Name": "embedding_plugin_files_pkey",
+          "IsPrimaryKey": true,
+          "IsUnique": true,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE UNIQUE INDEX embedding_plugin_files_pkey ON embedding_plugin_files USING btree (id)",
+          "ConstraintType": "p",
+          "ConstraintDefinition": "PRIMARY KEY (id)"
+        }
+      ],
+      "Constraints": null,
       "Triggers": []
     },
     {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -10169,7 +10169,7 @@
         {
           "Name": "contents",
           "Index": 3,
-          "TypeName": "text",
+          "TypeName": "bytea",
           "IsNullable": false,
           "Default": "",
           "CharacterMaximumLength": 0,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1337,7 +1337,7 @@ Referenced by:
 ---------------------+---------+-----------+----------+----------------------------------------------------
  id                  | integer |           | not null | nextval('embedding_plugin_files_id_seq'::regclass)
  file_path           | text    |           | not null | 
- contents            | text    |           | not null | 
+ contents            | bytea   |           | not null | 
  embedding_plugin_id | integer |           | not null | 
 Indexes:
     "embedding_plugin_files_pkey" PRIMARY KEY, btree (id)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1331,6 +1331,19 @@ Referenced by:
 
 ```
 
+# Table "public.embedding_plugin_files"
+```
+       Column        |  Type   | Collation | Nullable |                      Default                       
+---------------------+---------+-----------+----------+----------------------------------------------------
+ id                  | integer |           | not null | nextval('embedding_plugin_files_id_seq'::regclass)
+ file_path           | text    |           | not null | 
+ contents            | text    |           | not null | 
+ embedding_plugin_id | integer |           | not null | 
+Indexes:
+    "embedding_plugin_files_pkey" PRIMARY KEY, btree (id)
+
+```
+
 # Table "public.event_logs"
 ```
       Column       |           Type           | Collation | Nullable |                Default                 

--- a/migrations/frontend/1688731877_ddd2efilestorage/down.sql
+++ b/migrations/frontend/1688731877_ddd2efilestorage/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS embedding_plugin_files;

--- a/migrations/frontend/1688731877_ddd2efilestorage/metadata.yaml
+++ b/migrations/frontend/1688731877_ddd2efilestorage/metadata.yaml
@@ -1,0 +1,2 @@
+name: ddd2e-file-storage
+parents: [1687792857]

--- a/migrations/frontend/1688731877_ddd2efilestorage/up.sql
+++ b/migrations/frontend/1688731877_ddd2efilestorage/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS embedding_plugin_files (
     id SERIAL PRIMARY KEY,
     file_path TEXT NOT NULL,
-    contents TEXT NOT NULL,
+    contents bytea NOT NULL,
     embedding_plugin_id INT NOT NULL
 );

--- a/migrations/frontend/1688731877_ddd2efilestorage/up.sql
+++ b/migrations/frontend/1688731877_ddd2efilestorage/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS embedding_plugin_files (
+    id SERIAL PRIMARY KEY,
+    file_path TEXT NOT NULL,
+    contents TEXT NOT NULL,
+    embedding_plugin_id INT NOT NULL
+);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2204,7 +2204,7 @@ ALTER SEQUENCE discussion_threads_target_repo_id_seq OWNED BY discussion_threads
 CREATE TABLE embedding_plugin_files (
     id integer NOT NULL,
     file_path text NOT NULL,
-    contents text NOT NULL,
+    contents bytea NOT NULL,
     embedding_plugin_id integer NOT NULL
 );
 

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2201,6 +2201,23 @@ CREATE SEQUENCE discussion_threads_target_repo_id_seq
 
 ALTER SEQUENCE discussion_threads_target_repo_id_seq OWNED BY discussion_threads_target_repo.id;
 
+CREATE TABLE embedding_plugin_files (
+    id integer NOT NULL,
+    file_path text NOT NULL,
+    contents text NOT NULL,
+    embedding_plugin_id integer NOT NULL
+);
+
+CREATE SEQUENCE embedding_plugin_files_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE embedding_plugin_files_id_seq OWNED BY embedding_plugin_files.id;
+
 CREATE TABLE event_logs (
     id bigint NOT NULL,
     name text NOT NULL,
@@ -4977,6 +4994,8 @@ ALTER TABLE ONLY discussion_threads ALTER COLUMN id SET DEFAULT nextval('discuss
 
 ALTER TABLE ONLY discussion_threads_target_repo ALTER COLUMN id SET DEFAULT nextval('discussion_threads_target_repo_id_seq'::regclass);
 
+ALTER TABLE ONLY embedding_plugin_files ALTER COLUMN id SET DEFAULT nextval('embedding_plugin_files_id_seq'::regclass);
+
 ALTER TABLE ONLY event_logs ALTER COLUMN id SET DEFAULT nextval('event_logs_id_seq'::regclass);
 
 ALTER TABLE ONLY event_logs_export_allowlist ALTER COLUMN id SET DEFAULT nextval('event_logs_export_allowlist_id_seq'::regclass);
@@ -5304,6 +5323,9 @@ ALTER TABLE ONLY discussion_threads
 
 ALTER TABLE ONLY discussion_threads_target_repo
     ADD CONSTRAINT discussion_threads_target_repo_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY embedding_plugin_files
+    ADD CONSTRAINT embedding_plugin_files_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY event_logs_export_allowlist
     ADD CONSTRAINT event_logs_export_allowlist_pkey PRIMARY KEY (id);


### PR DESCRIPTION
Storing file contents for embedding plugins in a database table for now.

Will likely switch over to something more efficient in the future, like file storage, but in the spirit of getting an end-to-end demo working so that we can iterate, this feels like the quickest path to get there.

## Test plan

Migration only.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
