### PR TITLE
release: make release event attendees optional

### DIFF
--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -139,7 +139,7 @@ export async function ensureEvent(
         calendarId: 'primary',
         requestBody: {
             anyoneCanAddSelf,
-            attendees: attendees.map(email => ({ email })),
+            attendees: attendees.map(email => ({ email, optional: true })),
             start: { date: startDate, dateTime: startDateTime },
             end: { date: endDate, dateTime: endDateTime },
             description,


### PR DESCRIPTION
This marks everyone as optional when sending calendar events related to the release.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Run `pnpm run release tracking:timeline ` with `{dryRun.calendar}` set to `true` and the events generated should have an extra field of `optional: true`