### PR TITLE
codesearch: Fix error message when unknown perforce change state

### DIFF
--- a/internal/batches/state/BUILD.bazel
+++ b/internal/batches/state/BUILD.bazel
@@ -54,9 +54,13 @@ go_test(
         "//internal/extsvc/bitbucketserver",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
+        "//internal/gitserver/protocol",
         "//internal/timeutil",
         "//internal/types",
+        "//lib/errors",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/batches/state/state.go
+++ b/internal/batches/state/state.go
@@ -648,7 +648,7 @@ func computeSingleChangesetExternalState(c *btypes.Changeset) (s btypes.Changese
 		case protocol.PerforceChangelistStatePending, protocol.PerforceChangelistStateShelved:
 			s = btypes.ChangesetExternalStateOpen
 		default:
-			return "", errors.Errorf("unknown Gerrit Change state: %s", m.State)
+			return "", errors.Errorf("unknown Perforce Change state: %s", m.State)
 		}
 	default:
 		return "", errors.New("unknown changeset type")


### PR DESCRIPTION
Found a slight bug. When an unknown perforce state occurs, it had "Gerrit" in the message. Fixed that and added tests.

## Test plan

Added Go tests.