### PR TITLE
Embeddings: re-render the label every time the input changes

### DIFF
--- a/client/branded/src/components/Timestamp/Timestamp.tsx
+++ b/client/branded/src/components/Timestamp/Timestamp.tsx
@@ -55,6 +55,10 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Timestam
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout, noAgo))
     useEffect(() => {
+        // Update the label
+        setLabel(calculateLabel(date, now, strict, noAbout, noAgo))
+
+        // Refresh the label periodically
         const intervalHandle = window.setInterval(
             () => setLabel(calculateLabel(date, now, strict, noAbout, noAgo)),
             RERENDER_INTERVAL_MSEC


### PR DESCRIPTION
Previously, we would not re-render the label except on a timer. This updates it so that whenever the inputs change, we rerender immediately, then set a timer to update the label as time progresses.
<img width="451" alt="Screenshot 2023-07-13 at 15 24 50" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/28a225bb-71f8-4249-9170-bfb45572a1b3">

## Test plan

Tested manually that the rendered label is correct and matches the tooltip, even on update and refresh.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
