### PR TITLE
Embeddings: add file name to the error message from OpenAI weirdness

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
@@ -52,23 +52,9 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 
 	embeddings := make([]codygateway.Embedding, len(response.Data))
 	for i, d := range response.Data {
-		if len(d.Embedding) > 0 {
-			embeddings[i] = codygateway.Embedding{
-				Index: d.Index,
-				Data:  d.Embedding,
-			}
-		} else {
-			// HACK(camdencheek): Nondeterministically, the OpenAI API will
-			// occasionally send back a `null` for an embedding in the
-			// response. Try it again a few times and hope for the best.
-			resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, model, input.Input[d.Index], 3)
-			if err != nil {
-				return nil, 0, err
-			}
-			embeddings[i] = codygateway.Embedding{
-				Index: d.Index,
-				Data:  resp.Data[0].Embedding,
-			}
+		embeddings[i] = codygateway.Embedding{
+			Index: d.Index,
+			Data:  d.Embedding,
 		}
 	}
 
@@ -77,20 +63,6 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 		Model:           response.Model,
 		ModelDimensions: model.dimensions,
 	}, response.Usage.TotalTokens, nil
-}
-
-func (c *openaiClient) requestSingleEmbeddingWithRetryOnNull(ctx context.Context, model openAIModel, input string, retries int) (resp *openaiEmbeddingsResponse, err error) {
-	for i := 0; i < retries; i++ {
-		resp, err = c.requestEmbeddings(ctx, model, []string{input})
-		if err != nil {
-			return nil, err
-		}
-		if len(resp.Data) != 1 || len(resp.Data[0].Embedding) != model.dimensions {
-			continue // retry
-		}
-		return resp, err
-	}
-	return nil, errors.Newf("null response for embedding after %d retries", retries)
 }
 
 func (c *openaiClient) requestEmbeddings(ctx context.Context, model openAIModel, input []string) (*openaiEmbeddingsResponse, error) {

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
@@ -2,10 +2,7 @@ package embeddings
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
@@ -19,118 +16,6 @@ func TestOpenAI(t *testing.T) {
 			Input: []string{"a", ""}, // empty string is invalid
 		})
 		require.ErrorContains(t, err, "empty string")
-	})
-
-	t.Run("retry on empty embedding", func(t *testing.T) {
-		gotRequest1 := false
-		gotRequest2 := false
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			// On the first request, respond with a null embedding
-			if !gotRequest1 {
-				resp := openaiEmbeddingsResponse{
-					Data: []openaiEmbeddingsData{{
-						Index:     0,
-						Embedding: append(make([]float32, 1535), 1),
-					}, {
-						Index:     1,
-						Embedding: nil,
-					}},
-				}
-				json.NewEncoder(w).Encode(resp)
-				gotRequest1 = true
-				return
-			}
-
-			// The client should try that embedding once more. This time, actually return a value.
-			if !gotRequest2 {
-				resp := openaiEmbeddingsResponse{
-					Data: []openaiEmbeddingsData{{
-						Index:     0,
-						Embedding: append(make([]float32, 1535), 2),
-					}},
-				}
-				json.NewEncoder(w).Encode(resp)
-				gotRequest2 = true
-				return
-			}
-
-			panic("only expected 2 responses")
-		}))
-		defer s.Close()
-
-		httpClient := s.Client()
-		oldTransport := httpClient.Transport
-		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			r.URL, _ = url.Parse(s.URL)
-			return oldTransport.RoundTrip(r)
-		})
-
-		client := NewOpenAIClient(s.Client(), "")
-		resp, _, err := client.GenerateEmbeddings(context.Background(), codygateway.EmbeddingsRequest{
-			Model: string(ModelNameOpenAIAda),
-			Input: []string{"a", "b"},
-		})
-		require.NoError(t, err)
-		require.Equal(t, &codygateway.EmbeddingsResponse{
-			ModelDimensions: 1536,
-			Embeddings: []codygateway.Embedding{{
-				Index: 0,
-				Data:  append(make([]float32, 1535), 1),
-			}, {
-				Index: 1,
-				Data:  append(make([]float32, 1535), 2),
-			}},
-		}, resp)
-		require.True(t, gotRequest1)
-		require.True(t, gotRequest2)
-	})
-
-	t.Run("retry on empty embedding fails", func(t *testing.T) {
-		gotRequest1 := false
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			// On the first request, respond with a null embedding
-			if !gotRequest1 {
-				resp := openaiEmbeddingsResponse{
-					Data: []openaiEmbeddingsData{{
-						Index:     0,
-						Embedding: append(make([]float32, 1535), 1),
-					}, {
-						Index:     1,
-						Embedding: nil,
-					}},
-				}
-				json.NewEncoder(w).Encode(resp)
-				gotRequest1 = true
-				return
-			}
-
-			// After the first request, always respond with an invalid response
-			resp := openaiEmbeddingsResponse{
-				Data: []openaiEmbeddingsData{{
-					Index:     0,
-					Embedding: nil,
-				}},
-			}
-			json.NewEncoder(w).Encode(resp)
-			return
-		}))
-		defer s.Close()
-
-		httpClient := s.Client()
-
-		// HACK: override the URL to always go to the test server
-		oldTransport := httpClient.Transport
-		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			r.URL, _ = url.Parse(s.URL)
-			return oldTransport.RoundTrip(r)
-		})
-
-		client := NewOpenAIClient(s.Client(), "")
-		_, _, err := client.GenerateEmbeddings(context.Background(), codygateway.EmbeddingsRequest{
-			Model: string(ModelNameOpenAIAda),
-			Input: []string{"a", "b"},
-		})
-		require.Error(t, err, "expected request to error on failed retry")
 	})
 }
 

