### PR TITLE
sg: fix small typo in pending message

### DIFF
--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -312,7 +312,7 @@ func startCommandSet(ctx context.Context, set *sgconf.Commandset, conf *sgconf.C
 		}
 
 		if _, excluded := exceptSet[name]; excluded {
-			std.Out.WriteLine(output.Styledf(output.StylePending, "Skipping command %s since it's in --excluded.", cmd.Name))
+			std.Out.WriteLine(output.Styledf(output.StylePending, "Skipping command %s since it's in --except.", cmd.Name))
 			continue
 		}
 


### PR DESCRIPTION
`--excluded` flag doesn't exist, but `--except` does
## Test plan
```
sourcegraph on  wb/sg/typo [$?] via 🐹 v1.19.8 took 10s 
❯ go run ./dev/sg start --except symbols
ℹ️ We found some changes in dev-private that you're missing out on! If you want the new changes, 'cd ../dev-private' and then do a 'git stash' and a 'git pull'!
✅ Done checking dev-private changes
💡 Running 4 checks...
✅ Check "docker" success!
✅ Check "redis" success!
✅ Check "postgres" success!
✅ Check "git" success!
Skipping command symbols since it's in --except.
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
