### PR TITLE
search-blitz: build outside of docker

### DIFF
--- a/internal/cmd/search-blitz/.gitignore
+++ b/internal/cmd/search-blitz/.gitignore
@@ -1,0 +1,1 @@
+searchblitz

--- a/internal/cmd/search-blitz/Dockerfile
+++ b/internal/cmd/search-blitz/Dockerfile
@@ -1,12 +1,6 @@
-FROM golang:1.19.8-alpine@sha256:841c160ed35923d96c95c52403c4e6db5decd9cbce034aa851e412ade5d4b74f AS builder
-WORKDIR /build
-COPY go.sum go.mod ./
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o searchblitz ./internal/cmd/search-blitz
-
 FROM sourcegraph/alpine-3.14:213466_2023-04-17_5.0-bdda34a71619@sha256:6354a4ff578b685e36c8fbde81f62125ae0011b047fb2cc22d1b0de616b3c59a
 
-COPY --from=builder /build/searchblitz /usr/local/bin
+COPY searchblitz /usr/local/bin
 
 ARG COMMIT_SHA="unknown"
 

--- a/internal/cmd/search-blitz/scripts/build.sh
+++ b/internal/cmd/search-blitz/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 
 if [ -z "$1" ]; then
   echo "USAGE $0 VERSION"
@@ -11,8 +11,9 @@ fi
 
 set -x
 
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o searchblitz .
+
 docker build \
-  -f ./internal/cmd/search-blitz/Dockerfile \
   --platform linux/amd64 \
   --build-arg COMMIT_SHA="$(git rev-parse HEAD)" \
   -t "us.gcr.io/sourcegraph-dev/search-blitz:$1" \


### PR DESCRIPTION
At some point we started using the root go.mod, which made building the container image _very_ slow. So slow I wrote this before it had finished running.

Test Plan: built (without pushing) on my arm64 mac just to make sure the image still ran as linux/amd64 correctly.