### PR TITLE
site-admin: fix spinner on repositories page

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -392,14 +392,22 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
                     }),
             })
         }
-        if (loading && !error) {
-            items.splice(0, 1, {
-                value: <LoadingSpinner />,
-                description: 'Repositories',
-            })
-        }
         return items
-    }, [data, setFilterValues, loading, error])
+    }, [data, setFilterValues])
+
+    const [showSpinner, setShowSpinner] = useState(false)
+
+    useEffect(() => {
+        if (loading) {
+            const timeout = setTimeout(() => {
+                setShowSpinner(true)
+            }, 300)
+
+            return () => clearTimeout(timeout)
+        }
+
+        return setShowSpinner(false)
+    }, [loading])
 
     return (
         <>
@@ -436,6 +444,11 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
                             variant="regular"
                         />
                     </div>
+                    {showSpinner && !error && (
+                        <div className="d-flex justify-content-center align-items-center ">
+                            <LoadingSpinner />
+                        </div>
+                    )}
                     <ul className="list-group list-group-flush mt-4">
                         {(connection?.nodes || []).map(node => (
                             <RepositoryNode key={node.id} node={node} />

--- a/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesContainer.tsx
@@ -406,7 +406,8 @@ export const SiteAdminRepositoriesContainer: React.FunctionComponent<{ alwaysPol
             return () => clearTimeout(timeout)
         }
 
-        return setShowSpinner(false)
+        setShowSpinner(false)
+        return
     }, [loading])
 
     return (


### PR DESCRIPTION
This fixes an anoying behavior of the spinner on the **Site-Admin > Repositories** page.

**Current**

![Kapture 2023-07-20 at 16 11 40](https://github.com/sourcegraph/sourcegraph/assets/26413131/9dbeffb9-be61-4b93-9492-2624a14d06ca)

The spinner instantly shows up while we are fetching content. Ignoring that the other numbers don't show the spinner, this might be fine for very large instances, where fetching takes time, but on instances like s2 this just leads to a flickering repositories count in the top-left corner.

**Fix**
We move the spinner down to the top of the repositories list and only show it if loading takes longer than 300ms.

![Kapture 2023-07-20 at 16 20 43](https://github.com/sourcegraph/sourcegraph/assets/26413131/41a1d485-c191-4108-83a6-cc9f3bca8cde)



## Test plan
I visually inspected the change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
