### PR TITLE
Smart search: handle fully qualified symbol names

### DIFF
--- a/internal/search/smartsearch/rules_test.go
+++ b/internal/search/smartsearch/rules_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hexops/autogold/v2"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
@@ -185,6 +186,25 @@ func Test_rewriteRepoFilter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("rewrite repo filter", func(t *testing.T) {
+			autogold.ExpectFile(t, autogold.Raw(test(c)))
+		})
+	}
+}
+
+func Test_fullyQualifiedSymbolPattern(t *testing.T) {
+	rule := []transform{fullyQualifiedSymbolPattern}
+	test := func(input string) string {
+		return apply(input, rule)
+	}
+
+	cases := []string{
+		`type:symbol com.example.Main`,
+		`type:symbol com.example Main`,
+		`type:symbol Main`,
+	}
+
+	for _, c := range cases {
+		t.Run("fully qualified symbol pattern", func(t *testing.T) {
 			autogold.ExpectFile(t, autogold.Raw(test(c)))
 		})
 	}

--- a/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern#01.golden
+++ b/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern#01.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "type:symbol com.example Main",
+  "Query": "DOES NOT APPLY"
+}

--- a/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern#02.golden
+++ b/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern#02.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "type:symbol Main",
+  "Query": "DOES NOT APPLY"
+}

--- a/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern.golden
+++ b/internal/search/smartsearch/testdata/Test_fullyQualifiedSymbolPattern/fully_qualified_symbol_pattern.golden
@@ -1,0 +1,4 @@
+{
+  "Input": "type:symbol com.example.Main",
+  "Query": "type:symbol com.example Main"
+}


### PR DESCRIPTION
Previously, the query `type:symbol com.example.Main` didn't return results even if there was a symbol that has the fully qualified name `com.example.Main`. In our symbol backend, we store the "containerName" `com.example` and "name" `Main` separately so it should be technically possible to find the symbol by fully qualified name.

This commit fixes the problem by adding a smart search rule that takes fully qualified symbol names and infers the correct syntax to search for the container name. The current implementation only works for some languages where the container name is declared in the contents of the file. Ideally, the search syntax should have a filter for containerName directly so that we can target it precisely including in languages like Go or Python where the package name is implicit from the file path.


## Test plan

See updated unit test.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
