### PR TITLE
nix: fix direnv hanging when starting postgres

### DIFF
--- a/dev/nix/start-postgres.sh
+++ b/dev/nix/start-postgres.sh
@@ -31,5 +31,5 @@ EOF
 fi
 if ! pg_isready --quiet; then
   echo 'Starting postgresql database...'
-  pg_ctl start -l "$PGHOST/log"
+  pg_ctl start -l "$PGHOST/log" 3>&-
 fi


### PR DESCRIPTION
See related issues: https://github.com/direnv/direnv/issues/755, https://discourse.nixos.org/t/devenv-sh-starting-postgres/24272/7, https://github.com/shelljs/shelljs/issues/770

Long-standing issue where on first-boot, direnv wouldnt return to the shell, forcing me to kill the shell and then cd into sg/sg again

## Test plan

NA/, nix stuff
