### PR TITLE
gitserver: make list of ignored git commands for recording configurable

### DIFF
--- a/cmd/gitserver/shared/BUILD.bazel
+++ b/cmd/gitserver/shared/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/api",
         "//internal/authz",
         "//internal/codeintel/dependencies",
+        "//internal/collections",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -146,7 +146,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 			recordingCommandFactory.Disable()
 			return
 		}
-		recordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos), recordingConf.Size)
+		recordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos, recordingConf.IgnoredGitCommands), recordingConf.Size)
 	})
 
 	gitserver := server.Server{
@@ -615,9 +615,17 @@ func methodSpecificUnaryInterceptor(method string, next grpc.UnaryServerIntercep
 	}
 }
 
+var defaultIgnoredGitCommands = []string{
+	"show",
+	"rev-parse",
+	"log",
+	"diff",
+	"ls-tree",
+}
+
 // recordCommandsOnRepos returns a ShouldRecordFunc which determines whether the given command should be recorded
 // for a particular repository.
-func recordCommandsOnRepos(repos []string) wrexec.ShouldRecordFunc {
+func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.ShouldRecordFunc {
 	// empty repos, means we should never record since there is nothing to match on
 	if len(repos) == 0 {
 		return func(ctx context.Context, c *exec.Cmd) bool {
@@ -625,14 +633,16 @@ func recordCommandsOnRepos(repos []string) wrexec.ShouldRecordFunc {
 		}
 	}
 
-	// we won't record any git commands with these commands since they are considered to be not destructive
-	ignoredGitCommands := map[string]struct{}{
-		"show":      {},
-		"rev-parse": {},
-		"log":       {},
-		"diff":      {},
-		"ls-tree":   {},
+	if len(ignoredGitCommands) == 0 {
+		ignoredGitCommands = append(ignoredGitCommands, defaultIgnoredGitCommands...)
 	}
+
+	// we won't record any git commands with these commands since they are considered to be not destructive
+	var ignoredGitCommandsMap = make(map[string]struct{}, len(ignoredGitCommands))
+	for _, command := range ignoredGitCommands {
+		ignoredGitCommandsMap[command] = struct{}{}
+	}
+
 	return func(ctx context.Context, cmd *exec.Cmd) bool {
 		base := filepath.Base(cmd.Path)
 		if base != "git" {
@@ -654,7 +664,7 @@ func recordCommandsOnRepos(repos []string) wrexec.ShouldRecordFunc {
 		// we have to scan the Args, since it isn't guaranteed that the Arg at index 1 is the git command:
 		// git -c "protocol.version=2" remote show
 		for _, arg := range cmd.Args {
-			if _, ok := ignoredGitCommands[arg]; ok {
+			if _, ok := ignoredGitCommandsMap[arg]; ok {
 				return false
 			}
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1311,6 +1311,8 @@ type GitLabWebhook struct {
 
 // GitRecorder description: Record git operations that are executed on configured repositories. The following commands are not recorded: show, log, rev-parse and diff.
 type GitRecorder struct {
+	// IgnoredGitCommands description: List of git commands that should be ignored and not recorded.
+	IgnoredGitCommands []string `json:"ignoredGitCommands,omitempty"`
 	// Repos description: List of repositories whose git operations should be recorded.
 	Repos []string `json:"repos,omitempty"`
 	// Size description: Defines how many recordings to keep. Once this size is reached, the oldest entry will be removed.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2151,6 +2151,20 @@
           "items": {
             "type": "string"
           }
+        },
+        "ignoredGitCommands": {
+          "description": "List of git commands that should be ignored and not recorded.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
+          ]
         }
       },
       "examples": [
@@ -2159,6 +2173,13 @@
           "repos": [
             "github.com/sourcegraph/sourcegraph",
             "github.com/gorilla/mux"
+          ],
+          "ignoredGitCommands": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
           ]
         }
       ]

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -14,9 +14,7 @@
         "pointer": true
       },
       "group": "Search",
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "search.largeFiles": {
       "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
@@ -25,23 +23,13 @@
         "type": "string"
       },
       "group": "Search",
-      "examples": [
-        [
-          "go.sum",
-          "package-lock.json",
-          "**/*.thrift"
-        ]
-      ]
+      "examples": [["go.sum", "package-lock.json", "**/*.thrift"]]
     },
     "debug.search.symbolsParallelism": {
       "description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        [
-          "20"
-        ]
-      ]
+      "examples": [["20"]]
     },
     "cloneProgress.log": {
       "description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
@@ -145,10 +133,7 @@
         "eventLogging": {
           "description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
         "passwordPolicy": {
@@ -199,91 +184,61 @@
         "structuralSearch": {
           "description": "Enables structural search.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "goPackages": {
           "description": "Allow adding Go package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "jvmPackages": {
           "description": "Allow adding JVM package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "npmPackages": {
           "description": "Allow adding npm package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "pythonPackages": {
           "description": "Allow adding Python package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "rustPackages": {
           "description": "Allow adding Rust package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "rubyPackages": {
           "description": "Allow adding Ruby package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "pagure": {
           "description": "Allow adding Pagure code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "subRepoPermissions": {
@@ -325,9 +280,7 @@
               "items": {
                 "type": "string",
                 "pattern": "^-----BEGIN CERTIFICATE-----\n",
-                "examples": [
-                  "-----BEGIN CERTIFICATE-----\n..."
-                ]
+                "examples": ["-----BEGIN CERTIFICATE-----\n..."]
               }
             }
           }
@@ -340,10 +293,7 @@
             "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "domainPath",
-              "fetch"
-            ],
+            "required": ["domainPath", "fetch"],
             "properties": {
               "domainPath": {
                 "description": "Git clone URL domain/path",
@@ -376,14 +326,10 @@
             "type": "object",
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
-            "required": [
-              "revisions"
-            ],
+            "required": ["revisions"],
             "anyOf": [
               {
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             ],
             "properties": {
@@ -406,11 +352,7 @@
             [
               {
                 "name": "^github.com/org/.*",
-                "revisions": [
-                  "3.17",
-                  "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
-                  "v3.17.1"
-                ]
+                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
               }
             ]
           ]
@@ -427,14 +369,8 @@
           },
           "examples": [
             {
-              "github.com/sourcegraph/sourcegraph": [
-                "3.17",
-                "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
-                "v3.17.1"
-              ],
-              "name/of/repo": [
-                "develop"
-              ]
+              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
+              "name/of/repo": ["develop"]
             }
           ]
         },
@@ -609,9 +545,7 @@
         },
         {
           "tls.external": {
-            "certificates": [
-              "-----BEGIN CERTIFICATE-----\n..."
-            ],
+            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
             "insecureSkipVerify": true
           }
         }
@@ -658,9 +592,7 @@
       "items": {
         "title": "BatchChangeRolloutWindow",
         "type": "object",
-        "required": [
-          "rate"
-        ],
+        "required": ["rate"],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -697,18 +629,13 @@
           }
         },
         "dependencies": {
-          "start": [
-            "end"
-          ]
+          "start": ["end"]
         }
       },
       "examples": [
         {
           "rate": "10/hour",
-          "days": [
-            "saturday",
-            "sunday"
-          ],
+          "days": ["saturday", "sunday"],
           "start": "06:00",
           "end": "20:00"
         }
@@ -724,11 +651,7 @@
       "description": "How long changesets will be retained after they have been detached from a batch change.",
       "type": "string",
       "group": "BatchChanges",
-      "examples": [
-        "336h",
-        "48h",
-        "5h30m40s"
-      ]
+      "examples": ["336h", "48h", "5h30m40s"]
     },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
@@ -794,17 +717,13 @@
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [
-        "dev"
-      ]
+      "examples": ["dev"]
     },
     "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [
