### PR TITLE
grafana: remove duplicated dashboard for gitserver

### DIFF
--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5058,27 +5058,6 @@ Query: `sum by (op,extended_mode)(increase(src_insights_aggregations_errors_tota
 
 To see this dashboard, visit `/-/debug/grafana/d/gitserver/gitserver` on your Sourcegraph instance.
 
-#### gitserver: memory_working_set
-
-<p class="subtitle">Memory working set</p>
-
-
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100000` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (container_label_io_kubernetes_pod_name) (container_memory_working_set_bytes{container_label_io_kubernetes_container_name="gitserver", container_label_io_kubernetes_pod_name=~`${shard:regex}`})`
-
-</details>
-
-<br />
-
 #### gitserver: go_routines
 
 <p class="subtitle">Go routines</p>
@@ -5087,7 +5066,7 @@ Query: `sum by (container_label_io_kubernetes_pod_name) (container_memory_workin
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100001` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100000` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -45,18 +45,6 @@ func GitServer() *monitoring.Dashboard {
 				Rows: []monitoring.Row{
 					{
 						{
-							Name:        "memory_working_set",
-							Description: "memory working set",
-							Query:       "sum by (container_label_io_kubernetes_pod_name) (container_memory_working_set_bytes{container_label_io_kubernetes_container_name=\"gitserver\", container_label_io_kubernetes_pod_name=~`${shard:regex}`})",
-							NoAlert:     true,
-							Panel: monitoring.Panel().LegendFormat("{{container_label_io_kubernetes_pod_name}}").
-								Unit(monitoring.Bytes).
-								With(monitoring.PanelOptions.LegendOnRight()),
-							Owner: monitoring.ObservableOwnerSource,
-							Interpretation: `
-						`,
-						},
-						{
 							Name:        "go_routines",
 							Description: "go routines",
 							Query:       "go_goroutines{app=\"gitserver\", instance=~`${shard:regex}`}",


### PR DESCRIPTION
This fixes #44466 by removing a duplicate dashboard. As described in the ticket, this is already covered in the normal container dashboards.

Question: how do I regenerate the dashboards?

## Test plan

- N/A
