### PR TITLE
Fuzzy finder: allow line number at the end of a filename

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1873,6 +1873,7 @@ ts_project(
         "src/components/diff/DiffStat.test.tsx",
         "src/components/externalServices/ExternalServiceForm.test.tsx",
         "src/components/externalServices/externalServices.test.tsx",
+        "src/components/fuzzyFinder/FuzzyFiles.test.tsx",
         "src/components/fuzzyFinder/FuzzyFinder.mocks.tsx",
         "src/components/fuzzyFinder/FuzzyFinder.test.tsx",
         "src/components/legacyLayoutRouteContext.mock.ts",

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1873,7 +1873,7 @@ ts_project(
         "src/components/diff/DiffStat.test.tsx",
         "src/components/externalServices/ExternalServiceForm.test.tsx",
         "src/components/externalServices/externalServices.test.tsx",
-        "src/components/fuzzyFinder/FuzzyFiles.test.tsx",
+        "src/components/fuzzyFinder/FuzzyFiles.test.ts",
         "src/components/fuzzyFinder/FuzzyFinder.mocks.tsx",
         "src/components/fuzzyFinder/FuzzyFinder.test.tsx",
         "src/components/legacyLayoutRouteContext.mock.ts",

--- a/client/web/src/components/fuzzyFinder/FuzzyActions.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyActions.tsx
@@ -35,7 +35,6 @@ export function createActionsFSM(actions: FuzzyAction[]): FuzzyFSM {
             text: action.title,
             onClick: action.run,
             icon: <Icon aria-label={action.title} svgPath={mdiCodeGreaterThan} />,
-        })),
-        undefined
+        }))
     )
 }

--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.test.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.test.ts
@@ -1,0 +1,15 @@
+import { FuzzyFileQuery, parseFuzzyFileQuery } from './FuzzyFiles'
+
+function checkFuzzyFileQuery(query: string, expectedValue: FuzzyFileQuery): void {
+    test(query, () => {
+        expect(parseFuzzyFileQuery(query)).toStrictEqual(expectedValue)
+    })
+}
+
+describe('parseFuzzyFileQuery', () => {
+    checkFuzzyFileQuery('foo.ts', { filename: 'foo.ts' })
+    checkFuzzyFileQuery('foo.ts:', { filename: 'foo.ts', line: 0 })
+    checkFuzzyFileQuery('foo.ts:1:', { filename: 'foo.ts', line: 1, column: 0 })
+    checkFuzzyFileQuery('foo.ts:100', { filename: 'foo.ts', line: 100 })
+    checkFuzzyFileQuery('foo.ts:100:99', { filename: 'foo.ts', line: 100, column: 99 })
+})

--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -5,8 +5,8 @@ import { getDocumentNode, gql } from '@sourcegraph/http-client'
 import { Icon } from '@sourcegraph/wildcard'
 
 import { getWebGraphQLClient } from '../../backend/graphql'
+import { FuzzySearchTransformer, createUrlFunction } from '../../fuzzyFinder/FuzzySearch'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
-import { createUrlFunction } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import {
     FileNamesResult,
     FileNamesVariables,
@@ -70,40 +70,6 @@ function fileIcon(filename: string): JSX.Element {
     )
 }
 
-export async function loadFilesFSM(
-    apolloClient: ApolloClient<object> | undefined,
-    repoRevision: FuzzyRepoRevision,
-    createURL: createUrlFunction
-): Promise<FuzzyFSM> {
-    try {
-        const client = apolloClient || (await getWebGraphQLClient())
-        const response = await client.query<FileNamesResult, FileNamesVariables>({
-            query: getDocumentNode(FUZZY_GIT_LSFILES_QUERY),
-            variables: { repository: repoRevision.repositoryName, commit: repoRevision.revision },
-        })
-        if (response.errors && response.errors.length > 0) {
-            return { key: 'failed', errorMessage: JSON.stringify(response.errors) }
-        }
-        if (response.error) {
-            return { key: 'failed', errorMessage: JSON.stringify(response.error) }
-        }
-        const filenames = response.data.repository?.commit?.fileNames || []
-        return newFuzzyFSM(filenames, createURL)
-    } catch (error) {
-        return { key: 'failed', errorMessage: JSON.stringify(error) }
-    }
-}
-
-export function newFuzzyFSM(filenames: string[], createUrl: createUrlFunction): FuzzyFSM {
-    return newFuzzyFSMFromValues(
-        filenames.map(text => ({
-            text,
-            icon: fileIcon(text),
-        })),
-        createUrl
-    )
-}
-
 export class FuzzyRepoFiles {
     private fsm: FuzzyFSM = { key: 'empty' }
     constructor(
@@ -140,7 +106,7 @@ export class FuzzyRepoFiles {
             icon: fileIcon(text),
             historyRanking: () => this.userHistory.lastAccessedFilePath(this.repoRevision.repositoryName, text),
         }))
