### PR TITLE
gateway: Add actor tracking to upstream requests

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type bodyTransformer[T UpstreamRequest] func(*T)
+type bodyTransformer[T UpstreamRequest] func(*T, *actor.Actor)
 type requestTransformer func(*http.Request)
 type requestValidator[T UpstreamRequest] func(T) error
 type requestMetadataRetriever[T UpstreamRequest] func(T) (promptCharacterCount int, model string, additionalMetadata map[string]any)
@@ -133,7 +133,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				return
 			}
 
-			transformBody(&body)
+			transformBody(&body, act)
 
 			// Re-marshal the payload for upstream to unset metadata and remove any properties
 			// not known to us.

--- a/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/openai.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/response"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -86,10 +87,13 @@ func (c *openaiClient) GenerateEmbeddings(ctx context.Context, input codygateway
 }
 
 func (c *openaiClient) requestEmbeddings(ctx context.Context, model openAIModel, input []string) (*openaiEmbeddingsResponse, error) {
+	act := actor.FromContext(ctx)
+
 	request := openaiEmbeddingsRequest{
 		Model: model.upstreamName,
 		Input: input,
-		// TODO: Maybe set user.
+		// Set the actor ID for upstream tracking.
+		User: act.ID,
 	}
 
 	bodyBytes, err := json.Marshal(request)


### PR DESCRIPTION
We've had TODOs for these in already, so I went ahead and implemented them. This adds some additional information for upstream on whos behalf we're doing a request. Both providers claim to use this to help us detect bad actors in case of abuse.

## Test plan

Tested that requests still work. 