### PR TITLE
source: handle case when `gitRecorder` isn't configured on an instance

### DIFF
--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -12,6 +12,9 @@ import (
 
 func (r *RepositoryResolver) RecordedCommands(ctx context.Context) ([]RecordedCommandResolver, error) {
 	recordingConf := conf.Get().SiteConfig().GitRecorder
+	if recordingConf == nil {
+		return []RecordedCommandResolver{}, nil
+	}
 	store := rcache.NewFIFOList(wrexec.GetFIFOListKey(r.Name()), recordingConf.Size)
 	empty, err := store.IsEmpty()
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -35,10 +35,6 @@ func TestRecordedCommandsResolver(t *testing.T) {
 		backend.Mocks = backend.MockServices{}
 	})
 
-	repos := database.NewMockRepoStore()
-	repos.GetFunc.SetDefaultReturn(&types.Repo{Name: api.RepoName(repoName)}, nil)
-	db.ReposFunc.SetDefaultReturn(repos)
-
 	// When gitRecorder isn't set, we return an empty list.
 	RunTest(t, &Test{
 		Schema: mustParseGraphQLSchema(t, db),
@@ -88,6 +84,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{GitRecorder: &schema.GitRecorder{Size: 3}}})
 	t.Cleanup(func() { conf.Mock(nil) })
+
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&types.Repo{Name: api.RepoName(repoName)}, nil)
+	db.ReposFunc.SetDefaultReturn(repos)
 
 	RunTest(t, &Test{
 		Schema: mustParseGraphQLSchema(t, db),

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -14,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRecordedCommandsResolver(t *testing.T) {
@@ -23,6 +24,45 @@ func TestRecordedCommandsResolver(t *testing.T) {
 	timeFormat := "2006-01-02T15:04:05Z"
 	startTime, err := time.Parse(timeFormat, "2023-07-20T15:04:05Z")
 	require.NoError(t, err)
+
+	db := database.NewMockDB()
+
+	repoName := "github.com/sourcegraph/sourcegraph"
+	backend.Mocks.Repos.GetByName = func(context.Context, api.RepoName) (*types.Repo, error) {
+		return &types.Repo{Name: api.RepoName(repoName)}, nil
+	}
+	t.Cleanup(func() {
+		backend.Mocks = backend.MockServices{}
+	})
+
+	repos := database.NewMockRepoStore()
+	repos.GetFunc.SetDefaultReturn(&types.Repo{Name: api.RepoName(repoName)}, nil)
+	db.ReposFunc.SetDefaultReturn(repos)
+
+	// When gitRecorder isn't set, we return an empty list.
+	RunTest(t, &Test{
+		Schema: mustParseGraphQLSchema(t, db),
+		Query: `
+				{
+					repository(name: "github.com/sourcegraph/sourcegraph") {
+						recordedCommands {
+							start
+							duration
+							command
+							dir
+							path
+						}
+					}
+				}
+			`,
+		ExpectedResult: `
+				{
+					"repository": {
+						"recordedCommands": []
+					}
+				}
+			`,
+	})
 
 	cmd1 := wrexec.RecordedCommand{
 		Start:    startTime,
@@ -48,19 +88,6 @@ func TestRecordedCommandsResolver(t *testing.T) {
 
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{GitRecorder: &schema.GitRecorder{Size: 3}}})
 	t.Cleanup(func() { conf.Mock(nil) })
-	db := database.NewMockDB()
-
-	repoName := "github.com/sourcegraph/sourcegraph"
-	backend.Mocks.Repos.GetByName = func(context.Context, api.RepoName) (*types.Repo, error) {
-		return &types.Repo{Name: api.RepoName(repoName)}, nil
-	}
-	t.Cleanup(func() {
-		backend.Mocks = backend.MockServices{}
-	})
-
-	repos := database.NewMockRepoStore()
-	repos.GetFunc.SetDefaultReturn(&types.Repo{Name: api.RepoName(repoName)}, nil)
-	db.ReposFunc.SetDefaultReturn(repos)
 
 	RunTest(t, &Test{
 		Schema: mustParseGraphQLSchema(t, db),


### PR DESCRIPTION
This PR fixes [a situation](https://github.com/sourcegraph/sourcegraph/pull/55210#issuecomment-1647804475) where the `gitRecorder` configuration isn't set on a Sourcegraph instance.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Ensure `gitRecorder` isn't set in your site configuration
* Access any repository settings page and click on the `Logs` link
* You should be able to view the `Logs` page and a message saying there are no recorded commands for this repository.