### PR TITLE
authz resolvers: fix nil panic when 0 users are authorized

### DIFF
--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -62,13 +62,14 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, *g
 					break
 				}
 			}
-			if len(idSubset) == 0 {
-				// r.after is set, but there are no elements larger than it, so return empty slice.
-				r.users = []*types.User{}
-				r.pageInfo = graphqlutil.HasNextPage(false)
-				return
-			}
 		}
+
+		if len(idSubset) == 0 {
+			r.users = []*types.User{}
+			r.pageInfo = graphqlutil.HasNextPage(false)
+			return
+		}
+
 		// If we have more ids than we need, trim them
 		if int32(len(idSubset)) > r.first {
 			idSubset = idSubset[:r.first]


### PR DESCRIPTION
This fixes a nil panic reported in #39763.

When 0 users have access to a repository, this would panic in `(r *userConnectionResolver) compute(ctx context.Context)`.

The fix here is just moving the defensive check out of the condition so it applies regardless of whether an `after` is set or not.

I reworked the tests so I can inject how many users have access.

## Test plan

- Manual testing
- New unit test
