### PR TITLE
fix bug for gerrit repos that have a/ at the start of their name

### DIFF
--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/sourcegraph/log"

--- a/internal/repos/clone_url.go
+++ b/internal/repos/clone_url.go
@@ -255,8 +255,8 @@ func gerritCloneURL(logger log.Logger, project *gerrit.Project, cfg *schema.Gerr
 	}
 	u.User = url.UserPassword(cfg.Username, cfg.Password)
 
-	// Gerrit encodes slashes in IDs, so need to decode them.
-	u.Path = strings.ReplaceAll(project.ID, "%2F", "/")
+	// Gerrit encodes slashes in IDs, so need to decode them. The 'a' is for cloning with auth.
+	u.Path = path.Join("a", strings.ReplaceAll(project.ID, "%2F", "/"))
 
 	return u.String()
 }

--- a/internal/repos/clone_url_test.go
+++ b/internal/repos/clone_url_test.go
@@ -265,7 +265,7 @@ func TestGerritCloneURL(t *testing.T) {
 	}
 
 	got := gerritCloneURL(logtest.Scoped(t), project, &cfg)
-	want := "https://admin:pa$$word@gerrit.com/test-project"
+	want := "https://admin:pa$$word@gerrit.com/a/test-project"
 	if got != want {
 		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
 	}


### PR DESCRIPTION
We weren't including the `a/ `in the clone url for gerrit repos, which wasn't really a problem unless the gerrit repo's name started with an `a/`.

## Test plan

Manual
![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/cfc6918a-a8a5-48c1-ac0a-5e577f9e4d8f)
