### PR TITLE
JetBrains: Improve perceived autocomplete performance

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings({"unused", "FieldCanBeLocal", "CommentedOutCode"})
 public class CodyAutoCompleteItemProvider extends InlineAutoCompleteItemProvider {
   private static final Logger logger = Logger.getInstance(CodyAutoCompleteItemProvider.class);
-  public static final int nThreads = 3; // up to 3 completion API calls to run in parallel
+  public static final int nThreads = 1; // The number of API calls to run in parallel
   // should we reuse the scheduler from CodyCompletionsManager here later on?
   private final ExecutorService executor = Executors.newFixedThreadPool(nThreads);
   private final int promptTokens;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
@@ -8,7 +8,6 @@ import com.sourcegraph.config.UserLevelConfig;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -33,7 +32,6 @@ public class CodyAutoCompleteItemProvider extends InlineAutoCompleteItemProvider
   private final History history;
   private final int charsPerToken;
   private final int responseTokens;
-  private static final Pattern precedingLineMidWordPattern = Pattern.compile(".*[A-Za-z]$");
 
   public CodyAutoCompleteItemProvider(
       WebviewErrorMessenger webviewErrorMessenger,
@@ -129,8 +127,7 @@ public class CodyAutoCompleteItemProvider extends InlineAutoCompleteItemProvider
     //    int waitMs;
     List<AutoCompleteProvider> completers = new ArrayList<>();
 
-    if (context.selectedAutoCompleteSuggestionInfo != null
-        || precedingLineMidWordPattern.matcher(precedingLine).matches()) {
+    if (context.selectedAutoCompleteSuggestionInfo != null) {
       return emptyResult();
     }
 


### PR DESCRIPTION
- Decreased the parallel autocomplete request count from 3 to 1.
- Removed check for mid-word position to enable displaying completions mid-word.

## Test plan

Tested it, and it still works. Didn't do any benchmarking this time because we did it in VS Code, and it was significant, so I'm expecting the same speedup.