### PR TITLE
JetBrains: show one informative message when user has invalid access token

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Downgraded connection errors for invalid or inaccessible enterprise instances to warnings [#54916](https://github.com/sourcegraph/sourcegraph/pull/54916)
 - Try to log error stacktraces and recover from them, rather than re-throw the exception [#54917](https://github.com/sourcegraph/sourcegraph/pull/54917)
+- Show only one informative message in case of invalid access token [#54951](https://github.com/sourcegraph/sourcegraph/pull/54951)
 
 ### Security
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -471,15 +471,7 @@ class CodyToolWindowContent implements UpdatableChat {
           ChatMessage.createAssistantMessage(
               "I'm sorry, I can't connect to the server. Please make sure that the server is running and try again."));
     } else if (errorMessage.startsWith("Got error response 401")) {
-      String invalidAccessTokenText =
-          "<p>It looks like your Sourcegraph Access Token is invalid or not configured.</p>"
-              + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
-      AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
-          new AssistantMessageWithSettingsButton(project, invalidAccessTokenText);
-      var messageContentPanel = new JPanel(new BorderLayout());
-      messageContentPanel.add(assistantMessageWithSettingsButton);
-      ApplicationManager.getApplication()
-          .invokeLater(() -> this.addComponentToChat(messageContentPanel));
+      addMessageWithInformationAboutInvalidAccessToken();
     } else {
       this.addMessageToChat(
           ChatMessage.createAssistantMessage(
@@ -487,6 +479,18 @@ class CodyToolWindowContent implements UpdatableChat {
                   + errorMessage
                   + "\"."));
     }
+  }
+
+  private void addMessageWithInformationAboutInvalidAccessToken() {
+    String invalidAccessTokenText =
+        "<p>It looks like your Sourcegraph Access Token is invalid or not configured.</p>"
+            + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
+    AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
+        new AssistantMessageWithSettingsButton(project, invalidAccessTokenText);
+    var messageContentPanel = new JPanel(new BorderLayout());
+    messageContentPanel.add(assistantMessageWithSettingsButton);
+    ApplicationManager.getApplication()
+        .invokeLater(() -> this.addComponentToChat(messageContentPanel));
   }
 
   public synchronized void updateLastMessage(@NotNull ChatMessage message) {
@@ -602,28 +606,33 @@ class CodyToolWindowContent implements UpdatableChat {
                   logger.warn("Error sending message '" + humanMessage + "' to chat", e);
                 }
               } else {
-                List<ContextMessage> contextMessages =
-                    getContextFromEmbeddings(
-                        project, humanMessage, instanceUrl, repoName, accessTokenOrEmpty);
-                this.displayUsedContext(contextMessages);
-                List<ContextMessage> editorContextMessages =
-                    getEditorContextMessages(editorContext);
-                contextMessages.addAll(editorContextMessages);
-                List<ContextMessage> selectionContextMessages =
-                    getSelectionContextMessages(editorContext);
-                contextMessages.addAll(selectionContextMessages);
-                // Add human message
-                transcript.addInteraction(new Interaction(humanMessage, contextMessages));
-
-                List<Message> prompt =
-                    transcript.getPromptForLastInteraction(
-                        Preamble.getPreamble(repoName),
-                        TruncationUtils.getChatMaxAvailablePromptLength(project));
-
                 try {
-                  chat.sendMessageWithoutAgent(prompt, responsePrefix, this, cancellationToken);
-                } catch (Exception e) {
-                  logger.warn("Error sending message '" + humanMessage + "' to chat", e);
+                  List<ContextMessage> contextMessages =
+                      getContextFromEmbeddings(
+                          project, humanMessage, instanceUrl, repoName, accessTokenOrEmpty);
+                  this.displayUsedContext(contextMessages);
+                  List<ContextMessage> editorContextMessages =
+                      getEditorContextMessages(editorContext);
+                  contextMessages.addAll(editorContextMessages);
+                  List<ContextMessage> selectionContextMessages =
+                      getSelectionContextMessages(editorContext);
+                  contextMessages.addAll(selectionContextMessages);
+                  // Add human message
+                  transcript.addInteraction(new Interaction(humanMessage, contextMessages));
+
+                  List<Message> prompt =
+                      transcript.getPromptForLastInteraction(
+                          Preamble.getPreamble(repoName),
+                          TruncationUtils.getChatMaxAvailablePromptLength(project));
+
+                  try {
+                    chat.sendMessageWithoutAgent(prompt, responsePrefix, this, cancellationToken);
+                  } catch (Exception e) {
+                    logger.warn("Error sending message '" + humanMessage + "' to chat", e);
+                  }
+                } catch (InvalidAccessTokenException ex) {
+                  addMessageWithInformationAboutInvalidAccessToken();
+                  finishMessageProcessing();
                 }
               }
               GraphQlLogger.logCodyEvent(this.project, "recipe:chat-question", "executed");
@@ -681,6 +690,11 @@ class CodyToolWindowContent implements UpdatableChat {
                 + ", in repo: "
                 + repoName,
             e);
+        String message = e.getMessage();
+        if (message != null && message.contains("request failed with status code 401")) {
+          throw new InvalidAccessTokenException(
+              "Invalid access token while loading context messages", e);
+        }
       }
     }
     return contextMessages;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/InvalidAccessTokenException.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/InvalidAccessTokenException.java
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody;
+
+public class InvalidAccessTokenException extends RuntimeException {
+  public InvalidAccessTokenException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
If user has invalid token we will show only one informative message about invalid access token

closes https://github.com/sourcegraph/cody/issues/122 
## Test plan
Ask cody with invalid access token, only one message should appear in the chat

before:
![Screenshot 2023-07-14 at 09 37 37](https://github.com/sourcegraph/sourcegraph/assets/7345368/561ae026-91e7-4d77-8fdf-ed6dafe0932a)
now:
<img width="501" alt="Screenshot 2023-07-14 at 09 45 40" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/af72067c-40b6-46e2-8443-2ce3847f5f91">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
