### PR TITLE
github: show bazel diff again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,3 @@ cmd/repo-updater/repos/testdata/** linguist-generated=true
 **/*.pb.go linguist-generated=true
 CHANGELOG.md merge=union
 **/mocks*_*test.go linguist-generated=true
-**/BUILD.bazel linguist-generated=true


### PR DESCRIPTION
The original idea that motivated the decision to hide bazel changes was that during the migration, we were really putting out a lot of these changes and it was really noisy in PRs. 

Now we've reached the point where we're using Bazel normally everyday, diffs on these files are much smaller. If you were making changes to a Makefile in your PR because you added a new file, you would want to see them them. 

Well it's the same thing here, stuff could go wrong if the Buildfiles are not updated, it's code exacly like your Makefile is. 

Which is why, I'm pushing for having those not collapsed by default. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 