### PR TITLE
grpc: raise global default message size from 4MB to 90 MB

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -28,8 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const maxMessageSizeBytes = 64 * 1024 * 1024 // 64MiB
-
 var (
 	addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_gitserver_addr_for_repo_invoked",
@@ -446,9 +444,6 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 		conn, err := defaults.Dial(
 			addr,
 			clientLogger,
-
-			// Allow large messages to accomodate large diffs
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSizeBytes)),
 		)
 		after.grpcConns[addr] = connAndErr{conn: conn, err: err}
 	}

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -38,6 +38,10 @@ func DialContext(ctx context.Context, addr string, logger log.Logger, additional
 	return grpc.DialContext(ctx, addr, DialOptions(logger, additionalOpts...)...)
 }
 
+// defaultGRPCMessageReceiveSizeBytes is the default message size that gRPCs servers and clients are allowed to process.
+// This can be overridden by providing custom Server/Dial options.
+const defaultGRPCMessageReceiveSizeBytes = 90 * 1024 * 1024 // 90 MB
+
 // DialOptions is a set of default dial options that should be used for all
 // gRPC clients in Sourcegraph, along with any additional client-specific options.
 //
@@ -72,6 +76,7 @@ func DialOptions(logger log.Logger, additionalOptions ...grpc.DialOption) []grpc
 			internalerrs.LoggingUnaryClientInterceptor(logger),
 			contextconv.UnaryClientInterceptor,
 		),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaultGRPCMessageReceiveSizeBytes)),
 	}
 
 	out = append(out, additionalOptions...)
@@ -126,6 +131,7 @@ func ServerOptions(logger log.Logger, additionalOptions ...grpc.ServerOption) []
 			otelgrpc.UnaryServerInterceptor(),
 			contextconv.UnaryServerInterceptor,
 		),
+		grpc.MaxRecvMsgSize(defaultGRPCMessageReceiveSizeBytes),
 	}
 
 	out = append(out, additionalOptions...)


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/C04HCK4K3DL/p1689969401765809 for more context.

This raises our global maximum message size that gRPC servers and clients are allowed to receive to 90 MB (up from 4MB). 4MB megabytes seems too restrictive for many of our use cases, and many projects (in the Slack message) seem to also increase their minimum. https://sourcegraph.com/search?q=context:global+MaxCallRecvMsgSize+-f:vendor+-r:grpc/grpc-go&patternType=standard&sm=1&groupBy=repo

However, at the same time we should strive to keep our message sizes as small as possible. I will prioritize adding additional Prometheus metrics to track this next week. 

Note: Our existing REST code effectively has no cap on message sizes, so we're still no worse off than we were before.


## Test plan

CI