### PR TITLE
release: Update images of executors in deploy-sourcegraph-k8s

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -775,7 +775,10 @@ cc @${release.captainGitHubUsername}
                         head: `publish-${release.version.version}`,
                         commitMessage: defaultPRMessage,
                         title: defaultPRMessage,
-                        edits: [`sg ops update-images -pin-tag ${release.version.version} base/`],
+                        edits: [
+                            `sg ops update-images -pin-tag ${release.version.version} base/`,
+                            `sg ops update-images -pin-tag ${release.version.version} components/executors/`,
+                        ],
                         ...prBodyAndDraftState([]),
                     },
                     {


### PR DESCRIPTION
At the moment, only images under the `base/` directory are getting updated when releases occur. Executors are an optional component of Sourcegraph and do not live in the `base/` directory but under the `components/` directory.

## Changes

* In the `deploy-sourcegraph-k8s` repo, include the executor directory (`components/executors/`) to get images updated.
  * (I only included the executor directory because I do not know if there are negative consequences to doing the entire `components/` directory)

## Test plan

blessings of release guild