### PR TITLE
site-admin: filter repos by embedding status

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -82,6 +82,12 @@ const STATUS_FILTERS: { [label: string]: FilteredConnectionFilterValue } = {
         tooltip: 'Show only repositories which are corrupt',
         args: { corrupted: true },
     },
+    Embedded: {
+        label: 'Embedded',
+        value: 'embedded',
+        tooltip: 'Show only repositories which are embedded',
+        args: { notEmbedded: false },
+    },
 }
 
 const FILTERS: FilteredConnectionFilter[] = [
@@ -249,6 +255,8 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
             query: searchQuery,
             indexed: args.indexed ?? true,
             notIndexed: args.notIndexed ?? true,
+            embedded: args.embedded ?? true,
+            notEmbedded: args.notEmbedded ?? true,
             failedFetch: args.failedFetch ?? false,
             corrupted: args.corrupted ?? false,
             cloneStatus: args.cloneStatus ?? null,
@@ -351,6 +359,19 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
                     setFilterValues(values => {
                         const newValues = new Map(values)
                         newValues.set('status', STATUS_FILTERS.FailedFetchOrClone)
+                        return newValues
+                    }),
+            },
+            {
+                value: data.repositoryStats.embedded,
+                description: 'Embedded',
+                color: 'var(--body-color)',
+                position: 'right',
+                tooltip: 'The number of repositories that have been embedded for Cody.',
+                onClick: () =>
+                    setFilterValues(values => {
+                        const newValues = new Map(values)
+                        newValues.set('status', STATUS_FILTERS.Embedded)
                         return newValues
                     }),
             },

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -160,6 +160,8 @@ export const REPOSITORIES_QUERY = gql`
         $query: String
         $indexed: Boolean
         $notIndexed: Boolean
+        $embedded: Boolean
+        $notEmbedded: Boolean
         $failedFetch: Boolean
         $corrupted: Boolean
         $cloneStatus: CloneStatus
@@ -176,6 +178,8 @@ export const REPOSITORIES_QUERY = gql`
             query: $query
             indexed: $indexed
             notIndexed: $notIndexed
+            embedded: $embedded
+            notEmbedded: $notEmbedded
             failedFetch: $failedFetch
             corrupted: $corrupted
             cloneStatus: $cloneStatus
