### PR TITLE
JetBrains: Disable git recipe button when vcs is not available

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
+- Disable summarize recent code changes button if git repository is not available [#54859](https://github.com/sourcegraph/sourcegraph/pull/54859)
+
 ### Deprecated
 
 ### Removed

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vcs/VcsCommitsMetadataProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vcs/VcsCommitsMetadataProvider.java
@@ -2,9 +2,14 @@ package com.sourcegraph.cody.vcs;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.roots.VcsRootProblemNotifier;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcs.log.*;
 import com.intellij.vcs.log.graph.GraphCommit;
 import com.intellij.vcs.log.impl.VcsProjectLog;
+import git4idea.GitUtil;
+import git4idea.repo.GitRepository;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
@@ -14,9 +19,15 @@ class VcsCommitsMetadataProvider {
   private static final @NotNull Logger logger =
       Logger.getInstance(VcsCommitsMetadataProvider.class);
 
-  static String getVcsCommitsMetadataDescription(
+  static @NotNull String getVcsCommitsMetadataDescription(
       @NotNull Project project, @NotNull VcsFilter vcsFilter) {
     CommitMetadataConsumer commitMetadataConsumer = new CommitMetadataConsumer();
+
+    VcsRootProblemNotifier.createInstance(project).rescanAndNotifyIfNeeded();
+
+    if (!isGitRepositoryAvailable(project)) {
+      return commitMetadataConsumer.getCommitsContent();
+    }
 
     VcsProjectLog.getLogProviders(project)
         .forEach(
@@ -36,5 +47,16 @@ class VcsCommitsMetadataProvider {
               }
             });
     return commitMetadataConsumer.getCommitsContent();
+  }
+
+  public static boolean isGitRepositoryAvailable(Project project) {
+    @NotNull Collection<GitRepository> repositories = GitUtil.getRepositories(project);
+    for (GitRepository repository : repositories) {
+      VirtualFile gitDir = repository.getRoot().findChild(".git");
+      if (gitDir != null && gitDir.exists()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vcs/VcsCommitsMetadataProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vcs/VcsCommitsMetadataProvider.java
@@ -49,7 +49,7 @@ class VcsCommitsMetadataProvider {
     return commitMetadataConsumer.getCommitsContent();
   }
 
-  public static boolean isGitRepositoryAvailable(Project project) {
+  public static boolean isGitRepositoryAvailable(@NotNull Project project) {
     @NotNull Collection<GitRepository> repositories = GitUtil.getRepositories(project);
     for (GitRepository repository : repositories) {
       VirtualFile gitDir = repository.getRoot().findChild(".git");


### PR DESCRIPTION
This pr add automatic disabling/enabling of the summarize recent code changes button in the recipes tab
Automatic disabling/enabling works only if we interact with the git repository through the IDE, it won't work if we manually modify our file system externally. 

closes sourcegraph/cody#118 

## Test plan
- Open project with git repository and button should be enabled
- Open project without git repository and button should be disabled
- Adding/removing the git repository through the IDE should enable/disable the button

<img width="433" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/559814ee-f53e-487d-983b-d0a125126d43">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
