### PR TITLE
enable code insights in sg start enterprise

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1022,6 +1022,9 @@ commandsets:
       - zoekt-web-1
       - blobstore
       - embeddings
+    env:
+      DISABLE_CODE_INSIGHTS_HISTORICAL: false
+      DISABLE_CODE_INSIGHTS: false
 
   enterprise-e2e:
     <<: *enterprise_set


### PR DESCRIPTION
This was excluded for historical reasons that no longer apply. This will reduce confusion when people try to start code insights locally.

## Test plan

Code Insights starts with `sg start enterprise`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
