### PR TITLE
JetBrains: disable gradle copyAgentBinariesToPluginPath task

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -180,3 +180,7 @@ tasks {
 tasks.test {
     useJUnitPlatform()
 }
+
+tasks.getByName("copyAgentBinariesToPluginPath") {
+    enabled = false
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -8,9 +8,9 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 /**
  * Interface for the server-part of the Cody agent protocol. The implementation of this interface is
- * written in TypeScript in the file "cody/agent/src/agent.ts". The Eclipse LSP4J bindings
- * create a Java implementation of this interface by using a JVM-reflection feature called "Proxy",
- * which works similar to JavaScript Proxy.
+ * written in TypeScript in the file "cody/agent/src/agent.ts". The Eclipse LSP4J bindings create a
+ * Java implementation of this interface by using a JVM-reflection feature called "Proxy", which
+ * works similar to JavaScript Proxy.
  */
 public interface CodyAgentServer {
 


### PR DESCRIPTION
This disables failing gradle tasks, It's going to be fixed later
## Test plan
- Green CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
