### PR TITLE
App - Fix email verification if that occurs after app is started

### DIFF
--- a/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppWelcomeSetupStep.tsx
@@ -70,6 +70,9 @@ const EmailCheckVerificationForm: FC = () => {
     const { onNextStep } = useContext(SetupStepsContext)
     const { data } = useQuery(EMAIL_VERIFICATION_QUERY, { pollInterval: 3000 })
     const hasEmailBeenVerified = data?.user.hasVerifiedEmail ?? false
+    if (window.context.currentUser) {
+        window.context.currentUser.hasVerifiedEmail = hasEmailBeenVerified
+    }
 
     return (
         <div className={styles.emailForm}>


### PR DESCRIPTION
Currently Cody use in App requires a verified email, the web cody chat checks this against the window.context which is only updated during the initial loading of the page and any future reloads.

The App pauses until email verification occurs but this does not cause a page refresh so when the cody chat window loads it incorrectly things that the current user does not have a verified email.
## Test plan
Create a new user on dotcom - do not verify the email
Start release build of App  and connect to dotcom. Hit wait screen for verified email
Open email and verify
App allows me to continue, add & embed repos
Cody chat opens and works


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
