### PR TITLE
grpc: raise global default message size from 4MB to 90 MB (#55209)

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -24,8 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const maxMessageSizeBytes = 64 * 1024 * 1024 // 64MiB
-
 var addrForRepoInvoked = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "src_gitserver_addr_for_repo_invoked",
 	Help: "Number of times gitserver.AddrForRepo was invoked",
@@ -293,9 +291,6 @@ func (a *atomicGitServerConns) update(cfg *conf.Unified) {
 		conn, err := defaults.Dial(
 			addr,
 			clientLogger,
-
-			// Allow large messages to accomodate large diffs
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMessageSizeBytes)),
 		)
 		after.grpcConns[addr] = connAndErr{conn: conn, err: err}
 	}

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -38,6 +38,10 @@ func DialContext(ctx context.Context, addr string, logger log.Logger, additional
 	return grpc.DialContext(ctx, addr, DialOptions(logger, additionalOpts...)...)
 }
 
+// defaultGRPCMessageReceiveSizeBytes is the default message size that gRPCs servers and clients are allowed to process.
+// This can be overridden by providing custom Server/Dial options.
+const defaultGRPCMessageReceiveSizeBytes = 90 * 1024 * 1024 // 90 MB
+
 // DialOptions is a set of default dial options that should be used for all
 // gRPC clients in Sourcegraph, along with any additional client-specific options.
 //
@@ -72,6 +76,7 @@ func DialOptions(logger log.Logger, additionalOptions ...grpc.DialOption) []grpc
 			internalerrs.LoggingUnaryClientInterceptor(logger),
 			contextconv.UnaryClientInterceptor,
 		),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(defaultGRPCMessageReceiveSizeBytes)),
 	}
 
 	out = append(out, additionalOptions...)
@@ -126,6 +131,7 @@ func ServerOptions(logger log.Logger, additionalOptions ...grpc.ServerOption) []
 			otelgrpc.UnaryServerInterceptor(),
 			contextconv.UnaryServerInterceptor,
 		),
+		grpc.MaxRecvMsgSize(defaultGRPCMessageReceiveSizeBytes),
 	}
 
 	out = append(out, additionalOptions...)


### PR DESCRIPTION
(cherry picked from commit bce2029f622b1e652fe0624971d40f30943bd830)


This is a custom cherry-pick since https://github.com/sourcegraph/sourcegraph/pull/55209 's backport ran into merge conflicts: https://github.com/sourcegraph/sourcegraph/pull/55209#issuecomment-1646247112


## Test plan

CI
