### PR TITLE
chore: improve licensing message when license is invalid

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -83,9 +83,11 @@ func Init(
 			return nil
 		}
 
+		reason := licensing.GetLicenseInvalidReason()
+
 		return []*graphqlbackend.Alert{{
 			TypeValue:    graphqlbackend.AlertTypeError,
-			MessageValue: "To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration).",
+			MessageValue: fmt.Sprintf("The Sourcegraph license key is invalid. Reason: %s. To continue using Sourcegraph, a site admin must renew the Sourcegraph license (or downgrade to only using Sourcegraph Free features). Update the license key in the [**site configuration**](/site-admin/configuration). Please contact Sourcegraph support for more information.", reason),
 		}}
 	})
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -22,8 +22,9 @@ var (
 	ErrInvalidSiteIDMsg        = "invalid site ID, cannot parse UUID"
 	ErrFailedToAssignSiteIDMsg = "failed to assign site ID to license"
 
-	ReasonLicenseIsAlreadyInUseMsg = "license is already in use"
-	ReasonLicenseRevokedMsg        = "license revoked"
+	ReasonLicenseIsAlreadyInUseMsg = "license key is already in use by another instance"
+	ReasonLicenseRevokedMsg        = "license key was revoked"
+	ReasonLicenseExpired           = "license key is expired"
 
 	EventNameSuccess  = "license.check.api.success"
 	EventNameAssigned = "license.check.api.assigned"
@@ -98,7 +99,10 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 		if license.LicenseExpiresAt != nil && license.LicenseExpiresAt.Before(now) {
 			logger.Warn("license is expired")
 			replyWithJSON(w, http.StatusForbidden, licensing.LicenseCheckResponse{
-				Error: ErrExpiredLicenseMsg,
+				Data: &licensing.LicenseCheckResponseData{
+					IsValid: false,
+					Reason:  ReasonLicenseExpired,
+				},
 			})
 			return
 		}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	licensing "github.com/sourcegraph/sourcegraph/internal/accesstoken"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	elicensing "github.com/sourcegraph/sourcegraph/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -110,7 +110,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 			headers: http.Header{
 				"Authorization": {"Bearer " + hex.EncodeToString(expiredLicense.LicenseCheckToken)},
 			},
-			want:       elicensing.LicenseCheckResponse{Error: ErrExpiredLicenseMsg},
+			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: ReasonLicenseExpired}},
 			wantStatus: http.StatusForbidden,
 		},
 		{
@@ -119,7 +119,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 			headers: http.Header{
 				"Authorization": {"Bearer " + hex.EncodeToString(revokedLicense.LicenseCheckToken)},
 			},
-			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: "license revoked"}},
+			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: ReasonLicenseRevokedMsg}},
 			wantStatus: http.StatusForbidden,
 		},
 		{
@@ -137,7 +137,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 				"Authorization": {"Bearer " + hex.EncodeToString(assignedLicense.LicenseCheckToken)},
 			},
 			body:       getBody(""),
-			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: "license is already in use"}},
+			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: ReasonLicenseIsAlreadyInUseMsg}},
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -185,7 +185,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 			require.Equal(t, "application/json", res.Header().Get("Content-Type"))
 
 			var got elicensing.LicenseCheckResponse
-			json.Unmarshal([]byte(res.Body.String()), &got)
+			_ = json.Unmarshal([]byte(res.Body.String()), &got)
 			require.Equal(t, test.want, got)
 		})
 	}

