### PR TITLE
gitserver: introduce DB argument to NewClient

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -85,7 +85,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	t.Run("authenticated as user, using invalid scopes", func(t *testing.T) {
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		db := database.NewMockDB()
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID /* no scopes */, Note: "n"})
 		if err == nil {
 			t.Error("err == nil")
 		}
@@ -102,7 +102,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{
 			User:   uid1GQLID,
 			Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
 			Note:   "n",
@@ -230,7 +230,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), nil)
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -249,7 +249,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: differentNonSiteAdminUID})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx, &createAccessTokenInput{User: uid1GQLID, Note: "n"})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -270,7 +270,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(orig)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx,
 			&createAccessTokenInput{
 				User:   MarshalUserID(1),
 				Scopes: []string{authz.ScopeUserAll, authz.ScopeSiteAdminSudo},
@@ -292,7 +292,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		defer envvar.MockSourcegraphDotComMode(orig)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateAccessToken(ctx,
 			&createAccessTokenInput{
 				User:   MarshalUserID(1),
 				Scopes: []string{authz.ScopeUserAll},
@@ -396,7 +396,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), nil)
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -416,7 +416,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 		db.AccessTokensFunc.SetDefaultReturn(newMockAccessTokens(t))
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: differentNonSiteAdminUID})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
 		if err == nil {
 			t.Error("Expected error, but there was none")
 		}
@@ -445,7 +445,7 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 			UID:                 differentSiteAdminUID,
 			SourcegraphOperator: false,
 		})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).
 			DeleteAccessToken(ctx, &deleteAccessTokenInput{ByID: &token1GQLID})
 		require.Error(t, err)
 		autogold.Expect(`"sourcegraph-operator" user 2's token cannot be deleted by a non-"sourcegraph-operator" user`).Equal(t, err.Error())

--- a/cmd/frontend/graphqlbackend/commit_search_result.go
+++ b/cmd/frontend/graphqlbackend/commit_search_result.go
@@ -25,7 +25,7 @@ func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 		if r.gitCommitResolver != nil {
 			return
 		}
-		gitserverClient := gitserver.NewClient()
+		gitserverClient := gitserver.NewClient(r.db)
 		repoResolver := NewRepositoryResolver(r.db, gitserverClient, r.Repo.ToRepo())
 		r.gitCommitResolver = NewGitCommitResolver(r.db, gitserverClient, repoResolver, r.CommitMatch.Commit.ID, &r.CommitMatch.Commit)
 	})

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -41,7 +41,7 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 		db := database.NewDB(logger, dbtest.NewDB(logger, t))
 		act := actor.Actor{UID: 1}
 		ctx := actor.WithActor(context.Background(), &act)
-		sr := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs())
+		sr := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs())
 
 		spec := extsvc.AccountSpec{
 			ServiceType: extsvc.TypeGitHub,
@@ -172,7 +172,7 @@ func TestExternalAccounts_AddExternalAccount(t *testing.T) {
 				ctx = actor.WithActor(ctx, &act)
 			}
 
-			sr := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs())
+			sr := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs())
 
 			args := struct {
 				ServiceType    string

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -47,7 +47,7 @@ func TestAddExternalService(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).AddExternalService(ctx, &addExternalServiceArgs{})
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).AddExternalService(ctx, &addExternalServiceArgs{})
 		if want := auth.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %q", want, err)
 		}
