### PR TITLE
scip: optimize migrator, index size

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
+++ b/internal/codeintel/codenav/internal/lsifstore/lsifstore_documents.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"sort"
-	"strings"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
@@ -56,18 +55,51 @@ WHERE
 	sid.document_path = %s
 `
 
-func (s *store) GetFullSCIPNameByDescriptor(ctx context.Context, uploadID []int, symbolNames []string) (names []*symbols.ExplodedSymbol, err error) {
+func (s *store) GetFullSCIPNameByDescriptor(ctx context.Context, uploadIDs []int, symbolNames []string) (names []*symbols.ExplodedSymbol, err error) {
 	ctx, _, endObservation := s.operations.getFullSCIPNameByDescriptor.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{}})
 	defer endObservation(1, observation.Args{})
 
+	if len(uploadIDs) == 0 || len(symbolNames) == 0 {
+		return nil, nil
+	}
+
 	return scanExplodedSymbols(s.db.Query(ctx, sqlf.Sprintf(
 		getFullSCIPNameByDescriptorQuery,
-		pq.Array(uploadID),
-		pq.Array(formatSymbolNamesToLikeClause(symbolNames)),
+		pq.Array(uploadIDs),
+		sqlf.Join(fuzzyDescriptorSuffixConditions(symbolNames), "OR"),
 	)))
 }
 
 const getFullSCIPNameByDescriptorQuery = `
+WITH
+
+-- Perform search for matching descriptors
+fuzzy_descriptor_suffix_ids AS (
+	SELECT ssl.upload_id, ssl.id
+	FROM codeintel_scip_symbols_lookup ssl
+	WHERE
+		-- Index conditions for "codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name"
+		ssl.upload_id = ANY(%s) AND ssl.segment_type = 'DESCRIPTOR_SUFFIX' AND (%s) AND
+		-- Post-index filter condition to ensure we haven't precise descriptors when we have an explicit fuzzy one
+		ssl.segment_quality != 'PRECISE'
+),
+
+-- Translate fuzzy descriptor identifier into a precise identifier
+-- We express this as a union in a CTE to take advantage of the partial indexes on the
+-- descriptor and fuzzy descriptor suffixes. When we had inlined these expressions, Postgres
+-- generated a parallel seq scan over the entire lookup_leaves table.
+descriptor_suffix_ids AS (
+	(
+		SELECT ll.upload_id, ll.descriptor_suffix_id FROM fuzzy_descriptor_suffix_ids dsi
+		JOIN codeintel_scip_symbols_lookup_leaves ll ON (ll.upload_id = dsi.upload_id AND ll.fuzzy_descriptor_suffix_id = dsi.id)
+	) UNION (
+		SELECT ll.upload_id, ll.descriptor_suffix_id FROM fuzzy_descriptor_suffix_ids dsi
+		JOIN codeintel_scip_symbols_lookup_leaves ll ON (ll.upload_id = dsi.upload_id AND ll.fuzzy_descriptor_suffix_id IS NULL AND ll.descriptor_suffix_id = dsi.id)
+	)
+)
+
+--
+-- Follow parent path from descriptor l6->l5->l4->l3->l2->l1
 SELECT DISTINCT
     l1.name AS scheme,
     l2.name AS package_manager,
@@ -75,24 +107,13 @@ SELECT DISTINCT
     l4.name AS package_version,
     l5.name AS descriptor_namespace,
     l6.name AS descriptor_suffix
