### PR TITLE
JetBrains: Docs: Add "Experimental" badge

### DIFF
--- a/doc/cody/explanations/cody_clients.md
+++ b/doc/cody/explanations/cody_clients.md
@@ -44,16 +44,16 @@ See the full feature comparison for Cody IDE extensions:
 
 This represents the _current availability_. Notes on future availability and feature parity is coming soon.   
 
-| Subject                      | Description                                             | VS Code | JetBrains IDEs | Web UI | App |
-|-----------------------------|---------------------------------------------------------|:-:|:-:|:-:|:-:|
-|Chat                         | ChatGPT-like chat functionality                         |✅|✅|✅|✅|
-|Code autocomplete                  | Start typing a line of code and Cody will suggest a completion|✅|✅|✖️|✖️| 
-|Mutli-line code autocomplete      | Cody suggests multiple lines of a completion            |✅|✖️|✖️|✖️| 
-|Inline chat                | Start chats and fix code from within the code editor                |✅|✖️|✖️|✖️| 
-|Recipes                      | Predefined prompts |✅|✅|✅|✖️|
-|Multi-repo context          | Prompts can gather context from up to 10 repositories |✖️|✖️|✅|✅|
-|Context selection            | Specify repos you want the prompt to gather context from|✖️|✖️|✅|✅|
-|Connect to Cody app            | IDE uses Cody app as context|✅|✅|✖️||
+| Subject                      | Description                                             | VS Code | JetBrains IDEs <span class="badge badge-experimental">Experimental</span> | Web UI | App |
+|-----------------------------|---------------------------------------------------------|:-:|:---------------:|:-:|:-:|
+|Chat                         | ChatGPT-like chat functionality                         |✅|        ✅        |✅|✅|
+|Code autocomplete                  | Start typing a line of code and Cody will suggest a completion|✅|        ✅        |✖️|✖️| 
+|Mutli-line code autocomplete      | Cody suggests multiple lines of a completion            |✅|       ✖️        |✖️|✖️| 
+|Inline chat                | Start chats and fix code from within the code editor                |✅|       ✖️        |✖️|✖️| 
+|Recipes                      | Predefined prompts |✅|        ✅        |✅|✖️|
+|Multi-repo context          | Prompts can gather context from up to 10 repositories |✖️|       ✖️        |✅|✅|
+|Context selection            | Specify repos you want the prompt to gather context from|✖️|       ✖️        |✅|✅|
+|Connect to Cody app            | IDE uses Cody app as context|✅|        ✅        |✖️||
 
 ### Cody with Sourcegraph Enterprise
 


### PR DESCRIPTION
The purple badge wasn't there before this PR:

<img width="1139" alt="CleanShot 2023-07-18 at 12 53 02@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2552265/95153033-59e4-4dbf-87ff-6bb24289f92d">

## Test plan

(Only docs change)