### PR TITLE
JetBrains: Cody: Get the chat model max tokens value from the instance

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -615,7 +615,7 @@ class CodyToolWindowContent implements UpdatableChat {
                 List<Message> prompt =
                     transcript.getPromptForLastInteraction(
                         Preamble.getPreamble(repoName),
-                        TruncationUtils.MAX_AVAILABLE_PROMPT_LENGTH);
+                        TruncationUtils.getChatMaxAvailablePromptLength(project));
 
                 try {
                   chat.sendMessageWithoutAgent(prompt, responsePrefix, this, cancellationToken);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/TruncationUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/TruncationUtils.java
@@ -1,17 +1,16 @@
 package com.sourcegraph.cody;
 
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.api.CodyLLMConfigurationUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class TruncationUtils {
   public static final int CHARS_PER_TOKEN = 4;
-  public static final int MAX_PROMPT_TOKEN_LENGTH = 7000;
   public static final int SOLUTION_TOKEN_LENGTH = 1000;
   public static final int MAX_HUMAN_INPUT_TOKENS = 1000;
   public static final int MAX_RECIPE_INPUT_TOKENS = 2000;
   public static final int MAX_CURRENT_FILE_TOKENS = 1000;
   public static final int MAX_RECIPE_SURROUNDING_TOKENS = 500;
-  public static final int MAX_AVAILABLE_PROMPT_LENGTH =
-      MAX_PROMPT_TOKEN_LENGTH - SOLUTION_TOKEN_LENGTH;
 
   /** The number of code lines to include in the preceding and following texts near the selection */
   public static final int SURROUNDING_LINES = 50;
@@ -20,5 +19,13 @@ public class TruncationUtils {
   public static String truncateText(@NotNull String text, int maxTokens) {
     int maxLength = maxTokens * CHARS_PER_TOKEN;
     return text.length() <= maxLength ? text : text.substring(0, maxLength);
+  }
+
+  public static int getChatMaxAvailablePromptLength(@NotNull Project project) {
+    return getChatMaxPromptTokenLength(project) - SOLUTION_TOKEN_LENGTH;
+  }
+
+  public static int getChatMaxPromptTokenLength(@NotNull Project project) {
+    return CodyLLMConfigurationUtils.getChatModelMaxTokensForProject(project);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CodyLLMConfigurationUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/api/CodyLLMConfigurationUtils.java
@@ -1,0 +1,87 @@
+package com.sourcegraph.cody.api;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.api.GraphQlClient;
+import com.sourcegraph.api.GraphQlResponse;
+import com.sourcegraph.config.ConfigUtil;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+
+public class CodyLLMConfigurationUtils {
+  public static Logger logger = Logger.getInstance(CodyLLMConfigurationUtils.class);
+  public static final int DEFAULT_CHAT_MODEL_MAX_TOKENS = 7000;
+  private static final ConcurrentHashMap<String, Integer> projectNameToChatModelMaxTokensCache =
+      new ConcurrentHashMap<>();
+
+  public static int getChatModelMaxTokensForProject(@NotNull Project project) {
+    String projectName = project.getName();
+    return Optional.ofNullable(projectNameToChatModelMaxTokensCache.get(projectName))
+        .or(
+            () -> {
+              int newValue = fetchChatModelMaxTokens(project);
+              projectNameToChatModelMaxTokensCache.put(projectName, newValue);
+              return Optional.of(newValue);
+            })
+        .orElse(DEFAULT_CHAT_MODEL_MAX_TOKENS);
+  }
+
+  public static void refreshCacheForProject(@NotNull Project project) {
+    projectNameToChatModelMaxTokensCache.put(project.getName(), fetchChatModelMaxTokens(project));
+  }
+
+  private static int fetchChatModelMaxTokens(@NotNull Project project) {
+    String graphQlQuery =
+        "query fetchChatModelMaxTokens {\n"
+            + "  site {\n"
+            + "    codyLLMConfiguration {\n"
+            + "      chatModelMaxTokens\n"
+            // + "      completionModelMaxTokens\n" // TODO apply this for autocomplete later
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    String instanceUrl = ConfigUtil.getSourcegraphUrl(project);
+    String accessToken = ConfigUtil.getProjectAccessToken(project);
+    String customRequestHeaders = ConfigUtil.getCustomRequestHeaders(project);
+    try {
+      GraphQlResponse response =
+          GraphQlClient.callGraphQLService(
+              instanceUrl, accessToken, customRequestHeaders, graphQlQuery, new JsonObject());
+      JsonObject body = response.getBodyAsJson();
+      if (body.has("errors")) {
+        logger.warn("Fetching chat model max tokens failed with errors: " + body.get("errors"));
+        logger.warn("Defaulting chat model max tokens to: " + DEFAULT_CHAT_MODEL_MAX_TOKENS);
+        return DEFAULT_CHAT_MODEL_MAX_TOKENS;
+      }
+      return Optional.ofNullable(body.getAsJsonObject("data"))
+          .flatMap(data -> Optional.ofNullable(data.getAsJsonObject("site")))
+          .flatMap(site -> Optional.ofNullable(site.getAsJsonObject("codyLLMConfiguration")))
+          .flatMap(
+              codyLLMConfiguration ->
+                  Optional.ofNullable(
+                      codyLLMConfiguration.getAsJsonPrimitive(("chatModelMaxTokens"))))
+          .flatMap(
+              r -> {
+                try {
+                  return Optional.of(r.getAsInt());
+                } catch (NumberFormatException e) {
+                  logger.warn(e);
+                  logger.warn(
+                      "Failed to fetch a valid value, defaulting chat model max tokens to: "
+                          + DEFAULT_CHAT_MODEL_MAX_TOKENS);
+                  return Optional.of(DEFAULT_CHAT_MODEL_MAX_TOKENS);
+                }
+              })
+          .orElse(DEFAULT_CHAT_MODEL_MAX_TOKENS);
+    } catch (Exception e) {
+
+      logger.warn(e);
+      logger.warn(
+          "Could not fetch chat model max tokens from Sourcegraph instance, defaulting to: "
+              + DEFAULT_CHAT_MODEL_MAX_TOKENS);
+      return DEFAULT_CHAT_MODEL_MAX_TOKENS;
+    }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -17,6 +17,7 @@ import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentServer;
+import com.sourcegraph.cody.api.CodyLLMConfigurationUtils;
 import com.sourcegraph.cody.autocomplete.CodyAutoCompleteManager;
 import com.sourcegraph.find.browser.JavaToJSBridge;
 import com.sourcegraph.telemetry.GraphQlLogger;
@@ -106,6 +107,9 @@ public class SettingsChangeListener implements Disposable {
                   .map(fileEditor -> ((TextEditor) fileEditor).getEditor())
                   .forEach(codyAutoCompleteManager::clearAutoCompleteSuggestions);
             }
+
+            // refresh Cody LLM configuration
+            CodyLLMConfigurationUtils.refreshCacheForProject(project);
           }
         });
   }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/130

The limit is being fetched from the API when it's first needed after starting the app, afterwards it's fetched from a cache.
The limits are being cached per project in case there is a different instance configured on the project level.
Additionally, the cache is refreshed after updating settings.

## Test plan

- green CI 🟢 
- only the chat is affected, so might want to double check if nothing breaks there