### PR TITLE
local: hotfix ctags mess with symbols

### DIFF
--- a/cmd/symbols/build-ctags.sh
+++ b/cmd/symbols/build-ctags.sh
@@ -7,15 +7,26 @@ set -eu
 
 # If CTAGS_COMMAND is set to a custom executable, we don't need to build the
 # image. See /dev/universal-ctags-dev.
-if [[ "${CTAGS_COMMAND}" == "dev/universal-ctags-dev" ]]; then
+
+if [[ "${CTAGS_COMMAND}" != "dev/universal-ctags-dev" ]]; then
   echo "CTAGS_COMMAND set to custom executable. Building of Docker image not necessary."
 else
-  # Build ctags docker image for universal-ctags-dev
-  echo "Building universal-ctags docker image"
-  docker build -f cmd/symbols/Dockerfile -t ctags . \
-    --platform linux/amd64 \
-    --target=ctags \
-    --progress=plain
+  # Check if we need to build the image or not
+  TARGET=$("./dev/ctags-install.sh" which)
+
+  if [ ! -f "${TARGET}" ]; then
+    echo "CTAGS_COMMAND is not yet available. Building docker container."
+    echo "You can speed up this command by running ./dev/ctags-install."
+
+    # Build ctags docker image for universal-ctags-dev
+    echo "Building universal-ctags docker image"
+    docker build -f cmd/symbols/Dockerfile -t ctags . \
+      --platform linux/amd64 \
+      --target=ctags \
+      --progress=plain
+  else
+    echo "Found prebuilt universal-ctags binary"
+  fi
 fi
 
 # If SCIP_CTAGS_COMMAND is set to a custom executable, we don't need to build the
@@ -23,16 +34,25 @@ fi
 if [[ "${SCIP_CTAGS_COMMAND}" != "dev/scip-ctags-dev" ]]; then
   echo "SCIP_CTAGS_COMMAND set to custom executable. Building of Docker image or Rust code not necessary."
 else
-  if [[ "$(uname -m)" == "arm64" ]]; then
-    # build ctags with cargo; prevent x86-64 slowdown on mac
-    root="$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null
-    "$root"/dev/scip-ctags-install.sh
+  # Check if we need to build the image or not
+  TARGET=$("./dev/scip-ctags-install.sh" which)
+  if [ ! -f "${TARGET}" ]; then
+    echo "SCIP_CTAGS_COMMAND is not yet available. Building docker container."
+    echo "You can speed up this command by running ./dev/ctags-install."
+
+    if [[ "$(uname -m)" == "arm64" ]]; then
+      # build ctags with cargo; prevent x86-64 slowdown on mac
+      root="$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null
+      "$root"/dev/scip-ctags-install.sh
+    else
+      # Build ctags docker image for scip-ctags-dev
+      echo "Building scip-ctags docker image"
+      docker build -f cmd/symbols/Dockerfile -t scip-ctags . \
+        --platform linux/amd64 \
+        --target=scip-ctags \
+        --progress=plain
+    fi
   else
-    # Build ctags docker image for scip-ctags-dev
-    echo "Building scip-ctags docker image"
-    docker build -f cmd/symbols/Dockerfile -t scip-ctags . \
-      --platform linux/amd64 \
-      --target=scip-ctags \
-      --progress=plain
+    echo "Found prebuilt scip-ctags binary"
   fi
 fi


### PR DESCRIPTION
This stuff is really messy, but this will at least unblock folks using ctags command. 

@davejrt is going to make this bunch of scripts completely irrelevant by getting Bazel to fetch the universal ctags binary as part of our Q3 effort to rework local env to use Bazel more. 

So, with that in mind, this PR is really the dumbest fix possible for the time being. Honnestly these scripts are messy, and should be deleted entirely anyway. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 