### PR TITLE
JetBrains: Cody: don't throw exceptions when the enterprise instance is down

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- Downgraded connection errors for invalid or inaccessible enterprise instances to warnings [#54916](https://github.com/sourcegraph/sourcegraph/pull/54916)
+
 ### Security
 
 ## [3.0.4]

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/ChatUpdaterCallbacks.java
@@ -54,7 +54,7 @@ public class ChatUpdaterCallbacks implements CompletionsCallbacks {
     String message = error.getMessage();
     chat.respondToErrorFromServer(message != null ? message : "");
     chat.finishMessageProcessing();
-    logger.error("Error: " + error);
+    logger.warn(error);
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/SourcegraphNodeCompletionsClient.java
@@ -60,8 +60,8 @@ public class SourcegraphNodeCompletionsClient {
 
     @Override
     public void onError(Throwable error) {
-      promise.completeExceptionally(error);
-      logger.error(error);
+      promise.complete(new CompletionResponse("", error.getMessage()));
+      logger.warn(error);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/132 
(@vdavid can you update the ticket? I don't seem to have the right permissions to that board)

This is a temporary solution, I merely downgrade the errors to warnings.
What we should have is proper bubble notifications for error cases so that the user has feedback on what went wrong, why and how to fix it. 

We probably should change all the `logger.error` lines to an appropriate notification once we have the flows designed.

## Test plan
- check if the problem described in the issue is replicable
- green CI
