### PR TITLE
JetBrains: Catch AlreadyDisposedException in EditorUtil

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.serviceContainer.AlreadyDisposedException;
 import com.intellij.ui.ColorUtil;
 import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleTextAttributes;
@@ -85,7 +86,13 @@ public class EmbeddingStatusView extends JPanel {
   }
 
   private void updateEmbeddingStatusView() {
-    VirtualFile currentFile = EditorUtil.getCurrentFile(project);
+    VirtualFile currentFile;
+    try {
+      currentFile = EditorUtil.getCurrentFile(project);
+    } catch (AlreadyDisposedException e) {
+      return;
+    }
+
     ApplicationManager.getApplication()
         .executeOnPooledThread(
             () -> {


### PR DESCRIPTION
A user was getting
<details>
<summary>this stack trace</summary>

com.intellij.serviceContainer.AlreadyDisposedException: Already disposed: Project(name=internal, containerState=DISPOSE_COMPLETED, componentStore=/Users/cptmo/Projects/internal) (disposed)
	at com.intellij.serviceContainer.ComponentManagerImpl.checkState(ComponentManagerImpl.kt:201)
	at com.intellij.serviceContainer.ComponentManagerImpl.getComponent(ComponentManagerImpl.kt:593)
	at com.intellij.openapi.fileEditor.FileEditorManager.getInstance(FileEditorManager.java:26)
	**at com.sourcegraph.cody.editor.EditorUtil.getCurrentFile(EditorUtil.java:16)
	at com.sourcegraph.cody.context.EmbeddingStatusView.updateEmbeddingStatusView(EmbeddingStatusView.java:88)**
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at com.intellij.util.concurrency.SchedulingWrapper$MyScheduledFutureTask.run(SchedulingWrapper.java:275)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:194)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:838)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:454)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:74)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:114)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:36)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:779)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:730)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:724)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:749)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:909)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:756)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$5(IdeEventQueue.java:437)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:436)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:615)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:434)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:838)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:480)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
</details>

Looks like the place the error is thrown is `EditorUtil.java:16`, which is called every 10 seconds from `updateEmbeddingStatusView()`.
We should be prepared there for Project being already disposed, and catch the resulting exception.

## Test plan

Not sure how to reproduce the bug, but it makes sense that this would solve it.