### PR TITLE
sg: fix formatting errors in waitingMessages

### DIFF
--- a/dev/sg/internal/run/run.go
+++ b/dev/sg/internal/run/run.go
@@ -328,10 +328,10 @@ func (c *cmdRunner) waitForInstallation(ctx context.Context, cmdNames map[string
 		"Still waiting for %s to finish installing...",
 		"Before this I think the longest I ever had to wait was at Disneyland in '99, but %s is now #1",
 		"Still waiting for %s to finish installing...",
-		"At this point it could be anything - does your computer still have power?",
+		"At this point it could be anything - does your computer still have power? Come on, %s",
 		"Might as well check Slack. %s is taking its time...",
 		"In German there's a saying: ein guter Käse braucht seine Zeit - a good cheese needs its time. Maybe %s is cheese?",
-		"If %[1]s turns out to be cheese I'm gonna lose it. Hey, %[1]s, hurry up, will ya",
+		"If %ss turns out to be cheese I'm gonna lose it. Hey, hurry up, will ya",
 		"Still waiting for %s to finish installing...",
 	}
 	messageCount := 0


### PR DESCRIPTION
Noticed while waiting for `symbols`:
![screenshot_2023-07-24_14 15 21@2x](https://github.com/sourcegraph/sourcegraph/assets/1185253/f84521d8-f046-4171-886b-f60aa9ecc320)


## Test plan

- N/A