--- Initially fuzzy search (see WHERE clause)
-FROM codeintel_scip_symbols_lookup l7
-
--- Join to symbols table, which will bridge DESCRIPTOR_SUFFIX+FUZZY (syntect) and DESCRIPTOR_SUFFIX+PRECISE (indexed)
-JOIN codeintel_scip_symbols_lookup_leaves ll ON ll.upload_id = l7.upload_id AND ll.fuzzy_descriptor_suffix_id = l7.id
-
--- Follow parent path from descriptor l6->l5->l4->l3->l2->l1
-JOIN codeintel_scip_symbols_lookup l6 ON l6.upload_id = l6.upload_id AND l6.id = ll.descriptor_suffix_id -- DESCRIPTOR_SUFFIX
-JOIN codeintel_scip_symbols_lookup l5 ON l5.upload_id = l6.upload_id AND l5.id = l6.parent_id            -- DESCRIPTOR_NAMESPACE
-JOIN codeintel_scip_symbols_lookup l4 ON l4.upload_id = l6.upload_id AND l4.id = l5.parent_id            -- PACKAGE_VERSION
-JOIN codeintel_scip_symbols_lookup l3 ON l3.upload_id = l6.upload_id AND l3.id = l4.parent_id            -- PACKAGE_NAME
-JOIN codeintel_scip_symbols_lookup l2 ON l2.upload_id = l6.upload_id AND l2.id = l3.parent_id            -- PACKAGE_MANAGER
-JOIN codeintel_scip_symbols_lookup l1 ON l1.upload_id = l6.upload_id AND l1.id = l2.parent_id            -- SCHEME
-WHERE
-	l7.upload_id = ANY(%s) AND
-	l7.segment_type = 'DESCRIPTOR_SUFFIX' AND
-	l7.segment_quality != 'PRECISE' AND
-	reverse(l7.name) ILIKE ANY(%s)
+FROM descriptor_suffix_ids dsi
+JOIN codeintel_scip_symbols_lookup l6 ON l6.upload_id = dsi.upload_id AND l6.id = dsi.descriptor_suffix_id -- DESCRIPTOR_SUFFIX
+JOIN codeintel_scip_symbols_lookup l5 ON l5.upload_id = dsi.upload_id AND l5.id = l6.parent_id             -- DESCRIPTOR_NAMESPACE
+JOIN codeintel_scip_symbols_lookup l4 ON l4.upload_id = dsi.upload_id AND l4.id = l5.parent_id             -- PACKAGE_VERSION
+JOIN codeintel_scip_symbols_lookup l3 ON l3.upload_id = dsi.upload_id AND l3.id = l4.parent_id             -- PACKAGE_NAME
+JOIN codeintel_scip_symbols_lookup l2 ON l2.upload_id = dsi.upload_id AND l2.id = l3.parent_id             -- PACKAGE_MANAGER
+JOIN codeintel_scip_symbols_lookup l1 ON l1.upload_id = dsi.upload_id AND l1.id = l2.parent_id             -- SCHEME
 `
 
 var scanExplodedSymbols = basestore.NewSliceScanner(func(s dbutil.Scanner) (*symbols.ExplodedSymbol, error) {
@@ -101,34 +122,30 @@ var scanExplodedSymbols = basestore.NewSliceScanner(func(s dbutil.Scanner) (*sym
 	return &n, err
 })
 
-func formatSymbolNamesToLikeClause(symbolNames []string) []string {
-	trimmedDescriptorMap := make(map[string]struct{}, len(symbolNames))
+func fuzzyDescriptorSuffixConditions(symbolNames []string) []*sqlf.Query {
+	fuzzyDescriptorSuffixMap := make(map[string]struct{}, len(symbolNames))
 	for _, symbolName := range symbolNames {
 		ex, err := symbols.NewExplodedSymbol(symbolName)
 		if err != nil {
 			continue
 		}
+		symbol := ex.FuzzyDescriptorSuffix
 
-		trimmedDescriptorMap[ex.FuzzyDescriptorSuffix] = struct{}{}
-	}
-
-	descriptorWildcards := make([]string, 0, len(trimmedDescriptorMap))
-	for symbol := range trimmedDescriptorMap {
 		if symbol != "" {
-			// TODO - too lenient?
-			descriptorWildcards = append(descriptorWildcards, reverse(symbol)+"%")
+			fuzzyDescriptorSuffixMap[symbol] = struct{}{}
 		}
 	}
-	sort.Strings(descriptorWildcards)
 
-	return descriptorWildcards
-}
+	fuzzyDescriptorSuffixes := make([]string, 0, len(fuzzyDescriptorSuffixMap))
+	for symbol := range fuzzyDescriptorSuffixMap {
+		fuzzyDescriptorSuffixes = append(fuzzyDescriptorSuffixes, symbol)
+	}
+	sort.Strings(fuzzyDescriptorSuffixes)
 
-func reverse(s string) string {
-	b := strings.Builder{}
-	for i := len(s) - 1; i >= 0; i-- {
-		b.WriteByte(s[i])
+	conds := make([]*sqlf.Query, 0, len(fuzzyDescriptorSuffixes))
+	for _, descriptorSuffix := range fuzzyDescriptorSuffixes {
+		conds = append(conds, sqlf.Sprintf("reverse(ssl.name) LIKE reverse('%%' || %s)", descriptorSuffix))
 	}
 
-	return b.String()
+	return conds
 }

--- a/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
@@ -204,10 +204,10 @@ matching_symbol_names AS (
 
 		-- Initially match descriptor scoped to an upload
 		JOIN codeintel_scip_symbols_lookup l6 ON
-			l6.upload_id = ANY(%s) AND
-			l6.segment_type = 'DESCRIPTOR_SUFFIX' AND
-			l6.segment_quality != 'FUZZY' AND
-			l6.name = p.descriptor_suffix
+			-- Index conditions for "codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name"
+			l6.upload_id = ANY(%s) AND l6.segment_type = 'DESCRIPTOR_SUFFIX' AND reverse(l6.name) = reverse(p.descriptor_suffix) AND
+			-- Post-index filter condition to ensure we haven't matched stripped descriptors
+			l6.segment_quality != 'FUZZY'
 
 		-- Follow parent path l6->l5->l4->l3->l2->l1, filter out anything that doesn't match exploded symbol parts
 		JOIN codeintel_scip_symbols_lookup l5 ON l5.upload_id = l6.upload_id AND l5.id = l6.parent_id AND l5.name = p.descriptor_namespace

--- a/internal/database/schema.codeintel.json
+++ b/internal/database/schema.codeintel.json
@@ -960,22 +960,12 @@
           "ConstraintDefinition": ""
         },
         {
-          "Name": "codeintel_scip_symbols_lookup_descriptor_suffix",
+          "Name": "codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name",
           "IsPrimaryKey": false,
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_lookup_descriptor_suffix ON codeintel_scip_symbols_lookup USING btree (upload_id, name) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype AND segment_quality \u003c\u003e 'FUZZY'::symbolnamesegmentquality",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
-        },
-        {
-          "Name": "codeintel_scip_symbols_lookup_fuzzy_descriptor_suffix",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_lookup_fuzzy_descriptor_suffix ON codeintel_scip_symbols_lookup USING btree (upload_id, reverse(name) text_pattern_ops) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype AND segment_quality \u003c\u003e 'PRECISE'::symbolnamesegmentquality",
+          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name ON codeintel_scip_symbols_lookup USING btree (upload_id, reverse(name) text_pattern_ops) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }
@@ -1004,7 +994,7 @@
           "Name": "fuzzy_descriptor_suffix_id",
           "Index": 4,
           "TypeName": "integer",
-          "IsNullable": false,
+          "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,
           "IsIdentity": false,
@@ -1057,7 +1047,7 @@
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves USING btree (upload_id, fuzzy_descriptor_suffix_id)",
+          "IndexDefinition": "CREATE INDEX codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves USING btree (upload_id, fuzzy_descriptor_suffix_id) WHERE fuzzy_descriptor_suffix_id IS NOT NULL",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         }

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -219,8 +219,7 @@ A mapping from SCIP [Symbol names](https://sourcegraph.com/search?q=context:%40s
  parent_id       | integer                  |           |          | 
 Indexes:
     "codeintel_scip_symbols_lookup_id" UNIQUE, btree (upload_id, id)
-    "codeintel_scip_symbols_lookup_descriptor_suffix" btree (upload_id, name) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype AND segment_quality <> 'FUZZY'::symbolnamesegmentquality
-    "codeintel_scip_symbols_lookup_fuzzy_descriptor_suffix" btree (upload_id, reverse(name) text_pattern_ops) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype AND segment_quality <> 'PRECISE'::symbolnamesegmentquality
+    "codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name" btree (upload_id, reverse(name) text_pattern_ops) WHERE segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype
 
 ```
 
