### PR TITLE
gitserver: return git command output when fetching a repo.

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2264,7 +2264,6 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir common.GitD
 	go readCloneProgress(s.DB, logger, newURLRedactor(remoteURL), lock, pr, repo)
 
 	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, pw)
-	// best-effort update the output of the clone
 	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
     // best-effort update the output of the clone
 	go s.setLastOutput(context.Background(), repo, redactedOutput)

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2261,17 +2261,15 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir common.GitD
 	pr, pw := io.Pipe()
 	defer pw.Close()
 
-	redactor := newURLRedactor(remoteURL)
-
 	go readCloneProgress(s.DB, logger, newURLRedactor(remoteURL), lock, pr, repo)
 
 	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, pw)
-
 	// best-effort update the output of the clone
-	go s.setLastOutput(context.Background(), repo, redactor.redact(string(output)))
+	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+	go s.setLastOutput(context.Background(), repo, redactedOutput)
 
 	if err != nil {
-		return errors.Wrapf(err, "clone failed. Output: %s", redactor.redact(string(output)))
+		return errors.Wrapf(err, "clone failed. Output: %s", redactedOutput)
 	}
 
 	if testRepoCorrupter != nil {
@@ -2658,16 +2656,14 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 	// when the cleanup happens, just that it does.
 	defer s.cleanTmpFiles(dir)
 
-	redactor := newURLRedactor(remoteURL)
-
 	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
-
 	// best-effort update the output of the fetch
-	go s.setLastOutput(context.Background(), repo, redactor.redact(string(output)))
+	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+	go s.setLastOutput(context.Background(), repo, redactedOutput)
 
 	if err != nil {
 		if output != nil {
-			return errors.Wrapf(err, "failed to fetch repo %q with output %q", repo, redactor.redact(string(output)))
+			return errors.Wrapf(err, "failed to fetch repo %q with output %q", repo, redactedOutput)
 		} else {
 			return errors.Wrapf(err, "failed to fetch repo %q", repo)
 		}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2266,6 +2266,7 @@ func (s *Server) doClone(ctx context.Context, repo api.RepoName, dir common.GitD
 	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, pw)
 	// best-effort update the output of the clone
 	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+    // best-effort update the output of the clone
 	go s.setLastOutput(context.Background(), repo, redactedOutput)
 
 	if err != nil {
@@ -2659,6 +2660,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
 	// best-effort update the output of the fetch
 	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+    // best-effort update the output of the clone
 	go s.setLastOutput(context.Background(), repo, redactedOutput)
 
 	if err != nil {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2657,9 +2657,8 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 	defer s.cleanTmpFiles(dir)
 
 	output, err := syncer.Fetch(ctx, remoteURL, dir, revspec)
-	// best-effort update the output of the fetch
 	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
-    // best-effort update the output of the clone
+    // best-effort update the output of the fetch
 	go s.setLastOutput(context.Background(), repo, redactedOutput)
 
 	if err != nil {

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -71,13 +71,14 @@ func (s *gitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 }
 
 // Fetch tries to fetch updates of a Git repository.
-func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, revspec string) ([]byte, error) {
+func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, dir common.GitDir, _ string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
-	if output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil); err != nil {
+	output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.Wrap(ctx, log.NoOp(), cmd), configRemoteOpts, nil)
+	if err != nil {
 		return nil, &common.GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
 	}
-	return nil, nil
+	return output, nil
 }
 
 // RemoteShowCommand returns the command to be executed for showing remote of a Git repository.


### PR DESCRIPTION
This commit fixes behaviour of `gitRepoSyncer.Fetch` function which previously always returned `nil` output and because of that no git command logs were stored into the DB.

Test plan:
Local sg run and test that the logs are stored in the DB and displayed on "Mirroring" page.

### Demo

https://github.com/sourcegraph/sourcegraph/assets/94846361/8b87b98a-bf5b-480c-bfb2-2a8d9b7d94f0

