### PR TITLE
codesearch: Handle error if not a pushCommitError

### DIFF
--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -202,16 +202,19 @@ func (e *executor) pushChangesetPatch(ctx context.Context, triggerUpdateWebhook 
 	}
 	opts := css.BuildCommitOpts(e.targetRepo, e.ch, e.spec, pushConf)
 	resp, err := e.pushCommit(ctx, opts)
-	var pce pushCommitError
-	if errors.As(err, &pce) {
-		if acss, ok := css.(sources.ArchivableChangesetSource); ok {
-			if acss.IsArchivedPushError(pce.CombinedOutput) {
-				if err := e.handleArchivedRepo(ctx); err != nil {
-					return afterDone, errors.Wrap(err, "handling archived repo")
+	if err != nil {
+		var pce pushCommitError
+		if errors.As(err, &pce) {
+			if acss, ok := css.(sources.ArchivableChangesetSource); ok {
+				if acss.IsArchivedPushError(pce.CombinedOutput) {
+					if err := e.handleArchivedRepo(ctx); err != nil {
+						return afterDone, errors.Wrap(err, "handling archived repo")
+					}
+					return afterDone, errCannotPushToArchivedRepo
 				}
-				return afterDone, errCannotPushToArchivedRepo
 			}
 		}
+		return afterDone, errors.Wrap(err, "pushing commit")
 	}
 
 	// update the changeset's external_id column if a changelist id is returned

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -213,8 +213,9 @@ func (e *executor) pushChangesetPatch(ctx context.Context, triggerUpdateWebhook 
 					return afterDone, errCannotPushToArchivedRepo
 				}
 			}
+		} else {
+			return afterDone, errors.Wrap(err, "pushing commit")
 		}
-		return afterDone, errors.Wrap(err, "pushing commit")
 	}
 
 	// update the changeset's external_id column if a changelist id is returned


### PR DESCRIPTION
We are seeing a user have an issue where GitHub is not able to open a Pull Request because the branch does not exist. No errors are occurring prior to the PR creation. While investigating _why_ the branch may not be created, I noticed that we do not handle if the error is not `pushCommitError`.

So hopefully this can help narrow down or catch _why_ the user is running into GitHub getting angry about no branch.

## Test plan

Added a new unit test