### PR TITLE
chore: update text copy for permissions UI pages

### DIFF
--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -139,7 +139,7 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
                                 <tr>
                                     <th>
                                         Last partial sync{' '}
-                                        <Tooltip content="Syncs user permissions from the code host. If the user-centric sync returns this repository as accessible, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
+                                        <Tooltip content="Syncs user permissions from the code host. If a user-centric sync returns this repository as accessible, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
                                             <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
                                         </Tooltip>
                                     </th>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect, useState, useCallback } from 'react'
 
-import { mdiChevronDown } from '@mdi/js'
+import { mdiChevronDown, mdiInformationOutline } from '@mdi/js'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
@@ -24,6 +24,7 @@ import {
     Popover,
     Position,
     PopoverOpenEvent,
+    Tooltip,
 } from '@sourcegraph/wildcard'
 
 import { usePageSwitcherPagination } from '../../../components/FilteredConnection/hooks/usePageSwitcherPagination'
@@ -120,7 +121,12 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
                         <table className="table">
                             <tbody>
                                 <tr>
-                                    <th>Last complete sync</th>
+                                    <th>
+                                        Last complete sync{' '}
+                                        <Tooltip content="Syncs repository permissions from the code host. All users that have access to the repository on the code host will have access on Sourcegraph as well.">
+                                            <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
+                                        </Tooltip>
+                                    </th>
                                     <td>
                                         {permissionsInfo.syncedAt ? (
                                             <Timestamp date={permissionsInfo.syncedAt} />
@@ -128,10 +134,15 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
                                             'Never'
                                         )}
                                     </td>
-                                    <td className="text-muted">Updated by repository permissions syncing</td>
+                                    <td className="text-muted">Updated by repository-centric permission sync.</td>
                                 </tr>
                                 <tr>
-                                    <th>Last incremental sync</th>
+                                    <th>
+                                        Last partial sync{' '}
+                                        <Tooltip content="Syncs user permissions from the code host. If the user-centric sync returns this repository as accessible, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
+                                            <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
+                                        </Tooltip>
+                                    </th>
                                     <td>
                                         {permissionsInfo.updatedAt === null ? (
                                             'Never'
@@ -139,7 +150,7 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
                                             <Timestamp date={permissionsInfo.updatedAt} />
                                         )}
                                     </td>
-                                    <td className="text-muted">Updated by user permissions syncing</td>
+                                    <td className="text-muted">Partial update done by user-centric permission sync.</td>
                                 </tr>
                             </tbody>
                         </table>

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -119,7 +119,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
                             <tr>
                                 <th>
                                     Last partial sync{' '}
-                                    <Tooltip content="Syncs repository permissions from the code host. If the repository-centric sync returns this user as accessor, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
+                                    <Tooltip content="Syncs repository permissions from the code host. If a repository-centric sync returns this user as accessor, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
                                         <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
                                     </Tooltip>
                                 </th>

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react'
 
+import { mdiInformationOutline } from '@mdi/js'
+
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -13,6 +15,8 @@ import {
     Link,
     Badge,
     BadgeProps,
+    Tooltip,
+    Icon,
 } from '@sourcegraph/wildcard'
 
 import { usePageSwitcherPagination } from '../../../../components/FilteredConnection/hooks/usePageSwitcherPagination'
@@ -101,14 +105,24 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
                     <table className="table">
                         <tbody>
                             <tr>
-                                <th className="border-0">Last complete sync</th>
+                                <th className="border-0">
+                                    Last complete sync{' '}
+                                    <Tooltip content="Syncs user permissions from the code host. All repositories that the user has access to on the code host will be accessible on Sourcegraph as well.">
+                                        <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
+                                    </Tooltip>
+                                </th>
                                 <td className="border-0">
                                     {permissionsInfo.syncedAt ? <Timestamp date={permissionsInfo.syncedAt} /> : 'Never'}
                                 </td>
-                                <td className="text-muted border-0">Updated by user permissions syncing</td>
+                                <td className="text-muted border-0">Updated by user-centric permission sync.</td>
                             </tr>
                             <tr>
-                                <th>Last incremental sync</th>
+                                <th>
+                                    Last partial sync{' '}
+                                    <Tooltip content="Syncs repository permissions from the code host. If the repository-centric sync returns this user as accessor, it is noted here as partial sync. Partial syncs do not show in the list of permission sync jobs below.">
+                                        <Icon aria-label="more-info" svgPath={mdiInformationOutline} />
+                                    </Tooltip>
+                                </th>
                                 <td>
                                     {permissionsInfo.updatedAt === null ? (
                                         'Never'
@@ -116,7 +130,9 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
                                         <Timestamp date={permissionsInfo.updatedAt} />
                                     )}
                                 </td>
-                                <td className="text-muted">Updated by repository permissions syncing</td>
+                                <td className="text-muted">
+                                    Partial update done by repositor-centric permission sync.
+                                </td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
It was confusing what is full sync and incremental sync. Changed the text and added tooltip content to be more specific.

It now also aligns to what we say in the [permission docs](https://docs.sourcegraph.com/admin/permissions/syncing#permission-syncing).

Related issue:
- https://github.com/sourcegraph/sourcegraph/issues/55003

## Screenshots

### Before

![screenshot_2023-07-17_11 08 31@2x](https://github.com/sourcegraph/sourcegraph/assets/9974711/e2f48261-213f-4440-ba58-5efc3e5259cf)


### After

<img width="1118" alt="Screenshot 2023-07-17 at 18 04 47" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/2396566d-a785-44e8-9d5c-39b8fc4941c9">
<img width="899" alt="Screenshot 2023-07-17 at 18 05 07" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/8d29f651-64d2-4494-b3ae-0a83402848b6">
<img width="901" alt="Screenshot 2023-07-17 at 18 04 56" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/bdaafd04-4bbd-4b6e-81d6-3f9072728ed7">
<img width="1142" alt="Screenshot 2023-07-17 at 18 03 56" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/1e1a5ff0-4585-4d47-9ce2-13959fa7512e">
<img width="897" alt="Screenshot 2023-07-17 at 18 04 14" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/16237189-edf5-4761-b452-710615c521d7">
<img width="916" alt="Screenshot 2023-07-17 at 18 04 09" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/b30bdc11-dd47-46e0-99f5-305badf1c2dc">


## Test plan

Tested locally
