### PR TITLE
JetBrains: Cody: Gracefully recover from errors

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -596,7 +596,7 @@ class CodyToolWindowContent implements UpdatableChat {
                       this,
                       cancellationToken);
                 } catch (Exception e) {
-                  logger.error("Error sending message '" + humanMessage + "' to chat", e);
+                  logger.warn("Error sending message '" + humanMessage + "' to chat", e);
                 }
               } else {
                 List<ContextMessage> contextMessages =
@@ -620,7 +620,7 @@ class CodyToolWindowContent implements UpdatableChat {
                 try {
                   chat.sendMessageWithoutAgent(prompt, responsePrefix, this, cancellationToken);
                 } catch (Exception e) {
-                  logger.error("Error sending message '" + humanMessage + "' to chat", e);
+                  logger.warn("Error sending message '" + humanMessage + "' to chat", e);
                 }
               }
               GraphQlLogger.logCodyEvent(this.project, "recipe:chat-question", "executed");

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -107,12 +107,12 @@ public class CodyAgent implements Disposable {
             } catch (Exception e) {
               initializationErrorMessage =
                   "failed to send 'initialize' JSON-RPC request Cody agent";
-              logger.error(initializationErrorMessage, e);
+              logger.warn(initializationErrorMessage, e);
             }
           });
     } catch (Exception e) {
       initializationErrorMessage = "unable to start Cody agent";
-      logger.error(initializationErrorMessage, e);
+      logger.warn(initializationErrorMessage, e);
     }
   }
 
@@ -197,7 +197,7 @@ public class CodyAgent implements Disposable {
             Files.newOutputStream(
                 trace, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING));
       } catch (IOException e) {
-        logger.error("unable to trace JSON-RPC debugging information to path " + tracePath, e);
+        logger.warn("unable to trace JSON-RPC debugging information to path " + tracePath, e);
       }
     }
     return null;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/SSEClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/SSEClient.java
