### PR TITLE
Add Sonar Project Properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=sourcegraph_sourcegraph
+sonar.organization=sourcegraph
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=sourcegraph
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+sonar.exclusions=*/**.java,*/**.kt,*/**.py
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
Adding sonar project properties file to exclude few java, kotlin & c/cpp stuffs. (part of hackathon at BCN)


## Test plan

- Backup plan: revert this PR and `analysis method` as automatic on sonarcloud project setting
- Buildkite should automatically pickup this file for scanning