-        ""
-      ]
+      "examples": [""]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
@@ -815,9 +734,7 @@
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": [
-        "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
-      ],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
@@ -857,10 +774,7 @@
       "items": {
         "title": "UpdateIntervalRule",
         "type": "object",
-        "required": [
-          "pattern",
-          "interval"
-        ],
+        "required": ["pattern", "interval"],
         "additionalProperties": false,
         "properties": {
           "pattern": {
@@ -893,9 +807,7 @@
       "description": "Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",
       "group": "External services",
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "git.cloneURLToRepositoryName": {
       "description": "JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.",
@@ -905,10 +817,7 @@
         "description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P<name>\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "from",
-          "to"
-        ],
+        "required": ["from", "to"],
         "properties": {
           "from": {
             "description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
@@ -955,38 +864,24 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": [
-        "engine",
-        "languages",
-        "symbols"
-      ],
+      "required": ["engine", "languages", "symbols"],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": [
-            "default"
-          ],
+          "required": ["default"],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
               "type": "string",
-              "enum": [
-                "tree-sitter",
-                "syntect",
-                "scip-syntax"
-              ]
+              "enum": ["tree-sitter", "syntect", "scip-syntax"]
             },
             "overrides": {
               "description": "Manually specify overrides for syntax highlighting engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": [
-                  "tree-sitter",
-                  "syntect",
-                  "scip-syntax"
-                ]
+                "enum": ["tree-sitter", "syntect", "scip-syntax"]
               }
             }
           }
