### PR TITLE
App: Clearer CTAs on the extension install page

### DIFF
--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.module.scss
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.module.scss
@@ -86,8 +86,9 @@
     }
 
     &-suggestion-link {
-        display: flex;
-        justify-content: center;
         padding: 1rem;
+        font-size: 0.75rem;
+        text-align: center;
+        color: var(--text-muted);
     }
 }

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -63,10 +63,9 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
     return (
         <div className={classNames(styles.root, className)}>
             <div className={styles.description}>
-                <H1 className={styles.descriptionHeading}>Install the extension</H1>
+                <H1 className={styles.descriptionHeading}>Install an extension</H1>
                 <Text className={styles.descriptionText}>
-                    Ask Cody questions right within your editor. The Cody extension also has a fixup code feature,
-                    recipes, and experimental autocomplete.
+                    Use Cody from within your editor, using one of the Cody extensions.
                 </Text>
 
                 <Button size="lg" variant="primary" className={styles.descriptionNext} onClick={() => onNextStep()}>

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -15,8 +15,9 @@ interface Extension {
     name: string
     status: ExtensionStatus
     iconURL: string
-    docLink: string | null
-    extensionDeepLink: string | null
+    docLink?: string
+    installHref?: string
+    installLabel?: string
 }
 
 enum ExtensionStatus {
@@ -29,25 +30,23 @@ enum ExtensionStatus {
 
 const EXTENSIONS: Extension[] = [
     {
-        name: 'Cody for VS Code',
+        name: 'Visual Studio Code',
         status: ExtensionStatus.GA,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/vscode-icon.png',
-        docLink: null,
-        extensionDeepLink: 'vscode:extension/sourcegraph.cody-ai',
+        installHref: 'vscode:extension/sourcegraph.cody-ai',
+        installLabel: 'Install extension'
     },
     {
-        name: 'Cody for IntelliJ Idea',
+        name: 'IntelliJ Idea',
         status: ExtensionStatus.Experimental,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/idea-icon.png',
-        docLink: null,
-        extensionDeepLink: 'https://plugins.jetbrains.com/plugin/9682-sourcegraph',
+        installHref: 'https://plugins.jetbrains.com/plugin/9682-sourcegraph',
+        installLabel: 'Install plugin'
     },
     {
-        name: 'Cody for NeoVim',
+        name: 'NeoVim',
         status: ExtensionStatus.ComingSoon,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/neovim-icon.png',
-        docLink: null,
-        extensionDeepLink: null,
     },
 ]
 
@@ -55,8 +54,8 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
     const { onNextStep } = useContext(SetupStepsContext)
 
     const handleInstallExtensionClick = (extension: Extension): void => {
-        if (extension.extensionDeepLink) {
-            tauriShellOpen(extension.extensionDeepLink)
+        if (extension.installHref) {
+            tauriShellOpen(extension.installHref)
         }
     }
 
@@ -84,14 +83,16 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                             </Badge>
                         </div>
 
-                        {extension.extensionDeepLink && (
+                        {extension.installHref && (
                             <Button
                                 variant="secondary"
                                 outline={true}
                                 size="sm"
                                 onClick={() => handleInstallExtensionClick(extension)}
                             >
-                                <Icon svgPath={mdiDownload} aria-hidden={true} /> Install
+                                <Icon svgPath={mdiDownload} aria-hidden={true} />
+                                {' '}
+                                {extension.installLabel}
                             </Button>
                         )}
 

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -110,13 +110,17 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                 ))}
 
                 <li className={styles.extensionsSuggestionLink}>
-                    <Link
-                        to="https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&title=Cody%20extension%20suggestion"
-                        target="_blank"
-                        rel="noopener"
-                    >
-                        Suggest our next extension
-                    </Link>
+                    <span>
+                        Your editor not listed here?
+                        <br/>
+                        <Link
+                            to="https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&title=Cody%20extension%20suggestion"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Suggest an extension
+                        </Link>
+                    </span>
                 </li>
             </ul>
 

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -29,21 +29,21 @@ enum ExtensionStatus {
 
 const EXTENSIONS: Extension[] = [
     {
-        name: 'Visual Studio Code',
+        name: 'Cody for VS Code',
         status: ExtensionStatus.GA,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/vscode-icon.png',
         docLink: null,
         extensionDeepLink: 'vscode:extension/sourcegraph.cody-ai',
     },
     {
-        name: 'IntelliJ Idea',
+        name: 'Cody for IntelliJ Idea',
         status: ExtensionStatus.Experimental,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/idea-icon.png',
         docLink: null,
         extensionDeepLink: 'https://plugins.jetbrains.com/plugin/9682-sourcegraph',
     },
     {
-        name: 'NeoVim',
+        name: 'Cody for NeoVim',
         status: ExtensionStatus.ComingSoon,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/neovim-icon.png',
         docLink: null,

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -3,7 +3,7 @@ import { FC, useContext } from 'react'
 import { mdiDownload, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { Badge, Button, H1, H3, Link, Text, Icon, BadgeVariantType } from '@sourcegraph/wildcard'
+import { Badge, Button, H1, H3, Link, Text, Icon } from '@sourcegraph/wildcard'
 
 import { tauriShellOpen } from '../../../../app/tauriIcpUtils'
 import { FooterWidget, SetupStepsContext, StepComponentProps } from '../../../../setup-wizard/components'
@@ -78,7 +78,7 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                         <img src={extension.iconURL} alt="" className={styles.extensionsIcon} />
                         <div className={styles.extensionsName}>
                             <H3 className="m-0">{extension.name}</H3>
-                            <Badge variant={getBadgeStatus(extension.status)} small={true}>
+                            <Badge variant='outlineSecondary' small={true}>
                                 {extension.status}
                             </Badge>
                         </div>
@@ -131,14 +131,3 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
     )
 }
 
-function getBadgeStatus(status: ExtensionStatus): BadgeVariantType {
-    switch (status) {
-        case ExtensionStatus.Beta:
-        case ExtensionStatus.Experimental:
-            return 'secondary'
-        case ExtensionStatus.ComingSoon:
-            return 'outlineSecondary'
-        default:
-            return 'outlineSecondary'
-    }
-}

--- a/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
+++ b/client/web/src/enterprise/app/setup/steps/AppInstallExtensionsSetupStep.tsx
@@ -34,14 +34,14 @@ const EXTENSIONS: Extension[] = [
         status: ExtensionStatus.GA,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/vscode-icon.png',
         installHref: 'vscode:extension/sourcegraph.cody-ai',
-        installLabel: 'Install extension'
+        installLabel: 'Install extension',
     },
     {
         name: 'IntelliJ Idea',
         status: ExtensionStatus.Experimental,
         iconURL: 'https://storage.googleapis.com/sourcegraph-assets/setup/idea-icon.png',
         installHref: 'https://plugins.jetbrains.com/plugin/9682-sourcegraph',
-        installLabel: 'Install plugin'
+        installLabel: 'Install plugin',
     },
     {
         name: 'NeoVim',
@@ -78,7 +78,7 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                         <img src={extension.iconURL} alt="" className={styles.extensionsIcon} />
                         <div className={styles.extensionsName}>
                             <H3 className="m-0">{extension.name}</H3>
-                            <Badge variant='outlineSecondary' small={true}>
+                            <Badge variant="outlineSecondary" small={true}>
                                 {extension.status}
                             </Badge>
                         </div>
@@ -90,9 +90,7 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                                 size="sm"
                                 onClick={() => handleInstallExtensionClick(extension)}
                             >
-                                <Icon svgPath={mdiDownload} aria-hidden={true} />
-                                {' '}
-                                {extension.installLabel}
+                                <Icon svgPath={mdiDownload} aria-hidden={true} /> {extension.installLabel}
                             </Button>
                         )}
 
@@ -112,7 +110,7 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
                 <li className={styles.extensionsSuggestionLink}>
                     <span>
                         Your editor not listed here?
-                        <br/>
+                        <br />
                         <Link
                             to="https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&title=Cody%20extension%20suggestion"
                             target="_blank"
@@ -130,4 +128,3 @@ export const AppInstallExtensionsSetupStep: FC<StepComponentProps> = ({ classNam
         </div>
     )
 }
-


### PR DESCRIPTION
Based on [this user test by @meglynst](https://sourcegraph.dovetailapp.com/data/HgYNJ7Hwipazu5LkkvtgA#v=ewAiAGMAIgA6ACIANQA0ADEAYgAyADgAMABhAC0AYgBhAGYAOQAtADQAYQAwAGQALQA5ADgAOABkAC0ANABiADQAOQA0ADkAMQA4ADAANQBlAGIAIgB9AA), the design of the App’s Extensions page can mislead people into thinking that the "Install" link is about installing the IDE itself. This PR:

* Updates the CTA label of each extension to make it clearer that you’re installing the Cody extension, not the IDE itself. This should also help them if something goes wrong with the deep link (as it did in that use test), as generally most IDE users know how to install an extension from their marketplace.
* Cleans up left side words (multiple editors, and they have different capabilities so I removed the feature list)
* Smaller but more explicit CTA for requesting an editor extension (no use of "our")
* Uses a single badge style

| Before | After |
| - | - |
| <img width="1052" alt="Screenshot 2023-07-18 at 3 21 27 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/10ec4c15-a6f4-457b-a8a9-bab47463594a"> | <img width="1052" alt="Screenshot 2023-07-18 at 3 20 23 pm" src="https://github.com/sourcegraph/sourcegraph/assets/153/284d59e4-f2dc-4f5a-adb1-1c7a5c3a925f"> |

## Test plan

- Ran locally
- Tested links and buttons