### PR TITLE
JetBrains: Release 3.0.6

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,20 +4,6 @@
 
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [3.0.6]
-
-### Added
-
 - Automatic detection of Cody app status in the settings window [#54955](https://github.com/sourcegraph/sourcegraph/pull/54955)
 - Add "Enable Cody" option to settings [#55004](https://github.com/sourcegraph/sourcegraph/pull/55004)
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [3.0.6]
+
+### Added
+
 - Automatic detection of Cody app status in the settings window [#54955](https://github.com/sourcegraph/sourcegraph/pull/54955)
 - Add "Enable Cody" option to settings [#55004](https://github.com/sourcegraph/sourcegraph/pull/55004)
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Added
 
+- Automatic detection of Cody app status in the settings window [#54955](https://github.com/sourcegraph/sourcegraph/pull/54955)
 - Add "Enable Cody" option to settings [#55004](https://github.com/sourcegraph/sourcegraph/pull/55004)
 
 ### Changed
+
+- Disable "summarize recent code changes" button if git repository is not available [#54859](https://github.com/sourcegraph/sourcegraph/pull/54859)
+- Get the chat model max tokens value from the instance when available [#54954](https://github.com/sourcegraph/sourcegraph/pull/54954)
 
 ### Deprecated
 
@@ -14,6 +18,9 @@
 
 ### Fixed
 
+- Downgraded connection errors for invalid or inaccessible enterprise instances to warnings [#54916](https://github.com/sourcegraph/sourcegraph/pull/54916)
+- Try to log error stack traces and recover from them, rather than re-throw the exception [#54917](https://github.com/sourcegraph/sourcegraph/pull/54917)
+- Show only one informative message in case of invalid access token [#54951](https://github.com/sourcegraph/sourcegraph/pull/54951)
 - Don't display `<br />` tag in the chat message when trying to insert new line in the code block [#55007](https://github.com/sourcegraph/sourcegraph/pull/55007)
 
 ### Security
@@ -29,22 +36,12 @@
 - Copy code block button added to editor in the chat message to copy the text to clipboard [#54783](https://github.com/sourcegraph/sourcegraph/pull/54783)
 - Insert at Cursor button added to editor in the chat message to insert the text form the editor to main editor [#54815](https://github.com/sourcegraph/sourcegraph/pull/54815)
 - Added support for multiline autocomplete [#54848](https://github.com/sourcegraph/sourcegraph/pull/54848)
-- Automatic detection of Cody app status in the settings window [#54955](https://github.com/sourcegraph/sourcegraph/pull/54955)
 
 ### Changed
-
-- Disable summarize recent code changes button if git repository is not available [#54859](https://github.com/sourcegraph/sourcegraph/pull/54859)
-- Get the chat model max tokens value from the instance when able [#54954](https://github.com/sourcegraph/sourcegraph/pull/54954)
 
 ### Deprecated
 
 ### Removed
-
-### Fixed
-
-- Downgraded connection errors for invalid or inaccessible enterprise instances to warnings [#54916](https://github.com/sourcegraph/sourcegraph/pull/54916)
-- Try to log error stacktraces and recover from them, rather than re-throw the exception [#54917](https://github.com/sourcegraph/sourcegraph/pull/54917)
-- Show only one informative message in case of invalid access token [#54951](https://github.com/sourcegraph/sourcegraph/pull/54951)
 
 ### Security
 

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [3.0.6]
+
+### Added
+
 - Automatic detection of Cody app status in the settings window [#54955](https://github.com/sourcegraph/sourcegraph/pull/54955)
 - Add "Enable Cody" option to settings [#55004](https://github.com/sourcegraph/sourcegraph/pull/55004)
 
@@ -36,14 +50,6 @@
 - Copy code block button added to editor in the chat message to copy the text to clipboard [#54783](https://github.com/sourcegraph/sourcegraph/pull/54783)
 - Insert at Cursor button added to editor in the chat message to insert the text form the editor to main editor [#54815](https://github.com/sourcegraph/sourcegraph/pull/54815)
 - Added support for multiline autocomplete [#54848](https://github.com/sourcegraph/sourcegraph/pull/54848)
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Security
 
 ### Fixed
 

--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=3.0.5
+pluginVersion=3.0.6
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 #  - 2020.2 was the first version to have JCEF enabled by default

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.config;
 
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.Nullable;
 
 /** Provides controller functionality for application settings. */
-public class SettingsConfigurable implements Configurable, Disposable {
+public class SettingsConfigurable implements Configurable {
   private final Project project;
   private SettingsComponent mySettingsComponent;
 
@@ -33,7 +32,7 @@ public class SettingsConfigurable implements Configurable, Disposable {
   @Override
   public JComponent createComponent() {
     mySettingsComponent = new SettingsComponent();
-    Disposer.register(this, mySettingsComponent);
+    Disposer.register(project, mySettingsComponent);
     return mySettingsComponent.getPanel();
   }
 
@@ -168,7 +167,4 @@ public class SettingsConfigurable implements Configurable, Disposable {
   public void disposeUIResources() {
     mySettingsComponent = null;
   }
-
-  @Override
-  public void dispose() {}
 }


### PR DESCRIPTION
- Bumped version
- Updated changelog. Because of some merge conflicts, some cherry-picking was necessary to deliver the real changelog.
- Fixed my earlier mistake with disposer. Reintroduced a per-existing warning of "Don't use Project as disposable in plugin code", for the sake of avoiding
  > java.lang.RuntimeException: Memory leak detected: 'com.sourcegraph.config.SettingsConfigurable@2cf67686' of class com.sourcegraph.config.SettingsConfigurable is registered in Disposer but wasn't disposed.
  > Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
  > See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
  > The corresponding Disposer.register() stacktrace is shown as the cause: [...]
  > Caused by: java.lang.Throwable
  > [...]
  > at com.sourcegraph.config.SettingsConfigurable.createComponent(SettingsConfigurable.java:36)"

## Test plan

Tested that the memory leak error disappeared. The rest are docs changes.