@@ -231,10 +230,10 @@ Indexes:
  upload_id                  | integer |           | not null | 
  symbol_id                  | integer |           | not null | 
  descriptor_suffix_id       | integer |           | not null | 
- fuzzy_descriptor_suffix_id | integer |           | not null | 
+ fuzzy_descriptor_suffix_id | integer |           |          | 
 Indexes:
     "codeintel_scip_symbols_lookup_leaves_descriptor_suffix_id" btree (upload_id, descriptor_suffix_id)
-    "codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id" btree (upload_id, fuzzy_descriptor_suffix_id)
+    "codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id" btree (upload_id, fuzzy_descriptor_suffix_id) WHERE fuzzy_descriptor_suffix_id IS NOT NULL
 
 ```
 

--- a/internal/oobmigration/migrations/codeintel/scip/symbols_temp_tables.go
+++ b/internal/oobmigration/migrations/codeintel/scip/symbols_temp_tables.go
@@ -1,0 +1,177 @@
+package scip
+
+import (
+	"context"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/batch"
+)
+
+type inserterFunc func(ctx context.Context, symbolLookupInserter *batch.Inserter) error
+
+func withSymbolLookupSegmentTypeInserter(ctx context.Context, tx *basestore.Store, uploadID int, f inserterFunc) error {
+	createTempTableQuery := sqlf.Sprintf(`
+		CREATE TEMPORARY TABLE t_codeintel_scip_symbols_lookup_segment_type(
+			name text NOT NULL,
+			id integer NOT NULL,
+			segment_type SymbolNameSegmentType NOT NULL,
+			segment_quality SymbolNameSegmentQuality,
+			parent_id integer
+		) ON COMMIT DROP
+	`)
+
+	insertQuery := sqlf.Sprintf(`
+		INSERT INTO codeintel_scip_symbols_lookup (id, upload_id, name, segment_type, parent_id)
+		SELECT id, %s, name, segment_type, parent_id
+		FROM t_codeintel_scip_symbols_lookup_segment_type
+	`,
+		uploadID,
+	)
+
+	return withInserter(ctx, tx, f, createTempTableQuery, insertQuery, batch.NewInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols_lookup_segment_type",
+		batch.MaxNumPostgresParameters,
+		"segment_type",
+		"name",
+		"id",
+		"parent_id",
+	))
+}
+
+func withSymbolLookupSegmentQualityInserter(ctx context.Context, tx *basestore.Store, uploadID int, f inserterFunc) error {
+	createTempTableQuery := sqlf.Sprintf(`
+		CREATE TEMPORARY TABLE t_codeintel_scip_symbols_lookup_segment_quality(
+			name text NOT NULL,
+			id integer NOT NULL,
+			segment_quality SymbolNameSegmentQuality,
+			parent_id integer
+		) ON COMMIT DROP
+	`)
+
+	insertQuery := sqlf.Sprintf(`
+		INSERT INTO codeintel_scip_symbols_lookup (id, upload_id, name, segment_type, segment_quality, parent_id)
+		SELECT id, %s, name, 'DESCRIPTOR_SUFFIX', segment_quality, parent_id
+		FROM t_codeintel_scip_symbols_lookup_segment_quality
+	`,
+		uploadID,
+	)
+
+	return withInserter(ctx, tx, f, createTempTableQuery, insertQuery, batch.NewInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols_lookup_segment_quality",
+		batch.MaxNumPostgresParameters,
+		"segment_quality",
+		"name",
+		"id",
+		"parent_id",
+	))
+}
+
+func withSymbolLookupCommonSuffixInserter(ctx context.Context, tx *basestore.Store, uploadID int, f inserterFunc) error {
+	createTempTableQuery := sqlf.Sprintf(`
+		CREATE TEMPORARY TABLE t_codeintel_scip_symbols_lookup_common_suffix(
+			name text NOT NULL,
+			id integer NOT NULL,
+			parent_id integer
+		) ON COMMIT DROP
+	`)
+
+	insertQuery := sqlf.Sprintf(`
+		INSERT INTO codeintel_scip_symbols_lookup (id, upload_id, name, segment_type, segment_quality, parent_id)
+		SELECT id, %s, name, 'DESCRIPTOR_SUFFIX', 'BOTH', parent_id
+		FROM t_codeintel_scip_symbols_lookup_common_suffix
+	`,
+		uploadID,
+	)
+
+	return withInserter(ctx, tx, f, createTempTableQuery, insertQuery, batch.NewInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols_lookup_common_suffix",
+		batch.MaxNumPostgresParameters,
+		"name",
+		"id",
+		"parent_id",
+	))
+}
+
+func withSymbolLookupLeavesWithFuzzyInserter(ctx context.Context, tx *basestore.Store, uploadID int, f inserterFunc) error {
+	createTempTableQuery := sqlf.Sprintf(`
+		CREATE TEMPORARY TABLE t_codeintel_scip_symbols_lookup_leaves_with_fuzzy(
+			symbol_id integer NOT NULL,
+			descriptor_suffix_id integer NOT NULL,
+			fuzzy_descriptor_suffix_id integer NOT NULL
+		) ON COMMIT DROP
+	`)
+
+	insertQuery := sqlf.Sprintf(`
+		INSERT INTO codeintel_scip_symbols_lookup_leaves (upload_id, symbol_id, descriptor_suffix_id, fuzzy_descriptor_suffix_id)
+		SELECT %s, symbol_id, descriptor_suffix_id, fuzzy_descriptor_suffix_id
+		FROM t_codeintel_scip_symbols_lookup_leaves_with_fuzzy
+	`,
+		uploadID,
+	)
+
+	return withInserter(ctx, tx, f, createTempTableQuery, insertQuery, batch.NewInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols_lookup_leaves_with_fuzzy",
+		batch.MaxNumPostgresParameters,
+		"symbol_id",
+		"descriptor_suffix_id",
+		"fuzzy_descriptor_suffix_id",
+	))
+}
+
+func withSymbolLookupLeavesWithoutFuzzyInserter(ctx context.Context, tx *basestore.Store, uploadID int, f inserterFunc) error {
+	createTempTableQuery := sqlf.Sprintf(`
+		CREATE TEMPORARY TABLE t_codeintel_scip_symbols_lookup_leaves_without_fuzzy(
+			symbol_id integer NOT NULL,
+			descriptor_suffix_id integer NOT NULL
+		) ON COMMIT DROP
+	`)
+
+	insertQuery := sqlf.Sprintf(`
+		INSERT INTO codeintel_scip_symbols_lookup_leaves (upload_id, symbol_id, descriptor_suffix_id)
+		SELECT %s, symbol_id, descriptor_suffix_id
+		FROM t_codeintel_scip_symbols_lookup_leaves_without_fuzzy
+	`,
+		uploadID,
+	)
+
+	return withInserter(ctx, tx, f, createTempTableQuery, insertQuery, batch.NewInserter(
+		ctx,
+		tx.Handle(),
+		"t_codeintel_scip_symbols_lookup_leaves_without_fuzzy",
+		batch.MaxNumPostgresParameters,
+		"symbol_id",
+		"descriptor_suffix_id",
+	))
+}
+
+func withInserter(
+	ctx context.Context,
+	tx *basestore.Store,
+	f inserterFunc,
+	createTempTableQuery, insertQuery *sqlf.Query,
+	symbolLookupInserter *batch.Inserter,
+) error {
+	if err := tx.Exec(ctx, createTempTableQuery); err != nil {
+		return err
+	}
+
+	if err := f(ctx, symbolLookupInserter); err != nil {
+		return err
+	}
+
+	if err := symbolLookupInserter.Flush(ctx); err != nil {
+		return err
+	}
+
+	return tx.Exec(ctx, insertQuery)
+}

--- a/migrations/codeintel/1689175157_update_scip_symbol_tables/up.sql
+++ b/migrations/codeintel/1689175157_update_scip_symbol_tables/up.sql
@@ -10,23 +10,20 @@ CREATE TABLE IF NOT EXISTS codeintel_scip_symbols_lookup (
 -- Reconstruct names from leaf (descriptor) in tree
 CREATE UNIQUE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_id ON codeintel_scip_symbols_lookup(upload_id, id);
 
--- Search by exact descriptor suffix
-CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_descriptor_suffix ON codeintel_scip_symbols_lookup(upload_id, name)
-    WHERE segment_type = 'DESCRIPTOR_SUFFIX' AND segment_quality != 'FUZZY';
-
--- Search by fuzzily for descriptor suffix
-CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_fuzzy_descriptor_suffix ON codeintel_scip_symbols_lookup(upload_id, reverse(name) text_pattern_ops)
-    WHERE segment_type = 'DESCRIPTOR_SUFFIX' AND segment_quality != 'PRECISE';
+-- Search by descriptor suffix (supports fast exact + suffix match by comparing reversed string or wildcard)
+CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name
+    ON codeintel_scip_symbols_lookup(upload_id, reverse(name) text_pattern_ops)
+    WHERE segment_type = 'DESCRIPTOR_SUFFIX';
 
 CREATE TABLE IF NOT EXISTS codeintel_scip_symbols_lookup_leaves (
     upload_id                   integer NOT NULL,
     symbol_id                   integer NOT NULL,
     descriptor_suffix_id        integer NOT NULL,
-    fuzzy_descriptor_suffix_id  integer NOT NULL
+    fuzzy_descriptor_suffix_id  integer
 );
 
 CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_leaves_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves(upload_id, descriptor_suffix_id);
-CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves(upload_id, fuzzy_descriptor_suffix_id);
+CREATE INDEX IF NOT EXISTS codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves(upload_id, fuzzy_descriptor_suffix_id) WHERE fuzzy_descriptor_suffix_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS codeintel_scip_symbols_migration_progress (
     upload_id  integer NOT NULL PRIMARY KEY,

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -285,7 +285,7 @@ CREATE TABLE codeintel_scip_symbols_lookup_leaves (
     upload_id integer NOT NULL,
     symbol_id integer NOT NULL,
     descriptor_suffix_id integer NOT NULL,
-    fuzzy_descriptor_suffix_id integer NOT NULL
+    fuzzy_descriptor_suffix_id integer
 );
 
 CREATE TABLE codeintel_scip_symbols_migration_progress (
@@ -437,15 +437,13 @@ CREATE INDEX codeintel_scip_symbol_names_upload_id_roots ON codeintel_scip_symbo
 
 CREATE INDEX codeintel_scip_symbols_document_lookup_id ON codeintel_scip_symbols USING btree (document_lookup_id);
 
-CREATE INDEX codeintel_scip_symbols_lookup_descriptor_suffix ON codeintel_scip_symbols_lookup USING btree (upload_id, name) WHERE ((segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype) AND (segment_quality <> 'FUZZY'::symbolnamesegmentquality));
-
-CREATE INDEX codeintel_scip_symbols_lookup_fuzzy_descriptor_suffix ON codeintel_scip_symbols_lookup USING btree (upload_id, reverse(name) text_pattern_ops) WHERE ((segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype) AND (segment_quality <> 'PRECISE'::symbolnamesegmentquality));
-
 CREATE UNIQUE INDEX codeintel_scip_symbols_lookup_id ON codeintel_scip_symbols_lookup USING btree (upload_id, id);
 
 CREATE INDEX codeintel_scip_symbols_lookup_leaves_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves USING btree (upload_id, descriptor_suffix_id);
 
-CREATE INDEX codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves USING btree (upload_id, fuzzy_descriptor_suffix_id);
+CREATE INDEX codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id ON codeintel_scip_symbols_lookup_leaves USING btree (upload_id, fuzzy_descriptor_suffix_id) WHERE (fuzzy_descriptor_suffix_id IS NOT NULL);
+
+CREATE INDEX codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name ON codeintel_scip_symbols_lookup USING btree (upload_id, reverse(name) text_pattern_ops) WHERE (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype);
 
 CREATE INDEX codeisdntel_scip_symbol_names_upload_id_children ON codeintel_scip_symbol_names USING btree (upload_id, prefix_id) WHERE (prefix_id IS NOT NULL);
 


### PR DESCRIPTION
Changes in this PR include:

- `codeintel_scip_symbols_lookup_leaves.fuzzy_descriptor_suffix_id` nullable, and making it so that we only write the value when it differs from the `descriptor_suffix_id`. These two values being equal is the common case so we save about 50% storage by effectively removing this column from the leaves table. This also allows us to only index non-null values in a partial index, so we're not also storing the same value in two indexes (another 50% savings - _wow 100% savings!_). This comes at the cost of requiring a second search condition when querying for `fuzzy_descriptor_suffix_id`.
- Replace the descriptor suffix indexes, which were overlapping, with an index that stores always-reversed values. This allows us to do efficient suffix searches, but storing it as *always* reversed comes at the cost of requiring a `reverse(str)` to hit the index properly. These payloads are the only sizable data we were writing in this process, and we were writing the *exact* same data to two indexes. We now only write them to one index.
- Split the batch inserter into parts where we can optimize the batch sizes. We had two batch inserts ran in series. We now have a total of five.
- Instead of reconstructing large portions of the symbol trie in Postgres, pull back parentage information and reconstruct it in Go. We end up sending less data as the trie is a compressed list - send the compressed package and decompress it when you _read_ it, not before.

**Precise lookups**:

```sql
WITH symbols_parts AS (
    SELECT
        'npm' AS scheme,
        '' AS package_manager,
        'aws-sdk' AS package_name,
        '2.954.0' AS package_version,
        '' AS descriptor_namespace,
        '`scip-typescript npm aws-sdk 2.954.0 clients/``accessanalyzer.d.ts``/AccessAnalyzer#getAnalyzedResource().(params)`.' AS descriptor_suffix
)
SELECT
    ll.upload_id,
    ll.symbol_id,
    -- ROUGHLY reconstruct symbol names from parts
    -- We don't want to do this as it ignores SCIP's escaping rules, but we only use this
    -- value in a fairly inconsequential (diagnostic-only) path at the moment. We should
    -- remove usage of this field altogether (or reconstruct it on the consumer side).
    l1.name || ' ' || l2.name || ' ' || l3.name || ' ' || l4.name || ' ' || l5.name || l6.name AS symbol_name
