### PR TITLE
doc: mention json_gcp format for logs

### DIFF
--- a/doc/admin/observability/logs.md
+++ b/doc/admin/observability/logs.md
@@ -23,6 +23,7 @@ A Sourcegraph service's log output format is configured via the environment vari
 * `condensed`: Optimized for human readability.
 * `json`: Machine-readable JSON format.
   * For certain services and log entries, Sourcegraph exports a [OpenTelemetry-compliant log data model](#opentelemetry).
+* `json_gcp`: Machine-readable JSON format, tailored to GCP cloud-logging expected structure.
 * `logfmt`: The [logfmt](https://github.com/kr/logfmt) format.
   * Note that `logfmt` is no longer supported with [Sourcegraph's new internal logging standards](../../dev/how-to/add_logging.md) - if you need structured logs, we recommend using `json` instead. If set to `logfmt`, log output from new loggers will be in `condensed` format.
 

--- a/doc/admin/observability/logs.md
+++ b/doc/admin/observability/logs.md
@@ -23,7 +23,7 @@ A Sourcegraph service's log output format is configured via the environment vari
 * `condensed`: Optimized for human readability.
 * `json`: Machine-readable JSON format.
   * For certain services and log entries, Sourcegraph exports a [OpenTelemetry-compliant log data model](#opentelemetry).
-* `json_gcp`: Machine-readable JSON format, tailored to GCP cloud-logging expected structure.
+* `json_gcp`: Machine-readable JSON format, tailored to [GCP cloud-logging expected structure.](https://cloud.google.com/logging/docs/structured-logging#special-payload-fields) 
 * `logfmt`: The [logfmt](https://github.com/kr/logfmt) format.
   * Note that `logfmt` is no longer supported with [Sourcegraph's new internal logging standards](../../dev/how-to/add_logging.md) - if you need structured logs, we recommend using `json` instead. If set to `logfmt`, log output from new loggers will be in `condensed` format.
 


### PR DESCRIPTION
Mentions the availability of `SRC_LOG_FORMAT=json_gcp` in the admin/observability/logging page.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI. 