### PR TITLE
Embeddings: optimize memory usage during decode

### DIFF
--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -36,7 +36,7 @@ func searchRepoEmbeddingIndexes(
 	if err != nil {
 		return nil, err
 	}
-	embeddedQuery := embeddings.Quantize(floatQuery)
+	embeddedQuery := embeddings.Quantize(floatQuery, nil)
 
 	workerOpts := embeddings.WorkerOptions{
 		NumWorkers:     runtime.GOMAXPROCS(0),

--- a/internal/embeddings/BUILD.bazel
+++ b/internal/embeddings/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
     srcs = [
         "dot_test.go",
         "index_storage_test.go",
+        "quantize_test.go",
         "schedule_test.go",
         "similarity_search_test.go",
         "types_test.go",

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -106,7 +106,7 @@ func EmbedRepo(
 
 	insertIndex := func(index *embeddings.EmbeddingIndex, metadata []embeddings.RepoEmbeddingRowMetadata, vectors []float32) {
 		index.RowMetadata = append(index.RowMetadata, metadata...)
-		index.Embeddings = append(index.Embeddings, embeddings.Quantize(vectors)...)
+		index.Embeddings = append(index.Embeddings, embeddings.Quantize(vectors, nil)...)
 		// Unknown documents have rank 0. Zoekt is a bit smarter about this, assigning 0
 		// to "unimportant" files and the average for unknown files. We should probably
 		// add this here, too.

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -229,13 +229,14 @@ func (d *decoder) decode() (*RepoEmbeddingIndex, error) {
 			return nil, err
 		}
 
-		ei.Embeddings = make([]int8, 0, numChunks*ei.ColumnDimension)
+		ei.Embeddings = make([]int8, 0, numChunks*embeddingsChunkSize)
+		embeddingSlice := make([]float32, 0, embeddingsChunkSize)
+		quantizeBuf := make([]int8, embeddingsChunkSize)
 		for i := 0; i < numChunks; i++ {
-			var embeddingSlice []float32
 			if err := d.dec.Decode(&embeddingSlice); err != nil {
 				return nil, err
 			}
-			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingSlice)...)
+			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingSlice, quantizeBuf)...)
 		}
 	}
 

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -230,13 +230,13 @@ func (d *decoder) decode() (*RepoEmbeddingIndex, error) {
 		}
 
 		ei.Embeddings = make([]int8, 0, numChunks*embeddingsChunkSize)
-		embeddingSlice := make([]float32, 0, embeddingsChunkSize)
+		embeddingsBuf := make([]float32, 0, embeddingsChunkSize)
 		quantizeBuf := make([]int8, embeddingsChunkSize)
 		for i := 0; i < numChunks; i++ {
-			if err := d.dec.Decode(&embeddingSlice); err != nil {
+			if err := d.dec.Decode(&embeddingsBuf); err != nil {
 				return nil, err
 			}
-			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingSlice, quantizeBuf)...)
+			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingsBuf, quantizeBuf)...)
 		}
 	}
 

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -269,3 +269,29 @@ func BenchmarkCustomRepoEmbeddingIndexUpload(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCustomRepoEmbeddingIndexDownload(b *testing.B) {
+	// Roughly the size of the sourcegraph/sourcegraph index.
+	index := &RepoEmbeddingIndex{
+		RepoName:  api.RepoName("repo"),
+		Revision:  api.CommitID("commit"),
+		CodeIndex: getMockEmbeddingIndex(40_000, 1536),
+		TextIndex: getMockEmbeddingIndex(10_000, 1536),
+	}
+
+	ctx := context.Background()
+	uploadStore := newMockUploadStore()
+	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "index", index)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := downloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/embeddings/quantize.go
+++ b/internal/embeddings/quantize.go
@@ -10,6 +10,9 @@ import "math"
 // quantization function yielded rankings where the average change in rank was
 // only 1.2%. 93 of the top 100 rows  were unchanged, and 950 of the top 1000
 // were unchanged.
+//
+// When buf is large enough to fit the output, it will be used instead of
+// an allocation.
 func Quantize(input []float32, buf []int8) []int8 {
 	output := buf
 	if len(input) > len(buf) {

--- a/internal/embeddings/quantize.go
+++ b/internal/embeddings/quantize.go
@@ -10,8 +10,11 @@ import "math"
 // quantization function yielded rankings where the average change in rank was
 // only 1.2%. 93 of the top 100 rows  were unchanged, and 950 of the top 1000
 // were unchanged.
-func Quantize(input []float32) []int8 {
-	output := make([]int8, len(input))
+func Quantize(input []float32, buf []int8) []int8 {
+	output := buf
+	if len(input) > len(buf) {
+		output = make([]int8, len(input))
+	}
 	for i, val := range input {
 		// All our inputs should be in [-1, 1],
 		// but double check just in case.
@@ -27,7 +30,7 @@ func Quantize(input []float32) []int8 {
 		// better accuracy.
 		output[i] = int8(math.Round(float64(val) * 127.0))
 	}
-	return output
+	return output[:len(input)]
 }
 
 func Dequantize(input []int8) []float32 {

--- a/internal/embeddings/quantize_test.go
+++ b/internal/embeddings/quantize_test.go
@@ -1,0 +1,19 @@
+package embeddings
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestQuantize(t *testing.T) {
+	t.Run("buf doesn't affect output", func(t *testing.T) {
+		a := func(input []float32, buf []int8) []int8 {
+			return Quantize(input, buf)
+		}
+
+		b := func(input []float32, buf []int8) []int8 {
+			return Quantize(input, nil)
+		}
+		quick.CheckEqual(a, b, nil)
+	})
+}

--- a/internal/embeddings/types.go
+++ b/internal/embeddings/types.go
@@ -158,7 +158,7 @@ type OldEmbeddingIndex struct {
 
 func (o *OldEmbeddingIndex) ToNewIndex() EmbeddingIndex {
 	return EmbeddingIndex{
-		Embeddings:      Quantize(o.Embeddings),
+		Embeddings:      Quantize(o.Embeddings, nil),
 		ColumnDimension: o.ColumnDimension,
 		RowMetadata:     o.RowMetadata,
 		Ranks:           o.Ranks,


### PR DESCRIPTION
This makes memory usage ~constant during the decode process. Previously, we were undersizing the large allocation (which caused it to reallocate ~10 extra times) for the index and making a bunch of additional smaller allocations per loop. This meant we were spiking memory usage during decoding, and even if the garbage collector could keep up (which I wouldn't expect it to), we'd still need 2x the index size at the peak for live memory. This was causing an OOM. 

Before:
```
BenchmarkCustomRepoEmbeddingIndexDownload-10                   1        1212576041 ns/op        1299284528 B/op    96393 allocs/op
```

After:
```
BenchmarkCustomRepoEmbeddingIndexDownload-10                   1        1193088500 ns/op        589103720 B/op     65660 allocs/op
```

That's a 2.2x reduction in allocated bytes and a 1.4x reduction in allocation count. This is quite significant when our indexes are many GBs in memory.

## Test plan

A new benchmark to demonstrate better memory behavior, a new quick test on the quantize changes, existing tests on encode/decode, and manual E2E tests for generating and searching with an embeddings index.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