--- a/internal/embeddings/embed/client/client.go
+++ b/internal/embeddings/embed/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -28,3 +29,12 @@ type RateLimitExceededError struct {
 func (e RateLimitExceededError) Error() string { return "rate limit exceeded" }
 
 func (e RateLimitExceededError) RetryAfter() time.Time { return e.retryAfter }
+
+type PartialError struct {
+	Err   error
+	Index int
+}
+
+func (p PartialError) Error() string {
+	return fmt.Sprintf("partial error: input %d: %s", p.Index, p.Err)
+}

--- a/internal/embeddings/embed/client/openai/BUILD.bazel
+++ b/internal/embeddings/embed/client/openai/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/conf/conftypes",
+        "//internal/embeddings/embed/client",
         "//lib/errors",
     ],
 )

--- a/internal/embeddings/embed/client/openai/client.go
+++ b/internal/embeddings/embed/client/openai/client.go
@@ -88,7 +88,7 @@ func (c *openaiEmbeddingsClient) GetEmbeddings(ctx context.Context, texts []stri
 			// HACK(camdencheek): Nondeterministically, the OpenAI API will
 			// occasionally send back a `null` for an embedding in the
 			// response. Try it again a few times and hope for the best.
-			resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, augmentedTexts[embedding.Index], 0)
+			resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, augmentedTexts[embedding.Index], 3)
 			if err != nil {
 				return nil, client.PartialError{Err: err, Index: embedding.Index}
 			}

--- a/internal/embeddings/embed/client/openai/client.go
+++ b/internal/embeddings/embed/client/openai/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"sort"
 	"strings"
 