FROM symbols_parts p

-- Initially match descriptor scoped to an upload
JOIN codeintel_scip_symbols_lookup l6 ON
    -- Index conditions for "codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name"
    l6.upload_id = ANY('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}') AND l6.segment_type = 'DESCRIPTOR_SUFFIX' AND reverse(l6.name) = reverse(p.descriptor_suffix) AND
    -- Post-index filter condition to ensure we haven't matched stripped descriptors
    l6.segment_quality != 'FUZZY'

-- Follow parent path l6->l5->l4->l3->l2->l1, filter out anything that doesn't match exploded symbol parts
JOIN codeintel_scip_symbols_lookup l5 ON l5.upload_id = l6.upload_id AND l5.id = l6.parent_id AND l5.name = p.descriptor_namespace
JOIN codeintel_scip_symbols_lookup l4 ON l4.upload_id = l6.upload_id AND l4.id = l5.parent_id AND l4.name = p.package_version
JOIN codeintel_scip_symbols_lookup l3 ON l3.upload_id = l6.upload_id AND l3.id = l4.parent_id AND l3.name = p.package_name
JOIN codeintel_scip_symbols_lookup l2 ON l2.upload_id = l6.upload_id AND l2.id = l3.parent_id AND l2.name = p.package_manager
JOIN codeintel_scip_symbols_lookup l1 ON l1.upload_id = l6.upload_id AND l1.id = l2.parent_id AND l1.name = p.scheme

