### PR TITLE
JetBrains: Fix dotcom logging issue

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/Event.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/Event.java
@@ -37,10 +37,10 @@ public class Event {
     returnValue.addProperty("source", "IDEEXTENSION");
     returnValue.addProperty("referrer", "JETBRAINS");
     if (eventProperties != null) {
-      returnValue.add("argument", eventProperties);
+      returnValue.addProperty("argument", eventProperties.toString());
     }
     if (publicArgument != null) {
-      returnValue.add("publicArgument", publicArgument);
+      returnValue.addProperty("publicArgument", publicArgument.toString());
     }
     returnValue.addProperty("deviceID", this.anonymousUserId);
     return returnValue;


### PR DESCRIPTION
We didn't convert an object to a string → our Go backend rejected it → got no logs on Dotcom :bang-head:

Currently, I'm getting back a bunch of 429 – Too Many Requests responses from Dotcom for some reason, but the problem should be solved.

I feel sorry about losing all those logs, it really sucks. We were too much in a rush and didn't test this properly. Totally my mistake.

## Test plan

Tested it with the built-in-debugger and by copying the requests to our GraphQL API console.