--- a/internal/embeddings/embed/client/openai/client.go
+++ b/internal/embeddings/embed/client/openai/client.go
@@ -85,11 +85,6 @@ func (c *openaiEmbeddingsClient) GetEmbeddings(ctx context.Context, texts []stri
 		if len(embedding.Embedding) != 0 {
 			embeddings = append(embeddings, embedding.Embedding...)
 		} else {
-			err := os.WriteFile("/tmp/badchunk", []byte(augmentedTexts[embedding.Index]), 0755)
-			if err != nil {
-				panic(err)
-			}
-
 			// HACK(camdencheek): Nondeterministically, the OpenAI API will
 			// occasionally send back a `null` for an embedding in the
 			// response. Try it again a few times and hope for the best.

--- a/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
+++ b/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -9,7 +10,17 @@ go_library(
         "//internal/codygateway",
         "//internal/conf/conftypes",
         "//internal/embeddings/embed/client",
-        "//internal/httpcli",
         "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "sourcegraph_test",
+    srcs = ["client_test.go"],
+    embed = [":sourcegraph"],
+    deps = [
+        "//internal/codygateway",
+        "//internal/conf/conftypes",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/embeddings/embed/client/sourcegraph/client.go
+++ b/internal/embeddings/embed/client/sourcegraph/client.go
@@ -15,12 +15,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func NewClient(config *conftypes.EmbeddingsConfig) *sourcegraphEmbeddingsClient {
+func NewClient(client *http.Client, config *conftypes.EmbeddingsConfig) *sourcegraphEmbeddingsClient {
 	return &sourcegraphEmbeddingsClient{
+		httpClient:  client,
 		model:       config.Model,
 		dimensions:  config.Dimensions,
 		endpoint:    config.Endpoint,
@@ -29,6 +29,7 @@ func NewClient(config *conftypes.EmbeddingsConfig) *sourcegraphEmbeddingsClient 
 }
 
 type sourcegraphEmbeddingsClient struct {
+	httpClient  *http.Client
 	model       string
 	dimensions  int
 	endpoint    string
@@ -114,7 +115,7 @@ func (c *sourcegraphEmbeddingsClient) do(ctx context.Context, request codygatewa
 	if len(request.Input) > 1 {
 		req.Header.Set("X-Cody-Embed-Batch-Size", strconv.Itoa(len(request.Input)))
 	}
-	resp, err := httpcli.ExternalDoer.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/embeddings/embed/client/sourcegraph/client_test.go
+++ b/internal/embeddings/embed/client/sourcegraph/client_test.go
@@ -1,0 +1,123 @@
+package sourcegraph
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/codygateway"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAI(t *testing.T) {
+	t.Run("retry on empty embedding", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := codygateway.EmbeddingsResponse{
+					Embeddings: []codygateway.Embedding{{
+						Index: 0,
+						Data:  append(make([]float32, 1535), 1),
+					}, {
+						Index: 1,
+						Data:  nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. This time, actually return a value.
+			if !gotRequest2 {
+				resp := codygateway.EmbeddingsResponse{
+					Embeddings: []codygateway.Embedding{{
+						Index: 0,
+						Data:  append(make([]float32, 1535), 2),
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+
+		// HACK: override the URL to always go to the test server
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(httpClient, &conftypes.EmbeddingsConfig{})
+		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		require.NoError(t, err)
+		var expected []float32
+		{
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 1)
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 2)
+		}
+		require.Equal(t, expected, resp)
+		require.True(t, gotRequest1)
+		require.True(t, gotRequest2)
+	})
+
+	t.Run("retry on empty embedding fails", func(t *testing.T) {
+		gotRequest1 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := codygateway.EmbeddingsResponse{
+					Embeddings: []codygateway.Embedding{{
+						Index: 0,
+						Data:  append(make([]float32, 1535), 1),
+					}, {
+						Index: 1,
+						Data:  nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// Always return an invalid response to all the retry requests
+			resp := codygateway.EmbeddingsResponse{
+				Embeddings: []codygateway.Embedding{{
+					Index: 0,
+					Data:  nil,
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		_, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		require.Error(t, err, "expected request to error on failed retry")
+	})
+}
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/embeddings/embed/client/sourcegraph/client_test.go
+++ b/internal/embeddings/embed/client/sourcegraph/client_test.go
@@ -60,7 +60,7 @@ func TestOpenAI(t *testing.T) {
 			return oldTransport.RoundTrip(r)
 		})
 
-		client := NewClient(httpClient, &conftypes.EmbeddingsConfig{})
+		client := NewClient(httpClient, &conftypes.EmbeddingsConfig{Dimensions: 1536})
 		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err)
 		var expected []float32
@@ -112,7 +112,7 @@ func TestOpenAI(t *testing.T) {
 			return oldTransport.RoundTrip(r)
 		})
 
-		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{Dimensions: 1536})
 		_, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
 		require.Error(t, err, "expected request to error on failed retry")
 	})

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -193,7 +193,7 @@ func embedFiles(
 		batchEmbeddings, err := embeddingsClient.GetEmbeddings(ctx, batchChunks)
 		if err != nil {
 			if partErr := (client.PartialError{}); errors.As(err, &partErr) {
-				return errors.Wrapf(err, "batch failed on file %q", batch[partErr.Index].FileName)
+				return errors.Wrapf(partErr.Err, "batch failed on file %q", batch[partErr.Index].FileName)
 			}
 			return errors.Wrap(err, "error while getting embeddings")
 		}

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -22,7 +22,7 @@ import (
 func NewEmbeddingsClient(config *conftypes.EmbeddingsConfig) (client.EmbeddingsClient, error) {
 	switch config.Provider {
 	case "sourcegraph":
-		return sourcegraph.NewClient(config), nil
+		return sourcegraph.NewClient(httpcli.ExternalClient, config), nil
 	case "openai":
 		return openai.NewClient(httpcli.ExternalClient, config), nil
 	default:


### PR DESCRIPTION
This adds the failing file name to the error message when OpenAI decides it doesn't want to process a file.

## Test plan

Tested that both the OpenAI client and the Cody Gateway client both show the error message containing the problematic file name. 




<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
<img width="600" alt="Screenshot 2023-07-07 at 17 25 02" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/fb907b02-228c-47b0-8bd3-f7f12ab47dab">
