### PR TITLE
source: truncate hostname for repos regardless of how many slashes contained

### DIFF
--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -29,4 +29,9 @@ describe('displayRepoName', () => {
         const name = displayRepoName('gerrit.sgdev.org/sourcegraph')
         expect(name).toEqual('sourcegraph')
     })
+
+    test('returns repo name when code host information is unavailable', () => {
+        const name = displayRepoName('sourcegraph')
+        expect(name).toEqual('sourcegraph')
+    })
 })

--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -15,15 +15,18 @@ describe('RepoLink', () => {
 })
 
 describe('displayRepoName', () => {
-    test.each([
-        ['gerrit.sgdev.org/a/gabe/test', 'a/gabe/test'],
-        ['github.com/sourcegraph/sourcegraph', 'sourcegraph/sourcegraph'],
-        ['gerrit.sgdev.org/sourcegraph', 'sourcegraph'],
-        ['sourcegraph', 'sourcegraph'],
-        ['sourcegraph/sourcegraph', 'sourcegraph/sourcegraph'],
-        ['sg.exe/sourcegraph', 'sourcegraph'],
-    ])('should return repo name correctly', (repoName: string, result: string) => {
-        const name = displayRepoName(repoName)
-        expect(name).toEqual(result)
-    })
+    const testCases = [
+        { originalRepoName: 'gerrit.sgdev.org/a/gabe/test', repoDisplayName: 'a/gabe/test' },
+        { originalRepoName: 'github.com/sourcegraph/sourcegraph', repoDisplayName: 'sourcegraph/sourcegraph' },
+        { originalRepoName: 'gerrit.sgdev.org/sourcegraph', repoDisplayName: 'sourcegraph' },
+        { originalRepoName: 'sourcegraph', repoDisplayName: 'sourcegraph' },
+        { originalRepoName: 'sourcegraph/sourcegraph', repoDisplayName: 'sourcegraph/sourcegraph' },
+        { originalRepoName: 'sg.exe/sourcegraph', repoDisplayName: 'sourcegraph' },
+    ]
+
+    for (const { originalRepoName, repoDisplayName } of testCases) {
+        test(`displays ${repoDisplayName} for ${originalRepoName}`, () => {
+            expect(displayRepoName(originalRepoName)).toEqual(repoDisplayName)
+        })
+    }
 })

