### PR TITLE
App - add a developer menu for dev mode 

### DIFF
--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -19,7 +19,7 @@ fn create_system_tray_menu() -> SystemTrayMenu {
             .add_item(clear_all_data_item),
     );
 
-    SystemTrayMenu::new()
+    let menu = SystemTrayMenu::new()
         .add_item(CustomMenuItem::new("open".to_string(), "Open Cody"))
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(
@@ -37,7 +37,23 @@ fn create_system_tray_menu() -> SystemTrayMenu {
         ))
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(CustomMenuItem::new("restart".to_string(), "Restart"))
-        .add_item(CustomMenuItem::new("quit".to_string(), "Quit").accelerator("CmdOrCtrl+Q"))
+        .add_item(CustomMenuItem::new("quit".to_string(), "Quit").accelerator("CmdOrCtrl+Q"));
+
+    #[cfg(dev)]
+    {
+        let jump_to_chat_item = CustomMenuItem::new("dev_jump_chat".to_string(), "Jump to chat");
+        let jump_to_repo_setup_item =
+            CustomMenuItem::new("dev_jump_repo_setup".to_string(), "Jump to repo setup");
+        let developer_menu = SystemTraySubmenu::new(
+            "Developer",
+            SystemTrayMenu::new()
+                .add_item(jump_to_chat_item)
+                .add_item(jump_to_repo_setup_item),
+        );
+        return menu.clone().add_submenu(developer_menu);
+    }
+
+    return menu;
 }
 
 pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
@@ -61,6 +77,18 @@ pub fn on_system_tray_event(app: &AppHandle, event: SystemTrayEvent) {
             "restart" => app.restart(),
             "update" => app.trigger_global("tauri://update", None),
             "quit" => app.exit(0),
+            "dev_jump_repo_setup" => {
+                let window = app.get_window("main").unwrap();
+                window
+                    .eval("window.location.href = '/app-setup/local-repositories'")
+                    .unwrap();
+            }
+            "dev_jump_chat" => {
+                let window = app.get_window("main").unwrap();
+                window
+                    .eval("localStorage.setItem('app.setup.finished', true); window.location.href = '/'")
+                    .unwrap();
+            }
             _ => {}
         }
     }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -44,13 +44,13 @@ fn create_system_tray_menu() -> SystemTrayMenu {
         let jump_to_chat_item = CustomMenuItem::new("dev_jump_chat".to_string(), "Jump to chat");
         let jump_to_repo_setup_item =
             CustomMenuItem::new("dev_jump_repo_setup".to_string(), "Jump to repo setup");
-        let developer_menu = SystemTraySubmenu::new(
-            "Developer",
+        let dev_navigation_menu = SystemTraySubmenu::new(
+            "Dev Navigation",
             SystemTrayMenu::new()
                 .add_item(jump_to_chat_item)
                 .add_item(jump_to_repo_setup_item),
         );
-        return menu.clone().add_submenu(developer_menu);
+        return menu.clone().add_submenu(dev_navigation_menu);
     }
 
     return menu;


### PR DESCRIPTION
This adds a "Developer" menu in the system tray that is only available when running `sg start app`.  Currently the menu has two options:

1. Jump to repo setup in the setup flow
2. Jump to chat

These two options provide navigation that is not usually available but can be very helpful when doing dev work, by bypassing the connect to dotcom step,  skipping the setup flow or jumping back into the setup flow at the repo adding step

## Test plan
`sg start app` - verify menu is present and navigation works
build a release version - verify that developer menu is not present

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
