### PR TITLE
Revert "productsubscription: add labels to BigQuery queries"

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_service.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/codygateway_service.go
@@ -147,11 +147,6 @@ ORDER BY
 	)
 
 	q := client.Query(query)
-	q.Labels = map[string]string{
-		"query":       "CompletionsUsageForActor",
-		"feature":     string(feature),
-		"actorSource": string(actorSource),
-	}
 	q.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "source",
@@ -275,10 +270,6 @@ ORDER BY
 	)
 
 	q := client.Query(query)
-	q.Labels = map[string]string{
-		"query":       "EmbeddingsUsageForActor",
-		"actorSource": string(actorSource),
-	}
 	q.Parameters = []bigquery.QueryParameter{
 		{
 			Name:  "source",


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#54946. We need to sanitize the label values it seems

Test plan: n/a reverts to known state