### PR TITLE
observation: set Tracer in TestContext

### DIFF
--- a/internal/observation/context.go
+++ b/internal/observation/context.go
@@ -41,13 +41,20 @@ func (c *Context) Clone(opts ...Opt) *Context {
 }
 
 // TestContext is a behaviorless Context usable for unit tests.
-var TestContext = Context{Logger: log.NoOp(), Registerer: metrics.NoOpRegisterer}
+var TestContext = Context{
+	Logger:     log.NoOp(),
+	Tracer:     &trace.Tracer{TracerProvider: oteltrace.NewNoopTracerProvider()},
+	Registerer: metrics.NoOpRegisterer,
+	// We do not set HoneyDataset since if we accidently have HONEYCOMB_TEAM
+	// set in a test run it will log to honeycomb.
+}
 
 // TestContextTB creates a Context similar to `TestContext` but with a logger scoped
 // to the `testing.TB`.
 func TestContextTB(t testing.TB) *Context {
 	return &Context{
 		Logger:     logtest.Scoped(t),
+		Tracer:     &trace.Tracer{TracerProvider: oteltrace.NewNoopTracerProvider()},
 		Registerer: metrics.NoOpRegisterer,
 	}
 }


### PR DESCRIPTION
We have observation code paths that test if Tracer is set and optionally do work then. Outside of test environments Tracer should be set. So by setting Tracer in our test context we should start exercising more code paths during go test.

Test Plan: CI