### PR TITLE
postgresdsn: Fix double port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed validation of Bitbucket Cloud configuration in site-admin create/update form. [#54494](https://github.com/sourcegraph/sourcegraph/pull/54494)
 - Fixed race condition with grpc `server.send` message. [#54500](https://github.com/sourcegraph/sourcegraph/pull/54500)
 - Fixed a configuration initialization issue that broke the outbound request in the site admin page. [#54745](https://github.com/sourcegraph/sourcegraph/pull/54745)
+- Fixed Postgres DSN construction edge-case. [#54858](https://github.com/sourcegraph/sourcegraph/pull/54858)
 
 ## 5.1.1
 

--- a/internal/database/postgresdsn/postgresdsn.go
+++ b/internal/database/postgresdsn/postgresdsn.go
@@ -60,7 +60,7 @@ func New(prefix, currentUser string, getenv func(string) string) string {
 	// PGPORT values may be (legally) quoted, but should remain quoted
 	// when constructed as part of the DSN. Strip it here.
 	if port := dequote(env("PGPORT")); port != "" {
-		dsn.Host += ":" + port
+		dsn.Host = strings.Split(dsn.Host, ":")[0] + ":" + port
 	}
 
 	if db := env("PGDATABASE"); db != "" {

--- a/internal/database/postgresdsn/postgresdsn_test.go
+++ b/internal/database/postgresdsn/postgresdsn_test.go
@@ -119,6 +119,18 @@ func TestNew(t *testing.T) {
 			},
 			dsn: "postgres://sg:REDACTED@pgsql:5432/sg?sslmode=disable",
 		},
+
+		// #54858 fixes previous incorrect output that cannot be parsed
+		// as a legal URL due to the double port:
+		//
+		// `postgres://testuser@127.0.0.1:5432:5333`
+		{
+			name: "overwritten port",
+			env: map[string]string{
+				"PGPORT": "5333",
+			},
+			dsn: "postgres://testuser@127.0.0.1:5333",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/database/postgresdsn/postgresdsn_test.go
+++ b/internal/database/postgresdsn/postgresdsn_test.go
@@ -123,7 +123,7 @@ func TestNew(t *testing.T) {
 		// #54858 fixes previous incorrect output that cannot be parsed
 		// as a legal URL due to the double port:
 		//
-		// `postgres://testuser@127.0.0.1:5432:5333`
+		// postgres://testuser@127.0.0.1:5432:5333
 		{
 			name: "overwritten port",
 			env: map[string]string{


### PR DESCRIPTION
Fixes edge case where we construct a double-port postgres DSN.

## Test plan

Additional unit test case.