### PR TITLE
embeddings: name embeddings by id not by name

### DIFF
--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -53,8 +53,7 @@ func TestRecall(t *testing.T) {
 		return io.NopCloser(bytes.NewReader(b)), nil
 	})
 	getRepoEmbeddingIndex := func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		key := embeddings.GetRepoEmbeddingIndexNameDeprecated(repoName)
-		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, string(key))
+		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, repoID, repoName)
 	}
 
 	// Weaviate is disabled per default. We don't need it for this test.

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -53,7 +53,7 @@ func TestRecall(t *testing.T) {
 		return io.NopCloser(bytes.NewReader(b)), nil
 	})
 	getRepoEmbeddingIndex := func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		key := embeddings.GetRepoEmbeddingIndexName(repoID)
+		key := embeddings.GetRepoEmbeddingIndexNameDeprecated(repoName)
 		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, string(key))
 	}
 

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -52,8 +52,8 @@ func TestRecall(t *testing.T) {
 
 		return io.NopCloser(bytes.NewReader(b)), nil
 	})
-	getRepoEmbeddingIndex := func(ctx context.Context, repo api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		key := embeddings.GetRepoEmbeddingIndexName(repo)
+	getRepoEmbeddingIndex := func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+		key := embeddings.GetRepoEmbeddingIndexName(repoID)
 		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, string(key))
 	}
 

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers"
 	srp "github.com/sourcegraph/sourcegraph/internal/authz/subrepoperms"
@@ -69,8 +70,8 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		repoStore,
 		repoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-			return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, string(repoEmbeddingIndexName))
+		func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+			return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, repoID, repoName)
 		},
 		config.EmbeddingsCacheSize,
 	)

--- a/enterprise/cmd/embeddings/shared/main_test.go
+++ b/enterprise/cmd/embeddings/shared/main_test.go
@@ -62,7 +62,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		"repo4": makeIndex("repo4", 4),
 	}
 
