### PR TITLE
JetBrains: Cody: Partially improve the chat scroll panel flickering

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -62,11 +62,12 @@ import com.sourcegraph.config.SettingsComponent.InstanceType;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import com.sourcegraph.vcs.RepoUtil;
 import java.awt.*;
-import java.awt.event.AdjustmentListener;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import javax.swing.*;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -74,9 +75,6 @@ import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
-import java.util.Optional;
-import javax.swing.*;
-import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.ButtonUI;
 import org.apache.commons.lang3.StringUtils;
@@ -445,20 +443,20 @@ public class CodyToolWindowContent implements UpdatableChat {
   public synchronized void updateLastMessage(@NotNull ChatMessage message) {
     ApplicationManager.getApplication()
         .invokeLater(
-            () -> {
-              transcript.addAssistantResponse(message);
-              if (messagesPanel.getComponentCount() > 0) {
-                JPanel lastBubblePanel =
-                    (JPanel) messagesPanel.getComponent(messagesPanel.getComponentCount() - 1);
-                Component component = lastBubblePanel.getComponent(0);
-                if (component instanceof ChatBubble) {
-                  ChatBubble lastBubble = (ChatBubble) component;
-                  lastBubble.updateText(message, messagesPanel);
-                  messagesPanel.revalidate();
-                  messagesPanel.repaint();
-                }
-              }
-            });
+            () ->
+                Optional.of(messagesPanel)
+                    .filter(mp -> mp.getComponentCount() > 0)
+                    .map(mp -> mp.getComponent(mp.getComponentCount() - 1))
+                    .filter(component -> component instanceof JPanel)
+                    .map(component -> (JPanel) component)
+                    .map(lastBubblePanel -> lastBubblePanel.getComponent(0))
+                    .filter(component -> component instanceof ChatBubble)
+                    .map(component -> (ChatBubble) component)
+                    .ifPresent(
+                        lastBubble -> {
+                          transcript.addAssistantResponse(message);
+                          lastBubble.incrementallyUpdateText(message, messagesPanel);
+                        }));
   }
 
   private void startMessageProcessing() {


### PR DESCRIPTION
Related to https://github.com/sourcegraph/cody/issues/231 and https://github.com/sourcegraph/cody/issues/256
Doesn't really fix either issue, but makes things somewhat better (?)

Before:
https://github.com/sourcegraph/sourcegraph/assets/18601388/5168116d-ec3d-44b0-b377-3598095605ba

After these changes:
https://github.com/sourcegraph/sourcegraph/assets/18601388/209f941d-e399-464a-b4b8-2e8dffe7d587

Notice how the bottom part of the scroll is no longer jumping (but the top still is).

What has been done here:
- streaming chat message updates now are discarded if they're shorter than the previous streaming message handled (to prevent messages being handled out-of-order, we were just doing fire-and-forget updates as they came before)
- the hacky scrolling to the bottom got replaced with a more proper listener, which now auto-detects if a re-scroll to the bottom is necessary (instead of forcefully setting it with a flag from elsewhere, trying to guess whan a scroll is necessary, as before)
- some unnecessary repaints got removed
- some general refactors of the relevant parts

Just keep in mind that more work needs to be done on this.

## Test plan
- green CI