@@ -994,10 +889,7 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": [
-            "extensions",
-            "patterns"
-          ],
+          "required": ["extensions", "patterns"],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",
@@ -1012,10 +904,7 @@
               "items": {
                 "title": "SyntaxHighlightingLanguagePatterns",
                 "type": "object",
-                "required": [
-                  "pattern",
-                  "language"
-                ],
+                "required": ["pattern", "language"],
                 "properties": {
                   "pattern": {
                     "description": "Regular expression which matches the filepath",
@@ -1035,20 +924,14 @@
           "title": "SymbolConfiguration",
           "description": "Configure symbol generation",
           "type": "object",
-          "required": [
-            "engine"
-          ],
+          "required": ["engine"],
           "properties": {
             "engine": {
               "description": "Manually specify overrides for symbol generation engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": [
-                  "universal-ctags",
-                  "scip-ctags",
-                  "off"
-                ]
+                "enum": ["universal-ctags", "scip-ctags", "off"]
               }
             }
           }
@@ -1121,10 +1004,7 @@
     },
     "scim.identityProvider": {
       "type": "string",
-      "enum": [
-        "STANDARD",
-        "Azure AD"
-      ],
+      "enum": ["STANDARD", "Azure AD"],
       "description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
       "default": "STANDARD",
       "group": "External services"
@@ -1199,11 +1079,7 @@
         "allow": {
           "description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
           "type": "string",
-          "enum": [
-            "all-users-create",
-            "site-admin-create",
-            "none"
-          ],
+          "enum": ["all-users-create", "site-admin-create", "none"],
           "default": "all-users-create"
         }
       },
@@ -1233,11 +1109,7 @@
     "externalService.userMode": {
       "description": "Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.",
       "type": "string",
-      "enum": [
-        "public",
-        "disabled",
-        "all"
-      ],
+      "enum": ["public", "disabled", "all"],
       "default": "disabled"
     },
     "permissions.userMapping": {
@@ -1253,10 +1125,7 @@
         "bindID": {
           "description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
           "type": "string",
-          "enum": [
-            "email",
-            "username"
-          ],
+          "enum": ["email", "username"],
           "default": "email"
         }
       },
@@ -1372,11 +1241,7 @@
       "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "host",
-        "port",
-        "authentication"
-      ],
+      "required": ["host", "port", "authentication"],
       "properties": {
         "host": {
           "description": "The SMTP server host.",
@@ -1397,11 +1262,7 @@
         "authentication": {
           "description": "The type of authentication to use for the SMTP server.",
           "type": "string",
-          "enum": [
-            "none",
-            "PLAIN",
-            "CRAM-MD5"
-          ]
+          "enum": ["none", "PLAIN", "CRAM-MD5"]
         },
         "domain": {
           "description": "The HELO domain to provide to the SMTP server (if needed).",
@@ -1417,10 +1278,7 @@
           "items": {
             "title": "Header",
             "type": "object",
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "additionalProperties": false,
             "properties": {
               "key": {
@@ -1459,17 +1317,13 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "examples": [
-        "noreply@sourcegraph.example.com"
-      ]
+      "examples": ["noreply@sourcegraph.example.com"]
     },
     "email.senderName": {
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
-      "examples": [
-        "Sourcegraph"
-      ]
+      "examples": ["Sourcegraph"]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",
@@ -1501,9 +1355,7 @@
     "executors.frontendURL": {
       "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
-      "examples": [
-        "https://sourcegraph.example.com"
-      ]
+      "examples": ["https://sourcegraph.example.com"]
     },
     "executors.srcCLIImage": {
       "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
@@ -1513,16 +1365,12 @@
     "executors.srcCLIImageTag": {
       "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "4.1.0"
-      ]
+      "examples": ["4.1.0"]
     },
     "executors.lsifGoImage": {
       "description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "sourcegraph/lsif-go"
-      ]
+      "examples": ["sourcegraph/lsif-go"]
     },
     "executors.batcheshelperImage": {
       "description": "The image to use for batch changes in executors. Use this value to pull from a custom image registry.",
@@ -1532,17 +1380,13 @@
     "executors.batcheshelperImageTag": {
       "description": "The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "4.1.0"
-      ]
+      "examples": ["4.1.0"]
     },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",
       "minLength": 20,
-      "examples": [
-        "my-super-secret-access-token"
-      ]
+      "examples": ["my-super-secret-access-token"]
     },
     "executors.multiqueue": {
       "description": "The configuration for multiqueue executors.",
@@ -1555,10 +1399,7 @@
             "batches": {
               "description": "The configuration for the batches queue.",
               "type": "object",
-              "required": [
-                "limit",
-                "weight"
-              ],
+              "required": ["limit", "weight"],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1575,10 +1416,7 @@
             "codeintel": {
               "description": "The configuration for the codeintel queue.",
               "type": "object",
-              "required": [
-                "limit",
-                "weight"
-              ],
+              "required": ["limit", "weight"],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1607,9 +1445,7 @@
       },
       "examples": [
         {
-          "*": [
-            "myorg1"
-          ]
+          "*": ["myorg1"]
         }
       ],
       "hide": true
@@ -1674,19 +1510,10 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": [
-                "DEBUG",
-                "INFO",
-                "WARN",
-                "ERROR"
-              ]
+              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
             }
           },
-          "required": [
-            "internalTraffic",
-            "graphQL",
-            "gitserverAccess"
-          ],
+          "required": ["internalTraffic", "graphQL", "gitserverAccess"],
           "examples": [
             {
               "internalTraffic": false,
@@ -1703,12 +1530,7 @@
             "location": {
               "description": "Where to output the security event log [none, auditlog, database, all] where auditlog is the default logging to stdout with the specified audit log format",
               "type": "string",
-              "enum": [
-                "none",
-                "auditlog",
-                "database",
-                "all"
-              ],
+              "enum": ["none", "auditlog", "database", "all"],
               "default": "auditlog"
             }
           },
@@ -1723,9 +1545,7 @@
     "externalURL": {
       "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
-      "examples": [
-        "https://sourcegraph.example.com"
-      ]
+      "examples": ["https://sourcegraph.example.com"]
     },
     "observability.client": {
       "description": "EXPERIMENTAL: Configuration for client observability",
@@ -1739,10 +1559,7 @@
             "endpoint": {
               "description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
               "type": "string",
-              "examples": [
-                "/-/debug/otlp",
-                "https://COLLECTOR_ENDPOINT"
-              ],
+              "examples": ["/-/debug/otlp", "https://COLLECTOR_ENDPOINT"],
               "default": "/-/debug/otlp"
             }
           }
@@ -1768,20 +1585,13 @@
         "sampling": {
           "description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://docs.sourcegraph.com/admin/observability/opentelemetry#tracing ",
           "type": "string",
-          "enum": [
-            "selective",
-            "all",
-            "none"
-          ],
+          "enum": ["selective", "all", "none"],
           "default": "selective"
         },
         "type": {
           "description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
           "type": "string",
-          "enum": [
-            "opentelemetry",
-            "jaeger"
-          ],
+          "enum": ["opentelemetry", "jaeger"],
           "default": "opentelemetry"
         },
         "debug": {
@@ -1820,31 +1630,19 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "level",
-          "notifier"
-        ],
+        "required": ["level", "notifier"],
         "properties": {
           "level": {
             "description": "Sourcegraph alert level to subscribe to notifications for.",
             "type": "string",
-            "enum": [
-              "warning",
-              "critical"
-            ]
+            "enum": ["warning", "critical"]
           },
           "notifier": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "slack",
-                  "pagerduty",
-                  "webhook",
-                  "email",
-                  "opsgenie"
-                ]
+                "enum": ["slack", "pagerduty", "webhook", "email", "opsgenie"]
               }
             },
             "oneOf": [
@@ -1901,9 +1699,7 @@
           "level": "warning",
           "notifier": {
             "type": "email",
-            "addresses": [
-              "alerts@example.com"
-            ]
+            "addresses": ["alerts@example.com"]
           }
         }
       ]
@@ -1914,39 +1710,25 @@
       "items": {
         "type": "string"
       },
-      "examples": [
-        [
-          "warning_gitserver_disk_space_remaining"
-        ],
-        [
-          "critical_frontend_down",
-          "warning_high_load"
-        ]
-      ]
+      "examples": [["warning_gitserver_disk_space_remaining"], ["critical_frontend_down", "warning_high_load"]]
     },
     "observability.logSlowSearches": {
       "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        10000
-      ]
+      "examples": [10000]
     },
     "observability.logSlowGraphQLRequests": {
       "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        10000
-      ]
+      "examples": [10000]
     },
     "observability.captureSlowGraphQLRequestsLimit": {
       "description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        2000
-      ]
+      "examples": [2000]
     },
     "insights.backfill.interruptAfter": {
       "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
@@ -1973,19 +1755,14 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 1,
-      "examples": [
-        10
-      ]
+      "examples": [10]
     },
     "insights.query.worker.rateLimit": {
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10.0,
-        0.5
-      ],
+      "examples": [10.0, 0.5],
       "!go": {
         "pointer": true
       }
@@ -1995,20 +1772,14 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10,
-        20
-      ]
+      "examples": [10, 20]
     },
     "insights.historical.worker.rateLimit": {
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        50.0,
-        0.5
-      ],
+      "examples": [50.0, 0.5],
       "!go": {
         "pointer": true
       }
@@ -2018,10 +1789,7 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10,
-        20
-      ]
+      "examples": [10, 20]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
@@ -2041,11 +1809,7 @@
       "group": "CodeInsights",
       "default": 30,
       "maximum": 90,
-      "examples": [
-        12,
-        24,
-        50
-      ]
+      "examples": [12, 24, 50]
     },
     "own.bestEffortTeamMatching": {
       "description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
@@ -2158,29 +1922,14 @@
           "items": {
             "type": "string"
           },
-          "default": [
-            "show",
-            "rev-parse",
-            "log",
-            "diff",
-            "ls-tree"
-          ]
+          "default": ["show", "rev-parse", "log", "diff", "ls-tree"]
         }
       },
       "examples": [
         {
           "size": 1000,
-          "repos": [
-            "github.com/sourcegraph/sourcegraph",
-            "github.com/gorilla/mux"
-          ],
-          "ignoredGitCommands": [
-            "show",
-            "rev-parse",
-            "log",
-            "diff",
-            "ls-tree"
-          ]
+          "repos": ["github.com/sourcegraph/sourcegraph", "github.com/gorilla/mux"],
+          "ignoredGitCommands": ["show", "rev-parse", "log", "diff", "ls-tree"]
         }
       ]
     },