-        this.updateFSM(newFuzzyFSMFromValues(values, this.createURL))
+        this.updateFSM(newFuzzyFSMFromValues(values, { createURL: this.createURL, transformer: lineNumberTransformer }))
         this.loopIndexing()
         return values
     }
@@ -165,6 +131,51 @@ export class FuzzyRepoFiles {
             )
         }
     }
+}
+
+export interface FuzzyFileQuery {
+    filename: string
+    line?: number
+    column?: number
+}
+
+export function parseFuzzyFileQuery(query: string): FuzzyFileQuery {
+    if (query.endsWith(':')) {
+        // Infer the line number or column number if the user is typing :.
+        // Without this logic, the fuzzy finder briefly becomes empty for a
+        // split second when the user types a : character before typing the line
+        // number or column number.
+        query = query + '0'
+    }
+    const lineNumberPattern = /^([^:]+):(\d+)(?::(\d+))?$/
+    const match = query.match(lineNumberPattern)
+    if (match && match.length > 3) {
+        const value: FuzzyFileQuery = { filename: match[1] }
+        const line = Number.parseInt(match[2], 10)
+        if (isFinite(line)) {
+            value.line = line
+        }
+        const column = Number.parseInt(match[3], 10)
+        if (isFinite(column)) {
+            value.column = column
+        }
+        return value
+    }
+    return { filename: query }
+}
+
+const lineNumberTransformer: FuzzySearchTransformer = {
+    modifyQuery: (query: string) => {
+        const parsed = parseFuzzyFileQuery(query)
+        return parsed.filename
+    },
+    modifyURL: (query: string, url: string) => {
+        const parsed = parseFuzzyFileQuery(query)
+        if (parsed.line !== undefined && isFinite(parsed.line)) {
+            return `${url}?L${parsed.line}`
+        }
+        return url
+    },
 }
 
 export class FuzzyFiles extends FuzzyQuery {

--- a/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFiles.tsx
@@ -186,7 +186,7 @@ export class FuzzyFiles extends FuzzyQuery {
         private readonly repoRevision: React.MutableRefObject<FuzzyRepoRevision>,
         private readonly userHistory: UserHistory
     ) {
-        super(onNamesChanged, emptyFuzzyCache)
+        super(onNamesChanged, emptyFuzzyCache, { transformer: lineNumberTransformer })
     }
 
     /* override */ protected searchValues(): SearchValue[] {
@@ -202,7 +202,7 @@ export class FuzzyFiles extends FuzzyQuery {
 
     /* override */ protected rawQuery(query: string): string {
         const repoFilter = this.isGlobalFiles ? '' : fuzzyRepoRevisionSearchFilter(this.repoRevision.current)
-        return `${repoFilter}type:path count:100 ${query}`
+        return `${repoFilter}type:path count:100 ${parseFuzzyFileQuery(query).filename}`
     }
 
     /* override */ protected async handleRawQueryPromise(query: string): Promise<PersistableQueryResult[]> {

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -13,11 +13,13 @@ import { FUZZY_GIT_LSFILES_QUERY } from './FuzzyFiles'
 import { FuzzyFinderContainer } from './FuzzyFinder'
 import { FUZZY_REPOS_QUERY } from './FuzzyRepos'
 import { FUZZY_SYMBOLS_QUERY } from './FuzzySymbols'
+import { FuzzyTabKey } from './FuzzyTabs'
 
 export interface FuzzyWrapperProps {
     url: string
     experimentalFeatures: Settings['experimentalFeatures']
     initialQuery?: string
+    activeTab?: FuzzyTabKey
 }
 
 export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props => {
@@ -26,6 +28,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
     const client = useApolloClient()
     return (
         <FuzzyFinderContainer
+            defaultActiveTab={props.activeTab}
             client={client}
             isVisible={true}
             setIsVisible={() => {}}

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.story.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.story.tsx
@@ -26,6 +26,17 @@ export const ReadyStory: Story = () => (
     </MockedTestProvider>
 )
 
+export const ReadyFileLineStory: Story = () => (
+    <MockedTestProvider mocks={[FUZZY_FILES_MOCK]}>
+        <FuzzyWrapper
+            url="/github.com/sourcegraph/sourcegraph@main"
+            experimentalFeatures={{}}
+            activeTab="files"
+            initialQuery="clientb:100"
+        />
+    </MockedTestProvider>
+)
+
 export const TabsStory: Story = () => (
     <MockedTestProvider mocks={[FUZZY_FILES_MOCK]}>
         <FuzzyWrapper

--- a/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyFsm.ts
@@ -1,7 +1,7 @@
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'
-import { FuzzySearch, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
+import { FuzzySearch, FuzzySearchConstructorParameters, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
-import { createUrlFunction, WordSensitiveFuzzySearch } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
+import { WordSensitiveFuzzySearch } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 
 // The default value of 80k filenames is picked from the following observations:
 // - case-insensitive search is slow but works in the torvalds/linux repo (72k files)
@@ -51,14 +51,14 @@ export interface Failed {
     errorMessage: string
 }
 
-export function newFuzzyFSMFromValues(values: SearchValue[], createUrl: createUrlFunction): FuzzyFSM {
+export function newFuzzyFSMFromValues(values: SearchValue[], params?: FuzzySearchConstructorParameters): FuzzyFSM {
     if (values.length < DEFAULT_CASE_INSENSITIVE_FILE_COUNT_THRESHOLD) {
         return {
             key: 'ready',
-            fuzzy: new CaseInsensitiveFuzzySearch(values, createUrl),
+            fuzzy: new CaseInsensitiveFuzzySearch(values, params),
         }
     }
-    const indexing = WordSensitiveFuzzySearch.fromSearchValuesAsync(values, createUrl)
+    const indexing = WordSensitiveFuzzySearch.fromSearchValuesAsync(values, params)
     if (indexing.key === 'ready') {
         return {
             key: 'ready',

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -44,6 +44,7 @@ import { SearchValueRankingCache } from '../../fuzzyFinder/SearchValueRankingCac
 import { mergedHandler } from '../../fuzzyFinder/WordSensitiveFuzzySearch'
 import { Keybindings } from '../KeyboardShortcutsHelp/KeyboardShortcutsHelp'
 
+import { parseFuzzyFileQuery } from './FuzzyFiles'
 import { fuzzyErrors, FuzzyState, FuzzyTabs, FuzzyTabKey, FuzzyScope } from './FuzzyTabs'
 import { HighlightedLink, HighlightedLinkProps, linkStyle } from './HighlightedLink'
 
@@ -567,7 +568,9 @@ const SearchQueryLink: React.FunctionComponent<FuzzyState & { onClickItem: () =>
         case 'symbols':
             return searchQueryLink(`type:symbol ${props.query}${isScopeEverywhere ? '' : repoFilter(props)}`)
         case 'files':
-            return searchQueryLink(`type:path ${props.query}${isScopeEverywhere ? '' : repoFilter(props)}`)
+            return searchQueryLink(
+                `type:path ${parseFuzzyFileQuery(props.query).filename}${isScopeEverywhere ? '' : repoFilter(props)}`
+            )
         case 'repos':
             return searchQueryLink(`type:repo ${props.query}`)
         case 'all':

--- a/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
+++ b/client/web/src/components/fuzzyFinder/FuzzyQuery.ts
@@ -1,5 +1,10 @@
 import { CaseInsensitiveFuzzySearch } from '../../fuzzyFinder/CaseInsensitiveFuzzySearch'
-import { FuzzySearch, IndexingFSM, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
+import {
+    FuzzySearch,
+    FuzzySearchConstructorParameters,
+    IndexingFSM,
+    SearchIndexing,
+} from '../../fuzzyFinder/FuzzySearch'
 import { SearchValue } from '../../fuzzyFinder/SearchValue'
 
 import { FuzzyFSM } from './FuzzyFsm'
@@ -11,7 +16,11 @@ export abstract class FuzzyQuery {
     protected doneQueries: Set<string> = new Set()
     protected queryResults: Map<string, PersistableQueryResult> = new Map()
 
-    constructor(private readonly onNamesChanged: () => void, private readonly cache: FuzzyLocalCache) {
+    constructor(
+        private readonly onNamesChanged: () => void,
+        private readonly cache: FuzzyLocalCache,
+        private readonly fuzzySearchParams?: FuzzySearchConstructorParameters
+    ) {
         this.addQueryResults(this.cache.initialValues())
     }
 
@@ -61,7 +70,7 @@ export abstract class FuzzyQuery {
         return this.queries.has(query) || this.doneQueries.has(query)
     }
     protected fuzzySearch(): FuzzySearch {
-        return new CaseInsensitiveFuzzySearch(this.searchValues(), undefined)
+        return new CaseInsensitiveFuzzySearch(this.searchValues(), this.fuzzySearchParams)
     }
 
     public fuzzyFSM(): FuzzyFSM {

--- a/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyTabs.tsx
@@ -217,6 +217,7 @@ export interface FuzzyTabsProps {
     initialQuery?: string
     isVisible: boolean
     userHistory: UserHistory
+    defaultActiveTab?: FuzzyTabKey
 }
 
 export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
@@ -227,6 +228,7 @@ export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
         client: apolloClient,
         settingsCascade,
         userHistory,
+        defaultActiveTab,
     } = props
     let {
         repoName = '',
@@ -254,7 +256,7 @@ export function useFuzzyState(props: FuzzyTabsProps): FuzzyState {
     const { fuzzyFinderAll, fuzzyFinderActions, fuzzyFinderRepositories, fuzzyFinderSymbols } =
         useFuzzyFinderFeatureFlags()
 
-    const [activeTab, setActiveTab] = useState<FuzzyTabKey>('all')
+    const [activeTab, setActiveTab] = useState<FuzzyTabKey>(defaultActiveTab || 'all')
 
     // NOTE: the query is cached in session storage to mimic the file pickers in
     // IntelliJ (by default) and VS Code (when "Workbench > Quick Open >

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -2,10 +2,9 @@ import { extendedMatch, Fzf, FzfResultItem, Tiebreaker } from 'fzf'
 
 import { HighlightedLinkProps, RangePosition } from '../components/fuzzyFinder/HighlightedLink'
 
-import { FuzzySearch, FuzzySearchParameters, FuzzySearchResult } from './FuzzySearch'
+import { FuzzySearch, FuzzySearchConstructorParameters, FuzzySearchParameters, FuzzySearchResult } from './FuzzySearch'
 import { SearchValue } from './SearchValue'
 import { SearchValueRankingCache } from './SearchValueRankingCache'
-import { createUrlFunction } from './WordSensitiveFuzzySearch'
 
 function sortByTiebreakers<T>(values: FzfResultItem<T>[], tiebreakers: Tiebreaker<T>[]): FzfResultItem<T>[] {
     return values.sort((a, b) => {
@@ -25,12 +24,16 @@ function sortByTiebreakers<T>(values: FzfResultItem<T>[], tiebreakers: Tiebreake
 export class CaseInsensitiveFuzzySearch extends FuzzySearch {
     public totalFileCount: number
 
-    constructor(public readonly values: SearchValue[], private readonly createUrl: createUrlFunction) {
+    constructor(public readonly values: SearchValue[], private readonly params?: FuzzySearchConstructorParameters) {
         super()
         this.totalFileCount = values.length
     }
 
     public search(parameters: FuzzySearchParameters): FuzzySearchResult {
+        const query = this?.params?.transformer?.modifyQuery
+            ? this.params.transformer.modifyQuery(parameters.query)
+            : parameters.query
+        console.log({ query })
         const historyCache = parameters.cache ?? new SearchValueRankingCache()
         const tiebreakers: Tiebreaker<SearchValue>[] = [
             (a, b) => historyCache.rank(b.item) - historyCache.rank(a.item),
@@ -43,7 +46,7 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
             casing: 'case-insensitive',
             tiebreakers,
         })
-        const isEmpty = parameters.query === ''
+        const isEmpty = query === ''
         const candidates = isEmpty
             ? sortByTiebreakers(
                   this.values
@@ -51,18 +54,21 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
                       .map(value => ({ item: value, positions: new Set(), start: 0, end: 0, score: 0 })),
                   tiebreakers
               )
-            : fzf.find(parameters.query)
-        // this.cacheCandidates.push(new CacheCandidate(parameters.query, [...candidates.map(({ item }) => item)]))
+            : fzf.find(query)
         const isComplete = candidates.length < parameters.maxResults
         candidates.slice(0, parameters.maxResults)
 
         const links: HighlightedLinkProps[] = candidates.map<HighlightedLinkProps>(candidate => {
             const positions = compressedRangePositions([...candidate.positions])
+            const url = candidate.item.url || this?.params?.createURL?.(candidate.item.text)
             return {
                 ...candidate.item,
                 score: candidate.score,
                 positions,
-                url: candidate.item.url || this.createUrl?.(candidate.item.text),
+                url:
+                    url && this?.params?.transformer?.modifyURL
+                        ? this.params?.transformer.modifyURL(parameters.query, url)
+                        : url,
             }
         })
         return {

--- a/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/CaseInsensitiveFuzzySearch.ts
@@ -33,7 +33,6 @@ export class CaseInsensitiveFuzzySearch extends FuzzySearch {
         const query = this?.params?.transformer?.modifyQuery
             ? this.params.transformer.modifyQuery(parameters.query)
             : parameters.query
-        console.log({ query })
         const historyCache = parameters.cache ?? new SearchValueRankingCache()
         const tiebreakers: Tiebreaker<SearchValue>[] = [
             (a, b) => historyCache.rank(b.item) - historyCache.rank(a.item),

--- a/client/web/src/fuzzyFinder/FuzzySearch.ts
+++ b/client/web/src/fuzzyFinder/FuzzySearch.ts
@@ -1,3 +1,4 @@
+import { FuzzyTabKey } from '../components/fuzzyFinder/FuzzyTabs'
 import { HighlightedLinkProps } from '../components/fuzzyFinder/HighlightedLink'
 
 import { SearchValueRankingCache } from './SearchValueRankingCache'
@@ -6,6 +7,7 @@ export interface FuzzySearchParameters {
     query: string
     maxResults: number
     cache?: SearchValueRankingCache
+    fuzzyFinderTab?: FuzzyTabKey
 }
 
 export interface FuzzySearchResult {
@@ -48,4 +50,16 @@ export interface SearchReady {
 export abstract class FuzzySearch {
     public abstract totalFileCount: number
     public abstract search(parameters: FuzzySearchParameters): FuzzySearchResult
+}
+
+export interface FuzzySearchConstructorParameters {
+    createURL?: createUrlFunction
+    transformer?: FuzzySearchTransformer
+}
+
+export type createUrlFunction = undefined | ((value: string) => string)
+
+export interface FuzzySearchTransformer {
+    modifyQuery?: (query: string) => string
+    modifyURL?: (query: string, url: string) => string
 }


### PR DESCRIPTION
Previously, it was not possible to navigate straight to a specific line number with the "Files" tab of the fuzzy finder. This commit adds the ability to specify a line number with a `:NUMBER` suffix. This feature makes it possible to copy-paste error messages that use the `FILE:LINE:COLUMN` format and quickly open the location with the fuzzy finder.

## Test plan

- New storybook test
- New unit tests for query parsing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
