### PR TITLE
trace: do not mutate Tracer.TracerProvider

### DIFF
--- a/internal/trace/tracer.go
+++ b/internal/trace/tracer.go
@@ -17,12 +17,13 @@ type Tracer struct {
 
 // New returns a new Trace with the specified name. Must be closed with Finish().
 func (t Tracer) New(ctx context.Context, name string, attrs ...attribute.KeyValue) (*Trace, context.Context) {
+	tracerProvider := t.TracerProvider
 	if t.TracerProvider == nil {
-		t.TracerProvider = otel.GetTracerProvider()
+		tracerProvider = otel.GetTracerProvider()
 	}
 
 	var otelSpan oteltrace.Span
-	ctx, otelSpan = t.TracerProvider.
+	ctx, otelSpan = tracerProvider.
 		Tracer("sourcegraph/internal/trace").
 		Start(ctx, name, oteltrace.WithAttributes(attrs...))
 


### PR DESCRIPTION
I read this code and thought I found a bug since New can be called concurrently. However, t is a value and not a pointer so it worked fine. I think using a local variable more clearly communicates intent and prevents potential heart rate spikes in developers.

Test Plan: go test