@@ -2193,10 +1942,7 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "key",
-              "message"
-            ],
+            "required": ["key", "message"],
             "properties": {
               "key": {
                 "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2234,10 +1980,7 @@
         "srcCliVersionCache": {
           "description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
           "type": "object",
-          "required": [
-            "enabled",
-            "github"
-          ],
+          "required": ["enabled", "github"],
           "group": "Sourcegraph.com",
           "properties": {
             "enabled": {
@@ -2248,10 +1991,7 @@
             "github": {
               "description": "GitHub configuration, both for queries and receiving release webhooks.",
               "type": "object",
-              "required": [
-                "token",
-                "webhookSecret"
-              ],
+              "required": ["token", "webhookSecret"],
               "properties": {
                 "repository": {
                   "description": "The repository to get the latest version of.",
@@ -2336,10 +2076,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "key",
-          "message"
-        ],
+        "required": ["key", "message"],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2364,9 +2101,7 @@
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",
       "items": {
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "type": {
             "type": "string",
@@ -2434,9 +2169,7 @@
       "type": "string",
       "description": "The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.\n\nNote: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with \"session_\" from the Redis store:\n\n* For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`\n* For cluster deployments: \n  ```\n  REDIS_POD=\"$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})\";\n  kubectl exec \"$REDIS_POD\" -- redis-cli --raw keys 'session_*' | xargs kubectl exec \"$REDIS_POD\" -- redis-cli --raw del;\n  ```\n",
       "default": "2160h",
-      "examples": [
-        "168h"
-      ],
+      "examples": ["168h"],
       "group": "Authentication"
     },
     "auth.enableUsernameChanges": {
@@ -2531,17 +2264,10 @@
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
-      "type": [
-        "string"
-      ],
-      "enum": [
-        "release",
-        "none"
-      ],
+      "type": ["string"],
+      "enum": ["release", "none"],
       "default": "release",
-      "examples": [
-        "none"
-      ],
+      "examples": ["none"],
       "group": "Misc."
     },
     "productResearchPage.enabled": {
@@ -2644,16 +2370,12 @@
       "!go": {
         "pointer": true
       },
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": [
-        "signingKey"
-      ],
+      "required": ["signingKey"],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
@@ -2718,10 +2440,7 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": [
-            "openai",
-            "sourcegraph"
-          ]
+          "enum": ["openai", "sourcegraph"]
         },
         "endpoint": {
           "type": "string",
@@ -2763,13 +2482,7 @@
               "items": {
                 "type": "string"
               },
-              "examples": [
-                "*.go",
-                "*.ts",
-                "*.md",
-                "src/",
-                "cmd/"
-              ]
+              "examples": ["*.go", "*.ts", "*.md", "src/", "cmd/"]
             },
             "maxFileSizeBytes": {
               "description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
@@ -2838,11 +2551,7 @@
           "model": "text-embedding-ada-002",
           "accessToken": "your-access-token",
           "url": "https://api.openai.com/v1/embeddings",
-          "excludedFilePathPatterns": [
-            "*.svg",
-            "**/__mocks__/**",
-            "**/test/**"
-          ]
+          "excludedFilePathPatterns": ["*.svg", "**/__mocks__/**", "**/test/**"]
         }
       ]
     },
@@ -2894,11 +2603,7 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "anthropic",
-          "enum": [
-            "anthropic",
-            "openai",
-            "sourcegraph"
-          ]
+          "enum": ["anthropic", "openai", "sourcegraph"]
         },
         "endpoint": {
           "type": "string",
@@ -2947,9 +2652,7 @@
       "description": "Configures the builtin username-password authentication provider.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -2966,12 +2669,7 @@
       "description": "Configures the OpenID Connect authentication provider for SSO.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "issuer",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "issuer", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3030,20 +2728,11 @@
       "description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "dependencies": {
-        "serviceProviderCertificate": [
-          "serviceProviderPrivateKey"
-        ],
-        "serviceProviderPrivateKey": [
-          "serviceProviderCertificate"
-        ],
-        "signRequests": [
-          "serviceProviderCertificate",
-          "serviceProviderPrivateKey"
-        ]
+        "serviceProviderCertificate": ["serviceProviderPrivateKey"],
+        "serviceProviderPrivateKey": ["serviceProviderCertificate"],
+        "signRequests": ["serviceProviderCertificate", "serviceProviderPrivateKey"]
       },
       "properties": {
         "type": {
@@ -3154,10 +2843,7 @@
       "description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "usernameHeader"
-      ],
+      "required": ["type", "usernameHeader"],
       "properties": {
         "type": {
           "type": "string",
@@ -3166,23 +2852,17 @@
         "usernameHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": [
-            "X-Forwarded-User"
-          ]
+          "examples": ["X-Forwarded-User"]
         },
         "stripUsernameHeaderPrefix": {
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
-          "examples": [
-            "accounts.google.com:"
-          ]
+          "examples": ["accounts.google.com:"]
         },
         "emailHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": [
-            "X-App-Email"
-          ]
+          "examples": ["X-App-Email"]
         }
       }
     },
@@ -3190,11 +2870,7 @@
       "description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3254,13 +2930,8 @@
           },
           "examples": [
             {
-              "orgName": [
-                "team1"
-              ],
-              "anotherOrgName": [
-                "team2",
-                "team3"
-              ]
+              "orgName": ["team1"],
+              "anotherOrgName": ["team2", "team3"]
             }
           ]
         },
@@ -3275,11 +2946,7 @@
       "description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3322,10 +2989,7 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "api",
-          "enum": [
-            "api",
-            "read_api"
-          ]
+          "enum": ["api", "read_api"]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
@@ -3343,13 +3007,7 @@
             "type": "string",
             "minLength": 1
           },
-          "examples": [
-            [
-              "group",
-              "group/subgroup",
-              "group/subgroup/subgroup"
-            ]
-          ]
+          "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
         },
         "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
@@ -3362,11 +3020,7 @@
       "description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientKey",
