### PR TITLE
conf: add docs and default value for email.senderName

### DIFF
--- a/doc/admin/config/email.md
+++ b/doc/admin/config/email.md
@@ -31,15 +31,19 @@ To use Amazon SES with Sourcegraph, first [follow these steps to create an SES a
 
 Navigate to your site configuration (e.g. `https://sourcegraph.com/site-admin/configuration`) and fill in the configuration:
 
-```json
-  "email.address": "from@domain.com",
+```jsonc
+{
+  // [...]
+  "email.senderName": "Example Sourcegraph Instance", // Default: Sourcegraph
+  "email.address": "from@example.com",
   "email.smtp": {
     "authentication": "PLAIN",
     "username": "<SES SMTP username>",
     "password": "<SES SMTP password>",
     "host": "email-smtp.us-west-2.amazonaws.com",
     "port": 587
-  },
+  }
+}
 ```
 
 Please note that the configured `email.address` (the from address) must be a verified address with SES, see [this page for details](https://docs.aws.amazon.com/ses/latest/dg/verify-addresses-and-domains.html).
@@ -52,19 +56,23 @@ To use Google Workspace with Sourcegraph, you will need to [create an SMTP Relay
 
 Navigate to your site configuration (e.g. `https://sourcegraph.com/site-admin/configuration`) and fill in the configuration:
 
-```json
-  "email.address": "test@domain.com",
+```jsonc
+{
+  // [...]
+  "email.senderName": "Example Sourcegraph Instance", // Default: Sourcegraph
+  "email.address": "test@example.com",
   "email.smtp": {
     "authentication": "PLAIN",
-    "username": "test@domain.com",
+    "username": "test@example.com",
     "password": "<YOUR SECRET>",
     "host": "smtp-relay.gmail.com",
     "port": 587,
-    "domain": "domain.com"
-  },
+    "domain": "example.com"
+  }
+}
 ```
 
-Make sure that `test@domain.com` in both places of the configuration matches the email address of the account you created, and that `<YOUR SECRET>` is replaced with the account password or app password when 2FA enabled.
+Make sure that `test@example.com` in both places of the configuration matches the email address of the account you created, and that `<YOUR SECRET>` is replaced with the account password or app password when 2FA enabled.
 
 [Send a test email](#sending-a-test-email) to verify it is configured properly.
 
@@ -77,15 +85,19 @@ Other providers such as Mailchimp and Sendgrid may also be used with Sourcegraph
 
 Once you have an SMTP account, simply navigate to your site configuration (e.g. `https://sourcegraph.com/site-admin/configuration`) and fill in the configuration:
 
-```json
-  "email.address": "from@domain.com",
+```jsonc
+{
+  // [...]
+  "email.senderName": "Example Sourcegraph Instance", // Default: Sourcegraph
+  "email.address": "from@example.com",
   "email.smtp": {
     "authentication": "PLAIN",
-    "username": "test@domain.com",
+    "username": "test@example.com",
     "password": "<YOUR SECRET>",
     "host": "smtp-server.example.com",
     "port": 587
-  },
+  }
+}
 ```
 
 A few helpful tips:

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -126,6 +126,16 @@ func CanSendEmail() bool {
 	return Get().EmailSmtp != nil
 }
 
+// EmailSenderName returns `email.senderName`. If that's not set, it returns
+// the default value "Sourcegraph".
+func EmailSenderName() string {
+	sender := Get().EmailSenderName
+	if sender != "" {
+		return sender
+	}
+	return "Sourcegraph"
+}
+
 // UpdateChannel tells the update channel. Default is "release".
 func UpdateChannel() string {
 	channel := Get().UpdateChannel

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -1019,6 +1019,7 @@ func TestEmailSenderName(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			Mock(&Unified{SiteConfiguration: tc.siteConfig})
+			t.Cleanup(func() { Mock(nil) })
 
 			if got, want := EmailSenderName(), tc.want; got != want {
 				t.Fatalf("EmailSenderName() = %v, want %v", got, want)

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -995,3 +995,34 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestEmailSenderName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		siteConfig schema.SiteConfiguration
+		want       string
+	}{
+		{
+			name:       "nothing set",
+			siteConfig: schema.SiteConfiguration{},
+			want:       "Sourcegraph",
+		},
+		{
+			name: "value set",
+			siteConfig: schema.SiteConfiguration{
+				EmailSenderName: "Horsegraph",
+			},
+			want: "Horsegraph",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Mock(&Unified{SiteConfiguration: tc.siteConfig})
+
+			if got, want := EmailSenderName(), tc.want; got != want {
+				t.Fatalf("EmailSenderName() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1338,7 +1338,8 @@
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
-      "examples": ["Sourcegraph"]
+      "default": "Sourcegraph",
+      "examples": ["FooCorp Sourcegraph", "Horsegraph Code AI Platform"]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1339,7 +1339,7 @@
       "type": "string",
       "group": "Email",
       "default": "Sourcegraph",
-      "examples": ["FooCorp Sourcegraph", "Horsegraph Code AI Platform"]
+      "examples": ["Our Company Sourcegraph", "Example Inc Sourcegraph"]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",


### PR DESCRIPTION
This fixes #54984 by setting a default value for `email.senderName` and documenting the setting.

I also changed the docs to have valid syntax and changed from `domain.com` to `example.com`, which is the preferred way to refer to example emails.

## Test plan

- Manual testing
- New unit test
