### PR TITLE
ref panel: only uncollapse prototypes if requested

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -99,6 +99,7 @@ interface State {
         references: boolean
         definitions: boolean
         implementations: boolean
+        prototypes: boolean
     }
 }
 
@@ -119,10 +120,16 @@ function createStateFromLocation(location: H.Location): null | State {
         references: viewState === 'references',
         definitions: viewState === 'definitions',
         implementations: viewState?.startsWith('implementations_') ?? false,
+        prototypes: viewState?.startsWith('implementations_') ?? false,
     }
     // If the URL doesn't contain tab=<tab>, we open it (likely because the
     // user clicked on a link in the preview code blob) to show definitions.
-    if (!collapsedState.references && !collapsedState.definitions && !collapsedState.implementations) {
+    if (
+        !collapsedState.references &&
+        !collapsedState.definitions &&
+        !collapsedState.implementations &&
+        !collapsedState.prototypes
+    ) {
         collapsedState.definitions = true
     }
 


### PR DESCRIPTION
This treats the "Prototypes" list just like "Implementations":

It's open if `implementations_` is in the URL, otherwise it's closed by default.

### Before
![screenshot_2023-07-14_13 01 01@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/5f314865-7572-4be0-9bd4-50caafae4847)

### After

![screenshot_2023-07-14_13 55 40@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/c9db9e36-9fff-44a9-a0a9-fdc4150ec750)


## Test plan

- Manual testing
