### PR TITLE
[fix] use sane default for auth provider display name

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -133,7 +133,7 @@ Base pipeline (more steps might be included based on branch changes):
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
-- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Unit and integration tests for the Cody VS Code extension, E2E tests for the Cody VS Code extension, Stylelint (all)
+- **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Stylelint (all)
 - **Publish candidate images**: Push candidate Images
 - **End-to-end tests**: Executors E2E
 - **Publish images**: executor-vm, alpine-3.14, codeinsights-db, codeintel-db, postgres-12-alpine, prometheus-gcp, Push final images

--- a/internal/auth/providers/mock_auth_provider.go
+++ b/internal/auth/providers/mock_auth_provider.go
@@ -35,7 +35,9 @@ func (m MockAuthProvider) Config() schema.AuthProviders {
 }
 
 func (m MockAuthProvider) CachedInfo() *Info {
-	panic("should not be called")
+	return &Info{
+		DisplayName: m.MockConfigID.Type,
+	}
 }
 
 func (m MockAuthProvider) Refresh(_ context.Context) error {

--- a/internal/auth/providers/providers.go
+++ b/internal/auth/providers/providers.go
@@ -190,7 +190,9 @@ func SortedProviders() []Provider {
 // p (Provider): The authentication provider to extract common fields from.
 // Returns schema.AuthProviderCommon: The common fields from the provider's config struct.
 func GetAuthProviderCommon(p Provider) schema.AuthProviderCommon {
-	common := schema.AuthProviderCommon{}
+	common := schema.AuthProviderCommon{
+		DisplayName: p.CachedInfo().DisplayName,
+	}
 
 	v := reflect.ValueOf(p.Config())
 	for _, f := range reflect.VisibleFields(v.Type()) {
@@ -208,7 +210,7 @@ func GetAuthProviderCommon(p Provider) schema.AuthProviderCommon {
 				common.Order = order.Interface().(int)
 			}
 			dN := e.FieldByName("DisplayName")
-			if dN.IsValid() {
+			if dN.IsValid() && !dN.IsZero() {
 				common.DisplayName = dN.Interface().(string)
 			}
 			dP := e.FieldByName("DisplayPrefix")

--- a/internal/auth/providers/providers_test.go
+++ b/internal/auth/providers/providers_test.go
@@ -59,11 +59,14 @@ func TestGetAuthProviderCommon(t *testing.T) {
 					Hidden: false,
 					Order:  2,
 				},
+				MockConfigID: ConfigID{
+					Type: "mocked provider",
+				},
 			},
 			want: schema.AuthProviderCommon{
 				Hidden:        false,
 				Order:         2,
-				DisplayName:   "",
+				DisplayName:   "mocked provider",
 				DisplayPrefix: nil,
 			},
 		},


### PR DESCRIPTION
Previously we used DisplayName from CachedInfo() function return. But refactoring to support displayPrefix and other common fields introduced a regression where we did not use it as a default, resulting in empty strings for DisplayName.

This commit brings back the old behavior, where we default to DisplayName from CachedInfo() and only overwrite it with a different value if there is one defined and it is not an empty string.

fixes #54740 
- #54740

### Before
<img width="363" alt="Screenshot 2023-07-10 at 18 24 05" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/94196a51-aa58-43c5-9f16-429ce6908b4b">

### Now
<img width="370" alt="Screenshot 2023-07-10 at 18 23 27" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/8d92fc6b-7947-4dab-8cf2-bd1ed3d9151c">

## Test plan

Tested locally + unit test