-	getRepoEmbeddingIndex := func(_ context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	getRepoEmbeddingIndex := func(_ context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 		return indexes[repoName], nil
 	}
 	getMockQueryEmbedding := func(_ context.Context, query string) ([]float32, string, error) {
@@ -277,7 +277,7 @@ func TestEmbeddingModelMismatch(t *testing.T) {
 		"repo3": makeIndex("repo3", ""),
 	}
 
-	getRepoEmbeddingIndex := func(_ context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	getRepoEmbeddingIndex := func(_ context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 		return indexes[repoName], nil
 	}
 

--- a/enterprise/cmd/embeddings/shared/main_test.go
+++ b/enterprise/cmd/embeddings/shared/main_test.go
@@ -55,15 +55,15 @@ func TestEmbeddingsSearch(t *testing.T) {
 		}
 	}
 
-	indexes := map[api.RepoName]*embeddings.RepoEmbeddingIndex{
-		"repo1": makeIndex("repo1", 1),
-		"repo2": makeIndex("repo2", 2),
-		"repo3": makeIndex("repo3", 3),
-		"repo4": makeIndex("repo4", 4),
+	indexes := map[api.RepoID]*embeddings.RepoEmbeddingIndex{
+		0: makeIndex("repo1", 1),
+		1: makeIndex("repo2", 2),
+		2: makeIndex("repo3", 3),
+		3: makeIndex("repo4", 4),
 	}
 
 	getRepoEmbeddingIndex := func(_ context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		return indexes[repoName], nil
+		return indexes[repoID], nil
 	}
 	getMockQueryEmbedding := func(_ context.Context, query string) ([]float32, string, error) {
 		model := "openai/text-embedding-ada-002"
@@ -105,7 +105,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// embeddings.
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo2", "repo3", "repo4"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 1, 2, 3},
 			Query:            "one",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,
@@ -149,7 +149,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// Second test: providing a subset of repos should only search those repos
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo3"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 2},
 			Query:            "one",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,
@@ -193,7 +193,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// Third test: try a different file just to be safe
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo2", "repo3", "repo4"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 1, 2, 3},
 			Query:            "three",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
@@ -32,9 +32,9 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		mockRepoStore,
 		mockRepoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-			switch repoEmbeddingIndexName {
-			case embeddings.GetRepoEmbeddingIndexName(7):
+		func(ctx context.Context, repoID api.RepoID, _ api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+			switch repoID {
+			case 7:
 				hasDownloadedRepoEmbeddingIndex = true
 				return &embeddings.RepoEmbeddingIndex{}, nil
 			default:
@@ -155,7 +155,7 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		mockRepoStore,
 		mockRepoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
+		func(ctx context.Context, _ api.RepoID, _ api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 			mu.Lock()
 			defer mu.Unlock()
 

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
@@ -34,7 +34,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 		mockRepoEmbeddingJobsStore,
 		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
 			switch repoEmbeddingIndexName {
-			case embeddings.GetRepoEmbeddingIndexName("a"):
+			case embeddings.GetRepoEmbeddingIndexName(7):
 				hasDownloadedRepoEmbeddingIndex = true
 				return &embeddings.RepoEmbeddingIndex{}, nil
 			default:
@@ -54,8 +54,18 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	ctx := context.Background()
 
+	repo := types.Repo{
+		Name: "a",
+		ID:   7,
+	}
+
+	tooLarge := types.Repo{
+		Name: "tooLarge",
+		ID:   42,
+	}
+
 	// Initial request should download and cache the index.
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +75,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	// Subsequent requests should read from the cache.
 	hasDownloadedRepoEmbeddingIndex = false
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +85,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	// Simulate a newer completed repo embedding job.
 	finishedAt = finishedAt.Add(time.Hour)
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,13 +93,13 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 		t.Fatal("expected to download the index after a newer embedding job is completed")
 	}
 
-	_, err = indexGetter.Get(ctx, api.RepoName("toolarge"))
+	_, err = indexGetter.Get(ctx, tooLarge.ID, tooLarge.Name)
 	require.NoError(t, err)
 	require.Equal(t, 1, downloadLargeCount)
 
 	// Fetching a second time should trigger a second download since it's
 	// too large to fit in the cache
-	_, err = indexGetter.Get(ctx, api.RepoName("toolarge"))
+	_, err = indexGetter.Get(ctx, tooLarge.ID, tooLarge.Name)
 	require.NoError(t, err)
 	require.Equal(t, 2, downloadLargeCount)
 }
@@ -163,6 +173,11 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	repo := types.Repo{
+		Name: "a",
+		ID:   7,
+	}
+
 	numRequests := 4
 	var wg sync.WaitGroup
 	wg.Add(numRequests)
@@ -170,7 +185,7 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 		ctx := context.Background()
 		go func() {
 			defer wg.Done()
-			indexGetter.Get(ctx, api.RepoName("a"))
+			indexGetter.Get(ctx, repo.ID, repo.Name)
 		}()
 	}
 	wg.Wait()

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -18,7 +18,7 @@ const (
 )
 
 type (
-	getRepoEmbeddingIndexFn func(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
+	getRepoEmbeddingIndexFn func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
 	getQueryEmbeddingFn     func(ctx context.Context, model string) ([]float32, string, error)
 )
 
@@ -57,7 +57,7 @@ func searchRepoEmbeddingIndexes(
 			return weaviate.Search(ctx, repoName, repoID, floatQuery, params.CodeResultsCount, params.TextResultsCount)
 		}
 
-		embeddingIndex, err := getRepoEmbeddingIndex(ctx, repoName)
+		embeddingIndex, err := getRepoEmbeddingIndex(ctx, repoID, repoName)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "getting repo embedding index for repo %q", repoName)
 		}

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -194,7 +194,7 @@ func (h *handler) getPreviousEmbeddingIndex(ctx context.Context, logger log.Logg
 	index, err := embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
 	if err != nil {
 		// TODO (stefan): Remove support for downloading indexes based on repo name after 5.3
-		logger.Error("Error downloading previous embeddings index based on ID. Trying to download based on \"name\"")
+		logger.Info("Failed to download previous embeddings index based on ID. Trying to download based on \"name\"")
 		indexName = string(embeddings.GetRepoEmbeddingIndexNameDeprecated(repo.Name))
 		index, err = embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
 		if err != nil {

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -48,7 +48,7 @@ var splitOptions = codeintelContext.SplitOptions{
 	ChunkEarlySplitTokensThreshold: embeddingChunkEarlySplitTokensThreshold,
 }
 
-func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.RepoEmbeddingJob) error {
+func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.RepoEmbeddingJob) (err error) {
 	embeddingsConfig := conf.GetEmbeddingsConfig(conf.Get().SiteConfig())
 	if embeddingsConfig == nil {
 		return errors.New("embeddings are not configured or disabled")
@@ -71,6 +71,19 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		if err != nil {
+			return
+		}
+
+		// If we return with err=nil, then we have created a new index with a
+		// name based on the repo ID. It might be that the previous index had a
+		// name based on the repo name (deprecated), which we can delete now on
+		// a best-effort basis.
+		indexNameDeprecated := string(embeddings.GetRepoEmbeddingIndexNameDeprecated(repo.Name))
+		_ = h.uploadStore.Delete(ctx, indexNameDeprecated)
+	}()
 
 	embeddingsClient, err := embed.NewEmbeddingsClient(embeddingsConfig)
 	if err != nil {
@@ -136,11 +149,12 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.
 	logger.Info(
 		"finished generating repo embeddings",
 		log.String("repoName", string(repo.Name)),
+		log.Int32("repoID", int32(repo.ID)),
 		log.String("revision", string(record.Revision)),
 		log.Object("stats", stats.ToFields()...),
 	)
 
-	indexName := string(embeddings.GetRepoEmbeddingIndexName(repo.Name))
+	indexName := string(embeddings.GetRepoEmbeddingIndexName(repo.ID))
 	if stats.IsIncremental {
 		return embeddings.UpdateRepoEmbeddingIndex(ctx, h.uploadStore, indexName, previousIndex, repoEmbeddingIndex, toRemove, ranks)
 	} else {
@@ -174,11 +188,19 @@ func (h *handler) getPreviousEmbeddingIndex(ctx context.Context, logger log.Logg
 		return "", nil
 	}
 
-	indexName := string(embeddings.GetRepoEmbeddingIndexName(repo.Name))
+	indexName := string(embeddings.GetRepoEmbeddingIndexName(repo.ID))
+	// For a brief transition period, we support index names based on either ID
+	// or repo name.
 	index, err := embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
 	if err != nil {
-		logger.Error("Error downloading previous embeddings index. Falling back to full index")
-		return "", nil
+		// TODO (stefan): Remove support for downloading indexes based on repo name after 5.3
+		logger.Error("Error downloading previous embeddings index based on ID. Trying to download based on \"name\"")
+		indexName = string(embeddings.GetRepoEmbeddingIndexNameDeprecated(repo.Name))
+		index, err = embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
+		if err != nil {
+			logger.Error("Error downloading previous embeddings index. Falling back to full index")
+			return "", nil
+		}
 	}
 
 	logger.Info(

--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -188,19 +188,10 @@ func (h *handler) getPreviousEmbeddingIndex(ctx context.Context, logger log.Logg
 		return "", nil
 	}
 
-	indexName := string(embeddings.GetRepoEmbeddingIndexName(repo.ID))
-	// For a brief transition period, we support index names based on either ID
-	// or repo name.
-	index, err := embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
+	index, err := embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, repo.ID, repo.Name)
 	if err != nil {
-		// TODO (stefan): Remove support for downloading indexes based on repo name after 5.3
-		logger.Info("Failed to download previous embeddings index based on ID. Trying to download based on \"name\"")
-		indexName = string(embeddings.GetRepoEmbeddingIndexNameDeprecated(repo.Name))
-		index, err = embeddings.DownloadRepoEmbeddingIndex(ctx, h.uploadStore, indexName)
-		if err != nil {
-			logger.Error("Error downloading previous embeddings index. Falling back to full index")
-			return "", nil
-		}
+		logger.Error("Error downloading previous embeddings index. Falling back to full index")
+		return "", nil
 	}
 
 	logger.Info(

--- a/internal/embeddings/index_name.go
+++ b/internal/embeddings/index_name.go
@@ -15,9 +15,12 @@ var CONTEXT_DETECTION_INDEX_NAME = "context_detection.embeddingindex"
 
 type RepoEmbeddingIndexName string
 
-func GetRepoEmbeddingIndexName(repoName api.RepoName) RepoEmbeddingIndexName {
+func GetRepoEmbeddingIndexNameDeprecated(repoName api.RepoName) RepoEmbeddingIndexName {
 	fsSafeRepoName := nonAlphanumericCharsRegexp.ReplaceAllString(string(repoName), "_")
 	// Add a hash as well to avoid name collisions
 	hash := md5.Sum([]byte(repoName))
 	return RepoEmbeddingIndexName(fmt.Sprintf(`%s_%s.embeddingindex`, fsSafeRepoName, hex.EncodeToString(hash[:])))
+}
+func GetRepoEmbeddingIndexName(repoID api.RepoID) RepoEmbeddingIndexName {
+	return RepoEmbeddingIndexName(fmt.Sprintf(`%d.embeddingindex`, repoID))
 }

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
@@ -110,7 +111,25 @@ func UpdateRepoEmbeddingIndex(
 	return UploadRepoEmbeddingIndex(ctx, uploadStore, key, previous)
 }
 
-func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
+// DownloadRepoEmbeddingIndex wraps downloadRepoEmbeddingIndex to support
+// embeddings named based on either repo ID or repo Name.
+//
+// TODO: 2023/07: Remove this wrapper either after we have forced a complete
+// reindex or after we have removed the internal embeddings store, whichever
+// comes first.
+func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, repoID api.RepoID, repoName api.RepoName) (_ *RepoEmbeddingIndex, err error) {
+	index, err1 := downloadRepoEmbeddingIndex(ctx, uploadStore, string(GetRepoEmbeddingIndexName(repoID)))
+	if err1 != nil {
+		var err2 error
+		index, err2 = downloadRepoEmbeddingIndex(ctx, uploadStore, string(GetRepoEmbeddingIndexNameDeprecated(repoName)))
+		if err2 != nil {
+			return nil, errors.CombineErrors(err1, err2)
+		}
+	}
+	return index, nil
+}
+
+func downloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
 	tr, ctx := trace.New(ctx, "DownloadRepoEmbeddingIndex", attribute.String("key", key))
 	defer tr.EndWithErr(&err)
 

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -134,10 +134,10 @@ func TestRepoEmbeddingIndexStorage(t *testing.T) {
 	ctx := context.Background()
 	uploadStore := newMockUploadStore()
 
-	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "index", index)
+	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "0.embeddingindex", index)
 	require.NoError(t, err)
 
-	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
 	require.NoError(t, err)
 
 	require.Equal(t, index, downloadedIndex)
@@ -169,11 +169,11 @@ func TestIndexFormatVersion(t *testing.T) {
 	err := enc.encode(index)
 	require.NoError(t, err)
 
-	_, err = uploadStore.Upload(ctx, "index", &buf)
+	_, err = uploadStore.Upload(ctx, "0.embeddingindex", &buf)
 	require.NoError(t, err)
 
-	_, err = DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
-	require.EqualError(t, err, fmt.Sprintf("unrecognized index format version: %d", formatVersion))
+	_, err = DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
+	require.ErrorContains(t, err, fmt.Sprintf("unrecognized index format version: %d", formatVersion))
 }
 
 func TestOldEmbeddingIndexDecoding(t *testing.T) {
@@ -196,11 +196,11 @@ func TestOldEmbeddingIndexDecoding(t *testing.T) {
 	uploadStore := newMockUploadStore()
 
 	// Upload the index using the "old" function.
-	err := UploadIndex(ctx, uploadStore, "index", index)
+	err := UploadIndex(ctx, uploadStore, "0.embeddingindex", index)
 	require.NoError(t, err)
 
 	// Download the index using the new, custom function.
-	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
 	require.NoError(t, err)
 
 	require.Equal(t, index.ToNewIndex(), downloadedIndex)


### PR DESCRIPTION
With this PR we migrate embeddings to the new naming schema `<repo ID>.embeddingindex`. Old embeddings can still be read. New embeddings (full index and incremental) will follow the new naming schema.


Example: repo "qa-repo".

Old
```
qa_repo_d5e73055b0ac12179e03a9e6dc330d1c.embeddingindex
```

New
```
14.embeddingindex
```
*Why?*

- Our current naming schema makes it very inefficient to map embeddings to their repo. However, we need such a mapping, because we want to establish a representation of the existing embeddings in our database. So far we used the `repo_embeddings_jobs` table as a proxy, which is prone to diverge from the state of the store at some point. Using the new naming schema makes it trivial to map embeddings to their respective repos. 
-  Once we have embeddings represented in the db , we can leverage unions with the repo table to unlock improvements for admins, such as filtering the repos in **site-admin > repositories** based on whether they have embeddings or not.

## Test plan
- updated unit test
- manual testing: I verified that 
  - existing embeddings can stiill be read
  - existing embeddings are used for incremental updates
  - embeddings based on name are deleted once embeddings based on ID have been created   