-        "clientSecret"
-      ],
+      "required": ["type", "clientKey", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3404,11 +3058,7 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": [
-            "account",
-            "email",
-            "repository"
-          ]
+          "enum": ["account", "email", "repository"]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
@@ -3421,10 +3071,7 @@
       "description": "Gerrit auth provider",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "properties": {
         "type": {
           "type": "string",
@@ -3456,11 +3103,7 @@
       "description": "Azure auth provider for dev.azure.com",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3545,9 +3188,7 @@
     "NotifierSlack": {
       "description": "Slack notifier",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -3578,10 +3219,7 @@
     "NotifierPagerduty": {
       "description": "PagerDuty notifier",
       "type": "object",
-      "required": [
-        "type",
-        "integrationKey"
-      ],
+      "required": ["type", "integrationKey"],
       "properties": {
         "type": {
           "type": "string",
@@ -3603,10 +3241,7 @@
     "NotifierWebhook": {
       "description": "Webhook notifier",
       "type": "object",
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "properties": {
         "type": {
           "type": "string",
@@ -3629,10 +3264,7 @@
     "NotifierEmail": {
       "description": "Email notifier",
       "type": "object",
-      "required": [
-        "type",
-        "address"
-      ],
+      "required": ["type", "address"],
       "properties": {
         "type": {
           "type": "string",
@@ -3647,9 +3279,7 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -3677,12 +3307,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "team",
-                  "user",
-                  "escalation",
-                  "schedule"
-                ]
+                "enum": ["team", "user", "escalation", "schedule"]
               },
               "id": {
                 "type": "string"
@@ -3696,22 +3321,13 @@
             },
             "oneOf": [
               {
-                "required": [
-                  "type",
-                  "id"
-                ]
+                "required": ["type", "id"]
               },
               {
-                "required": [
-                  "type",
-                  "name"
-                ]
+                "required": ["type", "name"]
               },
               {
-                "required": [
-                  "type",
-                  "username"
-                ]
+                "required": ["type", "username"]
               }
             ]
           }
@@ -3721,18 +3337,11 @@
     "EncryptionKey": {
       "description": "Config for a key",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "cloudkms",
-            "awskms",
-            "mounted",
-            "noop"
-          ]
+          "enum": ["cloudkms", "awskms", "mounted", "noop"]
         }
       },
       "oneOf": [
@@ -3756,10 +3365,7 @@
     "CloudKMSEncryptionKey": {
       "description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
       "type": "object",
-      "required": [
-        "type",
-        "keyname"
-      ],
+      "required": ["type", "keyname"],
       "properties": {
         "type": {
           "type": "string",
@@ -3776,10 +3382,7 @@
     "AWSKMSEncryptionKey": {
       "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
       "type": "object",
-      "required": [
-        "type",
-        "keyId"
-      ],
+      "required": ["type", "keyId"],
       "properties": {
         "type": {
           "type": "string",
@@ -3799,10 +3402,7 @@
     "MountedEncryptionKey": {
       "description": "This encryption key is mounted from a given file path or an environment variable.",
       "type": "object",
-      "required": [
-        "type",
-        "keyname"
-      ],
+      "required": ["type", "keyname"],
       "properties": {
         "type": {
           "type": "string",
@@ -3825,9 +3425,7 @@
     "NoOpEncryptionKey": {
       "description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -3837,10 +3435,7 @@
     },
     "EmailTemplate": {
       "type": "object",
-      "required": [
-        "subject",
-        "html"
-      ],
+      "required": ["subject", "html"],
       "properties": {
         "subject": {
           "description": "Template for email subject header",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -14,7 +14,9 @@
         "pointer": true
       },
       "group": "Search",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "search.largeFiles": {
       "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
@@ -23,13 +25,23 @@
         "type": "string"
       },
       "group": "Search",
-      "examples": [["go.sum", "package-lock.json", "**/*.thrift"]]
+      "examples": [
+        [
+          "go.sum",
+          "package-lock.json",
+          "**/*.thrift"
+        ]
+      ]
     },
     "debug.search.symbolsParallelism": {
       "description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
       "type": "integer",
       "group": "Debug",
-      "examples": [["20"]]
+      "examples": [
+        [
+          "20"
+        ]
+      ]
     },
     "cloneProgress.log": {
       "description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
@@ -133,7 +145,10 @@
         "eventLogging": {
           "description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled"
         },
         "passwordPolicy": {
@@ -184,61 +199,91 @@
         "structuralSearch": {
           "description": "Enables structural search.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled"
         },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled"
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "goPackages": {
           "description": "Allow adding Go package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "jvmPackages": {
           "description": "Allow adding JVM package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "npmPackages": {
           "description": "Allow adding npm package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pythonPackages": {
           "description": "Allow adding Python package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rustPackages": {
           "description": "Allow adding Rust package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rubyPackages": {
           "description": "Allow adding Ruby package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pagure": {
           "description": "Allow adding Pagure code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "subRepoPermissions": {
@@ -280,7 +325,9 @@
               "items": {
                 "type": "string",
                 "pattern": "^-----BEGIN CERTIFICATE-----\n",
-                "examples": ["-----BEGIN CERTIFICATE-----\n..."]
+                "examples": [
+                  "-----BEGIN CERTIFICATE-----\n..."
+                ]
               }
             }
           }
@@ -293,7 +340,10 @@
             "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
             "type": "object",
             "additionalProperties": false,
-            "required": ["domainPath", "fetch"],
+            "required": [
+              "domainPath",
+              "fetch"
+            ],
             "properties": {
               "domainPath": {
                 "description": "Git clone URL domain/path",
@@ -326,10 +376,14 @@
             "type": "object",
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
-            "required": ["revisions"],
+            "required": [
+              "revisions"
+            ],
             "anyOf": [
               {
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             ],
             "properties": {
@@ -352,7 +406,11 @@
             [
               {
                 "name": "^github.com/org/.*",
-                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
+                "revisions": [
+                  "3.17",
+                  "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                  "v3.17.1"
+                ]
               }
             ]
           ]
@@ -369,8 +427,14 @@
           },
           "examples": [
             {
-              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
-              "name/of/repo": ["develop"]
+              "github.com/sourcegraph/sourcegraph": [
+                "3.17",
+                "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                "v3.17.1"
+              ],
+              "name/of/repo": [
+                "develop"
+              ]
             }
           ]
         },
@@ -545,7 +609,9 @@
         },
         {
           "tls.external": {
-            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
+            "certificates": [
+              "-----BEGIN CERTIFICATE-----\n..."
+            ],
             "insecureSkipVerify": true
           }
         }
@@ -592,7 +658,9 @@
       "items": {
         "title": "BatchChangeRolloutWindow",
         "type": "object",
-        "required": ["rate"],
+        "required": [
+          "rate"
+        ],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -629,13 +697,18 @@
           }
         },
         "dependencies": {
-          "start": ["end"]
+          "start": [
+            "end"
+          ]
         }
       },
       "examples": [
         {
           "rate": "10/hour",
-          "days": ["saturday", "sunday"],
+          "days": [
+            "saturday",
+            "sunday"
+          ],
           "start": "06:00",
           "end": "20:00"
         }
@@ -651,7 +724,11 @@
       "description": "How long changesets will be retained after they have been detached from a batch change.",
       "type": "string",
       "group": "BatchChanges",
-      "examples": ["336h", "48h", "5h30m40s"]
+      "examples": [
+        "336h",
+        "48h",
+        "5h30m40s"
+      ]
     },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
@@ -717,13 +794,17 @@
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": ["dev"]
+      "examples": [
+        "dev"
+      ]
     },
     "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [""]
+      "examples": [
+        ""
+      ]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
@@ -734,7 +815,9 @@
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
+      "examples": [
+        "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
+      ],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
@@ -774,7 +857,10 @@
       "items": {
         "title": "UpdateIntervalRule",
         "type": "object",
-        "required": ["pattern", "interval"],
+        "required": [
+          "pattern",
+          "interval"
+        ],
         "additionalProperties": false,
         "properties": {
           "pattern": {
@@ -807,7 +893,9 @@
       "description": "Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",
       "group": "External services",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "git.cloneURLToRepositoryName": {
       "description": "JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.",
@@ -817,7 +905,10 @@
         "description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P<name>\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
         "type": "object",
         "additionalProperties": false,
-        "required": ["from", "to"],
+        "required": [
+          "from",
+          "to"
+        ],
         "properties": {
           "from": {
             "description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
@@ -864,24 +955,38 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": ["engine", "languages", "symbols"],
+      "required": [
+        "engine",
+        "languages",
+        "symbols"
+      ],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": ["default"],
+          "required": [
+            "default"
+          ],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
               "type": "string",
-              "enum": ["tree-sitter", "syntect", "scip-syntax"]
+              "enum": [
+                "tree-sitter",
+                "syntect",
+                "scip-syntax"
+              ]
             },
             "overrides": {
               "description": "Manually specify overrides for syntax highlighting engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["tree-sitter", "syntect", "scip-syntax"]
+                "enum": [
+                  "tree-sitter",
+                  "syntect",
+                  "scip-syntax"
+                ]
               }
             }
           }
@@ -889,7 +994,10 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": ["extensions", "patterns"],
+          "required": [
+            "extensions",
+            "patterns"
+          ],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",
@@ -904,7 +1012,10 @@
               "items": {
                 "title": "SyntaxHighlightingLanguagePatterns",
                 "type": "object",
-                "required": ["pattern", "language"],
+                "required": [
+                  "pattern",
+                  "language"
+                ],
                 "properties": {
                   "pattern": {
                     "description": "Regular expression which matches the filepath",
@@ -924,14 +1035,20 @@
           "title": "SymbolConfiguration",
           "description": "Configure symbol generation",
           "type": "object",
-          "required": ["engine"],
+          "required": [
+            "engine"
+          ],
           "properties": {
             "engine": {
               "description": "Manually specify overrides for symbol generation engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["universal-ctags", "scip-ctags", "off"]
+                "enum": [
+                  "universal-ctags",
+                  "scip-ctags",
+                  "off"
+                ]
               }
             }
           }
@@ -1004,7 +1121,10 @@
     },
     "scim.identityProvider": {
       "type": "string",
-      "enum": ["STANDARD", "Azure AD"],
+      "enum": [
+        "STANDARD",
+        "Azure AD"
+      ],
       "description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
       "default": "STANDARD",
       "group": "External services"
@@ -1079,7 +1199,11 @@
         "allow": {
           "description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
           "type": "string",
-          "enum": ["all-users-create", "site-admin-create", "none"],
+          "enum": [
+            "all-users-create",
+            "site-admin-create",
+            "none"
+          ],
           "default": "all-users-create"
         }
       },
@@ -1109,7 +1233,11 @@
     "externalService.userMode": {
       "description": "Enable to allow users to add external services for public and private repositories to the Sourcegraph instance.",
       "type": "string",
-      "enum": ["public", "disabled", "all"],
+      "enum": [
+        "public",
+        "disabled",
+        "all"
+      ],
       "default": "disabled"
     },
     "permissions.userMapping": {
@@ -1125,7 +1253,10 @@
         "bindID": {
           "description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
           "type": "string",
-          "enum": ["email", "username"],
+          "enum": [
+            "email",
+            "username"
+          ],
           "default": "email"
         }
       },
@@ -1241,7 +1372,11 @@
       "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
-      "required": ["host", "port", "authentication"],
+      "required": [
+        "host",
+        "port",
+        "authentication"
+      ],
       "properties": {
         "host": {
           "description": "The SMTP server host.",
@@ -1262,7 +1397,11 @@
         "authentication": {
           "description": "The type of authentication to use for the SMTP server.",
           "type": "string",
-          "enum": ["none", "PLAIN", "CRAM-MD5"]
+          "enum": [
+            "none",
+            "PLAIN",
+            "CRAM-MD5"
+          ]
         },
         "domain": {
           "description": "The HELO domain to provide to the SMTP server (if needed).",
@@ -1278,7 +1417,10 @@
           "items": {
             "title": "Header",
             "type": "object",
-            "required": ["key", "value"],
+            "required": [
+              "key",
+              "value"
+            ],
             "additionalProperties": false,
             "properties": {
               "key": {
@@ -1317,13 +1459,17 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "examples": ["noreply@sourcegraph.example.com"]
+      "examples": [
+        "noreply@sourcegraph.example.com"
+      ]
     },
     "email.senderName": {
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
-      "examples": ["Sourcegraph"]
+      "examples": [
+        "Sourcegraph"
+      ]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",
@@ -1355,7 +1501,9 @@
     "executors.frontendURL": {
       "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "executors.srcCLIImage": {
       "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
@@ -1365,12 +1513,16 @@
     "executors.srcCLIImageTag": {
       "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.lsifGoImage": {
       "description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["sourcegraph/lsif-go"]
+      "examples": [
+        "sourcegraph/lsif-go"
+      ]
     },
     "executors.batcheshelperImage": {
       "description": "The image to use for batch changes in executors. Use this value to pull from a custom image registry.",
@@ -1380,13 +1532,17 @@
     "executors.batcheshelperImageTag": {
       "description": "The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",
       "minLength": 20,
-      "examples": ["my-super-secret-access-token"]
+      "examples": [
+        "my-super-secret-access-token"
+      ]
     },
     "executors.multiqueue": {
       "description": "The configuration for multiqueue executors.",
@@ -1399,7 +1555,10 @@
             "batches": {
               "description": "The configuration for the batches queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1416,7 +1575,10 @@
             "codeintel": {
               "description": "The configuration for the codeintel queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1445,7 +1607,9 @@
       },
       "examples": [
         {
-          "*": ["myorg1"]
+          "*": [
+            "myorg1"
+          ]
         }
       ],
       "hide": true
@@ -1510,10 +1674,19 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
+              "enum": [
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR"
+              ]
             }
           },
-          "required": ["internalTraffic", "graphQL", "gitserverAccess"],
+          "required": [
+            "internalTraffic",
+            "graphQL",
+            "gitserverAccess"
+          ],
           "examples": [
             {
               "internalTraffic": false,
@@ -1530,7 +1703,12 @@
             "location": {
               "description": "Where to output the security event log [none, auditlog, database, all] where auditlog is the default logging to stdout with the specified audit log format",
               "type": "string",
-              "enum": ["none", "auditlog", "database", "all"],
+              "enum": [
+                "none",
+                "auditlog",
+                "database",
+                "all"
+              ],
               "default": "auditlog"
             }
           },
@@ -1545,7 +1723,9 @@
     "externalURL": {
       "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "observability.client": {
       "description": "EXPERIMENTAL: Configuration for client observability",
@@ -1559,7 +1739,10 @@
             "endpoint": {
               "description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
               "type": "string",
-              "examples": ["/-/debug/otlp", "https://COLLECTOR_ENDPOINT"],
+              "examples": [
+                "/-/debug/otlp",
+                "https://COLLECTOR_ENDPOINT"
+              ],
               "default": "/-/debug/otlp"
             }
           }
@@ -1585,13 +1768,20 @@
         "sampling": {
           "description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://docs.sourcegraph.com/admin/observability/opentelemetry#tracing ",
           "type": "string",
-          "enum": ["selective", "all", "none"],
+          "enum": [
+            "selective",
+            "all",
+            "none"
+          ],
           "default": "selective"
         },
         "type": {
           "description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
           "type": "string",
-          "enum": ["opentelemetry", "jaeger"],
+          "enum": [
+            "opentelemetry",
+            "jaeger"
+          ],
           "default": "opentelemetry"
         },
         "debug": {
@@ -1630,19 +1820,31 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["level", "notifier"],
+        "required": [
+          "level",
+          "notifier"
+        ],
         "properties": {
           "level": {
             "description": "Sourcegraph alert level to subscribe to notifications for.",
             "type": "string",
-            "enum": ["warning", "critical"]
+            "enum": [
+              "warning",
+              "critical"
+            ]
           },
           "notifier": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["slack", "pagerduty", "webhook", "email", "opsgenie"]
+                "enum": [
+                  "slack",
+                  "pagerduty",
+                  "webhook",
+                  "email",
+                  "opsgenie"
+                ]
               }
             },
             "oneOf": [
@@ -1699,7 +1901,9 @@
           "level": "warning",
           "notifier": {
             "type": "email",
-            "addresses": ["alerts@example.com"]
+            "addresses": [
+              "alerts@example.com"
+            ]
           }
         }
       ]
@@ -1710,25 +1914,39 @@
       "items": {
         "type": "string"
       },
-      "examples": [["warning_gitserver_disk_space_remaining"], ["critical_frontend_down", "warning_high_load"]]
+      "examples": [
+        [
+          "warning_gitserver_disk_space_remaining"
+        ],
+        [
+          "critical_frontend_down",
+          "warning_high_load"
+        ]
+      ]
     },
     "observability.logSlowSearches": {
       "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.logSlowGraphQLRequests": {
       "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.captureSlowGraphQLRequestsLimit": {
       "description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
       "type": "integer",
       "group": "Debug",
-      "examples": [2000]
+      "examples": [
+        2000
+      ]
     },
     "insights.backfill.interruptAfter": {
       "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
@@ -1755,14 +1973,19 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 1,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "insights.query.worker.rateLimit": {
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10.0, 0.5],
+      "examples": [
+        10.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1772,14 +1995,20 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.historical.worker.rateLimit": {
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [50.0, 0.5],
+      "examples": [
+        50.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1789,7 +2018,10 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
@@ -1809,7 +2041,11 @@
       "group": "CodeInsights",
       "default": 30,
       "maximum": 90,
-      "examples": [12, 24, 50]
+      "examples": [
+        12,
+        24,
+        50
+      ]
     },
     "own.bestEffortTeamMatching": {
       "description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
@@ -1905,7 +2141,9 @@
         "size": {
           "description": "Defines how many recordings to keep. Once this size is reached, the oldest entry will be removed.",
           "type": "integer",
-          "default": 100000
+          "default": 10000,
+          "minimum": 1,
+          "maximum": 10000
         },
         "repos": {
           "description": "List of repositories whose git operations should be recorded.",
@@ -1918,7 +2156,10 @@
       "examples": [
         {
           "size": 1000,
-          "repos": ["github.com/sourcegraph/sourcegraph", "github.com/gorilla/mux"]
+          "repos": [
+            "github.com/sourcegraph/sourcegraph",
+            "github.com/gorilla/mux"
+          ]
         }
       ]
     },
@@ -1931,7 +2172,10 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": ["key", "message"],
+            "required": [
+              "key",
+              "message"
+            ],
             "properties": {
               "key": {
                 "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -1969,7 +2213,10 @@
         "srcCliVersionCache": {
           "description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
           "type": "object",
-          "required": ["enabled", "github"],
+          "required": [
+            "enabled",
+            "github"
+          ],
           "group": "Sourcegraph.com",
           "properties": {
             "enabled": {
@@ -1980,7 +2227,10 @@
             "github": {
               "description": "GitHub configuration, both for queries and receiving release webhooks.",
               "type": "object",
-              "required": ["token", "webhookSecret"],
+              "required": [
+                "token",
+                "webhookSecret"
+              ],
               "properties": {
                 "repository": {
                   "description": "The repository to get the latest version of.",
@@ -2065,7 +2315,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["key", "message"],
+        "required": [
+          "key",
+          "message"
+        ],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2090,7 +2343,9 @@
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",
       "items": {
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -2158,7 +2413,9 @@
       "type": "string",
       "description": "The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.\n\nNote: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with \"session_\" from the Redis store:\n\n* For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`\n* For cluster deployments: \n  ```\n  REDIS_POD=\"$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})\";\n  kubectl exec \"$REDIS_POD\" -- redis-cli --raw keys 'session_*' | xargs kubectl exec \"$REDIS_POD\" -- redis-cli --raw del;\n  ```\n",
       "default": "2160h",
-      "examples": ["168h"],
+      "examples": [
+        "168h"
+      ],
       "group": "Authentication"
     },
     "auth.enableUsernameChanges": {
@@ -2253,10 +2510,17 @@
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
-      "type": ["string"],
-      "enum": ["release", "none"],
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "release",
+        "none"
+      ],
       "default": "release",
-      "examples": ["none"],
+      "examples": [
+        "none"
+      ],
       "group": "Misc."
     },
     "productResearchPage.enabled": {
@@ -2359,12 +2623,16 @@
       "!go": {
         "pointer": true
       },
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": ["signingKey"],
+      "required": [
+        "signingKey"
+      ],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
@@ -2429,7 +2697,10 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": ["openai", "sourcegraph"]
+          "enum": [
+            "openai",
+            "sourcegraph"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -2471,7 +2742,13 @@
               "items": {
                 "type": "string"
               },
-              "examples": ["*.go", "*.ts", "*.md", "src/", "cmd/"]
+              "examples": [
+                "*.go",
+                "*.ts",
+                "*.md",
+                "src/",
+                "cmd/"
+              ]
             },
             "maxFileSizeBytes": {
               "description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
@@ -2540,7 +2817,11 @@
           "model": "text-embedding-ada-002",
           "accessToken": "your-access-token",
           "url": "https://api.openai.com/v1/embeddings",
-          "excludedFilePathPatterns": ["*.svg", "**/__mocks__/**", "**/test/**"]
+          "excludedFilePathPatterns": [
+            "*.svg",
+            "**/__mocks__/**",
+            "**/test/**"
+          ]
         }
       ]
     },
@@ -2592,7 +2873,11 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai", "sourcegraph"]
+          "enum": [
+            "anthropic",
+            "openai",
+            "sourcegraph"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -2641,7 +2926,9 @@
       "description": "Configures the builtin username-password authentication provider.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2658,7 +2945,12 @@
       "description": "Configures the OpenID Connect authentication provider for SSO.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "issuer", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "issuer",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2717,11 +3009,20 @@
       "description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "dependencies": {
-        "serviceProviderCertificate": ["serviceProviderPrivateKey"],
-        "serviceProviderPrivateKey": ["serviceProviderCertificate"],
-        "signRequests": ["serviceProviderCertificate", "serviceProviderPrivateKey"]
+        "serviceProviderCertificate": [
+          "serviceProviderPrivateKey"
+        ],
+        "serviceProviderPrivateKey": [
+          "serviceProviderCertificate"
+        ],
+        "signRequests": [
+          "serviceProviderCertificate",
+          "serviceProviderPrivateKey"
+        ]
       },
       "properties": {
         "type": {
@@ -2832,7 +3133,10 @@
       "description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "usernameHeader"],
+      "required": [
+        "type",
+        "usernameHeader"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2841,17 +3145,23 @@
         "usernameHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-Forwarded-User"]
+          "examples": [
+            "X-Forwarded-User"
+          ]
         },
         "stripUsernameHeaderPrefix": {
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
-          "examples": ["accounts.google.com:"]
+          "examples": [
+            "accounts.google.com:"
+          ]
         },
         "emailHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-App-Email"]
+          "examples": [
+            "X-App-Email"
+          ]
         }
       }
     },
@@ -2859,7 +3169,11 @@
       "description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2919,8 +3233,13 @@
           },
           "examples": [
             {
-              "orgName": ["team1"],
-              "anotherOrgName": ["team2", "team3"]
+              "orgName": [
+                "team1"
+              ],
+              "anotherOrgName": [
+                "team2",
+                "team3"
+              ]
             }
           ]
         },
@@ -2935,7 +3254,11 @@
       "description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -2978,7 +3301,10 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "api",
-          "enum": ["api", "read_api"]
+          "enum": [
+            "api",
+            "read_api"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
@@ -2996,7 +3322,13 @@
             "type": "string",
             "minLength": 1
           },
-          "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
+          "examples": [
+            [
+              "group",
+              "group/subgroup",
+              "group/subgroup/subgroup"
+            ]
+          ]
         },
         "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
@@ -3009,7 +3341,11 @@
       "description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientKey", "clientSecret"],
+      "required": [
+        "type",
+        "clientKey",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3047,7 +3383,11 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": ["account", "email", "repository"]
+          "enum": [
+            "account",
+            "email",
+            "repository"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
@@ -3060,7 +3400,10 @@
       "description": "Gerrit auth provider",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3092,7 +3435,11 @@
       "description": "Azure auth provider for dev.azure.com",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3177,7 +3524,9 @@
     "NotifierSlack": {
       "description": "Slack notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3208,7 +3557,10 @@
     "NotifierPagerduty": {
       "description": "PagerDuty notifier",
       "type": "object",
-      "required": ["type", "integrationKey"],
+      "required": [
+        "type",
+        "integrationKey"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3230,7 +3582,10 @@
     "NotifierWebhook": {
       "description": "Webhook notifier",
       "type": "object",
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3253,7 +3608,10 @@
     "NotifierEmail": {
       "description": "Email notifier",
       "type": "object",
-      "required": ["type", "address"],
+      "required": [
+        "type",
+        "address"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3268,7 +3626,9 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3296,7 +3656,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["team", "user", "escalation", "schedule"]
+                "enum": [
+                  "team",
+                  "user",
+                  "escalation",
+                  "schedule"
+                ]
               },
               "id": {
                 "type": "string"
@@ -3310,13 +3675,22 @@
             },
             "oneOf": [
               {
-                "required": ["type", "id"]
+                "required": [
+                  "type",
+                  "id"
+                ]
               },
               {
-                "required": ["type", "name"]
+                "required": [
+                  "type",
+                  "name"
+                ]
               },
               {
-                "required": ["type", "username"]
+                "required": [
+                  "type",
+                  "username"
+                ]
               }
             ]
           }
@@ -3326,11 +3700,18 @@
     "EncryptionKey": {
       "description": "Config for a key",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["cloudkms", "awskms", "mounted", "noop"]
+          "enum": [
+            "cloudkms",
+            "awskms",
+            "mounted",
+            "noop"
+          ]
         }
       },
       "oneOf": [
@@ -3354,7 +3735,10 @@
     "CloudKMSEncryptionKey": {
       "description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3371,7 +3755,10 @@
     "AWSKMSEncryptionKey": {
       "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
       "type": "object",
-      "required": ["type", "keyId"],
+      "required": [
+        "type",
+        "keyId"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3391,7 +3778,10 @@
     "MountedEncryptionKey": {
       "description": "This encryption key is mounted from a given file path or an environment variable.",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3414,7 +3804,9 @@
     "NoOpEncryptionKey": {
       "description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3424,7 +3816,10 @@
     },
     "EmailTemplate": {
       "type": "object",
-      "required": ["subject", "html"],
+      "required": [
+        "subject",
+        "html"
+      ],
       "properties": {
         "subject": {
           "description": "Template for email subject header",


### PR DESCRIPTION
Closes #55059

This PR makes the list of git commands that should be ignored for recording configurable via the site config setting.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Add an entry to the `gitRecorder.ignoredGitCommand` array.
* Perform an operation that will execute that command inside of `gitServer`, check redis for the value associated with key `recording-cmd` and it shouldn't be part of the result.