### PR TITLE
GitLab extension: Fix for repositories with `repositoryPathPattern` set

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -6,6 +6,7 @@ import { disableFetchCache, enableFetchCache, fetchCache, LineOrPositionOrRange 
 import { testCodeHostMountGetters as testMountGetters, testToolbarMountGetter } from '../shared/codeHostTestUtils'
 
 import { getToolbarMount, gitlabCodeHost, isPrivateRepository, parseHash } from './codeHost'
+import { repoNameOnSourcegraph } from './scrape'
 
 describe('gitlab/codeHost', () => {
     describe('gitlabCodeHost', () => {
@@ -24,13 +25,23 @@ describe('gitlab/codeHost', () => {
             jsdom.reconfigure({ url: 'https://gitlab.com/sourcegraph/jsonrpc2/merge_requests/1/diffs' })
             globalThis.gon = { gitlab_url: 'https://gitlab.com' }
         })
+
+        afterAll(() => {
+            // Reset resolved Sourcegraph repo name value
+            repoNameOnSourcegraph.next('')
+        })
+
         it('returns an URL to the Sourcegraph instance if the location has a viewState', () => {
+            const rawRepoName = 'gitlab.com/sourcegraph/sourcegraph'
+            // Update the resolved Sourcegraph repo name value
+            repoNameOnSourcegraph.next(rawRepoName)
+
             expect(
                 urlToFile(
                     sourcegraphURL,
                     {
                         repoName: 'sourcegraph/sourcegraph',
-                        rawRepoName: 'gitlab.com/sourcegraph/sourcegraph',
+                        rawRepoName,
                         revision: 'master',
                         filePath: 'browser/src/shared/code-hosts/code_intelligence.tsx',
                         position: {
@@ -47,12 +58,16 @@ describe('gitlab/codeHost', () => {
         })
 
         it('returns an absolute URL if the location is not on the same code host', () => {
+            const rawRepoName = 'gitlab.sgdev.org/sourcegraph/sourcegraph'
+            // Update the resolved Sourcegraph repo name value
+            repoNameOnSourcegraph.next(rawRepoName)
+
             expect(
                 urlToFile(
                     sourcegraphURL,
                     {
                         repoName: 'sourcegraph/sourcegraph',
-                        rawRepoName: 'gitlab.sgdev.org/sourcegraph/sourcegraph',
+                        rawRepoName,
                         revision: 'master',
                         filePath: 'browser/src/shared/code-hosts/code_intelligence.tsx',
                         position: {
@@ -67,12 +82,16 @@ describe('gitlab/codeHost', () => {
             )
         })
         it('returns an URL to a blob on the same code host if possible', () => {
+            const rawRepoName = 'gitlab.com/sourcegraph/sourcegraph'
+            // Update the resolved Sourcegraph repo name value
+            repoNameOnSourcegraph.next(rawRepoName)
+
             expect(
                 urlToFile(
                     sourcegraphURL,
                     {
                         repoName: 'sourcegraph/sourcegraph',
-                        rawRepoName: 'gitlab.com/sourcegraph/sourcegraph',
+                        rawRepoName,
                         revision: 'main',
                         filePath: 'browser/src/shared/code-hosts/code_intelligence.tsx',
                         position: {
@@ -87,12 +106,16 @@ describe('gitlab/codeHost', () => {
             )
         })
         it('returns an URL to the file on the same merge request if possible', () => {
+            const rawRepoName = 'gitlab.com/sourcegraph/jsonrpc2'
+            // Update the resolved Sourcegraph repo name value
+            repoNameOnSourcegraph.next(rawRepoName)
+
             expect(
                 urlToFile(
                     sourcegraphURL,
                     {
                         repoName: 'sourcegraph/jsonrpc2',
-                        rawRepoName: 'gitlab.com/sourcegraph/jsonrpc2',
+                        rawRepoName,
                         revision: 'changes',
                         filePath: 'call_opt.go',
                         position: {


### PR DESCRIPTION
closes https://github.com/sourcegraph/customer/issues/2189

## Description

We originally added support for `nameTransformations` in this PR: https://github.com/sourcegraph/sourcegraph/commit/39addfbfe2ef2002cb5ab550e03b5a9810209c19

That worked at the time, but made an assumption that all repositories have a host prefix on Sourcegraph (`e.g. 'gitlab.com/sourcegraph/jsonrpc2' -> 'sourcegraph/jsonrpc2'`). This is not necessarily the case if the Sourcegraph instance was set to use  `"repositoryPathPattern": "{pathWithNamespace}"`. If this was set, the repository would actually already be `sourcegraph/jsonrpc2`, so this code would remove the "sourcegraph" and try to build a repo name that didn't exist.

This PR updates the logic so that we always use the Sourcegraph resolved repo name for Sourcegraph API queries, and the GitLab repo name for GitLab API queries.

## Test plan

I don't have much prior experience with the GitLab extension so I did some manual testing for this:

### Setup:

1. Configure https://gitlab.sgdev.org/ on a Sourcegraph instance (I connected it to [k8s.sgdev.org](http://k8s.sgdev.org/))
2. Add the repository https://gitlab.sgdev.org/batch-changes-testing/tiny-go-test-repository
3. Run below tests
4. Update Gitlab code host config on instance to use repositoryPathPattern:
     `”repositoryPathPattern": "{pathWithNamespace}”`
5. Check that repo is accessible, e.g. https://k8s.sgdev.org/batch-changes-testing/tiny-go-test-repository 
6. Run below tests again
7. Update Gitlab code host config on instance to use nameTransformations.
	```
	  "nameTransformations": [
	    {
	      "regex": "tiny",
	      "replacement": "big"
	    },
	  ],
	```
8. Check repo is accessible, e.g. https://k8s.sgdev.org/batch-changes-testing/big-go-test-repository 
9. Run below tests again

### Tests:

- [merge request page](https://gitlab.sgdev.org/batch-changes-testing/tiny-go-test-repository/-/merge_requests/3/diffs?commit_id=4a89802af32cd85d51c15bb4a482aa05aa751947)
    - Check hovers work
    - Check SG logo shows

- [commit page](https://gitlab.sgdev.org/batch-changes-testing/tiny-go-test-repository/-/commit/4a89802af32cd85d51c15bb4a482aa05aa751947?merge_request_iid=3)
    - Check hovers work
    - Check SG logo shows

- [file page](https://gitlab.sgdev.org/batch-changes-testing/tiny-go-test-repository/-/blob/master/main.go)
    - Check hovers work
    - Check SG logo shows

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
