### PR TITLE
[draft] App - disable need for a verified email to use cody

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -576,15 +576,6 @@ func (r *siteResolver) PerUserCodeCompletionsQuota() *int32 {
 }
 
 func (r *siteResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
-	// This section can be removed if dotcom stops requiring verified emails
-	if deploy.IsApp() {
-		c := conf.GetCompletionsConfig(conf.Get().SiteConfig())
-		// App users can specify their own keys using one of the regular providers.
-		// If they use their own keys requests are not going through Cody Gateway
-		// which means a verified email is not needed.
-		return c == nil || c.Provider == conftypes.CompletionsProviderNameSourcegraph
-	}
-
 	// We only require this on dotcom
 	if !envvar.SourcegraphDotComMode() {
 		return false

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -2,11 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
@@ -17,94 +12,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 var timeNow = time.Now
 
 func (r *UserResolver) HasVerifiedEmail(ctx context.Context) (bool, error) {
-	if deploy.IsApp() {
-		return r.hasVerifiedEmailOnDotcom(ctx)
-	}
-
-	return r.hasVerifiedEmail(ctx)
-}
-
-func (r *UserResolver) hasVerifiedEmail(ctx context.Context) (bool, error) {
 	// 🚨 SECURITY: In the UserEmailsService we check that only the
 	// authenticated user and site admins can check
 	// whether the user has a verified email.
 	return backend.NewUserEmailsService(r.db, r.logger).HasVerifiedEmail(ctx, r.user.ID)
-}
-
-// hasVerifiedEmailOnDotcom - checks with sourcegraph.com to ensure the app user has verified email.
-func (r *UserResolver) hasVerifiedEmailOnDotcom(ctx context.Context) (bool, error) {
-	// 🚨 SECURITY: This resolves HasVerifiedEmail only for App by
-	// sending the request to dotcom to check if a verified email exists for the user.
-	// Dotcom will ensure that only the authenticated user and site admins can check
-	if !deploy.IsApp() {
-		return false, errors.New("attempt to check dotcom email verified outside of sourcegraph app")
-	}
-
-	if envvar.SourcegraphDotComMode() {
-		return false, errors.New("attempt to check dotcom email verified outside of sourcegraph app")
-	}
-
-	// If app isn't configured with dotcom auth return false immediately
-	appConfig := conf.Get().App
-	if appConfig == nil {
-		return false, nil
-	}
-	if len(appConfig.DotcomAuthToken) <= 0 {
-		return false, nil
-	}
-
-	// If we have an app user with a dotcom authtoken ask dotcom if the user has a verified email
-	url := "https://sourcegraph.com/.api/graphql?AppHasVerifiedEmailCheck"
-	cli := httpcli.ExternalDoer
-	payload := strings.NewReader(`{"query":"query AppHasVerifiedEmailCheck{ currentUser { hasVerifiedEmail } }","variables":{}}`)
-
-	// Send GraphQL request to sourcegraph.com to check if email is verified
-	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
-	if err != nil {
-		r.logger.Warn("failed creating email verification request ", log.Error(err))
-		return false, nil
-	}
-	req.Header.Add("Authorization", fmt.Sprintf("token %s", appConfig.DotcomAuthToken))
-
-	resp, err := cli.Do(req)
-	if err != nil {
-		r.logger.Warn("email verification request failed", log.Error(err))
-		return false, nil
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		r.logger.Warn("email verification failed", log.Int("status", resp.StatusCode))
-		return false, nil
-	}
-
-	// Get the response
-	type Response struct {
-		Data struct {
-			CurrentUser struct{ HasVerifiedEmail bool }
-		}
-	}
-	var result Response
-	b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
-	if err != nil {
-		r.logger.Warn("unable to read verified email response", log.Error(err))
-		return false, nil
-	}
-	if err := json.Unmarshal(b, &result); err != nil {
-		r.logger.Warn("unable to unmarshal verified email response", log.Error(err))
-		return false, nil
-	}
-
-	return result.Data.CurrentUser.HasVerifiedEmail, nil
 }
 
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -61,14 +61,10 @@ func (r CodyGatewayDotcomUserResolver) CodyGatewayDotcomUserByToken(ctx context.
 		}
 		return nil, err
 	}
-	verified, err := r.DB.UserEmails().HasVerifiedEmail(ctx, user.ID)
-	if err != nil {
-		return nil, err
-	}
+
 	return &dotcomCodyUserResolver{
-		db:            r.DB,
-		user:          user,
-		verifiedEmail: verified,
+		db:   r.DB,
+		user: user,
 	}, nil
 
 }
@@ -101,7 +97,7 @@ type codyUserGatewayAccessResolver struct {
 	verifiedEmail bool
 }
 
-func (r codyUserGatewayAccessResolver) Enabled() bool { return r.user.SiteAdmin || r.verifiedEmail }
+func (r codyUserGatewayAccessResolver) Enabled() bool { return true }
 
 func (r codyUserGatewayAccessResolver) ChatCompletionsRateLimit(ctx context.Context) (graphqlbackend.CodyGatewayRateLimit, error) {
 	// If the user isn't enabled return no rate limit

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -93,9 +93,9 @@ func TestCodyGatewayDotcomUserResolver(t *testing.T) {
 		{
 			name:        "unverified user",
 			user:        unverifiedUser,
-			wantChat:    0,
-			wantCode:    0,
-			wantEnabled: false,
+			wantChat:    graphqlbackend.BigInt(cfg.Completions.PerUserDailyLimit),
+			wantCode:    graphqlbackend.BigInt(cfg.Completions.PerUserCodeCompletionsDailyLimit),
+			wantEnabled: true,
 		},
 		{
 			name:        "override user",


### PR DESCRIPTION
The changes to `enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go` effectively disable the requirement for a verified email for App, that resolver is what the gateway checks to see if the user is allowed to use Cody, this would take effect when it rolls out to dotcom.

The change to the user_emails resolver unwinds the hack we put in place to forward those requests to dotcom to determine if the user does in fact have a verified email.   Removing this will mean the App's user will default to the auto created admin and that user have a verified email.  This should mean that all the setup steps are skipped but they should also be removed. 

I did not test this draft only.  Don't merge without testing.

## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
