### PR TITLE
cody-gateway: record custom upstreamStatusCode, resolvedStatusCode attributes

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//internal/trace",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_exp//slices",
     ],

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/slices"
 
@@ -180,6 +181,11 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				completionCharacterCount int = -1
 			)
 			defer func() {
+				if span := oteltrace.SpanFromContext(r.Context()); span.IsRecording() {
+					span.SetAttributes(
+						attribute.Int("upstreamStatusCode", upstreamStatusCode),
+						attribute.Int("resolvedStatusCode", resolvedStatusCode))
+				}
 				err := eventLogger.LogEvent(
 					r.Context(),
 					events.Event{

--- a/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
-        "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_exp//slices",
     ],


### PR DESCRIPTION
Makes filtering much easier in Cloud Trace. Now, for example, to identify requests where we have been rate limited by upstream:

```
upstreamStatusCode: 429
matched_source: dotcom-product-subscriptions
```

If we've rate limited the caller ourselves:

```
resolvedStatusCode: 429
matched_source: dotcom-product-subscriptions
```

Note that I just realized we could've achieved this as well with root-span searches https://cloud.google.com/trace/docs/trace-filters#search-root-span , but this might come in handy regardless

## Test plan

CI