### PR TITLE
JetBrains: Cody: Fix mouse wheel scrolling and manual mouse drag in the chat

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Improved the auto-scrolling of the Cody chat [#55150](https://github.com/sourcegraph/sourcegraph/pull/55150)
+- Fixed mouse wheel and mouse drag scrolling in the Cody chat [#55199](https://github.com/sourcegraph/sourcegraph/pull/55199)
+
 ### Security
 
 ## [3.0.7]

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -18,7 +18,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.IconUtil;
@@ -32,6 +31,7 @@ import com.sourcegraph.cody.chat.AssistantMessageWithSettingsButton;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatBubble;
 import com.sourcegraph.cody.chat.ChatMessage;
+import com.sourcegraph.cody.chat.ChatScrollPane;
 import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.Interaction;
 import com.sourcegraph.cody.chat.Transcript;
@@ -67,7 +67,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.*;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -144,28 +143,7 @@ public class CodyToolWindowContent implements UpdatableChat {
 
     // Chat panel
     messagesPanel.setLayout(new VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, true));
-    JBScrollPane chatPanel =
-        new JBScrollPane(
-            messagesPanel,
-            JBScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-            JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-    chatPanel.setBorder(BorderFactory.createEmptyBorder());
-
-    // Scroll all the way down after each message
-    chatPanel
-        .getVerticalScrollBar()
-        .addAdjustmentListener(
-            e ->
-                Optional.ofNullable(e.getSource())
-                    .filter(source -> source instanceof JScrollBar)
-                    .map(source -> (JScrollBar) source)
-                    .flatMap(scrollBar -> Optional.ofNullable(scrollBar.getModel()))
-                    // don't adjust if the user is himself scrolling
-                    .filter(brm -> !brm.getValueIsAdjusting())
-                    // only adjust if the scroll isn't at the bottom already
-                    .filter(brm -> brm.getValue() + brm.getExtent() != brm.getMaximum())
-                    // if all the above conditions are met, adjust the scroll to the bottom
-                    .ifPresent(brm -> brm.setValue(brm.getMaximum())));
+    ChatScrollPane chatPanel = new ChatScrollPane(messagesPanel);
 
     // Controls panel
     JPanel controlsPanel = new JPanel();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatScrollPane.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/chat/ChatScrollPane.java
@@ -1,0 +1,54 @@
+package com.sourcegraph.cody.chat;
+
+import com.intellij.ui.components.JBScrollPane;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.swing.*;
+
+public class ChatScrollPane extends JBScrollPane {
+  AtomicBoolean wasMouseWheelScrolled = new AtomicBoolean(false);
+  AtomicBoolean wasScrollBarDragged = new AtomicBoolean(false);
+
+  public ChatScrollPane(JPanel messagesPanel) {
+    super(
+        messagesPanel,
+        JBScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+        JBScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+    this.setBorder(BorderFactory.createEmptyBorder());
+    // this hack allows us to guess if an adjustment event isn't caused by the user mouse wheel
+    // scrolling and drag scrolling;
+    // we need to do that, as AdjustmentEvent doesn't account for the mouse wheel/drag scroll,
+    // and we don't want to rob the user of those
+    this.addMouseWheelListener(e -> wasMouseWheelScrolled.set(true));
+    // Scroll all the way down after each message
+    JScrollBar chatPanelVerticalScrollBar = this.getVerticalScrollBar();
+    chatPanelVerticalScrollBar.addMouseListener(
+        new MouseAdapter() {
+          @Override
+          public void mousePressed(MouseEvent e) {
+            wasScrollBarDragged.set(true);
+          }
+
+          @Override
+          public void mouseReleased(MouseEvent e) {
+            wasScrollBarDragged.set(false);
+          }
+        });
+    chatPanelVerticalScrollBar.addAdjustmentListener(
+        e ->
+            Optional.ofNullable(e.getSource())
+                .filter(source -> source instanceof JScrollBar)
+                .map(source -> (JScrollBar) source)
+                .flatMap(scrollBar -> Optional.ofNullable(scrollBar.getModel()))
+                // don't adjust if the user is himself scrolling
+                .filter(brm -> !brm.getValueIsAdjusting())
+                .filter(source -> !wasMouseWheelScrolled.getAndSet(false))
+                .filter(source -> !wasScrollBarDragged.getAndSet(false))
+                // only adjust if the scroll isn't at the bottom already
+                .filter(brm -> brm.getValue() + brm.getExtent() != brm.getMaximum())
+                // if all the above conditions are met, adjust the scroll to the bottom
+                .ifPresent(brm -> brm.setValue(brm.getMaximum())));
+  }
+}


### PR DESCRIPTION
This cleans the errors I accidentally introduced in https://github.com/sourcegraph/sourcegraph/pull/55150

By fixing the auto-scrolling I broke the manual wheel scroll and mouse drag.
They should be working, an `AdjustmentEvent`'s `getValueIsAdjusting` is supposed to give you information whether an event is caused by the  user or the system. 
However, in the beautiful world of Swing, all data is suspect.

I did not find any by-design way of pairing adjustment events and mouse wheel scroll / mouse motion events.
It seems there just isn't one from a `JBScrollPane`'s perspective.
If anyone finds a better way, be welcome to override the changes from this PR.

What I'm doing instead is trying to guess that an adjustment event happening immediately after a mouse wheel event or a mouse drag event is probably caused by the user - and should thus be ignored by the adjustment listener.

The result looks like this:
https://github.com/sourcegraph/sourcegraph/assets/18601388/07a1d0c3-1786-478b-9a4b-1f3efc840cda

This is, in fact, an inversion of the old `needsScrollingDown` flag hack we had before, where we tried to guess which plugin events would need the chat to actually be scrolled down.
However, there's just too much stuff happening in the chat UI to keep track of it, so if we are to have a hack like this, I'd rather filter user events than plugin events.

## Test plan

- green CI 🟢 
- mouse wheel works for the chat scroll
- mouse drag works for the chat scroll
