### PR TITLE
local: fix a bug that prevented using the native ctags binary

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -7,7 +7,7 @@ set -eu
 
 # If CTAGS_COMMAND is set to a custom executable, we don't need to build the
 # image. See /dev/universal-ctags-dev.
-if [[ "${CTAGS_COMMAND}" != "dev/universal-ctags-dev" ]]; then
+if [[ "${CTAGS_COMMAND}" == "dev/universal-ctags-dev" ]]; then
   echo "CTAGS_COMMAND set to custom executable. Building of Docker image not necessary."
 else
   # Build ctags docker image for universal-ctags-dev

--- a/dev/ctags-install.sh
+++ b/dev/ctags-install.sh
@@ -39,7 +39,7 @@ trap 'rm -Rf \"$tmpdir\" &>/dev/null' EXIT
 
 function build_ctags {
   case "$OSTYPE" in
-    darwin*)  NUMCPUS=$(sysctl -n hw.ncpu);; 
+    darwin*)  NUMCPUS=$(sysctl -n hw.ncpu);;
     linux*)   NUMCPUS=$(grep -c '^processor' /proc/cpuinfo) ;;
     bsd*)     NUMCPUS=$(grep -c '^processor' /proc/cpuinfo) ;;
     *)        NUMCPUS="4" ;;
@@ -70,9 +70,9 @@ function build_ctags {
   cp ./ctags "$TARGET"
 }
 
-if [ ! -f "${TARGET}" ]; then 
+if [ ! -f "${TARGET}" ]; then
   echo "Installing universal-ctags $CTAGS_VERSION"
-  build_ctags 
+  build_ctags
 else
   echo "universal-ctags $CTAGS_VERSION is already available at $TARGET"
 fi

--- a/dev/universal-ctags-dev
+++ b/dev/universal-ctags-dev
@@ -10,13 +10,13 @@
 root="$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 TARGET=$("$root/dev/ctags-install.sh" which)
 
-if [ ! -f "${TARGET}" ]; then 
+if [ ! -f "${TARGET}" ]; then
   exec docker run --rm -i \
     -a stdin -a stdout -a stderr \
     --user guest \
     --name=universal-ctags-$$ \
     --entrypoint /usr/local/bin/universal-ctags \
     ctags "$@"
-else 
+else
   ${TARGET} "$@"
 fi


### PR DESCRIPTION
Fix a small typo that inverted a predicate and let to always build the docker container for ctags. 

Fixes https://github.com/sourcegraph/devx-support/issues/110

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

locally tested 