### PR TITLE
[Backport 5.1] Backport a few embeddings PRs

### DIFF
--- a/client/branded/src/components/Timestamp/Timestamp.tsx
+++ b/client/branded/src/components/Timestamp/Timestamp.tsx
@@ -55,6 +55,10 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Timestam
 }) => {
     const [label, setLabel] = useState<string>(calculateLabel(date, now, strict, noAbout, noAgo))
     useEffect(() => {
+        // Update the label
+        setLabel(calculateLabel(date, now, strict, noAbout, noAgo))
+
+        // Refresh the label periodically
         const intervalHandle = window.setInterval(
             () => setLabel(calculateLabel(date, now, strict, noAbout, noAgo)),
             RERENDER_INTERVAL_MSEC

--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//internal/observation",
         "//internal/service",
         "//internal/trace",
+        "//internal/xcontext",
         "//lib/errors",
         "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_prometheus_client_golang//prometheus",

--- a/enterprise/cmd/embeddings/shared/context_qa_test.go
+++ b/enterprise/cmd/embeddings/shared/context_qa_test.go
@@ -52,9 +52,8 @@ func TestRecall(t *testing.T) {
 
 		return io.NopCloser(bytes.NewReader(b)), nil
 	})
-	getRepoEmbeddingIndex := func(ctx context.Context, repo api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		key := embeddings.GetRepoEmbeddingIndexName(repo)
-		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, string(key))
+	getRepoEmbeddingIndex := func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+		return embeddings.DownloadRepoEmbeddingIndex(context.Background(), mockStore, repoID, repoName)
 	}
 
 	// Weaviate is disabled per default. We don't need it for this test.

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/providers"
 	srp "github.com/sourcegraph/sourcegraph/internal/authz/subrepoperms"
@@ -69,8 +70,8 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		repoStore,
 		repoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-			return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, string(repoEmbeddingIndexName))
+		func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+			return embeddings.DownloadRepoEmbeddingIndex(ctx, uploadStore, repoID, repoName)
 		},
 		config.EmbeddingsCacheSize,
 	)

--- a/enterprise/cmd/embeddings/shared/main_test.go
+++ b/enterprise/cmd/embeddings/shared/main_test.go
@@ -55,15 +55,15 @@ func TestEmbeddingsSearch(t *testing.T) {
 		}
 	}
 
