### PR TITLE
Embeddings: make IsContextRequiredForChatQuery not an RPC call

### DIFF
--- a/enterprise/cmd/embeddings/shared/BUILD.bazel
+++ b/enterprise/cmd/embeddings/shared/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     name = "shared",
     srcs = [
         "config.go",
-        "context_detection.go",
         "main.go",
         "repo_embedding_index_cache.go",
         "search.go",
@@ -37,7 +36,6 @@ go_library(
         "//internal/honey",
         "//internal/httpserver",
         "//internal/instrumentation",
-        "//internal/lazyregexp",
         "//internal/observation",
         "//internal/service",
         "//internal/trace",
@@ -77,7 +75,6 @@ go_test(
     name = "shared_test",
     timeout = "moderate",
     srcs = [
-        "context_detection_test.go",
         "context_qa_test.go",
         "main_test.go",
         "repo_embedding_index_cache_test.go",

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -141,24 +141,6 @@ func NewHandler(
 		json.NewEncoder(w).Encode(res)
 	})
 
-	mux.HandleFunc("/isContextRequiredForChatQuery", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			http.Error(w, fmt.Sprintf("unsupported method %s", r.Method), http.StatusBadRequest)
-			return
-		}
-
-		var args embeddings.IsContextRequiredForChatQueryParameters
-		err := json.NewDecoder(r.Body).Decode(&args)
-		if err != nil {
-			http.Error(w, "could not parse request body", http.StatusBadRequest)
-			return
-		}
-
-		isRequired := isContextRequiredForChatQuery(args.Query)
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(embeddings.IsContextRequiredForChatQueryResult{IsRequired: isRequired})
-	})
-
 	return mux
 }
 

--- a/enterprise/cmd/embeddings/shared/main_test.go
+++ b/enterprise/cmd/embeddings/shared/main_test.go
@@ -232,14 +232,6 @@ func TestEmbeddingsSearch(t *testing.T) {
 			}},
 		}, results)
 	}
-
-	t.Run("IsContextRequiredForChatQuery", func(t *testing.T) {
-		res, err := client.IsContextRequiredForChatQuery(context.Background(), embeddings.IsContextRequiredForChatQueryParameters{
-			Query: "context detection",
-		})
-		require.NoError(t, err)
-		require.True(t, res)
-	})
 }
 
 func TestEmbeddingModelMismatch(t *testing.T) {

--- a/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/enterprise/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -110,9 +110,6 @@ func (r *Resolver) EmbeddingsMultiSearch(ctx context.Context, args graphqlbacken
 }
 
 func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graphqlbackend.IsContextRequiredForChatQueryInputArgs) (bool, error) {
-	if !conf.EmbeddingsEnabled() {
-		return false, errors.New("embeddings are not configured or disabled")
-	}
 	if isEnabled := cody.IsCodyEnabled(ctx); !isEnabled {
 		return false, errors.New("cody experimental feature flag is not enabled for current user")
 	}
@@ -121,7 +118,7 @@ func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graph
 		return false, err
 	}
 
-	return r.embeddingsClient.IsContextRequiredForChatQuery(ctx, embeddings.IsContextRequiredForChatQueryParameters{Query: args.Query})
+	return embeddings.IsContextRequiredForChatQuery(args.Query), nil
 }
 
 func (r *Resolver) RepoEmbeddingJobs(ctx context.Context, args graphqlbackend.ListRepoEmbeddingJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver], error) {

--- a/internal/embeddings/BUILD.bazel
+++ b/internal/embeddings/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "embeddings",
     srcs = [
         "client.go",
+        "context_detection.go",
         "dot.go",
         "dot_amd64.go",
         "dot_amd64.s",
@@ -57,6 +58,7 @@ go_test(
     name = "embeddings_test",
     timeout = "moderate",
     srcs = [
+        "context_detection_test.go",
         "dot_test.go",
         "index_storage_test.go",
         "quantize_test.go",

--- a/internal/embeddings/context_detection.go
+++ b/internal/embeddings/context_detection.go
@@ -1,4 +1,4 @@
-package shared
+package embeddings
 
 import (
 	"strings"
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
-var NO_CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
+var noContextMessagesRegexps = []*lazyregexp.Regexp{
 	// Common greetings
 	lazyregexp.New(`^(hello|hey|hi|what['’]s up|how's it going)( Cody)?[!\.\?]?$`),
 
@@ -39,10 +39,10 @@ var NO_CONTEXT_MESSAGES_REGEXPS = []*lazyregexp.Regexp{
 	lazyregexp.New("```"),
 }
 
-func isContextRequiredForChatQuery(query string) bool {
+func IsContextRequiredForChatQuery(query string) bool {
 	queryTrimmed := strings.TrimSpace(query)
 	queryLower := strings.ToLower(queryTrimmed)
-	for _, regexp := range NO_CONTEXT_MESSAGES_REGEXPS {
+	for _, regexp := range noContextMessagesRegexps {
 		if regexp.MatchString(queryLower) {
 			return false
 		}

--- a/internal/embeddings/context_detection_test.go
+++ b/internal/embeddings/context_detection_test.go
@@ -1,4 +1,4 @@
-package shared
+package embeddings
 
 import (
 	"testing"
@@ -57,7 +57,7 @@ func TestIsContextRequiredForChatQuery(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.query, func(t *testing.T) {
-			got := isContextRequiredForChatQuery(tt.query)
+			got := IsContextRequiredForChatQuery(tt.query)
 			if got != tt.want {
 				t.Fatalf("expected context required to be %t but was %t", tt.want, got)
 			}


### PR DESCRIPTION
We are making an RPC call to the embeddings service even though it's a stateless, importable function. This just calls the funtion directly from the resolver instead so we can skip all the surface area introduced by the RPC.

## Test plan

Existing tests, plus manual test that I can get the GraphQL call to return both true and false.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
