### PR TITLE
searcher: use ReposMap

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -312,12 +312,12 @@ func zoektIndexedCommit(ctx context.Context, client zoekt.Streamer, repo api.Rep
 	// NewSingleBranchesRepos and it went through a slow path.
 	q := zoektquery.NewRepoSet(string(repo))
 
-	resp, err := client.List(ctx, q, &zoekt.ListOptions{Minimal: true})
+	resp, err := client.List(ctx, q, &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap})
 	if err != nil {
 		return "", false, err
 	}
 
-	for _, v := range resp.Minimal { //nolint:staticcheck // See https://github.com/sourcegraph/sourcegraph/issues/45814
+	for _, v := range resp.ReposMap {
 		return api.CommitID(v.Branches[0].Version), true, nil
 	}
 


### PR DESCRIPTION
Minor change to move to non-deprecated ReposMap. The final change in the series.

Test Plan: CI