### PR TITLE
docs: update docs for user deletion

### DIFF
--- a/doc/admin/user_data_deletion.md
+++ b/doc/admin/user_data_deletion.md
@@ -9,7 +9,7 @@ On this page, you are presented two options:
 
 When deleting a user with either option, the following information is removed:
 
-- All user data (access tokens, email addresses, external account info, survey responses, etc)
+- All user data (access tokens, email addresses, external account info, repository permissions, survey responses, etc.)
 - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
 - Sourcegraph extensions published by the user on the instance the deletion request is sent to.
 - User, Organization, or Global settings authored or modified by the user.
@@ -27,6 +27,7 @@ When a user or organization is deleted (for both "delete" or "delete forever"), 
 | Code Insight chart | Sometimes | Private insights never shared with others are deleted. Insights shared to org-visible or global dashboards persist as long as the org and global dashboard continue to exist. |
 | Code Insight dashboard | Sometimes | If the dashboard was private to the user it is deleted on the user deletion; if it was private to the org it is deleted on the org deletion. If it was a global dashboard, it will continue to exist. |
 | Code Monitor | Yes | If the user that created the code monitor is deleted, their code monitors are deleted and will no longer trigger new actions. |
+| Repository Permissions | Yes | If you delete the user, the associated repository permissions will be deleted as well via a database trigger. If the user is revived later, the permissions need to be synced again. |
 | Search Notebook | Yes | If you delete the user or organization that owns the notebook, it no longer appears in the UI. In the organization-owned case, it's still preserved in the database. |
 | Search Context | Yes | If you delete the user or organization that owns the context, it no longer appears in the UI.  In cases where it was an organization notebook, it is preserved in the database. |
 | Settings file (extensions, experimental features, defaults) | Yes | If you delete the user or organization, the associated settings file is deleted. |

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -597,6 +597,7 @@ func (u *userStore) Update(ctx context.Context, id int32, update UserUpdate) (er
 }
 
 // Delete performs a soft-delete of the user and all resources associated with this user.
+// Permissions for soft-deleted users are removed from the user_repo_permissions table via a trigger.
 func (u *userStore) Delete(ctx context.Context, id int32) (err error) {
 	return u.DeleteList(ctx, []int32{id})
 }


### PR DESCRIPTION
Make it clear that deleting a user also removes their repository permissions.

## Test plan

N/A: Just a comment change and docs update.
