### PR TITLE
sg: add runtype manually triggered

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -13,8 +13,9 @@ type RunType int
 const (
 	// RunTypes should be defined by order of precedence.
 
-	PullRequest    RunType = iota // pull request build
-	WolfiExpBranch                // branch that only builds wolfi images
+	PullRequest       RunType = iota // pull request build
+	WolfiExpBranch                   // branch that only builds wolfi images
+	ManuallyTriggered                // build that is manually triggred - typically used to start CI for external contributions
 
 	// Nightly builds - must be first because they take precedence
 
@@ -156,6 +157,10 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "main-dry-run/",
 		}
+	case ManuallyTriggered:
+		return &RunTypeMatcher{
+			Branch: "_manually_triggered_external/",
+		}
 	case WolfiExpBranch:
 		return &RunTypeMatcher{
 			Branch: "wolfi/",
@@ -194,6 +199,8 @@ func (t RunType) String() string {
 		return "Pull request"
 	case WolfiExpBranch:
 		return "Wolfi Exp Branch"
+	case ManuallyTriggered:
+		return "Manually Triggered External Build"
 	case ReleaseNightly:
 		return "Release branch nightly healthcheck build"
 	case BextNightly:

--- a/dev/sg/sg_ci.go
+++ b/dev/sg/sg_ci.go
@@ -503,6 +503,7 @@ sg ci build docker-images-candidates-notest
 				if err != nil {
 					return err
 				}
+
 				commit := cmd.String("commit")
 				if commit == "" {
 					commit, err = run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
@@ -511,6 +512,7 @@ sg ci build docker-images-candidates-notest
 					}
 				}
 
+				var rt = runtype.PullRequest
 				// 🚨 SECURITY: We do a simple check to see if commit is in origin, this is
 				// non blocking but we ask for confirmation to double check that the user
 				// is aware that potentially unknown code is going to get run on our infra.
@@ -525,13 +527,11 @@ sg ci build docker-images-candidates-notest
 					if response != "yes" {
 						return errors.New("Cancelling request.")
 					}
-					branch = fmt.Sprintf("_manually_triggered_external/%s", commit)
+					branch = fmt.Sprintf("ext_%s", commit)
+					rt = runtype.ManuallyTriggered
 				}
 
-				var rt runtype.RunType
-				if cmd.NArg() == 0 {
-					rt = runtype.PullRequest
-				} else {
+				if cmd.NArg() > 0 {
 					rt = runtype.Compute("", fmt.Sprintf("%s/%s", cmd.Args().First(), branch), nil)
 					// If a special runtype is not detected then the argument was invalid
 					if rt == runtype.PullRequest {

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -116,6 +116,28 @@ sg ci build wolfi
 Base pipeline (more steps might be included based on branch changes):
 
 
+### Manually Triggered External Build
+
+The run type for branches matching `_manually_triggered_external/`.
+You can create a build of this run type for your changes using:
+
+```sh
+sg ci build _manually_triggered_external
+```
+
+Base pipeline (more steps might be included based on branch changes):
+
+- **Pipeline setup**: Trigger async
+- **Image builds**: Build Docker images
+- Ensure buildfiles are up to date
+- Tests
+- BackCompat Tests
+- **Linters and static analysis**: Run sg lint
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Unit and integration tests for the Cody VS Code extension, E2E tests for the Cody VS Code extension, Stylelint (all)
+- **Publish candidate images**: Push candidate Images
+- **End-to-end tests**: Executors E2E
+- **Publish images**: executor-vm, alpine-3.14, codeinsights-db, codeintel-db, postgres-12-alpine, prometheus-gcp, Push final images
+
 ### Release branch nightly healthcheck build
 
 The run type for environment including `{"RELEASE_NIGHTLY":"true"}`.

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -261,6 +261,7 @@ This command is useful when:
 Supported run types when providing an argument for 'sg ci build [runtype]':
 
 * wolfi - Wolfi Exp Branch
+* _manually_triggered_external - Manually Triggered External Build
 * main-dry-run - Main dry run
 * docker-images-patch - Patch image
 * docker-images-patch-notest - Patch image without testing


### PR DESCRIPTION
this also fixes the command so that we can push builds for external contributors



## Test plan
1. Created a fork
2. Made a [PR](https://github.com/sourcegraph/sourcegraph/pull/54711)
3. Submitted a [build](https://buildkite.com/sourcegraph/sourcegraph/builds/233315#0189308e-0634-465e-9d0d-47f73f164139)
```
go run ./dev/sg ci build --commit da6c539fd866d01cac56ab736091b7bb6c5acb7b
❗️ Commit "da6c539fd866d01cac56ab736091b7bb6c5acb7b" not found in in local 'origin/' branches - you might be triggering a build for a fork. Make sure all code has been reviewed before continuing.
Continue? (yes/no) yes
Pushing da6c539fd866d01cac56ab736091b7bb6c5acb7b to _manually_triggered_external/ext_da6c539fd866d01cac56ab736091b7bb6c5acb7b...
 remote: 
 remote: Create a pull request for '_manually_triggered_external/ext_da6c539fd866d01cac56ab736091b7bb6c5acb7b' on GitHub by visiting:        
 remote:      https://github.com/sourcegraph/sourcegraph/pull/new/_manually_triggered_external/ext_da6c539fd866d01cac56ab736091b7bb6c5acb7b        
 remote: 
 remote: GitHub found 17 vulnerabilities on sourcegraph/sourcegraph's default branch (5 high, 8 moderate, 4 low). To find out more, visit:        
 remote:      https://github.com/sourcegraph/sourcegraph/security/dependabot        
 remote: 
 To github.com:sourcegraph/sourcegraph
  * [new branch]            da6c539fd866d01cac56ab736091b7bb6c5acb7b -> _manually_triggered_external/ext_da6c539fd866d01cac56ab736091b7bb6c5acb7b
 
Polling for build for branch _manually_triggered_external/ext_da6c539fd866d01cac56ab736091b7bb6c5acb7b at da6c539fd866d01cac56ab736091b7bb6c5acb7b...
✅ Created build: https://buildkite.com/sourcegraph/sourcegraph/builds/233315
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
