### PR TITLE
graphqlbackend: fix Fast completions parameter

### DIFF
--- a/cmd/frontend/graphqlbackend/completions.graphql
+++ b/cmd/frontend/graphqlbackend/completions.graphql
@@ -2,7 +2,7 @@ extend type Query {
     """
     Returns a string of completion responses
     """
-    completions(input: CompletionsInput!): String!
+    completions(input: CompletionsInput!, fast: Boolean = false): String!
 }
 
 """


### PR DESCRIPTION
There was a bug in the graphql API backend for completions, where although the Go backend was set up to handle Fast completions the schema did not accurately reflect that.

I want to use this API with fast completions for various prototypes, so fixing this.

## Test plan

Logically matches the parameters [defined here](https://github.com/sourcegraph/sourcegraph/blob/429c6202041416d60daadc58cbadebbd578226e6/cmd/frontend/graphqlbackend/completions.go#L9-L12) and `sg start app` works. Existing CI tests will confirm it builds as expected.