### PR TITLE
source: disable edit button for codehost connections when it's uneditable

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditingDisabledAlert.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditingDisabledAlert.tsx
@@ -1,15 +1,17 @@
 import { FC } from 'react'
 
-import { Alert, H4, Code, Text } from '@sourcegraph/wildcard'
+import { Alert, H4, Code, Text, Link } from '@sourcegraph/wildcard'
 
 export const ExternalServiceEditingDisabledAlert: FC<{ className?: string }> = props => (
     <Alert variant="info" className={props.className}>
         <H4>Editing through UI disabled</H4>
         <Text className="mb-0">
-            Environment variable <Code>EXTSVC_CONFIG_FILE</Code> is set. You can't create or edit code host connections
-            when <Code>EXTSVC_CONFIG_FILE</Code> is set. If you also set <Code>EXTSVC_CONFIG_ALLOW_EDITS</Code> to{' '}
-            <Code>"true"</Code> you can edit code host connections, but changes will be discarded with the next restart
-            of the Sourcegraph instance.
+            Environment variable <Code>EXTSVC_CONFIG_FILE</Code> is set.{' '}
+            <Link to="/help/admin/config/advanced_config_file#code-host-configuration">
+                You can't create or edit code host connections when <Code>EXTSVC_CONFIG_FILE</Code> is set.
+            </Link>{' '}
+            If you also set <Code>EXTSVC_CONFIG_ALLOW_EDITS</Code> to <Code>"true"</Code> you can edit code host
+            connections, but changes will be discarded with the next restart of the Sourcegraph instance.
         </Text>
     </Alert>
 )

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -114,7 +114,7 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     <Tooltip
                         content={
                             editingDisabled
-                                ? 'Editing code host connection is disabled via the UI when EXTSVC_CONFIG_FILE is set.'
+                                ? 'Editing code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
                                 : 'Edit code host connection settings'
                         }
                     >
@@ -129,12 +129,18 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                             <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
                         </Button>
                     </Tooltip>{' '}
-                    <Tooltip content="Delete code host connection">
+                    <Tooltip
+                        content={
+                            editingDisabled
+                                ? 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
+                                : 'Delete code host connection'
+                        }
+                    >
                         <Button
                             aria-label="Delete"
                             className="test-delete-external-service-button"
                             onClick={onDelete}
-                            disabled={isDeleting === true}
+                            disabled={isDeleting === true || editingDisabled}
                             variant="danger"
                             size="sm"
                         >

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -111,21 +111,24 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     </div>
                 </div>
                 <div className="flex-shrink-0 ml-3">
-                    {!editingDisabled && (
-                        <>
-                            <Tooltip content="Edit code host connection settings">
-                                <Button
-                                    className="test-edit-external-service-button"
-                                    to={`/site-admin/external-services/${encodeURIComponent(node.id)}/edit`}
-                                    variant="secondary"
-                                    size="sm"
-                                    as={Link}
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
-                                </Button>
-                            </Tooltip>{' '}
-                        </>
-                    )}
+                    <Tooltip
+                        content={
+                            editingDisabled
+                                ? 'Editing code host connection is disabled via the UI when EXTSVC_CONFIG_FILE is set.'
+                                : 'Edit code host connection settings'
+                        }
+                    >
+                        <Button
+                            className="test-edit-external-service-button"
+                            to={`/site-admin/external-services/${encodeURIComponent(node.id)}/edit`}
+                            variant="secondary"
+                            size="sm"
+                            as={Link}
+                            disabled={editingDisabled}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
+                        </Button>
+                    </Tooltip>{' '}
                     <Tooltip content="Delete code host connection">
                         <Button
                             aria-label="Delete"

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -111,17 +111,21 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                     </div>
                 </div>
                 <div className="flex-shrink-0 ml-3">
