### PR TITLE
pr-auditor: use pr-auditor from new repo

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -3,18 +3,20 @@ name: pr-auditor
 on:
   pull_request_target:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
+  workflow_dispatch:
 
 jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with: { repository: 'sourcegraph/pr-auditor' }
-      - uses: actions/setup-go@v2
-        with: { go-version: '1.19' }
+        with:
+          repository: 'sourcegraph/pr-auditor'
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.20' }
 
-      - run: ./check-pr.sh
+      - run: './check-pr.sh'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
-          GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with: { repository: 'sourcegraph/sourcegraph' }
+        with: { repository: 'sourcegraph/pr-auditor' }
       - uses: actions/setup-go@v2
         with: { go-version: '1.19' }
 
-      - run: ./dev/pr-auditor/check-pr.sh
+      - run: ./check-pr.sh
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.CODENOTIFY_GITHUB_TOKEN }}


### PR DESCRIPTION
Use pr-auditor from `sourcegraph/pr-auditor`
## Test plan
`gh workflow run pr-auditor --ref wb/pr-auditor` + `on: workflow_dispatch:`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
