### PR TITLE
[gitlab] Support custom GitLab SSO sign-on URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Cody source code (for the VS Code extension, CLI, and client shared libraries) has been moved to the [sourcegraph/cody repository](https://github.com/sourcegraph/cody).
 - `golang.org/x/net/trace` instrumentation, previously available under `/debug/requests` and `/debug/events`, has been removed entirely from core Sourcegraph services. It remains available for Zoekt. [#53795](https://github.com/sourcegraph/sourcegraph/pull/53795)
 - Sourcegraph now supports more than one auth provider per URL. [#54289](https://github.com/sourcegraph/sourcegraph/pull/54289)
+- GitLab auth providers now support an `ssoURL` option that facilitates scenarios where a GitLab group requires SAML/SSO. [#54957](https://github.com/sourcegraph/sourcegraph/pull/54957)
 
 ### Fixed
 

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -327,6 +327,21 @@ You can use the following filters to control how users can create accounts and s
     }
   ```
 
+### How to set up GitLab auth provider for use with GitLab group SAML/SSO
+
+GitLab groups can require SAML/SSO sign-in to have access to the group. The regular OAuth sign-in won't work in this case, as users will be redirected to the normal GitLab sign-in page, requesting a username/password. In this scenario, add a `ssoURL` to your GitLab auth provider configuration:
+
+  ```json
+    {
+      "type": "gitlab",
+      // ...
+      "ssoURL": "https://gitlab.com/groups/your-group/-/saml/sso?token=xxxxxxxx"
+      ]
+    }
+  ```
+
+The `token` parameter can be found on the **Settings > SAML SSO** page on GitLab.
+
 ## Bitbucket Cloud
 
 [Create a Bitbucket Cloud OAuth consumer](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/). Set the following values, replacing `sourcegraph.example.com` with the IP or hostname of your

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     timeout = "short",
     srcs = [
         "config_test.go",
+        "login_test.go",
         "middleware_test.go",
         "session_test.go",
     ],
@@ -64,9 +65,12 @@ go_test(
         "//lib/errors",
         "//schema",
         "@com_github_davecgh_go_spew//spew",
+        "@com_github_dghubble_gologin//oauth2",
+        "@com_github_dghubble_gologin//testutils",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sergi_go_diff//diffmatchpatch",
         "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "@com_github_sergi_go_diff//diffmatchpatch",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
@@ -1,0 +1,41 @@
+package gitlaboauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	oauth2Login "github.com/dghubble/gologin/oauth2"
+	"github.com/dghubble/gologin/testutils"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func TestSSOLoginHandler(t *testing.T) {
+	expectedState := "state_val"
+	ssoURL := "https://api.example.com/-/saml/sso?token=1234"
+	expectedRedirect := ssoURL + "&redirect=" + url.QueryEscape("https://api.example.com/authorize?client_id=client_id&redirect_uri=redirect_url&response_type=code&state=state_val")
+	config := &oauth2.Config{
+		ClientID:     "client_id",
+		ClientSecret: "client_secret",
+		RedirectURL:  "redirect_url",
+		Endpoint: oauth2.Endpoint{
+			AuthURL: "https://api.example.com/authorize",
+		},
+	}
+	failure := testutils.AssertFailureNotCalled(t)
+
+	// SSOLoginHandler assert that:
+	// - redirects to the SSO URL, with a redirect to the authURL
+	// - redirect status code is 302
+	// - redirect url is the OAuth2 Config RedirectURL with the ClientID and ctx state
+	loginHandler := SSOLoginHandler(config, failure, ssoURL)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	ctx := oauth2Login.WithState(context.Background(), expectedState)
+	loginHandler.ServeHTTP(w, req.WithContext(ctx))
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, expectedRedirect, w.HeaderMap.Get("Location"))
+}

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
@@ -10,13 +10,14 @@ import (
 	oauth2Login "github.com/dghubble/gologin/oauth2"
 	"github.com/dghubble/gologin/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
 
 func TestSSOLoginHandler(t *testing.T) {
 	expectedState := "state_val"
 	ssoURL := "https://api.example.com/-/saml/sso?token=1234"
-	expectedRedirect := ssoURL + "&redirect=" + url.QueryEscape("https://api.example.com/authorize?client_id=client_id&redirect_uri=redirect_url&response_type=code&state=state_val")
+	expectedRedirectURL := "https://api.example.com/authorize?client_id=client_id&redirect_uri=redirect_url&response_type=code&state=state_val"
 	config := &oauth2.Config{
 		ClientID:     "client_id",
 		ClientSecret: "client_secret",
@@ -37,5 +38,9 @@ func TestSSOLoginHandler(t *testing.T) {
 	ctx := oauth2Login.WithState(context.Background(), expectedState)
 	loginHandler.ServeHTTP(w, req.WithContext(ctx))
 	assert.Equal(t, http.StatusFound, w.Code)
-	assert.Equal(t, expectedRedirect, w.HeaderMap.Get("Location"))
+	locationURL, err := url.Parse(w.HeaderMap.Get("Location"))
+	require.NoError(t, err)
+	locationRedirectURL, err := url.QueryUnescape(locationURL.Query().Get("redirect"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedRedirectURL, locationRedirectURL)
 }

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/login_test.go
@@ -17,7 +17,7 @@ import (
 func TestSSOLoginHandler(t *testing.T) {
 	expectedState := "state_val"
 	ssoURL := "https://api.example.com/-/saml/sso?token=1234"
-	expectedRedirectURL := "https://api.example.com/authorize?client_id=client_id&redirect_uri=redirect_url&response_type=code&state=state_val"
+	expectedRedirectURL := "/authorize?client_id=client_id&redirect_uri=redirect_url&response_type=code&state=state_val"
 	config := &oauth2.Config{
 		ClientID:     "client_id",
 		ClientSecret: "client_secret",

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -51,6 +51,12 @@ func parseProvider(logger log.Logger, db database.DB, callbackURL string, p *sch
 		ServiceID:    codeHost.ServiceID,
 		ServiceType:  codeHost.ServiceType,
 		Login: func(oauth2Cfg oauth2.Config) http.Handler {
+			// If p.SsoURL is set, we want to use our own SSOLoginHandler
+			// that takes care of GitLab SSO sign-in redirects.
+			if p.SsoURL != "" {
+				return SSOLoginHandler(&oauth2Cfg, nil, p.SsoURL)
+			}
+			// Otherwise use the normal LoginHandler
 			return LoginHandler(&oauth2Cfg, nil)
 		},
 		Callback: func(oauth2Cfg oauth2.Config) http.Handler {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1220,6 +1220,8 @@ type GitLabAuthProvider struct {
 	DisplayPrefix *string `json:"displayPrefix,omitempty"`
 	Hidden        bool    `json:"hidden,omitempty"`
 	Order         int     `json:"order,omitempty"`
+	// SsoURL description: An alternate sign-in URL used to ease SSO sign-in flows, such as https://gitlab.com/groups/your-group/saml/sso?token=xxxxxx
+	SsoURL string `json:"ssoURL,omitempty"`
 	// TokenRefreshWindowMinutes description: Time in minutes before token expiry when we should attempt to refresh it
 	TokenRefreshWindowMinutes int    `json:"tokenRefreshWindowMinutes,omitempty"`
 	Type                      string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2946,6 +2946,11 @@
           "description": "URL of the GitLab instance, such as https://gitlab.com or https://gitlab.example.com.",
           "default": "https://gitlab.com/"
         },
+        "ssoURL": {
+          "type": "string",
+          "description": "An alternate sign-in URL used to ease SSO sign-in flows, such as https://gitlab.com/groups/your-group/saml/sso?token=xxxxxx",
+          "default": ""
+        },
         "clientID": {
           "type": "string",
           "description": "The Client ID of the GitLab OAuth app, accessible from https://gitlab.com/oauth/applications (or the same path on your private GitLab instance)."


### PR DESCRIPTION
Closes #50879 

Adds a new Auth provider configuration option for GitLab auth providers, `ssoURL`. This is an optional URL that points to a GitLab group's SSO sign-in page, and adds the regular OAuth URL as a `redirect` parameter. So users will first sign in to GitLab using their SSO, then it  will redirect them to the normal OAuth flow.

GitLab's normal OAuth flow for groups that have SSO enabled is broken, and users will be redirected to the normal GitLab sign-in page where they have to provide a username and password, which they don't have, because they use SSO.

Imagine the following scenario:

- You work for a company, SecretOrg
- Your code is stored on GitLab, and your SecretOrg group uses SAML/SSO for signing in
- SecretOrg uses Sourcegraph, because SecretOrg is awesome
- You try to sign into Sourcegraph using the GitLab OAuth app that is configured for SecretOrg
- You get directed to https://gitlab.com/users/sign_in before you can authorise the OAuth app, and it asks for a username and password
- You don't have a username and password? You use SAML/SSO! What now!?
- You go back to Sourcegraph
- You open GitLab in a new tab, navigate to your GitLab group and sign in via SAML/SSO
- Then you go back to Sourcegraph, try to sign in again now that you have an active GitLab session, and it works

This is super annoying, and it's not intuitive how to solve this yourself unless you've been through this before.

## Test plan

Add unit test for new handler

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
