### PR TITLE
Embeddings: populate cache in background

### DIFF
--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//internal/observation",
         "//internal/service",
         "//internal/trace",
+        "//internal/xcontext",
         "//lib/errors",
         "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_prometheus_client_golang//prometheus",


### PR DESCRIPTION
If a query times out or a user navigates away while we are fetching an embeddings index, the fetch is canceled because it shares a context with the request. Instead, this PR updates the logic to spin up a detached background goroutine that will populate the cache 

## Test plan

Ran a query that was immediately canceled, then checked that a followup query did not miss the cache.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
