### PR TITLE
create grpc_backend_integration_test

### DIFF
--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -19,7 +19,7 @@ func BazelOperations(isMain bool) []operations.Operation {
 	ops := []operations.Operation{}
 	ops = append(ops, bazelConfigure())
 	if isMain {
-		ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test"))
+		ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
 	} else {
 		ops = append(ops, bazelTest("//...", "//client/web:test"))
 	}

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -110,7 +110,6 @@ server_integration_test(
         "manual",
     ],
 )
-)
 
 server_integration_test(
     name = "codeintel_integration_test",

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -75,6 +75,40 @@ server_integration_test(
 )
 
 server_integration_test(
+    name = "grpc_backend_integration_test",
+    args = [
+        "$(location //dev/gqltest:gqltest_test)",  # actual test
+        "$(location //dev/authtest:authtest_test)",  # actual test
+    ],
+    data = [
+        "//dev/authtest:authtest_test",
+        "//dev/gqltest:gqltest_test",
+    ],
+    env = {
+        "SG_FEATURE_FLAG_GRPC": "true",
+    },
+    env_inherit = [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_CODE_COMMIT_PASSWORD",
+        "AWS_CODE_COMMIT_USERNAME",
+        "AWS_SECRET_ACCESS_KEY",
+        "AZURE_DEVOPS_TOKEN",
+        "AZURE_DEVOPS_USERNAME",
+        "BITBUCKET_SERVER_TOKEN",
+        "BITBUCKET_SERVER_URL",
+        "BITBUCKET_SERVER_USERNAME",
+        "GHE_GITHUB_TOKEN",
+        "PERFORCE_PASSWORD",
+        "PERFORCE_PORT",
+        "PERFORCE_USER",
+        "SOURCEGRAPH_LICENSE_GENERATION_KEY",
+        "SOURCEGRAPH_LICENSE_KEY",
+    ],
+    port = "7082",
+    runner_src = ":backend_integration_test.sh",
+)
+
+server_integration_test(
     name = "codeintel_integration_test",
     args = [
         "$(location //internal/cmd/init-sg)",
@@ -118,7 +152,7 @@ server_integration_test(
         "SOURCEGRAPH_LICENSE_KEY",
     ],
     flaky = True,
-    port = "7082",
+    port = "7083",
     runner_src = ":codeintel_integration_test.sh",
     tags = [
         "manual",

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -106,6 +106,10 @@ server_integration_test(
     ],
     port = "7082",
     runner_src = ":backend_integration_test.sh",
+    tags = [
+        "manual",
+    ],
+)
 )
 
 server_integration_test(


### PR DESCRIPTION
creating backend integration test with grpc flag set to true
## Test plan
sg ci bazel --web test //testing:grpc_backend_integration_test 
https://buildkite.com/sourcegraph/sourcegraph/builds/235245#0189722a-8fad-4250-bf49-cf29d1a9b62d
sg ci build main-dry-run
https://buildkite.com/sourcegraph/sourcegraph/builds/235246#01897232-fb25-4ac3-90ff-77b8151162e4

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
