### PR TITLE
Added the export changeset button and its download logic for all chan…

### DIFF
--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -1,207 +1,265 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
-
-import { mdiChevronDown } from '@mdi/js'
-import { VisuallyHidden } from '@reach/visually-hidden'
-
+import React, { useCallback, useEffect, useMemo, useState, useContext } from 'react';
+import { mdiChevronDown, mdiDownload } from '@mdi/js';
+import { VisuallyHidden } from '@reach/visually-hidden';
 import {
-    ProductStatusBadge,
-    Button,
-    ButtonGroup,
-    Menu,
-    MenuButton,
-    MenuList,
-    Position,
-    MenuItem,
-    MenuDivider,
-    H4,
-    Text,
-    Icon,
-} from '@sourcegraph/wildcard'
+  ProductStatusBadge,
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuButton,
+  MenuList,
+  Position,
+  MenuItem,
+  MenuDivider,
+  H4,
+  Text,
+  Icon,
+} from '@sourcegraph/wildcard';
+import { useBatchChangesRolloutWindowConfig } from './backend';
+import styles from './DropdownButton.module.scss';
 
-import { useBatchChangesRolloutWindowConfig } from './backend'
 
-import styles from './DropdownButton.module.scss'
 
 export interface Action {
-    /* The type of action. Used internally. */
-    type: string
-    /* The button label for the action. */
-    buttonLabel: string
-    /* Whether or not the action is disabled. */
-    disabled?: boolean
-    /* The title in the dropdown menu item. */
-    dropdownTitle: string
-    /* The description in the dropdown menu item. */
-    dropdownDescription: string
-    /**
-     * Invoked when the action is triggered. Either onDone or onCancel need to
-     * be called eventually. Can return a JSX.Element to be rendered adjacent to
-     * the button (i.e. a modal).
-     */
-    onTrigger: (onDone: () => void, onCancel: () => void) => Promise<void | JSX.Element> | void | JSX.Element
-    /** If set, displays an experimental badge next to the dropdown title. */
-    experimental?: boolean
+  /* The type of action. Used internally. */
+  type: string;
+  /* The button label for the action. */
+  buttonLabel: string;
+  /* Whether or not the action is disabled. */
+  disabled?: boolean;
+  /* The title in the dropdown menu item. */
+  dropdownTitle: string;
+  /* The description in the dropdown menu item. */
+  dropdownDescription: string;
+  /**
+   * Invoked when the action is triggered. Either onDone or onCancel need to
+   * be called eventually. Can return a JSX.Element to be rendered adjacent to
+   * the button (i.e. a modal).
+   */
+  onTrigger: (onDone: () => void, onCancel: () => void) => Promise<void | JSX.Element> | void | JSX.Element;
+  /** If set, displays an experimental badge next to the dropdown title. */
+  experimental?: boolean;
+  changeset: any;
 }
 
 export interface Props {
-    actions: Action[]
-    defaultAction?: number
-    disabled?: boolean
-    onLabel?: (label: string | undefined) => void
-    placeholder?: string
+  actions: Action[];
+  defaultAction?: number;
+  disabled?: boolean;
+  onLabel?: (label: string | undefined) => void;
+  placeholder?: string;
+  selectedChangesets: any[]
 }
 
 export const DropdownButton: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    actions,
