### PR TITLE
release: update sourcegraph release instance

### DIFF
--- a/dev/release/src/batchChanges.ts
+++ b/dev/release/src/batchChanges.ts
@@ -22,7 +22,7 @@ export async function sourcegraphCLIConfig(): Promise<SourcegraphCLIConfig> {
     await commandExists('src') // CLI must be present for batch change interactions
     return {
         SRC_ENDPOINT: DEFAULT_SRC_ENDPOINT,
-        // I updated the file name here to avoid a situation where folks with existing k8s.sgdev.org token
+        // I updated the file name here to avoid a situation where folks with existing s2 token
         // cached will get a 403 because it's not valid for S2.
         SRC_ACCESS_TOKEN: await readLine('s2 src-cli token: ', `${cacheFolder}/src-cli-s2.txt`),
     }

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -15,7 +15,7 @@ import { getPreviousVersionExecutor, getPreviousVersionSrcCli } from './git'
 import { cloneRepo, EditFunc, getAuthenticatedGitHubClient, listIssues } from './github'
 import * as update from './update'
 
-const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://k8s.sgdev.org'
+const SOURCEGRAPH_RELEASE_INSTANCE_URL = 'https://sourcegraph.sourcegraph.com'
 
 export interface ReleaseTag {
     repo: string

--- a/dev/release/templates/patch_release_issue_template.md
+++ b/dev/release/templates/patch_release_issue_template.md
@@ -81,7 +81,7 @@ Once there is a release candidate available:
   ```
 - [ ] Ensure that the pipeline for the `v$MAJOR.$MINOR.$PATCH` tag has passed: [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH)
 - [ ] Wait for the `v$MAJOR.$MINOR.$PATCH` release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags)
-- [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes)):
+- [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://sourcegraph.sourcegraph.com/organizations/sourcegraph/batch-changes)):
   ```sh
   pnpm run release release:stage
   ```
@@ -90,7 +90,7 @@ Once there is a release candidate available:
 
 <!-- Keep in sync with release_issue_template's "Finalize release" section, except no blog post -->
 
-- [ ] From the [release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes), merge the release-publishing PRs created previously. Note: some PRs require certain actions performed before merging.
+- [ ] From the [release batch change](https:/sourcegraph.sourcegraph.com/organizations/sourcegraph/batch-changes), merge the release-publishing PRs created previously. Note: some PRs require certain actions performed before merging.
 - [ ] **After all the PRs are merged**, perform following checks/actions
   - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)
     - [ ] Ensure the [release tag](https://github.com/sourcegraph/deploy-sourcegraph/tags) has been created

--- a/dev/release/templates/release_issue_template.md
+++ b/dev/release/templates/release_issue_template.md
@@ -146,7 +146,7 @@ On the day of the release, confirm there are no more release-blocking issues (as
 - [ ] Ensure that the following pipelines all pass for the `v$MAJOR.$MINOR.$PATCH` tag:
   - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH)
 - [ ] Wait for the `v$MAJOR.$MINOR.$PATCH` release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags)
-- [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes)):
+- [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://sourcegraph.sourcegraph.com/organizations/sourcegraph/batch-changes)):
 
   ```sh
   pnpm run release release:stage
@@ -154,7 +154,7 @@ On the day of the release, confirm there are no more release-blocking issues (as
 
 ### Finalize release
 
-- [ ] From the [release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes), merge the release-publishing PRs created previously.
+- [ ] From the [release batch change](https://sourcegraph.sourcegraph.com/organizations/sourcegraph/batch-changes), merge the release-publishing PRs created previously.
   - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)
     - [ ] Ensure the [release tag `v$MAJOR.$MINOR.$PATCH`](https://github.com/sourcegraph/deploy-sourcegraph/tags) has been created
   - For [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
I noticed some of the release templates didn't have the `S2` instance as the release instance. This fixes that.