### PR TITLE
bzl: update to Go 1.20.5 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.19.8
+golang 1.20.5
 nodejs 16.18.1
 fd 8.6.0
 shfmt 3.5.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -278,7 +278,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.19.8",
+    version = "1.20.5",
 )
 
 linter_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,10 +43,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d",
+    sha256 = "51dc53293afe317d2696d4d6433a4c33feedb7748a9e352072e2ec3c0dafd2c6",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
     ],
 )
 

--- a/dev/backcompat/flakes.bzl
+++ b/dev/backcompat/flakes.bzl
@@ -24,5 +24,11 @@ FLAKES = {
             "reason": "Shifting constraints on table; ranking is experimental",
         },
     ],
-    "5.1.0": [],
+    "5.1.0": [
+        {
+            "path": "internal/database",
+            "prefix": "TestUserCredentials_CreateUpdate",
+            "reason": "Update to crypto internals affects ability to compare authenticators",
+        },
+    ],
 }

--- a/dev/go_stringer.bzl
+++ b/dev/go_stringer.bzl
@@ -15,11 +15,16 @@ def go_stringer(src, typ, name, additional_args=[]):
         # result in absolute paths. To account for this, we resolve the
         # relative path returned by location to an absolute path.
         cmd = """\
-GO_REL_PATH=`dirname $(location @go_sdk//:bin/go)`
-GO_ABS_PATH=`cd $$GO_REL_PATH && pwd`
-# Set GOPATH to something to workaround https://github.com/golang/go/issues/43938
-env PATH=$$GO_ABS_PATH HOME=$(GENDIR) GOPATH=/nonexist-gopath \
-$(location @org_golang_x_tools//cmd/stringer:stringer) -output=$@ -type={typ} {args} $<; \
+env \
+    PATH=$$(pwd)/external/go_sdk/bin \
+    GOCACHE=$$(pwd)/bazel-out/darwin_arm64-fastbuild/bin/Library/Caches/go-build \
+    GOROOT=$$(pwd)/external/go_sdk \
+    $(location @org_golang_x_tools//cmd/stringer:stringer) \
+        -output=$@ \
+        -type={typ} \
+        {args} \
+        $<; \
+
 # Because stringer will add a comment on the file saying how it generated that file, we end up
 # in a delicate case, where the comment mentions the path the bazel sandbox, which varies
 # depending on your OS (like bazel-out/darwin-fastbuild or bazel-out/linux-fastbuild) which
@@ -34,6 +39,8 @@ sed -i'' -e 's=$@='`basename $@`'=' $@
         visibility = [":__pkg__", "//pkg/gen:__pkg__"],
         exec_tools = [
             "@go_sdk//:bin/go",
+            "@go_sdk//:srcs",
+            "@go_sdk//:tools",
             "@org_golang_x_tools//cmd/stringer",
         ],
     )

--- a/dev/go_stringer.bzl
+++ b/dev/go_stringer.bzl
@@ -17,7 +17,7 @@ def go_stringer(src, typ, name, additional_args=[]):
         cmd = """\
 env \
     PATH=$$(pwd)/external/go_sdk/bin \
-    GOCACHE=$$(pwd)/bazel-out/darwin_arm64-fastbuild/bin/Library/Caches/go-build \
+    GOCACHE=$$(mktemp -d) \
     GOROOT=$$(pwd)/external/go_sdk \
     $(location @org_golang_x_tools//cmd/stringer:stringer) \
         -output=$@ \

--- a/dev/go_stringer.bzl
+++ b/dev/go_stringer.bzl
@@ -15,10 +15,13 @@ def go_stringer(src, typ, name, additional_args=[]):
         # result in absolute paths. To account for this, we resolve the
         # relative path returned by location to an absolute path.
         cmd = """\
+GO_ABS_PATH=`cd $$(dirname $(location @go_sdk//:bin/go)) && pwd`
+GO_SDK_ABS_PATH=`dirname $$GO_ABS_PATH`
+
 env \
-    PATH=$$(pwd)/external/go_sdk/bin \
+    PATH=$$GO_ABS_PATH \
     GOCACHE=$$(mktemp -d) \
-    GOROOT=$$(pwd)/external/go_sdk \
+    GOROOT=$$GO_SDK_ABS_PATH \
     $(location @org_golang_x_tools//cmd/stringer:stringer) \
         -output=$@ \
         -type={typ} \

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -34,7 +34,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"pnpm":                  check.Combine(check.InPath("pnpm"), checkPnpmVersion(">= 8.3.0")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.19.8")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.20.5")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -229,7 +229,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 			have, err := cred.Authenticator(fx.userCtx)
 			assert.NoError(t, err)
-			assert.Equal(t, authenticator, have)
+			assert.Equal(t, authenticator.Hash(), have.Hash())
 
 			// Ensure that trying to insert again fails.
 			second, err := fx.db.Create(fx.userCtx, scope, authenticator)


### PR DESCRIPTION
- bumps `rules_go` to `0.40.1` (didn't go for `0.41.0` yet, the breaking change with google apis is a bit messy to deal with, can be handled in a second time). 
- Because of an update to the crypto libs, we can't compare authenticators directly anymore. Instead I updated the test code to compare their `.Hash()`, which is semantically equivalent.
  - Added that particular test to the flakes, to green the back compat tests.  
- Big thanks to @camdencheek for fixing the issues with the Go compiler and the `execabs` mess which requires absolute paths, which needed to be fixed, as Go 1.20.X doesn't ship with precompiled code for the stdlib anymore. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI 