### PR TITLE
docs: mark bitbucket cloud repo permissions as supported

### DIFF
--- a/doc/integration/bitbucket_cloud.md
+++ b/doc/integration/bitbucket_cloud.md
@@ -5,7 +5,7 @@ You can use Sourcegraph with Git repositories hosted on [Bitbucket Cloud](https:
 Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_cloud.md) | ✅
-Repository permissions | Coming soon
+Repository permissions | ✅
 Browser extension | ✅
 Native extension | ❌ Not supported on Bitbucket.org
 

--- a/doc/integration/bitbucket_cloud.md
+++ b/doc/integration/bitbucket_cloud.md
@@ -5,7 +5,7 @@ You can use Sourcegraph with Git repositories hosted on [Bitbucket Cloud](https:
 Feature | Supported?
 ------- | ----------
 [Repository syncing](../admin/external_service/bitbucket_cloud.md) | ✅
-Repository permissions | ✅
+[Repository permissions](../admin/external_service/bitbucket_cloud.md#repository-permissions) | ✅
 Browser extension | ✅
 Native extension | ❌ Not supported on Bitbucket.org
 


### PR DESCRIPTION
These were supported for a long time already, but we did not update this page in the past PRs.



## Test plan

tested locally, can also be [viewed here](https://docs.sourcegraph.com/@milan_bitbucket_cloud_docs/integration/bitbucket_cloud)
