### PR TITLE
bazel: monitoring docs gen

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -329,23 +329,3 @@ exports_files([
     # under certain conditions. See //ui/assets/...
     "CONTRIBUTING.md",
 ])
-
-write_generated_to_source_files(
-    name = "write_monitoring_docs",
-    src = "//monitoring:generate_config",
-    dest = "doc/admin/observability/",
-    # :generate_config creates an outputs folder with:
-    # - grafana dashboards
-    # - prometheus config
-    # - docs describing dashboards and alerts
-    # the grafana dashboards and prometheus config are handled by other targets under //monitoring
-    # but we need to write the docs back to the repo root, and in Bazel we can't use relative paths
-    # to go to the parents directory (i.e one up from monitoring is the repo root)
-    files = [
-        "outputs/docs/alerts.md",
-        "outputs/docs/dashboards.md",
-    ],
-    # since :generate_config stores all the generated files under outputs, we want to copy them out without "outputs/"
-    strip_prefix = "outputs/docs/",
-    tags = ["go_generate"],
-)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ load("//dev/linters/staticcheck:analyzers.bzl", "STATIC_CHECK_ANALYZERS")
 load("@npm//:eslint/package_json.bzl", eslint_bin = "bin")
 load("//:stamp_tags.bzl", "stamp_tags")
 load("//dev:eslint.bzl", "eslint_test_with_types")
+load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
 
 # Gazelle config
 #
@@ -329,7 +330,22 @@ exports_files([
     "CONTRIBUTING.md",
 ])
 
-# stamp_tags(
-#     name = "tags",
-#     remote_tags = ["""($stamp.STABLE_VERSION // "0.0.0")"""],
-# )
+write_generated_to_source_files(
+    name = "write_monitoring_docs",
+    src = "//monitoring:generate_config",
+    dest = "doc/admin/observability/",
+    # :generate_config creates an outputs folder with:
+    # - grafana dashboards
+    # - prometheus config
+    # - docs describing dashboards and alerts
+    # the grafana dashboards and prometheus config are handled by other targets under //monitoring
+    # but we need to write the docs back to the repo root, and in Bazel we can't use relative paths
+    # to go to the parents directory (i.e one up from monitoring is the repo root)
+    files = [
+        "outputs/docs/alerts.md",
+        "outputs/docs/dashboards.md",
+    ],
+    # since :generate_config stores all the generated files under outputs, we want to copy them out without "outputs/"
+    strip_prefix = "outputs/docs/",
+    tags = ["go_generate"],
+)

--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -11,11 +11,12 @@ exports_files(srcs = ["eslint-report-test.sh"])
 write_source_files(
     name = "write_all_generated",
     additional_update_targets = [
-        "//lib/codeintel/lsif/protocol:write_symbol_kind",
-        "//lib/codeintel/lsif/protocol:write_symbol_tag",
-        "//internal/batches/search/syntax:write_token_type",
+        "//cmd/cody-gateway/internal/dotcom:write_genql_yaml",
+        "//doc/admin/observability:write_monitoring_docs",
         "//doc/cli/references:write_doc_files",
         "//enterprise/cmd/frontend/internal/guardrails/dotcom:write_genql_yaml",
-        "//cmd/cody-gateway/internal/dotcom:write_genql_yaml",
+        "//internal/batches/search/syntax:write_token_type",
+        "//lib/codeintel/lsif/protocol:write_symbol_kind",
+        "//lib/codeintel/lsif/protocol:write_symbol_tag",
     ],
 )

