### PR TITLE
ci: avoid building the oss bundle 

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -2186,8 +2186,16 @@ webpack_devserver(
 build_test(
     name = "webpack_test",
     size = "enormous",
+    tags = ["manual"],  # avoid building the oss bundle
     targets = [
         ":bundle",
+    ],
+)
+
+build_test(
+    name = "webpack_test_enterprise",
+    size = "enormous",
+    targets = [
         ":bundle-enterprise",
     ],
 )

--- a/cmd/frontend/BUILD.bazel
+++ b/cmd/frontend/BUILD.bazel
@@ -72,6 +72,7 @@ container_structure_test(
     image = ":image",
     tags = [
         "exclusive",
+        "manual",  # avoid building the oss frontend
         "requires-network",
     ],
 )

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -157,8 +157,8 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	// bazel build //client/web:bundle is very resource hungry and often crashes when ran along other targets
 	// so we run it first to avoid failing builds midway.
 	cmds = append(cmds,
-		bazelAnnouncef("bazel build //client/web:bundle-*"),
-		bk.Cmd(bazelCmd("build //client/web:bundle //client/web:bundle-enterprise")),
+		bazelAnnouncef("bazel build //client/web:bundle-enterprise"),
+		bk.Cmd(bazelCmd("build //client/web:bundle-enterprise")),
 	)
 
 	for _, target := range targets {


### PR DESCRIPTION
Fixes #54819

The oss bundle is not used in any artifact we publish. I'm assuming if that if theres is any error, because the enterprise bundle is built on top of it, it would catch them. 

This shaves off having to build the bundle entirely, because any client code change means we're building two bundles in CI, just because we're running a few tests against those. 

So to make this happen, I tagged the relevant test targets to be manual, see the PR diff. 

In order to see what will ultimately be built in CI, I've used the following command

```
$ bazel query 'deps(tests(//...) except attr("tags", "manual", //...))' --output=label --keep_going | grep "client/web:bundle"
# ...
//client/web:bundle-enterprise
//client/web:bundle-enterprise.webpack.config.js
//client/web:bundlesize-report
//client/web:bundlesize-report__entry_point
//client/web:bundlesize.config.js
```

Showing that running test on `//...` won't build the oss bundle. 

@vovakulikov @umpox can you folks double check me here that we're ok to not test / build it and that just building the enterprise one will catch mistakes that matters? 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

CI + above command. 