### PR TITLE
Allow for null revision resolver when using repo embeddings job's empty revision string

### DIFF
--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -58,6 +58,10 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
                                 {repo.name}@{revision.abbreviatedOID}
                             </Link>
                         )
+                    ) : repo ? (
+                        <>
+                            {repo.name}
+                        </>
                     ) : (
                         <div>Unknown repository</div>
                     )}

--- a/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
+++ b/client/web/src/enterprise/site-admin/cody/RepoEmbeddingJobNode.tsx
@@ -59,9 +59,7 @@ export const RepoEmbeddingJobNode: FC<RepoEmbeddingJobNodeProps> = ({
                             </Link>
                         )
                     ) : repo ? (
-                        <>
-                            {repo.name}
-                        </>
+                        <>{repo.name}</>
                     ) : (
                         <div>Unknown repository</div>
                     )}

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
@@ -214,9 +214,16 @@ func (r *repoEmbeddingJobResolver) Revision(ctx context.Context) (*graphqlbacken
 	if err != nil {
 		return nil, err
 	}
-	if repoResolver == nil {
+
+	// An empty revision value can accompany a valid repository if gitserver cannot resolve the default branch or latest revision during job scheduling.
+	// The job will always fail in this case and must be displayed in site admin despite the gitserver error.
+	// Site admin will only provide the job's failure_message in this case.
+	invalidRevision := r.job.Revision == ""
+
+	if repoResolver == nil || invalidRevision {
 		return nil, nil
 	}
+
 	return graphqlbackend.NewGitCommitResolver(r.db, r.gitserverClient, repoResolver, r.job.Revision, nil), nil
 }
 


### PR DESCRIPTION
This [PR](https://github.com/sourcegraph/sourcegraph/pull/54804) fixed an issue with job scheduling/execution in the backend. The interim fix of this PR relies on allowing for empty string `revision` values written with a repo embedding job when the repo is empty or some other issue occurs when fetching the repo's default branch (e.g. empty repo).

Empty revision value causes issues with graphql query repoEmbeddingJobs when [querying for Revision](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/enterprise/site-admin/cody/backend.ts?L32-35) as our site admin jobs panel does.

`Panic occurred: runtime error: slice bounds out of range [:7] with length 0`

This PR updates the embedding job resolver to consider empty revision string acceptable and not call constructor for git commit resolver. Also site admin jobs list will now show repo name if repo is non-null and revision is null.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

sg manual test