-	indexes := map[api.RepoName]*embeddings.RepoEmbeddingIndex{
-		"repo1": makeIndex("repo1", 1),
-		"repo2": makeIndex("repo2", 2),
-		"repo3": makeIndex("repo3", 3),
-		"repo4": makeIndex("repo4", 4),
+	indexes := map[api.RepoID]*embeddings.RepoEmbeddingIndex{
+		0: makeIndex("repo1", 1),
+		1: makeIndex("repo2", 2),
+		2: makeIndex("repo3", 3),
+		3: makeIndex("repo4", 4),
 	}
 
-	getRepoEmbeddingIndex := func(_ context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-		return indexes[repoName], nil
+	getRepoEmbeddingIndex := func(_ context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+		return indexes[repoID], nil
 	}
 	getMockQueryEmbedding := func(_ context.Context, query string) ([]float32, string, error) {
 		model := "openai/text-embedding-ada-002"
@@ -105,7 +105,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// embeddings.
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo2", "repo3", "repo4"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 1, 2, 3},
 			Query:            "one",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,
@@ -149,7 +149,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// Second test: providing a subset of repos should only search those repos
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo3"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 2},
 			Query:            "one",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,
@@ -193,7 +193,7 @@ func TestEmbeddingsSearch(t *testing.T) {
 		// Third test: try a different file just to be safe
 		params := embeddings.EmbeddingsSearchParameters{
 			RepoNames:        []api.RepoName{"repo1", "repo2", "repo3", "repo4"},
-			RepoIDs:          []api.RepoID{1, 2, 3, 4},
+			RepoIDs:          []api.RepoID{0, 1, 2, 3},
 			Query:            "three",
 			CodeResultsCount: 2,
 			TextResultsCount: 2,
@@ -277,7 +277,7 @@ func TestEmbeddingModelMismatch(t *testing.T) {
 		"repo3": makeIndex("repo3", ""),
 	}
 
-	getRepoEmbeddingIndex := func(_ context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	getRepoEmbeddingIndex := func(_ context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 		return indexes[repoName], nil
 	}
 

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-type downloadRepoEmbeddingIndexFn func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error)
+type downloadRepoEmbeddingIndexFn func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
 
 type repoEmbeddingIndexCacheEntry struct {
 	index      *embeddings.RepoEmbeddingIndex
@@ -148,27 +149,22 @@ type CachedEmbeddingIndexGetter struct {
 	sf    singleflight.Group
 }
 
-func (c *CachedEmbeddingIndexGetter) Get(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+func (c *CachedEmbeddingIndexGetter) Get(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 	// Run the fetch request through a singleflight to keep from fetching the
 	// same index multiple times concurrently
-	v, err, _ := c.sf.Do(string(repoName), func() (interface{}, error) {
-		return c.get(ctx, repoName)
+	v, err, _ := c.sf.Do(fmt.Sprintf("%d", repoID), func() (interface{}, error) {
+		return c.get(ctx, repoID, repoName)
 	})
 	return v.(*embeddings.RepoEmbeddingIndex), err
 }
 
-func (c *CachedEmbeddingIndexGetter) get(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
-	repo, err := c.repoStore.GetByName(ctx, repoName)
+func (c *CachedEmbeddingIndexGetter) get(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+	lastFinishedRepoEmbeddingJob, err := c.repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repoID)
 	if err != nil {
 		return nil, err
 	}
 
-	lastFinishedRepoEmbeddingJob, err := c.repoEmbeddingJobsStore.GetLastCompletedRepoEmbeddingJob(ctx, repo.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoName)
+	repoEmbeddingIndexName := embeddings.GetRepoEmbeddingIndexName(repoID)
 
 	cacheEntry, ok := c.cache.Get(repoEmbeddingIndexName)
 	if tr := trace.TraceFromContext(ctx); tr != nil {
@@ -176,21 +172,21 @@ func (c *CachedEmbeddingIndexGetter) get(ctx context.Context, repoName api.RepoN
 	}
 	if !ok {
 		// We do not have the index in the cache. Download and cache it.
-		return c.getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+		return c.getAndCacheIndex(ctx, repoID, repoName, lastFinishedRepoEmbeddingJob.FinishedAt)
 	} else if lastFinishedRepoEmbeddingJob.FinishedAt.After(cacheEntry.finishedAt) {
 		// Check if we have a newer finished embedding job. If so, download the new index, cache it, and return it instead.
-		return c.getAndCacheIndex(ctx, repoEmbeddingIndexName, lastFinishedRepoEmbeddingJob.FinishedAt)
+		return c.getAndCacheIndex(ctx, repoID, repoName, lastFinishedRepoEmbeddingJob.FinishedAt)
 	}
 
 	// Otherwise, return the cached index.
 	return cacheEntry.index, nil
 }
 
-func (c *CachedEmbeddingIndexGetter) getAndCacheIndex(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
-	embeddingIndex, err := c.downloadRepoEmbeddingIndex(ctx, repoEmbeddingIndexName)
+func (c *CachedEmbeddingIndexGetter) getAndCacheIndex(ctx context.Context, repoID api.RepoID, repoName api.RepoName, finishedAt *time.Time) (*embeddings.RepoEmbeddingIndex, error) {
+	embeddingIndex, err := c.downloadRepoEmbeddingIndex(ctx, repoID, repoName)
 	if err != nil {
 		return nil, errors.Wrap(err, "downloading repo embedding index")
 	}
-	c.cache.Add(repoEmbeddingIndexName, repoEmbeddingIndexCacheEntry{index: embeddingIndex, finishedAt: *finishedAt})
+	c.cache.Add(embeddings.GetRepoEmbeddingIndexName(repoID), repoEmbeddingIndexCacheEntry{index: embeddingIndex, finishedAt: *finishedAt})
 	return embeddingIndex, nil
 }

--- a/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
+++ b/enterprise/cmd/embeddings/shared/repo_embedding_index_cache_test.go
@@ -32,9 +32,9 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		mockRepoStore,
 		mockRepoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
-			switch repoEmbeddingIndexName {
-			case embeddings.GetRepoEmbeddingIndexName("a"):
+		func(ctx context.Context, repoID api.RepoID, _ api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
+			switch repoID {
+			case 7:
 				hasDownloadedRepoEmbeddingIndex = true
 				return &embeddings.RepoEmbeddingIndex{}, nil
 			default:
@@ -54,8 +54,18 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	ctx := context.Background()
 
+	repo := types.Repo{
+		Name: "a",
+		ID:   7,
+	}
+
+	tooLarge := types.Repo{
+		Name: "tooLarge",
+		ID:   42,
+	}
+
 	// Initial request should download and cache the index.
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +75,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	// Subsequent requests should read from the cache.
 	hasDownloadedRepoEmbeddingIndex = false
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +85,7 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 
 	// Simulate a newer completed repo embedding job.
 	finishedAt = finishedAt.Add(time.Hour)
-	_, err = indexGetter.Get(ctx, api.RepoName("a"))
+	_, err = indexGetter.Get(ctx, repo.ID, repo.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,13 +93,13 @@ func TestGetCachedRepoEmbeddingIndex(t *testing.T) {
 		t.Fatal("expected to download the index after a newer embedding job is completed")
 	}
 
-	_, err = indexGetter.Get(ctx, api.RepoName("toolarge"))
+	_, err = indexGetter.Get(ctx, tooLarge.ID, tooLarge.Name)
 	require.NoError(t, err)
 	require.Equal(t, 1, downloadLargeCount)
 
 	// Fetching a second time should trigger a second download since it's
 	// too large to fit in the cache
-	_, err = indexGetter.Get(ctx, api.RepoName("toolarge"))
+	_, err = indexGetter.Get(ctx, tooLarge.ID, tooLarge.Name)
 	require.NoError(t, err)
 	require.Equal(t, 2, downloadLargeCount)
 }
@@ -145,7 +155,7 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 	indexGetter, err := NewCachedEmbeddingIndexGetter(
 		mockRepoStore,
 		mockRepoEmbeddingJobsStore,
-		func(ctx context.Context, repoEmbeddingIndexName embeddings.RepoEmbeddingIndexName) (*embeddings.RepoEmbeddingIndex, error) {
+		func(ctx context.Context, _ api.RepoID, _ api.RepoName) (*embeddings.RepoEmbeddingIndex, error) {
 			mu.Lock()
 			defer mu.Unlock()
 
@@ -163,6 +173,11 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	repo := types.Repo{
+		Name: "a",
+		ID:   7,
+	}
+
 	numRequests := 4
 	var wg sync.WaitGroup
 	wg.Add(numRequests)
@@ -170,7 +185,7 @@ func TestConcurrentGetCachedRepoEmbeddingIndex(t *testing.T) {
 		ctx := context.Background()
 		go func() {
 			defer wg.Done()
-			indexGetter.Get(ctx, api.RepoName("a"))
+			indexGetter.Get(ctx, repo.ID, repo.Name)
 		}()
 	}
 	wg.Wait()

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -36,7 +36,7 @@ func searchRepoEmbeddingIndexes(
 	if err != nil {
 		return nil, err
 	}
-	embeddedQuery := embeddings.Quantize(floatQuery)
+	embeddedQuery := embeddings.Quantize(floatQuery, nil)
 
 	workerOpts := embeddings.WorkerOptions{
 		NumWorkers:     runtime.GOMAXPROCS(0),

--- a/enterprise/cmd/embeddings/shared/search.go
+++ b/enterprise/cmd/embeddings/shared/search.go
@@ -18,7 +18,7 @@ const (
 )
 
 type (
-	getRepoEmbeddingIndexFn func(ctx context.Context, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
+	getRepoEmbeddingIndexFn func(ctx context.Context, repoID api.RepoID, repoName api.RepoName) (*embeddings.RepoEmbeddingIndex, error)
 	getQueryEmbeddingFn     func(ctx context.Context, model string) ([]float32, string, error)
 )
 
@@ -57,7 +57,7 @@ func searchRepoEmbeddingIndexes(
 			return weaviate.Search(ctx, repoName, repoID, floatQuery, params.CodeResultsCount, params.TextResultsCount)
 		}
 
-		embeddingIndex, err := getRepoEmbeddingIndex(ctx, repoName)
+		embeddingIndex, err := getRepoEmbeddingIndex(ctx, repoID, repoName)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "getting repo embedding index for repo %q", repoName)
 		}

--- a/enterprise/cmd/worker/internal/embeddings/repo/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/embeddings/repo/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//internal/httpcli",
         "//internal/observation",
         "//internal/paths",
-        "//internal/types",
         "//internal/uploadstore",
         "//internal/workerutil",
         "//internal/workerutil/dbworker",

--- a/internal/embeddings/BUILD.bazel
+++ b/internal/embeddings/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
     srcs = [
         "dot_test.go",
         "index_storage_test.go",
+        "quantize_test.go",
         "schedule_test.go",
         "similarity_search_test.go",
         "types_test.go",

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -106,7 +106,7 @@ func EmbedRepo(
 
 	insertIndex := func(index *embeddings.EmbeddingIndex, metadata []embeddings.RepoEmbeddingRowMetadata, vectors []float32) {
 		index.RowMetadata = append(index.RowMetadata, metadata...)
-		index.Embeddings = append(index.Embeddings, embeddings.Quantize(vectors)...)
+		index.Embeddings = append(index.Embeddings, embeddings.Quantize(vectors, nil)...)
 		// Unknown documents have rank 0. Zoekt is a bit smarter about this, assigning 0
 		// to "unimportant" files and the average for unknown files. We should probably
 		// add this here, too.

--- a/internal/embeddings/index_name.go
+++ b/internal/embeddings/index_name.go
@@ -15,9 +15,12 @@ var CONTEXT_DETECTION_INDEX_NAME = "context_detection.embeddingindex"
 
 type RepoEmbeddingIndexName string
 
-func GetRepoEmbeddingIndexName(repoName api.RepoName) RepoEmbeddingIndexName {
+func GetRepoEmbeddingIndexNameDeprecated(repoName api.RepoName) RepoEmbeddingIndexName {
 	fsSafeRepoName := nonAlphanumericCharsRegexp.ReplaceAllString(string(repoName), "_")
 	// Add a hash as well to avoid name collisions
 	hash := md5.Sum([]byte(repoName))
 	return RepoEmbeddingIndexName(fmt.Sprintf(`%s_%s.embeddingindex`, fsSafeRepoName, hex.EncodeToString(hash[:])))
+}
+func GetRepoEmbeddingIndexName(repoID api.RepoID) RepoEmbeddingIndexName {
+	return RepoEmbeddingIndexName(fmt.Sprintf(`%d.embeddingindex`, repoID))
 }

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -201,13 +201,14 @@ func (d *decoder) decode() (*RepoEmbeddingIndex, error) {
 			return nil, err
 		}
 
-		ei.Embeddings = make([]int8, 0, numChunks*ei.ColumnDimension)
+		ei.Embeddings = make([]int8, 0, numChunks*embeddingsChunkSize)
+		embeddingsBuf := make([]float32, 0, embeddingsChunkSize)
+		quantizeBuf := make([]int8, embeddingsChunkSize)
 		for i := 0; i < numChunks; i++ {
-			var embeddingSlice []float32
-			if err := d.dec.Decode(&embeddingSlice); err != nil {
+			if err := d.dec.Decode(&embeddingsBuf); err != nil {
 				return nil, err
 			}
-			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingSlice)...)
+			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingsBuf, quantizeBuf)...)
 		}
 	}
 

--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/types"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
@@ -101,7 +102,25 @@ func UpdateRepoEmbeddingIndex(
 	return UploadRepoEmbeddingIndex(ctx, uploadStore, key, previous)
 }
 
-func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
+// DownloadRepoEmbeddingIndex wraps downloadRepoEmbeddingIndex to support
+// embeddings named based on either repo ID or repo Name.
+//
+// TODO: 2023/07: Remove this wrapper either after we have forced a complete
+// reindex or after we have removed the internal embeddings store, whichever
+// comes first.
+func DownloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, repoID api.RepoID, repoName api.RepoName) (_ *RepoEmbeddingIndex, err error) {
+	index, err1 := downloadRepoEmbeddingIndex(ctx, uploadStore, string(GetRepoEmbeddingIndexName(repoID)))
+	if err1 != nil {
+		var err2 error
+		index, err2 = downloadRepoEmbeddingIndex(ctx, uploadStore, string(GetRepoEmbeddingIndexNameDeprecated(repoName)))
+		if err2 != nil {
+			return nil, errors.CombineErrors(err1, err2)
+		}
+	}
+	return index, nil
+}
+
+func downloadRepoEmbeddingIndex(ctx context.Context, uploadStore uploadstore.Store, key string) (_ *RepoEmbeddingIndex, err error) {
 	tr, ctx := trace.New(ctx, "DownloadRepoEmbeddingIndex", attribute.String("key", key))
 	defer tr.FinishWithErr(&err)
 

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -120,10 +120,10 @@ func TestRepoEmbeddingIndexStorage(t *testing.T) {
 	ctx := context.Background()
 	uploadStore := newMockUploadStore()
 
-	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "index", index)
+	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "0.embeddingindex", index)
 	require.NoError(t, err)
 
-	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
 	require.NoError(t, err)
 
 	require.Equal(t, index, downloadedIndex)
@@ -155,11 +155,11 @@ func TestIndexFormatVersion(t *testing.T) {
 	err := enc.encode(index)
 	require.NoError(t, err)
 
-	_, err = uploadStore.Upload(ctx, "index", &buf)
+	_, err = uploadStore.Upload(ctx, "0.embeddingindex", &buf)
 	require.NoError(t, err)
 
-	_, err = DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
-	require.EqualError(t, err, fmt.Sprintf("unrecognized index format version: %d", formatVersion))
+	_, err = DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
+	require.ErrorContains(t, err, fmt.Sprintf("unrecognized index format version: %d", formatVersion))
 }
 
 func TestOldEmbeddingIndexDecoding(t *testing.T) {
@@ -182,11 +182,11 @@ func TestOldEmbeddingIndexDecoding(t *testing.T) {
 	uploadStore := newMockUploadStore()
 
 	// Upload the index using the "old" function.
-	err := UploadIndex(ctx, uploadStore, "index", index)
+	err := UploadIndex(ctx, uploadStore, "0.embeddingindex", index)
 	require.NoError(t, err)
 
 	// Download the index using the new, custom function.
-	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+	downloadedIndex, err := DownloadRepoEmbeddingIndex(ctx, uploadStore, 0, "")
 	require.NoError(t, err)
 
 	require.Equal(t, index.ToNewIndex(), downloadedIndex)

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -255,3 +255,29 @@ func BenchmarkCustomRepoEmbeddingIndexUpload(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCustomRepoEmbeddingIndexDownload(b *testing.B) {
+	// Roughly the size of the sourcegraph/sourcegraph index.
+	index := &RepoEmbeddingIndex{
+		RepoName:  api.RepoName("repo"),
+		Revision:  api.CommitID("commit"),
+		CodeIndex: getMockEmbeddingIndex(40_000, 1536),
+		TextIndex: getMockEmbeddingIndex(10_000, 1536),
+	}
+
+	ctx := context.Background()
+	uploadStore := newMockUploadStore()
+	err := UploadRepoEmbeddingIndex(ctx, uploadStore, "index", index)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := downloadRepoEmbeddingIndex(ctx, uploadStore, "index")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/embeddings/quantize.go
+++ b/internal/embeddings/quantize.go
@@ -10,8 +10,14 @@ import "math"
 // quantization function yielded rankings where the average change in rank was
 // only 1.2%. 93 of the top 100 rows  were unchanged, and 950 of the top 1000
 // were unchanged.
-func Quantize(input []float32) []int8 {
-	output := make([]int8, len(input))
+//
+// When buf is large enough to fit the output, it will be used instead of
+// an allocation.
+func Quantize(input []float32, buf []int8) []int8 {
+	output := buf
+	if len(input) > len(buf) {
+		output = make([]int8, len(input))
+	}
 	for i, val := range input {
 		// All our inputs should be in [-1, 1],
 		// but double check just in case.
@@ -27,7 +33,7 @@ func Quantize(input []float32) []int8 {
 		// better accuracy.
 		output[i] = int8(math.Round(float64(val) * 127.0))
 	}
-	return output
+	return output[:len(input)]
 }
 
 func Dequantize(input []int8) []float32 {

--- a/internal/embeddings/quantize_test.go
+++ b/internal/embeddings/quantize_test.go
@@ -1,0 +1,19 @@
+package embeddings
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestQuantize(t *testing.T) {
+	t.Run("buf doesn't affect output", func(t *testing.T) {
+		a := func(input []float32, buf []int8) []int8 {
+			return Quantize(input, buf)
+		}
+
+		b := func(input []float32, buf []int8) []int8 {
+			return Quantize(input, nil)
+		}
+		quick.CheckEqual(a, b, nil)
+	})
+}

--- a/internal/embeddings/types.go
+++ b/internal/embeddings/types.go
@@ -158,7 +158,7 @@ type OldEmbeddingIndex struct {
 
 func (o *OldEmbeddingIndex) ToNewIndex() EmbeddingIndex {
 	return EmbeddingIndex{
-		Embeddings:      Quantize(o.Embeddings),
+		Embeddings:      Quantize(o.Embeddings, nil),
 		ColumnDimension: o.ColumnDimension,
 		RowMetadata:     o.RowMetadata,
 		Ranks:           o.Ranks,


### PR DESCRIPTION
This backports a set of recent embeddings-related PRs from `main`, including a fix that we want to include in an early patch release.

## Test plan

Tested in original PRs. Will test on the 5.1 branch before release.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
