### PR TITLE
App - disable gitserver cleanup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ use {tauri::api::process::Command, tauri::api::process::CommandEvent};
 mod common;
 mod tray;
 use common::{extract_path_from_scheme_url, show_window};
+use std::collections::HashMap;
 use std::sync::RwLock;
 use tauri::Manager;
 use tauri_utils::config::RemoteDomainAccessScope;
@@ -216,6 +217,10 @@ fn start_embedded_services(handle: &tauri::AppHandle) {
     let (mut rx, _child) = Command::new_sidecar(sidecar)
         .expect(format!("failed to create `{sidecar}` binary command").as_str())
         .args(args)
+        .envs(HashMap::from([(
+            "SRC_REPOS_DESIRED_PERCENT_FREE".to_string(),
+            "0".to_string(),
+        )]))
         .spawn()
         .expect(format!("failed to spawn {sidecar} sidecar").as_str());
 


### PR DESCRIPTION
Disables the gitserver repo clean up by setting the env variable to 0 when spawning the sourcegraph process
## Test plan
Add a temporarly error log to print the variable value
Build release version
```SRC_REPOS_DESIRED_PERCENT_FREE	{"Resource": {"service.name": "sourcegraph-backend", "service.version": "2023.0.0+dev", "service.instance.id": "Chriss-MBP.warwick"}, "Attributes": {"value": 0}}```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
