### PR TITLE
Fix nextFetchLimit for packages exceeding 1000

### DIFF
--- a/client/web/src/site-admin/packages/components/MultiPackageForm.tsx
+++ b/client/web/src/site-admin/packages/components/MultiPackageForm.tsx
@@ -180,7 +180,7 @@ const PackageList: React.FunctionComponent<PackageListProps> = ({ blockState, qu
                 </span>
                 {nodes.length < totalCount && (
                     <Button variant="link" className="p-0 mr-3" onClick={() => setPackageFetchLimit(nextFetchLimit)}>
-                        <>Show {nextFetchLimit === totalCount ? 'all ' :  nextFetchLimit.toString() }</>
+                        <>Show {nextFetchLimit === totalCount ? 'all ' : nextFetchLimit.toString()}</>
                     </Button>
                 )}
             </div>

--- a/client/web/src/site-admin/packages/components/MultiPackageForm.tsx
+++ b/client/web/src/site-admin/packages/components/MultiPackageForm.tsx
@@ -180,7 +180,7 @@ const PackageList: React.FunctionComponent<PackageListProps> = ({ blockState, qu
                 </span>
                 {nodes.length < totalCount && (
                     <Button variant="link" className="p-0 mr-3" onClick={() => setPackageFetchLimit(nextFetchLimit)}>
-                        <>Show {nextFetchLimit === totalCount ? 'all ' : { nextFetchLimit }}</>
+                        <>Show {nextFetchLimit === totalCount ? 'all ' :  nextFetchLimit.toString() }</>
                     </Button>
                 )}
             </div>

--- a/client/web/src/site-admin/packages/components/SinglePackageForm.tsx
+++ b/client/web/src/site-admin/packages/components/SinglePackageForm.tsx
@@ -210,7 +210,7 @@ const VersionFilterSummary: React.FunctionComponent<VersionFilterSummaryProps> =
                 </span>
                 {versions.length < totalCount && (
                     <Button variant="link" className="p-0 mr-3" onClick={() => setVersionFetchLimit(nextFetchLimit)}>
-                        <>Show {nextFetchLimit === totalCount ? 'all ' : { nextFetchLimit }}</>
+                        <>Show {nextFetchLimit === totalCount ? 'all ' : nextFetchLimit.toString()}</>
                     </Button>
                 )}
             </div>


### PR DESCRIPTION
We currently limit packages to 1000. This PR fixes a bug that causes React to throw Minified React error #31 when trying to add 1000+ packages.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Tested locally.