### PR TITLE
feat(site-admin-ui): add extsvc sync job state badge variants

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
@@ -22,6 +22,7 @@ export const Default: Story = () => (
     <div>
         {Object.values(ExternalServiceSyncJobState).map(state => (
             <ExternalServiceSyncJobNode
+                key={state}
                 onUpdate={new Subject()}
                 node={{
                     __typename: 'ExternalServiceSyncJob',

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
@@ -11,6 +11,9 @@ const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 con
 const config: Meta = {
     title: 'web/External services/ExternalServiceSyncJobNode',
     decorators: [decorator],
+    parameters: {
+        chromatic: { disableSnapshot: false },
+    },
 }
 
 export default config

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
@@ -1,0 +1,40 @@
+import { DecoratorFn, Meta, Story } from '@storybook/react'
+import { Subject } from 'rxjs'
+
+import { ExternalServiceSyncJobState } from '../../graphql-operations'
+import { WebStory } from '../WebStory'
+
+import { ExternalServiceSyncJobNode } from './ExternalServiceSyncJobNode'
+
+const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
+
+const config: Meta = {
+    title: 'web/External services/ExternalServiceSyncJobNode',
+    decorators: [decorator],
+}
+
+export default config
+
+export const Default: Story = () => (
+    <div>
+        {Object.values(ExternalServiceSyncJobState).map(state => (
+            <ExternalServiceSyncJobNode
+                onUpdate={new Subject()}
+                node={{
+                    __typename: 'ExternalServiceSyncJob',
+                    id: '1',
+                    state,
+                    startedAt: '2023-08-25T06:31:00.000Z',
+                    finishedAt: '2023-08-25T06:44:00.000Z',
+                    failureMessage: null,
+                    reposAdded: 12,
+                    reposModified: 11,
+                    reposUnmodified: 10,
+                    reposSynced: 9,
+                    reposDeleted: 8,
+                    repoSyncErrors: 7,
+                }}
+            />
+        ))}
+    </div>
+)

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
@@ -25,7 +25,7 @@ const syncStateToBadgeVariant: Record<ExternalServiceSyncJobState, BadgeProps['v
     [ExternalServiceSyncJobState.FAILED]: 'danger',
     [ExternalServiceSyncJobState.ERRORED]: 'warning',
     [ExternalServiceSyncJobState.COMPLETED]: 'success',
-    [ExternalServiceSyncJobState.PROCESSING]: 'secondary',
+    [ExternalServiceSyncJobState.PROCESSING]: undefined,
     [ExternalServiceSyncJobState.QUEUED]: 'outlineSecondary',
     [ExternalServiceSyncJobState.CANCELED]: 'info',
     [ExternalServiceSyncJobState.CANCELING]: 'secondary',
@@ -108,7 +108,7 @@ export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalService
                     </Button>
                 </div>
                 <div className="d-flex mr-2 justify-content-left">
-                    <Badge variant={syncStateToBadgeVariant[node.state]}>{node.state}</Badge>{' '}
+                    <Badge variant={syncStateToBadgeVariant[node.state]}>{node.state}</Badge>
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.startedAt === null && 'Not started yet.'}

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.tsx
@@ -4,7 +4,7 @@ import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 import { Subject } from 'rxjs'
 
 import { Timestamp, TimestampFormat } from '@sourcegraph/branded/src/components/Timestamp'
-import { Badge, Button, ErrorAlert, Icon } from '@sourcegraph/wildcard'
+import { Badge, BadgeProps, Button, ErrorAlert, Icon } from '@sourcegraph/wildcard'
 
 import { ExternalServiceSyncJobListFields, ExternalServiceSyncJobState } from '../../graphql-operations'
 import { ValueLegendList, ValueLegendListProps } from '../../site-admin/analytics/components/ValueLegendList'
@@ -19,6 +19,16 @@ import styles from './ExternalServiceSyncJobNode.module.scss'
 export interface ExternalServiceSyncJobNodeProps {
     node: ExternalServiceSyncJobListFields
     onUpdate: Subject<void>
+}
+
+const syncStateToBadgeVariant: Record<ExternalServiceSyncJobState, BadgeProps['variant']> = {
+    [ExternalServiceSyncJobState.FAILED]: 'danger',
+    [ExternalServiceSyncJobState.ERRORED]: 'warning',
+    [ExternalServiceSyncJobState.COMPLETED]: 'success',
+    [ExternalServiceSyncJobState.PROCESSING]: 'secondary',
+    [ExternalServiceSyncJobState.QUEUED]: 'outlineSecondary',
+    [ExternalServiceSyncJobState.CANCELED]: 'info',
+    [ExternalServiceSyncJobState.CANCELING]: 'secondary',
 }
 
 export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalServiceSyncJobNodeProps> = ({
@@ -87,7 +97,7 @@ export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalService
 
     return (
         <li className="list-group-item py-3">
-            <div className="d-flex justify-content-left">
+            <div className="d-flex justify-content-left align-items-center">
                 <div className="d-flex mr-2 justify-content-left">
                     <Button
                         variant="icon"
@@ -98,7 +108,7 @@ export const ExternalServiceSyncJobNode: React.FunctionComponent<ExternalService
                     </Button>
                 </div>
                 <div className="d-flex mr-2 justify-content-left">
-                    <Badge>{node.state}</Badge>
+                    <Badge variant={syncStateToBadgeVariant[node.state]}>{node.state}</Badge>{' '}
                 </div>
                 <div className="flex-shrink-1 flex-grow-0 mr-1">
                     {node.startedAt === null && 'Not started yet.'}


### PR DESCRIPTION
The PR adds external service sync job state badge variants, so that different sync state statuses (failed, completed, etc) are visually quickly differentiated.

## Test plan
- Story added & screenshot test enabled
- `pnpm run storybook:web`
- Open http://localhost:9000/?path=/story/web-external-services-externalservicesyncjobnode--default

## Screenshots
| Before | After |
| --: | :-- |
| <img width="1297" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/eeaadd5e-b4d3-4b25-a71b-86529d9ce707">  | <img width="1297" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/20918b95-4f7c-44f7-8217-12d2aee449e1"> |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