--- a/dev/write_generated_to_source_files.bzl
+++ b/dev/write_generated_to_source_files.bzl
@@ -4,7 +4,6 @@ load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def write_generated_to_source_files(name, src, files, dest = "", strip_prefix = "", verbose_copy=True, **kwargs):
-
     currentTarget = native.package_relative_label(name)
     srcTarget = Label(src)
     copy_opts = {

--- a/dev/write_generated_to_source_files.bzl
+++ b/dev/write_generated_to_source_files.bzl
@@ -6,7 +6,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 def write_generated_to_source_files(name, src, files, strip_prefix = "", verbose_copy=False, **kwargs):
     # We use a copy_to_directory macro so write_source_files inputs and outputs are not at the same
     # path, which enables the write_doc_files_diff_test to work.
-    copy_to_directory(name="copy_"+name, src=[src], verbose=verbose_copy)
+    copy_to_directory(name="copy_"+name, srcs=[src], verbose=verbose_copy)
 
     write_source_files(
         name = name,

--- a/dev/write_generated_to_source_files.bzl
+++ b/dev/write_generated_to_source_files.bzl
@@ -3,7 +3,7 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def write_generated_to_source_files(name, src, files, dest = "", strip_prefix = "", verbose_copy=True, **kwargs):
+def write_generated_to_source_files(name, src, files, strip_prefix = "", verbose_copy=True, **kwargs):
     currentTarget = native.package_relative_label(name)
     srcTarget = Label(src)
     copy_opts = {
@@ -19,26 +19,15 @@ def write_generated_to_source_files(name, src, files, dest = "", strip_prefix = 
         copy_opts["root_paths"] = [
             srcTarget.package
         ]
-        # copy_opts["replace_prefixes"] = {
-        #     srcTarget.package: "",
-        # }
 
     # We use a copy_to_directory macro so write_source_files inputs and outputs are not at the same
     # path, which enables the write_doc_files_diff_test to work.
-    copy_to_directory(verbose=verbose_copy,**copy_opts)
-
-    def dest_path(value, strip_prefix):
-        target = value.removeprefix(strip_prefix)
-        if dest:
-            target = paths.join(dest, target)
-
-        print(target)
-        return target
+    copy_to_directory(verbose=verbose_copy, **copy_opts)
 
     write_source_files(
         name = name,
         files =  {
-            dest_path(out, strip_prefix): make_directory_path(
+            out.removeprefix(strip_prefix): make_directory_path(
                 out + "_directory_path",
                 "copy_" + name,
                 out,

--- a/dev/write_generated_to_source_files.bzl
+++ b/dev/write_generated_to_source_files.bzl
@@ -3,26 +3,10 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def write_generated_to_source_files(name, src, files, strip_prefix = "", verbose_copy=True, **kwargs):
-    currentTarget = native.package_relative_label(name)
-    srcTarget = Label(src)
-    copy_opts = {
-        "name" : "copy_" + name,
-        "srcs" : [src],
-    }
-
-    # when we're in the same package as the src target, we don't need to change the root path
-    # BUT when we're in different packages we need to replace the src target package root, since
-    # all it's outputs path will have the src package as part of the path. So set root_paths to
-    # the src target package path, which means it will be removed as part of copying
-    if currentTarget.package != srcTarget.package:
-        copy_opts["root_paths"] = [
-            srcTarget.package
-        ]
-
+def write_generated_to_source_files(name, src, files, strip_prefix = "", verbose_copy=False, **kwargs):
     # We use a copy_to_directory macro so write_source_files inputs and outputs are not at the same
     # path, which enables the write_doc_files_diff_test to work.
-    copy_to_directory(verbose=verbose_copy, **copy_opts)
+    copy_to_directory(name="copy_"+name, src=[src], verbose=verbose_copy)
 
     write_source_files(
         name = name,

--- a/dev/write_generated_to_source_files.bzl
+++ b/dev/write_generated_to_source_files.bzl
@@ -1,19 +1,45 @@
 load("@aspect_bazel_lib//lib:directory_path.bzl", "make_directory_path")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def write_generated_to_source_files(name, src, files, **kwargs):
+def write_generated_to_source_files(name, src, files, dest = "", strip_prefix = "", verbose_copy=True, **kwargs):
+
+    currentTarget = native.package_relative_label(name)
+    srcTarget = Label(src)
+    copy_opts = {
+        "name" : "copy_" + name,
+        "srcs" : [src],
+    }
+
+    # when we're in the same package as the src target, we don't need to change the root path
+    # BUT when we're in different packages we need to replace the src target package root, since
+    # all it's outputs path will have the src package as part of the path. So set root_paths to
+    # the src target package path, which means it will be removed as part of copying
+    if currentTarget.package != srcTarget.package:
+        copy_opts["root_paths"] = [
+            srcTarget.package
+        ]
+        # copy_opts["replace_prefixes"] = {
+        #     srcTarget.package: "",
+        # }
+
     # We use a copy_to_directory macro so write_source_files inputs and outputs are not at the same
     # path, which enables the write_doc_files_diff_test to work.
-    copy_to_directory(
-        name = "copy_" + name,
-        srcs = [src]
-    )
+    copy_to_directory(verbose=verbose_copy,**copy_opts)
+
+    def dest_path(value, strip_prefix):
+        target = value.removeprefix(strip_prefix)
+        if dest:
+            target = paths.join(dest, target)
+
+        print(target)
+        return target
 
     write_source_files(
         name = name,
-        files = {
-            out: make_directory_path(
+        files =  {
+            dest_path(out, strip_prefix): make_directory_path(
                 out + "_directory_path",
                 "copy_" + name,
                 out,

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -6,8 +6,8 @@ sh_test(
     args = ["$(location //dev/tools:docsite)"],
     data = [
         "//dev/tools:docsite",
-        "//doc/cli/references:doc_files",
         "//doc/admin/observability:doc_files",
+        "//doc/cli/references:doc_files",
     ] + glob(
         ["**/*"],
         ["test.sh"],

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -7,6 +7,7 @@ sh_test(
     data = [
         "//dev/tools:docsite",
         "//doc/cli/references:doc_files",
+        "//doc/admin/observability:doc_files",
     ] + glob(
         ["**/*"],
         ["test.sh"],

--- a/doc/admin/observability/BUILD.bazel
+++ b/doc/admin/observability/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
+
+write_generated_to_source_files(
+    name = "write_monitoring_docs",
+    src = "//monitoring:generate_config",
+    # :generate_config creates an outputs folder with:
+    # - grafana dashboards
+    # - prometheus config
+    # - docs describing dashboards and alerts
+    # the grafana dashboards and prometheus config are handled by other targets under //monitoring
+    # but we need to write the docs back to the repo root, and in Bazel we can't use relative paths
+    # to go to the parents directory (i.e one up from monitoring is the repo root)
+    files = [
+        "outputs/docs/alerts.md",
+        "outputs/docs/dashboards.md",
+    ],
+    # since :generate_config stores all the generated files under outputs, we want to copy them out without "outputs/"
+    strip_prefix = "outputs/docs/",
+    tags = ["go_generate"],
+)

--- a/doc/admin/observability/BUILD.bazel
+++ b/doc/admin/observability/BUILD.bazel
@@ -1,5 +1,16 @@
 load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
 
+filegroup(
+    name = "doc_files",
+    srcs = glob(
+        ["**/*"],
+        [
+            ".gitattributes",
+        ],
+    ),
+    visibility = ["//doc:__pkg__"],
+)
+
 write_generated_to_source_files(
     name = "write_monitoring_docs",
     src = "//monitoring:generate_config",

--- a/doc/admin/observability/BUILD.bazel
+++ b/doc/admin/observability/BUILD.bazel
@@ -7,14 +7,11 @@ write_generated_to_source_files(
     # - grafana dashboards
     # - prometheus config
     # - docs describing dashboards and alerts
-    # the grafana dashboards and prometheus config are handled by other targets under //monitoring
-    # but we need to write the docs back to the repo root, and in Bazel we can't use relative paths
-    # to go to the parents directory (i.e one up from monitoring is the repo root)
     files = [
-        "outputs/docs/alerts.md",
-        "outputs/docs/dashboards.md",
+        "monitoring/outputs/docs/alerts.md",
+        "monitoring/outputs/docs/dashboards.md",
     ],
-    # since :generate_config stores all the generated files under outputs, we want to copy them out without "outputs/"
-    strip_prefix = "outputs/docs/",
+    # since :generate_config stores all the generated files under monitroing/outputs when outside of the monitoring package
+    strip_prefix = "monitoring/outputs/docs/",
     tags = ["go_generate"],
 )

--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -1,5 +1,4 @@
-//go:generate go build -o /tmp/monitoring-generator
-//go:generate /tmp/monitoring-generator
+//go:generate bazel run //:write_monitoring_docs
 package main
 
 import (

--- a/monitoring/main.go
+++ b/monitoring/main.go
@@ -1,4 +1,9 @@
-//go:generate bazel run //:write_monitoring_docs
+// The monitoring generator is now called by Bazel targets instead of go generate
+//
+// To run monitoring generator run:
+// - bazel build //monitoring:generate_config # see bazel-bin/monitoring/outputs
+// - bazel build //monitoring:generate_config_zip # see bazel-bin/monitoring/monitoring.zip
+// - bazel build //monitoring:generate_grafana_config_tar # see bazel-bin/monitoring/monitoring.tar
 package main
 
 import (


### PR DESCRIPTION
### Changes
improve `write_generated_to_source_files` to:
- allow prefixes to be stripped from generated files
- specify a different destination
- handle being called from a different package than being next to the src target

This seemed like an easy change on the outset but it turned out to be quite involved. Some of the problems I encountered while doing this which required the above changes:

* monitoring-generator copies to a total different path in the repo route than what it normally outputs - ie. docs/alerts.md, docs/dashboard.md -> doc/admin/observability/
* `//monitoring:generate_config` outputs are local to it and AFAIK you can copy/move files to the parent package/dir
* The `//monitoring:generate_config` already does 90% of what we needed, but the outputs needed to be massaged a bit to fit out use case.
* When one target calls another target in a macro and they're not in the same package, the "outside" targets outputs will have it's package name prepended. Which is why we use `root_paths` during copy to have the copied file paths the same as if the target was called in the same package
Example:
```
bazel run //:write_monitoring_docs
-> calls //monitoring:generate_config
-> results in outputs being available under `bazel-out/.../monitoring/outputs/`

bazel run //monitoring:write_monitoring_docs
-> calls //monitoring:generate_config
-> results in outputs  being available under `bazel-out/.../outputs/
```


## Test plan
run locally

- [ ] Other generated targets still work
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