--- a/internal/licensing/check_test.go
+++ b/internal/licensing/check_test.go
@@ -212,6 +212,7 @@ func Test_licenseChecker(t *testing.T) {
 		want     bool
 		err      bool
 		baseUrl  *string
+		reason   *string
 	}{
 		"returns error if unable to make a request to license server": {
 			response: []byte(`{"error": "some error"}`),
@@ -232,6 +233,7 @@ func Test_licenseChecker(t *testing.T) {
 			response: []byte(`{"data": {"is_valid": false, "reason": "some reason"}}`),
 			status:   http.StatusOK,
 			want:     false,
+			reason:   pointers.Ptr("some reason"),
 		},
 		`uses sourcegraph baseURL from env`: {
 			response: []byte(`{"data": {"is_valid": true}}`),
@@ -271,6 +273,13 @@ func Test_licenseChecker(t *testing.T) {
 				got, err := store.Get(licenseValidityStoreKey).Bool()
 				require.NoError(t, err)
 				require.Equal(t, test.want, got)
+
+				// check result reason was set
+				if test.reason != nil {
+					got, err := store.Get(licenseInvalidReason).String()
+					require.NoError(t, err)
+					require.Equal(t, *test.reason, got)
+				}
 			}
 
 			// check last called at was set

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -112,6 +112,26 @@ func IsLicenseValid() bool {
 	return v
 }
 
+func GetLicenseInvalidReason() string {
+	if IsLicenseValid() {
+		return ""
+	}
+
+	defaultReason := "unknown"
+
+	val := store.Get(licenseInvalidReason)
+	if val.IsNil() {
+		return defaultReason
+	}
+
+	v, err := val.String()
+	if err != nil {
+		return defaultReason
+	}
+
+	return v
+}
+
 // GetConfiguredProductLicenseInfoWithSignature returns information about the current product license key
 // specified in site configuration, with the signed key's signature.
 func GetConfiguredProductLicenseInfoWithSignature() (*Info, string, error) {

--- a/internal/licensing/licensing_test.go
+++ b/internal/licensing/licensing_test.go
@@ -5,13 +5,15 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 
 func cleanupStore(t *testing.T, store redispool.KeyValue) {
 	t.Cleanup(func() {
 		store.Del(licenseValidityStoreKey)
+		store.Del(licenseInvalidReason)
 	})
 }
 
@@ -37,5 +39,40 @@ func TestIsLicenseValid(t *testing.T) {
 		cleanupStore(t, store)
 		require.NoError(t, store.Set(licenseValidityStoreKey, true))
 		require.True(t, IsLicenseValid())
+	})
+}
+
+func TestGetLicenseInvalidReason(t *testing.T) {
+	store = redispool.NewKeyValue("127.0.0.1:6379", &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 5 * time.Second,
+	})
+	store.Del(licenseValidityStoreKey)
+	store.Del(licenseInvalidReason)
+
+	t.Run("unset licenseValidityStoreKey returns empty string", func(t *testing.T) {
+		cleanupStore(t, store)
+		require.Empty(t, GetLicenseInvalidReason())
+	})
+
+	t.Run("true licenseValidityStoreKey returns empty string", func(t *testing.T) {
+		cleanupStore(t, store)
+		require.NoError(t, store.Set(licenseValidityStoreKey, true))
+		require.Empty(t, GetLicenseInvalidReason())
+	})
+
+	t.Run("unset reason returns `unknown`", func(t *testing.T) {
+		cleanupStore(t, store)
+		require.NoError(t, store.Set(licenseValidityStoreKey, false))
+		require.Equal(t, "unknown", GetLicenseInvalidReason())
+	})
+
+	t.Run("set reason returns the reason", func(t *testing.T) {
+		cleanupStore(t, store)
+
+		reason := "test reason"
+		require.NoError(t, store.Set(licenseValidityStoreKey, false))
+		require.NoError(t, store.Set(licenseInvalidReason, reason))
+		require.Equal(t, reason, GetLicenseInvalidReason())
 	})
 }


### PR DESCRIPTION
Added reason of why license is invalid. Changed the response for expired licenses not to return an error but return invalid state instead.

## Screenshots

### Before
<img width="1512" alt="Screenshot 2023-07-14 at 12 54 45" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/29ebbdc0-3f7f-4efa-87f4-931c344bdb2d">


### After
<img width="1512" alt="Screenshot 2023-07-14 at 12 50 11" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/78cd589c-bd42-451e-8193-75fcd40c9fec">
<img width="1512" alt="Screenshot 2023-07-14 at 12 51 08" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/1c154feb-22b2-4d0a-9d51-5dc6304e5222">


## Test plan

Tested locally by adding fields to Redis directly + unit tests.
