### PR TITLE
[bitbucket cloud] Code host connection updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)
+- Bitbucket Cloud code host connections no longer automatically syncs the repository of the username used. The appropriate workspace name will have to be added to the `teams` list if repositories for that account need to be synced. [#55095](https://github.com/sourcegraph/sourcegraph/pull/55095)
 
 ## 5.1.4
 

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -819,7 +819,14 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
                     >
                         instructions
                     </Link>
-                    ) with <b>read</b> scope over your repositories and teams. Set it to be the value of the{' '}
+                    ) with the following scopes:
+                    <ul>
+                        <li><strong>Workspace membership</strong>: Read</li>
+                        <li><strong>Repositories</strong>: Read</li>
+                    </ul>
+                </li>
+                <li>
+                    Paste your app password in the{' '}
                     <Field>appPassword</Field> field in the configuration below.
                 </li>
                 <li>

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -826,6 +826,12 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
                         </li>
                         <li>
                             <strong>Repositories</strong>: Read
+                            <ul>
+                                <li>
+                                    To enable repository permissions syncing, <strong>Repositories</strong>: Admin is
+                                    required.
+                                </li>
+                            </ul>
                         </li>
                     </ul>
                 </li>

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -821,13 +821,16 @@ const BITBUCKET_CLOUD: AddExternalServiceOptions = {
                     </Link>
                     ) with the following scopes:
                     <ul>
-                        <li><strong>Workspace membership</strong>: Read</li>
-                        <li><strong>Repositories</strong>: Read</li>
+                        <li>
+                            <strong>Workspace membership</strong>: Read
+                        </li>
+                        <li>
+                            <strong>Repositories</strong>: Read
+                        </li>
                     </ul>
                 </li>
                 <li>
-                    Paste your app password in the{' '}
-                    <Field>appPassword</Field> field in the configuration below.
+                    Paste your app password in the <Field>appPassword</Field> field in the configuration below.
                 </li>
                 <li>
                     Set the <Field>username</Field> field to be the username corresponding to <Field>appPassword</Field>

--- a/doc/integration/bitbucket_cloud.md
+++ b/doc/integration/bitbucket_cloud.md
@@ -12,3 +12,8 @@ Native extension | ❌ Not supported on Bitbucket.org
 ## Repository syncing
 
 Site admins can [add Bitbucket Cloud repositories to Sourcegraph](../admin/external_service/bitbucket_cloud.md).
+
+## User authorization
+
+Site admins can [add Bitbucket Cloud as an authentication provider to Sourcegraph](../admin/auth.md#bitbucket-cloud).
+This will allow users to sign into Sourcegraph using their Bitbucket Cloud accounts. Site admins can then also [enable repository permissions](../admin/external_service/bitbucket_cloud.md#repository-permissions) on their Bitbucket Cloud code host connections.

--- a/internal/authz/providers/bitbucketcloud/provider.go
+++ b/internal/authz/providers/bitbucketcloud/provider.go
@@ -61,7 +61,7 @@ func NewProvider(db database.DB, conn *types.BitbucketCloudConnection, opts Prov
 // ValidateConnection validates that the Provider has access to the Bitbucket Cloud API
 // with the credentials it was configured with.
 func (p *Provider) ValidateConnection(ctx context.Context) error {
-	_, err := p.client.CurrentUser(ctx)
+	_, _, err := p.client.Repos(ctx, nil, "", nil)
 	return err
 }
 

--- a/internal/authz/providers/bitbucketcloud/provider.go
+++ b/internal/authz/providers/bitbucketcloud/provider.go
@@ -60,7 +60,12 @@ func NewProvider(db database.DB, conn *types.BitbucketCloudConnection, opts Prov
 
 // ValidateConnection validates that the Provider has access to the Bitbucket Cloud API
 // with the credentials it was configured with.
+//
+// Credentials are verified by querying the "/2.0/repositories" endpoint.
+// This validates that the credentials have the `repository` scope.
+// See: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-get
 func (p *Provider) ValidateConnection(ctx context.Context) error {
+	// We don't care about the contents returned, only whether or not an error occurred
 	_, _, err := p.client.Repos(ctx, nil, "", nil)
 	return err
 }

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -52,6 +52,9 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 			conf: &schema.BitbucketCloudConnection{
 				Username:    bbtest.GetenvTestBitbucketCloudUsername(),
 				AppPassword: os.Getenv("BITBUCKET_CLOUD_APP_PASSWORD"),
+				Teams: []string{
+					bbtest.GetenvTestBitbucketCloudUsername(),
+				},
 			},
 			err: "<nil>",
 		},
@@ -68,6 +71,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 				AppPassword: os.Getenv("BITBUCKET_CLOUD_APP_PASSWORD"),
 				Teams: []string{
 					"sglocal",
+					bbtest.GetenvTestBitbucketCloudUsername(),
 				},
 			},
 			err: "<nil>",


### PR DESCRIPTION
Closes #54968 

This PR does a few things to better the Bitbucket Cloud connection experience:
- Some docs have been updated to reflect the current Bitbucket Cloud setup experience
- Code host connections no longer automatically clone the repositories of the username the App Password belongs to
  - Way-back-when, a user always had a personal workspace tied to their username. This is no longer the case, and newer Bitbucket Cloud accounts will always produce an error in the code host sync, because there is no workspace associated with their username
- Also removes the requirement for the `Account` scope on the App Password, and we use the List Repositories endpoint to verify a connection instead.

<img width="835" alt="Screenshot 2023-07-19 at 11 33 54" src="https://github.com/sourcegraph/sourcegraph/assets/6427795/41a2ebec-22f2-462f-91f5-2db83028b81c">


## Test plan

Update unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
