### PR TITLE
Marked JetBrains "Coming soon" → experimental

### DIFF
--- a/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.module.scss
+++ b/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.module.scss
@@ -50,6 +50,14 @@ h2 {
     color: var(--primary);
 }
 
+.experimental-badge {
+    --badge-base: transparent;
+    --badge-light: var(--secondary-2);
+    --badge-dark: var(--secondary-2);
+    --badge-text: var(--text-muted);
+    --badge-border: 1px solid var(--secondary);
+}
+
 .list {
     list-style: inside;
 }

--- a/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
@@ -4,7 +4,7 @@ import { mdiChevronRight, mdiMicrosoftVisualStudioCode } from '@mdi/js'
 import classNames from 'classnames'
 
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { ButtonLink, H1, H2, Icon, Link, Text } from '@sourcegraph/wildcard'
+import { ButtonLink, H1, H2, Icon, Link, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
 import { EventName } from '../../../util/constants'
@@ -101,10 +101,13 @@ export const TryCodySignUpCtaSection: React.FC<TelemetryProps & { className?: st
                         VS Code extension
                     </Text>
                     <Text as="li" size="small" className="mb-2">
-                        the Sourcegraph web application{' '}
+                        the Sourcegraph web application
+                    </Text>
+                    <Text as="li" size="small" className="mb-2">
+                        our JetBrains IDE plugin <ProductStatusBadge status="experimental" />
                     </Text>
                     <Text as="li" size="small" className="text-muted">
-                        JetBrains and other editors (Coming soon!)
+                        Neovim and other editors (Coming soon!)
                     </Text>
                 </ul>
                 <div className="mb-2">

--- a/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
@@ -104,7 +104,8 @@ export const TryCodySignUpCtaSection: React.FC<TelemetryProps & { className?: st
                         the Sourcegraph web application
                     </Text>
                     <Text as="li" size="small" className="mb-2">
-                        our JetBrains IDE plugin <ProductStatusBadge status="experimental" />
+                        our JetBrains IDE plugin{' '}
+                        <ProductStatusBadge status="experimental" className={styles.experimentalBadge} />
                     </Text>
                     <Text as="li" size="small" className="text-muted">
                         Neovim and other editors (Coming soon!)


### PR DESCRIPTION
Cody for JetBrains is actually out. Added it to the Cody landing.

Before:

<img width="800" alt="CleanShot 2023-07-20 at 12 26 27@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2552265/ff9e4512-ce56-455d-8ab5-496a368eef4f">

After:

<img width="800" alt="CleanShot 2023-07-20 at 12 23 54@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2552265/379051f2-04fe-4ebb-9180-422d641352bc">

## Test plan

Waiting for reviews and CI
