### PR TITLE
Cody: Log max tokens to sample in Honeycomb

### DIFF
--- a/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -52,7 +52,7 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 		chatModel = completionsConfig.ChatModel
 	}
 
-	ctx, done := httpapi.Trace(ctx, "resolver", chatModel).
+	ctx, done := httpapi.Trace(ctx, "resolver", chatModel, int(args.Input.MaxTokensToSample)).
 		WithErrorP(&err).
 		Build()
 	defer done()

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -54,7 +54,7 @@ func newCompletionsHandler(
 		requestParams.Model = getModel(requestParams, completionsConfig)
 
 		var err error
-		ctx, done := Trace(ctx, traceFamily, requestParams.Model).
+		ctx, done := Trace(ctx, traceFamily, requestParams.Model, requestParams.MaxTokensToSample).
 			WithErrorP(&err).
 			WithRequest(r).
 			Build()

--- a/internal/completions/httpapi/observability.go
+++ b/internal/completions/httpapi/observability.go
@@ -17,7 +17,7 @@ import (
 //
 // Family identifies the endpoint being used, while model is the model we pass
 // to GetCompletionClient.
-func Trace(ctx context.Context, family, model string) *traceBuilder {
+func Trace(ctx context.Context, family, model string, maxTokensToSample int) *traceBuilder {
 	// TODO consider integrating a wrapper in GetCompletionClient. Only issue
 	// is we need to somehow make it cleaner to access fields from the
 	// request.
@@ -28,6 +28,7 @@ func Trace(ctx context.Context, family, model string) *traceBuilder {
 		ev = honey.NewEvent("completions")
 		ev.AddField("family", family)
 		ev.AddField("model", model)
+		ev.AddField("maxTokensToSample", maxTokensToSample)
 		ev.AddField("actor", actor.FromContext(ctx).UIDString())
 		if req := requestclient.FromContext(ctx); req != nil {
 			ev.AddField("connecting_ip", req.ForwardedFor)


### PR DESCRIPTION
We need to fine tune model speed and right now, multi-line and single-line requests are logged without any way to distinguish them making it hard to reason about runtime performance.

This adds the `maxTokensToSample` config to the honeycomb logger so we can filter out only the ones for single-line (which will have this value set to `100`).

## Test plan

I need help with this. This change was not tested yet.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
