### PR TITLE
app: prepare for a more minimal distribution & reduce red-herring errors

### DIFF
--- a/enterprise/cmd/executor/internal/run/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/run/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//enterprise/cmd/executor/internal/worker/command",
         "//enterprise/cmd/executor/internal/worker/runner",
         "//enterprise/cmd/executor/internal/worker/workspace",
+        "//internal/conf/deploy",
         "//internal/download",
         "//internal/executor",
         "//internal/executor/types",

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -18,6 +18,7 @@ import (
 	apiworker "github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/command"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/worker/runner"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	executorutil "github.com/sourcegraph/sourcegraph/internal/executor/util"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -38,7 +39,7 @@ func newQueueTelemetryOptions(ctx context.Context, runner util.CmdRunner, useFir
 		logger.Error("Failed to get git version", log.Error(err))
 	}
 
-	if !config.IsKubernetes() {
+	if !config.IsKubernetes() && (!deploy.IsApp() || deploy.IsAppFullSourcegraph()) {
 		t.SrcCliVersion, err = util.GetSrcVersion(ctx, runner)
 		if err != nil {
 			logger.Error("Failed to get src-cli version", log.Error(err))

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -1,6 +1,9 @@
 package deploy
 
-import "os"
+import (
+	"os"
+	"strconv"
+)
 
 // Deploy type constants. Any changes here should be reflected in the DeployType type declared in client/web/src/jscontext.ts:
 // https://sourcegraph.com/search?q=r:github.com/sourcegraph/sourcegraph%24+%22type+DeployType%22
@@ -103,6 +106,15 @@ func IsValidDeployType(deployType string) bool {
 func IsApp() bool {
 	return Type() == App
 }
+
+// IsAppFullSourcegraph tells if the Cody app should run a full Sourcegraph instance (true),
+// or whether components not needed for the baseline Cody experience should be disabled
+// such as precise code intel, zoekt, etc.
+func IsAppFullSourcegraph() bool {
+	return IsApp() && appFullSourcegraph
+}
+
+var appFullSourcegraph, _ = strconv.ParseBool(os.Getenv("APP_FULL_SOURCEGRAPH"))
 
 // IsSingleBinary tells if the running deployment is a single-binary or not.
 //


### PR DESCRIPTION
Almost every user report I respond to has errors like this in their logs, which leads to users getting confused and thinking _that_ must be their issue (when in reality, it's some less verbose log line):

```
------------------------------------------------------------------------------|
 Docker is unavailable                                                        |
------------------------------------------------------------------------------|
 Sourcegraph is better when Docker is available; some features may not work:  
                                                                              
 - Batch changes                                                              
 - Symbol search                                                              
 - Symbols overview tab (on repository pages)                                 
                                                                              
------------------------------------------------------------------------------|
------------------------------------------------------------------------------|
 src-cli is unavailable                                                       |
------------------------------------------------------------------------------|
 Sourcegraph is better when src-cli is available; batch changes may not work. 
                                                                              
 Installation: https://github.com/sourcegraph/src-cli                         
                                                                              
------------------------------------------------------------------------------|

ERROR	service	run/util.go:44	github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/run.newQueueTelemetryOptions	Failed to get src-cli version	{"Resource": {"service.name": "sourcegraph-backend", "service.version": "2023.7.11+1384.7d20a90ce7", "service.instance.id": "ShankMacs-MacBook-Pro.local"}, "Attributes": {"error": "'src version -client-only': : exec: \"src\": executable file not found in $PATH"}}
ERROR	service	run/util.go:49	github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/run.newQueueTelemetryOptions	Failed to get docker version	{"Resource": {"service.name": "sourcegraph-backend", "service.version": "2023.7.11+1384.7d20a90ce7", "service.instance.id": "ShankMacs-MacBook-Pro.local"}, "Attributes": {"error": "'docker version -f {{.Server.Version}}': : exec: \"docker\": executable file not found in $PATH"}}
```

The verbosity of these errors made sense when the app was a single `sourcegraph` binary, and we wanted it to be a full Sourcegraph instance with precise code intel, zoekt, and more. These days, however, we removed code search from the product and it's just the Cody app. We're still doing the same stuff behind the scenes, and it's affecting the user experience.

What I have done is introduced an env var `APP_FULL_SOURCEGRAPH=false` by default, which one can check via `deploy.IsAppFullSourcegraph()` to determine if this Cody app should 'behave as a full Sourcegraph instance does'. By default, it is off - and we can use this to start disabling various logic while still keeping that code functional for when we _do_ want to bring it back in the future. I have used this to disable the red-herring errors above.

## Test plan

`sg start app` ran & didn't blow up, reading the code confirms this shouldn't affect any other deployment types.