### PR TITLE
Syntax highlighting: use different color for string escapes in dark theme

### DIFF
--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -994,13 +994,13 @@
         color: var(--hl-red);
     }
     .hl-typed-StringLiteralEscape {
-        color: var(--hl-red);
+        color: var(--hl-dark-yellow);
     }
     .hl-typed-StringLiteralSpecial {
-        color: var(--hl-red);
+        color: var(--hl-dark-yellow);
     }
     .hl-typed-StringLiteralKey {
-        color: var(--hl-red);
+        color: var(--hl-dark-yellow);
     }
     .hl-typed-CharacterLiteral {
         color: var(--hl-red);


### PR DESCRIPTION
Previously, the dark syntax highlighthing theme didn't distinguish between string literals and string literal keys, or string literal escapes. For example, the object keys of a JSON or YAML file use the `StringLiteralKey` syntax kind, while string literal values use `StringLiteral`. By using the same color for both kinds, the dark theme made it difficult to read JSON/YAML files. This commit fixes the problem by using a different color, mirroring the behavior of the light theme, which also uses different colors for these kinds.


## Test plan

Manually tested with `SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone`

**After**
<img width="732" alt="CleanShot 2023-07-24 at 09 34 18@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/a7ba674c-45f4-4f3e-8f1d-0ab3b190eaf1">


**Before**

<img width="788" alt="CleanShot 2023-07-24 at 09 38 41@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/09353640-fe40-4a0c-b924-44de2b61f48b">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
