### PR TITLE
sg: ease transition to bazel handled go:generate

### DIFF
--- a/dev/sg/internal/generate/generate.go
+++ b/dev/sg/internal/generate/generate.go
@@ -34,10 +34,10 @@ type Target struct {
 // RunScript runs the given script from the root of sourcegraph/sourcegraph.
 // If arguments are to be to passed down the script, they should be incorporated
 // in the script variable.
-func RunScript(header string, script string) Runner {
+func RunScript(command string) Runner {
 	return func(ctx context.Context, args []string) *Report {
 		start := time.Now()
-		out, err := run.BashInRoot(ctx, script, nil)
+		out, err := run.BashInRoot(ctx, command, nil)
 		return &Report{
 			Output:   out,
 			Err:      err,

--- a/dev/sg/internal/generate/golang/golang.go
+++ b/dev/sg/internal/generate/golang/golang.go
@@ -49,6 +49,13 @@ func Generate(ctx context.Context, args []string, progressBar bool, verbosity Ou
 		reportOut = std.NewOutput(&sb, false)
 	)
 
+	// Run bazel run //dev:write_all_generated, but only in local
+	if os.Getenv("CI") != "true" {
+		if report := generate.RunScript("bazel run //dev:write_all_generated")(ctx, args); report.Err != nil {
+			return report
+		}
+	}
+
 	// Run go generate [./...]
 	if err := runGoGenerate(ctx, args, progressBar, verbosity, reportOut, &sb); err != nil {
 		return &generate.Report{Output: sb.String(), Err: err}

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1,6 +1,6 @@
 # Alerts reference
 
-<!-- DO NOT EDIT: generated via: 'RELOAD=false sg run monitoring-generator' -->
+<!-- DO NOT EDIT: generated via: bazel run //dev:write_all_generated -->
 
 This document contains a complete reference of all alerts in Sourcegraph's monitoring, and next steps for when you find alerts that are firing.
 If your alert isn't mentioned here, or if the next steps don't help, [contact us](mailto:support@sourcegraph.com) for assistance.

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -1,6 +1,6 @@
 # Dashboards reference
 
-<!-- DO NOT EDIT: generated via: 'RELOAD=false sg run monitoring-generator' -->
+<!-- DO NOT EDIT: generated via: bazel run //dev:write_all_generated -->
 
 This document contains a complete reference on Sourcegraph's available dashboards, as well as details on how to interpret the panels and metrics.
 

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -21,7 +21,7 @@ const (
 
 const alertsReferenceHeader = `# Alerts reference
 
-<!-- DO NOT EDIT: generated via: 'RELOAD=false sg run monitoring-generator' -->
+<!-- DO NOT EDIT: generated via: bazel run //dev:write_all_generated -->
 
 This document contains a complete reference of all alerts in Sourcegraph's monitoring, and next steps for when you find alerts that are firing.
 If your alert isn't mentioned here, or if the next steps don't help, [contact us](mailto:support@sourcegraph.com) for assistance.
@@ -32,7 +32,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 const dashboardsHeader = `# Dashboards reference
 
-<!-- DO NOT EDIT: generated via: 'RELOAD=false sg run monitoring-generator' -->
+<!-- DO NOT EDIT: generated via: bazel run //dev:write_all_generated -->
 
 This document contains a complete reference on Sourcegraph's available dashboards, as well as details on how to interpret the panels and metrics.
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -761,12 +761,8 @@ commands:
     cmd: ./dev/postgres_exporter.sh
 
   monitoring-generator:
-    cmd: (cd monitoring/ && go generate ./... )
+    cmd: echo "monitoring-generator is deprecated, please run 'sg generate go' or 'bazel run //dev:write_all_generated' instead"
     env:
-      RELOAD: true
-    watch:
-      - monitoring
-    continueWatchOnExit: true
 
   loki:
     cmd: |
@@ -1363,7 +1359,6 @@ commandsets:
       - prometheus
       - grafana
       - postgres_exporter
-      - monitoring-generator
 
   monitoring-alerts:
     checks:


### PR DESCRIPTION
Previous changes made it work, but in between the outdated PR description in https://github.com/sourcegraph/sourcegraph/pull/54965 and the fact that nothing really tells you about `bazel run //dev:write_all_generated`, this was very confusing. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

Locally tested. 