### PR TITLE
Create buf-breaking-check.yml

### DIFF
--- a/.github/workflows/buf-breaking-check.yml
+++ b/.github/workflows/buf-breaking-check.yml
@@ -1,0 +1,13 @@
+on: pull_request # Apply to all pull requests
+jobs:
+  validate-protos:
+    runs-on: ubuntu-latest
+    steps:
+      # Run `git checkout`
+      - uses: actions/checkout@v2
+      # Install the `buf` CLI
+      - uses: bufbuild/buf-setup-action@v1
+      # Run breaking change detection against the `main` branch
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: 'https://github.com/sourcegraph/sourcegraph.git#branch=main'

--- a/.github/workflows/buf-breaking-check.yml
+++ b/.github/workflows/buf-breaking-check.yml
@@ -1,4 +1,9 @@
-on: pull_request # Apply to all pull requests
+on:
+  pull_request:
+    types:
+      - opened
+    paths:
+      - '*.proto'
 jobs:
   validate-protos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
An alternative solution to https://github.com/sourcegraph/sourcegraph/pull/55036

Using this github action, we wouldn't have to worry about handing the image.binpb file



## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
