### PR TITLE
search: use ReposMap in search path

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -617,7 +617,7 @@ func (r *Resolver) filterRepoHasFileContent(
 				q := searchzoekt.QueryForFileContentArgs(opt, op.CaseSensitiveRepoFilters)
 				q = zoektquery.NewAnd(&zoektquery.BranchesRepos{List: indexed.BranchRepos()}, q)
 
-				repos, err := r.zoekt.List(ctx, q, &zoekt.ListOptions{Minimal: true})
+				repos, err := r.zoekt.List(ctx, q, &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap})
 				if err != nil {
 					return err
 				}
@@ -625,7 +625,7 @@ func (r *Resolver) filterRepoHasFileContent(
 				addBackendsMissing(repos.Crashes)
 
 				foundRevs := Set[repoAndRev]{}
-				for repoID, repo := range repos.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+				for repoID, repo := range repos.ReposMap {
 					inputRevs := indexed.RepoRevs[api.RepoID(repoID)].Revs
 					for _, branch := range repo.Branches {
 						for _, inputRev := range inputRevs {

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -533,7 +533,7 @@ func TestRepoHasFileContent(t *testing.T) {
 	cases := []struct {
 		name          string
 		filters       []query.RepoHasFileContentArgs
-		matchingRepos map[uint32]*zoekt.MinimalRepoListEntry
+		matchingRepos zoekt.ReposMap
 		expected      []*search.RepositoryRevisions
 	}{{
 		name:          "no filters",
@@ -558,7 +558,7 @@ func TestRepoHasFileContent(t *testing.T) {
 		filters: []query.RepoHasFileContentArgs{{
 			Path: "pathB",
 		}},
-		matchingRepos: map[uint32]*zoekt.MinimalRepoListEntry{
+		matchingRepos: zoekt.ReposMap{
 			2: {
 				Branches: []zoekt.RepositoryBranch{{
 					Name: "HEAD",
@@ -613,7 +613,7 @@ func TestRepoHasFileContent(t *testing.T) {
 			// Only repos A and B are indexed
 			mockZoekt := NewMockStreamer()
 			mockZoekt.ListFunc.PushReturn(&zoekt.RepoList{
-				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+				ReposMap: zoekt.ReposMap{
 					uint32(repoA.ID): {
 						Branches: []zoekt.RepositoryBranch{{Name: "HEAD"}},
 					},
@@ -624,7 +624,7 @@ func TestRepoHasFileContent(t *testing.T) {
 			}, nil)
 
 			mockZoekt.ListFunc.PushReturn(&zoekt.RepoList{
-				Minimal: tc.matchingRepos,
+				ReposMap: tc.matchingRepos,
 			}, nil)
 
 			res := NewResolver(logtest.Scoped(t), db, mockGitserver, endpoint.Static("test"), mockZoekt)

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -80,7 +80,7 @@ func (rb *IndexedRepoRevs) GetRepoRevsFromBranchRepos() map[api.RepoID]*search.R
 // add will add reporev and repo to the list of repository and branches to
 // search if reporev's refs are a subset of repo's branches. It will return
 // the revision specifiers it can't add.
-func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo *zoekt.MinimalRepoListEntry) []string {
+func (rb *IndexedRepoRevs) add(reporev *search.RepositoryRevisions, repo zoekt.MinimalRepoListEntry) []string {
 	// A repo should only appear once in revs. However, in case this
 	// invariant is broken we will treat later revs as if it isn't
 	// indexed.
@@ -228,9 +228,9 @@ func PartitionRepos(
 	defer tr.FinishWithErr(&err)
 
 	// Only include indexes with symbol information if a symbol request.
-	var filterFunc func(repo *zoekt.MinimalRepoListEntry) bool
+	var filterFunc func(repo zoekt.MinimalRepoListEntry) bool
 	if typ == search.SymbolRequest {
-		filterFunc = func(repo *zoekt.MinimalRepoListEntry) bool {
+		filterFunc = func(repo zoekt.MinimalRepoListEntry) bool {
 			return repo.HasSymbols
 		}
 	}
@@ -238,7 +238,7 @@ func PartitionRepos(
 	// Consult Zoekt to find out which repository revisions can be searched.
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
-	list, err := zoektStreamer.List(ctx, &zoektquery.Const{Value: true}, &zoekt.ListOptions{Minimal: true})
+	list, err := zoektStreamer.List(ctx, &zoektquery.Const{Value: true}, &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap})
 	if err != nil {
 		if ctx.Err() == nil {
 			// Only hard fail if the user specified index:only
@@ -255,10 +255,10 @@ func PartitionRepos(
 	// Note: We do not need to handle list.Crashes since we will fallback to
 	// unindexed search for any repository unavailable due to rollout.
 
-	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.Minimal))) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+	tr.SetAttributes(attribute.Int("all_indexed_set.size", len(list.ReposMap)))
 
 	// Split based on indexed vs unindexed
-	indexed, unindexed = zoektIndexedRepos(list.Minimal, repos, filterFunc) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+	indexed, unindexed = zoektIndexedRepos(list.ReposMap, repos, filterFunc) //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
 
 	tr.SetAttributes(
 		attribute.Int("indexed.size", len(indexed.RepoRevs)),
@@ -617,7 +617,7 @@ func contextWithoutDeadline(cOld context.Context) (context.Context, context.Canc
 // zoektIndexedRepos splits the revs into two parts: (1) the repository
 // revisions in indexedSet (indexed) and (2) the repositories that are
 // unindexed.
-func zoektIndexedRepos(indexedSet map[uint32]*zoekt.MinimalRepoListEntry, revs []*search.RepositoryRevisions, filter func(repo *zoekt.MinimalRepoListEntry) bool) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions) {
+func zoektIndexedRepos(indexedSet zoekt.ReposMap, revs []*search.RepositoryRevisions, filter func(repo zoekt.MinimalRepoListEntry) bool) (indexed *IndexedRepoRevs, unindexed []*search.RepositoryRevisions) {
 	// PERF: If len(revs) is large, we expect to be doing an indexed
 	// search. So set indexed to the max size it can be to avoid growing.
 	indexed = &IndexedRepoRevs{

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -375,7 +375,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 		"foo/unindexed-two",
 	)
 
-	zoektRepos := map[uint32]*zoekt.MinimalRepoListEntry{}
+	zoektRepos := zoekt.ReposMap{}
 	for i, branches := range [][]zoekt.RepositoryBranch{
 		{
 			{Name: "HEAD", Version: "deadbeef"},
@@ -393,7 +393,7 @@ func TestZoektIndexedRepos(t *testing.T) {
 	} {
 		r := repos[i]
 		branches := branches
-		zoektRepos[uint32(r.Repo.ID)] = &zoekt.MinimalRepoListEntry{Branches: branches}
+		zoektRepos[uint32(r.Repo.ID)] = zoekt.MinimalRepoListEntry{Branches: branches}
 	}
 
 	cases := []struct {
@@ -453,7 +453,7 @@ func TestZoektIndexedRepos_single(t *testing.T) {
 			Revs: []string{revSpec},
 		}
 	}
-	zoektRepos := map[uint32]*zoekt.MinimalRepoListEntry{
+	zoektRepos := zoekt.ReposMap{
 		1: {
 			Branches: []zoekt.RepositoryBranch{
 				{


### PR DESCRIPTION
This required updating pointers to MinimalRepoListEntry to be values which should be acceptable since they are small values. Minimal is deprecated.

Test Plan: CI