### PR TITLE
Blob UI: Improve file path breadcrumbs UI 

### DIFF
--- a/client/web/src/components/Breadcrumbs.tsx
+++ b/client/web/src/components/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useMemo, useCallback } from 'react'
+import React, { FC, useState, useEffect, useMemo, useCallback, ReactNode } from 'react'
 
 import { mdiChevronRight } from '@mdi/js'
 import classNames from 'classnames'
@@ -151,12 +151,13 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
 interface BreadcrumbsInternalProps {
     breadcrumbs: BreadcrumbAtDepth[]
     className?: string
+    children?: ReactNode
 }
 
 /**
  * Renders breadcrumbs by depth.
  */
-export const Breadcrumbs: FC<BreadcrumbsInternalProps> = ({ breadcrumbs, className }) => {
+export const Breadcrumbs: FC<BreadcrumbsInternalProps> = ({ breadcrumbs, className, children }) => {
     const location = useLocation()
 
     return (
@@ -192,6 +193,7 @@ export const Breadcrumbs: FC<BreadcrumbsInternalProps> = ({ breadcrumbs, classNa
                         </span>
                     )
                 })}
+            {children}
         </nav>
     )
 }

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -450,7 +450,7 @@ describe('Repository', () => {
             const breadcrumbTexts = await driver.page.evaluate(() =>
                 [...document.querySelectorAll('.test-breadcrumb')].map(breadcrumb => breadcrumb.textContent?.trim())
             )
-            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', `/${clickedFileName}`])
+            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', `${clickedFileName}`])
 
             // Return to repo page
             await driver.page.waitForSelector('.test-repo-header-repo-link')
@@ -546,7 +546,7 @@ describe('Repository', () => {
             assert.deepStrictEqual(breadcrumbTexts, [
                 shortRepositoryName,
                 '@master',
-                "/Geoffrey's random queries.32r242442bf/% token.4288249258.sql",
+                "Geoffrey's random queries.32r242442bf/% token.4288249258.sql",
             ])
 
             {
@@ -605,7 +605,7 @@ describe('Repository', () => {
             const breadcrumbTexts = await driver.page.evaluate(() =>
                 [...document.querySelectorAll('.test-breadcrumb')].map(breadcrumb => breadcrumb.textContent?.trim())
             )
-            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', '/readme.md'])
+            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', 'readme.md'])
         })
 
         it('shows repo cloning in progress page', async () => {
@@ -654,7 +654,7 @@ describe('Repository', () => {
             const breadcrumbTexts = await driver.page.evaluate(() =>
                 [...document.querySelectorAll('.test-breadcrumb')].map(breadcrumb => breadcrumb.textContent?.trim())
             )
-            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', '/readme.md'])
+            assert.deepStrictEqual(breadcrumbTexts, [shortRepositoryName, '@master', 'readme.md'])
         })
     })
 

--- a/client/web/src/repo/FilePathBreadcrumbs.module.scss
+++ b/client/web/src/repo/FilePathBreadcrumbs.module.scss
@@ -1,31 +1,4 @@
 .file-path-breadcrumbs {
-    display: flex;
-    min-width: 0;
-    overflow: hidden;
-    align-items: center;
-    white-space: nowrap;
-    justify-content: flex-end;
-
-    .part {
-        /* Ensure focus shadow is not clipped by overflow: hidden */
-        margin: 0.125rem;
-    }
-
-    .root-directory {
-        min-width: 0.5rem !important;
-    }
-
-    .part-directory {
-        min-width: 1px;
-        max-width: fit-content;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        text-align: center;
-    }
-
-    .part-separator {
-        color: var(--link-color);
-        min-width: 0.5em;
-        text-align: center;
-    }
+    min-width: 7rem;
+    flex-grow: 1;
 }

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -1,133 +1,37 @@
-import * as React from 'react'
+import { FC } from 'react'
 
-import classNames from 'classnames'
-
+import { CopyPathAction } from '@sourcegraph/branded'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { toRepoURL, RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
-import { Tooltip, LinkOrSpan, useIsTruncated } from '@sourcegraph/wildcard'
+import { RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
+import { Breadcrumbs } from '@sourcegraph/wildcard'
 
 import { toTreeURL } from '../util/url'
 
 import styles from './FilePathBreadcrumbs.module.scss'
 
-interface Props extends RepoRevision, TelemetryProps {
-    filePath: string
+interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps {
     isDir: boolean
+    filePath: string
 }
-
-const MAX_ITEMS = 20
 
 /**
  * Displays a file path in a repository in breadcrumb style, with ancestor path
  * links.
  */
-export const FilePathBreadcrumbs: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
-    repoName,
-    revision,
-    filePath,
-    isDir,
-    telemetryService,
-}) => {
-    const parts = filePath.split('/')
-    const partToUrl = (index: number): string => {
-        const partPath = parts.slice(0, index + 1).join('/')
-        if (isDir || index < parts.length - 1) {
+export const FilePathBreadcrumbs: FC<FilePathBreadcrumbsProps> = props => {
+    const { repoName, revision, filePath, isDir, telemetryService } = props
+
+    const partToUrl = (segment: string, index: number, segments: string[]): string => {
+        const partPath = segments.slice(0, index + 1).join('/')
+        if (isDir || index < segments.length - 1) {
             return toTreeURL({ repoName, revision, filePath: partPath })
         }
         return toPrettyBlobURL({ repoName, revision, filePath: partPath })
     }
-    const partToClassName = (index: number): string =>
-        index === parts.length - 1
-            ? 'test-breadcrumb-part-last'
-            : classNames('test-breadcrumb-part-directory', styles.partDirectory)
 
-    // Ensure that we never show more than at most MAX_ITEMS elements
-    const truncatedElements = parts.length > MAX_ITEMS ? parts.length - MAX_ITEMS : 0
-
-    const spans: JSX.Element[] = [
-        <FilePath
-            key="root-dir"
-            label="/"
-            className={classNames('test-breadcrumb-part-directory', styles.partDirectory, styles.rootDirectory)}
-            isFirst={true}
-            isLast={false}
-            link={toRepoURL({ repoName, revision })}
-            onClick={() => telemetryService.log('RootBreadcrumbClicked', { action: 'click', label: 'root directory' })}
-        />,
-    ]
-
-    if (truncatedElements > 0) {
-        const truncatedParts = parts.slice(0, truncatedElements)
-        const truncatedPath = truncatedParts.join('/')
-        const link = partToUrl(truncatedParts.length - 1)
-        spans.push(
-            <FilePath
-                key="truncated-dir"
-                className={classNames('test-breadcrumb-part-truncated', styles.partDirectory)}
-                link={link}
-                isFirst={false}
-                isLast={false}
-                label="..."
-                fullLabel={truncatedPath}
-            />
-        )
-    }
-
-    for (const [index, part] of parts.entries()) {
-        if (index < truncatedElements) {
-            continue
-        }
-
-        const link = partToUrl(index)
-        const className = classNames(styles.part, partToClassName?.(index))
-        const isLast = index === parts.length - 1
-        spans.push(
-            <FilePath
-                key={`link-${index}`}
-                className={className}
-                link={link}
-                isFirst={false}
-                isLast={index === parts.length - 1}
-                label={part}
-            />
-        )
-        if (!isLast) {
-            spans.push()
-        }
-    }
-
-    // Important: do not put spaces between the breadcrumbs or spaces will get added when copying the path
-    return <span className={styles.filePathBreadcrumbs}>{spans}</span>
-}
-
-interface FilePathProps {
-    label: string
-    isFirst: boolean
-    isLast: boolean
-    className: string
-    link: string
-    fullLabel?: string
-    onClick?: () => void
-}
-function FilePath({ label, isFirst, isLast, className, link, fullLabel, onClick }: FilePathProps): JSX.Element {
-    const [ref, truncated, checkTruncation] = useIsTruncated<HTMLAnchorElement>()
     return (
-        <>
-            <Tooltip content={fullLabel || (truncated ? label : null)}>
-                <LinkOrSpan
-                    className={className}
-                    to={link}
-                    onFocus={checkTruncation}
-                    onMouseEnter={checkTruncation}
-                    aria-current={isLast ? 'page' : 'false'}
-                    aria-label={fullLabel}
-                    ref={ref}
-                    onClick={onClick}
-                >
-                    {label}
-                </LinkOrSpan>
-            </Tooltip>
-            {!isFirst && !isLast ? <span className={styles.partSeparator}>/</span> : null}
-        </>
+        <Breadcrumbs filename={filePath} getSegmentLink={partToUrl} className={styles.filePathBreadcrumbs}>
+            <CopyPathAction filePath={filePath} telemetryService={telemetryService} />
+        </Breadcrumbs>
     )
 }

--- a/client/web/src/repo/RepoHeader.module.scss
+++ b/client/web/src/repo/RepoHeader.module.scss
@@ -1,9 +1,10 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .repo-header {
-    flex: none;
-    padding: 0;
+    display: flex;
+    flex-wrap: nowrap;
     align-items: center;
+    padding: 0;
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
 
@@ -25,8 +26,16 @@
     }
 }
 
+.breadcrumb {
+    flex-grow: 1;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+
 .action-list {
     gap: 0.625rem;
+    margin-left: auto;
 }
 
 .action-list-item:not(:empty) {

--- a/client/web/src/repo/RepoHeader.story.tsx
+++ b/client/web/src/repo/RepoHeader.story.tsx
@@ -123,7 +123,7 @@ const createBreadcrumbs = (path: string) => [
     {
         breadcrumb: {
             key: 'treePath',
-            className: 'flex-shrink-past-contents',
+            className: 'flex-shrink-past-contents flex-grow-1',
             element: (
                 <FilePathBreadcrumbs
                     key="path"

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -196,21 +196,28 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
 
     return (
         <nav data-testid="repo-header" className={classNames('navbar navbar-expand', 'px-3', styles.repoHeader)}>
-            <div className="d-flex align-items-center flex-shrink-past-contents">
-                {/* Breadcrumb for the nav elements */}
-                <Breadcrumbs
-                    breadcrumbs={props.breadcrumbs}
-                    className={classNames('justify-content-start', !props.forceWrap ? styles.breadcrumbWrap : '')}
-                />
-            </div>
-            <ul className="navbar-nav">
-                {leftActions.map((a, index) => (
-                    <li className="nav-item" key={a.id || index}>
-                        {a.element}
-                    </li>
-                ))}
-            </ul>
-            <div className={styles.spacer} />
+            {/*<div className={styles.breadcrumb}>*/}
+            {/*    /!* Breadcrumb for the nav elements *!/*/}
+            {/*    */}
+            {/*</div>*/}
+
+            <Breadcrumbs
+                breadcrumbs={props.breadcrumbs}
+                className={classNames(
+                    'justify-content-start flex-grow-1',
+                    !props.forceWrap ? styles.breadcrumbWrap : ''
+                )}
+            />
+
+            {leftActions.length !== 0 && (
+                <ul className="navbar-nav">
+                    {leftActions.map((a, index) => (
+                        <li className="nav-item" key={a.id || index}>
+                            {a.element}
+                        </li>
+                    ))}
+                </ul>
+            )}
             <ErrorBoundary
                 location={location}
                 // To be clear to users that this isn't an error reported by extensions

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -196,11 +196,6 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
 
     return (
         <nav data-testid="repo-header" className={classNames('navbar navbar-expand', 'px-3', styles.repoHeader)}>
-            {/*<div className={styles.breadcrumb}>*/}
-            {/*    /!* Breadcrumb for the nav elements *!/*/}
-            {/*    */}
-            {/*</div>*/}
-
             <Breadcrumbs
                 breadcrumbs={props.breadcrumbs}
                 className={classNames(

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -1,8 +1,8 @@
 import { FC, useCallback, useMemo, useState } from 'react'
 
-import { Route, Routes, useLocation } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
-import { StreamingSearchResultsListProps, CopyPathAction } from '@sourcegraph/branded'
+import { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import { isErrorLike } from '@sourcegraph/common'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -21,9 +21,7 @@ import { CodeInsightsProps } from '../insights/types'
 import { NotebookProps } from '../notebooks'
 import { OwnConfigProps } from '../own/OwnConfigProps'
 import { SearchStreamingProps } from '../search'
-import { eventLogger } from '../tracking/eventLogger'
 import { RouteV6Descriptor } from '../util/contributions'
-import { parseBrowserRepoURL } from '../util/url'
 
 import { GoToPermalinkAction } from './actions/GoToPermalinkAction'
 import { ResolvedRevision } from './backend'
@@ -167,7 +165,6 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
  */
 export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
     const { useBreadcrumb, resolvedRevision, revision, repo, repoName, routes } = props
-    const location = useLocation()
 
     const breadcrumbSetters = useBreadcrumb(
         useMemo(() => {
@@ -201,8 +198,6 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
         resolvedRevision,
     }
 
-    const { filePath } = parseBrowserRepoURL(location.pathname)
-
     return (
         <RepoRevisionWrapper className="px-3">
             <Routes>
@@ -213,15 +208,6 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                         )
                 )}
             </Routes>
-            <RepoHeaderContributionPortal
-                position="left"
-                id="copy-path"
-                repoHeaderContributionsLifecycleProps={props.repoHeaderContributionsLifecycleProps}
-            >
-                {() => (
-                    <CopyPathAction telemetryService={eventLogger} filePath={filePath || repoName} key="copy-path" />
-                )}
-            </RepoHeaderContributionPortal>
             {resolvedRevision && !isPackage && (
                 <RepoHeaderContributionPortal
                     position="right"

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -176,7 +176,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
 
             return {
                 key: 'filePath',
-                className: 'flex-shrink-past-contents',
+                className: 'flex-shrink-past-contents flex-grow-1',
                 element: (
                     // TODO should these be "flattened" all using setBreadcrumb()?
                     <FilePathBreadcrumbs

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -136,7 +136,7 @@ export const TreePage: FC<Props> = ({
 
             return {
                 key: 'treePath',
-                className: 'flex-shrink-past-contents',
+                className: 'flex-shrink-past-contents flex-grow-1',
                 element: (
                     <FilePathBreadcrumbs
                         key="path"

--- a/client/wildcard/BUILD.bazel
+++ b/client/wildcard/BUILD.bazel
@@ -124,6 +124,8 @@ ts_project(
         "src/components/Badge/index.ts",
         "src/components/BeforeUnloadPrompt/BeforeUnloadPrompt.tsx",
         "src/components/BeforeUnloadPrompt/index.ts",
+        "src/components/Breadcrumbs/Breadcrumbs.tsx",
+        "src/components/Breadcrumbs/index.ts",
         "src/components/Button/Button.tsx",
         "src/components/Button/ButtonGroup.tsx",
         "src/components/Button/constants.ts",

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -6,6 +6,20 @@
     flex-wrap: nowrap;
     white-space: nowrap;
     list-style: none;
+    position: relative;
+    width: 100%;
+    overflow: hidden;
 }
 
+.item {
+    z-index: 1;
+
+    &--hidden {
+        position: absolute;
+        top: 0;
+        left: 0;
+        visibility: hidden;
+        z-index: -1;
+    }
+}
 

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,0 +1,11 @@
+
+.list {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    list-style: none;
+}
+
+

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,4 +1,3 @@
-
 .list {
     margin: 0;
     padding: 0;
@@ -11,6 +10,10 @@
     overflow: hidden;
 }
 
+.separator {
+    padding: 0 0.25rem;
+}
+
 .item {
     z-index: 1;
 
@@ -21,5 +24,44 @@
         visibility: hidden;
         z-index: -1;
     }
+
+    &--with-button {
+        display: flex;
+    }
 }
 
+.more-button {
+    display: flex !important;
+    border: none !important;
+    padding: 0 0.25rem !important;
+
+    &--active,
+    &:hover,
+    &:focus {
+        background-color: var(--dropdown-link-hover-bg) !important;
+    }
+}
+
+.truncated-list {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    padding: 0 !important;
+    margin: 0;
+    border-radius: 2px !important;
+
+    &-item {
+        cursor: pointer;
+        padding: 0.15rem 0.35rem !important;
+        display: flex !important;
+        gap: 0.25rem;
+        align-items: center;
+
+        &[data-reach-menu-item] {
+            &[data-selected]:not(:active) {
+                background-color: var(--primary);
+                color: var(--light-text);
+            }
+        }
+    }
+}

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -3,6 +3,7 @@
     padding: 0;
     display: flex;
     flex-wrap: nowrap;
+    align-items: center;
     white-space: nowrap;
     list-style: none;
     position: relative;
@@ -12,6 +13,7 @@
 
 .separator {
     padding: 0 0.25rem;
+    color: var(--link-color);
 }
 
 .item {
@@ -34,10 +36,12 @@
     display: flex !important;
     border: none !important;
     padding: 0 0.25rem !important;
+    color: var(--link-color);
 
     &--active,
     &:hover,
     &:focus {
+        color: var(--link-color) !important;
         background-color: var(--dropdown-link-hover-bg) !important;
     }
 }

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -17,8 +17,6 @@
 }
 
 .item {
-    z-index: 1;
-
     &--hidden {
         position: absolute;
         top: 0;

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -30,6 +30,11 @@
     &--with-button {
         display: flex;
     }
+
+    &--last {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }
 
 .more-button {

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -13,7 +13,7 @@ const config: Meta = {
 export default config
 
 export const BreadcrumbsGallery: Story = () => (
-    <ResizableBox width={500} axis="x" minConstraints={[200, 0]}>
-        <Breadcrumbs filename='sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx'/>
+    <ResizableBox width={500} height={30} axis="x" minConstraints={[200, 0]}>
+        <Breadcrumbs filename="sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx" />
     </ResizableBox>
 )

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -14,6 +14,9 @@ export default config
 
 export const BreadcrumbsGallery: Story = () => (
     <ResizableBox width={500} height={30} axis="x" minConstraints={[200, 0]}>
-        <Breadcrumbs filename="sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx" />
+        <Breadcrumbs
+            filename="sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx"
+            getSegmentLink={segment => `https://www.google.com/search?q=${segment}`}
+        />
     </ResizableBox>
 )

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -1,4 +1,5 @@
 import { Meta, Story } from '@storybook/react'
+import { ResizableBox } from 'react-resizable'
 
 import { BrandedStory } from '../../stories'
 
@@ -12,7 +13,7 @@ const config: Meta = {
 export default config
 
 export const BreadcrumbsGallery: Story = () => (
-    <div style={{ width: 500, overflow: 'hidden', border: '1px solid black'}}>
+    <ResizableBox width={500} axis="x" minConstraints={[200, 0]}>
         <Breadcrumbs filename='sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx'/>
-    </div>
+    </ResizableBox>
 )

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from '@storybook/react'
+
+import { BrandedStory } from '../../stories'
+
+import { Breadcrumbs } from './Breadcrumbs'
+
+const config: Meta = {
+    title: 'wildcard/Badge',
+    decorators: [story => <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>],
+}
+
+export default config
+
+export const BreadcrumbsGallery: Story = () => (
+    <div style={{ width: 500, overflow: 'hidden', border: '1px solid black'}}>
+        <Breadcrumbs filename='sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx'/>
+    </div>
+)

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -13,7 +13,7 @@ const config: Meta = {
 export default config
 
 export const BreadcrumbsGallery: Story = () => (
-    <ResizableBox width={500} height={30} axis="x" minConstraints={[200, 0]}>
+    <ResizableBox width={500} height={30} axis="x" minConstraints={[100, 0]}>
         <Breadcrumbs
             filename="sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx"
             getSegmentLink={segment => `https://www.google.com/search?q=${segment}`}

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,67 @@
+import { FC, useLayoutEffect, useMemo, useRef, useState } from 'react'
+
+import styles from './Breadcrumbs.module.scss'
+import classNames from 'classnames';
+import useResizeObserver from 'use-resize-observer';
+
+type Index = number
+type Width = number
+
+interface BreadcrumbsProps {
+    filename: string
+    className?: string
+}
+
+export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
+    const { filename, className } = props
+
+    const rootElementRef = useRef<HTMLUListElement>(null)
+    const { width = 0 } = useResizeObserver({ ref: rootElementRef })
+
+    const segmentsRef = useRef(() => new Set())
+    const segments = useMemo(() => filename.split('/'), [filename])
+
+    useLayoutEffect(() => {
+        // Base guards for root element and it's width
+        if (!rootElementRef.current || width === 0) {
+            return
+        }
+
+        // Measure segments elements sizes
+        let totalWidth = 0
+        const elementSizesMap: Record<Index, Width> = {}
+        const segmentsElements = rootElementRef.current.querySelectorAll('li')
+
+        for (const element of segmentsElements) {
+            const index = +(element.dataset?.index ?? 0)
+            const width = element.getBoundingClientRect().width
+            elementSizesMap[index] = width
+
+            totalWidth += width
+        }
+
+        // Elements overflow parent container, we should remove some elements in the middle
+        // until all reset elements fit in the parent element
+        if (totalWidth > width) {
+            let offset: number = 0
+            const middleElementIndex = Math.floor(segmentsElements.length - 1 / 2)
+
+            while (totalWidth > width - 40) {
+                const elementToRemoveIndex = middleElementIndex + offset
+
+                offset = offset === 0 ? 1 : offset - (-offset)
+            }
+        }
+
+    }, [filename, width])
+
+    return (
+        <ul ref={rootElementRef} className={classNames(styles.list, className)}>
+            { segments.map((segment, index) =>
+                <li key={`${segment}-${index}`} data-index={index}>
+                    { index !== segments.length - 1 ? `${segment}/` : segment}
+                </li>
+            )}
+        </ul>
+    )
+}

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,10 +2,21 @@ import { FC, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import styles from './Breadcrumbs.module.scss'
 import classNames from 'classnames';
-import useResizeObserver from 'use-resize-observer';
+import { Button } from '../Button';
 
 type Index = number
 type Width = number
+
+enum SegmentType {
+    Common,
+    Invisible,
+    MoreButton
+}
+
+type Segment =
+    { type: SegmentType.MoreButton } |
+    { type: SegmentType.Invisible, value: string } |
+    { type: SegmentType.Common, value: string }
 
 interface BreadcrumbsProps {
     filename: string
@@ -15,53 +26,135 @@ interface BreadcrumbsProps {
 export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
     const { filename, className } = props
 
+    const [hidedSegments, setHidedSegments] = useState<number[]>([])
     const rootElementRef = useRef<HTMLUListElement>(null)
-    const { width = 0 } = useResizeObserver({ ref: rootElementRef })
-
-    const segmentsRef = useRef(() => new Set())
     const segments = useMemo(() => filename.split('/'), [filename])
 
     useLayoutEffect(() => {
-        // Base guards for root element and it's width
-        if (!rootElementRef.current || width === 0) {
+        if (!rootElementRef.current) {
             return
         }
 
-        // Measure segments elements sizes
-        let totalWidth = 0
-        const elementSizesMap: Record<Index, Width> = {}
-        const segmentsElements = rootElementRef.current.querySelectorAll('li')
+        function fixItemsAppearance(width: number) {
+            // Base guards for root element and it's width
+            if (!rootElementRef.current || width === 0) {
+                return
+            }
 
-        for (const element of segmentsElements) {
-            const index = +(element.dataset?.index ?? 0)
-            const width = element.getBoundingClientRect().width
-            elementSizesMap[index] = width
+            // Measure segments elements sizes
+            let totalWidth = 0
+            const elementSizesMap: Record<Index, Width> = {}
+            const segmentsElements = rootElementRef.current.querySelectorAll('li')
 
-            totalWidth += width
-        }
+            for (const element of segmentsElements) {
+                const index = +(element.dataset?.index ?? 0)
+                const width = element.getBoundingClientRect().width
+                elementSizesMap[index] = width
 
-        // Elements overflow parent container, we should remove some elements in the middle
-        // until all reset elements fit in the parent element
-        if (totalWidth > width) {
-            let offset: number = 0
-            const middleElementIndex = Math.floor(segmentsElements.length - 1 / 2)
+                totalWidth += width
+            }
 
-            while (totalWidth > width - 40) {
-                const elementToRemoveIndex = middleElementIndex + offset
+            // Elements overflow parent container, we should remove some elements in the middle
+            // until all reset elements fit in the parent element
+            if (totalWidth > width) {
+                let offset: number = 0
+                const segmentsToHide = []
+                const middleElementIndex = Math.floor((segmentsElements.length - 1) / 2)
 
-                offset = offset === 0 ? 1 : offset - (-offset)
+                while (totalWidth > width - 40) {
+                    const elementToRemoveIndex = middleElementIndex + offset
+
+                    totalWidth -= elementSizesMap[elementToRemoveIndex]
+                    segmentsToHide.push(elementToRemoveIndex)
+
+                    // Produce the sequence 0, 1, -1, 2, -2, 3, -3, ....
+                    if (offset === 0) {
+                        offset = 1
+                    } else if (offset > 0) {
+                        offset = offset * -1
+                    } else {
+                        offset = offset * -1 + 1
+                    }
+                }
+
+                setHidedSegments(segmentsToHide)
             }
         }
 
-    }, [filename, width])
+        // Force initial fix item appearance synchronously to avoid flashes
+        fixItemsAppearance(rootElementRef.current.getBoundingClientRect().width ?? 0)
+
+        const resizeObserver = new ResizeObserver(entries => {
+            const entry = entries[0]
+
+            fixItemsAppearance(entry.contentRect.width)
+        })
+
+        resizeObserver.observe(rootElementRef.current)
+
+        return () => resizeObserver.disconnect()
+    }, [filename])
+
+    const fixedSegments = useMemo<Segment[]>(() => {
+        if (hidedSegments.length === 0) {
+            return segments
+        }
+
+        const result: Segment[] = []
+
+        for (const [index, segment] of segments.entries()) {
+            if (hidedSegments.includes(index)) {
+                result.push({
+                    type: SegmentType.Invisible,
+                    value: segment
+                })
+            } else {
+                result.push({
+                    type: SegmentType.Common,
+                    value: segment
+                })
+            }
+        }
+
+        const firstInvisibleElement = result.findIndex(item => item.type === SegmentType.Invisible)
+
+        if (firstInvisibleElement === -1) {
+            result.splice(firstInvisibleElement, 0, { type: SegmentType.MoreButton })
+        }
+
+        return result
+    }, [segments, hidedSegments])
 
     return (
         <ul ref={rootElementRef} className={classNames(styles.list, className)}>
             { segments.map((segment, index) =>
-                <li key={`${segment}-${index}`} data-index={index}>
-                    { index !== segments.length - 1 ? `${segment}/` : segment}
+                <li
+                    key={`${segment}-${index}`}
+                    data-index={index}
+                    className={classNames(styles.item, { [styles.itemHidden]: hidedSegments.includes(index)})}
+                >
+                    { getSegmentText(segments, index, segment) }
                 </li>
             )}
         </ul>
+    )
+}
+
+function getSegmentText(segments: string[], index: number, segment: string): string {
+    return index !== segments.length - 1 ? `${segment}/` : segment
+}
+
+interface TruncatedItemsButton {
+    segments: string[]
+    truncatedSegments: Set<number>
+}
+
+const TruncatedItemsButton: FC<TruncatedItemsButton> = props => {
+    const { segments, truncatedSegments} = props
+
+    return (
+        <Button variant='secondary' outline={true}>
+            ...
+        </Button>
     )
 }

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -64,7 +64,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
             return
         }
 
-        function fixItemsAppearance(width: number) {
+        function fixItemsAppearance(width: number): void {
             // Base guards for root element and it's width
             if (!rootElementRef.current || width === 0) {
                 return
@@ -90,7 +90,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
             // Elements overflow parent container, we should remove some elements in the middle
             // until all reset elements fit in the parent element
             if (totalWidth > width) {
-                let offset: number = 0
+                let offset = 0
                 const segmentsToHide = []
                 const middleElementIndex = Math.floor((segmentsElements.length - 1) / 2)
 
@@ -220,7 +220,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
     )
 }
 
-const Separator = () => <span className={styles.separator}>/</span>
+const Separator: FC = () => <span className={styles.separator}>/</span>
 
 interface TruncatedItemsButton {
     truncatedSegments: InvisibleSegment[]

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -38,11 +38,12 @@ interface MoreButtonSegment {
 type Segment = CommonSegment | InvisibleSegment | MoreButtonSegment
 
 const isInvisibleSegment = (segment: Segment): segment is InvisibleSegment => segment.type === SegmentType.Invisible
+const isCommonSegment = (segment: Segment): segment is CommonSegment => segment.type === SegmentType.Common
 const isMoreButtonSegment = (segment: Segment): segment is MoreButtonSegment => segment.type === SegmentType.MoreButton
 
 // Static width value for the more width value, it's used below
 // in items layout calculation in useLayoutEffect
-const MORE_BUTTON_WIDTH = 30
+const MORE_BUTTON_WIDTH = 40
 
 interface BreadcrumbsProps {
     filename: string
@@ -95,6 +96,12 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
 
                 while (totalWidth > width - MORE_BUTTON_WIDTH) {
                     const elementToRemoveIndex = middleElementIndex + offset
+
+                    // Always render the last segment (truncation of the last segment is
+                    // handled by CSS truncation
+                    if (elementToRemoveIndex === segmentsElements.length - 1) {
+                        break
+                    }
 
                     totalWidth -= elementSizesMap[elementToRemoveIndex]
                     segmentsToHide.push(elementToRemoveIndex)
@@ -168,6 +175,8 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
         return result
     }, [segments, hidedSegments])
 
+    const isOnlyFileNameVisible = fixedSegments.filter(isCommonSegment).length === 1
+
     return (
         <ul ref={rootElementRef} className={classNames(styles.list, className)}>
             {fixedSegments.map((segment, index) => (
@@ -178,6 +187,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
                     className={classNames(styles.item, {
                         [styles.itemHidden]: isInvisibleSegment(segment),
                         [styles.itemWithButton]: isMoreButtonSegment(segment),
+                        [styles.itemLast]: isOnlyFileNameVisible && index === fixedSegments.length - 1,
                     })}
                 >
                     {isMoreButtonSegment(segment) && (
@@ -228,7 +238,7 @@ const TruncatedItemsButton: FC<TruncatedItemsButton> = props => {
                         outline={true}
                         className={classNames(styles.moreButton, { [styles.moreButtonActive]: isOpen })}
                     >
-                        ... <span aria-hidden={true}>▾</span>
+                        ...
                     </MenuButton>
 
                     <MenuList as="ul" className={styles.truncatedList}>

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -162,7 +162,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
                     key={segment.id}
                     data-index={segment.id}
                     data-type={isMoreButtonSegment(segment) ? 'internal' : 'common'}
-                    className={classNames(styles.item, {
+                    className={classNames({
                         [styles.itemHidden]: isInvisibleSegment(segment),
                         [styles.itemWithButton]: isMoreButtonSegment(segment),
                         [styles.itemLast]: isOnlyFileNameVisible && index === fixedSegments.length - 1,
@@ -189,11 +189,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
                     )}
                 </li>
             ))}
-            {children && (
-                <li data-type="extra-content" className={styles.item}>
-                    {children}
-                </li>
-            )}
+            {children && <li data-type="extra-content">{children}</li>}
         </ul>
     )
 }

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -188,6 +188,8 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = props => {
                         [styles.itemHidden]: isInvisibleSegment(segment),
                         [styles.itemWithButton]: isMoreButtonSegment(segment),
                         [styles.itemLast]: isOnlyFileNameVisible && index === fixedSegments.length - 1,
+                        // Only for test purpose (see nav.test.ts integration test)
+                        'test-breadcrumb-part-last': index === fixedSegments.length - 1,
                     })}
                 >
                     {isMoreButtonSegment(segment) && (

--- a/client/wildcard/src/components/Breadcrumbs/index.ts
+++ b/client/wildcard/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { Breadcrumbs } from './Breadcrumbs'

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -1,6 +1,7 @@
 /** Component exports */
 export { BeforeUnloadPrompt } from './BeforeUnloadPrompt'
 export { Button, ButtonGroup, BUTTON_SIZES } from './Button'
+export { Breadcrumbs } from './Breadcrumbs'
 export { Alert, AlertLink } from './Alert'
 export { Container } from './Container'
 export { ErrorAlert } from './ErrorAlert'


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/54796

This PR adds a new smart file path breadcrumbs component. It works in a way that we render only a reasonable amount of filepaths and hide the part in the middle of the file path that doesn't fit in a given space width. The hidden items are still accessible through ... dropdown button.

Loom demo https://www.loom.com/embed/72a0ec19d0624ae4927a525294e08dc9?sid=7dc48532-943f-4eaa-8287-8aee3341dc79

| Before | After |
| ------- | -------- |
| <img width="1095" alt="Screenshot 2023-07-13 at 20 41 34" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/97fdeff2-0be8-413b-ad92-a7aa43ed90dd"> | <img width="1095" alt="Screenshot 2023-07-13 at 20 36 01" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/fdbd0c28-7dda-4a98-b460-36f96c9ac099"> |

## Tech note
The new hiding items mechanism unblocks the next big issue for code search UI refresh (https://github.com/sourcegraph/sourcegraph/issues/54794). In a follow-up PR, I will try to generalise an item-hiding mechanism that we could reuse for hiding global navigation items in a three-dot menu if the screen is too small to fit the search bar and navigation items. 

## Test plan
- Check repository and blob UI pages on small/middle/big screen sizes, check that filepath breadcrumbs works as expected without content overflowing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
