### PR TITLE
Repo metadata: remove stray printlns

### DIFF
--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/keegancsmith/sqlf"
 
@@ -111,8 +110,6 @@ func (s *repoKVPStore) ListKeys(ctx context.Context, options RepoKVPListKeysOpti
 	q := sqlf.Sprintf(`SELECT key FROM repo_kvps WHERE (%s) GROUP BY key`, sqlf.Join(where, ") AND ("))
 	q = p.AppendOrderToQuery(q)
 	q = p.AppendLimitToQuery(q)
-	fmt.Println(q.Query(sqlf.PostgresBindVar))
-	fmt.Println(q.Args())
 	return basestore.ScanStrings(s.Query(ctx, q))
 }
 

--- a/internal/database/repo_kvps.go
+++ b/internal/database/repo_kvps.go
@@ -144,8 +144,6 @@ func (s *repoKVPStore) ListValues(ctx context.Context, options RepoKVPListValues
 	q := sqlf.Sprintf(`SELECT DISTINCT value FROM repo_kvps WHERE (%s)`, sqlf.Join(where, ") AND ("))
 	q = p.AppendOrderToQuery(q)
 	q = p.AppendLimitToQuery(q)
-	fmt.Println(q.Query(sqlf.PostgresBindVar))
-	fmt.Println(q.Args())
 	return basestore.ScanStrings(s.Query(ctx, q))
 }
 


### PR DESCRIPTION
This just removes some leftover `fmt.Println` statements, presumably from debugging. However, now they're littering the logs whenever metadata is used.

## Test plan

Tested that the logs were clean when adding or reading metadata.



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
