### PR TITLE
gitserver: remote dash check for git-diff

### DIFF
--- a/internal/gitserver/gitdomain/exec.go
+++ b/internal/gitserver/gitdomain/exec.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/sourcegraph/log"
 )
@@ -141,7 +140,7 @@ func IsAllowedGitCmd(logger log.Logger, args []string) bool {
 		logger.Warn("command not allowed", log.String("cmd", cmd))
 		return false
 	}
-	for i, arg := range args[1:] {
+	for _, arg := range args[1:] {
 		if strings.HasPrefix(arg, "-") {
 			// Special-case `git log -S` and `git log -G`, which interpret any characters
 			// after their 'S' or 'G' as part of the query. There is no long form of this
@@ -169,8 +168,7 @@ func IsAllowedGitCmd(logger log.Logger, args []string) bool {
 		}
 		// Special-case for `git diff` to check if argument before `--` is not a file
 		if cmd == "diff" {
-			dashIndex := slices.Index(args[1:], "--")
-			if (dashIndex < 0 || i < dashIndex) && !isAllowedDiffArg(arg) {
+			if !isAllowedDiffArg(arg) {
 				logger.Warn("IsAllowedGitCmd.isAllowedGitArgcmd", log.String("cmd", cmd), log.String("arg", arg))
 				return false
 			}


### PR DESCRIPTION
Resolves: https://github.com/sourcegraph/security-issues/issues/348.

Where paths could be added after `--`. This is not exploitable by regular users, but can be when HTTP endpoints are exposed over `HTTP` and `gitserver` is called directly.

## Test plan
Check out branch and try to run PoC again.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