-- Find symbol identifier matching descriptor
JOIN codeintel_scip_symbols_lookup_leaves ll ON ll.upload_id = l5.upload_id AND ll.descriptor_suffix_id = l6.id;
```

```
                         QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=1441.16..50155.05 rows=2 width=40) (actual time=1.615..14.282 rows=1 loops=1)
   Join Filter: (l5.upload_id = ll.upload_id)
   ->  Nested Loop  (cost=1440.58..50152.20 rows=1 width=208) (actual time=1.594..14.258 rows=1 loops=1)
         Join Filter: (l5.upload_id = l1.upload_id)
         ->  Nested Loop  (cost=1440.01..50149.46 rows=1 width=178) (actual time=1.587..14.248 rows=1 loops=1)
               Join Filter: (l5.upload_id = l2.upload_id)
               ->  Nested Loop  (cost=1439.43..50146.64 rows=1 width=144) (actual time=1.580..14.239 rows=1 loops=1)
                     Join Filter: (l5.upload_id = l3.upload_id)
                     ->  Gather  (cost=1438.85..50143.83 rows=1 width=110) (actual time=1.573..14.228 rows=1 loops=1)
                           Workers Planned: 2
                           Workers Launched: 2
                           ->  Nested Loop  (cost=438.85..49143.73 rows=1 width=110) (actual time=0.315..0.318 rows=0 loops=3)
                                 ->  Nested Loop  (cost=438.27..49100.02 rows=16 width=76) (actual time=0.312..0.314 rows=0 loops=3)
                                       ->  Parallel Bitmap Heap Scan on codeintel_scip_symbols_lookup l6  (cost=437.70..24303.08 rows=8868 width=42) (actual time=0.301..0.302 rows=0 loops=3)
                                             Recheck Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) = '.`)smarap(.)(ecruoseRdezylanAteg#rezylanAsseccA/``st.d.rezylanassecca``/stneilc 0.459.2 kds-swa mpn tpircsepyt-pics`'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype))
                                             Filter: (segment_quality <> 'FUZZY'::symbolnamesegmentquality)
                                             Heap Blocks: exact=1
                                             ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..432.38 rows=21333 width=0) (actual time=0.165..0.165 rows=1 loops=1)
                                                   Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) = '.`)smarap(.)(ecruoseRdezylanAteg#rezylanAsseccA/``st.d.rezylanassecca``/stneilc 0.459.2 kds-swa mpn tpircsepyt-pics`'::text))
                                       ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l5  (cost=0.58..2.80 rows=1 width=42) (actual time=0.025..0.026 rows=1 loops=1)
                                             Index Cond: ((upload_id = l6.upload_id) AND (id = l6.parent_id))
                                             Filter: (name = ''::text)
                                 ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l4  (cost=0.58..2.73 rows=1 width=42) (actual time=0.005..0.005 rows=1 loops=1)
                                       Index Cond: ((upload_id = l5.upload_id) AND (id = l5.parent_id))
                                       Filter: (name = '2.954.0'::text)
                     ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l3  (cost=0.58..2.80 rows=1 width=42) (actual time=0.004..0.005 rows=1 loops=1)
                           Index Cond: ((upload_id = l4.upload_id) AND (id = l4.parent_id))
                           Filter: (name = 'aws-sdk'::text)
               ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l2  (cost=0.58..2.80 rows=1 width=42) (actual time=0.004..0.004 rows=1 loops=1)
                     Index Cond: ((upload_id = l3.upload_id) AND (id = l3.parent_id))
                     Filter: (name = ''::text)
         ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l1  (cost=0.58..2.73 rows=1 width=38) (actual time=0.004..0.004 rows=1 loops=1)
               Index Cond: ((upload_id = l2.upload_id) AND (id = l2.parent_id))
               Filter: (name = 'npm'::text)
   ->  Index Scan using codeintel_scip_symbols_lookup_leaves_descriptor_suffix_id on codeintel_scip_symbols_lookup_leaves ll  (cost=0.58..2.79 rows=1 width=12) (actual time=0.014..0.015 rows=1 loops=1)
         Index Cond: ((upload_id = l6.upload_id) AND (descriptor_suffix_id = l6.id))
 Planning Time: 21.041 ms
 Execution Time: 14.429 ms