@@ -755,6 +759,7 @@ export const STATUS_AND_REPO_STATS = gql`
             failedFetch
             corrupted
             indexed
+            embedded
         }
         statusMessages {
             ... on GitUpdatesDisabled {

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -261,6 +261,7 @@ go_library(
         "//internal/database/migration/runner",
         "//internal/database/migration/schemas",
         "//internal/deviceid",
+        "//internal/embeddings/background/repo",
         "//internal/encryption",
         "//internal/encryption/keyring",
         "//internal/env",

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )
@@ -25,6 +26,14 @@ type repositoryStatsResolver struct {
 	gitDirBytesOnce sync.Once
 	gitDirBytes     int64
 	gitDirBytesErr  error
+
+	embeddedStatsOnce sync.Once
+	embeddedRepos     int32
+	embeddedStatsErr  error
+}
+
+func (r *repositoryStatsResolver) Embedded(ctx context.Context) (int32, error) {
+	return r.computeEmbeddedRepos(ctx)
 }
 
 func (r *repositoryStatsResolver) GitDirBytes(ctx context.Context) (BigInt, error) {
@@ -153,6 +162,19 @@ func (r *repositoryStatsResolver) computeRepoStatistics(ctx context.Context) (da
 		r.repoStatistics, r.repoStatisticsErr = r.db.RepoStatistics().GetRepoStatistics(ctx)
 	})
 	return r.repoStatistics, r.repoStatisticsErr
+}
+
+func (r *repositoryStatsResolver) computeEmbeddedRepos(ctx context.Context) (int32, error) {
+	r.embeddedStatsOnce.Do(func() {
+		count, err := repo.NewRepoEmbeddingJobsStore(r.db).CountRepoEmbeddings(ctx)
+		if err != nil {
+			r.embeddedStatsErr = err
+			return
+		}
+		r.embeddedRepos = int32(count)
+	})
+
+	return r.embeddedRepos, r.embeddedStatsErr
 }
 
 func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsResolver, error) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1512,6 +1512,14 @@ type Query {
         """
         notIndexed: Boolean = true
         """
+        Include repositories that have embeddings.
+        """
+        embedded: Boolean = true
+        """
+        Include repositories that don't have embeddings.
+        """
+        notEmbedded: Boolean = true
+        """
         Include only repositories that have encountered errors when cloning or fetching
         """
         failedFetch: Boolean = false
@@ -8461,6 +8469,10 @@ type RepositoryStats {
     The number of repositories that are currently corrupt
     """
     corrupted: Int!
+    """
+    The number of repositories that have embeddings
+    """
+    embedded: Int!
 }
 
 """

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -664,6 +664,12 @@ type ReposListOptions struct {
 	// OnlyIndexed excludes repositories that are not indexed by zoekt from the list.
 	OnlyIndexed bool
 
+	// NoEmbedded excludes repositories that are embedded from the list.
+	NoEmbedded bool
+
+	// OnlyEmbedded excludes repositories that are not embedded from the list.
+	OnlyEmbedded bool
+
 	// CloneStatus if set will only return repos of that clone status.
 	CloneStatus types.CloneStatus
 
@@ -1049,6 +1055,12 @@ func (s *repoStore) listSQL(ctx context.Context, tr trace.Trace, opt ReposListOp
 	if opt.OnlyIndexed {
 		where = append(where, sqlf.Sprintf("zr.index_status = 'indexed'"))
 	}
+	if opt.NoEmbedded {
+		where = append(where, sqlf.Sprintf("embedded IS NULL"))
+	}
+	if opt.OnlyEmbedded {
+		where = append(where, sqlf.Sprintf("embedded IS NOT NULL"))
+	}
 
 	if opt.FailedFetch {
 		where = append(where, sqlf.Sprintf("gr.last_error IS NOT NULL"))
@@ -1154,6 +1166,11 @@ func (s *repoStore) listSQL(ctx context.Context, tr trace.Trace, opt ReposListOp
 	}
 	if opt.OnlyIndexed || opt.NoIndexed {
 		joins = append(joins, sqlf.Sprintf("JOIN zoekt_repos zr ON zr.repo_id = repo.id"))
+	}
+
+	if opt.NoEmbedded || opt.OnlyEmbedded {
+		embeddedRepoQuery := sqlf.Sprintf(embeddedReposQueryFmtstr)
+		joins = append(joins, sqlf.Sprintf("LEFT JOIN (%s) embedded on embedded.repo_id = id", embeddedRepoQuery))
 	}
 
 	if len(opt.KVPFilters) > 0 {
@@ -1273,6 +1290,10 @@ func containsOrderBySizeField(orderBy OrderBy) bool {
 	}
 	return false
 }
+
+const embeddedReposQueryFmtstr = `
+	SELECT DISTINCT ON (repo_id) repo_id, true embedded FROM repo_embedding_jobs WHERE state = 'completed' ORDER BY repo_id, finished_at DESC
+`
 
 const userReposCTEFmtstr = `
 SELECT repo_id as id FROM external_service_repos WHERE user_id = %d

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1292,7 +1292,7 @@ func containsOrderBySizeField(orderBy OrderBy) bool {
 }
 
 const embeddedReposQueryFmtstr = `
-	SELECT DISTINCT ON (repo_id) repo_id, true embedded FROM repo_embedding_jobs WHERE state = 'completed' ORDER BY repo_id, finished_at DESC
+	SELECT DISTINCT ON (repo_id) repo_id, true embedded FROM repo_embedding_jobs WHERE state = 'completed'
 `
 
 const userReposCTEFmtstr = `

--- a/internal/embeddings/background/repo/mocks_temp.go
+++ b/internal/embeddings/background/repo/mocks_temp.go
@@ -26,6 +26,9 @@ type MockRepoEmbeddingJobsStore struct {
 	// CountRepoEmbeddingJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method CountRepoEmbeddingJobs.
 	CountRepoEmbeddingJobsFunc *RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc
+	// CountRepoEmbeddingsFunc is an instance of a mock function object
+	// controlling the behavior of the method CountRepoEmbeddings.
+	CountRepoEmbeddingsFunc *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc
 	// CreateRepoEmbeddingJobFunc is an instance of a mock function object
 	// controlling the behavior of the method CreateRepoEmbeddingJob.
 	CreateRepoEmbeddingJobFunc *RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc
@@ -76,6 +79,11 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
 			defaultHook: func(context.Context, ListOpts) (r0 int, r1 error) {
+				return
+			},
+		},
+		CountRepoEmbeddingsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc{
+			defaultHook: func(context.Context) (r0 int, r1 error) {
 				return
 			},
 		},
@@ -152,6 +160,11 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CountRepoEmbeddingJobs")
 			},
 		},
+		CountRepoEmbeddingsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc{
+			defaultHook: func(context.Context) (int, error) {
+				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CountRepoEmbeddings")
+			},
+		},
 		CreateRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc{
 			defaultHook: func(context.Context, api.RepoID, api.CommitID) (int, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.CreateRepoEmbeddingJob")
@@ -220,6 +233,9 @@ func NewMockRepoEmbeddingJobsStoreFrom(i RepoEmbeddingJobsStore) *MockRepoEmbedd
 		},
 		CountRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFunc{
 			defaultHook: i.CountRepoEmbeddingJobs,
+		},
+		CountRepoEmbeddingsFunc: &RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc{
+			defaultHook: i.CountRepoEmbeddings,
 		},
 		CreateRepoEmbeddingJobFunc: &RepoEmbeddingJobsStoreCreateRepoEmbeddingJobFunc{
 			defaultHook: i.CreateRepoEmbeddingJob,
@@ -475,6 +491,115 @@ func (c RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall) Args() []interface
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RepoEmbeddingJobsStoreCountRepoEmbeddingJobsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc describes the behavior when
+// the CountRepoEmbeddings method of the parent MockRepoEmbeddingJobsStore
+// instance is invoked.
+type RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc struct {
+	defaultHook func(context.Context) (int, error)
+	hooks       []func(context.Context) (int, error)
+	history     []RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall
+	mutex       sync.Mutex
+}
+
+// CountRepoEmbeddings delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockRepoEmbeddingJobsStore) CountRepoEmbeddings(v0 context.Context) (int, error) {
+	r0, r1 := m.CountRepoEmbeddingsFunc.nextHook()(v0)
+	m.CountRepoEmbeddingsFunc.appendCall(RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall{v0, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CountRepoEmbeddings
+// method of the parent MockRepoEmbeddingJobsStore instance is invoked and
+// the hook queue is empty.
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) SetDefaultHook(hook func(context.Context) (int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CountRepoEmbeddings method of the parent MockRepoEmbeddingJobsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) PushHook(hook func(context.Context) (int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) SetDefaultReturn(r0 int, r1 error) {
+	f.SetDefaultHook(func(context.Context) (int, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) PushReturn(r0 int, r1 error) {
+	f.PushHook(func(context.Context) (int, error) {
+		return r0, r1
+	})
+}
+
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) nextHook() func(context.Context) (int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) appendCall(r0 RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall objects describing the
+// invocations of this function.
+func (f *RepoEmbeddingJobsStoreCountRepoEmbeddingsFunc) History() []RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall is an object that
+// describes an invocation of method CountRepoEmbeddings on an instance of
+// MockRepoEmbeddingJobsStore.
+type RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 int
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoEmbeddingJobsStoreCountRepoEmbeddingsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/embeddings/background/repo/store.go
+++ b/internal/embeddings/background/repo/store.go
@@ -548,14 +548,9 @@ WHERE
 `
 
 const countRepoEmbeddingsQuery = `
-SELECT COUNT(*) as count
-FROM (
-    SELECT DISTINCT ON (repo_id) repo_id
-    FROM repo_embedding_jobs
-    WHERE state = 'completed'
-    ORDER BY repo_id, finished_at DESC
-) subquery;
-
+SELECT COUNT(DISTINCT repo_id) AS count
+FROM repo_embedding_jobs
+WHERE state = 'completed';
 `
 
 func (s *repoEmbeddingJobsStore) CountRepoEmbeddings(ctx context.Context) (int, error) {


### PR DESCRIPTION
We show the number of embedded repos in the top-right of **Site-Admin > Repositories** and make it possible to filter repositories based on whether they have been embedded or not (click on number or select from status dropdown).

With the new filter, admins can now, for the first time, get an overview of the available embeddings.

![Kapture 2023-07-20 at 14 46 31](https://github.com/sourcegraph/sourcegraph/assets/26413131/59e53fdd-957f-49b6-8bf4-71478a10cb85)

Test plan:
- the implementation follows closely that for "indexed"
- I verified locally that the behavior of the filter and the count of embedded repos matches the expectation (see video)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
