### PR TITLE
Hide the "Cody Settings" link in App

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -250,7 +250,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiOpenInNew} /> Cody Docs & FAQ
                                 </MenuLink>
-                                {authenticatedUser?.siteAdmin && (
+                                {!isSourcegraphApp && authenticatedUser?.siteAdmin && (
                                     <MenuLink as={Link} to="/site-admin/cody">
                                         <Icon aria-hidden={true} svgPath={mdiCogOutline} /> Cody Settings
                                     </MenuLink>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/cody/issues/163

## Test plan

- Loaded the chat in App
- Verified link isn't rendered