-                    <Tooltip content={`${editingDisabled ? 'View' : 'Edit'} code host connection settings`}>
-                        <Button
-                            className="test-edit-external-service-button"
-                            to={`/site-admin/external-services/${encodeURIComponent(node.id)}/edit`}
-                            variant="secondary"
-                            size="sm"
-                            as={Link}
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiCog} /> {editingDisabled ? 'View' : 'Edit'}
-                        </Button>
-                    </Tooltip>{' '}
+                    {!editingDisabled && (
+                        <>
+                            <Tooltip content="Edit code host connection settings">
+                                <Button
+                                    className="test-edit-external-service-button"
+                                    to={`/site-admin/external-services/${encodeURIComponent(node.id)}/edit`}
+                                    variant="secondary"
+                                    size="sm"
+                                    as={Link}
+                                >
+                                    <Icon aria-hidden={true} svgPath={mdiCog} /> Edit
+                                </Button>
+                            </Tooltip>{' '}
+                        </>
+                    )}
                     <Tooltip content="Delete code host connection">
                         <Button
                             aria-label="Delete"

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -230,12 +230,18 @@ export const ExternalServicePage: FC<Props> = props => {
                                     </div>
                                 )}
                                 <div className="flex-shrink-0 ml-1">
-                                    <Tooltip content="Delete code host connection">
+                                    <Tooltip
+                                        content={
+                                            editingEnabled
+                                                ? 'Delete code host connection'
+                                                : 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
+                                        }
+                                    >
                                         <Button
                                             aria-label="Delete"
                                             className="test-delete-external-service-button"
                                             onClick={onDelete}
-                                            disabled={isDeleting === true}
+                                            disabled={isDeleting === true || !editingEnabled}
                                             variant="danger"
                                             size="sm"
                                         >

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -99,7 +99,7 @@ export const ExternalServicePage: FC<Props> = props => {
 
     const externalServiceCategory = resolveExternalServiceCategory(externalService)
 
-    const editingEnabled = allowEditExternalServicesWithFile || !externalServicesFromFile
+    const editingDisabled = externalServicesFromFile && !allowEditExternalServicesWithFile
 
     const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
     const client = useApolloClient()
@@ -211,7 +211,7 @@ export const ExternalServicePage: FC<Props> = props => {
                                         />
                                     </Tooltip>
                                 </div>
-                                {editingEnabled && (
+                                {!editingDisabled && (
                                     <div className="flex-grow-1 ml-1">
                                         <Tooltip content="Edit code host connection settings">
                                             <Button
@@ -232,16 +232,16 @@ export const ExternalServicePage: FC<Props> = props => {
                                 <div className="flex-shrink-0 ml-1">
                                     <Tooltip
                                         content={
-                                            editingEnabled
-                                                ? 'Delete code host connection'
-                                                : 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
+                                            editingDisabled
+                                                ? 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
+                                                : 'Delete code host connection'
                                         }
                                     >
                                         <Button
                                             aria-label="Delete"
                                             className="test-delete-external-service-button"
                                             onClick={onDelete}
-                                            disabled={isDeleting === true || !editingEnabled}
+                                            disabled={isDeleting === true || editingDisabled}
                                             variant="danger"
                                             size="sm"
                                         >


### PR DESCRIPTION
Closes #54974

Having a `View` label that leads to the `Edit` page (in a read-only mode) can be confusing to users. This PR ensures the label doesn't change and we toggle the button's disabled state instead.

<img width="957" alt="CleanShot 2023-07-17 at 12 16 35@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/9c6575bd-de3d-4082-a0d4-c7c15aa7e5da">

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Start up your Sourcegraph instance.
* Ensure your code host connections are set via the `EXTSVC_CONFIG_FILE` environment variable.
* Navigate to the [code host connections](https://sourcegraph.test:3443/site-admin/external-services) page.
* The button label should be `Edit`, and it'll be disabled.

If the `EXTSVC_CONFIG_FILE` isn't set though, the button label will remain unchanged and will be enabled.

#### Changes

* Added a link to the docs in the Banner displayed when External Services can't be edited.

<img width="1010" alt="CleanShot 2023-07-17 at 13 14 12@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/7336ff61-80cf-4652-85bb-6f72b9aab187">

* Disabled the `Edit` and `Delete` button when editing is disabled for external services.

<img width="908" alt="CleanShot 2023-07-17 at 13 15 14@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/a9c8de07-1c7e-4054-9212-9b4e4ef72aa4">

* Disabled the `Delete` button in the external service page:

![CleanShot 2023-07-17 at 13 16 20@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/392f90bb-b168-47aa-b9dd-6a3186daa79d)
