### PR TITLE
App - disable debug endpoints on port 6060

### DIFF
--- a/CHANGELOG.app.md
+++ b/CHANGELOG.app.md
@@ -16,6 +16,7 @@ All notable changes to the Cody app are documented in this file.
 ## Unreleased
 
 - Added a new settings screen to view Cody rate limits and usage
+- Fixes conflicts on port 6060
 
 ## v2023.7.4
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -217,10 +217,13 @@ fn start_embedded_services(handle: &tauri::AppHandle) {
     let (mut rx, _child) = Command::new_sidecar(sidecar)
         .expect(format!("failed to create `{sidecar}` binary command").as_str())
         .args(args)
-        .envs(HashMap::from([(
-            "SRC_REPOS_DESIRED_PERCENT_FREE".to_string(),
-            "0".to_string(),
-        )]))
+        .envs(HashMap::from([
+            (
+                "SRC_REPOS_DESIRED_PERCENT_FREE".to_string(),
+                "0".to_string(),
+            ),
+            ("SRC_PROF_HTTP".to_string(), "".to_string()),
+        ]))
         .spawn()
         .expect(format!("failed to spawn {sidecar} sidecar").as_str());
 


### PR DESCRIPTION
Passes an empty `SRC_PROF_HTTP` env variable when starting up the sourcegraph backend to disable the debug server in App.

resolves https://github.com/sourcegraph/sourcegraph/issues/54731
## Test plan
Build release version of app and check localhost:6060 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
