### PR TITLE
database: re-enable flaky test & remove sleep

### DIFF
--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -3,8 +3,8 @@ package database
 import (
 	"context"
 	"testing"
-	"time"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -301,12 +301,21 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
+
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
 
-	user, err := db.Users().Create(ctx, NewUser{
+	// We setup the configuration so that password reset links are valid for 60s
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			AuthPasswordResetLinkExpiry: 60,
+		},
+	})
+	defer conf.Mock(nil)
+
+	users := db.Users()
+	user, err := users.Create(ctx, NewUser{
 		Email:                 "foo@bar.com",
 		Username:              "foo",
 		Password:              "right-password",
@@ -316,45 +325,37 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resetCode, err := db.Users().RenewPasswordResetCode(ctx, user.ID)
+	resetCode, err := users.RenewPasswordResetCode(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(time.Second) // the lowest expiry is 1 second
 
-	t.Run("expired link", func(t *testing.T) {
-		// This flaked with a data race in https://buildkite.com/sourcegraph/sourcegraph/builds/193660#0185bb03-890a-486f-a119-e5e80dd2c29e
-		t.Skip()
-		conf.Mock(&conf.Unified{
-			SiteConfiguration: schema.SiteConfiguration{
-				AuthPasswordResetLinkExpiry: 1,
-			},
-		})
-		defer conf.Mock(nil)
+	// Reset the passwd_reset_time to be 5min in the past, so that it's expired
+	_, err = users.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_time = now()-'5 minutes'::interval WHERE users.id = %s", user.ID))
+	if err != nil {
+		t.Fatalf("failed to update reset time: %s", err)
+	}
 
-		success, err := db.Users().SetPassword(ctx, user.ID, resetCode, "new-password")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if success {
-			t.Fatal("accepted an expired password reset")
-		}
-	})
+	// This should fail, because it has been reset 5min ago, but link is only valid 60s
+	success, err := users.SetPassword(ctx, user.ID, resetCode, "new-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if success {
+		t.Fatal("accepted an expired password reset")
+	}
 
-	t.Run("valid link", func(t *testing.T) {
-		conf.Mock(&conf.Unified{
-			SiteConfiguration: schema.SiteConfiguration{
-				AuthPasswordResetLinkExpiry: 3600,
-			},
-		})
-		defer conf.Mock(nil)
+	// Now we want the link to be fresh by setting passwd_reset_time to now
+	_, err = users.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_time = now() WHERE users.id = %s", user.ID))
+	if err != nil {
+		t.Fatalf("failed to update reset time: %s", err)
+	}
 
-		success, err := db.Users().SetPassword(ctx, user.ID, resetCode, "new-password")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !success {
-			t.Fatal("did not accept a valid password reset")
-		}
-	})
+	success, err = users.SetPassword(ctx, user.ID, resetCode, "new-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !success {
+		t.Fatal("did not accept a valid password reset")
+	}
 }

--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -312,7 +312,7 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 			AuthPasswordResetLinkExpiry: 60,
 		},
 	})
-	defer conf.Mock(nil)
+	t.Cleanup(func() { conf.Mock(nil)})
 
 	users := db.Users()
 	user, err := users.Create(ctx, NewUser{


### PR DESCRIPTION
This fixes #46510 by re-enabling the test and fixing its flakiness.

Test was flaky because it was `t.Parallel` but used `conf.Mock`, which writes to a global var.

So I removed `t.Parallel`, which fixes the data race.

But I also removed the `time.Sleep`, beacuse we don't need that. We can just reset the time.

## Test plan

- Ran the tests
