### PR TITLE
search: use zoekt RepoStats.Repos instead of length of map

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -93,7 +93,7 @@ func (r *repositoryStatsResolver) computeIndexedStats(ctx context.Context) (int3
 			r.indexedStatsErr = err
 			return
 		}
-		r.indexedRepos = int32(len(repos.Minimal)) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+		r.indexedRepos = int32(repos.Stats.Repos)
 		r.indexedLinesCount = int64(repos.Stats.DefaultBranchNewLinesCount) + int64(repos.Stats.OtherBranchesNewLinesCount)
 	})
 

--- a/internal/search/BUILD.bazel
+++ b/internal/search/BUILD.bazel
@@ -32,8 +32,6 @@ go_library(
         "//lib/errors",
         "//schema",
         "@com_github_grafana_regexp//:regexp",
-        "@com_github_prometheus_client_golang//prometheus",
-        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",


### PR DESCRIPTION
We added a metric to ensure these values always agree, and they do. So we also remove that metric.

Test Plan: CI