### PR TITLE
JetBrains: Fix NullPointerException if there's no chat component

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- Now avoiding NullPointerException in an edge case when the chat doesn't exist [#54785](https://github.com/sourcegraph/sourcegraph/pull/54785)
+
 ### Security
 
 ## [3.0.3]

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -16,6 +16,7 @@
 - rename `completion` to `autocomplete` in both the UI and code [#54606](https://github.com/sourcegraph/sourcegraph/pull/54606)
 - Increased minimum rows of prompt input form 2 to 3 [#54733](https://github.com/sourcegraph/sourcegraph/pull/54733)
 - improved completion prompt with changes from the VS Code plugin [#54668](https://github.com/sourcegraph/sourcegraph/pull/54668)
+- Display more informative message when no context has been found [#54480](https://github.com/sourcegraph/sourcegraph/pull/54480)
 
 ### Deprecated
 
@@ -37,7 +38,6 @@
 
 - Use smaller Cody logo in toolbar and editor context menu [#54481](https://github.com/sourcegraph/sourcegraph/pull/54481)
 - Sourcegraph link sharing and opening file in browser actions are disabled when working with Cody app [#54473](https://github.com/sourcegraph/sourcegraph/pull/54473)
-- Display more informative message when no context has been found [#54480](https://github.com/sourcegraph/sourcegraph/pull/54480)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -140,12 +140,6 @@ class CodyToolWindowContent implements UpdatableChat {
     JButton findCodeSmellsButton = createRecipeButton("Smell code");
     findCodeSmellsButton.addActionListener(
         e -> new FindCodeSmellsAction().executeRecipeWithPromptProvider(this, project));
-    // JButton fixupButton = createWideButton("Fixup code from inline instructions");
-    // fixupButton.addActionListener(e -> recipeRunner.runFixup());
-    // JButton contextSearchButton = createWideButton("Codebase context search");
-    // contextSearchButton.addActionListener(e -> recipeRunner.runContextSearch());
-    // JButton releaseNotesButton = createWideButton("Generate release notes");
-    // releaseNotesButton.addActionListener(e -> recipeRunner.runReleaseNotes());
     recipesPanel.add(explainCodeDetailedButton);
     recipesPanel.add(explainCodeHighLevelButton);
     recipesPanel.add(generateUnitTestButton);
@@ -154,9 +148,6 @@ class CodyToolWindowContent implements UpdatableChat {
     recipesPanel.add(translateToLanguageButton);
     recipesPanel.add(gitHistoryButton);
     recipesPanel.add(findCodeSmellsButton);
-    //    recipesPanel.add(fixupButton);
-    //    recipesPanel.add(contextSearchButton);
-    //    recipesPanel.add(releaseNotesButton);
 
     // Chat panel
     messagesPanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, true));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -404,7 +404,7 @@ class CodyToolWindowContent implements UpdatableChat {
             });
   }
 
-  private void addComponentToChat(JPanel message) {
+  private void addComponentToChat(@NotNull JPanel message) {
 
     var bubblePanel = new JPanel();
     bubblePanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, false));
@@ -533,7 +533,8 @@ class CodyToolWindowContent implements UpdatableChat {
     sendMessage(project, ChatMessage.createHumanMessage(messageText, messageText), "");
   }
 
-  private void sendMessage(@NotNull Project project, ChatMessage message, String responsePrefix) {
+  private void sendMessage(
+      @NotNull Project project, @NotNull ChatMessage message, @NotNull String responsePrefix) {
     if (!sendButton.isEnabled()) {
       return;
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChatHolderService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/UpdatableChatHolderService.java
@@ -1,13 +1,15 @@
 package com.sourcegraph.cody;
 
-public class UpdatableChatHolderService {
-  private UpdatableChat updatableChat;
+import org.jetbrains.annotations.Nullable;
 
-  public UpdatableChat getUpdatableChat() {
+public class UpdatableChatHolderService {
+  private @Nullable UpdatableChat updatableChat;
+
+  public @Nullable UpdatableChat getUpdatableChat() {
     return updatableChat;
   }
 
-  public void setUpdatableChat(UpdatableChat updatableChat) {
+  public void setUpdatableChat(@Nullable UpdatableChat updatableChat) {
     this.updatableChat = updatableChat;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
@@ -11,15 +11,15 @@ import org.jetbrains.annotations.Nullable;
 
 public class ChatUpdaterCallbacks implements CompletionsCallbacks {
   private static final Logger logger = Logger.getInstance(ChatUpdaterCallbacks.class);
-  private final UpdatableChat chat;
-  private final CancellationToken cancellationToken;
-  private final String prefix;
+  @NotNull private final UpdatableChat chat;
+  @NotNull private final CancellationToken cancellationToken;
+  @NotNull private final String prefix;
   private boolean gotFirstMessage = false;
 
   public ChatUpdaterCallbacks(
       @NotNull UpdatableChat chat,
       @NotNull CancellationToken cancellationToken,
-      @Nullable String prefix) {
+      @NotNull String prefix) {
     this.chat = chat;
     this.cancellationToken = cancellationToken;
     this.prefix = prefix;
@@ -74,11 +74,11 @@ public class ChatUpdaterCallbacks implements CompletionsCallbacks {
     chat.finishMessageProcessing();
   }
 
-  private static @NotNull String reformatBotMessage(@NotNull String text, @Nullable String prefix) {
+  private static @NotNull String reformatBotMessage(@NotNull String text, @NotNull String prefix) {
     String STOP_SEQUENCE_REGEXP = "(H|Hu|Hum|Huma|Human|Human:)$";
     Pattern stopSequencePattern = Pattern.compile(STOP_SEQUENCE_REGEXP);
 
-    String reformattedMessage = (prefix != null ? prefix : "") + text.stripTrailing();
+    String reformattedMessage = prefix + text.stripTrailing();
 
     Matcher stopSequenceMatcher = stopSequencePattern.matcher(reformattedMessage);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/Chat.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class Chat {
   private final @NotNull CompletionsService completionsService;
@@ -33,7 +32,7 @@ public class Chat {
 
   public void sendMessageWithoutAgent(
       @NotNull List<Message> prompt,
-      @Nullable String prefix,
+      @NotNull String prefix,
       @NotNull UpdatableChat chat,
       @NotNull CancellationToken cancellationToken) {
     completionsService.streamCompletion(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatBubble.java
@@ -20,17 +20,25 @@ public class ChatBubble extends JPanel {
 
   @NotNull
   private JPanel buildMessagePanel(@NotNull ChatMessage message) {
+    /* Create panel */
     MessagePanel messagePanel =
         new MessagePanel(message.getSpeaker(), ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
+
+    /* Convert markdown-formatted chat message to Swing components */
     Parser parser = Parser.builder().extensions(List.of(TablesExtension.create())).build();
     Node document = parser.parse(message.getDisplayText());
     MessageContentCreatorFromMarkdownNodes messageContentCreator =
         new MessageContentCreatorFromMarkdownNodes(
             messagePanel, message.getSpeaker(), ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
     document.accept(messageContentCreator);
+
     return messagePanel;
   }
 
+  /**
+   * This is useful when receiving the streamed response. In the background, it removes the last
+   * message and adds the updated one.
+   */
   public void updateText(@NotNull ChatMessage message) {
     JPanel newMessage = buildMessagePanel(message);
     this.remove(0);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatMessage.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatMessage.java
@@ -21,6 +21,7 @@ public class ChatMessage extends Message {
     return new ChatMessage(Speaker.HUMAN, prompt, displayText);
   }
 
+  /* This is considered a markdown formatted string */
   @NotNull
   public String getDisplayText() {
     return displayText;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -31,6 +31,11 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * This class is to be used with a Markdown document like this: Node document =
+ * parser.parse(message.getDisplayText()); document.accept(messageContentCreator); It converts a
+ * single chat message to a JPanel and other Swing components inside it.
+ */
 public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   private final HtmlRenderer htmlRenderer =
       HtmlRenderer.builder().extensions(List.of(TablesExtension.create())).build();
@@ -116,15 +121,22 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   private void insertCodeEditor(@NotNull String codeContent, @Nullable String languageName) {
     /* Create document */
     Document codeDocument = EditorFactory.getInstance().createDocument(codeContent);
+
+    /* Create editor */
     EditorEx editor = (EditorEx) EditorFactory.getInstance().createViewer(codeDocument);
     setHighlighting(editor, languageName);
     fillEditorSettings(editor.getSettings());
     editor.setVerticalScrollbarVisible(false);
     editor.getGutterComponentEx().setPaintBackground(false);
+
+    /* Create editor panel and add it to a parent */
+    JPanel editorPanel = new JPanel(new BorderLayout());
     editorPanel.setBorder(new EmptyBorder(JBInsets.create(new Insets(0, gradientWidth, 0, 0))));
     editorPanel.add(editor.getComponent(), BorderLayout.CENTER);
     editorPanel.setOpaque(false);
     messagePanel.add(editorPanel, BorderLayout.CENTER, textPaneIndex++);
+
+    /* Start a new block */
     htmlContent = new StringBuilder();
     createNewEmptyTextPane();
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/MessageContentCreatorFromMarkdownNodes.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.PlainTextFileType;
 import com.intellij.ui.ColorUtil;
+import com.intellij.util.concurrency.annotations.RequiresEdt;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.SwingHelper;
 import com.intellij.util.ui.UIUtil;
@@ -28,6 +29,7 @@ import org.commonmark.node.Image;
 import org.commonmark.renderer.html.HtmlRenderer;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   private final HtmlRenderer htmlRenderer =
@@ -40,7 +42,7 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   private JEditorPane textPane;
 
   public MessageContentCreatorFromMarkdownNodes(
-      JPanel messagePanel, Speaker speaker, int gradientWidth) {
+      @NotNull JPanel messagePanel, @NotNull Speaker speaker, int gradientWidth) {
     this.messagePanel = messagePanel;
     this.speaker = speaker;
     this.gradientWidth = gradientWidth;
@@ -48,70 +50,71 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   }
 
   private void createNewEmptyTextPane() {
-    textPane = HtmlViewer.createHtmlViewer(getInlineCodeBackgroundColor());
+    textPane = HtmlViewer.createHtmlViewer(getInlineCodeBackgroundColor(this.speaker));
     messagePanel.add(textPane, textPaneIndex++);
   }
 
   @NotNull
-  private Color getInlineCodeBackgroundColor() {
-    return this.speaker == Speaker.ASSISTANT
+  private static Color getInlineCodeBackgroundColor(@NotNull Speaker speaker) {
+    return speaker == Speaker.ASSISTANT
         ? ColorUtil.darker(UIUtil.getPanelBackground(), 3)
         : ColorUtil.brighter(UIUtil.getPanelBackground(), 3);
   }
 
   @Override
-  public void visit(Paragraph paragraph) {
+  public void visit(@NotNull Paragraph paragraph) {
     addContentOfNodeAsHtml(htmlRenderer.render(paragraph));
   }
 
   @Override
-  public void visit(Code code) {
+  public void visit(@NotNull Code code) {
     addContentOfNodeAsHtml(htmlRenderer.render(code));
     super.visit(code);
   }
 
   @Override
-  public void visit(IndentedCodeBlock indentedCodeBlock) {
+  public void visit(@NotNull IndentedCodeBlock indentedCodeBlock) {
     insertCodeEditor(indentedCodeBlock.getLiteral(), "");
     super.visit(indentedCodeBlock);
   }
 
   @Override
-  public void visit(Text text) {
+  public void visit(@NotNull Text text) {
     addContentOfNodeAsHtml(htmlRenderer.render(text));
     super.visit(text);
   }
 
   @Override
-  public void visit(BlockQuote blockQuote) {
+  public void visit(@NotNull BlockQuote blockQuote) {
     addContentOfNodeAsHtml(htmlRenderer.render(blockQuote));
     super.visit(blockQuote);
   }
 
   @Override
-  public void visit(BulletList bulletList) {
+  public void visit(@NotNull BulletList bulletList) {
     addContentOfNodeAsHtml(htmlRenderer.render(bulletList));
   }
 
   @Override
-  public void visit(OrderedList orderedList) {
+  public void visit(@NotNull OrderedList orderedList) {
     addContentOfNodeAsHtml(htmlRenderer.render(orderedList));
   }
 
   @Override
-  public void visit(Emphasis emphasis) {
+  public void visit(@NotNull Emphasis emphasis) {
     addContentOfNodeAsHtml(htmlRenderer.render(emphasis));
     super.visit(emphasis);
   }
 
   @Override
-  public void visit(FencedCodeBlock fencedCodeBlock) {
+  public void visit(@NotNull FencedCodeBlock fencedCodeBlock) {
     insertCodeEditor(fencedCodeBlock.getLiteral(), fencedCodeBlock.getInfo());
     super.visit(fencedCodeBlock);
   }
 
-  private void insertCodeEditor(String codeContent, String languageName) {
-    JPanel editorPanel = new JPanel(new BorderLayout());
+  @RequiresEdt
+  private void insertCodeEditor(@NotNull String codeContent, @Nullable String languageName) {
+    /* Create document */
     Document codeDocument = EditorFactory.getInstance().createDocument(codeContent);
     EditorEx editor = (EditorEx) EditorFactory.getInstance().createViewer(codeDocument);
     setHighlighting(editor, languageName);
@@ -127,89 +130,89 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
   }
 
   @Override
-  public void visit(HardLineBreak hardLineBreak) {
+  public void visit(@NotNull HardLineBreak hardLineBreak) {
     addContentOfNodeAsHtml(htmlRenderer.render(hardLineBreak));
     super.visit(hardLineBreak);
   }
 
   @Override
-  public void visit(Heading heading) {
+  public void visit(@NotNull Heading heading) {
     addContentOfNodeAsHtml(htmlRenderer.render(heading));
     super.visit(heading);
   }
 
   @Override
-  public void visit(ThematicBreak thematicBreak) {
+  public void visit(@NotNull ThematicBreak thematicBreak) {
     addContentOfNodeAsHtml(htmlRenderer.render(thematicBreak));
     super.visit(thematicBreak);
   }
 
   @Override
-  public void visit(HtmlInline htmlInline) {
+  public void visit(@NotNull HtmlInline htmlInline) {
     addContentOfNodeAsHtml(htmlRenderer.render(htmlInline));
     super.visit(htmlInline);
   }
 
   @Override
-  public void visit(HtmlBlock htmlBlock) {
+  public void visit(@NotNull HtmlBlock htmlBlock) {
     addContentOfNodeAsHtml(htmlRenderer.render(htmlBlock));
     super.visit(htmlBlock);
   }
 
   @Override
-  public void visit(Image image) {
+  public void visit(@NotNull Image image) {
     addContentOfNodeAsHtml(htmlRenderer.render(image));
     super.visit(image);
   }
 
   @Override
-  public void visit(Link link) {
+  public void visit(@NotNull Link link) {
     addContentOfNodeAsHtml(htmlRenderer.render(link));
   }
 
   @Override
-  public void visit(ListItem listItem) {
+  public void visit(@NotNull ListItem listItem) {
     addContentOfNodeAsHtml(htmlRenderer.render(listItem));
     super.visit(listItem);
   }
 
   @Override
-  public void visit(SoftLineBreak softLineBreak) {
+  public void visit(@NotNull SoftLineBreak softLineBreak) {
     addContentOfNodeAsHtml(htmlRenderer.render(softLineBreak));
     super.visit(softLineBreak);
   }
 
   @Override
-  public void visit(StrongEmphasis strongEmphasis) {
+  public void visit(@NotNull StrongEmphasis strongEmphasis) {
     addContentOfNodeAsHtml(htmlRenderer.render(strongEmphasis));
     super.visit(strongEmphasis);
   }
 
   @Override
-  public void visit(LinkReferenceDefinition linkReferenceDefinition) {
+  public void visit(@NotNull LinkReferenceDefinition linkReferenceDefinition) {
     addContentOfNodeAsHtml(htmlRenderer.render(linkReferenceDefinition));
     super.visit(linkReferenceDefinition);
   }
 
   @Override
-  public void visit(CustomBlock customBlock) {
+  public void visit(@NotNull CustomBlock customBlock) {
     addContentOfNodeAsHtml(htmlRenderer.render(customBlock));
   }
 
-  private void addContentOfNodeAsHtml(String renderedHtml) {
+  private void addContentOfNodeAsHtml(@Nullable String renderedHtml) {
     htmlContent.append(renderedHtml);
     textPane.setText(buildHtmlContent(htmlContent.toString()));
   }
 
   @NotNull
-  private static @Nls String buildHtmlContent(String bodyContent) {
+  private static @Nls String buildHtmlContent(@NotNull String bodyContent) {
     return SwingHelper.buildHtml(
         UIUtil.getCssFontDeclaration(
             UIUtil.getLabelFont(), UIUtil.getActiveTextColor(), null, null),
         bodyContent);
   }
 
-  private static void setHighlighting(EditorEx editor, String languageName) {
+  private static void setHighlighting(@NotNull EditorEx editor, @Nullable String languageName) {
     FileType fileType =
         Language.getRegisteredLanguages().stream()
             .filter(it -> it.getDisplayName().equalsIgnoreCase(languageName))
@@ -224,7 +227,7 @@ public class MessageContentCreatorFromMarkdownNodes extends AbstractVisitor {
     editor.setHighlighter(editorHighlighter);
   }
 
-  private static void fillEditorSettings(final EditorSettings editorSettings) {
+  private static void fillEditorSettings(@NotNull final EditorSettings editorSettings) {
     editorSettings.setAdditionalColumnsCount(0);
     editorSettings.setAdditionalLinesCount(0);
     editorSettings.setGutterIconsShown(false);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/RefreshCodyAppDetection.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/RefreshCodyAppDetection.java
@@ -18,7 +18,9 @@ public class RefreshCodyAppDetection extends DumbAwareAction {
     UpdatableChatHolderService updatableChatHolderService =
         project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-    updatableChat.refreshPanelsVisibility();
+    if (updatableChat != null) {
+      updatableChat.refreshPanelsVisibility();
+    }
   }
 
   /**
@@ -33,7 +35,9 @@ public class RefreshCodyAppDetection extends DumbAwareAction {
       UpdatableChatHolderService updatableChatHolderService =
           project.getService(UpdatableChatHolderService.class);
       UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-      updatableChat.refreshPanelsVisibility();
+      if (updatableChat != null) {
+        updatableChat.refreshPanelsVisibility();
+      }
     }
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
@@ -21,7 +21,9 @@ public class ResetCurrentConversationAction extends DumbAwareAction {
     UpdatableChatHolderService updatableChatHolderService =
         ServiceManager.getService(project, UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-    updatableChat.resetConversation();
+    if (updatableChat != null) {
+      updatableChat.resetConversation();
+    }
   }
 
   @Override
@@ -31,7 +33,9 @@ public class ResetCurrentConversationAction extends DumbAwareAction {
       UpdatableChatHolderService updatableChatHolderService =
           project.getService(UpdatableChatHolderService.class);
       UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-      e.getPresentation().setVisible(updatableChat.isChatVisible());
+      if (updatableChat != null) {
+        e.getPresentation().setVisible(updatableChat.isChatVisible());
+      }
     }
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.chat;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.UpdatableChat;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ResetCurrentConversationAction.java
@@ -19,7 +19,7 @@ public class ResetCurrentConversationAction extends DumbAwareAction {
       return;
     }
     UpdatableChatHolderService updatableChatHolderService =
-        ServiceManager.getService(project, UpdatableChatHolderService.class);
+        project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
     if (updatableChat != null) {
       updatableChat.resetConversation();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
@@ -22,7 +22,8 @@ public abstract class SimpleRecipeAction extends BaseRecipeAction {
     }
   }
 
-  public void executeRecipeWithPromptProvider(@NotNull UpdatableChat updatableChat, @NotNull Project project) {
+  public void executeRecipeWithPromptProvider(
+      @NotNull UpdatableChat updatableChat, @NotNull Project project) {
     GraphQlLogger.logCodyEvents(project, this.getActionComponentName(), "clicked");
     RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
     ActionUtil.runIfCodeSelected(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
@@ -17,10 +17,12 @@ public abstract class SimpleRecipeAction extends BaseRecipeAction {
     UpdatableChatHolderService updatableChatHolderService =
         project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
-    executeRecipeWithPromptProvider(updatableChat, project);
+    if (updatableChat != null) {
+      executeRecipeWithPromptProvider(updatableChat, project);
+    }
   }
 
-  public void executeRecipeWithPromptProvider(UpdatableChat updatableChat, Project project) {
+  public void executeRecipeWithPromptProvider(@NotNull UpdatableChat updatableChat, @NotNull Project project) {
     GraphQlLogger.logCodyEvents(project, this.getActionComponentName(), "clicked");
     RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
     ActionUtil.runIfCodeSelected(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/TranslateToLanguageAction.java
@@ -25,6 +25,9 @@ public class TranslateToLanguageAction extends BaseRecipeAction {
     UpdatableChatHolderService updatableChatHolderService =
         project.getService(UpdatableChatHolderService.class);
     UpdatableChat updatableChat = updatableChatHolderService.getUpdatableChat();
+    if (updatableChat == null) {
+      return;
+    }
     RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
     ActionUtil.runIfCodeSelected(
         updatableChat,


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/sourcegraph/issues/54592

There were some missing null annotations that allowed us to overlook this case. The main takeaway for me is to keep the habit of always using `@NotNull`/`@Nullable` annotations.

Also:
- Docs: Added some comments to clarify what some parts of the code do
- Cleanup: Fixed a deprecation warning
- Cleanup: Removed two commented code blocks
- Docs fix: Moved an unreleased changelog item

The above changes are all in separate commits for easier review.

## Test plan

I couldn't repro the original issue TBH, but based on the provided stack trace, I don't see how it could happen again after these changes.