### PR TITLE
search: use ReposMap for ListAllIndexed

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -745,7 +745,7 @@ func TestRepositories_Integration(t *testing.T) {
 		}
 
 		if rsc.indexed {
-			err := db.ZoektRepos().UpdateIndexStatuses(ctx, map[uint32]*zoekt.MinimalRepoListEntry{
+			err := db.ZoektRepos().UpdateIndexStatuses(ctx, zoekt.ReposMap{
 				uint32(rsc.repo.ID): {},
 			})
 			if err != nil {

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -504,12 +504,12 @@ func (h *searchIndexerServer) handleIndexStatusUpdate(_ http.ResponseWriter, r *
 func (h *searchIndexerServer) doIndexStatusUpdate(ctx context.Context, args *indexStatusUpdateArgs) error {
 	var (
 		ids     = make([]int32, len(args.Repositories))
-		minimal = make(map[uint32]*zoekt.MinimalRepoListEntry, len(args.Repositories))
+		minimal = make(zoekt.ReposMap, len(args.Repositories))
 	)
 
 	for i, repo := range args.Repositories {
 		ids[i] = int32(repo.RepoID)
-		minimal[repo.RepoID] = &zoekt.MinimalRepoListEntry{Branches: repo.Branches, IndexTimeUnix: repo.IndexTimeUnix}
+		minimal[repo.RepoID] = zoekt.MinimalRepoListEntry{Branches: repo.Branches, IndexTimeUnix: repo.IndexTimeUnix}
 	}
 
 	h.logger.Info("updating index status", log.Int32s("repositories", ids))

--- a/cmd/frontend/internal/httpapi/search_test.go
+++ b/cmd/frontend/internal/httpapi/search_test.go
@@ -519,7 +519,7 @@ func TestIndexStatusUpdate(t *testing.T) {
 		called := false
 
 		zoektReposStore := database.NewMockZoektReposStore()
-		zoektReposStore.UpdateIndexStatusesFunc.SetDefaultHook(func(_ context.Context, indexed map[uint32]*zoekt.MinimalRepoListEntry) error {
+		zoektReposStore.UpdateIndexStatusesFunc.SetDefaultHook(func(_ context.Context, indexed zoekt.ReposMap) error {
 			entry, ok := indexed[1234]
 			if !ok {
 				t.Fatalf("wrong repo ID")
@@ -562,7 +562,7 @@ func TestIndexStatusUpdate(t *testing.T) {
 		called := false
 
 		zoektReposStore := database.NewMockZoektReposStore()
-		zoektReposStore.UpdateIndexStatusesFunc.SetDefaultHook(func(_ context.Context, indexed map[uint32]*zoekt.MinimalRepoListEntry) error {
+		zoektReposStore.UpdateIndexStatusesFunc.SetDefaultHook(func(_ context.Context, indexed zoekt.ReposMap) error {
 			entry, ok := indexed[wantRepoID]
 			if !ok {
 				t.Fatalf("wrong repo ID")

--- a/cmd/worker/internal/zoektrepos/zoektrepos.go
+++ b/cmd/worker/internal/zoektrepos/zoektrepos.go
@@ -67,7 +67,7 @@ func (h *handler) Handle(ctx context.Context) error {
 		return err
 	}
 
-	return h.db.ZoektRepos().UpdateIndexStatuses(ctx, indexed.Minimal) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+	return h.db.ZoektRepos().UpdateIndexStatuses(ctx, indexed.ReposMap)
 }
 
 func (h *handler) HandleError(err error) {

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -88185,7 +88185,7 @@ func NewMockZoektReposStore() *MockZoektReposStore {
 			},
 		},
 		UpdateIndexStatusesFunc: &ZoektReposStoreUpdateIndexStatusesFunc{
-			defaultHook: func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) (r0 error) {
+			defaultHook: func(context.Context, zoekt.ReposMap) (r0 error) {
 				return
 			},
 		},
@@ -88217,7 +88217,7 @@ func NewStrictMockZoektReposStore() *MockZoektReposStore {
 			},
 		},
 		UpdateIndexStatusesFunc: &ZoektReposStoreUpdateIndexStatusesFunc{
-			defaultHook: func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error {
+			defaultHook: func(context.Context, zoekt.ReposMap) error {
 				panic("unexpected invocation of MockZoektReposStore.UpdateIndexStatuses")
 			},
 		},
@@ -88570,15 +88570,15 @@ func (c ZoektReposStoreHandleFuncCall) Results() []interface{} {
 // UpdateIndexStatuses method of the parent MockZoektReposStore instance is
 // invoked.
 type ZoektReposStoreUpdateIndexStatusesFunc struct {
-	defaultHook func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error
-	hooks       []func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error
+	defaultHook func(context.Context, zoekt.ReposMap) error
+	hooks       []func(context.Context, zoekt.ReposMap) error
 	history     []ZoektReposStoreUpdateIndexStatusesFuncCall
 	mutex       sync.Mutex
 }
 
 // UpdateIndexStatuses delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockZoektReposStore) UpdateIndexStatuses(v0 context.Context, v1 map[uint32]*zoekt.MinimalRepoListEntry) error {
+func (m *MockZoektReposStore) UpdateIndexStatuses(v0 context.Context, v1 zoekt.ReposMap) error {
 	r0 := m.UpdateIndexStatusesFunc.nextHook()(v0, v1)
 	m.UpdateIndexStatusesFunc.appendCall(ZoektReposStoreUpdateIndexStatusesFuncCall{v0, v1, r0})
 	return r0
@@ -88587,7 +88587,7 @@ func (m *MockZoektReposStore) UpdateIndexStatuses(v0 context.Context, v1 map[uin
 // SetDefaultHook sets function that is called when the UpdateIndexStatuses
 // method of the parent MockZoektReposStore instance is invoked and the hook
 // queue is empty.
-func (f *ZoektReposStoreUpdateIndexStatusesFunc) SetDefaultHook(hook func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error) {
+func (f *ZoektReposStoreUpdateIndexStatusesFunc) SetDefaultHook(hook func(context.Context, zoekt.ReposMap) error) {
 	f.defaultHook = hook
 }
 
@@ -88596,7 +88596,7 @@ func (f *ZoektReposStoreUpdateIndexStatusesFunc) SetDefaultHook(hook func(contex
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *ZoektReposStoreUpdateIndexStatusesFunc) PushHook(hook func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error) {
+func (f *ZoektReposStoreUpdateIndexStatusesFunc) PushHook(hook func(context.Context, zoekt.ReposMap) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -88605,19 +88605,19 @@ func (f *ZoektReposStoreUpdateIndexStatusesFunc) PushHook(hook func(context.Cont
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *ZoektReposStoreUpdateIndexStatusesFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error {
+	f.SetDefaultHook(func(context.Context, zoekt.ReposMap) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *ZoektReposStoreUpdateIndexStatusesFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error {
+	f.PushHook(func(context.Context, zoekt.ReposMap) error {
 		return r0
 	})
 }
 
-func (f *ZoektReposStoreUpdateIndexStatusesFunc) nextHook() func(context.Context, map[uint32]*zoekt.MinimalRepoListEntry) error {
+func (f *ZoektReposStoreUpdateIndexStatusesFunc) nextHook() func(context.Context, zoekt.ReposMap) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -88656,7 +88656,7 @@ type ZoektReposStoreUpdateIndexStatusesFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 map[uint32]*zoekt.MinimalRepoListEntry
+	Arg1 zoekt.ReposMap
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -135,7 +135,7 @@ func setZoektIndexed(t *testing.T, db DB, name api.RepoName) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.ZoektRepos().UpdateIndexStatuses(ctx, map[uint32]*zoekt.MinimalRepoListEntry{
+	err = db.ZoektRepos().UpdateIndexStatuses(ctx, zoekt.ReposMap{
 		uint32(repo.ID): {},
 	})
 	if err != nil {

--- a/internal/database/zoekt_repos.go
+++ b/internal/database/zoekt_repos.go
@@ -23,7 +23,7 @@ type ZoektReposStore interface {
 
 	// UpdateIndexStatuses updates the index status of the rows in zoekt_repos
 	// whose repo_id matches an entry in the `indexed` map.
-	UpdateIndexStatuses(ctx context.Context, indexed map[uint32]*zoekt.MinimalRepoListEntry) error
+	UpdateIndexStatuses(ctx context.Context, indexed zoekt.ReposMap) error
 
 	// GetStatistics returns a summary of the zoekt_repos table.
 	GetStatistics(ctx context.Context) (ZoektRepoStatistics, error)
@@ -110,7 +110,7 @@ AND
 ;
 `
 
-func (s *zoektReposStore) UpdateIndexStatuses(ctx context.Context, indexed map[uint32]*zoekt.MinimalRepoListEntry) (err error) {
+func (s *zoektReposStore) UpdateIndexStatuses(ctx context.Context, indexed zoekt.ReposMap) (err error) {
 	tx, err := s.Store.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/database/zoekt_repos_test.go
+++ b/internal/database/zoekt_repos_test.go
@@ -70,7 +70,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 	})
 
 	// 1/3 repo is indexed
-	indexed := map[uint32]*zoekt.MinimalRepoListEntry{
+	indexed := zoekt.ReposMap{
 		uint32(repos[0].ID): {
 			Branches:      []zoekt.RepositoryBranch{{Name: "main", Version: "d34db33f"}},
 			IndexTimeUnix: timeUnix,
@@ -95,7 +95,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 	})
 
 	// Index all repositories
-	indexed = map[uint32]*zoekt.MinimalRepoListEntry{
+	indexed = zoekt.ReposMap{
 		// different commit
 		uint32(repos[0].ID): {Branches: []zoekt.RepositoryBranch{{Name: "main", Version: "f00b4r"}}},
 		// new
@@ -129,7 +129,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 	})
 
 	// Add an additional branch to a single repository
-	indexed = map[uint32]*zoekt.MinimalRepoListEntry{
+	indexed = zoekt.ReposMap{
 		// additional branch
 		uint32(repos[2].ID): {Branches: []zoekt.RepositoryBranch{
 			{Name: "main", Version: "d00d00"},
@@ -165,7 +165,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 
 	// Now we update the indexing status of a repository that doesn't exist and
 	// check that the index status in unchanged:
-	indexed = map[uint32]*zoekt.MinimalRepoListEntry{
+	indexed = zoekt.ReposMap{
 		9999: {Branches: []zoekt.RepositoryBranch{{Name: "main", Version: "d00d00"}}},
 	}
 	if err := s.UpdateIndexStatuses(ctx, indexed); err != nil {
@@ -219,10 +219,10 @@ func benchmarkUpdateIndexStatus(b *testing.B, numRepos int) {
 	b.Logf("Creating %d repositories...", numRepos)
 
 	var (
-		indexedAll         = make(map[uint32]*zoekt.MinimalRepoListEntry, numRepos)
+		indexedAll         = make(zoekt.ReposMap, numRepos)
 		indexedAllBranches = []zoekt.RepositoryBranch{{Name: "main", Version: "d00d00"}}
 
-		indexedHalf         = make(map[uint32]*zoekt.MinimalRepoListEntry, numRepos/2)
+		indexedHalf         = make(zoekt.ReposMap, numRepos/2)
 		indexedHalfBranches = []zoekt.RepositoryBranch{{Name: "main-2", Version: "f00b4r"}}
 	)
 
@@ -232,9 +232,9 @@ func benchmarkUpdateIndexStatus(b *testing.B, numRepos int) {
 			b.Fatal(err)
 		}
 
-		indexedAll[uint32(i+1)] = &zoekt.MinimalRepoListEntry{Branches: indexedAllBranches}
+		indexedAll[uint32(i+1)] = zoekt.MinimalRepoListEntry{Branches: indexedAllBranches}
 		if i%2 == 0 {
-			indexedHalf[uint32(i+1)] = &zoekt.MinimalRepoListEntry{Branches: indexedHalfBranches}
+			indexedHalf[uint32(i+1)] = zoekt.MinimalRepoListEntry{Branches: indexedHalfBranches}
 		}
 	}
 	if err := inserter.Flush(ctx); err != nil {
@@ -262,7 +262,7 @@ func benchmarkUpdateIndexStatus(b *testing.B, numRepos int) {
 
 	b.Run("update-none", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			if err := s.UpdateIndexStatuses(ctx, make(map[uint32]*zoekt.MinimalRepoListEntry)); err != nil {
+			if err := s.UpdateIndexStatuses(ctx, make(zoekt.ReposMap)); err != nil {
 				b.Fatalf("unexpected error: %s", err)
 			}
 		}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -284,7 +284,7 @@ func TestStatusMessages(t *testing.T) {
 				if id == 0 {
 					continue
 				}
-				err := db.ZoektRepos().UpdateIndexStatuses(ctx, map[uint32]*zoekt.MinimalRepoListEntry{
+				err := db.ZoektRepos().UpdateIndexStatuses(ctx, zoekt.ReposMap{
 					id: {
 						Branches: []zoekt.RepositoryBranch{{Name: "main", Version: "d34db33f"}},
 					},

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -70,16 +70,28 @@ func Indexed() zoekt.Streamer {
 	return indexedSearch
 }
 
-// ListAllIndexed lists all indexed repositories with `Minimal: true`.
-func ListAllIndexed(ctx context.Context) (*zoekt.RepoList, error) {
+// ZoektAllIndexed is the subset of zoekt.RepoList that we set in
+// ListAllIndexed.
+type ZoektAllIndexed struct {
+	ReposMap zoekt.ReposMap
+	Crashes  int
+	Stats    zoekt.RepoStats
+}
+
+// ListAllIndexed lists all indexed repositories.
+func ListAllIndexed(ctx context.Context) (*ZoektAllIndexed, error) {
 	q := &query.Const{Value: true}
-	opts := &zoekt.ListOptions{Minimal: true}
+	opts := &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap}
 
 	repos, err := Indexed().List(ctx, q, opts)
 	if err != nil {
 		return nil, err
 	}
-	return repos, nil
+	return &ZoektAllIndexed{
+		ReposMap: repos.ReposMap,
+		Crashes:  repos.Crashes,
+		Stats:    repos.Stats,
+	}, nil
 }
 
 func Indexers() *backend.Indexers {


### PR DESCRIPTION
Minimal is deprecated since ReposMap has a more garbage collector friendly representation. This switches us over for ListAllIndexed calls. Additionally we update the return type to only have the fields that will be set by this call. This is to prevent accidental use of an unset field.

Test Plan: CI

Based on #54884 