### PR TITLE
gitserver: Use address lookup cache conditionally 

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -267,9 +267,17 @@ func (g *GitserverAddresses) AddrForRepo(ctx context.Context, logger log.Logger,
 		return getRepoAddress(repoName)
 	}
 
-	if addr := g.getCachedRepoAddress(repoName); addr != "" {
-		addrForRepoCacheHit.WithLabelValues(userAgent).Inc()
-		return addr
+	expConf := conf.ExperimentalFeatures()
+
+	// Only skip the cache lookup if the config is explicitly set to false. While we may skip the
+	// cache lookup, our return path below always updates the cache. This ensures that when we
+	// enable the flag, the existing cache can be used immediately without waiting to prepopulate
+	// for repositories that may already have been looked up once in the TTL window of the cache.
+	if expConf.UseGitserverAddressLookupCache == nil || *expConf.UseGitserverAddressLookupCache == true {
+		if addr := g.getCachedRepoAddress(repoName); addr != "" {
+			addrForRepoCacheHit.WithLabelValues(userAgent).Inc()
+			return addr
+		}
 	}
 
 	addrForRepoCacheMiss.WithLabelValues(userAgent).Inc()

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -269,7 +269,7 @@ func (g *GitserverAddresses) AddrForRepo(ctx context.Context, logger log.Logger,
 
 	expConf := conf.ExperimentalFeatures()
 
-	// Always check the cache and only skip it the config is explicitly set to false. While we may
+	// Always check the cache and only skip it if the config is explicitly set to false. While we may
 	// skip the cache lookup, our return path below always updates the cache. This ensures that when
 	// we enable the flag, the existing cache can be used immediately without waiting to prepopulate
 	// for repositories that may already have been looked up once in the TTL window of the cache.

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -269,11 +269,11 @@ func (g *GitserverAddresses) AddrForRepo(ctx context.Context, logger log.Logger,
 
 	expConf := conf.ExperimentalFeatures()
 
-	// Only skip the cache lookup if the config is explicitly set to false. While we may skip the
-	// cache lookup, our return path below always updates the cache. This ensures that when we
-	// enable the flag, the existing cache can be used immediately without waiting to prepopulate
+	// Always check the cache and only skip it the config is explicitly set to false. While we may
+	// skip the cache lookup, our return path below always updates the cache. This ensures that when
+	// we enable the flag, the existing cache can be used immediately without waiting to prepopulate
 	// for repositories that may already have been looked up once in the TTL window of the cache.
-	if expConf.UseGitserverAddressLookupCache == nil || *expConf.UseGitserverAddressLookupCache == true {
+	if expConf.UseGitserverAddressLookupCache == nil || *expConf.UseGitserverAddressLookupCache {
 		if addr := g.getCachedRepoAddress(repoName); addr != "" {
 			addrForRepoCacheHit.WithLabelValues(userAgent).Inc()
 			return addr

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -887,8 +887,10 @@ type ExperimentalFeatures struct {
 	StructuralSearch   string              `json:"structuralSearch,omitempty"`
 	SubRepoPermissions *SubRepoPermissions `json:"subRepoPermissions,omitempty"`
 	// TlsExternal description: Global TLS/SSL settings for Sourcegraph to use when communicating with code hosts.
-	TlsExternal *TlsExternal   `json:"tls.external,omitempty"`
-	Additional  map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
+	TlsExternal *TlsExternal `json:"tls.external,omitempty"`
+	// UseGitserverAddressLookupCache description: (Internal development only) Short lived experimental flag to test the effect of caching vs no caching of repo address lookup
+	UseGitserverAddressLookupCache *bool          `json:"useGitserverAddressLookupCache,omitempty"`
+	Additional                     map[string]any `json:"-"` // additionalProperties not explicitly defined in the schema
 }
 
 func (v ExperimentalFeatures) MarshalJSON() ([]byte, error) {
@@ -952,6 +954,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "structuralSearch")
 	delete(m, "subRepoPermissions")
 	delete(m, "tls.external")
+	delete(m, "useGitserverAddressLookupCache")
 	if len(m) > 0 {
 		v.Additional = make(map[string]any, len(m))
 	}

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -125,6 +125,14 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "useGitserverAddressLookupCache": {
+          "description": "(Internal development only) Short lived experimental flag to test the effect of caching vs no caching of repo address lookup",
+          "type": "boolean",
+          "default": true,
+          "!go": {
+            "pointer": true
+          }
+        },
         "rateLimitAnonymous": {
           "description": "Configures the hourly rate limits for anonymous calls to the GraphQL API. Setting limit to 0 disables the limiter. This is only relevant if unauthenticated calls to the API are permitted.",
           "type": "integer",


### PR DESCRIPTION
Part of #54741 and follow up on #55001.

## What 

In this PR we make two changes:

1. Add a new site config `experimentalFeatures.useGitserverAddressLookupCache`
2. Use the site config to bypass the cache if it is explicitly set to `false

## Why

In #55001 we added DB reads to the repository address lookup code along with a cache to support git deduplication in the future. We want to test the impact on a production instance with and without the cache.

On the left we have the cache miss metric and on the right the cache hit metric. Notice how the cache hit metric starts trending down to 0 only after I set `false` in the config explicitly.

<img width="2183" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/2682729/25b38c26-f79d-48f6-926d-e064d5758b2c">

And again notice how the cache hits start showing up again and the cache miss has more or less stopped showing up after I removed the config after some time.

<img width="2249" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/2682729/9500a184-6975-43df-8820-eb0642eef232">

Simulated this by triggering address lookup like visiting a repo and triggering repo refresh from the UI.


## Test plan

- Tested manually (see above)
- CI should pass

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
