### PR TITLE
conf: Fix httpcli config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixes a crash when uploading indexes with malformed source ranges (this was a bug in scip-go). [#54304](https://github.com/sourcegraph/sourcegraph/pull/54304)
 - Fixed validation of Bitbucket Cloud configuration in site-admin create/update form. [#54494](https://github.com/sourcegraph/sourcegraph/pull/54494)
 - Fixed race condition with grpc `server.send` message. [#54500](https://github.com/sourcegraph/sourcegraph/pull/54500)
+- Fixed a configuration initialization issue that broke the outbound request in the site admin page. [#54745](https://github.com/sourcegraph/sourcegraph/pull/54745)
 
 ## 5.1.1
 

--- a/enterprise/cmd/frontend/shared/shared.go
+++ b/enterprise/cmd/frontend/shared/shared.go
@@ -140,6 +140,7 @@ func SwitchableSiteConfig() conftypes.WatchableSiteConfig {
 
 	go func() {
 		<-shared.AutoUpgradeDone
+		conf.EnsureHTTPClientIsConfigured()
 		switchable.WatchableSiteConfig = confClient
 		for _, watcher := range switchable.watchers {
 			confClient.Watch(watcher)


### PR DESCRIPTION
See [this comment](https://github.com/sourcegraph/sourcegraph/pull/52242/files#r1254598066) for the source issue. Looks like #52242 introduced a condition where certain httpcli settings were not being configured in the frontend due to some cyclic package dependency-avoidance trickery in the `conf.Init` function.

This PR ensures that this setup code is hit in the frontend initialization process. No other service should need this (as they hit the `conf.Init` function directly from `SingleServiceMain` on startup), and no other feature should have been affected (as these are the only settings missing from that path).

## Test plan

Tested locally.