@@ -110,7 +110,7 @@ public class SSEClient {
       try {
         inputStream.close();
       } catch (Exception e) {
-        logger.error("Got error stopCurrentRequest: " + e.getMessage());
+        logger.warn("Got error stopCurrentRequest: " + e.getMessage());
       }
     }
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteProviderType.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteProviderType.java
@@ -17,7 +17,7 @@ public enum AutoCompleteProviderType {
     try {
       return Optional.of(AutoCompleteProviderType.valueOf(normalizedName));
     } catch (IllegalArgumentException e) {
-      logger.error("Cody: Error: Invalid autocomplete provider type: " + name);
+      logger.warn("Cody: Error: Invalid autocomplete provider type: " + name);
       return Optional.empty();
     }
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -165,7 +165,7 @@ public class CodyAutoCompleteManager {
                         });
               } catch (Exception e) {
                 // TODO: do something smarter with unexpected errors.
-                logger.error(e);
+                logger.warn(e);
               }
             });
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AnthropicAutoCompleteProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AnthropicAutoCompleteProvider.java
@@ -41,7 +41,7 @@ public class AnthropicAutoCompleteProvider extends AutoCompleteProvider {
   @Override
   protected List<Message> createPromptPrefix() {
     String[] prefixLines = this.prefix.split("\n");
-    if (prefixLines.length == 0) logger.error("Cody: Anthropic: missing prefix lines");
+    if (prefixLines.length == 0) logger.warn("Cody: Anthropic: missing prefix lines");
 
     PrefixComponents pc = getHeadAndTail(this.prefix);
 
@@ -68,7 +68,7 @@ public class AnthropicAutoCompleteProvider extends AutoCompleteProvider {
     // Create prompt
     List<Message> prompt = this.createPrompt();
     if (prompt.size() > this.promptChars) {
-      logger.error("Cody: Anthropic: prompt length exceeded maximum allotted chars");
+      logger.warn("Cody: Anthropic: prompt length exceeded maximum allotted chars");
       return CompletableFuture.completedFuture(Collections.emptyList());
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/UnstableCodegenEndOfLineAutoCompleteProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/UnstableCodegenEndOfLineAutoCompleteProvider.java
@@ -89,7 +89,7 @@ public class UnstableCodegenEndOfLineAutoCompleteProvider extends AutoCompletePr
 
       return result;
     } catch (JsonProcessingException | UnsupportedEncodingException e) {
-      logger.error(e);
+      logger.warn(e);
       return null;
     }
   }
@@ -102,7 +102,7 @@ public class UnstableCodegenEndOfLineAutoCompleteProvider extends AutoCompletePr
         () -> {
           StringEntity params = getParams();
           if (params == null) {
-            logger.error("Cody: Could not create params for unstable-codegen");
+            logger.warn("Cody: Could not create params for unstable-codegen");
             return Collections.emptyList();
           }
           HttpPost httpPost = new HttpPost(autocompleteEndpoint);
@@ -118,7 +118,7 @@ public class UnstableCodegenEndOfLineAutoCompleteProvider extends AutoCompletePr
             CloseableHttpResponse response = client.execute(httpPost);
             int responseCode = response.getStatusLine().getStatusCode();
             if (responseCode != 200) {
-              logger.error(
+              logger.warn(
                   "Cody: `unstable-codegen` autocomplete provider returned non-200 response code: "
                       + responseCode);
               return Collections.emptyList();
@@ -144,10 +144,10 @@ public class UnstableCodegenEndOfLineAutoCompleteProvider extends AutoCompletePr
                   .collect(Collectors.toList());
             }
           } catch (ConnectException e) {
-            logger.error("Cody: Could not connect to the 'unstable-codegen' autocomplete provider");
+            logger.warn("Cody: Could not connect to the 'unstable-codegen' autocomplete provider");
             return Collections.emptyList();
           } catch (Exception e) {
-            logger.error(e);
+            logger.warn(e);
             return Collections.emptyList();
           }
           return Collections.emptyList();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/WebviewErrorMessenger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/WebviewErrorMessenger.java
@@ -6,6 +6,6 @@ public class WebviewErrorMessenger {
   private static final Logger logger = Logger.getInstance(WebviewErrorMessenger.class);
 
   public void show(String message) {
-    logger.error("WebviewErrorMessenger: " + message);
+    logger.warn("WebviewErrorMessenger: " + message);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppManager.java
@@ -125,7 +125,7 @@ public class LocalAppManager {
               try {
                 Desktop.getDesktop().open(new File(p.codyAppFile.toString()));
               } catch (IOException e) {
-                logger.error(e);
+                logger.warn(e);
               }
             });
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/localapp/LocalAppPaths.java
@@ -51,7 +51,7 @@ public class LocalAppPaths {
         LocalAppInfo appInfo = objectMapper.readValue(jsonContent, LocalAppInfo.class);
         return Optional.of(appInfo);
       } catch (IOException e) {
-        logger.error("Error reading local Cody app JSON file: " + e.getMessage());
+        logger.warn("Error reading local Cody app JSON file: " + e.getMessage());
         return Optional.empty();
       }
     } else return Optional.empty();

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ThemeUtil.java
@@ -28,7 +28,7 @@ public class ThemeUtil {
           intelliJTheme.addProperty(key.toString(), getHexString(UIManager.getColor(key)));
         }
       } catch (Exception e) {
-        logger.error(e.getMessage());
+        logger.warn(e.getMessage());
       }
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindService.java
@@ -99,7 +99,7 @@ public class FindService implements Disposable {
                   try {
                     mainPanel.getPreviewPanel().getPreviewContent().openInEditorOrBrowser();
                   } catch (Exception e) {
-                    logger.error("Error opening file in editor", e);
+                    logger.warn("Error opening file in editor", e);
                   }
                 });
         return true;

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -144,7 +144,7 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
               }
             } catch (Exception ex) {
               Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
-              logger.error("Error opening file in editor: " + ex.getMessage());
+              logger.warn("Error opening file in editor: " + ex.getMessage());
             }
           }
         });

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/SelectionMetadataPanel.java
@@ -31,7 +31,7 @@ public class SelectionMetadataPanel extends JPanel {
                   previewContent.openInEditorOrBrowser();
                 } catch (Exception e) {
                   Logger logger = Logger.getInstance(SelectionMetadataPanel.class);
-                  logger.error(
+                  logger.warn(
                       "Error opening file in editor: \"" + selectionMetadataLabel.getText() + "\"",
                       e);
                 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -65,7 +65,7 @@ public class RepoUtil {
       }
       ErrorNotification.show(project, message);
       Logger.getInstance(RepoUtil.class).warn(message);
-      logger.error(err);
+      logger.warn(err);
     }
     return new RepoInfo(
         vcsType,


### PR DESCRIPTION
This is a rather simple follow-up to https://github.com/sourcegraph/sourcegraph/pull/54916
We probably shouldn't throw exceptions for error states. 
as `logger.error` does rethrow the exception, it should probably be used with care.
I swapped all of its uses to `logger.warn` for now.
It provides better UX to try and gracefully recover while logging the stacktrace.
Once more, we should have some sort of invalid state feedback in the form of notifications for the user at some point.


## Test plan

- green CI 🟢 
