### PR TITLE
Check once on startup for upgrades.

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -10,6 +10,7 @@ import { useTheme, Theme } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { FeedbackPrompt, LoadingSpinner, useLocalStorage } from '@sourcegraph/wildcard'
 
+import { StartupUpdateChecker } from './cody/update/StartupUpdateChecker'
 import { communitySearchContextsRoutes } from './communitySearchContexts/routes'
 import { AppRouterContainer } from './components/AppRouterContainer'
 import { RouteError } from './components/ErrorBoundary'
@@ -253,6 +254,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     showFeedbackModal={showFeedbackModal}
                 />
             )}
+            {props.isSourcegraphApp && <StartupUpdateChecker />}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}
             <ApplicationRoutes routes={props.routes} />
             <GlobalContributions

--- a/client/web/src/cody/update/StartupUpdateChecker.tsx
+++ b/client/web/src/cody/update/StartupUpdateChecker.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+import { ChangelogModal } from './ReviewAndInstallModal'
+import { useUpdater } from './updater'
+
+/**
+ * Checks -- once -- if an update is available and displays the upgrade modal.
+ *
+ * Used in the main window to act as a startup reminder to upgrade.
+ *
+ * @returns the modal with update information and actions
+ */
+export function StartupUpdateChecker(): JSX.Element {
+    const update = useUpdater({ keepChecking: false })
+    const [firstShowing, setFirstShowing] = useState<boolean>(true)
+    const [showReviewAndInstall, setShowReviewAndInstall] = useState<boolean>(false)
+
+    useEffect(() => {
+        if (update.hasNewVersion && firstShowing) {
+            setShowReviewAndInstall(true)
+            setFirstShowing(false)
+        }
+    }, [update, firstShowing])
+
+    return showReviewAndInstall ? (
+        <ChangelogModal details={update} fromSettingsPage={false} onClose={() => setShowReviewAndInstall(false)} />
+    ) : (
+        <></>
+    )
+}

--- a/client/web/src/cody/update/updater.tsx
+++ b/client/web/src/cody/update/updater.tsx
@@ -22,6 +22,10 @@ export interface UpdateInfo {
     error?: string
 }
 
+export interface UpdaterSettings {
+    keepChecking?: boolean
+}
+
 /**
  * A React hook to check for app updates.
  *
@@ -35,7 +39,8 @@ export interface UpdateInfo {
  * - `checkNow(force)`: A function to manually check for updates. Pass `true` to force a check even if an update was recently found.
  * - `error`: Any error that occurred during update checking
  */
-export function useUpdater(): UpdateInfo {
+export function useUpdater({ keepChecking }: UpdaterSettings = { keepChecking: true }): UpdateInfo {
+    const [firstCheck, setFirstCheck] = useState<boolean>(false)
     const [lastCheck, setLastCheck] = useState<UpdateInfo>({
         stage: 'CHECKING',
         hasNewVersion: false,
@@ -83,14 +88,17 @@ export function useUpdater(): UpdateInfo {
     }, [])
 
     useEffect(() => {
-        const timer = setInterval(() => {
-            if (lastCheck.stage !== 'IDLE') {
-                return
-            }
-            lastCheck.checkNow?.(false)
-        }, UpdateCheckIntervalMs)
-        return () => clearInterval(timer)
-    }, [lastCheck])
+        if (keepChecking) {
+            const timer = setInterval(() => {
+                if (lastCheck.stage !== 'IDLE') {
+                    return
+                }
+                lastCheck.checkNow?.(false)
+            }, UpdateCheckIntervalMs)
+            return () => clearInterval(timer)
+        }
+        return () => {}
+    }, [keepChecking, lastCheck])
 
     useEffect(() => {
         const unregisterAvailable = listen<UpdateManifest>(TauriEvent.UPDATE_AVAILABLE, ({ payload }) => {

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -10,6 +10,7 @@ import { useTheme, Theme } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { FeedbackPrompt, LoadingSpinner, useLocalStorage } from '@sourcegraph/wildcard'
 
+import { StartupUpdateChecker } from '../../../cody/update/StartupUpdateChecker'
 import { communitySearchContextsRoutes } from '../../../communitySearchContexts/routes'
 import { AppRouterContainer } from '../../../components/AppRouterContainer'
 import { ErrorBoundary } from '../../../components/ErrorBoundary'
@@ -219,6 +220,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
                     showFeedbackModal={showFeedbackModal}
                 />
             )}
+            {props.isSourcegraphApp && <StartupUpdateChecker />}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}
             <ErrorBoundary location={location}>
                 <Suspense


### PR DESCRIPTION
Taps on the update check and displays the upgrade options on application start. Showing happens once.

## Test plan

1. Launch Cody App with at least a version behind the latest
2. In a few seconds the upgrade dialog must popup
3. Observe it does not popup again