### PR TITLE
all: replace "single binary OR app" with just "app" deploy type

### DIFF
--- a/cmd/symbols/internal/api/handler.go
+++ b/cmd/symbols/internal/api/handler.go
@@ -153,7 +153,7 @@ func handleSearchWith(l logger.Logger, searchFunc types.SearchFunc) http.Handler
 
 func handleListLanguages(ctagsBinary string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if deploy.IsSingleBinary() && ctagsBinary == "" {
+		if deploy.IsApp() && ctagsBinary == "" {
 			// app: ctags is not available
 			var mapping map[string][]string
 			if err := json.NewEncoder(w).Encode(mapping); err != nil {

--- a/cmd/symbols/shared/sqlite.go
+++ b/cmd/symbols/shared/sqlite.go
@@ -47,7 +47,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 	// anything that tries to open a SQLite database.
 	sqlite.Init()
 
-	if deploy.IsSingleBinary() && config.Ctags.UniversalCommand == "" {
+	if deploy.IsApp() && config.Ctags.UniversalCommand == "" {
 		// app: ctags is not available
 		searchFunc := func(ctx context.Context, params search.SymbolsParameters) (result.Symbols, error) {
 			return nil, nil
@@ -82,7 +82,7 @@ func SetupSqlite(observationCtx *observation.Context, db database.DB, gitserverC
 }
 
 func parserTypesForDeployment() []ctags_config.ParserType {
-	if deploy.IsSingleBinary() {
+	if deploy.IsApp() {
 		// ScipCtags is not available
 		// TODO(burmudar): make it available
 		return []ctags_config.ParserType{ctags_config.UniversalCtags}

--- a/cmd/symbols/types/types.go
+++ b/cmd/symbols/types/types.go
@@ -61,12 +61,12 @@ func LoadCtagsConfig(baseConfig env.BaseConfig) CtagsConfig {
 	}
 
 	ctagsCommandDefault := "universal-ctags"
-	if deploy.IsSingleBinary() {
+	if deploy.IsApp() {
 		ctagsCommandDefault = ""
 	}
 
 	scipCtagsCommandDefault := "scip-ctags"
-	if deploy.IsSingleBinary() {
+	if deploy.IsApp() {
 		scipCtagsCommandDefault = ""
 	}
 

--- a/internal/conf/deploy/deploytype.go
+++ b/internal/conf/deploy/deploytype.go
@@ -95,14 +95,6 @@ func IsValidDeployType(deployType string) bool {
 }
 
 // IsApp tells if the running deployment is a Sourcegraph App deployment.
-//
-// Sourcegraph App is always a single-binary, but not all single-binary deployments are
-// a Sourcegraph app.
-//
-// In the future, all Sourcegraph deployments will be a single-binary. For example gitserver will
-// be `sourcegraph --as=gitserver` or similar. Use IsSingleBinary() for code that should always
-// run in a single-binary setting, and use IsApp() for code that should only run as part of the
-// Sourcegraph desktop app.
 func IsApp() bool {
 	return Type() == App
 }
@@ -115,18 +107,3 @@ func IsAppFullSourcegraph() bool {
 }
 
 var appFullSourcegraph, _ = strconv.ParseBool(os.Getenv("APP_FULL_SOURCEGRAPH"))
-
-// IsSingleBinary tells if the running deployment is a single-binary or not.
-//
-// Sourcegraph App is always a single-binary, but not all single-binary deployments are
-// a Sourcegraph app.
-//
-// In the future, all Sourcegraph deployments will be a single-binary. For example gitserver will
-// be `sourcegraph --as=gitserver` or similar. Use IsSingleBinary() for code that should always
-// run in a single-binary setting, and use IsApp() for code that should only run as part of the
-// Sourcegraph desktop app.
-func IsSingleBinary() bool {
-	// TODO(single-binary): check in the future if this is any single-binary deployment, not just
-	// app.
-	return Type() == App
-}

--- a/internal/conf/deploy/endpoints.go
+++ b/internal/conf/deploy/endpoints.go
@@ -10,7 +10,7 @@ func BlobstoreDefaultEndpoint() string {
 	if IsApp() {
 		return "http://127.0.0.1:49000"
 	}
-	if IsSingleBinary() || IsDeployTypeSingleDockerContainer(Type()) {
+	if IsDeployTypeSingleDockerContainer(Type()) {
 		return "http://127.0.0.1:9000"
 	}
 	return "http://blobstore:9000"
@@ -21,7 +21,7 @@ func BlobstoreHostPort() (string, string) {
 	if IsApp() {
 		return "127.0.0.1", "49000"
 	}
-	if env.InsecureDev || IsSingleBinary() || IsDeployTypeSingleDockerContainer(Type()) {
+	if env.InsecureDev || IsDeployTypeSingleDockerContainer(Type()) {
 		return "127.0.0.1", "9000"
 	}
 	return "", "9000"

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1532,7 +1532,7 @@ func ExternalRepoSpec(repo *Repository, baseURL *url.URL) api.ExternalRepoSpec {
 }
 
 func githubBaseURLDefault() string {
-	if deploy.IsSingleBinary() {
+	if deploy.IsApp() {
 		return ""
 	}
 	return "http://github-proxy"

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -43,7 +43,7 @@ var addresses = func() struct {
 	for _, addr := range []string{
 		env.Get("REDIS_CACHE_ENDPOINT", "", "redis used for cache data. Default redis-cache:6379"),
 		fallback,
-		maybe(deploy.IsSingleBinary(), MemoryKeyValueURI),
+		maybe(deploy.IsApp(), MemoryKeyValueURI),
 		"redis-cache:6379",
 	} {
 		if addr != "" {
@@ -56,7 +56,7 @@ var addresses = func() struct {
 	for _, addr := range []string{
 		env.Get("REDIS_STORE_ENDPOINT", "", "redis used for persistent stores (eg HTTP sessions). Default redis-store:6379"),
 		fallback,
-		maybe(deploy.IsSingleBinary(), DBKeyValueURI("store")),
+		maybe(deploy.IsApp(), DBKeyValueURI("store")),
 		"redis-store:6379",
 	} {
 		if addr != "" {


### PR DESCRIPTION
Originally, the intent was to use the single-binary version of Sourcegraph in many more places. e.g. inside each enterprise Docker container, you'd find the single binary version of Sourcegraph.

This didn't really catch on with the rest of the company/team, I left the Delivery team so can't push this idea forward myself, and we ended up adding many more app-specific behaviors in the codebase. If we wanted this idea to come back, we would need to vet each `deploy.IsApp()` case to see which ones should apply to a 'single binary enterprise' version of Sourcegraph.

It's just not worth it right now, so removing.

## Test plan

Existing CI tests + careful manual review.
