### PR TITLE
search-blitz: remove group

### DIFF
--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -18,11 +18,6 @@ var queriesFS embed.FS
 var attributionFS embed.FS
 
 type Config struct {
-	Groups []*QueryGroupConfig
-}
-
-type QueryGroupConfig struct {
-	Name    string
 	Queries []*QueryConfig
 }
 
@@ -104,10 +99,7 @@ func loadQueries(env string) (_ *Config, err error) {
 	add()
 
 	return &Config{
-		Groups: []*QueryGroupConfig{{
-			Name:    "monitoring_queries",
-			Queries: queries,
-		}},
+		Queries: queries,
 	}, err
 }
 

--- a/internal/cmd/search-blitz/config_test.go
+++ b/internal/cmd/search-blitz/config_test.go
@@ -10,16 +10,12 @@ func TestLoadQueries(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if len(c.Groups) < 1 {
-				t.Fatal("expected atleast 1 group")
-			}
-
-			if len(c.Groups[0].Queries) < 2 {
+			if len(c.Queries) < 2 {
 				t.Fatal("expected atleast 2 queries")
 			}
 
 			names := map[string]bool{}
-			for _, q := range c.Groups[0].Queries {
+			for _, q := range c.Queries {
 				if names[q.Name] {
 					t.Fatalf("name %q is not unique", q.Name)
 				}
@@ -27,7 +23,7 @@ func TestLoadQueries(t *testing.T) {
 			}
 
 			if testing.Verbose() {
-				for _, q := range c.Groups[0].Queries {
+				for _, q := range c.Queries {
 					t.Logf("% -25s %s", q.Name, q.Query)
 				}
 			}

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -52,12 +52,12 @@ func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 		return nil
 	}
 
-	loopSearch := func(ctx context.Context, c genericClient, group string, qc *QueryConfig) {
+	loopSearch := func(ctx context.Context, c genericClient, qc *QueryConfig) {
 		if qc.Interval == 0 {
 			qc.Interval = time.Minute
 		}
 
-		log := log15.New("group", group, "name", qc.Name, "query", qc.Query, "type", c.clientType())
+		log := log15.New("name", qc.Name, "query", qc.Query, "type", c.clientType())
 
 		// Randomize start to a random time in the initial interval so our
 		// queries aren't all scheduled at the same time.
@@ -90,10 +90,10 @@ func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 
 				tookSeconds, firstResultSeconds := m.took.Seconds(), m.firstResult.Seconds()
 
-				tsv.Log(group, qc.Name, c.clientType(), m.trace, m.matchCount, tookSeconds, firstResultSeconds)
-				durationSearchSeconds.WithLabelValues(group, qc.Name, c.clientType()).Observe(tookSeconds)
-				firstResultSearchSeconds.WithLabelValues(group, qc.Name, c.clientType()).Observe(firstResultSeconds)
-				matchCount.WithLabelValues(group, qc.Name, c.clientType()).Set(float64(m.matchCount))
+				tsv.Log(qc.Name, c.clientType(), m.trace, m.matchCount, tookSeconds, firstResultSeconds)
+				durationSearchSeconds.WithLabelValues(qc.Name, c.clientType()).Observe(tookSeconds)
+				firstResultSearchSeconds.WithLabelValues(qc.Name, c.clientType()).Observe(firstResultSeconds)
+				matchCount.WithLabelValues(qc.Name, c.clientType()).Set(float64(m.matchCount))
 			}
 
 			select {
@@ -104,7 +104,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 		}
 	}
 
-	scheduleQuery := func(ctx context.Context, group string, qc *QueryConfig) {
+	scheduleQuery := func(ctx context.Context, qc *QueryConfig) {
 		if len(qc.Protocols) == 0 {
 			qc.Protocols = allProtocols
 		}
@@ -114,15 +114,13 @@ func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				loopSearch(ctx, client, group, qc)
+				loopSearch(ctx, client, qc)
 			}()
 		}
 	}
 
-	for _, group := range config.Groups {
-		for _, qc := range group.Queries {
-			scheduleQuery(ctx, group.Name, qc)
-		}
+	for _, qc := range config.Queries {
+		scheduleQuery(ctx, qc)
 	}
 }
 

--- a/internal/cmd/search-blitz/prometheus.go
+++ b/internal/cmd/search-blitz/prometheus.go
@@ -11,15 +11,15 @@ var durationSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "search_blitz_duration_seconds",
 	Help:    "e2e duration search-blitz where client is either stream or batch",
 	Buckets: Buckets,
-}, []string{"group", "query_name", "client"})
+}, []string{"query_name", "client"})
 
 var firstResultSearchSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "search_blitz_first_result_seconds",
 	Help:    "e2e time to first result search-blitz where client is either stream or batch",
 	Buckets: Buckets,
-}, []string{"group", "query_name", "client"})
+}, []string{"query_name", "client"})
 
 var matchCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "search_blitz_match_count",
 	Help: "the match count where client is either stream or batch",
-}, []string{"group", "query_name", "client"})
+}, []string{"query_name", "client"})


### PR DESCRIPTION
We have only ever had one group. I think this was introduced at a time when we thought we may have different groups of queries, but we ended up just relying on the query name for that.

Group was only used in local observability, but not in the metrics we record in the frontend. So this _might_ break the local grafana dashboard (which we can fix). But my main motivation was removing some of the log noise.

Test Plan: go test