### PR TITLE
Use `conf.EmailSenderName` when rendering email

### DIFF
--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -101,7 +101,7 @@ func Send(ctx context.Context, source string, message Message) (err error) {
 		emailSendCounter.WithLabelValues(strconv.FormatBool(err == nil), source).Inc()
 	}()
 
-	m, err := render(config.EmailAddress, config.EmailSenderName, message)
+	m, err := render(config.EmailAddress, conf.EmailSenderName(), message)
 	if err != nil {
 		return errors.Wrap(err, "render")
 	}


### PR DESCRIPTION
This is a follow-up to #55139 and _actually_ uses the new value I added.


## Test plan

- N/A