@@ -136,7 +136,7 @@ func TestUpdateExternalService(t *testing.T) {
 		db.ExternalServicesFunc.SetDefaultReturn(externalServices)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateExternalService(ctx, &updateExternalServiceArgs{
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateExternalService(ctx, &updateExternalServiceArgs{
 			Input: updateExternalServiceInput{
 				ID:     "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
 				Config: strptr(""),
@@ -527,7 +527,7 @@ func TestDeleteExternalService(t *testing.T) {
 			db.UsersFunc.SetDefaultReturn(users)
 
 			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-			result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteExternalService(ctx, &deleteExternalServiceArgs{
+			result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteExternalService(ctx, &deleteExternalServiceArgs{
 				ExternalService: "RXh0ZXJuYWxTZXJ2aWNlOjQ=",
 			})
 			if want := auth.ErrMustBeSiteAdmin; err != want {
@@ -588,7 +588,7 @@ func TestExternalServicesResolver(t *testing.T) {
 			db := database.NewMockDB()
 			db.UsersFunc.SetDefaultReturn(users)
 
-			result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).ExternalServices(context.Background(), &ExternalServicesArgs{})
+			result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).ExternalServices(context.Background(), &ExternalServicesArgs{})
 			if want := auth.ErrMustBeSiteAdmin; err != want {
 				t.Errorf("err: want %q but got %v", want, err)
 			}
@@ -609,7 +609,7 @@ func TestExternalServicesResolver(t *testing.T) {
 			db := database.NewMockDB()
 			db.UsersFunc.SetDefaultReturn(users)
 
-			_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).ExternalServices(context.Background(), &ExternalServicesArgs{})
+			_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).ExternalServices(context.Background(), &ExternalServicesArgs{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/externallink/repository_test.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository_test.go
@@ -136,7 +136,7 @@ func TestFileOrDir(t *testing.T) {
 			db := database.NewMockDB()
 			db.PhabricatorFunc.SetDefaultReturn(phabricator)
 
-			links, err := FileOrDir(context.Background(), db, gitserver.NewClient(), repo, rev, path, isDir)
+			links, err := FileOrDir(context.Background(), db, gitserver.NewClient(db), repo, rev, path, isDir)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -189,7 +189,7 @@ func TestFileOrDir(t *testing.T) {
 		db := database.NewMockDB()
 		db.PhabricatorFunc.SetDefaultReturn(phabricator)
 
-		links, err := FileOrDir(context.Background(), db, gitserver.NewClient(), &types.Repo{Name: "myrepo"}, rev, path, true)
+		links, err := FileOrDir(context.Background(), db, gitserver.NewClient(db), &types.Repo{Name: "myrepo"}, rev, path, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/frontend/graphqlbackend/file_match.go
+++ b/cmd/frontend/graphqlbackend/file_match.go
@@ -34,11 +34,11 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 		Commit: fm.Commit(),
 		Stat:   CreateFileInfo(fm.Path, false),
 	}
-	return NewGitTreeEntryResolver(fm.db, gitserver.NewClient(), opts)
+	return NewGitTreeEntryResolver(fm.db, gitserver.NewClient(fm.db), opts)
 }
 
 func (fm *FileMatchResolver) Commit() *GitCommitResolver {
-	commit := NewGitCommitResolver(fm.db, gitserver.NewClient(), fm.RepoResolver, fm.CommitID, nil)
+	commit := NewGitCommitResolver(fm.db, gitserver.NewClient(fm.db), fm.RepoResolver, fm.CommitID, nil)
 	commit.inputRev = fm.InputRev
 	return commit
 }

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -47,7 +47,7 @@ func TestGitCommitResolver(t *testing.T) {
 	}
 
 	t.Run("URL Escaping", func(t *testing.T) {
-		repo := NewRepositoryResolver(db, gitserver.NewClient(), &types.Repo{Name: "xyz"})
+		repo := NewRepositoryResolver(db, client, &types.Repo{Name: "xyz"})
 		commitResolver := NewGitCommitResolver(db, client, repo, "c1", commit)
 		{
 			inputRev := "master^1"
@@ -135,7 +135,7 @@ func TestGitCommitResolver(t *testing.T) {
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {
-				repo := NewRepositoryResolver(db, gitserver.NewClient(), repo)
+				repo := NewRepositoryResolver(db, client, repo)
 				// We pass no commit here to test that it gets lazy loaded via
 				// the git.GetCommit mock above.
 				r := NewGitCommitResolver(db, client, repo, "c1", nil)
@@ -185,7 +185,7 @@ func TestGitCommitResolver(t *testing.T) {
 			ExternalRepo: api.ExternalRepoSpec{ServiceType: extsvc.TypePerforce},
 		}
 
-		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(), repo)
+		repoResolver := NewRepositoryResolver(db, client, repo)
 
 		repos := database.NewMockRepoStore()
 		repos.GetFunc.SetDefaultReturn(repo, nil)

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -77,7 +77,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, GitObjectType, error) {
 	o.once.Do(func() {
-		obj, err := gitserver.NewClient().GetObject(ctx, o.repo.RepoName(), o.revspec)
+		obj, err := o.repo.gitserverClient.GetObject(ctx, o.repo.RepoName(), o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := gitserver.NewClient().ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
+	oid, err := r.repo.gitserverClient.ResolveRevision(ctx, r.repo.RepoName(), r.expr, gitserver.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -383,43 +383,43 @@ func prometheusGraphQLRequestName(requestName string) string {
 }
 
 func NewSchemaWithoutResolvers(db database.DB) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{})
 }
 
 func NewSchemaWithNotebooksResolver(db database.DB, notebooks NotebooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{NotebooksResolver: notebooks}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{NotebooksResolver: notebooks}})
 }
 
 func NewSchemaWithAuthzResolver(db database.DB, authz AuthzResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{AuthzResolver: authz}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{AuthzResolver: authz}})
 }
 
 func NewSchemaWithBatchChangesResolver(db database.DB, batchChanges BatchChangesResolver, githubApps GitHubAppsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{BatchChangesResolver: batchChanges}, {GitHubAppsResolver: githubApps}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{BatchChangesResolver: batchChanges}, {GitHubAppsResolver: githubApps}})
 }
 
 func NewSchemaWithCodeMonitorsResolver(db database.DB, codeMonitors CodeMonitorsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{CodeMonitorsResolver: codeMonitors}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{CodeMonitorsResolver: codeMonitors}})
 }
 
 func NewSchemaWithLicenseResolver(db database.DB, license LicenseResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{LicenseResolver: license}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{LicenseResolver: license}})
 }
 
 func NewSchemaWithWebhooksResolver(db database.DB, webhooksResolver WebhooksResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{WebhooksResolver: webhooksResolver}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{WebhooksResolver: webhooksResolver}})
 }
 
 func NewSchemaWithRBACResolver(db database.DB, rbacResolver RBACResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{RBACResolver: rbacResolver}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{RBACResolver: rbacResolver}})
 }
 
 func NewSchemaWithOwnResolver(db database.DB, own OwnResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{OwnResolver: own}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{OwnResolver: own}})
 }
 
 func NewSchemaWithCompletionsResolver(db database.DB, completionsResolver CompletionsResolver) (*graphql.Schema, error) {
-	return NewSchema(db, gitserver.NewClient(), nil, []OptionalResolver{{CompletionsResolver: completionsResolver}})
+	return NewSchema(db, gitserver.NewClient(db), nil, []OptionalResolver{{CompletionsResolver: completionsResolver}})
 }
 
 func NewSchema(

--- a/cmd/frontend/graphqlbackend/hunk.go
+++ b/cmd/frontend/graphqlbackend/hunk.go
@@ -50,7 +50,7 @@ func (r *hunkResolver) Message() string {
 }
 
 func (r *hunkResolver) Commit(ctx context.Context) (*GitCommitResolver, error) {
-	return NewGitCommitResolver(r.db, gitserver.NewClient(), r.repo, r.hunk.CommitID, nil), nil
+	return NewGitCommitResolver(r.db, gitserver.NewClient(r.db), r.repo, r.hunk.CommitID, nil), nil
 }
 
 func (r *hunkResolver) Filename() string {

--- a/cmd/frontend/graphqlbackend/package_repos.go
+++ b/cmd/frontend/graphqlbackend/package_repos.go
@@ -204,7 +204,7 @@ func (r *packageRepoReferenceResolver) Repository(ctx context.Context) (*Reposit
 	}
 
 	if repo, ok := repos[repoName]; ok {
-		return NewRepositoryResolver(r.db, gitserver.NewClient(), repo), nil
+		return NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repo), nil
 	}
 
 	return nil, nil

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -218,7 +218,7 @@ func (s *repositoriesConnectionStore) ComputeNodes(ctx context.Context, args *da
 	opt := s.opt
 	opt.PaginationArgs = args
 
-	client := gitserver.NewClient()
+	client := gitserver.NewClientDeprecatedNeedsDB()
 	repos, err := backend.NewRepos(s.logger, s.db, client).List(ctx, opt)
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 		return nil, err
 	}
 	resolvers := make([]*RepositoryResolver, 0, len(repos))
-	client := gitserver.NewClient()
+	client := gitserver.NewClientDeprecatedNeedsDB()
 	for i, repo := range repos {
 		if r.opt.LimitOffset != nil && i == r.opt.Limit {
 			break

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -274,7 +274,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 			}
 		}
 
-		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient())
+		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient(r.db))
 		for {
 			// Cursor-based pagination requires that we fetch limit+1 records, so
 			// that we know whether or not there's an additional page (or more)

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -92,7 +92,7 @@ func (s *repositoryContributorConnectionStore) ComputeNodes(ctx context.Context,
 
 func (s *repositoryContributorConnectionStore) compute(ctx context.Context) ([]*gitdomain.ContributorCount, error) {
 	s.once.Do(func() {
-		client := gitserver.NewClient()
+		client := gitserver.NewClientDeprecatedNeedsDB()
 		var opt gitserver.ContributorOptions
 		if s.args.RevisionRange != nil {
 			opt.Range = *s.args.RevisionRange

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -37,7 +37,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var branches []*gitdomain.Branch
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		var err error
-		branches, err = gitserver.NewClient().ListBranches(ctx, r.RepoName(), gitserver.BranchesOptions{
+		branches, err = gitserver.NewClientDeprecatedNeedsDB().ListBranches(ctx, r.RepoName(), gitserver.BranchesOptions{
 			// We intentionally do not ask for commits here since it requires
 			// a separate git call per branch. We only need the git commits to
 			// sort by author/commit date and there are few enough branches to
@@ -104,7 +104,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var tags []*gitdomain.Tag
 	if args.Type == nil || *args.Type == gitRefTypeTag {
 		var err error
-		tags, err = gitserver.NewClient().ListTags(ctx, r.RepoName())
+		tags, err = gitserver.NewClientDeprecatedNeedsDB().ListTags(ctx, r.RepoName())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata_test.go
@@ -49,7 +49,7 @@ func TestRepositoryMetadata(t *testing.T) {
 	repo, err := db.Repos().GetByName(ctx, "testrepo")
 	require.NoError(t, err)
 
-	schema := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs())
+	schema := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs())
 	gqlID := MarshalRepositoryID(repo.ID)
 
 	t.Run("add", func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -38,7 +38,7 @@ func (r *repositoryStatsResolver) GitDirBytes(ctx context.Context) (BigInt, erro
 
 func (r *repositoryStatsResolver) computeGitDirBytes(ctx context.Context) (int64, error) {
 	r.gitDirBytesOnce.Do(func() {
-		stats, err := gitserver.NewClient().ReposStats(ctx)
+		stats, err := gitserver.NewClientDeprecatedNeedsDB().ReposStats(ctx)
 		if err != nil {
 			r.gitDirBytesErr = err
 			return

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -156,7 +156,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(), minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
 		assertRepoResolverHydrated(ctx, t, repoResolver, hydratedRepo)
 		mockrequire.CalledOnce(t, rs.GetFunc)
 	})
@@ -171,7 +171,7 @@ func TestRepositoryHydration(t *testing.T) {
 		db := database.NewMockDB()
 		db.ReposFunc.SetDefaultReturn(rs)
 
-		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(), minimalRepo)
+		repoResolver := NewRepositoryResolver(db, gitserver.NewClient(db), minimalRepo)
 		_, err := repoResolver.Description(ctx)
 		require.ErrorIs(t, err, dbErr)
 

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -42,7 +42,7 @@ func TestSavedSearches(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	resolver, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
+	resolver, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestSavedSearchesForSameUser(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	resolver, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
+	resolver, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestSavedSearchesForDifferentUser(t *testing.T) {
 		Namespace:              MarshalUserID(key),
 	}
 
-	_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(userID)), args)
+	_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(userID)), args)
 	if err == nil {
 		t.Error("got nil, want error to be returned for accessing saved searches of different user by non site admin.")
 	}
@@ -171,7 +171,7 @@ func TestSavedSearchesForDifferentOrg(t *testing.T) {
 		Namespace:              MarshalOrgID(key),
 	}
 
-	if _, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args); err != auth.ErrNotAnOrgMember {
+	if _, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SavedSearches(actor.WithActor(context.Background(), actor.FromUser(key)), args); err != auth.ErrNotAnOrgMember {
 		t.Errorf("got %v+, want %v+", err, auth.ErrNotAnOrgMember)
 	}
 }
@@ -207,7 +207,7 @@ func TestSavedSearchByIDOwner(t *testing.T) {
 		UID: userID,
 	})
 
-	savedSearch, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).savedSearchByID(ctx, ssID)
+	savedSearch, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).savedSearchByID(ctx, ssID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestSavedSearchByIDNonOwner(t *testing.T) {
 		UID: adminID,
 	})
 
-	_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).savedSearchByID(ctx, ssID)
+	_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).savedSearchByID(ctx, ssID)
 	t.Log(err)
 	if err == nil {
 		t.Fatal("expected an error")
@@ -291,7 +291,7 @@ func TestCreateSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	userID := MarshalUserID(key)
-	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateSavedSearch(ctx, &struct {
+	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateSavedSearch(ctx, &struct {
 		Description string
 		Query       string
 		NotifyOwner bool
@@ -319,7 +319,7 @@ func TestCreateSavedSearch(t *testing.T) {
 	}
 
 	// Ensure create saved search errors when patternType is not provided in the query.
-	_, err = newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).CreateSavedSearch(ctx, &struct {
+	_, err = newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).CreateSavedSearch(ctx, &struct {
 		Description string
 		Query       string
 		NotifyOwner bool
@@ -362,7 +362,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	userID := MarshalUserID(key)
-	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
+	savedSearches, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
 		ID          graphql.ID
 		Description string
 		Query       string
@@ -396,7 +396,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 	}
 
 	// Ensure update saved search errors when patternType is not provided in the query.
-	_, err = newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
+	_, err = newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
 		ID          graphql.ID
 		Description string
 		Query       string
@@ -489,7 +489,7 @@ func TestUpdateSavedSearchPermissions(t *testing.T) {
 			db.SavedSearchesFunc.SetDefaultReturn(savedSearches)
 			db.OrgMembersFunc.SetDefaultReturn(orgMembers)
 
-			_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
+			_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateSavedSearch(ctx, &struct {
 				ID          graphql.ID
 				Description string
 				Query       string
@@ -539,7 +539,7 @@ func TestDeleteSavedSearch(t *testing.T) {
 	db.SavedSearchesFunc.SetDefaultReturn(ss)
 
 	firstSavedSearchGraphqlID := graphql.ID("U2F2ZWRTZWFyY2g6NTI=")
-	_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteSavedSearch(ctx, &struct {
+	_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteSavedSearch(ctx, &struct {
 		ID graphql.ID
 	}{ID: firstSavedSearchGraphqlID})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -79,7 +79,7 @@ func (c *SearchResultsResolver) repositoryResolvers(ctx context.Context, ids []a
 		return nil, nil
 	}
 
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	resolvers := make([]*RepositoryResolver, 0, len(ids))
 	err := c.db.Repos().StreamMinimalRepos(ctx, database.ReposListOptions{
 		IDs: ids,
@@ -134,7 +134,7 @@ func matchesToResolvers(db database.DB, matches []result.Match) []SearchResultRe
 		Rev  string
 	}
 	repoResolvers := make(map[repoKey]*RepositoryResolver, 10)
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	getRepoResolver := func(repoName types.MinimalRepo, rev string) *RepositoryResolver {
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
@@ -244,7 +244,7 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *result.
 		return time.Time{}, nil
 	}
 	hm := fm.ChunkMatches[0]
-	hunks, err := gitserver.NewClient().BlameFile(ctx, authz.DefaultSubRepoPermsChecker, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
+	hunks, err := gitserver.NewClientDeprecatedNeedsDB().BlameFile(ctx, authz.DefaultSubRepoPermsChecker, fm.Repo.Name, fm.Path, &gitserver.BlameOptions{
 		NewestCommit: fm.CommitID,
 		StartLine:    hm.Ranges[0].Start.Line,
 		EndLine:      hm.Ranges[0].Start.Line,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -28,7 +28,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 	}
 
 	logger := srs.logger.Scoped("languages", "provide stats on langauges from the search results")
-	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(r.db), matches)
+	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(srs.sr.db), matches)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -28,7 +28,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 	}
 
 	logger := srs.logger.Scoped("languages", "provide stats on langauges from the search results")
-	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(), matches)
+	langs, err := searchResultsStatsLanguages(ctx, logger, srs.sr.db, gitserver.NewClient(r.db), matches)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -42,7 +42,7 @@ func TestSearchResults(t *testing.T) {
 	db := database.NewMockDB()
 
 	getResults := func(t *testing.T, query, version string) []string {
-		r, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Search(ctx, &SearchArgs{Query: query, Version: version})
+		r, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).Search(ctx, &SearchArgs{Query: query, Version: version})
 		require.Nil(t, err)
 
 		results, err := r.Results(ctx)

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -159,7 +159,7 @@ func TestSettingsMutation(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SettingsMutation(
+				_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SettingsMutation(
 					test.ctx,
 					&settingsMutationArgs{
 						Input: &settingsMutationGroupInput{

--- a/cmd/frontend/graphqlbackend/site_admin_test.go
+++ b/cmd/frontend/graphqlbackend/site_admin_test.go
@@ -32,7 +32,7 @@ func TestDeleteUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteUser(ctx, &struct {
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteUser(ctx, &struct {
 			User graphql.ID
 			Hard *bool
 		}{
@@ -54,7 +54,7 @@ func TestDeleteUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).DeleteUser(ctx, &struct {
+		_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).DeleteUser(ctx, &struct {
 			User graphql.ID
 			Hard *bool
 		}{
@@ -438,7 +438,7 @@ func TestSetIsSiteAdmin(t *testing.T) {
 			db.UsersFunc.SetDefaultReturn(users)
 			db.SecurityEventLogsFunc.SetDefaultReturn(securityLogEvents)
 
-			s := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs())
+			s := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs())
 
 			actorCtx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 			result, err := s.SetUserIsSiteAdmin(actorCtx, &struct {

--- a/cmd/frontend/graphqlbackend/site_config_change_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_test.go
@@ -17,7 +17,7 @@ func TestSiteConfigurationDiff(t *testing.T) {
 	stubs := setupSiteConfigStubs(t)
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: stubs.users[0].ID})
-	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{})
+	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClientDeprecatedNeedsDB(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{})
 	if err != nil {
 		t.Fatalf("failed to create schemaResolver: %v", err)
 	}

--- a/cmd/frontend/graphqlbackend/site_test.go
+++ b/cmd/frontend/graphqlbackend/site_test.go
@@ -28,7 +28,7 @@ func TestSiteConfiguration(t *testing.T) {
 			db.UsersFunc.SetDefaultReturn(users)
 
 			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-			_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
+			_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
 				ReturnSafeConfigsOnly: pointers.Ptr(false),
 			})
 
@@ -44,7 +44,7 @@ func TestSiteConfiguration(t *testing.T) {
 			db.UsersFunc.SetDefaultReturn(users)
 
 			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-			r, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
+			r, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
 				ReturnSafeConfigsOnly: pointers.Ptr(true),
 			})
 			if err != nil {
@@ -97,7 +97,7 @@ func TestSiteConfiguration(t *testing.T) {
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
 		t.Run("ReturnSafeConfigsOnly is false", func(t *testing.T) {
-			r, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
+			r, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
 				ReturnSafeConfigsOnly: pointers.Ptr(false),
 			})
 			if err != nil {
@@ -129,7 +129,7 @@ func TestSiteConfiguration(t *testing.T) {
 		})
 
 		t.Run("ReturnSafeConfigsOnly is true", func(t *testing.T) {
-			r, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
+			r, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{
 				ReturnSafeConfigsOnly: pointers.Ptr(true),
 			})
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/site_test.go
+++ b/cmd/frontend/graphqlbackend/site_test.go
@@ -163,7 +163,7 @@ func TestSiteConfigurationHistory(t *testing.T) {
 	stubs := setupSiteConfigStubs(t)
 
 	ctx := actor.WithActor(context.Background(), &actor.Actor{UID: stubs.users[0].ID})
-	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{})
+	schemaResolver, err := newSchemaResolver(stubs.db, gitserver.NewClientDeprecatedNeedsDB(), jobutil.NewUnimplementedEnterpriseJobs()).Site().Configuration(ctx, &SiteConfigurationArgs{})
 	if err != nil {
 		t.Fatalf("failed to create schemaResolver: %v", err)
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -54,7 +54,7 @@ func TestStatusMessages(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).StatusMessages(context.Background())
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).StatusMessages(context.Background())
 		if want := auth.ErrNotAuthenticated; err != want {
 			t.Errorf("got err %v, want %v", err, want)
 		}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -125,7 +125,7 @@ func (r symbolResolver) Location() *locationResolver {
 		Stat:   stat,
 	}
 	return &locationResolver{
-		resource: NewGitTreeEntryResolver(r.db, gitserver.NewClient(), opts),
+		resource: NewGitTreeEntryResolver(r.db, gitserver.NewClient(r.db), opts),
 		lspRange: &sr,
 	}
 }

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -20,7 +20,7 @@ import (
 )
 
 func mustParseGraphQLSchema(t *testing.T, db database.DB) *graphql.Schema {
-	return mustParseGraphQLSchemaWithClient(t, db, gitserver.NewClient())
+	return mustParseGraphQLSchemaWithClient(t, db, gitserver.NewClient(db))
 }
 
 func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverClient gitserver.Client) *graphql.Schema {

--- a/cmd/frontend/graphqlbackend/user_collaborators.go
+++ b/cmd/frontend/graphqlbackend/user_collaborators.go
@@ -29,7 +29,7 @@ func (r *UserResolver) InvitableCollaborators(ctx context.Context) ([]*invitable
 	// We'll search for collaborators in 25 of the user's most-starred repositories.
 	const maxReposToScan = 25
 	db := r.db
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	pickedRepos, err := backend.NewRepos(r.logger, db, gsClient).List(ctx, database.ReposListOptions{
 		// SECURITY: This must be the authenticated user's ID.
 		UserID:     a.UID,

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -166,7 +166,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SetUserEmailVerified(
+				_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SetUserEmailVerified(
 					test.ctx,
 					&setUserEmailVerifiedArgs{
 						User: MarshalUserID(1),

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -342,7 +342,7 @@ func TestUpdateUser(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, Username: "2"}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(context.Background(),
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(context.Background(),
 			&updateUserArgs{
 				User: "VXNlcjox",
 			},
@@ -363,7 +363,7 @@ func TestUpdateUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(ctx,
+		_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(ctx,
 			&updateUserArgs{
 				User:     MarshalUserID(1),
 				Username: strptr("about"),
@@ -390,7 +390,7 @@ func TestUpdateUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(ctx,
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(ctx,
 			&updateUserArgs{
 				User:     "VXNlcjox",
 				Username: strptr("alice"),
@@ -493,7 +493,7 @@ func TestUpdateUser(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(
+				_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(
 					test.ctx,
 					&updateUserArgs{
 						User: MarshalUserID(1),
@@ -525,7 +525,7 @@ func TestUpdateUser(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				_, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(
+				_, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).UpdateUser(
 					actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
 					&updateUserArgs{
 						User:      MarshalUserID(2),
@@ -772,7 +772,7 @@ func TestSchema_SetUserCompletionsQuota(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, Username: "2"}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SetUserCompletionsQuota(context.Background(),
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SetUserCompletionsQuota(context.Background(),
 			SetUserCompletionsQuotaArgs{
 				User:  MarshalUserID(1),
 				Quota: nil,
@@ -847,7 +847,7 @@ func TestSchema_SetUserCodeCompletionsQuota(t *testing.T) {
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 2, Username: "2"}, nil)
 		db.UsersFunc.SetDefaultReturn(users)
 
-		schemaResolver := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs())
+		schemaResolver := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs())
 		result, err := schemaResolver.SetUserCodeCompletionsQuota(context.Background(),
 			SetUserCodeCompletionsQuotaArgs{
 				User:  MarshalUserID(1),
@@ -926,7 +926,7 @@ func TestSchema_SetCompletedPostSignup(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		userID := MarshalUserID(1)
-		result, err := newSchemaResolver(db, gitserver.NewClient(), jobutil.NewUnimplementedEnterpriseJobs()).SetCompletedPostSignup(context.Background(),
+		result, err := newSchemaResolver(db, gitserver.NewClient(db), jobutil.NewUnimplementedEnterpriseJobs()).SetCompletedPostSignup(context.Background(),
 			&userMutationArgs{UserID: &userID},
 		)
 		got := fmt.Sprintf("%v", err)

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -29,7 +29,7 @@ func editorRev(ctx context.Context, logger log.Logger, db database.DB, repoName 
 	if rev == "HEAD" {
 		return ""
 	}
-	repos := backend.NewRepos(logger, db, gitserver.NewClient())
+	repos := backend.NewRepos(logger, db, gitserver.NewClient(db))
 	repo, err := repos.GetByName(ctx, repoName)
 	if err != nil {
 		// We weren't able to fetch the repo. This means it either doesn't

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -466,7 +466,7 @@ func serveTree(db database.DB, title func(c *Common, r *http.Request) string) ha
 			w.Header().Set("X-Robots-Tag", "noindex")
 		}
 
-		handled, err := redirectTreeOrBlob(routeTree, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient())
+		handled, err := redirectTreeOrBlob(routeTree, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient(db))
 		if handled {
 			return nil
 		}
@@ -497,7 +497,7 @@ func serveRepoOrBlob(db database.DB, routeName string, title func(c *Common, r *
 			w.Header().Set("X-Robots-Tag", "noindex")
 		}
 
-		handled, err := redirectTreeOrBlob(routeName, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient())
+		handled, err := redirectTreeOrBlob(routeName, mux.Vars(r)["Path"], common, w, r, db, gitserver.NewClient(db))
 		if handled {
 			return nil
 		}

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -89,7 +89,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		db.ReposFunc.SetDefaultReturn(rstore)
 		rstore.GetByNameFunc.SetDefaultReturn(&types.Repo{ID: 123}, nil)
 
-		err := serveRaw(db, gitserver.NewClient())(w, req)
+		err := serveRaw(db, gitserver.NewClient(db))(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -112,7 +112,7 @@ func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
 		db.ReposFunc.SetDefaultReturn(rstore)
 		rstore.GetByNameFunc.SetDefaultReturn(nil, &database.RepoNotFoundErr{ID: 123})
 
-		err := serveRaw(db, gitserver.NewClient())(w, req)
+		err := serveRaw(db, gitserver.NewClient(db))(w, req)
 		if err == nil {
 			t.Fatal("Want error but got nil")
 		}
@@ -147,7 +147,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		db := database.NewMockDB()
-		err := serveRaw(db, gitserver.NewClient())(w, req)
+		err := serveRaw(db, gitserver.NewClient(db))(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}
@@ -187,7 +187,7 @@ func Test_serveRawWithContentArchive(t *testing.T) {
 		w := httptest.NewRecorder()
 
 		db := database.NewMockDB()
-		err := serveRaw(db, gitserver.NewClient())(w, req)
+		err := serveRaw(db, gitserver.NewClient(db))(w, req)
 		if err != nil {
 			t.Fatalf("Failed to invoke serveRaw: %v", err)
 		}

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -396,7 +396,7 @@ func initRouter(db database.DB, enterpriseJobs jobutil.EnterpriseJobs, router *m
 	})))
 
 	// raw
-	router.Get(routeRaw).Handler(handler(db, serveRaw(db, gitserver.NewClient())))
+	router.Get(routeRaw).Handler(handler(db, serveRaw(db, gitserver.NewClient(db))))
 
 	// All other routes that are not found.
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -219,7 +219,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 
 	schema, err := graphqlbackend.NewSchema(
 		db,
-		gitserver.NewClient(),
+		gitserver.NewClientDeprecatedNeedsDB(),
 		enterpriseServices.EnterpriseSearchJobs,
 		[]graphqlbackend.OptionalResolver{enterpriseServices.OptionalResolver},
 	)

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -37,7 +37,7 @@ func GetRepo(ctx context.Context, logger log.Logger, db database.DB, vars map[st
 // getRepoRev resolves the repository and commit specified in the route vars.
 func getRepoRev(ctx context.Context, logger log.Logger, db database.DB, vars map[string]string, repoID api.RepoID) (api.RepoID, api.CommitID, error) {
 	repoRev := routevar.ToRepoRev(vars)
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	repo, err := backend.NewRepos(logger, db, gsClient).Get(ctx, repoID)
 	if err != nil {
 		return repoID, "", err

--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -22,7 +22,7 @@ import (
 func GetRepo(ctx context.Context, logger log.Logger, db database.DB, vars map[string]string) (*types.Repo, error) {
 	origRepo := routevar.ToRepo(vars)
 
-	repo, err := backend.NewRepos(logger, db, gitserver.NewClient()).GetByName(ctx, origRepo)
+	repo, err := backend.NewRepos(logger, db, gitserver.NewClient(db)).GetByName(ctx, origRepo)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -175,7 +175,7 @@ func NewHandler(
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCli).Handler(trace.Route(newSrcCliVersionHandler(logger)))
 
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	m.Get(apirouter.GitBlameStream).Handler(trace.Route(handleStreamBlame(logger, db, gsClient)))
 
 	// Set up the src-cli version cache handler (this will effectively be a
@@ -222,7 +222,7 @@ func RegisterInternalServices(
 	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
 
 	// zoekt-indexserver endpoints
-	gsClient := gitserver.NewClient()
+	gsClient := gitserver.NewClientDeprecatedNeedsDB()
 	indexer := &searchIndexerServer{
 		db:              db,
 		logger:          logger.Scoped("searchIndexerServer", "zoekt-indexserver endpoints"),

--- a/cmd/frontend/internal/search/decorate.go
+++ b/cmd/frontend/internal/search/decorate.go
@@ -168,7 +168,7 @@ func DecorateFileHunksHTML(ctx context.Context, fm *result.FileMatch) []stream.D
 }
 
 func fetchContent(ctx context.Context, repo api.RepoName, commit api.CommitID, path string) (content []byte, err error) {
-	content, err = gitserver.NewClient().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, commit, path)
+	content, err = gitserver.NewClientDeprecatedNeedsDB().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, repo, commit, path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -280,7 +280,7 @@ func (s *Store) fetch(ctx context.Context, repo api.RepoName, commit api.CommitI
 
 	filter.CommitIgnore = func(hdr *tar.Header) bool { return false } // default: don't filter
 	if s.FilterTar != nil {
-		filter.CommitIgnore, err = s.FilterTar(ctx, gitserver.NewClient(), repo, commit)
+		filter.CommitIgnore, err = s.FilterTar(ctx, gitserver.NewClientDeprecatedNeedsDB(), repo, commit)
 		if err != nil {
 			return nil, errors.Errorf("error while calling FilterTar: %w", err)
 		}
@@ -438,7 +438,7 @@ func (s *Store) watchAndEvict() {
 func (s *Store) watchConfig() {
 	for {
 		// Allow roughly 10 fetches per gitserver
-		limit := 10 * len(gitserver.NewClient().Addrs())
+		limit := 10 * len(gitserver.NewClientDeprecatedNeedsDB().Addrs())
 		if limit == 0 {
 			limit = 15
 		}

--- a/cmd/searcher/shared/shared.go
+++ b/cmd/searcher/shared/shared.go
@@ -126,7 +126,7 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 	// Explicitly don't scope Store logger under the parent logger
 	storeObservationCtx := observation.NewContext(log.Scoped("Store", "searcher archives store"))
 
-	git := gitserver.NewClient()
+	git := gitserver.NewClientDeprecatedNeedsDB()
 
 	sService := &search.Service{
 		Store: &search.Store{

--- a/cmd/symbols/gitserver/client.go
+++ b/cmd/symbols/gitserver/client.go
@@ -49,7 +49,7 @@ type gitserverClient struct {
 
 func NewClient(observationCtx *observation.Context) GitserverClient {
 	return &gitserverClient{
-		innerClient: gitserver.NewClient(),
+		innerClient: gitserver.NewClientDeprecatedNeedsDB(),
 		operations:  newOperations(observationCtx),
 	}
 }

--- a/enterprise/cmd/frontend/internal/app/init.go
+++ b/enterprise/cmd/frontend/internal/app/init.go
@@ -23,7 +23,7 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	if deploy.IsApp() {
-		gitserverClient := gitserver.NewClient()
+		gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 		enterpriseServices.OptionalResolver.AppResolver = resolvers.NewAppResolver(observationCtx.Logger, db, gitserverClient)
 	}
 	return nil

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/resolver_test.go
@@ -60,7 +60,7 @@ func TestResolver_DeleteGitHubApp(t *testing.T) {
 	adminCtx := userCtx(1)
 	userCtx := userCtx(2)
 
-	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
+	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(db), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
 	require.NoError(t, err)
 
 	graphqlbackend.RunTests(t, []*graphqlbackend.Test{{
@@ -136,7 +136,7 @@ func TestResolver_GitHubApps(t *testing.T) {
 	adminCtx := userCtx(1)
 	userCtx := userCtx(2)
 
-	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
+	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(db), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
 	require.NoError(t, err)
 
 	graphqlbackend.RunTests(t, []*graphqlbackend.Test{
@@ -234,7 +234,7 @@ func TestResolver_GitHubApp(t *testing.T) {
 	adminCtx := userCtx(1)
 	userCtx := userCtx(2)
 
-	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
+	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(db), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
 	require.NoError(t, err)
 
 	graphqlbackend.RunTests(t, []*graphqlbackend.Test{{
@@ -303,7 +303,7 @@ func TestResolver_GitHubAppByAppID(t *testing.T) {
 	adminCtx := userCtx(1)
 	userCtx := userCtx(2)
 
-	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
+	schema, err := graphqlbackend.NewSchema(db, gitserver.NewClient(db), nil, []graphqlbackend.OptionalResolver{{GitHubAppsResolver: NewResolver(logger, db)}})
 	require.NoError(t, err)
 
 	graphqlbackend.RunTests(t, []*graphqlbackend.Test{{

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -126,7 +126,7 @@ func (r permissionsInfoRepositoryResolver) ID() graphql.ID {
 }
 
 func (r permissionsInfoRepositoryResolver) Repository() *graphqlbackend.RepositoryResolver {
-	return graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), r.perm.Repo)
+	return graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), r.perm.Repo)
 }
 
 func (r permissionsInfoRepositoryResolver) Reason() string {

--- a/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/permissions_sync_jobs.go
@@ -85,7 +85,7 @@ func (s *permissionsSyncJobConnectionStore) resolveSubject(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		repoResolver = graphqlbackend.NewRepositoryResolver(s.db, gitserver.NewClient(), repo)
+		repoResolver = graphqlbackend.NewRepositoryResolver(s.db, gitserver.NewClient(s.db), repo)
 	}
 
 	return &subject{

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -111,7 +111,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 	}
 	resolvers := make([]*graphqlbackend.RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), repos[i])
+		resolvers[i] = graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repos[i])
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/init.go
+++ b/enterprise/cmd/frontend/internal/batches/init.go
@@ -44,7 +44,7 @@ func Init(
 	bstore := store.New(db, observationCtx, keyring.Default().BatchChangesCredentialKey)
 
 	// Register enterprise services.
-	gitserverClient := gitserver.NewClient()
+	gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 	logger := sglog.Scoped("Batches", "batch changes webhooks")
 	enterpriseServices.BatchChangesResolver = resolvers.New(db, bstore, gitserverClient, logger)
 	enterpriseServices.BatchesGitHubWebhook = webhooks.NewGitHubWebhook(bstore, gitserverClient, logger)

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace.go
@@ -52,7 +52,7 @@ func newBatchSpecWorkspaceResolverWithRepo(store *store.Store, logger log.Logger
 		execution:    execution,
 		batchSpec:    batchSpec,
 		repo:         repo,
-		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), gitserver.NewClient(), repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(store.DatabaseDB(), gitserver.NewClient(store.DatabaseDB()), repo),
 	}
 }
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_step.go
@@ -158,10 +158,10 @@ func (r *batchSpecWorkspaceStepV1Resolver) DiffStat(ctx context.Context) (*graph
 
 func (r *batchSpecWorkspaceStepV1Resolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
 	if r.CachedResultFound() {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.cachedResult.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
 	if r.stepInfo.DiffFound {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.stepInfo.Diff)
 	}
 	return nil, nil
 }
@@ -348,10 +348,10 @@ func (r *batchSpecWorkspaceStepV2Resolver) Diff(ctx context.Context) (graphqlbac
 	// If a cached result was found previously, or one was generated for this step, we can
 	// use it to return a comparison resolver.
 	if r.cachedResult != nil {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.cachedResult.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.cachedResult.Diff)
 	}
 	if r.stepInfo != nil && r.stepInfo.DiffFound {
-		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repo, r.baseRev, r.stepInfo.Diff)
+		return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repo, r.baseRev, r.stepInfo.Diff)
 	}
 	return nil, nil
 }

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -87,7 +87,7 @@ func (r *changesetSpecResolver) Description(ctx context.Context) (graphqlbackend
 		store: r.store,
 		spec:  r.changesetSpec,
 		// Note: r.repo can never be nil, because Description is a VisibleChangesetSpecResolver-only field.
-		repoResolver: graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(), r.repo),
+		repoResolver: graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.repo),
 		diffStat:     r.changesetSpec.DiffStat(),
 	}
 

--- a/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/changeset_spec.go
@@ -178,7 +178,7 @@ func (r *changesetDescriptionResolver) DiffStat() *graphqlbackend.DiffStat {
 }
 
 func (r *changesetDescriptionResolver) Diff(ctx context.Context) (graphqlbackend.PreviewRepositoryComparisonResolver, error) {
-	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(), r.repoResolver, r.spec.BaseRev, r.spec.Diff)
+	return graphqlbackend.NewPreviewRepositoryComparisonResolver(ctx, r.store.DatabaseDB(), gitserver.NewClient(r.store.DatabaseDB()), r.repoResolver, r.spec.BaseRev, r.spec.Diff)
 }
 
 func (r *changesetDescriptionResolver) Commits() []graphqlbackend.GitCommitDescriptionResolver {

--- a/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
+++ b/enterprise/cmd/frontend/internal/batches/resolvers/resolved_batch_spec_workspace.go
@@ -51,7 +51,7 @@ func (r *resolvedBatchSpecWorkspaceResolver) SearchResultPaths() []string {
 func (r *resolvedBatchSpecWorkspaceResolver) computeRepoResolver() *graphqlbackend.RepositoryResolver {
 	r.repoResolverOnce.Do(func() {
 		db := r.store.DatabaseDB()
-		r.repoResolver = graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(), r.workspace.Repo)
+		r.repoResolver = graphqlbackend.NewRepositoryResolver(db, gitserver.NewClient(db), r.workspace.Repo)
 	})
 
 	return r.repoResolver

--- a/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -196,7 +196,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
 			return existing
 		}
-		resolver := gql.NewRepositoryResolver(db, gitserver.NewClient(), repoName.ToRepo())
+		resolver := gql.NewRepositoryResolver(db, gitserver.NewClient(db), repoName.ToRepo())
 		resolver.RepoMatch.Rev = rev
 		repoResolvers[repoKey{repoName, rev}] = resolver
 		return resolver

--- a/enterprise/cmd/frontend/internal/embeddings/init.go
+++ b/enterprise/cmd/frontend/internal/embeddings/init.go
@@ -23,7 +23,7 @@ func Init(
 	enterpriseServices *enterprise.Services,
 ) error {
 	repoEmbeddingsStore := repo.NewRepoEmbeddingJobsStore(db)
-	gitserverClient := gitserver.NewClient()
+	gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 	embeddingsClient := embeddings.NewDefaultClient()
 	enterpriseServices.EmbeddingsResolver = resolvers.NewResolver(
 		db,

--- a/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/queuehandler.go
@@ -50,7 +50,7 @@ func newExecutorQueuesHandler(
 
 	multiHandler := handler.NewMultiHandler(executorStore, jobTokenStore, metricsStore, codeIntelQueueHandler, batchesQueueHandler)
 
-	gitserverClient := gitserver.NewClient()
+	gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 
 	// Auth middleware
 	executorAuth := executorAuthMiddleware(logger, accessToken)

--- a/enterprise/cmd/frontend/internal/own/init.go
+++ b/enterprise/cmd/frontend/internal/own/init.go
@@ -22,7 +22,7 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
-	g := gitserver.NewClient()
+	g := gitserver.NewClientDeprecatedNeedsDB()
 	enterpriseServices.OwnResolver = resolvers.New(db, g, observationCtx.Logger.Scoped("own", "Code ownership"))
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/searchcontexts/resolvers/resolvers.go
@@ -500,7 +500,7 @@ func (r *searchContextResolver) Repositories(ctx context.Context) ([]graphqlback
 
 	searchContextRepositories := make([]graphqlbackend.SearchContextRepositoryRevisionsResolver, len(repoRevs))
 	for idx, repoRev := range repoRevs {
-		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), repoRev.Repo.ToRepo()), repoRev.Revisions}
+		searchContextRepositories[idx] = &searchContextRepositoryRevisionsResolver{graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(r.db), repoRev.Repo.ToRepo()), repoRev.Revisions}
 	}
 	return searchContextRepositories, nil
 }

--- a/enterprise/cmd/worker/internal/batches/reconciler_job.go
+++ b/enterprise/cmd/worker/internal/batches/reconciler_job.go
@@ -47,7 +47,7 @@ func (j *reconcilerJob) Routines(_ context.Context, observationCtx *observation.
 		observationCtx,
 		bstore,
 		reconcilerStore,
-		gitserver.NewClient(),
+		gitserver.NewClientDeprecatedNeedsDB(),
 		sources.NewSourcer(httpcli.NewExternalClientFactory(
 			httpcli.NewLoggingMiddleware(observationCtx.Logger.Scoped("sourcer", "batches sourcer")),
 		)),

--- a/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -39,7 +39,7 @@ func (r repoEmbeddingSchedulerJob) Routines(_ context.Context, observationCtx *o
 	ctx := context.Background()
 
 	return []goroutine.BackgroundRoutine{
-		newRepoEmbeddingScheduler(ctx, gitserver.NewClient(), db, repo.NewRepoEmbeddingJobsStore(db)),
+		newRepoEmbeddingScheduler(ctx, gitserver.NewClient(db), db, repo.NewRepoEmbeddingJobsStore(db)),
 	}, nil
 }
 

--- a/enterprise/cmd/worker/internal/embeddings/repo/worker.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/worker.go
@@ -60,7 +60,7 @@ func (s *repoEmbeddingJob) Routines(_ context.Context, observationCtx *observati
 			repoembeddingsbg.NewRepoEmbeddingJobWorkerStore(observationCtx, db.Handle()),
 			db,
 			uploadStore,
-			gitserver.NewClient(),
+			gitserver.NewClientDeprecatedNeedsDB(),
 			services.ContextService,
 			repoembeddingsbg.NewRepoEmbeddingJobsStore(db),
 		),

--- a/enterprise/internal/authz/perforce/perforce.go
+++ b/enterprise/internal/authz/perforce/perforce.go
@@ -72,7 +72,7 @@ func NewProvider(logger log.Logger, urn, host, user, password string, depots []e
 		host:               host,
 		user:               user,
 		password:           password,
-		p4Execer:           gitserver.NewClient(),
+		p4Execer:           gitserver.NewClientDeprecatedNeedsDB(),
 		cachedGroupMembers: make(map[string][]string),
 	}
 }

--- a/enterprise/internal/batches/processor/bulk_processor.go
+++ b/enterprise/internal/batches/processor/bulk_processor.go
@@ -188,7 +188,7 @@ func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.Changese
 		b.logger.Error("Events", log.Error(err))
 		return nil, errcode.MakeNonRetryable(err)
 	}
-	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(), cs.Changeset, events)
+	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClientDeprecatedNeedsDB(), cs.Changeset, events)
 
 	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		b.logger.Error("UpsertChangesetEvents", log.Error(err))
@@ -224,7 +224,7 @@ func (b *bulkProcessor) closeChangeset(ctx context.Context) (afterDone func(*sto
 		b.logger.Error("Events", log.Error(err))
 		return nil, errcode.MakeNonRetryable(err)
 	}
-	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClient(), cs.Changeset, events)
+	state.SetDerivedState(ctx, b.tx.Repos(), gitserver.NewClientDeprecatedNeedsDB(), cs.Changeset, events)
 
 	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		b.logger.Error("UpsertChangesetEvents", log.Error(err))

--- a/enterprise/internal/batches/service/workspace_resolver.go
+++ b/enterprise/internal/batches/service/workspace_resolver.go
@@ -77,7 +77,7 @@ func NewWorkspaceResolver(s *store.Store) WorkspaceResolver {
 	return &workspaceResolver{
 		store:               s,
 		logger:              log.Scoped("batches.workspaceResolver", "The batch changes execution workspace resolver"),
-		gitserverClient:     gitserver.NewClient(),
+		gitserverClient:     gitserver.NewClientDeprecatedNeedsDB(),
 		frontendInternalURL: internalapi.Client.URL + "/.internal",
 	}
 }

--- a/enterprise/internal/batches/sources/perforce.go
+++ b/enterprise/internal/batches/sources/perforce.go
@@ -32,7 +32,7 @@ func NewPerforceSource(ctx context.Context, svc *types.ExternalService, _ *httpc
 		return nil, errors.Wrapf(err, "external service id=%d", svc.ID)
 	}
 
-	return &PerforceSource{server: c, gitServerClient: gitserver.NewClient()}, nil
+	return &PerforceSource{server: c, gitServerClient: gitserver.NewClientDeprecatedNeedsDB()}, nil
 }
 
 // GitserverPushConfig returns an authenticated push config used for pushing commits to the code host.

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -496,7 +496,7 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	return SyncChangeset(ctx, s.syncStore, gitserver.NewClient(), source, repo, cs)
+	return SyncChangeset(ctx, s.syncStore, gitserver.NewClientDeprecatedNeedsDB(), source, repo, cs)
 }
 
 // SyncChangeset refreshes the metadata of the given changeset and

--- a/enterprise/internal/insights/gitserver/client.go
+++ b/enterprise/internal/insights/gitserver/client.go
@@ -13,7 +13,7 @@ import (
 func NewGitCommitClient() *GitCommitClient {
 	return &GitCommitClient{
 		cachedFirstCommit: NewCachedGitFirstEverCommit(),
-		Gitclient:         gitserver.NewClient(),
+		Gitclient:         gitserver.NewClientDeprecatedNeedsDB(),
 	}
 }
 

--- a/enterprise/internal/insights/gitserver/first_commit.go
+++ b/enterprise/internal/insights/gitserver/first_commit.go
@@ -30,7 +30,7 @@ func isFirstCommitEmptyRepoError(err error) bool {
 }
 
 func GitFirstEverCommit(ctx context.Context, repoName api.RepoName) (*gitdomain.Commit, error) {
-	commit, err := gitserver.NewClient().FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repoName)
+	commit, err := gitserver.NewClientDeprecatedNeedsDB().FirstEverCommit(ctx, authz.DefaultSubRepoPermsChecker, repoName)
 	if err != nil && isFirstCommitEmptyRepoError(err) {
 		return nil, errors.Wrap(EmptyRepoErr, err.Error())
 	}

--- a/internal/codeintel/autoindexing/internal/inference/iface.go
+++ b/internal/codeintel/autoindexing/internal/inference/iface.go
@@ -32,7 +32,7 @@ func NewDefaultGitService(checker authz.SubRepoPermissionChecker) GitService {
 
 	return &gitService{
 		checker: checker,
-		client:  gitserver.NewClient(),
+		client:  gitserver.NewClientDeprecatedNeedsDB(),
 	}
 }
 

--- a/internal/codeintel/services.go
+++ b/internal/codeintel/services.go
@@ -36,7 +36,7 @@ type ServiceDependencies struct {
 
 func NewServices(deps ServiceDependencies) (Services, error) {
 	db, codeIntelDB := deps.DB, deps.CodeIntelDB
-	gitserverClient := gitserver.NewClient()
+	gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 
 	uploadsSvc := uploads.NewService(deps.ObservationCtx, db, codeIntelDB, gitserverClient)
 	dependenciesSvc := dependencies.NewService(deps.ObservationCtx, db)

--- a/internal/codeintel/shared/resolvers/gitresolvers/tree_entry.go
+++ b/internal/codeintel/shared/resolvers/gitresolvers/tree_entry.go
@@ -52,7 +52,7 @@ func (r *treeEntryResolver) Content(ctx context.Context, args *resolvers.GitTree
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	content, err := gitserver.NewClient().ReadFile(
+	content, err := gitserver.NewClientDeprecatedNeedsDB().ReadFile(
 		ctx,
 		authz.DefaultSubRepoPermsChecker,
 		api.RepoName(r.commit.Repository().Name()), // repository name

--- a/internal/compute/replace_command.go
+++ b/internal/compute/replace_command.go
@@ -52,7 +52,7 @@ func replace(ctx context.Context, content []byte, matchPattern MatchPattern, rep
 func (c *Replace) Run(ctx context.Context, r result.Match) (Result, error) {
 	switch m := r.(type) {
 	case *result.FileMatch:
-		content, err := gitserver.NewClient().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, m.Repo.Name, m.CommitID, m.Path)
+		content, err := gitserver.NewClientDeprecatedNeedsDB().ReadFile(ctx, authz.DefaultSubRepoPermsChecker, m.Repo.Name, m.CommitID, m.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//internal/authz",
         "//internal/byteutils",
         "//internal/conf",
+        "//internal/database",
         "//internal/extsvc/gitolite",
         "//internal/fileutil",
         "//internal/gitserver/gitdomain",

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
@@ -82,7 +83,7 @@ type ClientSource interface {
 }
 
 // NewClient returns a new gitserver.Client.
-func NewClient() Client {
+func NewClient(_ database.DB) Client {
 	return &clientImplementor{
 		logger:      sglog.Scoped("NewClient", "returns a new gitserver.Client"),
 		httpClient:  defaultDoer,

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -82,6 +82,24 @@ type ClientSource interface {
 	Addresses() []AddressWithClient
 }
 
+// NewClientDeprecatedNeedsDB means this call site needs to be updated to use
+// NewClient and pass in a DB.
+//
+// Right now the DB is not used so this is not a bug. This variable was
+// introduced to make it possible to break out the updates to NewClient happen
+// over multiple PRs.
+//
+// If you are introducing DB, prefer changing your code so that gitserver
+// client is injected from a higher layer rather than constructed at your call
+// site.
+//
+// Shout at Keegan and Indradhanush if you still see this call in August 2023.
+// Context: we want to make looking up which shard to speak to stateful. First
+// target is deduplicating storage for forks.
+func NewClientDeprecatedNeedsDB() Client {
+	return NewClient(nil)
+}
+
 // NewClient returns a new gitserver.Client.
 func NewClient(_ database.DB) Client {
 	return &clientImplementor{

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -149,7 +149,7 @@ func TestDiffWithSubRepoFiltering(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.label, func(t *testing.T) {
 			repo := MakeGitRepository(t, append(cmds, tc.extraGitCommands...)...)
-			c := NewClient()
+			c := NewClientDeprecatedNeedsDB()
 			commits, err := c.Commits(ctx, nil, repo, CommitsOptions{})
 			if err != nil {
 				t.Fatalf("err fetching commits: %s", err)
@@ -203,7 +203,7 @@ func TestDiff(t *testing.T) {
 			".foo",
 		} {
 			t.Run("invalid base: "+input, func(t *testing.T) {
-				i, err := NewClient().Diff(ctx, nil, DiffOptions{Base: input})
+				i, err := NewClientDeprecatedNeedsDB().Diff(ctx, nil, DiffOptions{Base: input})
 				if i != nil {
 					t.Errorf("unexpected non-nil iterator: %+v", i)
 				}
@@ -454,7 +454,7 @@ func TestRepository_BlameFile(t *testing.T) {
 		},
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	for label, test := range tests {
 		newestCommitID, err := client.ResolveRevision(ctx, test.repo, string(test.opt.NewestCommit), ResolveRevisionOptions{})
 		if err != nil {
@@ -496,7 +496,7 @@ func runBlameFileTest(ctx context.Context, t *testing.T, repo api.RepoName, path
 	checker authz.SubRepoPermissionChecker, label string, wantHunks []*Hunk,
 ) {
 	t.Helper()
-	hunks, err := NewClient().BlameFile(ctx, checker, repo, path, opt)
+	hunks, err := NewClientDeprecatedNeedsDB().BlameFile(ctx, checker, repo, path, opt)
 	if err != nil {
 		t.Errorf("%s: BlameFile(%s, %+v): %s", label, path, opt, err)
 		return
@@ -541,7 +541,7 @@ func TestRepository_ResolveBranch(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := NewClientDeprecatedNeedsDB().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -573,7 +573,7 @@ func TestRepository_ResolveBranch_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
+		commitID, err := NewClientDeprecatedNeedsDB().ResolveRevision(context.Background(), test.repo, test.branch, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -606,7 +606,7 @@ func TestRepository_ResolveTag(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := NewClientDeprecatedNeedsDB().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if err != nil {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -638,7 +638,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 	}
 
 	for label, test := range tests {
-		commitID, err := NewClient().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
+		commitID, err := NewClientDeprecatedNeedsDB().ResolveRevision(context.Background(), test.repo, test.tag, ResolveRevisionOptions{})
 		if !test.wantErr(err) {
 			t.Errorf("%s: ResolveRevision: %s", label, err)
 			continue
@@ -653,7 +653,7 @@ func TestRepository_ResolveTag_error(t *testing.T) {
 func TestLsFiles(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	runFileListingTest(t, func(ctx context.Context, checker authz.SubRepoPermissionChecker, repo api.RepoName, commit string) ([]string, error) {
 		return client.LsFiles(ctx, checker, repo, api.CommitID(commit))
 	})
@@ -796,7 +796,7 @@ func TestCleanDirectoriesForLsTree(t *testing.T) {
 func TestListDirectoryChildren(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	gitCommands := []string{
 		"mkdir -p dir{1..3}/sub{1..3}",
 		"touch dir1/sub1/file",
@@ -883,7 +883,7 @@ func TestListTags(t *testing.T) {
 		{Name: "t3", CommitID: "afeafc4a918c144329807df307e68899e6b65018", CreatorDate: MustParseTime(time.RFC3339, "2006-01-02T15:04:05Z")},
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	tags, err := client.ListTags(context.Background(), repo)
 	require.Nil(t, err)
 
@@ -944,7 +944,7 @@ func TestMerger_MergeBase(t *testing.T) {
 	defer ResetClientMocks()
 
 	ctx := context.Background()
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 
 	// TODO(sqs): implement for hg
 	// TODO(sqs): make a more complex test case
@@ -1031,7 +1031,7 @@ func TestRepository_FileSystem_Symlinks(t *testing.T) {
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 
 	commitID := api.CommitID(ComputeCommitHash(dir, true))
 
@@ -1117,7 +1117,7 @@ func TestStat(t *testing.T) {
 
 	dir := InitGitRepository(t, gitCommands...)
 	repo := api.RepoName(filepath.Base(dir))
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 
 	commitID := api.CommitID(ComputeCommitHash(dir, true))
 
@@ -1197,7 +1197,7 @@ func TestRepository_GetCommit(t *testing.T) {
 		revisionNotFoundError bool
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	runGetCommitTests := func(checker authz.SubRepoPermissionChecker, tests map[string]testCase) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
@@ -1366,7 +1366,7 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 		},
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	t.Run("basic", func(t *testing.T) {
 		for _, tc := range testCases {
 			t.Run(tc.label, func(t *testing.T) {
@@ -1445,7 +1445,7 @@ func TestRepository_FirstEverCommit(t *testing.T) {
 			want: "2007-01-02T15:04:05Z",
 		},
 	}
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	t.Run("basic", func(t *testing.T) {
 		for _, tc := range testCases {
 			gitCommands := make([]string, len(tc.commitDates))
@@ -1525,7 +1525,7 @@ func TestCommitExists(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	testCommitExists := func(label string, gitCommands []string, commitID, nonExistentCommitID api.CommitID, checker authz.SubRepoPermissionChecker) {
 		t.Run(label, func(t *testing.T) {
 			repo := MakeGitRepository(t, gitCommands...)
@@ -1602,7 +1602,7 @@ func TestRepository_Commits(t *testing.T) {
 			wantTotal:   2,
 		},
 	}
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	runCommitsTests := func(checker authz.SubRepoPermissionChecker) {
 		for label, test := range tests {
 			t.Run(label, func(t *testing.T) {
@@ -1694,7 +1694,7 @@ func TestCommits_SubRepoPerms(t *testing.T) {
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
-			commits, err := NewClient().Commits(ctx, checker, repo, test.opt)
+			commits, err := NewClientDeprecatedNeedsDB().Commits(ctx, checker, repo, test.opt)
 			if err != nil {
 				t.Errorf("%s: Commits(): %s", label, err)
 				return
@@ -1786,7 +1786,7 @@ func TestCommits_SubRepoPerms_ReturnNCommits(t *testing.T) {
 		},
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			checker := getTestSubRepoPermsChecker(test.noAccessPaths...)
@@ -1883,7 +1883,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			repo := MakeGitRepository(t)
 			before := ""
 			after := time.Date(2022, 11, 11, 12, 10, 0, 4, time.UTC).Format(time.RFC3339)
-			_, err := NewClient().Commits(ctx, checker, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before})
+			_, err := NewClientDeprecatedNeedsDB().Commits(ctx, checker, repo, CommitsOptions{N: 0, DateOrder: true, NoEnsureRevision: true, After: after, Before: before})
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
@@ -2178,7 +2178,7 @@ func TestFilterRefDescriptions(t *testing.T) { // KEEP
 	}
 
 	checker := getTestSubRepoPermsChecker("file3")
-	client := NewClient().(*clientImplementor)
+	client := NewClientDeprecatedNeedsDB().(*clientImplementor)
 	filtered := client.filterRefDescriptions(ctx, repo, refDescriptions, checker)
 	expectedRefDescriptions := map[string][]gitdomain.RefDescription{
 		"d38233a79e037d2ab8170b0d0bc0aa438473e6da": {},
@@ -2196,7 +2196,7 @@ func TestRefDescriptions(t *testing.T) { // KEEP
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	gitCommands := append(getGitCommandsWithFiles("file1", "file2"), "git checkout -b my-other-branch")
 	gitCommands = append(gitCommands, getGitCommandsWithFiles("file1-b2", "file2-b2")...)
 	gitCommands = append(gitCommands, "git checkout -b my-branch-no-access")
@@ -2244,7 +2244,7 @@ func TestCommitsUniqueToBranch(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	gitCommands := append([]string{"git checkout -b my-branch"}, getGitCommandsWithFiles("file1", "file2")...)
 	gitCommands = append(gitCommands, getGitCommandsWithFiles("file3", "file-with-no-access")...)
 	repo := MakeGitRepository(t, gitCommands...)
@@ -2288,7 +2288,7 @@ func TestCommitDate(t *testing.T) {
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	gitCommands := getGitCommandsWithFiles("file1", "file2")
 	repo := MakeGitRepository(t, gitCommands...)
 
@@ -2322,7 +2322,7 @@ func TestCommitDate(t *testing.T) {
 
 func testCommits(ctx context.Context, label string, repo api.RepoName, opt CommitsOptions, checker authz.SubRepoPermissionChecker, wantCommits []*gitdomain.Commit, t *testing.T) {
 	t.Helper()
-	client := NewClient().(*clientImplementor)
+	client := NewClientDeprecatedNeedsDB().(*clientImplementor)
 	commits, err := client.Commits(ctx, checker, repo, opt)
 	if err != nil {
 		t.Errorf("%s: Commits(): %s", label, err)
@@ -2456,7 +2456,7 @@ func TestArchiveReaderForRepoWithSubRepoPermissions(t *testing.T) {
 		Treeish:   commitID,
 		Pathspecs: []gitdomain.Pathspec{"."},
 	}
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	if _, err := client.ArchiveReader(context.Background(), checker, repo.Name, opts); err == nil {
 		t.Error("Error should not be null because ArchiveReader is invoked for a repo with sub-repo permissions")
 	}
@@ -2491,7 +2491,7 @@ func TestArchiveReaderForRepoWithoutSubRepoPermissions(t *testing.T) {
 		Treeish:   commitID,
 		Pathspecs: []gitdomain.Pathspec{"."},
 	}
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	readCloser, err := client.ArchiveReader(context.Background(), checker, repo.Name, opts)
 	if err != nil {
 		t.Error("Error should not be thrown because ArchiveReader is invoked for a repo without sub-repo permissions")
@@ -2564,7 +2564,7 @@ func TestRead(t *testing.T) {
 		},
 	}
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	ClientMocks.LocalGitserver = true
 	t.Cleanup(func() {
 		ResetClientMocks()
@@ -2662,7 +2662,7 @@ func TestRead(t *testing.T) {
 func runNewFileReaderTest(ctx context.Context, t *testing.T, repo api.RepoName, commitID api.CommitID, file string,
 	checker authz.SubRepoPermissionChecker, checkFn func(*testing.T, error, []byte)) {
 	t.Helper()
-	rc, err := NewClient().NewFileReader(ctx, checker, repo, commitID, file)
+	rc, err := NewClientDeprecatedNeedsDB().NewFileReader(ctx, checker, repo, commitID, file)
 	if err != nil {
 		checkFn(t, err, nil)
 		return
@@ -2728,7 +2728,7 @@ func TestRepository_Branches_MergedInto(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	wantBranches := gitBranches
 	for branch, mergedInto := range wantBranches {
-		branches, err := NewClient().ListBranches(context.Background(), repo, BranchesOptions{MergedInto: branch})
+		branches, err := NewClientDeprecatedNeedsDB().ListBranches(context.Background(), repo, BranchesOptions{MergedInto: branch})
 		require.Nil(t, err)
 		if diff := cmp.Diff(mergedInto, branches); diff != "" {
 			t.Fatalf("branch mismatch (-want +got):\n%s", diff)
@@ -2759,7 +2759,7 @@ func TestRepository_Branches_ContainsCommit(t *testing.T) {
 	repo := MakeGitRepository(t, gitCommands...)
 	commitToWantBranches := gitWantBranches
 	for commit, wantBranches := range commitToWantBranches {
-		branches, err := NewClient().ListBranches(context.Background(), repo, BranchesOptions{ContainsCommit: commit})
+		branches, err := NewClientDeprecatedNeedsDB().ListBranches(context.Background(), repo, BranchesOptions{ContainsCommit: commit})
 		require.Nil(t, err)
 
 		sort.Sort(gitdomain.Branches(branches))
@@ -2841,7 +2841,7 @@ func testBranches(t *testing.T, gitCommands []string, wantBranches []*gitdomain.
 	t.Helper()
 
 	repo := MakeGitRepository(t, gitCommands...)
-	gotBranches, err := NewClient().ListBranches(context.Background(), repo, options)
+	gotBranches, err := NewClientDeprecatedNeedsDB().ListBranches(context.Background(), repo, options)
 	require.Nil(t, err)
 
 	sort.Sort(gitdomain.Branches(wantBranches))
@@ -3271,7 +3271,7 @@ func Test_CommitLog(t *testing.T) {
 	for label, test := range tests {
 		t.Run(label, func(t *testing.T) {
 			repo := MakeGitRepository(t, test.extraGitCommands...)
-			logResults, err := NewClient().CommitLog(context.Background(), repo, time.Time{})
+			logResults, err := NewClientDeprecatedNeedsDB().CommitLog(context.Background(), repo, time.Time{})
 			if err != nil {
 				require.ErrorContains(t, err, test.wantErr)
 			}

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -76,7 +76,7 @@ func TestClient_GRPCRouting(t *testing.T) {
 		},
 	})
 
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 	_, _ = client.ResolveRevision(context.Background(), "a", "HEAD", ResolveRevisionOptions{})
 
 	if !(m1.called && !m2.called) {
@@ -92,7 +92,7 @@ func TestClient_GRPCRouting(t *testing.T) {
 }
 
 func TestClient_AddrForRepo_UsesConfToRead_PinnedRepos(t *testing.T) {
-	client := NewClient()
+	client := NewClientDeprecatedNeedsDB()
 
 	cfg := newConfig(
 		[]string{"gitserver1", "gitserver2"},

--- a/internal/own/background/analytics.go
+++ b/internal/own/background/analytics.go
@@ -24,7 +24,7 @@ func handleAnalytics(ctx context.Context, lgr log.Logger, repoId api.RepoID, db 
 	// 🚨 SECURITY: we use the internal actor because the background indexer is not associated with any user,
 	// and needs to see all repos and files.
 	internalCtx := actor.WithInternalActor(ctx)
-	indexer := newAnalyticsIndexer(gitserver.NewClient(), db, subRepoPermsCache, lgr)
+	indexer := newAnalyticsIndexer(gitserver.NewClient(db), db, subRepoPermsCache, lgr)
 	err := indexer.indexRepo(internalCtx, repoId, authz.DefaultSubRepoPermsChecker)
 	if err != nil {
 		lgr.Error("own analytics indexing failure", log.String("msg", err.Error()))

--- a/internal/own/background/recent_contributors.go
+++ b/internal/own/background/recent_contributors.go
@@ -25,7 +25,7 @@ func handleRecentContributors(ctx context.Context, lgr logger.Logger, repoId api
 	// to see all repos and files
 	internalCtx := actor.WithInternalActor(ctx)
 
-	indexer := newRecentContributorsIndexer(gitserver.NewClient(), db, lgr, subRepoPermsCache)
+	indexer := newRecentContributorsIndexer(gitserver.NewClient(db), db, lgr, subRepoPermsCache)
 	return indexer.indexRepo(internalCtx, repoId, authz.DefaultSubRepoPermsChecker)
 }
 

--- a/internal/repos/purge.go
+++ b/internal/repos/purge.go
@@ -90,7 +90,7 @@ func PurgeOldestRepos(logger log.Logger, db database.DB, limit int, perSecond fl
 // purge purges repos, returning the number of repos that were successfully purged
 func purge(ctx context.Context, logger log.Logger, db database.DB, options database.IteratePurgableReposOptions) error {
 	start := time.Now()
-	gitserverClient := gitserver.NewClient()
+	gitserverClient := gitserver.NewClientDeprecatedNeedsDB()
 	var (
 		total   int
 		success int

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -270,7 +270,7 @@ func getCustomInterval(logger log.Logger, c *conf.Unified, repoName string) time
 
 // requestRepoUpdate sends a request to gitserver to request an update.
 var requestRepoUpdate = func(ctx context.Context, repo configuredRepo, since time.Duration) (*gitserverprotocol.RepoUpdateResponse, error) {
-	return gitserver.NewClient().RequestRepoUpdate(ctx, repo.Name, since)
+	return gitserver.NewClientDeprecatedNeedsDB().RequestRepoUpdate(ctx, repo.Name, since)
 }
 
 // configuredLimiter returns a mutable limiter that is

--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -47,7 +47,7 @@ type Observer struct {
 // raising NoResolvedRepos alerts with suggestions when we know the original
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
-	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(), o.Searcher, o.Zoekt)
+	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(o.Db), o.Searcher, o.Zoekt)
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -177,7 +177,7 @@ func (s *searchClient) JobClients() job.RuntimeClients {
 		Zoekt:                       s.zoekt,
 		SearcherURLs:                s.searcherURLs,
 		SearcherGRPCConnectionCache: s.searcherGRPCConnectionCache,
-		Gitserver:                   gitserver.NewClient(),
+		Gitserver:                   gitserver.NewClient(s.db),
 	}
 }
 

--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -110,7 +110,7 @@ func (s *TextSearchJob) Run(ctx context.Context, clients job.RuntimeClients, str
 					ctx, done := limitCtx, limitDone
 					defer done()
 
-					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.SearcherURLs, clients.SearcherGRPCConnectionCache, repo, repo.Name, rev, s.Indexed, s.PatternInfo, fetchTimeout, stream)
+					repoLimitHit, err := s.searchFilesInRepo(ctx, clients.Gitserver, clients.SearcherURLs, clients.SearcherGRPCConnectionCache, repo, repo.Name, rev, s.Indexed, s.PatternInfo, fetchTimeout, stream)
 					if err != nil {
 						tr.SetAttributes(
 							repo.Name.Attr(),
@@ -175,6 +175,7 @@ var MockSearchFilesInRepo func(
 
 func (s *TextSearchJob) searchFilesInRepo(
 	ctx context.Context,
+	client gitserver.Client,
 	searcherURLs *endpoint.Map,
 	searcherGRPCConnectionCache *defaults.ConnectionCache,
 	repo types.MinimalRepo,
@@ -193,7 +194,7 @@ func (s *TextSearchJob) searchFilesInRepo(
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commit, err := gitserver.NewClient().ResolveRevision(ctx, gitserverRepo, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
+	commit, err := client.ResolveRevision(ctx, gitserverRepo, rev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return false, err
 	}

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -42,7 +42,7 @@ func GetRepositories(ctx context.Context, db database.DB) (*Repositories, error)
 	var total Repositories
 
 	// Since this hits gitserver, we should use an internal actor.
-	stats, err := gitserver.NewClient().ReposStats(actor.WithInternalActor(ctx))
+	stats, err := gitserver.NewClient(db).ReposStats(actor.WithInternalActor(ctx))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To colocate forks and parent repositories on the same shard we will need to consult the database when doing AddrForRepo. The is a partial migration to injecting the DB into the gitserver client for that use case. This PR does not actually use the field yet since we won't be able to use it until all call sites are migrated. There are individual commits containing mostly mechanical refactors to pass in a DB. There are some other commits which manually migrated our use of NewClient. But there are still many call sites which we didn't look at yet / do not have a mechanical transformation. Those will be tackled in follow up commits. For now all non-migrated sites now use the telling constructor name NewClientDeprecatedNeedsDB.

Alternatively we considered introducing DB as an argument to AddrForRepo, but this similarly will be a large change. We might still do that since ClientSource is a singleton in practice. Additionally the client having this dependency feels like how we would design it when creating this from scratch.

Test Plan: go test. All changes which introduced the use of a DB used an existing one. The only risk here is we introduce a new way to access the db => something is nil along the way and there is no test coverage of it. We only did that in one or two places, and they are safe. The vast majority are mechanical changes which do not exercise anything new.

Co-authored-by: @indradhanush 