### PR TITLE
App - don't allow users to skip setup via settings

### DIFF
--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -29,9 +29,6 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         name: 'Add local repositories',
         path: 'local-repositories',
         component: AddLocalRepositoriesSetupPage,
-        onView: () => {
-            localStorage.setItem('app.setup.finished', 'false')
-        },
     },
     {
         id: 'install-extensions',

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -29,6 +29,9 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         name: 'Add local repositories',
         path: 'local-repositories',
         component: AddLocalRepositoriesSetupPage,
+        onView: () => {
+            localStorage.setItem('app.setup.finished', 'false')
+        },
     },
     {
         id: 'install-extensions',
@@ -42,9 +45,6 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
         path: 'all-set',
         component: AppAllSetSetupStep,
         nextURL: '/',
-        onView: () => {
-            localStorage.setItem('app.setup.finished', 'true')
-        },
         onNext: async () => {
             await appWindow.setResizable(true)
             await appWindow.setSize(new LogicalSize(1024, 768))
@@ -62,12 +62,7 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
 
     const handleStepChange = useCallback(
         (nextStep: StepConfiguration): void => {
-            const currentStepIndex = APP_SETUP_STEPS.findIndex(step => step.id === nextStep.id)
-            const isLastStep = currentStepIndex === APP_SETUP_STEPS.length - 1
-
-            // Reset the last visited step if you're on the last step in the
-            // setup pipeline
-            setStepId(!isLastStep ? nextStep.id : '')
+            setStepId(nextStep.id)
         },
         [setStepId]
     )

--- a/client/web/src/enterprise/app/setup/steps/AppAllSetSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppAllSetSetupStep.tsx
@@ -14,6 +14,7 @@ export const AppAllSetSetupStep: FC<StepComponentProps> = ({ className }) => {
     const [isProgressFinished, setProgressFinished] = useState(false)
 
     const handleOneRepositoryFinished = useCallback(() => {
+        localStorage.setItem('app.setup.finished', 'true')
         setProgressFinished(true)
     }, [])
 


### PR DESCRIPTION
Users were able to skip past the setup by using the system menu.  This disables that until at least one repo has finished.
## Test plan
`sg reset app`
`sg start app` go though setup and make sure settings doesn't jump you past setup until at least 1 repo is ready.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
