### PR TITLE
cody-gateway: instrument upstream requests with UpDownCounter

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/BUILD.bazel
@@ -33,6 +33,5 @@ go_library(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_metric//:metric",
-        "@org_uber_go_atomic//:atomic",
     ],
 )


### PR DESCRIPTION
For the most part we're seeing lower-than-expected concurrent requests reported by the metric, I think we want to use UpDownCounter instead - concurrent bag items is explicitly listed as a use case: https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter

## Test plan

Same as https://github.com/sourcegraph/sourcegraph/pull/55134
