### PR TITLE
gitserver: add recording for missed git commands.

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -886,7 +886,7 @@ func TestCloneRepoRecordsFailures(t *testing.T) {
 			name: "Not cloneable",
 			getVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
 				m := NewMockVCSSyncer()
-				m.IsCloneableFunc.SetDefaultHook(func(ctx context.Context, url *vcs.URL) error {
+				m.IsCloneableFunc.SetDefaultHook(func(context.Context, api.RepoName, *vcs.URL) error {
 					return errors.New("not_cloneable")
 				})
 				return m, nil

--- a/cmd/gitserver/server/vcs_packages_syncer.go
+++ b/cmd/gitserver/server/vcs_packages_syncer.go
@@ -67,7 +67,7 @@ type dependenciesService interface {
 	IsPackageRepoVersionAllowed(ctx context.Context, scheme string, pkg reposource.PackageName, version string) (allowed bool, err error)
 }
 
-func (s *vcsPackagesSyncer) IsCloneable(ctx context.Context, repoUrl *vcs.URL) error {
+func (s *vcsPackagesSyncer) IsCloneable(_ context.Context, _ api.RepoName, _ *vcs.URL) error {
 	return nil
 }
 

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -16,7 +16,7 @@ type VCSSyncer interface {
 	Type() string
 	// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
 	// error indicates there is a problem.
-	IsCloneable(ctx context.Context, remoteURL *vcs.URL) error
+	IsCloneable(ctx context.Context, repoName api.RepoName, remoteURL *vcs.URL) error
 	// CloneCommand returns the command to be executed for cloning from remote.
 	CloneCommand(ctx context.Context, remoteURL *vcs.URL, tmpPath string) (cmd *exec.Cmd, err error)
 	// Fetch tries to fetch updates from the remote to given directory.

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -28,7 +28,7 @@ func (s *gitRepoSyncer) Type() string {
 }
 
 // IsCloneable checks to see if the Git remote URL is cloneable.
-func (s *gitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
+func (s *gitRepoSyncer) IsCloneable(ctx context.Context, repoName api.RepoName, remoteURL *vcs.URL) error {
 	if isAlwaysCloningTestRemoteURL(remoteURL) {
 		return nil
 	}
@@ -41,7 +41,7 @@ func (s *gitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) err
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := runRemoteGitCommand(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd), true, nil)
+	out, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd), true, nil)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = ctxerr

--- a/cmd/gitserver/server/vcs_syncer_mock_test.go
+++ b/cmd/gitserver/server/vcs_syncer_mock_test.go
@@ -52,7 +52,7 @@ func NewMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		IsCloneableFunc: &VCSSyncerIsCloneableFunc{
-			defaultHook: func(context.Context, *vcs.URL) (r0 error) {
+			defaultHook: func(context.Context, api.RepoName, *vcs.URL) (r0 error) {
 				return
 			},
 		},
@@ -84,7 +84,7 @@ func NewStrictMockVCSSyncer() *MockVCSSyncer {
 			},
 		},
 		IsCloneableFunc: &VCSSyncerIsCloneableFunc{
-			defaultHook: func(context.Context, *vcs.URL) error {
+			defaultHook: func(context.Context, api.RepoName, *vcs.URL) error {
 				panic("unexpected invocation of MockVCSSyncer.IsCloneable")
 			},
 		},
@@ -353,24 +353,24 @@ func (c VCSSyncerFetchFuncCall) Results() []interface{} {
 // VCSSyncerIsCloneableFunc describes the behavior when the IsCloneable
 // method of the parent MockVCSSyncer instance is invoked.
 type VCSSyncerIsCloneableFunc struct {
-	defaultHook func(context.Context, *vcs.URL) error
-	hooks       []func(context.Context, *vcs.URL) error
+	defaultHook func(context.Context, api.RepoName, *vcs.URL) error
+	hooks       []func(context.Context, api.RepoName, *vcs.URL) error
 	history     []VCSSyncerIsCloneableFuncCall
 	mutex       sync.Mutex
 }
 
 // IsCloneable delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockVCSSyncer) IsCloneable(v0 context.Context, v1 *vcs.URL) error {
-	r0 := m.IsCloneableFunc.nextHook()(v0, v1)
-	m.IsCloneableFunc.appendCall(VCSSyncerIsCloneableFuncCall{v0, v1, r0})
+func (m *MockVCSSyncer) IsCloneable(v0 context.Context, v1 api.RepoName, v2 *vcs.URL) error {
+	r0 := m.IsCloneableFunc.nextHook()(v0, v1, v2)
+	m.IsCloneableFunc.appendCall(VCSSyncerIsCloneableFuncCall{v0, v1, v2, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the IsCloneable method
 // of the parent MockVCSSyncer instance is invoked and the hook queue is
 // empty.
-func (f *VCSSyncerIsCloneableFunc) SetDefaultHook(hook func(context.Context, *vcs.URL) error) {
+func (f *VCSSyncerIsCloneableFunc) SetDefaultHook(hook func(context.Context, api.RepoName, *vcs.URL) error) {
 	f.defaultHook = hook
 }
 
@@ -378,7 +378,7 @@ func (f *VCSSyncerIsCloneableFunc) SetDefaultHook(hook func(context.Context, *vc
 // IsCloneable method of the parent MockVCSSyncer instance invokes the hook
 // at the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *VCSSyncerIsCloneableFunc) PushHook(hook func(context.Context, *vcs.URL) error) {
+func (f *VCSSyncerIsCloneableFunc) PushHook(hook func(context.Context, api.RepoName, *vcs.URL) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -387,19 +387,19 @@ func (f *VCSSyncerIsCloneableFunc) PushHook(hook func(context.Context, *vcs.URL)
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *VCSSyncerIsCloneableFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, *vcs.URL) error {
+	f.SetDefaultHook(func(context.Context, api.RepoName, *vcs.URL) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *VCSSyncerIsCloneableFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, *vcs.URL) error {
+	f.PushHook(func(context.Context, api.RepoName, *vcs.URL) error {
 		return r0
 	})
 }
 
-func (f *VCSSyncerIsCloneableFunc) nextHook() func(context.Context, *vcs.URL) error {
+func (f *VCSSyncerIsCloneableFunc) nextHook() func(context.Context, api.RepoName, *vcs.URL) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -437,7 +437,10 @@ type VCSSyncerIsCloneableFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 *vcs.URL
+	Arg1 api.RepoName
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 *vcs.URL
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -446,7 +449,7 @@ type VCSSyncerIsCloneableFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c VCSSyncerIsCloneableFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -69,7 +69,7 @@ func (s *PerforceDepotSyncer) Type() string {
 }
 
 // IsCloneable checks to see if the Perforce remote URL is cloneable.
-func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, remoteURL *vcs.URL) error {
+func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, _ api.RepoName, remoteURL *vcs.URL) error {
 	username, password, host, path, err := decomposePerforceRemoteURL(remoteURL)
 	if err != nil {
 		return errors.Wrap(err, "decompose")

--- a/dev/linters/unparam/BUILD.bazel
+++ b/dev/linters/unparam/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//dev/linters/nolint",
-        "@cc_mvdan_unparam//check:go_default_library",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/analysis/passes/buildssa",
         "@org_golang_x_tools//go/packages",

--- a/dev/linters/unparam/BUILD.bazel
+++ b/dev/linters/unparam/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//dev/linters/nolint",
+        "@cc_mvdan_unparam//check:go_default_library",
         "@org_golang_x_tools//go/analysis",
         "@org_golang_x_tools//go/analysis/passes/buildssa",
         "@org_golang_x_tools//go/packages",

--- a/internal/gitserver/adapters/BUILD.bazel
+++ b/internal/gitserver/adapters/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//internal/api",
         "//internal/gitserver/gitdomain",
         "//internal/gitserver/protocol",
+        "//internal/wrexec",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/internal/gitserver/adapters/git.go
+++ b/internal/gitserver/adapters/git.go
@@ -7,24 +7,32 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type Git struct {
-	ReposDir string // The root directory where repos are stored
+	// ReposDir is the root directory where repos are stored.
+	ReposDir string
+	// RecordingCommandFactory is a factory that creates recordable commands by
+	// wrapping os/exec.Commands. The factory creates recordable commands with a set
+	// predicate, which is used to determine whether a particular command should be
+	// recorded or not.
+	RecordingCommandFactory *wrexec.RecordingCommandFactory
 }
 
 // RevParse will run rev-parse on the given rev
 func (g *Git) RevParse(ctx context.Context, repo api.RepoName, rev string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", rev)
 	cmd.Dir = repoDir(repo, g.ReposDir)
-
-	out, err := cmd.CombinedOutput()
+	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
+	out, err := wrappedCmd.CombinedOutput()
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, out))
+		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))
 	}
 
 	return string(out), nil
@@ -34,10 +42,10 @@ func (g *Git) RevParse(ctx context.Context, repo api.RepoName, rev string) (stri
 func (g *Git) GetObjectType(ctx context.Context, repo api.RepoName, objectID string) (gitdomain.ObjectType, error) {
 	cmd := exec.CommandContext(ctx, "git", "cat-file", "-t", "--", objectID)
 	cmd.Dir = repoDir(repo, g.ReposDir)
-
-	out, err := cmd.CombinedOutput()
+	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
+	out, err := wrappedCmd.CombinedOutput()
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, out))
+		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))
 	}
 
 	objectType := gitdomain.ObjectType(bytes.TrimSpace(out))

--- a/internal/gitserver/adapters/git.go
+++ b/internal/gitserver/adapters/git.go
@@ -29,7 +29,7 @@ type Git struct {
 func (g *Git) RevParse(ctx context.Context, repo api.RepoName, rev string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", rev)
 	cmd.Dir = repoDir(repo, g.ReposDir)
-	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
+	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repo, cmd)
 	out, err := wrappedCmd.CombinedOutput()
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))
@@ -42,7 +42,7 @@ func (g *Git) RevParse(ctx context.Context, repo api.RepoName, rev string) (stri
 func (g *Git) GetObjectType(ctx context.Context, repo api.RepoName, objectID string) (gitdomain.ObjectType, error) {
 	cmd := exec.CommandContext(ctx, "git", "cat-file", "-t", "--", objectID)
 	cmd.Dir = repoDir(repo, g.ReposDir)
-	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
+	wrappedCmd := g.RecordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repo, cmd)
 	out, err := wrappedCmd.CombinedOutput()
 	if err != nil {
 		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))

--- a/internal/gitserver/gitdomain/services_test.go
+++ b/internal/gitserver/gitdomain/services_test.go
@@ -123,5 +123,4 @@ func TestGetObjectService(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -74,7 +74,9 @@ func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult
 			continue
 		}
 		syncer := server.PerforceDepotSyncer{}
-		if err := syncer.IsCloneable(ctx, p4Url); err == nil {
+		// We don't need to provide repo name and use "" instead because p4 commands are
+		// not recorded in the following `syncer.IsCloneable` call.
+		if err := syncer.IsCloneable(ctx, "", p4Url); err == nil {
 			results <- SourceResult{Source: s, Repo: s.makeRepo(depot)}
 		} else {
 			results <- SourceResult{Source: s, Err: err}


### PR DESCRIPTION
Test plan:
CI.
Commands are wrapped in a same way as previously, so they will work.

Closes https://github.com/sourcegraph/sourcegraph/issues/55101