### PR TITLE
executors: Remove beta and experimental tags for server-side execution

### DIFF
--- a/doc/batch_changes/explanations/server_side.md
+++ b/doc/batch_changes/explanations/server_side.md
@@ -1,11 +1,5 @@
 # Running batch changes server-side
 
-<aside class="beta">
-<p>
-<span class="badge badge-beta">Beta</span> <strong>This feature is currently in beta.</strong>
-</p>
-</aside>
-
 By default, Batch Changes uses a command line interface in your local environment to [compute diffs](how_src_executes_a_batch_spec.md) and create changesets. This can be impractical for creating batch changes affecting hundreds or thousands of repositories, with large numbers of workspaces, or if the batch change steps require CPU, memory, or disk resources that are unavailable locally.
 
 Instead of computing Batch Changes locally using `src-cli`, you can offload this task to one or many remote server called an [executor](../../admin/executors/deploy_executors.md). Executors are also required to enable code navigation [auto-indexing](../../code_navigation/explanations/auto_indexing.md).

--- a/doc/batch_changes/explanations/server_side_debugging.md
+++ b/doc/batch_changes/explanations/server_side_debugging.md
@@ -1,7 +1,5 @@
 # Debugging when you run batch changes server-side
 
-<aside class="experimental">This feature is experimental. Follow the <a href="server_side#setup">setup guide</a> to get started.</aside>
-
 When you run batch changes server-side, you can monitor various artifacts of an execution, like per-step logs, timing information and output variables in a persisted, sharable UI.
 
 From the UI, you can start from a high level perspective for the entire batch spec and then drill down to find the problem.

--- a/doc/batch_changes/explanations/server_side_getting_started.md
+++ b/doc/batch_changes/explanations/server_side_getting_started.md
@@ -1,7 +1,5 @@
 # Getting started with running batch changes server-side
 
-<aside class="experimental">This feature is experimental. Follow the <a href="server_side#setup">setup guide</a> to get started.</aside>
-
 ## Creating your first batch change
 
 To get started, click on the "Create batch change" button on the Batch Changes page, or go to `/batch-changes/create`.

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -74,7 +74,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Batch Changes design](explanations/batch_changes_design.md)
 - [How `src` executes a batch spec](explanations/how_src_executes_a_batch_spec.md)
 - [Re-executing batch specs multiple times](explanations/reexecuting_batch_specs_multiple_times.md)
-- <span class="badge badge-beta">Beta</span> [Running batch changes server-side](explanations/server_side.md)
+- [Running batch changes server-side](explanations/server_side.md)
 
 ## How-tos
 


### PR DESCRIPTION
I missed some tags when we GA executors for server-side execution.

## Test plan

No tests, just docs.