### PR TITLE
JetBrains: add go to settings from the cogwheel menu in the toolbar

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- New menu item in the toolbar cogwheel menu to open the Cody app settings [#55146](https://github.com/sourcegraph/sourcegraph/pull/55146)
+
 ### Changed
 
 - Store global access token in a safe place [#55052](https://github.com/sourcegraph/sourcegraph/pull/55052)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -351,7 +351,7 @@ public class CodyToolWindowContent implements UpdatableChat {
           "<p>It looks like you don't have Sourcegraph Access Token configured.</p>"
               + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
       AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
-          new AssistantMessageWithSettingsButton(project, noAccessTokenText);
+          new AssistantMessageWithSettingsButton(noAccessTokenText);
       var messageContentPanel = new JPanel(new BorderLayout());
       messageContentPanel.add(assistantMessageWithSettingsButton);
       ApplicationManager.getApplication()
@@ -436,7 +436,7 @@ public class CodyToolWindowContent implements UpdatableChat {
         "<p>It looks like your Sourcegraph Access Token is invalid or not configured.</p>"
             + "<p>See our <a href=\"https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token\">user docs</a> how to create one and configure it in the settings to use Cody.</p>";
     AssistantMessageWithSettingsButton assistantMessageWithSettingsButton =
-        new AssistantMessageWithSettingsButton(project, invalidAccessTokenText);
+        new AssistantMessageWithSettingsButton(invalidAccessTokenText);
     var messageContentPanel = new JPanel(new BorderLayout());
     messageContentPanel.add(assistantMessageWithSettingsButton);
     ApplicationManager.getApplication()

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
@@ -2,13 +2,16 @@ package com.sourcegraph.cody;
 
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.openapi.wm.ex.ToolWindowEx;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.config.OpenPluginSettingsAction;
 import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +29,10 @@ public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
             .createContent(toolWindowContent.getContentPanel(), "", false);
     content.setPreferredFocusableComponent(toolWindowContent.getPreferredFocusableComponent());
     toolWindow.getContentManager().addContent(content);
+    DefaultActionGroup customCodySettings = new DefaultActionGroup();
+    customCodySettings.add(new OpenPluginSettingsAction("Cody Settings..."));
+    customCodySettings.addSeparator();
+    ((ToolWindowEx) toolWindow).setAdditionalGearActions(customCodySettings);
     List<AnAction> titleActions = new ArrayList<>();
     createTitleActions(titleActions);
     if (!titleActions.isEmpty()) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/AssistantMessageWithSettingsButton.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/AssistantMessageWithSettingsButton.java
@@ -2,7 +2,6 @@ package com.sourcegraph.cody.chat;
 
 import static com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.ui.BrowserHyperlinkListener;
 import com.intellij.util.ui.JBInsets;
 import com.intellij.util.ui.SwingHelper;
@@ -14,8 +13,7 @@ import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 
 public class AssistantMessageWithSettingsButton extends MessagePanel {
-  public AssistantMessageWithSettingsButton(
-      @NotNull Project project, @NotNull String htmlTextContent) {
+  public AssistantMessageWithSettingsButton(@NotNull String htmlTextContent) {
     super(Speaker.ASSISTANT, ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDTH);
     this.setLayout(new BorderLayout());
     JEditorPane jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null);
@@ -25,7 +23,6 @@ public class AssistantMessageWithSettingsButton extends MessagePanel {
         JBInsets.create(new Insets(TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN, TEXT_MARGIN)));
     SwingHelper.setHtml(jEditorPane, htmlTextContent, UIUtil.getActiveTextColor());
     this.add(jEditorPane, BorderLayout.CENTER);
-    this.add(
-        GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(project), BorderLayout.EAST);
+    this.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(), BorderLayout.EAST);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/GoToPluginSettingsButtonFactory.java
@@ -1,12 +1,8 @@
 package com.sourcegraph.config;
 
 import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.impl.ActionButton;
-import com.intellij.openapi.options.ShowSettingsUtil;
-import com.intellij.openapi.project.DumbAwareAction;
-import com.intellij.openapi.project.Project;
 import com.intellij.util.IconUtil;
 import com.intellij.util.ui.JBDimension;
 import com.intellij.util.ui.JBUI;
@@ -17,16 +13,10 @@ import org.jetbrains.annotations.NotNull;
 public class GoToPluginSettingsButtonFactory {
 
   @NotNull
-  public static ActionButton createGoToPluginSettingsButton(@NotNull Project project) {
+  public static ActionButton createGoToPluginSettingsButton() {
     JBDimension actionButtonSize = JBUI.size(22, 22);
 
-    AnAction action =
-        new DumbAwareAction() {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-            ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable.class);
-          }
-        };
+    AnAction action = new OpenPluginSettingsAction();
     Presentation presentation = new Presentation("Open Plugin Settings");
 
     ActionButton button =

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -82,7 +82,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
     }
     browserContainerForOptionalBorder.add(browserAndLoadingPanel, BorderLayout.CENTER);
 
-    HeaderPanel headerPanel = new HeaderPanel(project);
+    HeaderPanel headerPanel = new HeaderPanel();
 
     BorderLayoutPanel topPanel = new BorderLayoutPanel();
     topPanel.add(headerPanel, BorderLayout.NORTH);

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/HeaderPanel.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.find;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.util.ui.JBEmptyBorder;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
@@ -9,7 +8,7 @@ import java.awt.*;
 import javax.swing.*;
 
 public class HeaderPanel extends BorderLayoutPanel {
-  public HeaderPanel(Project project) {
+  public HeaderPanel() {
     super();
     setBorder(new JBEmptyBorder(5, 5, 2, 5));
 
@@ -18,7 +17,7 @@ public class HeaderPanel extends BorderLayoutPanel {
     title.add(new JLabel("Find with Sourcegraph", Icons.SourcegraphLogo, SwingConstants.LEFT));
 
     JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT, 0, 0));
-    buttons.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton(project));
+    buttons.add(GoToPluginSettingsButtonFactory.createGoToPluginSettingsButton());
 
     add(title, BorderLayout.WEST);
     add(buttons, BorderLayout.EAST);


### PR DESCRIPTION
closes https://github.com/sourcegraph/cody/issues/141

![Screenshot 2023-07-20 at 13 16 12](https://github.com/sourcegraph/sourcegraph/assets/7345368/3a960abe-98a5-4aca-871f-6d4be1f5d0e1)


## Test plan
- In the cody toolbar cogwheel menu new item should be displayed "Cody Settings..." which opens IntelliJ Cody settings window

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
