### PR TITLE
ref panel: switch from chevron up/down to right/down for open/closed

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
-import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronUp, mdiFilterOutline, mdiOpenInNew } from '@mdi/js'
+import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronRight, mdiFilterOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 import * as H from 'history'
 import { capitalize, uniqBy } from 'lodash'
@@ -594,9 +594,9 @@ const CollapsibleLocationList: React.FunctionComponent<
                         className="d-flex p-0 justify-content-start w-100"
                     >
                         {isOpen ? (
-                            <Icon aria-hidden={true} svgPath={mdiChevronUp} />
-                        ) : (
                             <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                        ) : (
+                            <Icon aria-hidden={true} svgPath={mdiChevronRight} />
                         )}{' '}
                         <H4 className="mb-0">{capitalize(props.name)}</H4>
                         <span className={classNames('ml-2 text-muted small', styles.cardHeaderSmallText)}>
@@ -839,7 +839,7 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                     type="button"
                     className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
                 >
-                    <Icon aria-hidden="true" svgPath={open ? mdiChevronUp : mdiChevronDown} />
+                    <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
                     <small>
                         <span className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}>
                             {displayRepoName(repoLocationGroup.repoName)}
@@ -963,9 +963,9 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                     )}
                 >
                     {open ? (
-                        <Icon aria-hidden={true} svgPath={mdiChevronUp} />
-                    ) : (
                         <Icon aria-hidden={true} svgPath={mdiChevronDown} />
+                    ) : (
+                        <Icon aria-hidden={true} svgPath={mdiChevronRight} />
                     )}
                     <small className={styles.locationGroupHeaderFilename}>
                         <span>


### PR DESCRIPTION
This has been bugging me for a long time. Last time we talked about this in March there was consensus that right/down are common in dev tools and that the existing solution is confusing.

### Before
![screenshot_2023-07-13_10 14 59@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/c125a1ce-567c-4064-823a-d583e9bf8f01)

### After
![screenshot_2023-07-13_10 15 24@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/435f3df4-529a-42c2-8937-532c3372983d)

### Other examples

#### VS Code

<img width="393" alt="screenshot_2023-07-13_10 18 17@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/8f7dad81-64b0-4305-a4f4-a78bd1326388">

#### Goland

<img width="515" alt="screenshot_2023-07-13_10 19 48@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/b44eccda-0f27-48fa-8bb1-2743910173d4">

#### Zed

<img width="313" alt="screenshot_2023-07-13_10 20 58@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/d3fb372a-fd0e-4762-b375-74e56ce45a4a">


## Test plan

- manual testing
