### PR TITLE
WIP gitserver: introduce Init to VCSSyncer

### DIFF
--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"io"
 	"os/exec"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
@@ -28,6 +29,11 @@ type VCSSyncer interface {
 	Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error)
 	// RemoteShowCommand returns the command to be executed for showing remote.
 	RemoteShowCommand(ctx context.Context, remoteURL *vcs.URL) (cmd *exec.Cmd, err error)
+}
+
+type Initer interface {
+	Init(ctx context.Context, remoteURL *vcs.URL, tmpPath string) error
+	Fetch2(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string, output io.Writer) error
 }
 
 type notFoundError struct{ error }


### PR DESCRIPTION
Breaking it up this way may be useful for things like setting alternates before cloning. Future will be removing clone command and instead always doing init followed by fetch.