--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -15,23 +15,15 @@ describe('RepoLink', () => {
 })
 
 describe('displayRepoName', () => {
-    test('removes code host from repo name with >= 3 slashes', () => {
-        const name = displayRepoName('gerrit.sgdev.org/a/gabe/test')
-        expect(name).toEqual('a/gabe/test')
-    })
-
-    test('removes code host from repo name with 2 slashes', () => {
-        const name = displayRepoName('github.com/sourcegraph/sourcegraph')
-        expect(name).toEqual('sourcegraph/sourcegraph')
-    })
-
-    test('removes code host from repo name with one slash', () => {
-        const name = displayRepoName('gerrit.sgdev.org/sourcegraph')
-        expect(name).toEqual('sourcegraph')
-    })
-
-    test('returns repo name when code host information is unavailable', () => {
-        const name = displayRepoName('sourcegraph')
-        expect(name).toEqual('sourcegraph')
+    test.each([
+        ['gerrit.sgdev.org/a/gabe/test', 'a/gabe/test'],
+        ['github.com/sourcegraph/sourcegraph', 'sourcegraph/sourcegraph'],
+        ['gerrit.sgdev.org/sourcegraph', 'sourcegraph'],
+        ['sourcegraph', 'sourcegraph'],
+        ['sourcegraph/sourcegraph', 'sourcegraph/sourcegraph'],
+        ['sg.exe/sourcegraph', 'sourcegraph'],
+    ])('should return repo name correctly', (repoName: string, result: string) => {
+        const name = displayRepoName(repoName)
+        expect(name).toEqual(result)
     })
 })

--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 
-import { RepoLink } from './RepoLink'
+import { RepoLink, displayRepoName } from './RepoLink'
 
 describe('RepoLink', () => {
     test('renders a link when "to" is set', () => {
@@ -11,5 +11,22 @@ describe('RepoLink', () => {
     test('renders a fragment when "to" is null', () => {
         const component = render(<RepoLink repoName="my/repo" to={null} />)
         expect(component.asFragment()).toMatchSnapshot()
+    })
+})
+
+describe('displayRepoName', () => {
+    test('removes code host from repo name with >= 3 slashes', () => {
+        const name = displayRepoName('gerrit.sgdev.org/a/gabe/test')
+        expect(name).toEqual('a/gabe/test')
+    })
+
+    test('removes code host from repo name with 2 slashes', () => {
+        const name = displayRepoName('github.com/sourcegraph/sourcegraph')
+        expect(name).toEqual('sourcegraph/sourcegraph')
+    })
+
+    test('removes code host from repo name with one slash', () => {
+        const name = displayRepoName('gerrit.sgdev.org/sourcegraph')
+        expect(name).toEqual('sourcegraph')
     })
 })

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -8,7 +8,7 @@ import { LinkOrSpan } from '@sourcegraph/wildcard'
 export function displayRepoName(repoName: string): string {
     let parts = repoName.split('/')
     if (parts.length > 0 && parts[0].includes('.')) {
-        parts = parts.slice(1)
+        parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
     }
     return parts.join('/')
 }

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -7,8 +7,8 @@ import { LinkOrSpan } from '@sourcegraph/wildcard'
  */
 export function displayRepoName(repoName: string): string {
     let parts = repoName.split('/')
-    if (parts.length >= 3 && parts[0].includes('.')) {
-        parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
+    if (parts.length > 0 && parts[0].includes('.')) {
+        parts = parts.slice(1)
     }
     return parts.join('/')
 }

--- a/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
@@ -10,7 +10,7 @@ import { useOpenSearchResultsContext } from '../MatchHandlersContext'
  */
 export function displayRepoName(repoName: string): string {
     let parts = repoName.split('/')
-    if (parts.length >= 3 && parts[0].includes('.')) {
+    if (parts.length > 0 && parts[0].includes('.')) {
         parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
     }
     return parts.join('/')

--- a/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
+++ b/client/vscode/src/webview/search-panel/alias/RepoFileLink.tsx
@@ -1,20 +1,10 @@
 import * as React from 'react'
 
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { parseRepoRevision } from '@sourcegraph/shared/src/util/url'
 import { Button, Tooltip, useIsTruncated } from '@sourcegraph/wildcard'
 
 import { useOpenSearchResultsContext } from '../MatchHandlersContext'
-
-/**
- * Returns the friendly display form of the repository name (e.g., removing "github.com/").
- */
-export function displayRepoName(repoName: string): string {
-    let parts = repoName.split('/')
-    if (parts.length > 0 && parts[0].includes('.')) {
-        parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
-    }
-    return parts.join('/')
-}
 
 /**
  * Splits the repository name into the dir and base components.

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -62,7 +62,7 @@ export { type FetchFileParameters, fetchHighlightedFileLineRanges } from '@sourc
  */
 export function displayRepoName(repoName: string): string {
     let parts = repoName.split('/')
-    if (parts.length >= 3 && parts[0].includes('.')) {
+    if (parts.length > 0 && parts[0].includes('.')) {
         parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
     }
     return parts.join('/')


### PR DESCRIPTION
Closes [#54975](https://github.com/sourcegraph/sourcegraph/issues/54975)

I made an assumption here that the repository name will always be in the format `<hostname>/...`. That way we can assume that the repo name in the `displayRepoName` function will always contain at least one slash.

This P

| Before  | After  |
|---|---|
| <img width="954" alt="CleanShot 2023-07-20 at 13 58 30@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/79618455-cfee-48c2-9830-5dc6d68f104e">  | <img width="940" alt="CleanShot 2023-07-20 at 13 57 50@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/5e96750c-a3d5-4e26-a759-f89abe2ed277">  |

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Add a mix of repos to external services with multiple amounts of slashes. In my case, I added Gerrit repos in the `gerrit.sgdev.org` namespace.

```json
"GERRIT": [
    {
      "url": "https://gerrit.sgdev.org",
      "username": "bolaji.o",
      "password": "C/Y4afoDftfYr19aySlluPFbVXdDLLhOGPcdjGzBlw",
      "projects": [ // If not set, all projects on the Gerrit instance will be mirrored
        "src-cli",
        "gabe",
        "gabe/test",
        "beatrix",
        "a/gabe/repo"
      ]
    }
  ]
```

The repository names will be displayed properly without the instance name.
