### PR TITLE
gitserver: Don't delete repos when DB is down

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -504,7 +504,7 @@ func TestCleanup_RemoveNonExistentRepos(t *testing.T) {
 		if strings.Contains(string(name), "repo-exists") {
 			return &types.GitserverRepo{}, nil
 		} else {
-			return nil, errors.Newf("gitserver repo not found")
+			return nil, &database.ErrGitserverRepoNotFound{}
 		}
 	})
 	mockRepos := database.NewMockRepoStore()

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -329,7 +329,7 @@ func (s *gitserverRepoStore) GetByID(ctx context.Context, id api.RepoID) (*types
 	repo, _, err := scanGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(getGitserverRepoByIDQueryFmtstr, id)))
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, &errGitserverRepoNotFound{}
+			return nil, &ErrGitserverRepoNotFound{}
 		}
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (s *gitserverRepoStore) GetByName(ctx context.Context, name api.RepoName) (
 	repo, _, err := scanGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(getGitserverRepoByNameQueryFmtstr, name)))
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, &errGitserverRepoNotFound{}
+			return nil, &ErrGitserverRepoNotFound{}
 		}
 		return nil, err
 	}
@@ -390,10 +390,10 @@ LEFT OUTER JOIN gitserver_repos_sync_output go ON gr.repo_id = go.repo_id
 WHERE r.name = %s
 `
 
-type errGitserverRepoNotFound struct{}
+type ErrGitserverRepoNotFound struct{}
 
-func (err *errGitserverRepoNotFound) Error() string { return "gitserver repo not found" }
-func (errGitserverRepoNotFound) NotFound() bool     { return true }
+func (err *ErrGitserverRepoNotFound) Error() string { return "gitserver repo not found" }
+func (ErrGitserverRepoNotFound) NotFound() bool     { return true }
 
 const getByNamesQueryTemplate = `
 SELECT


### PR DESCRIPTION
First, this is not a terribly huge problem, as this cleanup job is off by default. But while debugging something else, this struck me as potentially dangerous. In case of a DB outage or broken query, we would drain the entire gitserver disk here slowly because repo will be nil when general connectivity issues occur. To fix this, we add an error check and only do this for not found errors. I also dropped a duplicative log message. The cleanup function returning an error already logs all the relevant details.

## Test plan

Just a slight refactor to error checking, trusting CI and code review with this.
