### PR TITLE
App (draft): Add global shortcut handler

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-utils = "1.4.0"
 
 [dependencies.tauri]
 version = "1.4.1"
-features = ["devtools", "dialog-confirm", "dialog-open", "fs-remove-dir", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "updater", "window-set-resizable", "window-set-size", "window-start-dragging"]
+features = [ "global-shortcut-all","devtools", "dialog-confirm", "dialog-open", "fs-remove-dir", "process-command-api", "shell-open", "shell-sidecar", "system-tray", "updater", "window-set-resizable", "window-set-size", "window-start-dragging", "global-shortcut"]
 
 [dependencies.fix-path-env]
 git = "https://github.com/tauri-apps/fix-path-env-rs"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ mod tray;
 use common::{extract_path_from_scheme_url, show_window};
 use std::collections::HashMap;
 use std::sync::RwLock;
+use tauri::GlobalShortcutManager;
 use tauri::Manager;
 use tauri_utils::config::RemoteDomainAccessScope;
 
@@ -68,6 +69,9 @@ fn set_launch_path(url: String) {
 // Url scheme for sourcegraph:// urls.
 const SCHEME: &str = "sourcegraph";
 const BUNDLE_IDENTIFIER: &str = "com.sourcegraph.cody";
+
+// Global shortcut key combination
+const SHORTCUT: &str = "Ctrl+Space";
 
 fn main() {
     // Prepare handler for sourcegraph:// scheme urls.
@@ -139,6 +143,7 @@ fn main() {
         .plugin(tauri_plugin_positioner::init())
         .setup(|app| {
             let handle = app.handle();
+            register_shortcut(&handle);
             start_embedded_services(&handle);
             // Register handler for sourcegraph:// scheme urls.
             tauri_plugin_deep_link::register(SCHEME, move |request| {
@@ -295,4 +300,20 @@ fn get_sourcegraph_args(app_handle: &tauri::AppHandle) -> Vec<String> {
         args.push(data_dir.to_string_lossy().to_string())
     }
     return args;
+}
+
+fn handle_shortcut_press(_app_handle: &tauri::AppHandle) {
+    println!("Shortcut pressed!");
+}
+
+fn register_shortcut(app_handle: &tauri::AppHandle) {
+    let app_handle_clone = app_handle.clone();
+    let mut shortcut_manager = app_handle.global_shortcut_manager();
+
+    if shortcut_manager.is_registered(SHORTCUT).unwrap() {
+        return;
+    }
+
+    println!("Registering shortcut");
+    shortcut_manager.register(SHORTCUT, move || handle_shortcut_press(&app_handle_clone));
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,9 @@
   },
   "tauri": {
     "allowlist": {
+      "globalShortcut": {
+        "all": true
+      },
       "dialog": {
         "open": true,
         "confirm": true


### PR DESCRIPTION
Prototype for the ability to handle a shortcut key combination in the app. It triggers a handler function whether the app is focused or not. 

The intent is to trigger a Spotlight-like input box or other shortcut functionality in the app.

## Test plan

- Press Control+Space and look for the debug message in logs.