### PR TITLE
JetBrains: set minimum 3 rows for input text area

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix logging to use JetBrains api + other minor fixes [#54579](https://github.com/sourcegraph/sourcegraph/pull/54579)
 - Enable editor recipe context menu items when working with Cody app only when Cody app is running [#54583](https://github.com/sourcegraph/sourcegraph/pull/54583)
 - rename `completion` to `autocomplete` in both the UI and code [#54606](https://github.com/sourcegraph/sourcegraph/pull/54606)
+- Increased minimum rows of prompt input form 2 to 3 [#54733](https://github.com/sourcegraph/sourcegraph/pull/54733)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -176,7 +176,7 @@ class CodyToolWindowContent implements UpdatableChat {
     controlsPanel.setBorder(new EmptyBorder(JBUI.insets(14)));
     JPanel messagePanel = new JPanel(new BorderLayout());
     sendButton = createSendButton(this.project);
-    AutoGrowingTextArea autoGrowingTextArea = new AutoGrowingTextArea(2, 9, messagePanel);
+    AutoGrowingTextArea autoGrowingTextArea = new AutoGrowingTextArea(3, 9, messagePanel);
     promptInput = autoGrowingTextArea.getTextArea();
     /* Submit on enter */
     KeyboardShortcut JUST_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, 0), null);


### PR DESCRIPTION
Prompt input displays 3 rows instead of 2
## Test plan
- Prompt input should display 3 rows instead of 2
before:
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/6ff1a434-aa94-4ef5-8460-3ce4d4617f0e)

now:
![image](https://github.com/sourcegraph/sourcegraph/assets/7345368/c06845c3-751c-4ede-8092-cc1e19e59d70)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