(38 rows)
```

**23-symbol name search** (24 symbols happen to degrade to a slow parallel index scan, looking into this):

```sql
WITH
fuzzy_descriptor_suffix_ids AS (
	SELECT
		ssl.upload_id,
		ssl.id
	FROM codeintel_scip_symbols_lookup ssl WHERE
		ssl.upload_id = ANY('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}') AND ssl.segment_type = 'DESCRIPTOR_SUFFIX' AND
        (
			   reverse(ssl.name) LIKE reverse('%' || '``ɵAnimationGroupPlayer``#`.')
			OR reverse(ssl.name) LIKE reverse('%' || '``ɵStyleData``#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer/AccessPointArn#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer/AccessPointPolicy#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer/AccessPreview#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer/AccessPreviewFinding#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer/AccessPreviewFindingId#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AccessAnalyzer#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationDriver#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationEngineInstruction#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationSequenceMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationStaggerMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationStateMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationStyleMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationTransitionMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'AnimationTriggerMetadata#`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#getPullRequest().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#getPullRequestApprovalStates().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#getRepository().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#getRepositoryTriggers().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#listApprovalRuleTemplates().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#listBranches().(callback)`.')
			OR reverse(ssl.name) LIKE reverse('%' || 'CodeCommit#listPullRequests().(callback)`.')
        )
        AND
		ssl.segment_quality != 'PRECISE'
),
descriptor_suffix_ids AS (
	(
		SELECT ll.upload_id, ll.descriptor_suffix_id FROM fuzzy_descriptor_suffix_ids dsi
		JOIN codeintel_scip_symbols_lookup_leaves ll ON (ll.upload_id = dsi.upload_id AND ll.fuzzy_descriptor_suffix_id = dsi.id)
	) UNION (
		SELECT ll.upload_id, ll.descriptor_suffix_id FROM fuzzy_descriptor_suffix_ids dsi
		JOIN codeintel_scip_symbols_lookup_leaves ll ON (ll.upload_id = dsi.upload_id AND ll.fuzzy_descriptor_suffix_id IS NULL AND ll.descriptor_suffix_id = dsi.id)
	)
)
SELECT DISTINCT
    l1.name AS scheme,
    l2.name AS package_manager,
    l3.name AS package_name,
    l4.name AS package_version,
    l5.name AS descriptor_namespace,
    l6.name AS descriptor_suffix
FROM descriptor_suffix_ids dsi
JOIN codeintel_scip_symbols_lookup l6 ON l6.upload_id = dsi.upload_id AND l6.id = dsi.descriptor_suffix_id
JOIN codeintel_scip_symbols_lookup l5 ON l5.upload_id = dsi.upload_id AND l5.id = l6.parent_id
JOIN codeintel_scip_symbols_lookup l4 ON l4.upload_id = dsi.upload_id AND l4.id = l5.parent_id
JOIN codeintel_scip_symbols_lookup l3 ON l3.upload_id = dsi.upload_id AND l3.id = l4.parent_id
JOIN codeintel_scip_symbols_lookup l2 ON l2.upload_id = dsi.upload_id AND l2.id = l3.parent_id
JOIN codeintel_scip_symbols_lookup l1 ON l1.upload_id = dsi.upload_id AND l1.id = l2.parent_id;
```

```
                                                                             QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=62686475.88..63054056.47 rows=21004605 width=180) (actual time=7.746..7.781 rows=24 loops=1)
   CTE fuzzy_descriptor_suffix_ids
     ->  Bitmap Heap Scan on codeintel_scip_symbols_lookup ssl  (cost=15002.45..643649.85 rows=484821 width=8) (actual time=1.925..2.149 rows=25 loops=1)
           Recheck Cond: (((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#``reyalPpuorGnoitaminAɵ``%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#``ataDelytSɵ``%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#nrAtnioPsseccA/rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#yciloPtnioPsseccA/rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#weiverPsseccA/rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#gnidniFweiverPsseccA/rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#dIgnidniFweiverPsseccA/rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#rezylanAsseccA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#revirDnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#noitcurtsnIenignEnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMecneuqeSnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMreggatSnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMetatSnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMelytSnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMnoitisnarTnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`#atadateMreggirTnoitaminA%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,174244
5,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(tseuqeRlluPteg#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(setatSlavorppAtseuqeRlluPteg#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(yrotisopeRteg#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(sreggirTyrotisopeRteg#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(setalpmeTeluRlavorppAtsil#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(sehcnarBtsil#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)) OR ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~~ '.`)kcabllac(.)(stseuqeRlluPtsil#timmoCedoC%'::text) AND (segment_type = 'DESCRIPTOR_SUFFIX'::symbolnamesegmenttype)))
           Filter: ((segment_quality <> 'PRECISE'::symbolnamesegmentquality) AND (upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND ((reverse(name) ~~ '.`#``reyalPpuorGnoitaminAɵ``%'::text) OR (reverse(name) ~~ '.`#``ataDelytSɵ``%'::text) OR (reverse(name) ~~ '.`#nrAtnioPsseccA/rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#yciloPtnioPsseccA/rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#weiverPsseccA/rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#gnidniFweiverPsseccA/rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#dIgnidniFweiverPsseccA/rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#rezylanAsseccA%'::text) OR (reverse(name) ~~ '.`#revirDnoitaminA%'::text) OR (reverse(name) ~~ '.`#noitcurtsnIenignEnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMecneuqeSnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMreggatSnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMetatSnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMelytSnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMnoitisnarTnoitaminA%'::text) OR (reverse(name) ~~ '.`#atadateMreggirTnoitaminA%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(tseuqeRlluPteg#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(setatSlavorppAtseuqeRlluPteg#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(yrotisopeRteg#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(sreggirTyrotisopeRteg#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(setalpmeTeluRlavorppAtsil#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(sehcnarBtsil#timmoCedoC%'::text) OR (reverse(name) ~~ '.`)kcabllac(.)(stseuqeRlluPtsil#timmoCedoC%'::text)))
           Heap Blocks: exact=20
           ->  BitmapOr  (cost=15002.45..15002.45 rows=513201 width=0) (actual time=1.890..1.905 rows=0 loops=1)
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.205..0.205 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#``reyalPpuorGnoitaminAɵ``'::text) AND (reverse(name) ~<~ '.`#``reyalPpuorGnoitaminAɵ`a'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.073..0.073 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#``ataDelytSɵ``'::text) AND (reverse(name) ~<~ '.`#``ataDelytSɵ`a'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.105..0.105 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#nrAtnioPsseccA/rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#nrAtnioPsseccA/rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.128..0.128 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#yciloPtnioPsseccA/rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#yciloPtnioPsseccA/rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.079..0.080 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#weiverPsseccA/rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#weiverPsseccA/rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.082..0.082 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#gnidniFweiverPsseccA/rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#gnidniFweiverPsseccA/rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.072..0.073 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#dIgnidniFweiverPsseccA/rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#dIgnidniFweiverPsseccA/rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.081..0.081 rows=2 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#rezylanAsseccA'::text) AND (reverse(name) ~<~ '.`#rezylanAsseccB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.068..0.068 rows=2 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#revirDnoitaminA'::text) AND (reverse(name) ~<~ '.`#revirDnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.068..0.068 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#noitcurtsnIenignEnoitaminA'::text) AND (reverse(name) ~<~ '.`#noitcurtsnIenignEnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.073..0.074 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMecneuqeSnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMecneuqeSnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.068..0.069 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMreggatSnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMreggatSnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.066..0.067 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMetatSnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMetatSnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.065..0.066 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMelytSnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMelytSnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.065..0.066 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMnoitisnarTnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMnoitisnarTnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.065..0.066 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`#atadateMreggirTnoitaminA'::text) AND (reverse(name) ~<~ '.`#atadateMreggirTnoitaminB'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.104..0.104 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(tseuqeRlluPteg#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(tseuqeRlluPteg#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.071..0.071 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(setatSlavorppAtseuqeRlluPteg#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(setatSlavorppAtseuqeRlluPteg#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.066..0.067 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(yrotisopeRteg#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(yrotisopeRteg#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.068..0.068 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(sreggirTyrotisopeRteg#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(sreggirTyrotisopeRteg#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.064..0.065 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(setalpmeTeluRlavorppAtsil#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(setalpmeTeluRlavorppAtsil#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.067..0.067 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(sehcnarBtsil#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(sehcnarBtsil#timmoCedoD'::text))
                 ->  Bitmap Index Scan on codeintel_scip_symbols_lookup_reversed_descriptor_suffix_name  (cost=0.00..531.08 rows=22313 width=0) (actual time=0.076..0.077 rows=1 loops=1)
                       Index Cond: ((upload_id = ANY ('{1742763,1742761,1742754,1742749,1742748,1742741,1742728,1742717,1742704,1742676,1742671,1742632,1742622,1742572,1742569,1742516,1742503,1742460,1742453,1742452,1742451,1742446,1742445,1742443,1742431,1742416,1742377,1742366,1742357,1742352}'::integer[])) AND (reverse(name) ~>=~ '.`)kcabllac(.)(stseuqeRlluPtsil#timmoCedoC'::text) AND (reverse(name) ~<~ '.`)kcabllac(.)(stseuqeRlluPtsil#timmoCedoD'::text))
   ->  Sort  (cost=62042826.03..62095337.54 rows=21004605 width=180) (actual time=7.744..7.752 rows=25 loops=1)
         Sort Key: l1.name, l2.name, l3.name, l4.name, l5.name, l6.name
         Sort Method: quicksort  Memory: 31kB
         ->  Nested Loop  (cost=1931454.70..57301608.62 rows=21004605 width=180) (actual time=2.502..7.439 rows=25 loops=1)
               Join Filter: (l6.upload_id = l1.upload_id)
               ->  Nested Loop  (cost=1931454.12..29279503.54 rows=10293220 width=178) (actual time=2.496..7.366 rows=25 loops=1)
                     Join Filter: (l6.upload_id = l2.upload_id)
                     ->  Nested Loop  (cost=1931453.54..15547386.55 rows=5044150 width=144) (actual time=2.491..7.293 rows=25 loops=1)
                           Join Filter: (l6.upload_id = l3.upload_id)
                           ->  Nested Loop  (cost=1931452.96..8818018.98 rows=2471865 width=110) (actual time=2.485..7.219 rows=25 loops=1)
                                 Join Filter: (l6.upload_id = l4.upload_id)
                                 ->  Nested Loop  (cost=1931452.39..5520320.84 rows=1211327 width=76) (actual time=2.478..7.141 rows=25 loops=1)
                                       ->  Nested Loop  (cost=1931451.81..3911717.00 rows=593606 width=42) (actual time=2.466..7.036 rows=25 loops=1)
                                             ->  HashAggregate  (cost=1931451.23..1938651.44 rows=720021 width=8) (actual time=2.445..6.824 rows=25 loops=1)
                                                   Group Key: ll.upload_id, ll.descriptor_suffix_id
                                                   ->  Append  (cost=0.12..1927851.13 rows=720021 width=8) (actual time=2.201..2.303 rows=26 loops=1)
                                                         ->  Nested Loop  (cost=0.12..584342.13 rows=1 width=8) (actual time=2.181..2.182 rows=0 loops=1)
                                                               ->  CTE Scan on fuzzy_descriptor_suffix_ids dsi  (cost=0.00..9696.42 rows=484821 width=8) (actual time=1.929..2.147 rows=25 loops=1)
                                                               ->  Index Scan using codeintel_scip_symbols_lookup_leaves_fuzzy_descriptor_suffix_id on codeintel_scip_symbols_lookup_leaves ll  (cost=0.12..1.18 rows=1 width=12) (actual time=0.001..0.001 rows=0 loops=25)
                                                                     Index Cond: ((upload_id = dsi.upload_id) AND (fuzzy_descriptor_suffix_id = dsi.id))
                                                         ->  Nested Loop  (cost=0.58..1332708.68 rows=720020 width=8) (actual time=0.020..0.116 rows=26 loops=1)
                                                               ->  CTE Scan on fuzzy_descriptor_suffix_ids dsi_1  (cost=0.00..9696.42 rows=484821 width=8) (actual time=0.000..0.004 rows=25 loops=1)
                                                               ->  Index Scan using codeintel_scip_symbols_lookup_leaves_descriptor_suffix_id on codeintel_scip_symbols_lookup_leaves ll_1  (cost=0.58..2.72 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=25)
                                                                     Index Cond: ((upload_id = dsi_1.upload_id) AND (descriptor_suffix_id = dsi_1.id))
                                                                     Filter: (fuzzy_descriptor_suffix_id IS NULL)
                                             ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l6  (cost=0.58..2.73 rows=1 width=42) (actual time=0.007..0.007 rows=1 loops=25)
                                                   Index Cond: ((upload_id = ll.upload_id) AND (id = ll.descriptor_suffix_id))
                                       ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l5  (cost=0.58..2.71 rows=1 width=42) (actual time=0.003..0.003 rows=1 loops=25)
                                             Index Cond: ((upload_id = l6.upload_id) AND (id = l6.parent_id))
                                 ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l4  (cost=0.58..2.71 rows=1 width=42) (actual time=0.002..0.002 rows=1 loops=25)
                                       Index Cond: ((upload_id = l5.upload_id) AND (id = l5.parent_id))
                           ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l3  (cost=0.58..2.71 rows=1 width=42) (actual time=0.002..0.002 rows=1 loops=25)
                                 Index Cond: ((upload_id = l4.upload_id) AND (id = l4.parent_id))
                     ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l2  (cost=0.58..2.71 rows=1 width=42) (actual time=0.002..0.002 rows=1 loops=25)
                           Index Cond: ((upload_id = l3.upload_id) AND (id = l3.parent_id))
               ->  Index Scan using codeintel_scip_symbols_lookup_id on codeintel_scip_symbols_lookup l1  (cost=0.58..2.71 rows=1 width=38) (actual time=0.002..0.002 rows=1 loops=25)
                     Index Cond: ((upload_id = l2.upload_id) AND (id = l2.parent_id))
 Planning Time: 18.489 ms
 Execution Time: 32.707 ms
(92 rows)
```

## Test plan

Unit tests; scale-tested in clone of dotcom database (see above).