### PR TITLE
[gerrit] Fix account security page display bug

### DIFF
--- a/internal/extsvc/gerrit/account.go
+++ b/internal/extsvc/gerrit/account.go
@@ -11,6 +11,7 @@ import (
 
 // AccountData stores information of a Gerrit account.
 type AccountData struct {
+	Name      string `json:"name"`
 	Username  string `json:"username"`
 	Email     string `json:"email"`
 	AccountID int32  `json:"account_id"`
@@ -39,7 +40,8 @@ func GetPublicExternalAccountData(ctx context.Context, data *extsvc.AccountData)
 	}
 
 	return &extsvc.PublicAccountData{
-		DisplayName: &usr.Username,
+		DisplayName: &usr.Name,
+		Login:       &usr.Username,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #55035

Fixes a minor display bug where the username and display name of gerrit accounts aren't properly handled.

<img width="1143" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6427795/2152b3de-487d-40d3-9a6c-c98269048faa">

## Test plan

Visual

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
