### PR TITLE
observation: set Tracer in TestContext

### DIFF
--- a/internal/observation/context.go
+++ b/internal/observation/context.go
@@ -40,7 +40,13 @@ func (c *Context) Clone(opts ...Opt) *Context {
 }
 
 // TestContext is a behaviorless Context usable for unit tests.
-var TestContext = Context{Logger: log.NoOp(), Registerer: metrics.NoOpRegisterer}
+var TestContext = Context{
+	Logger:     log.NoOp(),
+	Tracer:     oteltrace.NewNoopTracerProvider().Tracer("noop"),
+	Registerer: metrics.NoOpRegisterer,
+	// We do not set HoneyDataset since if we accidently have HONEYCOMB_TEAM
+	// set in a test run it will log to honeycomb.
+}
 
 // TestContextTB creates a Context similar to `TestContext` but with a logger scoped
 // to the `testing.TB`.


### PR DESCRIPTION
We recently set tracer in TestContextTB. We should do the same for TestContext which is also used a fair amount. Tracer is set in prod, so exercising the paths in tests is valuable.

Note: This is take two on https://github.com/sourcegraph/sourcegraph/pull/54908 since I forgot to push my fixes before merging :O

Test Plan: CI