### PR TITLE
licensing: allow multiple instances with same license key

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -3,7 +3,9 @@ package productsubscription
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -11,8 +13,10 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/internal/slack"
 )
 
 var (
@@ -51,6 +55,35 @@ func logEvent(ctx context.Context, db database.DB, name string, siteID string) {
 
 	// this is best effort, so ignore errors
 	_ = db.EventLogs().Insert(ctx, e)
+}
+
+const multipleInstancesSameKeySlackFmt = `
+The license key ID <%s/site-admin/dotcom/product/subscriptions/%s#%s|%s> is used on multiple customer instances with site IDs: ` + "`%s`" + ` and ` + "`%s`" + `.
+
+To fix it, <https://app.golinks.io/internal-licensing-faq-slack-multiple|follow the guide to update the siteID and license key for all customer instances>.
+`
+
+func sendSlackMessage(logger log.Logger, license *dbLicense, siteID string) {
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
+	if err != nil {
+		logger.Error("parsing external URL from site config", log.Error(err))
+		return
+	}
+
+	dotcom := conf.Get().Dotcom
+	if dotcom == nil {
+		logger.Error("cannot parse dotcom site settings")
+		return
+	}
+
+	client := slack.New(dotcom.SlackLicenseExpirationWebhook)
+	err = client.Post(context.Background(), &slack.Payload{
+		Text: fmt.Sprintf(multipleInstancesSameKeySlackFmt, externalURL.String(), url.QueryEscape(license.ProductSubscriptionID), url.QueryEscape(license.ID), license.ID, *license.SiteID, siteID),
+	})
+	if err != nil {
+		logger.Error("error sending Slack message", log.Error(err))
+		return
+	}
 }
 
 func NewLicenseCheckHandler(db database.DB) http.Handler {
@@ -115,13 +148,16 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 		}
 
 		if license.SiteID != nil && !strings.EqualFold(*license.SiteID, siteID) {
-			logger.Warn("license being used with multiple site IDs", log.String("previousSiteID", *license.SiteID))
+			logger.Warn("license being used with multiple site IDs", log.String("previousSiteID", *license.SiteID), log.String("licenseKeyID", license.ID), log.String("subscriptionID", license.ProductSubscriptionID))
 			replyWithJSON(w, http.StatusOK, licensing.LicenseCheckResponse{
+				// TODO: revert this to false again in the future, once most customers have a separate
+				// license key per instance
 				Data: &licensing.LicenseCheckResponseData{
-					IsValid: false,
+					IsValid: true,
 					Reason:  ReasonLicenseIsAlreadyInUseMsg,
 				},
 			})
+			sendSlackMessage(logger, license, siteID)
 			return
 		}
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_check_handler_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	licensing "github.com/sourcegraph/sourcegraph/internal/accesstoken"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	elicensing "github.com/sourcegraph/sourcegraph/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -137,7 +137,7 @@ func TestNewLicenseCheckHandler(t *testing.T) {
 				"Authorization": {"Bearer " + hex.EncodeToString(assignedLicense.LicenseCheckToken)},
 			},
 			body:       getBody(""),
-			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: false, Reason: "license is already in use"}},
+			want:       elicensing.LicenseCheckResponse{Data: &elicensing.LicenseCheckResponseData{IsValid: true, Reason: ReasonLicenseIsAlreadyInUseMsg}},
 			wantStatus: http.StatusOK,
 		},
 		{


### PR DESCRIPTION
Rationale: https://docs.google.com/document/d/1o8fypurDxsukEbn9GaPQDv96PNyBPcoKlxpBQTW6l7U/edit

We do have customers who were broken because they use more than one instance with the same license key. We changed the v5.1 license key validation to only allow 1 license key per 1 instance. Until v5.1 it was a common setup to have multiple instances with the same key and it adds burden to customers and CE/TA teams to fix this.

This change is meant to switch from being reactive - mark the license on the instance as invalid when such a situation happens to be proactive - send a slack message to us instead and notify the customer that we need to change their license keys.

This change only needs releasing to dotcom, hence does not need backporting.

## Test plan

Tested locally via API calls + unit tests.

Slack message:
<img width="1156" alt="Screenshot 2023-07-14 at 13 54 40" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/db32df80-09e7-4881-bfe9-803f62e59c06">


API response:
<img width="349" alt="Screenshot 2023-07-14 at 13 54 00" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/548fe73c-3b16-4bd7-99bc-197166f91ad2">
