### PR TITLE
codesearch: Handle push error to not archived repo

### DIFF
--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -213,9 +213,8 @@ func (e *executor) pushChangesetPatch(ctx context.Context, triggerUpdateWebhook 
 					return afterDone, errCannotPushToArchivedRepo
 				}
 			}
-		} else {
-			return afterDone, errors.Wrap(err, "pushing commit")
 		}
+		return afterDone, errors.Wrap(err, "pushing commit")
 	}
 
 	// update the changeset's external_id column if a changelist id is returned

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -273,6 +273,29 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 				PublicationState: btypes.ChangesetPublicationStateUnpublished,
 			},
 		},
+		"push error and not archived repo": {
+			hasCurrentSpec: true,
+			changeset: bt.TestChangesetOpts{
+				PublicationState: btypes.ChangesetPublicationStateUnpublished,
+			},
+			plan: &Plan{
+				Ops: Operations{
+					btypes.ReconcilerOperationPush,
+					btypes.ReconcilerOperationPublish,
+				},
+			},
+			gitClientErr: &gitprotocol.CreateCommitFromPatchError{
+				CombinedOutput: "archived",
+			},
+			isRepoArchived: false,
+			sourcerErr:     repoArchivedErr,
+
+			wantGitserverCommit: true,
+
+			wantChangeset: bt.ChangesetAssertions{
+				PublicationState: btypes.ChangesetPublicationStateUnpublished,
+			},
+		},
 		"general push error": {
 			hasCurrentSpec: true,
 			changeset: bt.TestChangesetOpts{


### PR DESCRIPTION
There is a possibility that the repo is not archived and we still failed to push the commit. Bail out with the error in this case.

## Test plan

Added a new unit test