### PR TITLE
use public argument for simple search for dot-com

### DIFF
--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -83,7 +83,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             id="simpleSearchToggle"
                             value={simpleSearch}
                             onToggle={val => {
-                                const arg = {state: val}
+                                const arg = { state: val }
                                 telemetryService.log('SimpleSearchToggle', arg, arg)
                                 setSimpleSearch(val)
                             }}

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -83,7 +83,8 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             id="simpleSearchToggle"
                             value={simpleSearch}
                             onToggle={val => {
-                                telemetryService.log('SimpleSearchToggle', { state: val })
+                                const arg = {state: val}
+                                telemetryService.log('SimpleSearchToggle', arg, arg)
                                 setSimpleSearch(val)
                             }}
                         />

--- a/client/web/src/storm/pages/SearchPage/SimpleSearch.tsx
+++ b/client/web/src/storm/pages/SearchPage/SimpleSearch.tsx
@@ -20,13 +20,15 @@ export const SimpleSearch: FC<SimpleSearchProps> = props => {
     const [showState, setShowState] = useState<string>('default')
 
     function onSubmitWithTelemetry(event?: React.FormEvent): void {
-        props.telemetryService.log(eventName('SubmitSearch'), { type: showState })
+        const arg = { type: showState }
+        props.telemetryService.log(eventName('SubmitSearch'), arg, arg)
         props.onSubmit(event)
     }
 
     function pickRender(): JSX.Element {
         const changeState = (nextState: string): void => {
-            props.telemetryService.log(eventName('SelectJob'), { next: nextState })
+            const arg = { next: nextState }
+            props.telemetryService.log(eventName('SelectJob'), arg, arg)
             setShowState(nextState)
         }
 


### PR DESCRIPTION
We truncate `argument` in dot-com, and only send public-argument. For the cloud pipeline, we get argument because it uses an allowlist of safe events.

## Test plan
Tested locally, events are sending both args.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
