### PR TITLE
cody-gateway: commit usage with background context

### DIFF
--- a/enterprise/cmd/cody-gateway/internal/limiter/limiter.go
+++ b/enterprise/cmd/cody-gateway/internal/limiter/limiter.go
@@ -130,6 +130,9 @@ func (l StaticLimiter) TryAcquire(ctx context.Context) (_ func(context.Context, 
 	// just one token. This seems fine. Note: this isn't an issue on subsequent requests in the
 	// same time block since the TTL would have been set.
 	return func(ctx context.Context, usage int) (err error) {
+		// NOTE: This is to make sure we still commit usage even if the context was canceled.
+		ctx = backgroundContextWithSpan(ctx)
+
 		var incrementedTo, ttlSeconds int
 		// We need to start a new span because the previous one has ended
 		// TODO: ctx is unused after this, but if a usage is added, we need
@@ -172,7 +175,7 @@ func (l StaticLimiter) TryAcquire(ctx context.Context) (_ func(context.Context, 
 		}
 
 		if l.RateLimitAlerter != nil {
-			go l.RateLimitAlerter(backgroundContextWithSpan(ctx), float32(currentUsage+usage)/float32(l.Limit), alertTTL)
+			go l.RateLimitAlerter(ctx, float32(currentUsage+usage)/float32(l.Limit), alertTTL)
 		}
 
 		return nil


### PR DESCRIPTION
We should not rely on the call site to pass down a context that won't be cancelled by accident, and although our redis methods aren't taking a context right now, nothing prevent them from taking a context in the future (through a renovation/refactoring) by someone who absolutely has no "context" about it could cause we silently stop committing usage for rate limit of cancelled requests.

## Test plan

CI
