### PR TITLE
bzl: enable go_test to turn off race detector

### DIFF
--- a/dev/go_defs.bzl
+++ b/dev/go_defs.bzl
@@ -5,6 +5,10 @@ def go_test(**kwargs):
     if "timeout" not in kwargs:
         kwargs["timeout"] = "short"
 
+    # All go tests have the race detector turned on
+    if "race" not in kwargs:
+        kwargs["race"] = "on"
+
     # All go tests are tagged with "go" by default
     if "tags" in kwargs:
         if "go" not in kwargs["tags"]:
@@ -12,4 +16,4 @@ def go_test(**kwargs):
     else:
         kwargs["tags"] = ["go"]
 
-    _go_test(race="on", **kwargs)
+    _go_test(**kwargs)


### PR DESCRIPTION
We might need to turn off the race detector for a target, see https://sourcegraph.slack.com/archives/C04MYFW01NV/p1688741821325559

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 