-    defaultAction,
-    disabled,
-    onLabel,
-    placeholder = 'Select action',
+  actions,
+  defaultAction,
+  disabled,
+  onLabel,
+  placeholder = 'Select action',
+  selectedChangesets,
 }) => {
-    const [isDisabled, setIsDisabled] = useState(!!disabled)
+  const [isDisabled, setIsDisabled] = useState(!!disabled);
+  const [selected, setSelected] = useState<number | undefined>(undefined);
 
-    const [selected, setSelected] = useState<number | undefined>(undefined)
-    const selectedAction = useMemo(() => {
-        if (actions.length === 1) {
-            return actions[0]
-        }
 
-        const id = selected !== undefined ? selected : defaultAction
-        if (id !== undefined && id >= 0 && id < actions.length) {
-            return actions[id]
-        }
-        return undefined
-    }, [actions, defaultAction, selected])
+  const selectedAction = useMemo(() => {
+    if (actions.length === 1) {
+      return actions[0];
+    }
 
-    const onSelectedTypeSelect = useCallback(
-        (type: string) => {
-            const index = actions.findIndex(action => action.type === type)
-            if (index >= 0) {
-                setSelected(actions.findIndex(action => action.type === type))
-            } else {
-                setSelected(undefined)
-            }
+    const id = selected !== undefined ? selected : defaultAction;
+    if (id !== undefined && id >= 0 && id < actions.length) {
+      return actions[id];
+    }
+    return undefined;
+  }, [actions, defaultAction, selected]);
+
+  const onSelectedTypeSelect = useCallback(
+    (type: string) => {
+      const index = actions.findIndex((action) => action.type === type);
+      if (index >= 0) {
+        setSelected(actions.findIndex((action) => action.type === type));
+      } else {
+        setSelected(undefined);
+      }
+    },
+    [actions, setSelected]
+  );
+
+  const [renderedElement, setRenderedElement] = useState<JSX.Element | undefined>();
+
+  const onTriggerAction = useCallback(async () => {
+    if (selectedAction === undefined) {
+      return;
+    }
+
+    // Right now, we don't handle onDone or onCancel separately, but we may
+    // want to expose this at a later stage.
+    setIsDisabled(true);
+    const element = await Promise.resolve(
+      selectedAction.onTrigger(
+        () => {
+          setIsDisabled(false);
+          setRenderedElement(undefined);
         },
-        [actions, setSelected]
-    )
-
-    const [renderedElement, setRenderedElement] = useState<JSX.Element | undefined>()
-    const onTriggerAction = useCallback(async () => {
-        if (selectedAction === undefined) {
-            return
+        () => {
+          setIsDisabled(false);
+          setRenderedElement(undefined);
         }
+      )
+    );
+    if (element !== undefined) {
+      setRenderedElement(element);
+    }
+  }, [selectedAction]);
 
-        // Right now, we don't handle onDone or onCancel separately, but we may
-        // want to expose this at a later stage.
-        setIsDisabled(true)
-        const element = await Promise.resolve(
-            selectedAction.onTrigger(
-                () => {
-                    setIsDisabled(false)
-                    setRenderedElement(undefined)
-                },
-                () => {
-                    setIsDisabled(false)
-                    setRenderedElement(undefined)
-                }
-            )
-        )
-        if (element !== undefined) {
-            setRenderedElement(element)
-        }
-    }, [selectedAction])
+  const selectedChangesetExportClick = useCallback(() => {
+    if (selectedChangesets) {
+      const csvData = [
+        ['Title', 'State', 'CheckState', 'ReviewState', 'External URL', 'Repo Name'],
+      ];
+      
+      selectedChangesets.forEach(node => {
+        csvData.push([
+          node.title,
+          node.state,
+          node.checkState,
+          node.reviewState,
+          node.externalURL?.url || '',
+          node.repository.name,
+        ]);
+      })
 
-    const label = useMemo(() => {
-        const label = selectedAction
-            ? selectedAction.buttonLabel + (selectedAction.experimental ? ' (Experimental)' : '')
-            : undefined
+        const csvString = csvData.map((row) => row.join(',')).join('\n');
+        const blob = new Blob([csvString], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
 
-        return label ?? placeholder
-    }, [placeholder, selectedAction])
+        const body = selectedChangesets[0].body; // Assuming selectedChangesets exists
+        const startIndex = body.indexOf("batch-changes/") + 14; // Add the length of "batch-changes/"
+        const endIndex = body.indexOf(")", startIndex);
+        const batchChangeName = body.substring(startIndex, endIndex);
 
-    useEffect(() => {
-        if (onLabel) {
-            if (selectedAction) {
-                onLabel(selectedAction.buttonLabel + (selectedAction.experimental ? ' (Experimental)' : ''))
-            }
-        }
-    })
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${batchChangeName}-changesets.csv`; 
+        a.click();
+  
+        URL.revokeObjectURL(url);
+        a.remove();
+      }
+    },[selectedChangesets]);
 
-    return (
-        <>
-            {renderedElement}
-            <Menu>
-                <ButtonGroup>
-                    <Button
-                        className="text-nowrap"
-                        onClick={onTriggerAction}
-                        disabled={isDisabled || actions.length === 0 || selectedAction === undefined}
-                        variant="primary"
-                    >
-                        {label}
-                    </Button>
-                    {actions.length > 1 && (
-                        <MenuButton variant="primary" className={styles.dropdownButton}>
-                            <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
-                            <VisuallyHidden>Actions</VisuallyHidden>
-                        </MenuButton>
-                    )}
-                </ButtonGroup>
-                {actions.length > 1 && (
-                    <MenuList className={styles.menuList} position={Position.bottomEnd}>
-                        {actions.map((action, index) => (
-                            <React.Fragment key={action.type}>
-                                <DropdownItem action={action} setSelectedType={onSelectedTypeSelect} />
-                                {index !== actions.length - 1 && <MenuDivider />}
-                            </React.Fragment>
-                        ))}
-                    </MenuList>
-                )}
-            </Menu>
-        </>
-    )
-}
+
+
+
+  
+  
+
+  const label = useMemo(() => {
+    const label =
+      selectedAction && selectedAction.experimental
+        ? `${selectedAction.buttonLabel} (Experimental)`
+        : selectedAction?.buttonLabel;
+
+    return label ?? placeholder;
+  }, [placeholder, selectedAction]);
+  
+ 
+
+  useEffect(() => {
+    if (onLabel && selectedAction) {
+      onLabel(
+        selectedAction.experimental ? `${selectedAction.buttonLabel} (Experimental)` : selectedAction.buttonLabel
+      );
+    }
+  });
+
+  return (
+    <>
+      {renderedElement}
+      <Menu>
+        <ButtonGroup>
+          <Button
+            className="text-nowrap"
+            onClick={onTriggerAction}
+            disabled={isDisabled || actions.length === 0 || selectedAction === undefined}
+            variant="primary"
+          >
+            {label}
+          </Button>
+          {actions.length > 1 && (
+            <MenuButton variant="primary" className={styles.dropdownButton}>
+              <Icon svgPath={mdiChevronDown} inline={false} aria-hidden={true} />
+              <VisuallyHidden>Actions</VisuallyHidden>
+            </MenuButton>
+          )}
+
+          {/* Add the export button */}
+          <div style={{ marginLeft: '8px' }}>
+          <Button className="text-nowrap" variant="primary" 
+          onClick={selectedChangesetExportClick}
+          >
+                    <Icon aria-hidden={true} svgPath={mdiDownload} /> Export 
+                </Button> 
+          </div>
+
+        </ButtonGroup>
+        {actions.length > 1 && (
+          <MenuList className={styles.menuList} position={Position.bottomEnd}>
+            {actions.map((action, index) => (
+              <React.Fragment key={action.type}>
+                <DropdownItem action={action} setSelectedType={onSelectedTypeSelect} />
+                {index !== actions.length - 1 && <MenuDivider />}
+              </React.Fragment>
+            ))}
+          </MenuList>
+        )}
+      </Menu>
+    </>
+  );
+};
 
 interface DropdownItemProps {
-    setSelectedType: (type: string) => void
-    action: Action
+  setSelectedType: (type: string) => void;
+  action: Action;
 }
 
 const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItemProps>> = ({
-    action,
-    setSelectedType,
+  action,
+  setSelectedType,
 }) => {
-    const { rolloutWindowConfig, loading } = useBatchChangesRolloutWindowConfig()
-    const onSelect = useCallback(() => {
-        setSelectedType(action.type)
-    }, [setSelectedType, action.type])
-    const shouldDisplayRolloutInfo = action.type === 'publish' && rolloutWindowConfig && rolloutWindowConfig.length > 0
+  const { rolloutWindowConfig, loading } = useBatchChangesRolloutWindowConfig();
+  const onSelect = useCallback(() => {
+    setSelectedType(action.type);
+  }, [setSelectedType, action.type]);
+  const shouldDisplayRolloutInfo = action.type === 'publish' && rolloutWindowConfig && rolloutWindowConfig.length > 0;
 
-    return (
-        <MenuItem className={styles.menuListItem} onSelect={onSelect} disabled={action.disabled}>
-            <H4 className="mb-1">
-                {action.dropdownTitle}
-                {action.experimental && (
-                    <>
-                        {' '}
-                        <ProductStatusBadge status="experimental" as="small" />
-                    </>
-                )}
-            </H4>
-            <Text className="text-wrap text-muted mb-0">
-                <small>
-                    {action.dropdownDescription}
-                    {!loading && shouldDisplayRolloutInfo && (
-                        <>
-                            <br />
-                            <strong>
-                                Note: Rollout windows have been set up by the admin. This means that some of the
-                                selected changesets won't be processed until a time in the future.
-                            </strong>
-                        </>
-                    )}
-                </small>
-            </Text>
-        </MenuItem>
-    )
-}
+  return (
+    <MenuItem className={styles.menuListItem} onSelect={onSelect} disabled={action.disabled}>
+      <H4 className="mb-1">
+        {action.dropdownTitle}
+        {action.experimental && (
+          <>
+            {' '}
+            <ProductStatusBadge status="experimental" as="small" />
+          </>
+        )}
+      </H4>
+      <Text className="text-wrap text-muted mb-0">
+        <small>
+          {action.dropdownDescription}
+          {!loading && shouldDisplayRolloutInfo && (
+            <>
+              <br />
+              <strong>
+                Note: Rollout windows have been set up by the admin. This means that some of the selected changesets won't
+                be processed until a time in the future.
+              </strong>
+            </>
+          )}
+        </small>
+      </Text>
+    </MenuItem>
+  );
+};

--- a/client/web/src/enterprise/batches/MultiSelectContext.tsx
+++ b/client/web/src/enterprise/batches/MultiSelectContext.tsx
@@ -149,7 +149,7 @@ export const MultiSelectContextProvider: React.FunctionComponent<
             selectVisible()
         }
     }, [areAllVisibleSelected, deselectVisible, selectVisible])
-
+    
     const selectSingle = useCallback(
         (id: string) => {
             if (selected === 'all') {
@@ -215,7 +215,7 @@ export const MultiSelectContextProvider: React.FunctionComponent<
                 toggleAll,
                 toggleSingle,
                 toggleVisible,
-                visible,
+                visible,                
             }}
         >
             {children}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.tsx
@@ -48,7 +48,7 @@ export interface ActionsMenuProps {
 
 export const ActionsMenu: React.FunctionComponent<React.PropsWithChildren<ActionsMenuProps>> = ({ defaultMode }) => {
     const { batchChange, batchSpec, setActionsError } = useBatchSpecContext<BatchSpecExecutionFields>()
-
+    
     return (
         <MemoizedActionsMenu
             batchChange={batchChange}

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -46,7 +46,7 @@ import {
     PublishChangesetsVariables,
     AvailableBulkOperationsVariables,
     AvailableBulkOperationsResult,
-    BulkOperationType,
+    BulkOperationType,   
 } from '../../../graphql-operations'
 import { VIEWER_BATCH_CHANGES_CODE_HOST_FRAGMENT } from '../MissingCredentialsAlert'
 

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -40,6 +40,9 @@ import { EmptyChangesetSearchElement } from './EmptyChangesetSearchElement'
 import { EmptyDraftChangesetListElement } from './EmptyDraftChangesetListElement'
 
 import styles from './BatchChangeChangesets.module.scss'
+import { node } from 'src/site-admin/SiteAdminPackagesPage.module.scss'
+
+// const [selectedChangesets, setSelectedChangesets] = useState();
 
 interface Props {
     batchChangeID: Scalars['ID']
@@ -68,6 +71,10 @@ export const BatchChangeChangesets: React.FunctionComponent<React.PropsWithChild
     </MultiSelectContextProvider>
 )
 
+
+
+
+
 const BATCH_COUNT = 15
 
 const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
@@ -89,7 +96,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
     // ugly destructured set of variables here.
     const { selected, deselectAll, areAllVisibleSelected, isSelected, toggleSingle, toggleVisible, setVisible } =
         useContext(MultiSelectContext)
-
+    const [selectedChangesets, setSelectedChangesets] = useState();
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,
         state: null,
@@ -151,7 +158,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
             if (data.node.__typename !== 'BatchChange') {
                 throw new Error(`The given ID is a ${data.node.__typename as string}, not a BatchChange`)
             }
-            return data.node.changesets
+            return data.node.changesets      
         },
     })
 
@@ -164,7 +171,7 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
             )
         }
     }, [connection?.nodes, setVisible])
-
+    
     const containerElements = useMemo(() => new Subject<HTMLElement | null>(), [])
     const nextContainerElement = useMemo(() => containerElements.next.bind(containerElements), [containerElements])
 
@@ -186,13 +193,26 @@ const BatchChangeChangesetsImpl: React.FunctionComponent<React.PropsWithChildren
         return <EmptyChangesetListElement />
     }, [changesetFilters, onlyArchived, batchChangeState, isExecutionEnabled])
 
+
+    useEffect(() => {
+        const result = connection?.nodes.filter(items => {
+            const values = [];
+            selected.forEach(item => values.push(item));
+            // return items.id === selected})
+            return values.includes(items.id)
+        })
+        setSelectedChangesets(result)
+      }, [selected])
+
     return (
         <Container>
-            {!hideFilters && !showSelectRow && (
-                <ChangesetFilterRow onFiltersChange={setChangesetFiltersAndDeselectAll} />
+            
+            {!hideFilters && !showSelectRow && connection?.nodes && (
+                <ChangesetFilterRow onFiltersChange={setChangesetFiltersAndDeselectAll} connectionNode={connection.nodes } />
             )}
             {showSelectRow && queryArguments && (
                 <ChangesetSelectRow
+                    selectedChangesets={selectedChangesets}
                     batchChangeID={batchChangeID}
                     onSubmit={onSubmitBulkAction}
                     queryAllChangesetIDs={queryAllChangesetIDs}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext } from 'react'
+import React, { useMemo, useContext, useState, useEffect } from 'react'
 
 import { mdiInformationOutline } from '@mdi/js'
 import { of } from 'rxjs'
@@ -152,6 +152,7 @@ const AVAILABLE_ACTIONS: Record<BulkOperationType, ChangesetListAction> = {
 }
 
 export interface ChangesetSelectRowProps {
+    selectedChangesets: any[]
     batchChangeID: Scalars['ID']
     onSubmit: () => void
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
@@ -171,9 +172,9 @@ export const ChangesetSelectRow: React.FunctionComponent<React.PropsWithChildren
     queryArguments,
     queryAllChangesetIDs = _queryAllChangesetIDs,
     queryAvailableBulkOperations = _queryAvailableBulkOperations,
+    selectedChangesets
 }) => {
     const { areAllVisibleSelected, selected, selectAll } = useContext(MultiSelectContext)
-
     const allChangesetIDs: string[] | undefined = useObservable(
         useMemo(() => queryAllChangesetIDs(queryArguments), [queryArguments, queryAllChangesetIDs])
     )
@@ -246,7 +247,7 @@ export const ChangesetSelectRow: React.FunctionComponent<React.PropsWithChildren
                 <div className="m-0 col col-md-auto">
                     <div className="row no-gutters">
                         <div className="col ml-0 ml-sm-2">
-                            <DropdownButton actions={actions} placeholder="Select action" />
+                            <DropdownButton actions={actions} placeholder="Select action" selectedChangesets={selectedChangesets} />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This PR  is created to add an Export button to enable users to download specific changeset info for all or selected changesets in a batch change.

This is what the changeset page currently looks like:
![image](https://github.com/sourcegraph/sourcegraph/assets/111276665/335c2ba6-2d9c-4f78-87fa-d2f13cc8cd78)

Here's what it looks like with the added export button
![image](https://github.com/sourcegraph/sourcegraph/assets/111276665/c965540c-4cce-4b7f-8ab6-2ed513e150ee)

The csv file, when you download for all changesets
![image](https://github.com/sourcegraph/sourcegraph/assets/111276665/790d2d75-f739-454d-b32b-d41783da4762)


When you select changesets, there is now an export button next to `Select Action`
![image](https://github.com/sourcegraph/sourcegraph/assets/111276665/65676132-6ea9-4a7d-92b2-5d3ddc27af34)

What the csv file now looks like
![image](https://github.com/sourcegraph/sourcegraph/assets/111276665/bd161bf3-0683-4552-98af-5846fa784021)





## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
