### PR TITLE
cleanup database drifts

### DIFF
--- a/internal/database/migration/shared/data/cmd/generator/consts.go
+++ b/internal/database/migration/shared/data/cmd/generator/consts.go
@@ -8,7 +8,7 @@ import (
 
 // NOTE: This should be kept up-to-date with cmd/migrator/build.sh so that we "bake in"
 // fallback schemas everything we support migrating to. The release tool automates this upgrade, so don't touch this :)
-const maxVersionString = "5.0.0"
+const maxVersionString = "5.1.0"
 
 // MaxVersion is the highest known released version at the time the migrator was built.
 var MaxVersion = func() oobmigration.Version {

--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -473,7 +473,7 @@
 				"ID": 1659572248,
 				"Name": "refresh_scoped_insights",
 				"UpQuery": "ALTER TABLE IF EXISTS insight_series\n    ADD COLUMN IF NOT EXISTS needs_migration bool;\n\n\nupdate insight_series\nset needs_migration = true\nwhere cardinality(repositories) \u003e 0 AND generation_method in ('search', 'search-compute') AND needs_migration is NULL;",
-				"DownQuery": "-- take no action on down so that the next up will not trigger another refreshing of series data.",
+				"DownQuery": "-- take no action on down so that the next up will not trigger another refreshing of series data.\nALTER TABLE insight_series DROP COLUMN IF EXISTS needs_migration;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -632,7 +632,7 @@
 				"ID": 1672921606,
 				"Name": "data_retention_jobs_series_metadata",
 				"UpQuery": "ALTER TABLE IF EXISTS insights_data_retention_jobs\nADD COLUMN IF NOT EXISTS series_id_string text not null default '';",
-				"DownQuery": "ALTER TABLE IF EXISTS insight_data_retention_jobs\nDROP COLUMN IF EXISTS series_id_string;",
+				"DownQuery": "ALTER TABLE IF EXISTS insight_data_retention_jobs\nDROP COLUMN IF EXISTS series_id_string;\n\nALTER TABLE IF EXISTS insights_data_retention_jobs DROP COLUMN IF EXISTS series_id_string;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -676,6 +676,19 @@
 				"NonIdempotent": false,
 				"Parents": [
 					1675113463
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1679051112,
+				"Name": "remove_commit_index_tables",
+				"UpQuery": "DROP TABLE IF EXISTS commit_index, commit_index_metadata CASCADE;",
+				"DownQuery": "CREATE TABLE IF NOT EXISTS commit_index (\n    committed_at timestamp with time zone NOT NULL,\n    repo_id integer NOT NULL,\n    commit_bytea bytea NOT NULL,\n    indexed_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,\n    debug_field text\n);\n\nCREATE TABLE IF NOT EXISTS commit_index_metadata (\n   repo_id integer NOT NULL,\n   enabled boolean DEFAULT true NOT NULL,\n   last_indexed_at timestamp with time zone DEFAULT '1900-01-01 00:00:00+00'::timestamp with time zone NOT NULL\n);\n\nALTER TABLE IF EXISTS commit_index_metadata DROP CONSTRAINT IF EXISTS commit_index_metadata_pkey;\nALTER TABLE IF EXISTS ONLY commit_index_metadata\n    ADD CONSTRAINT commit_index_metadata_pkey PRIMARY KEY (repo_id);\n\nALTER TABLE IF EXISTS commit_index DROP CONSTRAINT IF EXISTS commit_index_pkey;\nALTER TABLE IF EXISTS ONLY commit_index\n    ADD CONSTRAINT commit_index_pkey PRIMARY KEY (committed_at, repo_id, commit_bytea);\n\nCREATE INDEX IF NOT EXISTS commit_index_repo_id_idx ON commit_index USING btree (repo_id, committed_at);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1675347548
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
@@ -890,6 +903,13 @@
 				"RootID": 1000000027,
 				"LeafIDs": [
 					1675347548
+				],
+				"PreCreation": false
+			},
+			"v5.1.0": {
+				"RootID": 1000000027,
+				"LeafIDs": [
+					1679051112
 				],
 				"PreCreation": false
 			}
@@ -1375,8 +1395,8 @@
 			{
 				"ID": 1665531314,
 				"Name": "Remove API docs tables",
-				"UpQuery": "DROP TRIGGER IF EXISTS lsif_data_docs_search_private_delete ON lsif_data_docs_search_private;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_insert ON lsif_data_docs_search_private;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_delete ON lsif_data_docs_search_public;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_insert ON lsif_data_docs_search_public;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_delete ON lsif_data_documentation_pages;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_insert ON lsif_data_documentation_pages;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_update ON lsif_data_documentation_pages;\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_private_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_private_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_public_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_public_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_update();\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_dumps CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_dumps_indexed CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_pages CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_search_results_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_search_results_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_current_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_current_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_lang_names_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_lang_names_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_repo_names_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_repo_names_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_tags_private CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_tags_public CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_documentation_mappings CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_documentation_pages CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_documentation_path_info CASCADE;",
-				"DownQuery": "CREATE OR REPLACE FUNCTION lsif_data_docs_search_private_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_private_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_private SET count = count + (select count(*) from newtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_public_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_public SET count = count - (select count(*) from oldtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_public_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_public SET count = count + (select count(*) from newtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_pages SET count = count - (select count(*) from oldtbl);\nUPDATE lsif_data_apidocs_num_dumps SET count = count - (select count(DISTINCT dump_id) from oldtbl);\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count = count - (select count(DISTINCT dump_id) from oldtbl WHERE search_indexed='true');\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_pages SET count = count + (select count(*) from newtbl);\nUPDATE lsif_data_apidocs_num_dumps SET count = count + (select count(DISTINCT dump_id) from newtbl);\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count = count + (select count(DISTINCT dump_id) from newtbl WHERE search_indexed='true');\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_update() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nWITH\n    beforeIndexed AS (SELECT count(DISTINCT dump_id) FROM oldtbl WHERE search_indexed='true'),\n    afterIndexed AS (SELECT count(DISTINCT dump_id) FROM newtbl WHERE search_indexed='true')\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count=count + ((select * from afterIndexed) - (select * from beforeIndexed));\nRETURN NULL;\nEND $$;\n\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_dumps (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_dumps_indexed (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_pages (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_search_results_private (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_search_results_public (count bigint);\n\nINSERT INTO lsif_data_apidocs_num_dumps VALUES (0);\nINSERT INTO lsif_data_apidocs_num_dumps_indexed VALUES (0);\nINSERT INTO lsif_data_apidocs_num_pages VALUES (0);\nINSERT INTO lsif_data_apidocs_num_search_results_private VALUES (0);\nINSERT INTO lsif_data_apidocs_num_search_results_public VALUES (0);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_current_private (\n    repo_id integer NOT NULL,\n    dump_root text NOT NULL,\n    lang_name_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    last_cleanup_scan_at timestamp with time zone DEFAULT now() NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    id BIGSERIAL,\n    PRIMARY KEY(id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_current_public (\n    repo_id integer NOT NULL,\n    dump_root text NOT NULL,\n    lang_name_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    last_cleanup_scan_at timestamp with time zone DEFAULT now() NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    id BIGSERIAL,\n    PRIMARY KEY(id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_lang_names_private (\n    id BIGSERIAL,\n    lang_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(lang_name)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_lang_names_public (\n    id BIGSERIAL,\n    lang_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(lang_name)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_private (\n    id BIGSERIAL,\n    repo_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    dump_root text NOT NULL,\n    path_id text NOT NULL,\n    detail text NOT NULL,\n    lang_name_id integer NOT NULL,\n    repo_name_id integer NOT NULL,\n    tags_id integer NOT NULL,\n    search_key text NOT NULL,\n    search_key_tsv tsvector NOT NULL,\n    search_key_reverse_tsv tsvector NOT NULL,\n    label text NOT NULL,\n    label_tsv tsvector NOT NULL,\n    label_reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_public (\n    id BIGSERIAL,\n    repo_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    dump_root text NOT NULL,\n    path_id text NOT NULL,\n    detail text NOT NULL,\n    lang_name_id integer NOT NULL,\n    repo_name_id integer NOT NULL,\n    tags_id integer NOT NULL,\n    search_key text NOT NULL,\n    search_key_tsv tsvector NOT NULL,\n    search_key_reverse_tsv tsvector NOT NULL,\n    label text NOT NULL,\n    label_tsv tsvector NOT NULL,\n    label_reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_repo_names_private (\n    id BIGSERIAL,\n    repo_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(repo_name)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_repo_names_public (\n    id BIGSERIAL,\n    repo_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(repo_name)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_tags_private (\n    id BIGSERIAL,\n    tags text NOT NULL UNIQUE,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_tags_public (\n    id BIGSERIAL,\n    tags text NOT NULL UNIQUE,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(tags)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_mappings (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    result_id integer NOT NULL,\n    file_path text,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_pages (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    data bytea,\n    search_indexed boolean DEFAULT false,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_path_info (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    data bytea,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_private_last_cleanup_scan_at ON lsif_data_docs_search_current_private USING btree (last_cleanup_scan_at);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_private_lookup ON lsif_data_docs_search_current_private USING btree (repo_id, dump_root, lang_name_id, created_at) INCLUDE (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_public_last_cleanup_scan_at ON lsif_data_docs_search_current_public USING btree (last_cleanup_scan_at);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_public_lookup ON lsif_data_docs_search_current_public USING btree (repo_id, dump_root, lang_name_id, created_at) INCLUDE (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_lang_names_private_tsv_idx ON lsif_data_docs_search_lang_names_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_lang_names_public_tsv_idx ON lsif_data_docs_search_lang_names_public USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_dump_id_idx ON lsif_data_docs_search_private USING btree (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_dump_root_idx ON lsif_data_docs_search_private USING btree (dump_root);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_label_reverse_tsv_idx ON lsif_data_docs_search_private USING gin (label_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_label_tsv_idx ON lsif_data_docs_search_private USING gin (label_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_repo_id_idx ON lsif_data_docs_search_private USING btree (repo_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_search_key_reverse_tsv_idx ON lsif_data_docs_search_private USING gin (search_key_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_search_key_tsv_idx ON lsif_data_docs_search_private USING gin (search_key_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_dump_id_idx ON lsif_data_docs_search_public USING btree (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_dump_root_idx ON lsif_data_docs_search_public USING btree (dump_root);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_label_reverse_tsv_idx ON lsif_data_docs_search_public USING gin (label_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_label_tsv_idx ON lsif_data_docs_search_public USING gin (label_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_repo_id_idx ON lsif_data_docs_search_public USING btree (repo_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_search_key_reverse_tsv_idx ON lsif_data_docs_search_public USING gin (search_key_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_search_key_tsv_idx ON lsif_data_docs_search_public USING gin (search_key_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_private_reverse_tsv_idx ON lsif_data_docs_search_repo_names_private USING gin (reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_private_tsv_idx ON lsif_data_docs_search_repo_names_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_public_reverse_tsv_idx ON lsif_data_docs_search_repo_names_public USING gin (reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_public_tsv_idx ON lsif_data_docs_search_repo_names_public USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_tags_private_tsv_idx ON lsif_data_docs_search_tags_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_tags_public_tsv_idx ON lsif_data_docs_search_tags_public USING gin (tsv);\nCREATE UNIQUE INDEX IF NOT EXISTS lsif_data_documentation_mappings_inverse_unique_idx ON lsif_data_documentation_mappings USING btree (dump_id, result_id);\nCREATE INDEX IF NOT EXISTS lsif_data_documentation_pages_dump_id_unindexed ON lsif_data_documentation_pages USING btree (dump_id) WHERE (NOT search_indexed);\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_delete ON lsif_data_docs_search_private;\nCREATE TRIGGER lsif_data_docs_search_private_delete AFTER DELETE ON lsif_data_docs_search_private REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_private_delete();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_insert ON lsif_data_docs_search_private;\nCREATE TRIGGER lsif_data_docs_search_private_insert AFTER INSERT ON lsif_data_docs_search_private REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_private_insert();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_delete ON lsif_data_docs_search_public;\nCREATE TRIGGER lsif_data_docs_search_public_delete AFTER DELETE ON lsif_data_docs_search_public REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_public_delete();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_insert ON lsif_data_docs_search_public;\nCREATE TRIGGER lsif_data_docs_search_public_insert AFTER INSERT ON lsif_data_docs_search_public REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_public_insert();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_delete ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_delete AFTER DELETE ON lsif_data_documentation_pages REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_delete();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_insert ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_insert AFTER INSERT ON lsif_data_documentation_pages REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_insert();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_update ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_update AFTER UPDATE ON lsif_data_documentation_pages REFERENCING OLD TABLE AS oldtbl NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_update();\n\nCOMMENT ON TABLE lsif_data_docs_search_current_private IS 'A table indicating the most current search index for a unique repository, root, and language.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.repo_id IS 'The repository identifier of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.dump_root IS 'The root of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.lang_name_id IS 'The interned index name of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.dump_id IS 'The associated dump identifier.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.last_cleanup_scan_at IS 'The last time this record was checked as part of a data retention scan.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.created_at IS 'The time this record was inserted. The records with the latest created_at value for the same repository, root, and language is the only visible one and others will be deleted asynchronously.';\n\nCOMMENT ON TABLE lsif_data_docs_search_current_public IS 'A table indicating the most current search index for a unique repository, root, and language.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.repo_id IS 'The repository identifier of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.dump_root IS 'The root of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.lang_name_id IS 'The interned index name of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.dump_id IS 'The associated dump identifier.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.last_cleanup_scan_at IS 'The last time this record was checked as part of a data retention scan.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.created_at IS 'The time this record was inserted. The records with the latest created_at value for the same repository, root, and language is the only visible one and others will be deleted asynchronously.';\n\nCOMMENT ON TABLE lsif_data_docs_search_lang_names_private IS 'Each unique language name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.id IS 'The ID of the language name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.lang_name IS 'The lowercase language name (go, java, etc.) OR, if unknown, the LSIF indexer name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_lang_names_public IS 'Each unique language name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.id IS 'The ID of the language name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.lang_name IS 'The lowercase language name (go, java, etc.) OR, if unknown, the LSIF indexer name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_private IS 'A tsvector search index over API documentation (private repos only)';\nCOMMENT ON COLUMN lsif_data_docs_search_private.id IS 'The row ID of the search result.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.repo_id IS 'The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_docs_search_private.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.path_id IS 'The fully qualified documentation page path ID, e.g. including \"#section\". See GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.detail IS 'The detail string (e.g. the full function signature and its docs). See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_private.lang_name_id IS 'The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.repo_name_id IS 'The repository name that produced the result. Foreign key into lsif_data_docs_search_repo_names_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.tags_id IS 'The tags from the documentation node. Foreign key into lsif_data_docs_search_tags_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key IS 'The search key generated by the indexer, e.g. mux.Router.ServeHTTP. It is language-specific, and likely unique within a repository (but not always.) See protocol/documentation.go:Documentation.SearchKey';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key_tsv IS 'Indexed tsvector for the search_key field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key_reverse_tsv IS 'Indexed tsvector for the reverse of the search_key field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label IS 'The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label_tsv IS 'Indexed tsvector for the label field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label_reverse_tsv IS 'Indexed tsvector for the reverse of the label field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_public IS 'A tsvector search index over API documentation (public repos only)';\nCOMMENT ON COLUMN lsif_data_docs_search_public.id IS 'The row ID of the search result.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.repo_id IS 'The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_docs_search_public.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.path_id IS 'The fully qualified documentation page path ID, e.g. including \"#section\". See GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.detail IS 'The detail string (e.g. the full function signature and its docs). See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_public.lang_name_id IS 'The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.repo_name_id IS 'The repository name that produced the result. Foreign key into lsif_data_docs_search_repo_names_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.tags_id IS 'The tags from the documentation node. Foreign key into lsif_data_docs_search_tags_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key IS 'The search key generated by the indexer, e.g. mux.Router.ServeHTTP. It is language-specific, and likely unique within a repository (but not always.) See protocol/documentation.go:Documentation.SearchKey';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key_tsv IS 'Indexed tsvector for the search_key field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key_reverse_tsv IS 'Indexed tsvector for the reverse of the search_key field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label IS 'The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label_tsv IS 'Indexed tsvector for the label field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label_reverse_tsv IS 'Indexed tsvector for the reverse of the label field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_repo_names_private IS 'Each unique repository name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.id IS 'The ID of the repository name.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.repo_name IS 'The fully qualified name of the repository.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.reverse_tsv IS 'Indexed tsvector for the reverse of the lang_name field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_repo_names_public IS 'Each unique repository name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.id IS 'The ID of the repository name.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.repo_name IS 'The fully qualified name of the repository.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.reverse_tsv IS 'Indexed tsvector for the reverse of the lang_name field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_tags_private IS 'Each uniques sequence of space-separated tags being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.id IS 'The ID of the tags.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.tags IS 'The full sequence of space-separated tags. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.tsv IS 'Indexed tsvector for the tags field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_tags_public IS 'Each uniques sequence of space-separated tags being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.id IS 'The ID of the tags.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.tags IS 'The full sequence of space-separated tags. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.tsv IS 'Indexed tsvector for the tags field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_documentation_mappings IS 'Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.result_id IS 'The documentationResult vertex ID.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.file_path IS 'The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.';\n\nCOMMENT ON TABLE lsif_data_documentation_pages IS 'Associates documentation pathIDs to their documentation page hierarchy chunk.';\nCOMMENT ON COLUMN lsif_data_documentation_pages.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_pages.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_pages.data IS 'A gob-encoded payload conforming to a `type DocumentationPageData struct` pointer (lib/codeintel/semantic/types.go)';\n\nCOMMENT ON TABLE lsif_data_documentation_path_info IS 'Associates documentation page pathIDs to information about what is at that pathID, its immediate children, etc.';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.data IS 'A gob-encoded payload conforming to a `type DocumentationPathInoData struct` pointer (lib/codeintel/semantic/types.go)';",
+				"UpQuery": "DROP TRIGGER IF EXISTS lsif_data_docs_search_private_delete ON lsif_data_docs_search_private;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_insert ON lsif_data_docs_search_private;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_delete ON lsif_data_docs_search_public;\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_insert ON lsif_data_docs_search_public;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_delete ON lsif_data_documentation_pages;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_insert ON lsif_data_documentation_pages;\n\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_update ON lsif_data_documentation_pages;\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_private_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_private_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_public_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_docs_search_public_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_delete();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_insert();\n\nDROP FUNCTION IF EXISTS lsif_data_documentation_pages_update();\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_dumps CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_dumps_indexed CASCADE;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_pages CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_apidocs_num_pages_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_search_results_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_apidocs_num_search_results_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_apidocs_num_search_results_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_apidocs_num_search_results_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_current_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_current_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_current_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_current_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_lang_names_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_lang_names_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_lang_names_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_lang_names_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_repo_names_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_repo_names_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_repo_names_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_repo_names_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_tags_private CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_tags_private_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_docs_search_tags_public CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_docs_search_tags_public_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_documentation_mappings CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_documentation_mappings_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_documentation_pages CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_documentation_pages_id_seq;\n\nDROP TABLE IF EXISTS lsif_data_documentation_path_info CASCADE;\nDROP SEQUENCE IF EXISTS lsif_data_documentation_path_info_id_seq;",
+				"DownQuery": "CREATE OR REPLACE FUNCTION lsif_data_docs_search_private_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_private SET count = count - (select count(*) from oldtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_private_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_private SET count = count + (select count(*) from newtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_public_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_public SET count = count - (select count(*) from oldtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_docs_search_public_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_search_results_public SET count = count + (select count(*) from newtbl);\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_delete() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_pages SET count = count - (select count(*) from oldtbl);\nUPDATE lsif_data_apidocs_num_dumps SET count = count - (select count(DISTINCT dump_id) from oldtbl);\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count = count - (select count(DISTINCT dump_id) from oldtbl WHERE search_indexed='true');\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nUPDATE lsif_data_apidocs_num_pages SET count = count + (select count(*) from newtbl);\nUPDATE lsif_data_apidocs_num_dumps SET count = count + (select count(DISTINCT dump_id) from newtbl);\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count = count + (select count(DISTINCT dump_id) from newtbl WHERE search_indexed='true');\nRETURN NULL;\nEND $$;\n\nCREATE OR REPLACE FUNCTION lsif_data_documentation_pages_update() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\nWITH\n    beforeIndexed AS (SELECT count(DISTINCT dump_id) FROM oldtbl WHERE search_indexed='true'),\n    afterIndexed AS (SELECT count(DISTINCT dump_id) FROM newtbl WHERE search_indexed='true')\nUPDATE lsif_data_apidocs_num_dumps_indexed SET count=count + ((select * from afterIndexed) - (select * from beforeIndexed));\nRETURN NULL;\nEND $$;\n\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_dumps (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_dumps_indexed (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_pages (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_search_results_private (count bigint);\nCREATE TABLE IF NOT EXISTS lsif_data_apidocs_num_search_results_public (count bigint);\n\nINSERT INTO lsif_data_apidocs_num_dumps VALUES (0);\nINSERT INTO lsif_data_apidocs_num_dumps_indexed VALUES (0);\nINSERT INTO lsif_data_apidocs_num_pages VALUES (0);\nINSERT INTO lsif_data_apidocs_num_search_results_private VALUES (0);\nINSERT INTO lsif_data_apidocs_num_search_results_public VALUES (0);\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_current_private_id_seq\n    AS integer\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_current_private (\n    repo_id integer NOT NULL,\n    dump_root text NOT NULL,\n    lang_name_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    last_cleanup_scan_at timestamp with time zone DEFAULT now() NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    id int NOT NULL DEFAULT nextval('lsif_data_docs_search_current_private_id_seq'),\n    PRIMARY KEY(id)\n);\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_current_public_id_seq\n    AS integer\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_current_public (\n    repo_id integer NOT NULL,\n    dump_root text NOT NULL,\n    lang_name_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    last_cleanup_scan_at timestamp with time zone DEFAULT now() NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    id int NULL DEFAULT nextval('lsif_data_docs_search_current_public_id_seq'),\n    PRIMARY KEY(id)\n);\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_lang_names_private_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_lang_names_private (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_lang_names_private_id_seq'),\n    lang_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(lang_name)\n);\n\nALTER SEQUENCE lsif_data_docs_search_lang_names_private_id_seq OWNED BY lsif_data_docs_search_lang_names_private.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_lang_names_public_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_lang_names_public (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_lang_names_public_id_seq'),\n    lang_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(lang_name)\n);\n\nALTER SEQUENCE lsif_data_docs_search_lang_names_public_id_seq OWNED BY lsif_data_docs_search_lang_names_public.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_private_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_private (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_private_id_seq'),\n    repo_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    dump_root text NOT NULL,\n    path_id text NOT NULL,\n    detail text NOT NULL,\n    lang_name_id integer NOT NULL,\n    repo_name_id integer NOT NULL,\n    tags_id integer NOT NULL,\n    search_key text NOT NULL,\n    search_key_tsv tsvector NOT NULL,\n    search_key_reverse_tsv tsvector NOT NULL,\n    label text NOT NULL,\n    label_tsv tsvector NOT NULL,\n    label_reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\n\nALTER TABLE lsif_data_docs_search_private\n    DROP CONSTRAINT IF EXISTS lsif_data_docs_search_private_lang_name_id_fk;\nALTER TABLE lsif_data_docs_search_private ADD CONSTRAINT lsif_data_docs_search_private_lang_name_id_fk FOREIGN KEY (lang_name_id) REFERENCES lsif_data_docs_search_lang_names_private(id);\n\nALTER SEQUENCE lsif_data_docs_search_private_id_seq OWNED BY lsif_data_docs_search_private.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_public_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_public (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_public_id_seq'),\n    repo_id integer NOT NULL,\n    dump_id integer NOT NULL,\n    dump_root text NOT NULL,\n    path_id text NOT NULL,\n    detail text NOT NULL,\n    lang_name_id integer NOT NULL,\n    repo_name_id integer NOT NULL,\n    tags_id integer NOT NULL,\n    search_key text NOT NULL,\n    search_key_tsv tsvector NOT NULL,\n    search_key_reverse_tsv tsvector NOT NULL,\n    label text NOT NULL,\n    label_tsv tsvector NOT NULL,\n    label_reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\n\nALTER TABLE lsif_data_docs_search_public\n    DROP CONSTRAINT IF EXISTS lsif_data_docs_search_public_lang_name_id_fk;\nALTER TABLE lsif_data_docs_search_public ADD CONSTRAINT lsif_data_docs_search_public_lang_name_id_fk FOREIGN KEY (lang_name_id) REFERENCES lsif_data_docs_search_lang_names_public(id);\n\nALTER SEQUENCE lsif_data_docs_search_public_id_seq OWNED BY lsif_data_docs_search_public.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_repo_names_private_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_repo_names_private (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_repo_names_private_id_seq'),\n    repo_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(repo_name)\n);\n\nALTER TABLE lsif_data_docs_search_private\n    DROP CONSTRAINT IF EXISTS lsif_data_docs_search_private_repo_name_id_fk;\nALTER TABLE lsif_data_docs_search_private ADD CONSTRAINT lsif_data_docs_search_private_repo_name_id_fk FOREIGN KEY (repo_name_id) REFERENCES lsif_data_docs_search_repo_names_private(id);\n\nALTER SEQUENCE lsif_data_docs_search_repo_names_private_id_seq OWNED BY lsif_data_docs_search_repo_names_private.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_repo_names_public_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_repo_names_public (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_repo_names_public_id_seq'),\n    repo_name text NOT NULL,\n    tsv tsvector NOT NULL,\n    reverse_tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(repo_name)\n);\nALTER TABLE lsif_data_docs_search_public\n    DROP CONSTRAINT IF EXISTS lsif_data_docs_search_public_repo_name_id_fk;\nALTER TABLE lsif_data_docs_search_public ADD CONSTRAINT lsif_data_docs_search_public_repo_name_id_fk FOREIGN KEY (repo_name_id) REFERENCES lsif_data_docs_search_repo_names_public(id);\n\nALTER SEQUENCE lsif_data_docs_search_repo_names_public_id_seq OWNED BY lsif_data_docs_search_repo_names_public.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_tags_private_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_tags_private (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_tags_private_id_seq'),\n    tags text NOT NULL UNIQUE,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id)\n);\nALTER TABLE lsif_data_docs_search_private DROP CONSTRAINT IF EXISTS lsif_data_docs_search_private_tags_id_fk;\nALTER TABLE lsif_data_docs_search_private ADD CONSTRAINT lsif_data_docs_search_private_tags_id_fk FOREIGN KEY (tags_id) REFERENCES lsif_data_docs_search_tags_private(id);\n\nALTER SEQUENCE lsif_data_docs_search_tags_private_id_seq OWNED BY lsif_data_docs_search_tags_private.id;\n\nCREATE SEQUENCE IF NOT EXISTS lsif_data_docs_search_tags_public_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\nCREATE TABLE IF NOT EXISTS lsif_data_docs_search_tags_public (\n    id BIGINT NOT NULL DEFAULT nextval('lsif_data_docs_search_tags_public_id_seq'),\n    tags text NOT NULL UNIQUE,\n    tsv tsvector NOT NULL,\n    PRIMARY KEY(id),\n    UNIQUE(tags)\n);\nALTER TABLE lsif_data_docs_search_public DROP CONSTRAINT IF EXISTS lsif_data_docs_search_public_tags_id_fk;\nALTER TABLE lsif_data_docs_search_public ADD CONSTRAINT lsif_data_docs_search_public_tags_id_fk FOREIGN KEY (tags_id) REFERENCES lsif_data_docs_search_tags_public(id);\n\nALTER SEQUENCE lsif_data_docs_search_tags_public_id_seq OWNED BY lsif_data_docs_search_tags_public.id;\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_mappings (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    result_id integer NOT NULL,\n    file_path text,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_pages (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    data bytea,\n    search_indexed boolean DEFAULT false,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE TABLE IF NOT EXISTS lsif_data_documentation_path_info (\n    dump_id integer NOT NULL,\n    path_id text NOT NULL,\n    data bytea,\n    PRIMARY KEY(dump_id, path_id)\n);\n\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_private_last_cleanup_scan_at ON lsif_data_docs_search_current_private USING btree (last_cleanup_scan_at);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_private_lookup ON lsif_data_docs_search_current_private USING btree (repo_id, dump_root, lang_name_id, created_at) INCLUDE (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_public_last_cleanup_scan_at ON lsif_data_docs_search_current_public USING btree (last_cleanup_scan_at);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_current_public_lookup ON lsif_data_docs_search_current_public USING btree (repo_id, dump_root, lang_name_id, created_at) INCLUDE (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_lang_names_private_tsv_idx ON lsif_data_docs_search_lang_names_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_lang_names_public_tsv_idx ON lsif_data_docs_search_lang_names_public USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_dump_id_idx ON lsif_data_docs_search_private USING btree (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_dump_root_idx ON lsif_data_docs_search_private USING btree (dump_root);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_label_reverse_tsv_idx ON lsif_data_docs_search_private USING gin (label_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_label_tsv_idx ON lsif_data_docs_search_private USING gin (label_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_repo_id_idx ON lsif_data_docs_search_private USING btree (repo_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_search_key_reverse_tsv_idx ON lsif_data_docs_search_private USING gin (search_key_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_private_search_key_tsv_idx ON lsif_data_docs_search_private USING gin (search_key_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_dump_id_idx ON lsif_data_docs_search_public USING btree (dump_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_dump_root_idx ON lsif_data_docs_search_public USING btree (dump_root);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_label_reverse_tsv_idx ON lsif_data_docs_search_public USING gin (label_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_label_tsv_idx ON lsif_data_docs_search_public USING gin (label_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_repo_id_idx ON lsif_data_docs_search_public USING btree (repo_id);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_search_key_reverse_tsv_idx ON lsif_data_docs_search_public USING gin (search_key_reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_public_search_key_tsv_idx ON lsif_data_docs_search_public USING gin (search_key_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_private_reverse_tsv_idx ON lsif_data_docs_search_repo_names_private USING gin (reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_private_tsv_idx ON lsif_data_docs_search_repo_names_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_public_reverse_tsv_idx ON lsif_data_docs_search_repo_names_public USING gin (reverse_tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_repo_names_public_tsv_idx ON lsif_data_docs_search_repo_names_public USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_tags_private_tsv_idx ON lsif_data_docs_search_tags_private USING gin (tsv);\nCREATE INDEX IF NOT EXISTS lsif_data_docs_search_tags_public_tsv_idx ON lsif_data_docs_search_tags_public USING gin (tsv);\nCREATE UNIQUE INDEX IF NOT EXISTS lsif_data_documentation_mappings_inverse_unique_idx ON lsif_data_documentation_mappings USING btree (dump_id, result_id);\nCREATE INDEX IF NOT EXISTS lsif_data_documentation_pages_dump_id_unindexed ON lsif_data_documentation_pages USING btree (dump_id) WHERE (NOT search_indexed);\n\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_delete ON lsif_data_docs_search_private;\nCREATE TRIGGER lsif_data_docs_search_private_delete AFTER DELETE ON lsif_data_docs_search_private REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_private_delete();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_private_insert ON lsif_data_docs_search_private;\nCREATE TRIGGER lsif_data_docs_search_private_insert AFTER INSERT ON lsif_data_docs_search_private REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_private_insert();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_delete ON lsif_data_docs_search_public;\nCREATE TRIGGER lsif_data_docs_search_public_delete AFTER DELETE ON lsif_data_docs_search_public REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_public_delete();\nDROP TRIGGER IF EXISTS lsif_data_docs_search_public_insert ON lsif_data_docs_search_public;\nCREATE TRIGGER lsif_data_docs_search_public_insert AFTER INSERT ON lsif_data_docs_search_public REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_docs_search_public_insert();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_delete ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_delete AFTER DELETE ON lsif_data_documentation_pages REFERENCING OLD TABLE AS oldtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_delete();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_insert ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_insert AFTER INSERT ON lsif_data_documentation_pages REFERENCING NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_insert();\nDROP TRIGGER IF EXISTS lsif_data_documentation_pages_update ON lsif_data_documentation_pages;\nCREATE TRIGGER lsif_data_documentation_pages_update AFTER UPDATE ON lsif_data_documentation_pages REFERENCING OLD TABLE AS oldtbl NEW TABLE AS newtbl FOR EACH STATEMENT EXECUTE FUNCTION lsif_data_documentation_pages_update();\n\nCOMMENT ON TABLE lsif_data_docs_search_current_private IS 'A table indicating the most current search index for a unique repository, root, and language.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.repo_id IS 'The repository identifier of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.dump_root IS 'The root of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.lang_name_id IS 'The interned index name of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.dump_id IS 'The associated dump identifier.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.last_cleanup_scan_at IS 'The last time this record was checked as part of a data retention scan.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_private.created_at IS 'The time this record was inserted. The records with the latest created_at value for the same repository, root, and language is the only visible one and others will be deleted asynchronously.';\n\nCOMMENT ON TABLE lsif_data_docs_search_current_public IS 'A table indicating the most current search index for a unique repository, root, and language.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.repo_id IS 'The repository identifier of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.dump_root IS 'The root of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.lang_name_id IS 'The interned index name of the associated dump.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.dump_id IS 'The associated dump identifier.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.last_cleanup_scan_at IS 'The last time this record was checked as part of a data retention scan.';\nCOMMENT ON COLUMN lsif_data_docs_search_current_public.created_at IS 'The time this record was inserted. The records with the latest created_at value for the same repository, root, and language is the only visible one and others will be deleted asynchronously.';\n\nCOMMENT ON TABLE lsif_data_docs_search_lang_names_private IS 'Each unique language name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.id IS 'The ID of the language name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.lang_name IS 'The lowercase language name (go, java, etc.) OR, if unknown, the LSIF indexer name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_private.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_lang_names_public IS 'Each unique language name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.id IS 'The ID of the language name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.lang_name IS 'The lowercase language name (go, java, etc.) OR, if unknown, the LSIF indexer name.';\nCOMMENT ON COLUMN lsif_data_docs_search_lang_names_public.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_private IS 'A tsvector search index over API documentation (private repos only)';\nCOMMENT ON COLUMN lsif_data_docs_search_private.id IS 'The row ID of the search result.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.repo_id IS 'The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_docs_search_private.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.path_id IS 'The fully qualified documentation page path ID, e.g. including \"#section\". See GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.detail IS 'The detail string (e.g. the full function signature and its docs). See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_private.lang_name_id IS 'The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.repo_name_id IS 'The repository name that produced the result. Foreign key into lsif_data_docs_search_repo_names_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.tags_id IS 'The tags from the documentation node. Foreign key into lsif_data_docs_search_tags_private.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key IS 'The search key generated by the indexer, e.g. mux.Router.ServeHTTP. It is language-specific, and likely unique within a repository (but not always.) See protocol/documentation.go:Documentation.SearchKey';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key_tsv IS 'Indexed tsvector for the search_key field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.search_key_reverse_tsv IS 'Indexed tsvector for the reverse of the search_key field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label IS 'The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label_tsv IS 'Indexed tsvector for the label field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_private.label_reverse_tsv IS 'Indexed tsvector for the reverse of the label field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_public IS 'A tsvector search index over API documentation (public repos only)';\nCOMMENT ON COLUMN lsif_data_docs_search_public.id IS 'The row ID of the search result.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.repo_id IS 'The repo ID, from the main app DB repo table. Used to search over a select set of repos by ID.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_docs_search_public.dump_root IS 'Identical to lsif_dumps.root; The working directory of the indexer image relative to the repository root.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.path_id IS 'The fully qualified documentation page path ID, e.g. including \"#section\". See GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.detail IS 'The detail string (e.g. the full function signature and its docs). See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_public.lang_name_id IS 'The programming language (or indexer name) that produced the result. Foreign key into lsif_data_docs_search_lang_names_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.repo_name_id IS 'The repository name that produced the result. Foreign key into lsif_data_docs_search_repo_names_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.tags_id IS 'The tags from the documentation node. Foreign key into lsif_data_docs_search_tags_public.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key IS 'The search key generated by the indexer, e.g. mux.Router.ServeHTTP. It is language-specific, and likely unique within a repository (but not always.) See protocol/documentation.go:Documentation.SearchKey';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key_tsv IS 'Indexed tsvector for the search_key field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.search_key_reverse_tsv IS 'Indexed tsvector for the reverse of the search_key field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label IS 'The label string of the result, e.g. a one-line function signature. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label_tsv IS 'Indexed tsvector for the label field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_public.label_reverse_tsv IS 'Indexed tsvector for the reverse of the label field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_repo_names_private IS 'Each unique repository name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.id IS 'The ID of the repository name.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.repo_name IS 'The fully qualified name of the repository.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_private.reverse_tsv IS 'Indexed tsvector for the reverse of the lang_name field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_repo_names_public IS 'Each unique repository name being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.id IS 'The ID of the repository name.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.repo_name IS 'The fully qualified name of the repository.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.tsv IS 'Indexed tsvector for the lang_name field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\nCOMMENT ON COLUMN lsif_data_docs_search_repo_names_public.reverse_tsv IS 'Indexed tsvector for the reverse of the lang_name field, for suffix lexeme/word matching. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_tags_private IS 'Each uniques sequence of space-separated tags being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.id IS 'The ID of the tags.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.tags IS 'The full sequence of space-separated tags. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_private.tsv IS 'Indexed tsvector for the tags field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_docs_search_tags_public IS 'Each uniques sequence of space-separated tags being stored in the API docs search index.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.id IS 'The ID of the tags.';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.tags IS 'The full sequence of space-separated tags. See protocol/documentation.go:Documentation';\nCOMMENT ON COLUMN lsif_data_docs_search_tags_public.tsv IS 'Indexed tsvector for the tags field. Crafted for ordered, case, and punctuation sensitivity, see data_write_documentation.go:textSearchVector.';\n\nCOMMENT ON TABLE lsif_data_documentation_mappings IS 'Maps documentation path IDs to their corresponding integral documentationResult vertex IDs, which are unique within a dump.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.result_id IS 'The documentationResult vertex ID.';\nCOMMENT ON COLUMN lsif_data_documentation_mappings.file_path IS 'The document file path for the documentationResult, if any. e.g. the path to the file where the symbol described by this documentationResult is located, if it is a symbol.';\n\nCOMMENT ON TABLE lsif_data_documentation_pages IS 'Associates documentation pathIDs to their documentation page hierarchy chunk.';\nCOMMENT ON COLUMN lsif_data_documentation_pages.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_pages.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_pages.data IS 'A gob-encoded payload conforming to a `type DocumentationPageData struct` pointer (lib/codeintel/semantic/types.go)';\n\nCOMMENT ON TABLE lsif_data_documentation_path_info IS 'Associates documentation page pathIDs to information about what is at that pathID, its immediate children, etc.';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.dump_id IS 'The identifier of the associated dump in the lsif_uploads table (state=completed).';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.path_id IS 'The documentation page path ID, see see GraphQL codeintel.schema:documentationPage for what this is.';\nCOMMENT ON COLUMN lsif_data_documentation_path_info.data IS 'A gob-encoded payload conforming to a `type DocumentationPathInoData struct` pointer (lib/codeintel/semantic/types.go)';",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -1467,7 +1487,7 @@
 				"ID": 1670365552,
 				"Name": "Fix SCIP document schema counting",
 				"UpQuery": "-- Add shard id to documents\nALTER TABLE codeintel_scip_documents ADD COLUMN IF NOT EXISTS metadata_shard_id integer NOT NULL DEFAULT floor(random() * 128 + 1)::integer;\nCOMMENT ON COLUMN codeintel_scip_documents.metadata_shard_id IS 'A randomly generated integer used to arbitrarily bucket groups of documents for things like expiration checks and data migrations.';\n\n-- Replace table and triggers\nDROP TABLE IF EXISTS codeintel_scip_documents_schema_versions;\nCREATE TABLE codeintel_scip_documents_schema_versions (\n    metadata_shard_id integer NOT NULL,\n    min_schema_version integer,\n    max_schema_version integer,\n    PRIMARY KEY(metadata_shard_id)\n);\n\nCOMMENT ON TABLE codeintel_scip_documents_schema_versions IS 'Tracks the range of `schema_versions` values associated with each document metadata shard in the [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) table.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.metadata_shard_id IS 'The identifier of the associated document metadata shard.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.min_schema_version IS 'A lower-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `metadata_shard_id` column matches the associated document metadata shard.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.max_schema_version IS 'An upper-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `metadata_shard_id` column matches the associated document metadata shard.';\n\nCREATE OR REPLACE FUNCTION update_codeintel_scip_documents_schema_versions_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$ BEGIN\n    INSERT INTO codeintel_scip_documents_schema_versions\n    SELECT\n        newtab.metadata_shard_id,\n        MIN(codeintel_scip_documents.schema_version) as min_schema_version,\n        MAX(codeintel_scip_documents.schema_version) as max_schema_version\n    FROM newtab\n    JOIN codeintel_scip_documents ON codeintel_scip_documents.metadata_shard_id = newtab.metadata_shard_id\n    GROUP BY newtab.metadata_shard_id\n    ON CONFLICT (metadata_shard_id) DO UPDATE SET\n        -- Update with min(old_min, new_min) and max(old_max, new_max)\n        min_schema_version = LEAST(codeintel_scip_documents_schema_versions.min_schema_version, EXCLUDED.min_schema_version),\n        max_schema_version = GREATEST(codeintel_scip_documents_schema_versions.max_schema_version, EXCLUDED.max_schema_version);\n    RETURN NULL;\nEND $$;\n\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents;\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents_schema_versions;\nCREATE TRIGGER codeintel_scip_documents_schema_versions_insert AFTER INSERT ON codeintel_scip_documents\nREFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_schema_versions_insert();",
-				"DownQuery": "-- Restore table and triggers\nDROP TABLE codeintel_scip_documents_schema_versions;\nCREATE TABLE IF NOT EXISTS codeintel_scip_documents_schema_versions (\n    upload_id integer NOT NULL,\n    min_schema_version integer,\n    max_schema_version integer,\n    PRIMARY KEY(upload_id)\n);\n\nCOMMENT ON TABLE codeintel_scip_documents_schema_versions IS 'Tracks the range of `schema_versions` values associated with each SCIP index in the [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) table.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.upload_id IS 'The identifier of the associated SCIP index.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.min_schema_version IS 'A lower-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `upload_id` column matches the associated SCIP index.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.max_schema_version IS 'An upper-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `upload_id` column matches the associated SCIP index.';\n\nCREATE OR REPLACE FUNCTION update_codeintel_scip_documents_schema_versions_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$ BEGIN\n    INSERT INTO codeintel_scip_documents_schema_versions\n    SELECT\n        upload_id,\n        MIN(documents.schema_version) as min_schema_version,\n        MAX(documents.schema_version) as max_schema_version\n    FROM newtab\n    JOIN codeintel_scip_documents ON codeintel_scip_documents.id = newtab.document_id\n    GROUP BY newtab.upload_id\n    ON CONFLICT (upload_id) DO UPDATE SET\n        -- Update with min(old_min, new_min) and max(old_max, new_max)\n        min_schema_version = LEAST(codeintel_scip_documents_schema_versions.min_schema_version, EXCLUDED.min_schema_version),\n        max_schema_version = GREATEST(codeintel_scip_documents_schema_versions.max_schema_version, EXCLUDED.max_schema_version);\n    RETURN NULL;\nEND $$;\n\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents;\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents_schema_versions;\nCREATE TRIGGER codeintel_scip_documents_schema_versions_insert AFTER INSERT ON codeintel_scip_documents_schema_versions\nREFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_codeintel_scip_documents_schema_versions_insert();\n\n-- Restore documents table\nALTER TABLE codeintel_scip_documents DROP COLUMN IF EXISTS metadata_shard_id;",
+				"DownQuery": "-- Restore table and triggers\nDROP TABLE codeintel_scip_documents_schema_versions;\nCREATE TABLE IF NOT EXISTS codeintel_scip_documents_schema_versions (\n    upload_id integer NOT NULL,\n    min_schema_version integer,\n    max_schema_version integer,\n    PRIMARY KEY(upload_id)\n);\n\nCOMMENT ON TABLE codeintel_scip_documents_schema_versions IS 'Tracks the range of `schema_versions` values associated with each SCIP index in the [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) table.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.upload_id IS 'The identifier of the associated SCIP index.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.min_schema_version IS 'A lower-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `upload_id` column matches the associated SCIP index.';\nCOMMENT ON COLUMN codeintel_scip_documents_schema_versions.max_schema_version IS 'An upper-bound on the `schema_version` values of the records in the table [`codeintel_scip_documents`](#table-publiccodeintel_scip_documents) where the `upload_id` column matches the associated SCIP index.';\n\nCREATE OR REPLACE FUNCTION update_codeintel_scip_documents_schema_versions_insert() RETURNS trigger\n    LANGUAGE plpgsql\n    AS $$ BEGIN\n    INSERT INTO codeintel_scip_documents_schema_versions\n    SELECT\n        upload_id,\n        MIN(documents.schema_version) as min_schema_version,\n        MAX(documents.schema_version) as max_schema_version\n    FROM newtab\n    JOIN codeintel_scip_documents ON codeintel_scip_documents.id = newtab.document_id\n    GROUP BY newtab.upload_id\n    ON CONFLICT (upload_id) DO UPDATE SET\n        -- Update with min(old_min, new_min) and max(old_max, new_max)\n        min_schema_version = LEAST(codeintel_scip_documents_schema_versions.min_schema_version, EXCLUDED.min_schema_version),\n        max_schema_version = GREATEST(codeintel_scip_documents_schema_versions.max_schema_version, EXCLUDED.max_schema_version);\n    RETURN NULL;\nEND $$;\n\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents;\nDROP TRIGGER IF EXISTS codeintel_scip_documents_schema_versions_insert ON codeintel_scip_documents_schema_versions;\n\n-- Restore documents table\nALTER TABLE codeintel_scip_documents DROP COLUMN IF EXISTS metadata_shard_id;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -1612,6 +1632,19 @@
 					"TableName": "codeintel_scip_metadata",
 					"IndexName": "codeintel_scip_metadata_upload_id"
 				}
+			},
+			{
+				"ID": 1686315964,
+				"Name": "Clean out schema_versions tables",
+				"UpQuery": "DROP TABLE IF EXISTS codeintel_scip_documents_schema_versions;\n\n-- Clear data that we've been neglecting to clean up\nDELETE FROM codeintel_scip_symbols_schema_versions sv         WHERE NOT EXISTS (SELECT 1 FROM codeintel_scip_metadata m WHERE m.upload_id = sv.upload_id);\nDELETE FROM codeintel_scip_document_lookup_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM codeintel_scip_metadata m WHERE m.upload_id = sv.upload_id);",
+				"DownQuery": "CREATE TABLE IF NOT EXISTS codeintel_scip_documents_schema_versions (\n    upload_id integer PRIMARY KEY,\n    min_schema_version integer,\n    max_schema_version integer\n);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679010276
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
 			}
 		],
 		"BoundsByRev": {
@@ -1825,6 +1858,13 @@
 				"RootID": 1000000033,
 				"LeafIDs": [
 					1679010276
+				],
+				"PreCreation": false
+			},
+			"v5.1.0": {
+				"RootID": 1000000033,
+				"LeafIDs": [
+					1686315964
 				],
 				"PreCreation": false
 			}
@@ -5972,7 +6012,7 @@
 				"ID": 1648628900,
 				"Name": "rename_localclone_worker_table",
 				"UpQuery": "-- drop view\nDROP VIEW IF EXISTS gitserver_localclone_jobs_with_repo_name;\n\n-- drop the table\nDROP TABLE IF EXISTS gitserver_localclone_jobs;\n\n-- create the new table\nCREATE TABLE IF NOT EXISTS gitserver_relocator_jobs (\n    id                  SERIAL PRIMARY KEY,\n    state               text DEFAULT 'queued',\n    queued_at           timestamptz DEFAULT NOW(),\n    failure_message     text,\n    started_at          timestamp with time zone,\n    finished_at         timestamp with time zone,\n    process_after       timestamp with time zone,\n    num_resets          integer not null DEFAULT 0,\n    num_failures        integer not null DEFAULT 0,\n    last_heartbeat_at   timestamp with time zone,\n    execution_logs      json[],\n    worker_hostname     text not null DEFAULT '',\n\n    repo_id             integer not null,\n    source_hostname     text not null,\n    dest_hostname       text not null,\n    delete_source       boolean not null DEFAULT false\n);\n\n-- create the view\nCREATE OR REPLACE VIEW gitserver_relocator_jobs_with_repo_name AS\n  SELECT glj.*, r.name AS repo_name\n  FROM gitserver_relocator_jobs glj\n  JOIN repo r ON r.id = glj.repo_id;",
-				"DownQuery": "-- drop view\nDROP VIEW IF EXISTS gitserver_relocator_jobs_with_repo_name;\n\n-- drop the table\nDROP TABLE IF EXISTS gitserver_relocator_jobs;\n\n-- create the old table\nCREATE TABLE IF NOT EXISTS gitserver_localclone_jobs (\n    id                  SERIAL PRIMARY KEY,\n    state               text DEFAULT 'queued',\n    queued_at           timestamptz DEFAULT NOW(),\n    failure_message     text,\n    started_at          timestamp with time zone,\n    finished_at         timestamp with time zone,\n    process_after       timestamp with time zone,\n    num_resets          integer not null DEFAULT 0,\n    num_failures        integer not null DEFAULT 0,\n    last_heartbeat_at   timestamp with time zone,\n    execution_logs      json[],\n    worker_hostname     text not null DEFAULT '',\n\n    repo_id             integer not null,\n    source_hostname     text not null,\n    dest_hostname       text not null,\n    delete_source       boolean not null DEFAULT false\n);\n\n-- create the old view\nCREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS\n  SELECT glj.*, r.name AS repo_name\n  FROM gitserver_localclone_jobs glj\n  JOIN repo r ON r.id = glj.repo_id;",
+				"DownQuery": "-- drop view\nDROP VIEW IF EXISTS gitserver_relocator_jobs_with_repo_name;\n\n-- drop the table\nDROP TABLE IF EXISTS gitserver_relocator_jobs;\n\n-- create the old table\nCREATE TABLE IF NOT EXISTS gitserver_localclone_jobs (\n    id                  SERIAL PRIMARY KEY,\n    state               text DEFAULT 'queued',\n    queued_at           timestamptz DEFAULT NOW(),\n    failure_message     text,\n    started_at          timestamp with time zone,\n    finished_at         timestamp with time zone,\n    process_after       timestamp with time zone,\n    num_resets          integer not null DEFAULT 0,\n    num_failures        integer not null DEFAULT 0,\n    last_heartbeat_at   timestamp with time zone,\n    execution_logs      json[],\n    worker_hostname     text not null DEFAULT '',\n\n    repo_id             integer not null,\n    source_hostname     text not null,\n    dest_hostname       text not null,\n    delete_source       boolean not null DEFAULT false\n);\n\n-- create the old view\nCREATE OR REPLACE VIEW gitserver_localclone_jobs_with_repo_name AS SELECT glj.id,\n  glj.state,\n  glj.failure_message,\n  glj.started_at,\n  glj.finished_at,\n  glj.process_after,\n  glj.num_resets,\n  glj.num_failures,\n  glj.last_heartbeat_at,\n  glj.execution_logs,\n  glj.worker_hostname,\n  glj.repo_id,\n  glj.source_hostname,\n  glj.dest_hostname,\n  glj.delete_source,\n  glj.queued_at,\n  r.name AS repo_name\nFROM (gitserver_localclone_jobs glj\nJOIN repo r ON ((r.id = glj.repo_id)));",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -6181,7 +6221,7 @@
 				"ID": 1652707934,
 				"Name": "add last_check_at to codeintel_lockfile_references",
 				"UpQuery": "DROP INDEX IF EXISTS codeintel_lockfile_references_repository_id_commit_bytea;\n\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea)\nWHERE\n    repository_id IS NOT NULL\n    AND commit_bytea IS NOT NULL;\n\nALTER TABLE\n    codeintel_lockfile_references\nADD\n    COLUMN IF NOT EXISTS last_check_at timestamptz;\n\nCOMMENT ON COLUMN codeintel_lockfile_references.last_check_at IS 'Timestamp when background job last checked this row for repository resolution';\n\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_last_check_at ON codeintel_lockfile_references USING btree (last_check_at);",
-				"DownQuery": "ALTER TABLE\n    codeintel_lockfile_references\nDROP\n    COLUMN IF EXISTS last_check_at;",
+				"DownQuery": "ALTER TABLE\n    codeintel_lockfile_references\nDROP\n    COLUMN IF EXISTS last_check_at;\n\nDROP INDEX codeintel_lockfile_references_repository_id_commit_bytea;\nCREATE UNIQUE INDEX codeintel_lockfile_references_repository_id_commit_bytea\nON codeintel_lockfile_references\nUSING btree (repository_id, commit_bytea)\nWHERE repository_id IS NOT NULL AND commit_bytea IS NOT NULL;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -6559,7 +6599,7 @@
 				"ID": 1655157509,
 				"Name": "no_more_ssbc_access_tokens",
 				"UpQuery": "DELETE FROM access_tokens WHERE internal and note = 'batch-spec-execution';\n\nDROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;\nCREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (\n    SELECT\n        j.id,\n        j.batch_spec_workspace_id,\n        j.state,\n        j.failure_message,\n        j.started_at,\n        j.finished_at,\n        j.process_after,\n        j.num_resets,\n        j.num_failures,\n        j.execution_logs,\n        j.worker_hostname,\n        j.last_heartbeat_at,\n        j.created_at,\n        j.updated_at,\n        j.cancel,\n        j.queued_at,\n        j.user_id,\n        q.place_in_global_queue,\n        q.place_in_user_queue\n    FROM\n        batch_spec_workspace_execution_jobs j\n    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id\n);\n\nALTER TABLE batch_spec_workspace_execution_jobs DROP COLUMN IF EXISTS access_token_id;",
-				"DownQuery": "ALTER TABLE batch_spec_workspace_execution_jobs ADD COLUMN IF NOT EXISTS access_token_id integer REFERENCES access_tokens(id);\n\nDROP VIEW IF EXISTS batch_spec_workspace_execution_jobs_with_rank;\nCREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS (\n    SELECT\n        j.*,\n        q.place_in_global_queue,\n        q.place_in_user_queue\n    FROM\n        batch_spec_workspace_execution_jobs j\n    LEFT JOIN batch_spec_workspace_execution_queue q ON j.id = q.id\n);",
+				"DownQuery": "ALTER TABLE batch_spec_workspace_execution_jobs ADD COLUMN IF NOT EXISTS access_token_id bigint REFERENCES access_tokens(id);\n\nALTER TABLE batch_spec_workspace_execution_jobs DROP CONSTRAINT batch_spec_workspace_execution_jobs_access_token_id_fkey;\nALTER TABLE batch_spec_workspace_execution_jobs\nADD CONSTRAINT batch_spec_workspace_execution_jobs_access_token_id_fkey\nFOREIGN KEY (access_token_id)\nREFERENCES access_tokens(id) ON DELETE SET NULL DEFERRABLE;\n\nDROP VIEW batch_spec_workspace_execution_jobs_with_rank;\nCREATE VIEW batch_spec_workspace_execution_jobs_with_rank AS SELECT j.id,\n  j.batch_spec_workspace_id,\n  j.state,\n  j.failure_message,\n  j.started_at,\n  j.finished_at,\n  j.process_after,\n  j.num_resets,\n  j.num_failures,\n  j.execution_logs,\n  j.worker_hostname,\n  j.last_heartbeat_at,\n  j.created_at,\n  j.updated_at,\n  j.cancel,\n  j.access_token_id,\n  j.queued_at,\n  j.user_id,\n  q.place_in_global_queue,\n  q.place_in_user_queue\n FROM (batch_spec_workspace_execution_jobs j\n LEFT JOIN batch_spec_workspace_execution_queue q ON ((j.id = q.id)));",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -7610,7 +7650,7 @@
 				"ID": 1667220626,
 				"Name": "Rename codeintel_path_ranks key",
 				"UpQuery": "-- Rename default constraint name to something we can control\nALTER TABLE codeintel_path_ranks DROP CONSTRAINT IF EXISTS codeintel_path_ranks_repository_id_key;\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id ON codeintel_path_ranks (repository_id);",
-				"DownQuery": "-- Note: same as up.sql\nALTER TABLE codeintel_path_ranks DROP CONSTRAINT IF EXISTS codeintel_path_ranks_repository_id_key;\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id ON codeintel_path_ranks (repository_id);",
+				"DownQuery": "ALTER TABLE codeintel_path_ranks DROP CONSTRAINT IF EXISTS codeintel_path_ranks_repository_id_key;\nALTER TABLE codeintel_path_ranks ADD CONSTRAINT codeintel_path_ranks_repository_id_key UNIQUE (repository_id);\nDROP INDEX IF EXISTS codeintel_path_ranks_repository_id;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -8121,7 +8161,7 @@
 				"ID": 1670934184,
 				"Name": "add_gitserver_corruption_columns",
 				"UpQuery": "ALTER TABLE gitserver_repos\n    ADD COLUMN IF NOT EXISTS corrupted_at TIMESTAMP WITH TIME ZONE,\n    ADD COLUMN IF NOT EXISTS corruption_logs JSONB NOT NULL DEFAULT '[]';\n\nCOMMENT ON COLUMN gitserver_repos.corrupted_at IS 'Timestamp of when repo corruption was detected';\nCOMMENT ON COLUMN gitserver_repos.corruption_logs IS 'Log output of repo corruptions that have been detected - encoded as json';",
-				"DownQuery": "ALTER TABLE gitserver_repos\n    DROP COLUMN IF EXISTS corrupted_at,\n    DROP COLUMN IF EXISTS corrupted_logs;",
+				"DownQuery": "ALTER TABLE gitserver_repos\n    DROP COLUMN IF EXISTS corrupted_at;\n\nALTER TABLE gitserver_repos\n    DROP COLUMN IF EXISTS corrupted_logs;\n\nALTER TABLE gitserver_repos DROP COLUMN IF EXISTS corruption_logs;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -8337,7 +8377,7 @@
 				"ID": 1674455760,
 				"Name": "add cancellation_reason to permission_sync_jobs table",
 				"UpQuery": "ALTER TABLE permission_sync_jobs ADD COLUMN IF NOT EXISTS cancellation_reason TEXT;\n\nCOMMENT ON COLUMN permission_sync_jobs.cancellation_reason IS 'Specifies why permissions sync job was cancelled.';",
-				"DownQuery": "ALTER TABLE permission_sync_jobs\n    DROP COLUMN IF EXISTS reason,\n    DROP COLUMN IF EXISTS triggered_by_user_id;",
+				"DownQuery": "ALTER TABLE permission_sync_jobs DROP COLUMN IF EXISTS cancellation_reason;",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -8574,7 +8614,7 @@
 				"ID": 1675962678,
 				"Name": "remove_action_namespace_perms",
 				"UpQuery": "ALTER TABLE namespace_permissions DROP COLUMN IF EXISTS action;\n\nALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;\n\nCREATE UNIQUE INDEX IF NOT EXISTS unique_resource_permission ON namespace_permissions (namespace, resource_id, user_id);",
-				"DownQuery": "ALTER TABLE namespace_permissions\n    ADD COLUMN IF NOT EXISTS action text NOT NULL;\n\nALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;\n\nCREATE UNIQUE INDEX IF NOT EXISTS unique_resource_permission ON namespace_permissions (namespace, resource_id, action, user_id);",
+				"DownQuery": "ALTER TABLE namespace_permissions\n    ADD COLUMN IF NOT EXISTS action text NOT NULL;\n\nALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;\n\nCREATE UNIQUE INDEX IF NOT EXISTS unique_resource_permission ON namespace_permissions (namespace, resource_id, action, user_id);\n\nDROP INDEX IF EXISTS unique_resource_permission;\nALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS unique_resource_permission;\nALTER TABLE namespace_permissions ADD CONSTRAINT unique_resource_permission UNIQUE (namespace, resource_id, action, user_id);\nALTER TABLE namespace_permissions DROP CONSTRAINT IF EXISTS action_not_blank;\nALTER TABLE namespace_permissions ADD CONSTRAINT action_not_blank CHECK (action \u003c\u003e ''::text);",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -8600,7 +8640,7 @@
 				"ID": 1677003167,
 				"Name": "package_repos_separate_versions_table_stage2",
 				"UpQuery": "DROP TRIGGER IF EXISTS lsif_dependency_repos_backfill ON lsif_dependency_repos;\nDROP FUNCTION IF EXISTS func_lsif_dependency_repos_backfill;\n\nALTER TABLE lsif_dependency_repos\nDROP COLUMN IF EXISTS version;\n\nDELETE FROM lsif_dependency_repos\nWHERE id IN (\n    SELECT lr.id\n    FROM lsif_dependency_repos lr\n    LEFT JOIN package_repo_versions prv\n    ON lr.id = prv.package_id\n    WHERE prv.package_id IS NULL\n);",
-				"DownQuery": "ALTER TABLE lsif_dependency_repos ADD COLUMN IF NOT EXISTS version TEXT DEFAULT '👁️temporary_sentinel_value👁️';\n\nCREATE OR REPLACE FUNCTION func_lsif_dependency_repos_backfill() RETURNS TRIGGER AS $$\n    BEGIN\n        INSERT INTO package_repo_versions (package_id, version)\n        VALUES (NEW.id, NEW.version);\n\n        RETURN NULL;\n    END;\n$$ LANGUAGE plpgsql;\n\nDROP TRIGGER IF EXISTS lsif_dependency_repos_backfill ON lsif_dependency_repos;\nCREATE TRIGGER lsif_dependency_repos_backfill AFTER INSERT ON lsif_dependency_repos\nFOR EACH ROW\nWHEN (NEW.version \u003c\u003e '👁️temporary_sentinel_value👁️')\nEXECUTE FUNCTION func_lsif_dependency_repos_backfill();",
+				"DownQuery": "ALTER TABLE lsif_dependency_repos ADD COLUMN IF NOT EXISTS version TEXT DEFAULT '👁️temporary_sentinel_value👁️';\nALTER TABLE lsif_dependency_repos ALTER COLUMN version SET NOT NULL;\n\nCREATE OR REPLACE FUNCTION func_lsif_dependency_repos_backfill() RETURNS TRIGGER AS $$\n    BEGIN\n        INSERT INTO package_repo_versions (package_id, version)\n        VALUES (NEW.id, NEW.version);\n\n        RETURN NULL;\n    END;\n$$ LANGUAGE plpgsql;\n\nDROP TRIGGER IF EXISTS lsif_dependency_repos_backfill ON lsif_dependency_repos;\nCREATE TRIGGER lsif_dependency_repos_backfill AFTER INSERT ON lsif_dependency_repos\nFOR EACH ROW\nWHEN (NEW.version \u003c\u003e '👁️temporary_sentinel_value👁️')\nEXECUTE FUNCTION func_lsif_dependency_repos_backfill();\n\nALTER TABLE lsif_dependency_repos DROP CONSTRAINT IF EXISTS lsif_dependency_repos_unique_triplet;\nALTER TABLE lsif_dependency_repos ADD CONSTRAINT lsif_dependency_repos_unique_triplet UNIQUE (scheme, name, version);",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -8697,7 +8737,7 @@
 				"ID": 1676420496,
 				"Name": "frontend",
 				"UpQuery": "-- Note that we have to regenerate the reconciler_changesets view, as the SELECT\n-- statement in the view definition isn't refreshed when the fields change within the\n-- changesets table.\nDROP VIEW IF EXISTS\n    reconciler_changesets;\n\nALTER TABLE\n  changesets\nADD COLUMN IF NOT EXISTS\n  previous_failure_message TEXT NULL;\n\nCREATE VIEW reconciler_changesets AS\nSELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.diff_stat_added,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.computed_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_name,\n    c.external_fork_namespace,\n    c.detached_at,\n    c.previous_failure_message\nFROM changesets c\nJOIN repo r ON r.id = c.repo_id\nWHERE r.deleted_at IS NULL AND EXISTS (\n    SELECT 1\n    FROM batch_changes\n        LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id\n        LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id\n    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL\n    );",
-				"DownQuery": "-- Note that we have to regenerate the reconciler_changesets view, as the SELECT\n-- statement in the view definition isn't refreshed when the fields change within the\n-- changesets table.\nDROP VIEW IF EXISTS\n    reconciler_changesets;\n\nALTER TABLE\n  changesets\nDROP COLUMN IF EXISTS\n    previous_failure_message;\n\nCREATE VIEW reconciler_changesets AS\nSELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.diff_stat_added,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.computed_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_namespace,\n    c.detached_at\nFROM changesets c\nJOIN repo r ON r.id = c.repo_id\nWHERE r.deleted_at IS NULL AND EXISTS (\n    SELECT 1\n    FROM batch_changes\n        LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id\n        LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id\n    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL\n    );",
+				"DownQuery": "-- Note that we have to regenerate the reconciler_changesets view, as the SELECT\n-- statement in the view definition isn't refreshed when the fields change within the\n-- changesets table.\nDROP VIEW IF EXISTS\n    reconciler_changesets;\n\nALTER TABLE\n  changesets\nDROP COLUMN IF EXISTS\n    previous_failure_message;\n\nCREATE VIEW reconciler_changesets AS\nSELECT c.id,\n  c.batch_change_ids,\n  c.repo_id,\n  c.queued_at,\n  c.created_at,\n  c.updated_at,\n  c.metadata,\n  c.external_id,\n  c.external_service_type,\n  c.external_deleted_at,\n  c.external_branch,\n  c.external_updated_at,\n  c.external_state,\n  c.external_review_state,\n  c.external_check_state,\n  c.diff_stat_added,\n  c.diff_stat_deleted,\n  c.sync_state,\n  c.current_spec_id,\n  c.previous_spec_id,\n  c.publication_state,\n  c.owned_by_batch_change_id,\n  c.reconciler_state,\n  c.computed_state,\n  c.failure_message,\n  c.started_at,\n  c.finished_at,\n  c.process_after,\n  c.num_resets,\n  c.closing,\n  c.num_failures,\n  c.log_contents,\n  c.execution_logs,\n  c.syncer_error,\n  c.external_title,\n  c.worker_hostname,\n  c.ui_publication_state,\n  c.last_heartbeat_at,\n  c.external_fork_name,\n  c.external_fork_namespace,\n  c.detached_at\nFROM (changesets c\nJOIN repo r ON ((r.id = c.repo_id)))\nWHERE ((r.deleted_at IS NULL) AND (EXISTS (\n    SELECT 1\n    FROM ((batch_changes\n        LEFT JOIN users namespace_user ON ((batch_changes.namespace_user_id = namespace_user.id)))\n        LEFT JOIN orgs namespace_org ON ((batch_changes.namespace_org_id = namespace_org.id)))\n        WHERE ((c.batch_change_ids ? (batch_changes.id)::text) AND (namespace_user.deleted_at IS NULL) AND (namespace_org.deleted_at IS NULL\n    ))\n)));",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -9005,7 +9045,7 @@
 				"ID": 1677944752,
 				"Name": "drop unused lockfiles tables",
 				"UpQuery": "DROP TABLE IF EXISTS last_lockfile_scan;\nDROP TABLE IF EXISTS codeintel_lockfile_references;\nDROP TABLE IF EXISTS codeintel_lockfiles;",
-				"DownQuery": "CREATE TABLE IF NOT EXISTS codeintel_lockfile_references (\n    id SERIAL PRIMARY KEY,\n    repository_name text NOT NULL,\n    revspec text NOT NULL,\n    package_scheme text NOT NULL,\n    package_name text NOT NULL,\n    package_version text NOT NULL,\n    repository_id integer,\n    commit_bytea bytea,\n    last_check_at timestamp with time zone,\n    depends_on integer[] DEFAULT '{}'::integer[],\n    resolution_lockfile text,\n    resolution_repository_id integer,\n    resolution_commit_bytea bytea\n);\n\nCREATE TABLE IF NOT EXISTS codeintel_lockfiles (\n    id SERIAL PRIMARY KEY,\n    repository_id integer NOT NULL,\n    commit_bytea bytea NOT NULL,\n    codeintel_lockfile_reference_ids integer[] NOT NULL,\n    lockfile text,\n    fidelity text DEFAULT 'flat'::text NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    updated_at timestamp with time zone DEFAULT now() NOT NULL\n);\n\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_last_check_at ON codeintel_lockfile_references USING btree (last_check_at);\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea) WHERE ((repository_id IS NOT NULL) AND (commit_bytea IS NOT NULL));\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_name_revspec_package_r ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version, resolution_lockfile, resolution_repository_id, resolution_commit_bytea);\nCREATE INDEX IF NOT EXISTS codeintel_lockfiles_codeintel_lockfile_reference_ids ON codeintel_lockfiles USING gin (codeintel_lockfile_reference_ids gin__int_ops);\nCREATE INDEX IF NOT EXISTS codeintel_lockfiles_references_depends_on ON codeintel_lockfile_references USING gin (depends_on gin__int_ops);\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfiles_repository_id_commit_bytea_lockfile ON codeintel_lockfiles USING btree (repository_id, commit_bytea, lockfile);",
+				"DownQuery": "CREATE TABLE IF NOT EXISTS codeintel_lockfile_references (\n    id SERIAL PRIMARY KEY,\n    repository_name text NOT NULL,\n    revspec text NOT NULL,\n    package_scheme text NOT NULL,\n    package_name text NOT NULL,\n    package_version text NOT NULL,\n    repository_id integer,\n    commit_bytea bytea,\n    last_check_at timestamp with time zone,\n    depends_on integer[] DEFAULT '{}'::integer[],\n    resolution_lockfile text,\n    resolution_repository_id integer,\n    resolution_commit_bytea bytea\n);\n\nCREATE TABLE IF NOT EXISTS codeintel_lockfiles (\n    id SERIAL PRIMARY KEY,\n    repository_id integer NOT NULL,\n    commit_bytea bytea NOT NULL,\n    codeintel_lockfile_reference_ids integer[] NOT NULL,\n    lockfile text,\n    fidelity text DEFAULT 'flat'::text NOT NULL,\n    created_at timestamp with time zone DEFAULT now() NOT NULL,\n    updated_at timestamp with time zone DEFAULT now() NOT NULL\n);\n\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_last_check_at ON codeintel_lockfile_references USING btree (last_check_at);\nCREATE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_id_commit_bytea ON codeintel_lockfile_references USING btree (repository_id, commit_bytea) WHERE ((repository_id IS NOT NULL) AND (commit_bytea IS NOT NULL));\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfile_references_repository_name_revspec_package_r ON codeintel_lockfile_references USING btree (repository_name, revspec, package_scheme, package_name, package_version, resolution_lockfile, resolution_repository_id, resolution_commit_bytea);\nCREATE INDEX IF NOT EXISTS codeintel_lockfiles_codeintel_lockfile_reference_ids ON codeintel_lockfiles USING gin (codeintel_lockfile_reference_ids gin__int_ops);\nCREATE INDEX IF NOT EXISTS codeintel_lockfiles_references_depends_on ON codeintel_lockfile_references USING gin (depends_on gin__int_ops);\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_lockfiles_repository_id_commit_bytea_lockfile ON codeintel_lockfiles USING btree (repository_id, commit_bytea, lockfile);\n\nCREATE TABLE IF NOT EXISTS last_lockfile_scan (\n    repository_id integer NOT NULL PRIMARY KEY,\n    last_lockfile_scan_at timestamp with time zone NOT NULL\n);\n\nCOMMENT ON TABLE last_lockfile_scan IS 'Tracks the last time repository was checked for lockfile indexing.';\n\nCOMMENT ON COLUMN last_lockfile_scan.last_lockfile_scan_at IS 'The last time this repository was considered for lockfile indexing.';",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -9117,7 +9157,7 @@
 				"ID": 1678214530,
 				"Name": "fix indexes on ranking tables",
 				"UpQuery": "DROP INDEX IF EXISTS codeintel_ranking_definitions_symbol_name;\nDROP INDEX IF EXISTS codeintel_ranking_definitions_upload_id;\nDROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_and_repository_id;\nDROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_id;\nDROP INDEX IF EXISTS codeintel_ranking_references_graph_key_id;\nDROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id;\nDROP INDEX IF EXISTS codeintel_path_ranks_updated_at;\n\nTRUNCATE codeintel_ranking_definitions CASCADE;\nTRUNCATE codeintel_ranking_references CASCADE;\nTRUNCATE codeintel_ranking_path_counts_inputs CASCADE;\nTRUNCATE codeintel_path_ranks CASCADE;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_symbol_search ON codeintel_ranking_definitions(graph_key, symbol_name, upload_id, document_path);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_references_graph_key_id ON codeintel_ranking_references(graph_key, id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id, id) WHERE NOT processed;\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_graph_key ON codeintel_path_ranks(graph_key, updated_at NULLS FIRST, id);\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id_updated_at_id ON codeintel_path_ranks(repository_id, updated_at NULLS FIRST, id);",
-				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id;\nDROP INDEX IF EXISTS codeintel_ranking_references_graph_key_id;\nDROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_symbol_search;\nDROP INDEX IF EXISTS codeintel_path_ranks_graph_key;\nDROP INDEX IF EXISTS codeintel_path_ranks_repository_id_updated_at_id;\n\nTRUNCATE codeintel_ranking_definitions CASCADE;\nTRUNCATE codeintel_ranking_path_counts_inputs CASCADE;\nTRUNCATE codeintel_path_ranks CASCADE;\nTRUNCATE codeintel_path_ranks CASCADE;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_and_repository_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id, id) INCLUDE (document_path) WHERE NOT processed;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_upload_id ON codeintel_ranking_definitions(upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_symbol_name ON codeintel_ranking_definitions(symbol_name);\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id ON codeintel_path_ranks(repository_id);\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_updated_at ON codeintel_path_ranks(updated_at);",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id;\nDROP INDEX IF EXISTS codeintel_ranking_references_graph_key_id;\nDROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_symbol_search;\nDROP INDEX IF EXISTS codeintel_path_ranks_graph_key;\nDROP INDEX IF EXISTS codeintel_path_ranks_repository_id_updated_at_id;\nDROP INDEX IF EXISTS codeintel_path_ranks_updated_at;\n\nTRUNCATE codeintel_ranking_definitions CASCADE;\nTRUNCATE codeintel_ranking_path_counts_inputs CASCADE;\nTRUNCATE codeintel_path_ranks CASCADE;\nTRUNCATE codeintel_path_ranks CASCADE;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_and_repository_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id, id) INCLUDE (document_path) WHERE NOT processed;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_upload_id ON codeintel_ranking_definitions(upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_symbol_name ON codeintel_ranking_definitions(symbol_name);\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id ON codeintel_path_ranks(repository_id);\nCREATE INDEX IF NOT EXISTS codeintel_path_ranks_updated_at ON codeintel_path_ranks USING btree (updated_at) INCLUDE (repository_id);",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -9257,7 +9297,7 @@
 				"ID": 1678456448,
 				"Name": "make_role_name_citext",
 				"UpQuery": "-- we create a temporary column to store citext for this migration\nALTER TABLE roles ADD COLUMN IF NOT EXISTS name_citext citext;\n\n-- we then, update the created column to have the same values as `name`\nUPDATE roles SET name_citext = name;\n\n-- remove the previous constraint on roles.name\nALTER TABLE roles DROP CONSTRAINT IF EXISTS roles_name;\n\n-- Drop the current `name` which is of type `text`\nALTER TABLE roles DROP COLUMN IF EXISTS name;\n\nDO $$\nBEGIN\n    -- Rename the newly created column to `name`.\n    ALTER TABLE roles RENAME COLUMN name_citext TO name;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column name_text does not exist in table roles';\nEND $$;\n\nALTER TABLE roles ALTER COLUMN name SET NOT NULL;\n\n-- add a unique index\nCREATE UNIQUE INDEX IF NOT EXISTS unique_role_name ON roles (name);",
-				"DownQuery": "-- we create a temporary column to store text for this migration\nALTER TABLE roles ADD COLUMN IF NOT EXISTS name_text text;\n\n-- we then, update the created column to have the same values as `name`\nUPDATE roles SET name_text = name;\n\nDROP INDEX IF EXISTS unique_role_name;\n\n-- Drop the current `name` which is of type `citext`\nALTER TABLE roles DROP COLUMN name;\n\nDO $$\nBEGIN\n    -- Rename the newly created column to `name`.\n    ALTER TABLE roles RENAME COLUMN name_text TO name;\n    ALTER TABLE roles ADD CONSTRAINT roles_name UNIQUE (name);\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column name_text does not exist in table roles';\n    WHEN duplicate_object THEN RAISE NOTICE 'constrant roles_name already exists';\nEND $$;",
+				"DownQuery": "-- we create a temporary column to store text for this migration\nALTER TABLE roles ADD COLUMN IF NOT EXISTS name_text text;\n\n-- we then, update the created column to have the same values as `name`\nUPDATE roles SET name_text = name;\n\nDROP INDEX IF EXISTS unique_role_name;\n\n-- Drop the current `name` which is of type `citext`\nALTER TABLE roles DROP COLUMN name;\n\nDO $$\nBEGIN\n    -- Rename the newly created column to `name`.\n    ALTER TABLE roles RENAME COLUMN name_text TO name;\n    ALTER TABLE roles ADD CONSTRAINT roles_name UNIQUE (name);\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column name_text does not exist in table roles';\n    WHEN duplicate_object THEN RAISE NOTICE 'constrant roles_name already exists';\nEND $$;\n\nALTER TABLE roles ALTER COLUMN name SET NOT NULL;\nALTER TABLE roles ADD CONSTRAINT name_not_blank CHECK (name \u003c\u003e ''::text);",
 				"Privileged": false,
 				"NonIdempotent": false,
 				"Parents": [
@@ -9321,6 +9361,1141 @@
 				"Parents": [
 					1678601228,
 					1678832491
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1680707560,
+				"Name": "sg_telemetry_allowlist",
+				"UpQuery": "-- This migration was generated by the command `sg telemetry add`\nINSERT INTO event_logs_export_allowlist (event_name) VALUES (UNNEST('{AccessRequestsPageViewed,AccessRequestFailed,CreateAccessRequestSucceeded,AccessRequestRejected,AccessRequestApproved,SearchInputAdd,SearchInputGoto,SearchInputCommand}'::TEXT[])) ON CONFLICT DO NOTHING;",
+				"DownQuery": "-- This migration was generated by the command `sg telemetry add`\nDELETE FROM event_logs_export_allowlist WHERE event_name IN (SELECT * FROM UNNEST('{AccessRequestsPageViewed,AccessRequestFailed,CreateAccessRequestSucceeded,AccessRequestRejected,AccessRequestApproved,SearchInputAdd,SearchInputGoto,SearchInputCommand}'::TEXT[]));",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678899992,
+					1678994673
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1679058200,
+				"Name": "Upsize codeintel_ranking_references_processed datatype",
+				"UpQuery": "-- Create and backfill new bigint identity column (with temporary name)\nALTER TABLE codeintel_ranking_references_processed ADD COLUMN idx bigint;\nUPDATE codeintel_ranking_references_processed SET idx = id;\n\n-- Alter integer sequence to be backed by bigint\nALTER SEQUENCE codeintel_ranking_references_processed_id_seq as bigint MAXVALUE 9223372036854775807;\n\n-- Register sequence as column default (POST BACKFILL)\nALTER TABLE codeintel_ranking_references_processed ALTER COLUMN idx SET DEFAULT nextval('codeintel_ranking_references_processed_id_seq'::regclass);\n\n-- Swap primary key constraint\nALTER TABLE codeintel_ranking_references_processed DROP CONSTRAINT codeintel_ranking_references_processed_pkey;\nALTER TABLE codeintel_ranking_references_processed ADD PRIMARY KEY (idx);\n\n-- Swap ownership (sequence can't be owned by id before we drop it)\nALTER SEQUENCE codeintel_ranking_references_processed_id_seq OWNED BY codeintel_ranking_references_processed.idx;\n\n-- Swap id columns\nALTER TABLE codeintel_ranking_references_processed DROP COLUMN id;\nALTER TABLE codeintel_ranking_references_processed RENAME COLUMN idx TO id;",
+				"DownQuery": "-- Hey you know what, deal with it.\n\nDROP SEQUENCE IF EXISTS codeintel_ranking_references_processed_id_seq CASCADE;\nCREATE SEQUENCE codeintel_ranking_references_processed_id_seq\n    START WITH 1\n    INCREMENT BY 1\n    NO MINVALUE\n    NO MAXVALUE\n    CACHE 1;\n\n-- ALTER SEQUENCE codeintel_ranking_references_processed_id_seq OWNED BY codeintel_ranking_references_processed.id;\nALTER SEQUENCE codeintel_ranking_references_processed_id_seq as integer MAXVALUE 2147483647;\nALTER TABLE ONLY codeintel_ranking_references_processed ALTER COLUMN id TYPE integer USING (id::integer);\nALTER TABLE ONLY codeintel_ranking_references_processed ALTER COLUMN id SET DEFAULT nextval('codeintel_ranking_references_processed_id_seq'::regclass);\n-- ALTER SEQUENCE codeintel_ranking_references_processed_id_seq as bigint MAXVALUE 2147483647;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678601228,
+					1678832491
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1679404397,
+				"Name": "Add missing index for vacuum",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_id ON codeintel_ranking_path_counts_inputs(graph_key, id);",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1678899992,
+					1678994673,
+					1679058200
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "codeintel_ranking_path_counts_inputs",
+					"IndexName": "codeintel_ranking_path_counts_inputs_graph_key_id"
+				}
+			},
+			{
+				"ID": 1679426934,
+				"Name": "soft_deleted_repository_name_reconciling_names",
+				"UpQuery": "CREATE OR REPLACE FUNCTION soft_deleted_repository_name(name text) RETURNS text\n    LANGUAGE plpgsql\n    AS $$\nBEGIN\n    IF name LIKE 'DELETED-%' THEN\n        RETURN name;\n    ELSE\n        RETURN 'DELETED-' || extract(epoch from transaction_timestamp()) || '-' || name;\n    END IF;\nEND;\n$$;",
+				"DownQuery": "CREATE OR REPLACE FUNCTION soft_deleted_repository_name(name text) RETURNS text\n    LANGUAGE plpgsql STRICT\n    AS $$\nBEGIN\n    RETURN 'DELETED-' || extract(epoch from transaction_timestamp()) || '-' || name;\nEND;\n$$;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679404397
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1679428966,
+				"Name": "Speed up deletes from ranking table",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_references_processed_reference_id ON codeintel_ranking_references_processed (codeintel_ranking_reference_id);",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_references_processed_reference_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679404397
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "codeintel_ranking_references_processed",
+					"IndexName": "codeintel_ranking_references_processed_reference_id"
+				}
+			},
+			{
+				"ID": 1679432506,
+				"Name": "Speed up deletes from cm_trigger_jobs",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS cm_action_jobs_trigger_event ON cm_action_jobs (trigger_event);",
+				"DownQuery": "DROP INDEX IF EXISTS cm_action_jobs_trigger_event;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679428966
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "cm_action_jobs",
+					"IndexName": "cm_action_jobs_trigger_event"
+				}
+			},
+			{
+				"ID": 1679603787,
+				"Name": "keep_cloning_progress_in_gitserver_repos",
+				"UpQuery": "ALTER TABLE IF EXISTS gitserver_repos\nADD COLUMN IF NOT EXISTS cloning_progress text DEFAULT '';",
+				"DownQuery": "ALTER TABLE IF EXISTS gitserver_repos\nDROP COLUMN IF EXISTS cloning_progress;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679426934,
+					1679432506
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1679690266,
+				"Name": "Batch initial path counts",
+				"UpQuery": "ALTER TABLE codeintel_initial_path_ranks ALTER COLUMN document_path SET DEFAULT '';\nALTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS document_paths TEXT[] NOT NULL DEFAULT '{}';",
+				"DownQuery": "ALTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS document_paths;\nALTER TABLE codeintel_initial_path_ranks ALTER COLUMN document_path DROP DEFAULT;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679603787
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1680088638,
+				"Name": "add is_partial_success to permission_sync_jobs",
+				"UpQuery": "ALTER TABLE IF EXISTS permission_sync_jobs\n    ADD COLUMN IF NOT EXISTS is_partial_success BOOLEAN DEFAULT FALSE;",
+				"DownQuery": "ALTER TABLE IF EXISTS permission_sync_jobs\n    DROP COLUMN IF EXISTS is_partial_success;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679690266
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1681300431,
+				"Name": "ownership_signals",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS repo_paths (\n    id SERIAL PRIMARY KEY,\n    repo_id INTEGER NOT NULL REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE,\n    absolute_path TEXT NOT NULL,\n    parent_id INTEGER NULL REFERENCES repo_paths(id)\n);\n\nCOMMENT ON COLUMN repo_paths.absolute_path\nIS 'Absolute path does not start or end with forward slash. Example: \"a/b/c\". Root directory is empty path \"\".';\n\nCREATE UNIQUE INDEX IF NOT EXISTS repo_paths_index_absolute_path\nON repo_paths\nUSING btree (repo_id, absolute_path);\n\nCREATE TABLE IF NOT EXISTS commit_authors (\n    id SERIAL PRIMARY KEY,\n    email TEXT NOT NULL,\n    name TEXT NOT NULL\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS commit_authors_email_name\nON commit_authors\nUSING btree (email, name);\n\nCREATE TABLE IF NOT EXISTS own_signal_recent_contribution (\n    id SERIAL PRIMARY KEY,\n    commit_author_id INTEGER NOT NULL REFERENCES commit_authors(id),\n    changed_file_path_id INTEGER NOT NULL REFERENCES repo_paths(id),\n    commit_timestamp TIMESTAMP NOT NULL,\n    commit_id bytea NOT NULL\n);\n\nCOMMENT ON TABLE own_signal_recent_contribution\nIS 'One entry per file changed in every commit that classifies as a contribution signal.';\n\nCREATE TABLE IF NOT EXISTS own_aggregate_recent_contribution (\n    id SERIAL PRIMARY KEY,\n    commit_author_id INTEGER NOT NULL REFERENCES commit_authors(id),\n    changed_file_path_id INTEGER NOT NULL REFERENCES repo_paths(id),\n    contributions_count INTEGER DEFAULT 0\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS own_aggregate_recent_contribution_file_author\nON own_aggregate_recent_contribution\nUSING btree (changed_file_path_id, commit_author_id);\n\nCREATE OR REPLACE FUNCTION update_own_aggregate_recent_contribution() RETURNS TRIGGER AS $$\nBEGIN\n    WITH RECURSIVE ancestors AS (\n        SELECT id, parent_id, 1 AS level\n        FROM repo_paths\n        WHERE id = NEW.changed_file_path_id\n        UNION ALL\n        SELECT p.id, p.parent_id, a.level + 1\n        FROM repo_paths p\n        JOIN ancestors a ON p.id = a.parent_id\n    )\n    UPDATE own_aggregate_recent_contribution\n    SET contributions_count = contributions_count + 1\n    WHERE commit_author_id = NEW.commit_author_id AND changed_file_path_id IN (\n        SELECT id FROM ancestors\n    );\n\n    WITH RECURSIVE ancestors AS (\n        SELECT id, parent_id, 1 AS level\n        FROM repo_paths\n        WHERE id = NEW.changed_file_path_id\n        UNION ALL\n        SELECT p.id, p.parent_id, a.level + 1\n        FROM repo_paths p\n        JOIN ancestors a ON p.id = a.parent_id\n    )\n    INSERT INTO own_aggregate_recent_contribution (commit_author_id, changed_file_path_id, contributions_count)\n    SELECT NEW.commit_author_id, id, 1\n    FROM ancestors\n    WHERE NOT EXISTS (\n        SELECT 1 FROM own_aggregate_recent_contribution\n        WHERE commit_author_id = NEW.commit_author_id AND changed_file_path_id = ancestors.id\n    );\n\n    RETURN NEW;\nEND;\n$$ LANGUAGE plpgsql;\n\nDO $$\nDECLARE\n    trigger_exists INTEGER;\nBEGIN\n    -- Check if the trigger already exists\n    SELECT COUNT(*)\n    INTO trigger_exists\n    FROM pg_trigger\n    WHERE tgname = 'update_own_aggregate_recent_contribution';\n\n    -- If the trigger exists, drop it\n    IF trigger_exists \u003e 0 THEN\n        EXECUTE 'DROP TRIGGER update_own_aggregate_recent_contribution ON own_signal_recent_contribution';\n    END IF;\n\n    -- Create the trigger\n    EXECUTE 'CREATE TRIGGER update_own_aggregate_recent_contribution\n        AFTER INSERT\n        ON own_signal_recent_contribution\n        FOR EACH ROW\n        EXECUTE FUNCTION update_own_aggregate_recent_contribution()';\nEND $$;",
+				"DownQuery": "DROP TRIGGER IF EXISTS update_own_aggregate_recent_contribution ON own_signal_recent_contribution;\nDROP FUNCTION IF EXISTS update_own_aggregate_recent_contribution();\n\nDROP INDEX IF EXISTS own_aggregate_recent_contribution_file_author;\nDROP TABLE IF EXISTS own_aggregate_recent_contribution;\n\nDROP TABLE IF EXISTS own_signal_recent_contribution;\n\nDROP INDEX IF EXISTS commit_authors_email_name;\nDROP TABLE IF EXISTS commit_authors;\n\nDROP INDEX IF EXISTS repo_paths_index_absolute_path;\nDROP TABLE IF EXISTS repo_paths;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1680088638,
+					1680707560
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1681807446,
+				"Name": "add github_apps table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS github_apps (\n    id SERIAL PRIMARY KEY,\n    app_id INT NOT NULL,\n    name TEXT NOT NULL,\n    slug TEXT NOT NULL,\n    base_url TEXT NOT NULL,\n    client_id TEXT NOT NULL,\n    client_secret TEXT NOT NULL,\n    private_key TEXT NOT NULL,\n    encryption_key_id TEXT NOT NULL,\n    logo TEXT,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),\n    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS github_apps_app_id_slug_base_url_unique\nON github_apps USING btree (app_id, slug, base_url);",
+				"DownQuery": "DROP TABLE IF EXISTS github_apps;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1680088638,
+					1680707560
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1681923094,
+				"Name": "sg_telemetry_allowlist",
+				"UpQuery": "-- This migration was generated by the command `sg telemetry add`\nINSERT INTO event_logs_export_allowlist (event_name) VALUES (UNNEST('{CodyVSCodeExtension:recipe:rewrite-to-functional:executed,CodyVSCodeExtension:recipe:improve-variable-names:executed,CodyVSCodeExtension:recipe:replace:executed,CodyVSCodeExtension:recipe:generate-docstring:executed,CodyVSCodeExtension:recipe:generate-unit-test:executed,CodyVSCodeExtension:recipe:rewrite-functional:executed,CodyVSCodeExtension:recipe:code-refactor:executed,CodyVSCodeExtension:recipe:fixup:executed,CodyVSCodeExtension:recipe:explain-code-high-level:executed,CodyVSCodeExtension:recipe:explain-code-detailed:executed,CodyVSCodeExtension:recipe:find-code-smells:executed,CodyVSCodeExtension:recipe:git-history:executed,CodyVSCodeExtension:recipe:rate-code:executed,CodyVSCodeExtension:recipe:chat-question:executed,CodyVSCodeExtension:recipe:translate-to-language:executed}'::TEXT[])) ON CONFLICT DO NOTHING;",
+				"DownQuery": "-- This migration was generated by the command `sg telemetry add`\nDELETE FROM event_logs_export_allowlist WHERE event_name IN (SELECT * FROM UNNEST('{CodyVSCodeExtension:recipe:rewrite-to-functional:executed,CodyVSCodeExtension:recipe:improve-variable-names:executed,CodyVSCodeExtension:recipe:replace:executed,CodyVSCodeExtension:recipe:generate-docstring:executed,CodyVSCodeExtension:recipe:generate-unit-test:executed,CodyVSCodeExtension:recipe:rewrite-functional:executed,CodyVSCodeExtension:recipe:code-refactor:executed,CodyVSCodeExtension:recipe:fixup:executed,CodyVSCodeExtension:recipe:explain-code-high-level:executed,CodyVSCodeExtension:recipe:explain-code-detailed:executed,CodyVSCodeExtension:recipe:find-code-smells:executed,CodyVSCodeExtension:recipe:git-history:executed,CodyVSCodeExtension:recipe:rate-code:executed,CodyVSCodeExtension:recipe:chat-question:executed,CodyVSCodeExtension:recipe:translate-to-language:executed}'::TEXT[]));",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1680088638,
+					1680707560
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682012624,
+				"Name": "own_background_jobs",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS own_background_jobs\n(\n    id                SERIAL PRIMARY KEY,\n    state             TEXT                     DEFAULT 'queued',\n    failure_message   TEXT,\n    queued_at         TIMESTAMP WITH TIME ZONE DEFAULT NOW(),\n    started_at        TIMESTAMP WITH TIME ZONE,\n    finished_at       TIMESTAMP WITH TIME ZONE,\n    process_after     TIMESTAMP WITH TIME ZONE,\n    num_resets        INTEGER NOT NULL         DEFAULT 0,\n    num_failures      INTEGER NOT NULL         DEFAULT 0,\n    last_heartbeat_at TIMESTAMP WITH TIME ZONE,\n    execution_logs    JSON[],\n    worker_hostname   TEXT    NOT NULL         DEFAULT '',\n    cancel            BOOLEAN NOT NULL         DEFAULT FALSE,\n    repo_id           INT     NOT NULL,\n    job_type          INT     NOT NULL\n);\n\nCREATE INDEX IF NOT EXISTS own_background_jobs_state_idx ON own_background_jobs (state);\nCREATE INDEX IF NOT EXISTS own_background_jobs_repo_id_idx ON own_background_jobs (repo_id);",
+				"DownQuery": "DROP TABLE IF EXISTS own_background_jobs;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681807446,
+					1681923094
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682626931,
+				"Name": "subscription_llm_proxy_state",
+				"UpQuery": "ALTER TABLE product_subscriptions\nADD COLUMN IF NOT EXISTS llm_proxy_enabled BOOLEAN NOT NULL DEFAULT TRUE,\nADD COLUMN IF NOT EXISTS llm_proxy_rate_limit INTEGER,\nADD COLUMN IF NOT EXISTS llm_proxy_rate_interval_seconds INTEGER;\n\nCOMMENT ON COLUMN product_subscriptions.llm_proxy_enabled IS 'Whether or not this subscription has access to LLM-proxy';\nCOMMENT ON COLUMN product_subscriptions.llm_proxy_rate_limit IS 'Custom requests per time interval allowed for LLM-proxy';\nCOMMENT ON COLUMN product_subscriptions.llm_proxy_rate_interval_seconds IS 'Custom time interval over which the for LLM-proxy rate limit is applied';\n\n-- Initially, mark any subscription that has no active license as without LLM-proxy access,\n-- since there are a lot of old subscriptions out there.\nUPDATE product_subscriptions\nSET llm_proxy_enabled = false\nWHERE id IN (\n    SELECT product_subscription_id\n    FROM product_licenses\n    WHERE license_expires_at \u003e NOW()\n    GROUP BY product_subscription_id\n    HAVING COUNT(*) = 0\n);",
+				"DownQuery": "ALTER TABLE product_subscriptions\nDROP COLUMN IF EXISTS llm_proxy_enabled,\nDROP COLUMN IF EXISTS llm_proxy_rate_limit,\nDROP COLUMN IF EXISTS llm_proxy_rate_interval_seconds;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682012624
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1681982430,
+				"Name": "user_completions_quota",
+				"UpQuery": "ALTER TABLE users ADD COLUMN IF NOT EXISTS completions_quota INTEGER;",
+				"DownQuery": "ALTER TABLE users DROP COLUMN IF EXISTS completions_quota;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1680088638,
+					1680707560
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682114198,
+				"Name": "product_license_access_tokens",
+				"UpQuery": "-- Add toggle\nALTER TABLE product_licenses\nADD COLUMN IF NOT EXISTS access_token_enabled BOOLEAN NOT NULL DEFAULT false;\n\n-- Documentation!\nCOMMENT ON COLUMN product_licenses.access_token_enabled\nIS 'Whether this license key can be used as an access token to authenticate API requests';\n\n-- In-band migration to enable usage as access tokens for existing, active license keys\nUPDATE product_licenses\nSET access_token_enabled = true\nWHERE license_expires_at \u003e NOW();",
+				"DownQuery": "ALTER TABLE product_licenses\nDROP COLUMN IF EXISTS access_token_enabled;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681982430
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682683129,
+				"Name": "add recent view ownership signal",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS own_aggregate_recent_view\n(\n    id                  SERIAL PRIMARY KEY,\n    viewer_id           INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE DEFERRABLE,\n    viewed_file_path_id INTEGER NOT NULL REFERENCES repo_paths (id),\n    views_count         INTEGER DEFAULT 0\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS own_aggregate_recent_view_viewer\n    ON own_aggregate_recent_view\n        USING btree (viewed_file_path_id, viewer_id);\n\nCOMMENT ON TABLE own_aggregate_recent_view\n    IS 'One entry contains a number of views of a single file by a given viewer.';\n\nCREATE TABLE IF NOT EXISTS event_logs_scrape_state_own\n(\n    id          SERIAL\n        CONSTRAINT event_logs_scrape_state_own_pk\n            PRIMARY KEY,\n    bookmark_id INT NOT NULL,\n    job_type    INT NOT NULL\n);\n\nCOMMENT ON TABLE event_logs_scrape_state_own IS 'Contains state for own jobs that scrape events if enabled.';\nCOMMENT ON COLUMN event_logs_scrape_state_own.bookmark_id IS 'Bookmarks the maximum most recent successful event_logs.id that was scraped';",
+				"DownQuery": "DROP TABLE IF EXISTS own_aggregate_recent_view;\nDROP TABLE IF EXISTS event_logs_scrape_state_own;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681300431,
+					1682012624,
+					1682114198
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683053825,
+				"Name": "sg_telemetry_allowlist",
+				"UpQuery": "-- This migration was generated by the command `sg telemetry remove`\nDELETE FROM event_logs_export_allowlist WHERE event_name IN (SELECT * FROM UNNEST('{SearchSubmitted,AccessRequestApproved,AccessRequestRejected}'::TEXT[]));",
+				"DownQuery": "-- This migration was generated by the command `sg telemetry remove`\nINSERT INTO event_logs_export_allowlist (event_name) VALUES (UNNEST('{SearchSubmitted,AccessRequestApproved,AccessRequestRejected}'::TEXT[])) ON CONFLICT DO NOTHING;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681300431,
+					1682114198,
+					1682626931
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682598027,
+				"Name": "add github app installations table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS github_app_installs (\n    id SERIAL PRIMARY KEY,\n    app_id INT NOT NULL REFERENCES github_apps(id) ON DELETE CASCADE,\n    installation_id INT NOT NULL,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\n\nCREATE INDEX IF NOT EXISTS installation_id_idx ON github_app_installs USING btree (installation_id);\nCREATE INDEX IF NOT EXISTS app_id_idx ON github_app_installs USING btree (app_id);",
+				"DownQuery": "DROP TABLE IF EXISTS github_app_installs;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681982430,
+					1682012624
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683246005,
+				"Name": "llm-proxy-no-access-token-enable",
+				"UpQuery": "ALTER TABLE product_licenses ALTER COLUMN access_token_enabled SET DEFAULT TRUE;\n\nALTER TABLE product_subscriptions ALTER COLUMN llm_proxy_enabled SET DEFAULT FALSE;\n\n-- One time migration to disable all licenses again, we want to enable them manually.\nUPDATE product_subscriptions SET llm_proxy_enabled = FALSE;",
+				"DownQuery": "ALTER TABLE product_licenses ALTER COLUMN access_token_enabled SET DEFAULT FALSE;\n-- One time migration to disable all licenses again.\nUPDATE product_licenses SET access_token_enabled = FALSE;\n\nALTER TABLE product_subscriptions ALTER COLUMN llm_proxy_enabled SET DEFAULT TRUE;\n\nUPDATE product_subscriptions\nSET llm_proxy_enabled = TRUE;\n-- Initially, mark any subscription that has no active license as without LLM-proxy access,\n-- since there are a lot of old subscriptions out there.\nUPDATE product_subscriptions\nSET llm_proxy_enabled = false\nWHERE id IN (\n    SELECT product_subscription_id\n    FROM product_licenses\n    WHERE license_expires_at \u003e NOW()\n    GROUP BY product_subscription_id\n    HAVING COUNT(*) = 0\n);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682598027,
+					1683053825
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683290474,
+				"Name": "user_code_completions_quota",
+				"UpQuery": "ALTER TABLE users ADD COLUMN IF NOT EXISTS code_completions_quota INTEGER;",
+				"DownQuery": "ALTER TABLE users DROP COLUMN IF EXISTS code_completions_quota;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682598027,
+					1682683129,
+					1683053825
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683295546,
+				"Name": "add app_url column for github_apps",
+				"UpQuery": "ALTER TABLE github_apps\n    ADD COLUMN IF NOT EXISTS app_url TEXT NOT NULL DEFAULT '';",
+				"DownQuery": "ALTER TABLE github_apps DROP COLUMN IF EXISTS app_url;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682598027,
+					1682683129,
+					1683053825
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683561153,
+				"Name": "Add autoindexing repo exceptions table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS codeintel_autoindexing_exceptions(\n    id                  SERIAL PRIMARY KEY,\n    repository_id       INTEGER NOT NULL UNIQUE,\n    disable_scheduling  BOOLEAN NOT NULL DEFAULT FALSE,\n    disable_inference   BOOLEAN NOT NULL DEFAULT FALSE,\n    FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE\n);",
+				"DownQuery": "DROP TABLE IF EXISTS codeintel_autoindexing_exceptions;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683290474,
+					1683295546
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683593618,
+				"Name": "add table for storing the most recent output from gitserver clones",
+				"UpQuery": "-- Perform migration here.\n--\n-- See /migrations/README.md. Highlights:\n--  * Make migrations idempotent (use IF EXISTS)\n--  * Make migrations backwards-compatible (old readers/writers must continue to work)\n--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement\n--    is defined per file, and that each such statement is NOT wrapped in a transaction.\n--    Each such migration must also declare \"createIndexConcurrently: true\" in their\n--    associated metadata.yaml file.\n--  * If you are modifying Postgres extensions, you must also declare \"privileged: true\"\n--    in the associated metadata.yaml file.\nCREATE TABLE IF NOT EXISTS gitserver_repos_sync_output (\n    repo_id integer primary key,\n    last_output text DEFAULT ''::text NOT NULL,\n    updated_at timestamp with time zone DEFAULT now() NOT NULL,\n    CONSTRAINT gitserver_repos_sync_output_repo_id_fkey FOREIGN KEY (repo_id)\n        REFERENCES repo (id) MATCH SIMPLE\n        ON UPDATE NO ACTION\n        ON DELETE CASCADE\n);\n\nCOMMENT ON TABLE gitserver_repos_sync_output IS 'Contains the most recent output from gitserver repository sync jobs.';",
+				"DownQuery": "-- Undo the changes made in the up migration\nDROP TABLE IF EXISTS gitserver_repos_sync_output;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683290474,
+					1683295546
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682604499,
+				"Name": "Add soft-delete timestamp to ranking exports",
+				"UpQuery": "AlTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;\nAlTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;\nAlTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;",
+				"DownQuery": "AlTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS deleted_at;\nAlTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS deleted_at;\nAlTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS deleted_at;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1681300431,
+					1681982430,
+					1682012624
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1682967255,
+				"Name": "Add ranking graph key table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS codeintel_ranking_progress (\n    id                          BIGSERIAL PRIMARY KEY,\n    graph_key                   TEXT NOT NULL UNIQUE,\n    max_definition_id           INTEGER NOT NULL,\n    max_reference_id            INTEGER NOT NULL,\n    max_path_id                 INTEGER NOT NULL,\n    mappers_started_at          TIMESTAMP WITH TIME ZONE NOT NULL,\n    mapper_completed_at         TIMESTAMP WITH TIME ZONE,\n    seed_mapper_completed_at    TIMESTAMP WITH TIME ZONE,\n    reducer_started_at          TIMESTAMP WITH TIME ZONE,\n    reducer_completed_at        TIMESTAMP WITH TIME ZONE\n);",
+				"DownQuery": "DROP TABLE IF EXISTS codeintel_ranking_progress;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682114198,
+					1682604499
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683640362,
+				"Name": "Expand ranking unique key",
+				"UpQuery": "DELETE FROM codeintel_path_ranks WHERE graph_key IS NULL;\nALTER TABLE codeintel_path_ranks ALTER COLUMN graph_key SET NOT NULL;\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_path_ranks_graph_key_repository_id ON codeintel_path_ranks(graph_key, repository_id);\nDROP INDEX IF EXISTS codeintel_path_ranks_repository_id;",
+				"DownQuery": "CREATE UNIQUE INDEX IF NOT EXISTS codeintel_path_ranks_repository_id ON codeintel_path_ranks(repository_id);\nDROP INDEX IF EXISTS codeintel_path_ranks_graph_key_repository_id;\nALTER TABLE codeintel_path_ranks ALTER COLUMN graph_key DROP NOT NULL;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1682967255
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683641757,
+				"Name": "sg_telemetry_allowlist",
+				"UpQuery": "-- This migration was generated by the command `sg telemetry add`\nINSERT INTO event_logs_export_allowlist (event_name) VALUES (UNNEST('{CodySignup,VSCodeInstall,VSCodeMarketplace,TryCodyWeb,TryCodyWebOnboardingDisplayed}'::TEXT[])) ON CONFLICT DO NOTHING;",
+				"DownQuery": "-- This migration was generated by the command `sg telemetry add`\nDELETE FROM event_logs_export_allowlist WHERE event_name IN (SELECT * FROM UNNEST('{CodySignup,VSCodeInstall,VSCodeMarketplace,TryCodyWeb,TryCodyWebOnboardingDisplayed}'::TEXT[]));",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683246005,
+					1683290474,
+					1683295546,
+					1683561153,
+					1683640362
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683670271,
+				"Name": "Remove ranking object_prefix",
+				"UpQuery": "ALTER TABLE codeintel_ranking_exports DROP COLUMN IF EXISTS object_prefix;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_exports ADD COLUMN IF NOT EXISTS object_prefix TEXT;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683246005,
+					1683561153,
+					1683640362
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683670735,
+				"Name": "Move deleted fields for ranking",
+				"UpQuery": "ALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS last_scanned_at;\nALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS deleted_at;\n\nALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS last_scanned_at;\nALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS deleted_at;\n\nALTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS last_scanned_at;\nALTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS deleted_at;\n\nALTER TABLE codeintel_ranking_exports ADD COLUMN IF NOT EXISTS last_scanned_at TIMESTAMP WITH TIME ZONE;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_exports_graph_key_last_scanned_at ON codeintel_ranking_exports(graph_key, last_scanned_at NULLS FIRST, id);\nALTER TABLE codeintel_ranking_exports ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_exports DROP COLUMN IF EXISTS last_scanned_at;\nALTER TABLE codeintel_ranking_exports DROP COLUMN IF EXISTS deleted_at;\n\nALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS last_scanned_at TIMESTAMP WITH TIME ZONE;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_last_scanned_at ON codeintel_ranking_definitions(graph_key, last_scanned_at NULLS FIRST, id);\nALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;\n\nALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS last_scanned_at TIMESTAMP WITH TIME ZONE;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_references_graph_key_last_scanned_at ON codeintel_ranking_references(graph_key, last_scanned_at NULLS FIRST, id);\nALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;\n\nALTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS last_scanned_at TIMESTAMP WITH TIME ZONE;\nCREATE INDEX IF NOT EXISTS codeintel_initial_path_ranks_graph_key_last_scanned_at ON codeintel_initial_path_ranks(graph_key, last_scanned_at NULLS FIRST, id);\nALTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;\n\nDROP INDEX codeintel_ranking_definitions_graph_key_last_scanned_at;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_last_scanned_at_id ON codeintel_ranking_definitions USING btree (graph_key, last_scanned_at NULLS FIRST, id);\nDROP INDEX codeintel_ranking_references_graph_key_last_scanned_at;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_references_graph_key_last_scanned_at_id ON codeintel_ranking_references USING btree (graph_key, last_scanned_at NULLS FIRST, id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683670271
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683753933,
+				"Name": "Move upload relation in ranking export data",
+				"UpQuery": "TRUNCATE codeintel_ranking_definitions CASCADE;\nTRUNCATE codeintel_ranking_references CASCADE;\nTRUNCATE codeintel_initial_path_ranks CASCADE;\n\nALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS upload_id;\nALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS upload_id;\nALTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS upload_id;\n\nALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS exported_upload_id INTEGER NOT NULL REFERENCES codeintel_ranking_exports(id) ON DELETE CASCADE;\nALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS exported_upload_id INTEGER NOT NULL REFERENCES codeintel_ranking_exports(id) ON DELETE CASCADE;\nALTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS exported_upload_id INTEGER NOT NULL REFERENCES codeintel_ranking_exports(id) ON DELETE CASCADE;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_exported_upload_id ON codeintel_ranking_definitions(exported_upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_references_exported_upload_id ON codeintel_ranking_references(exported_upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_initial_path_ranks_exported_upload_id ON codeintel_initial_path_ranks(exported_upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_symbol_search ON codeintel_ranking_definitions(graph_key, symbol_name, exported_upload_id, document_path);",
+				"DownQuery": "TRUNCATE codeintel_ranking_definitions CASCADE;\nTRUNCATE codeintel_ranking_references CASCADE;\nTRUNCATE codeintel_initial_path_ranks CASCADE;\n\nALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS exported_upload_id;\nALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS exported_upload_id;\nALTER TABLE codeintel_initial_path_ranks DROP COLUMN IF EXISTS exported_upload_id;\n\nALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS upload_id INTEGER NOT NULL;\nALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS upload_id INTEGER NOT NULL;\nALTER TABLE codeintel_initial_path_ranks ADD COLUMN IF NOT EXISTS upload_id INTEGER NOT NULL;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_symbol_search ON codeintel_ranking_definitions(graph_key, symbol_name, upload_id, document_path);\nCREATE INDEX IF NOT EXISTS codeintel_ranking_references_upload_id ON codeintel_ranking_references(upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_initial_path_ranks_upload_id ON codeintel_initial_path_ranks(upload_id);\nCREATE INDEX IF NOT EXISTS codeintel_initial_path_upload_id ON codeintel_initial_path_ranks USING btree (upload_id);\nDROP INDEX codeintel_initial_path_ranks_upload_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683670735
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683782561,
+				"Name": "github-app-webhooks",
+				"UpQuery": "ALTER TABLE github_apps\n    ADD COLUMN IF NOT EXISTS webhook_id INTEGER REFERENCES webhooks(id) ON DELETE SET NULL;",
+				"DownQuery": "ALTER TABLE github_apps\n    DROP COLUMN IF EXISTS webhook_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683246005,
+					1683561153,
+					1683640362
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683913757,
+				"Name": "Add ranking progress columns",
+				"UpQuery": "ALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_path_records_total INT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_reference_records_total INT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_count_records_total INT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_path_records_processed INT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_reference_records_processed INT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS num_count_records_processed INT;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_path_records_total;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_reference_records_total;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_count_records_total;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_path_records_processed;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_reference_records_processed;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS num_count_records_processed;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683641757,
+					1683753933,
+					1683782561
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684180461,
+				"Name": "sg_telemetry_allowlist",
+				"UpQuery": "-- This migration was generated by the command `sg telemetry add`\nINSERT INTO event_logs_export_allowlist (event_name) VALUES (UNNEST('{SearchSubmitted,AccessRequestApproved,AccessRequestRejected}'::TEXT[])) ON CONFLICT DO NOTHING;",
+				"DownQuery": "-- This migration was generated by the command `sg telemetry add`\nDELETE FROM event_logs_export_allowlist WHERE event_name IN (SELECT * FROM UNNEST('{SearchSubmitted,AccessRequestApproved,AccessRequestRejected}'::TEXT[]));",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683641757,
+					1683753933,
+					1683782561
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684207923,
+				"Name": "Embeddings Proxy",
+				"UpQuery": "ALTER TABLE product_subscriptions\n    ADD COLUMN IF NOT EXISTS cody_gateway_embeddings_api_rate_limit INTEGER,\n    ADD COLUMN IF NOT EXISTS cody_gateway_embeddings_api_rate_interval_seconds INTEGER,\n    ADD COLUMN IF NOT EXISTS cody_gateway_embeddings_api_allowed_models TEXT[];\n\nCOMMENT ON COLUMN product_subscriptions.cody_gateway_embeddings_api_rate_limit IS 'Custom requests per time interval allowed for embeddings';\nCOMMENT ON COLUMN product_subscriptions.cody_gateway_embeddings_api_rate_interval_seconds IS 'Custom time interval over which the embeddings rate limit is applied';\nCOMMENT ON COLUMN product_subscriptions.cody_gateway_embeddings_api_allowed_models IS 'Custom override for the set of models allowed for embedding';",
+				"DownQuery": "ALTER TABLE product_subscriptions\n    DROP COLUMN IF EXISTS cody_gateway_embeddings_api_rate_limit,\n    DROP COLUMN IF EXISTS cody_gateway_embeddings_api_rate_interval_seconds,\n    DROP COLUMN IF EXISTS cody_gateway_embeddings_api_allowed_models;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683641757,
+					1683753933,
+					1683782561
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684217409,
+				"Name": "create assigned_owners table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS assigned_owners\n(\n    id                   SERIAL PRIMARY KEY,\n    owner_user_id        INTEGER   NOT NULL REFERENCES users (id) ON DELETE CASCADE DEFERRABLE,\n    file_path_id         INTEGER   NOT NULL REFERENCES repo_paths (id),\n    who_assigned_user_id INTEGER   NULL REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,\n    assigned_at          TIMESTAMP NOT NULL DEFAULT NOW()\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS assigned_owners_file_path\n    ON assigned_owners\n        USING btree (file_path_id);\n\nCOMMENT ON TABLE assigned_owners\n    IS 'Table for ownership assignments, one entry contains an assigned user ID, which repo_path is assigned and the date and user who assigned the owner.';",
+				"DownQuery": "DROP TABLE IF EXISTS assigned_owners",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683641757,
+					1683753933,
+					1683782561
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684248574,
+				"Name": "Upsize id columns",
+				"UpQuery": "ALTER TABLE codeintel_ranking_progress\n    ADD COLUMN new_max_definition_id BIGINT,\n    ADD COLUMN new_max_reference_id BIGINT,\n    ADD COLUMN new_max_path_id BIGINT;\n\nUPDATE codeintel_ranking_progress\nSET\n    new_max_definition_id = max_definition_id,\n    new_max_reference_id = max_reference_id,\n    new_max_path_id = max_path_id;\n\nALTER TABLE codeintel_ranking_progress\n    DROP COLUMN max_definition_id,\n    DROP COLUMN max_reference_id,\n    DROP COLUMN max_path_id,\n    ALTER COLUMN new_max_definition_id SET NOT NULL,\n    ALTER COLUMN new_max_reference_id SET NOT NULL,\n    ALTER COLUMN new_max_path_id SET NOT NULL;\n\nALTER TABLE codeintel_ranking_progress RENAME new_max_definition_id TO max_definition_id;\nALTER TABLE codeintel_ranking_progress RENAME new_max_reference_id TO max_reference_id;\nALTER TABLE codeintel_ranking_progress RENAME new_max_path_id TO max_path_id;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_progress\n    ADD COLUMN new_max_definition_id INTEGER,\n    ADD COLUMN new_max_reference_id INTEGER,\n    ADD COLUMN new_max_path_id INTEGER;\n\nUPDATE codeintel_ranking_progress\nSET\n    new_max_definition_id = max_definition_id,\n    new_max_reference_id = max_reference_id,\n    new_max_path_id = max_path_id;\n\nALTER TABLE codeintel_ranking_progress\n    DROP COLUMN max_definition_id,\n    DROP COLUMN max_reference_id,\n    DROP COLUMN max_path_id,\n    ALTER COLUMN new_max_definition_id SET NOT NULL,\n    ALTER COLUMN new_max_reference_id SET NOT NULL,\n    ALTER COLUMN new_max_path_id SET NOT NULL;\n\nALTER TABLE codeintel_ranking_progress RENAME new_max_definition_id TO max_definition_id;\nALTER TABLE codeintel_ranking_progress RENAME new_max_reference_id TO max_reference_id;\nALTER TABLE codeintel_ranking_progress RENAME new_max_path_id TO max_path_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683641757,
+					1683753933,
+					1683782561
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684306784,
+				"Name": "make assigned_owners index non-unique",
+				"UpQuery": "DROP INDEX IF EXISTS assigned_owners_file_path;\n\nCREATE INDEX IF NOT EXISTS assigned_owners_file_path\n    ON assigned_owners\n        USING btree (file_path_id);",
+				"DownQuery": "DROP INDEX IF EXISTS assigned_owners_file_path;\n\nCREATE UNIQUE INDEX IF NOT EXISTS assigned_owners_file_path\n    ON assigned_owners\n        USING btree (file_path_id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684180461,
+					1684217409,
+					1684248574
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1683924275,
+				"Name": "own_signal_state",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS own_signal_configurations\n(\n    id                     SERIAL PRIMARY KEY,\n    name                   TEXT    NOT NULL,\n    description            TEXT    NOT NULL DEFAULT '',\n    excluded_repo_patterns TEXT[]  NULL,\n    enabled                BOOLEAN NOT NULL DEFAULT FALSE\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS own_signal_configurations_name_uidx ON own_signal_configurations(name);\n\nINSERT INTO own_signal_configurations (id, name, enabled, description)\nVALUES (1, 'recent-contributors', FALSE, 'Indexes contributors in each file using repository history.')\nON CONFLICT DO NOTHING;\nINSERT INTO own_signal_configurations (id, name, enabled, description)\nVALUES (2, 'recent-views', FALSE, 'Indexes users that recently viewed files in Sourcegraph.')\nON CONFLICT DO NOTHING;",
+				"DownQuery": "DROP TABLE IF EXISTS own_signal_configurations;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683246005,
+					1683561153,
+					1683640362
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684396562,
+				"Name": "add table repo_commits_changelists",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS repo_commits_changelists (\n    id SERIAL PRIMARY KEY,\n    repo_id integer NOT NULL REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE,\n    commit_sha bytea NOT NULL,\n    perforce_changelist_id integer NOT NULL,\n    created_at timestamp WITH TIME ZONE NOT NULL DEFAULT now()\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS repo_id_perforce_changelist_id_unique ON repo_commits_changelists USING btree (repo_id, perforce_changelist_id);",
+				"DownQuery": "DROP INDEX IF EXISTS repo_id_perforce_changelist_id_unique;\n\nDROP TABLE IF EXISTS repo_commits_changelists;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683913757,
+					1683924275,
+					1684306784
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684398004,
+				"Name": "drop github_app_installs table",
+				"UpQuery": "DROP TABLE IF EXISTS github_app_installs;",
+				"DownQuery": "-- This repeats migration 1682598027 that introduced the table\nCREATE TABLE IF NOT EXISTS github_app_installs (\n    id SERIAL PRIMARY KEY,\n    app_id INT NOT NULL REFERENCES github_apps(id) ON DELETE CASCADE,\n    installation_id INT NOT NULL,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\n\nCREATE INDEX IF NOT EXISTS installation_id_idx ON github_app_installs USING btree (installation_id);\nCREATE INDEX IF NOT EXISTS app_id_idx ON github_app_installs USING btree (app_id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683913757,
+					1683924275,
+					1684306784
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684429687,
+				"Name": "own_signal_config_view",
+				"UpQuery": "CREATE OR REPLACE VIEW own_background_jobs_config_aware AS\nSELECT obj.*, osc.name AS config_name\nFROM own_background_jobs obj\n         JOIN own_signal_configurations osc ON obj.job_type = osc.id\nWHERE osc.enabled IS TRUE;",
+				"DownQuery": "DROP VIEW IF EXISTS own_background_jobs_config_aware;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1683913757,
+					1683924275,
+					1684306784
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684632550,
+				"Name": "Simplify mapper max id",
+				"UpQuery": "ALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS max_definition_id;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS max_reference_id;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS max_path_id;\n\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS max_export_id BIGINT;\nUPDATE codeintel_ranking_progress SET max_export_id = 0;\nALTER TABLE codeintel_ranking_progress ALTER COLUMN max_export_id SET NOT NULL;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS max_export_id;\n\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS max_definition_id BIGINT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS max_reference_id BIGINT;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS max_path_id BIGINT;\n\nUPDATE codeintel_ranking_progress SET\n    max_definition_id = 0,\n    max_reference_id = 0,\n    max_path_id = 0;\n\nALTER TABLE codeintel_ranking_progress ALTER COLUMN max_definition_id SET NOT NULL;\nALTER TABLE codeintel_ranking_progress ALTER COLUMN max_reference_id SET NOT NULL;\nALTER TABLE codeintel_ranking_progress ALTER COLUMN max_path_id SET NOT NULL;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684398004,
+					1684429687
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684771948,
+				"Name": "add_domain_to_github_app",
+				"UpQuery": "ALTER TABLE github_apps\n    ADD COLUMN IF NOT EXISTS domain TEXT NOT NULL DEFAULT 'repos';",
+				"DownQuery": "ALTER TABLE github_apps\n    DROP COLUMN IF EXISTS domain;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684396562,
+					1684632550
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684831743,
+				"Name": "switch to bigserial on user_repo_permissions table",
+				"UpQuery": "-- change the id column to bigint\nALTER TABLE IF EXISTS user_repo_permissions \nALTER COLUMN id TYPE BIGINT;\n\n-- update the sequence\nALTER SEQUENCE IF EXISTS user_repo_permissions_id_seq AS BIGINT OWNED BY user_repo_permissions.id;",
+				"DownQuery": "LOCK user_repo_permissions IN EXCLUSIVE MODE;\n\n-- drop primary key constraint first\nALTER TABLE IF EXISTS user_repo_permissions \nDROP CONSTRAINT IF EXISTS user_repo_permissions_pkey;\n\n-- change the id column back to plain int\nALTER TABLE IF EXISTS user_repo_permissions \nALTER COLUMN id TYPE INT;\n\n-- update the sequence\nALTER SEQUENCE IF EXISTS user_repo_permissions_id_seq AS INT OWNED BY user_repo_permissions.id RESTART WITH 1;\n\n-- reassign all the primary keys\nUPDATE user_repo_permissions \nSET id = nextval('user_repo_permissions_id_seq');\n\n-- add back the primary key constraint\nALTER TABLE IF EXISTS user_repo_permissions ADD CONSTRAINT user_repo_permissions_pkey PRIMARY KEY (id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684396562,
+					1684632550
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684753192,
+				"Name": "set repo meta empty values to null",
+				"UpQuery": "-- Perform migration here.\n--\n-- See /migrations/README.md. Highlights:\n--  * Make migrations idempotent (use IF EXISTS)\n--  * Make migrations backwards-compatible (old readers/writers must continue to work)\n--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement\n--    is defined per file, and that each such statement is NOT wrapped in a transaction.\n--    Each such migration must also declare \"createIndexConcurrently: true\" in their\n--    associated metadata.yaml file.\n--  * If you are modifying Postgres extensions, you must also declare \"privileged: true\"\n--    in the associated metadata.yaml file.\n\nUPDATE repo_kvps\n    SET value = NULL\nWHERE TRIM(value) = '';",
+				"DownQuery": "-- Update cannot be reverted, because this is actually a fix.",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684398004,
+					1684429687
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684854090,
+				"Name": "Add embeddings to policies",
+				"UpQuery": "ALTER TABLE lsif_configuration_policies DROP COLUMN IF EXISTS lockfile_indexing_enabled;\nALTER TABLE lsif_configuration_policies ADD COLUMN IF NOT EXISTS embeddings_enabled BOOLEAN NOT NULL DEFAULT false;\n\nCREATE OR REPLACE VIEW codeintel_configuration_policies AS\nSELECT\n    id,\n    repository_id,\n    name,\n    type,\n    pattern,\n    retention_enabled,\n    retention_duration_hours,\n    retain_intermediate_commits,\n    indexing_enabled,\n    index_commit_max_age_hours,\n    index_intermediate_commits,\n    protected,\n    repository_patterns,\n    last_resolved_at,\n    embeddings_enabled\nFROM lsif_configuration_policies;\n\nCREATE OR REPLACE VIEW codeintel_configuration_policies_repository_pattern_lookup AS\nSELECT\n    policy_id,\n    repo_id\nFROM lsif_configuration_policies_repository_pattern_lookup;",
+				"DownQuery": "DROP VIEW IF EXISTS codeintel_configuration_policies;\nDROP VIEW IF EXISTS codeintel_configuration_policies_repository_pattern_lookup;\n\nALTER TABLE lsif_configuration_policies DROP COLUMN IF EXISTS embeddings_enabled;\nALTER TABLE lsif_configuration_policies ADD COLUMN IF NOT EXISTS lockfile_indexing_enabled BOOLEAN NOT NULL DEFAULT false;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684753192,
+					1684831743
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684854389,
+				"Name": "LLM Proxy separate rate limits",
+				"UpQuery": "DO $$\nBEGIN\n    ALTER TABLE product_subscriptions RENAME COLUMN llm_proxy_rate_limit TO llm_proxy_chat_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE product_subscriptions RENAME COLUMN llm_proxy_rate_interval_seconds TO llm_proxy_chat_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nALTER TABLE product_subscriptions\n    ADD COLUMN IF NOT EXISTS llm_proxy_chat_rate_limit_allowed_models TEXT[],\n    ADD COLUMN IF NOT EXISTS llm_proxy_code_rate_limit INTEGER,\n\tADD COLUMN IF NOT EXISTS llm_proxy_code_rate_interval_seconds INTEGER,\n\tADD COLUMN IF NOT EXISTS llm_proxy_code_rate_limit_allowed_models TEXT[];",
+				"DownQuery": "DO $$\nBEGIN\n    ALTER TABLE product_subscriptions RENAME COLUMN llm_proxy_chat_rate_limit TO llm_proxy_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_chat_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE product_subscriptions RENAME COLUMN llm_proxy_chat_rate_interval_seconds TO llm_proxy_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nALTER TABLE product_subscriptions\n    DROP COLUMN IF EXISTS llm_proxy_chat_rate_limit_allowed_models,\n    DROP COLUMN IF EXISTS llm_proxy_code_rate_limit,\n\tDROP COLUMN IF EXISTS llm_proxy_code_rate_interval_seconds,\n\tDROP COLUMN IF EXISTS llm_proxy_code_rate_limit_allowed_models;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684753192,
+					1684831743
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684933018,
+				"Name": "Add ranking mapper index",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_ranking_exports_graph_key_deleted_at_id ON codeintel_ranking_exports(graph_key, deleted_at DESC NULLS FIRST, id);",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_exports_graph_key_deleted_at_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684753192,
+					1684831743
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "codeintel_ranking_exports",
+					"IndexName": "codeintel_ranking_exports_graph_key_deleted_at_id"
+				}
+			},
+			{
+				"ID": 1685103392,
+				"Name": "Add ranking export hash key",
+				"UpQuery": "ALTER TABLE codeintel_ranking_exports ADD COLUMN IF NOT EXISTS upload_key TEXT;\n\nUPDATE codeintel_ranking_exports SET upload_key = (\n    SELECT md5(u.repository_id || ':' || u.root || ':' || u.indexer)\n    FROM lsif_uploads u\n    WHERE u.id = upload_id\n) WHERE upload_key IS NULL;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_exports DROP COLUMN IF EXISTS upload_key;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684854090,
+					1684933018
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685105270,
+				"Name": "Simplify ranking reducer table",
+				"UpQuery": "ALTER TABLE codeintel_ranking_path_counts_inputs DROP COLUMN IF EXISTS document_path;\nALTER TABLE codeintel_ranking_path_counts_inputs DROP COLUMN IF EXISTS repository_id;\nALTER TABLE codeintel_ranking_path_counts_inputs ADD COLUMN IF NOT EXISTS definition_id BIGINT;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_definition_id ON codeintel_ranking_path_counts_inputs(graph_key, definition_id, id) WHERE NOT processed;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_path_counts_inputs DROP COLUMN IF EXISTS definition_id;\nALTER TABLE codeintel_ranking_path_counts_inputs ADD COLUMN IF NOT EXISTS document_path TEXT NOT NULL;\nALTER TABLE codeintel_ranking_path_counts_inputs ADD COLUMN IF NOT EXISTS repository_id INTEGER NOT NULL;\n\nCREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_repository_id_id ON codeintel_ranking_path_counts_inputs(graph_key, repository_id, id) WHERE NOT processed;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685103392
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685453088,
+				"Name": "create_github_apps_install_tables",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS github_app_installs (\n    id SERIAL PRIMARY KEY,\n    app_id INT NOT NULL REFERENCES github_apps(id) ON DELETE CASCADE,\n    installation_id INT NOT NULL,\n    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\n);\n\nCREATE INDEX IF NOT EXISTS installation_id_idx ON github_app_installs USING btree (installation_id);\nCREATE INDEX IF NOT EXISTS app_id_idx ON github_app_installs USING btree (app_id);",
+				"DownQuery": "DROP TABLE IF EXISTS github_app_installs;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684771948,
+					1685105270
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685495400,
+				"Name": "Rename LLM Proxy to Cody Gateway",
+				"UpQuery": "DO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_enabled TO cody_gateway_enabled;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_enabled does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_enabled IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_chat_rate_limit TO cody_gateway_chat_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_chat_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_chat_rate_limit IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_chat_rate_interval_seconds TO cody_gateway_chat_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_chat_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_chat_rate_interval_seconds IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_chat_rate_limit_allowed_models TO cody_gateway_chat_rate_limit_allowed_models;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_chat_rate_limit_allowed_models does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_chat_rate_limit_allowed_models IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_code_rate_limit TO cody_gateway_code_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_code_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_code_rate_limit IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_code_rate_interval_seconds TO cody_gateway_code_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_code_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_code_rate_interval_seconds IS NULL;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN llm_proxy_code_rate_limit_allowed_models TO cody_gateway_code_rate_limit_allowed_models;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column llm_proxy_code_rate_limit_allowed_models does not exist in table product_subscriptions';\nEND $$;\n\nCOMMENT ON COLUMN public.product_subscriptions.cody_gateway_code_rate_limit_allowed_models IS NULL;",
+				"DownQuery": "DO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n            RENAME COLUMN cody_gateway_enabled TO llm_proxy_enabled;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_enabled does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_chat_rate_limit TO llm_proxy_chat_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_chat_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_chat_rate_interval_seconds TO llm_proxy_chat_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_chat_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_chat_rate_limit_allowed_models TO llm_proxy_chat_rate_limit_allowed_models;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_chat_rate_limit_allowed_models does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_code_rate_limit TO llm_proxy_code_rate_limit;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_code_rate_limit does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_code_rate_interval_seconds TO llm_proxy_code_rate_interval_seconds;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_code_rate_interval_seconds does not exist in table product_subscriptions';\nEND $$;\n\nDO $$\nBEGIN\n    ALTER TABLE public.product_subscriptions\n        RENAME COLUMN cody_gateway_code_rate_limit_allowed_models TO llm_proxy_code_rate_limit_allowed_models;\nEXCEPTION\n    WHEN undefined_column THEN RAISE NOTICE 'column cody_gateway_code_rate_limit_allowed_models does not exist in table product_subscriptions';\nEND $$;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684854389,
+					1685105270
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685525992,
+				"Name": "add license fields to support auto billing",
+				"UpQuery": "ALTER TABLE IF EXISTS product_licenses\n    ADD COLUMN IF NOT EXISTS site_id UUID,\n    ADD COLUMN IF NOT EXISTS license_check_token bytea,\n    ADD COLUMN IF NOT EXISTS revoked_at timestamptz,\n    ADD COLUMN IF NOT EXISTS salesforce_sub_id text,\n    ADD COLUMN IF NOT EXISTS salesforce_opp_id text;\n\nCREATE UNIQUE INDEX IF NOT EXISTS product_licenses_license_check_token_idx ON product_licenses(license_check_token);",
+				"DownQuery": "DROP INDEX IF EXISTS product_licenses_license_check_token_idx;\n\nALTER TABLE IF EXISTS product_licenses\n    DROP COLUMN IF EXISTS site_id,\n    DROP COLUMN IF EXISTS license_check_token,\n    DROP COLUMN IF EXISTS revoked_at,\n    DROP COLUMN IF EXISTS salesforce_sub_id,\n    DROP COLUMN IF EXISTS salesforce_opp_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684854389,
+					1685105270
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685562535,
+				"Name": "Add missing ranking index",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS codeintel_initial_path_ranks_processed_codeintel_initial_path_ranks_id ON codeintel_initial_path_ranks_processed(codeintel_initial_path_ranks_id);",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_initial_path_ranks_processed_codeintel_initial_path_ranks_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684854389,
+					1685105270
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "codeintel_initial_path_ranks_processed",
+					"IndexName": "codeintel_initial_path_ranks_processed_codeintel_initial_path_ranks_id"
+				}
+			},
+			{
+				"ID": 1685570436,
+				"Name": "Add ranking graph key table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS codeintel_ranking_graph_keys (\n    id SERIAL PRIMARY KEY,\n    graph_key TEXT NOT NULL,\n    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()\n);",
+				"DownQuery": "DROP TABLE IF EXISTS codeintel_ranking_graph_keys;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685562535
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685695443,
+				"Name": "codeowners_stats_and_counts",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS codeowners_owners (\n    id SERIAL NOT NULL PRIMARY KEY,\n    reference TEXT NOT NULL\n);\n\nCOMMENT ON TABLE codeowners_owners IS 'Text reference in CODEOWNERS entry to use in codeowners_individual_stats. Reference is either email or handle without @ in front.';\nCOMMENT ON COLUMN codeowners_owners.reference IS 'We just keep the reference as opposed to splitting it to handle or email\nsince the distinction is not relevant for query, and this makes indexing way easier.';\n\nCREATE INDEX IF NOT EXISTS codeowners_owners_reference ON codeowners_owners USING btree (reference);\n\nCREATE TABLE IF NOT EXISTS ownership_path_stats (\n    file_path_id INTEGER NOT NULL PRIMARY KEY REFERENCES repo_paths(id),\n    tree_codeowned_files_count INTEGER NULL,\n    last_updated_at TIMESTAMP NOT NULL\n);\n\nCOMMENT ON TABLE ownership_path_stats IS 'Data on how many files in given tree are owned by anyone.\n\nWe choose to have a table for `ownership_path_stats` - more general than for CODEOWNERS,\nwith a specific tree_codeowned_files_count CODEOWNERS column. The reason for that\nis that we aim at expanding path stats by including total owned files (via CODEOWNERS\nor assigned ownership), and perhaps files count by assigned ownership only.';\nCOMMENT ON COLUMN ownership_path_stats.last_updated_at IS 'When the last background job updating counts run.';\n\n\nCREATE TABLE IF NOT EXISTS codeowners_individual_stats (\n    file_path_id INTEGER NOT NULL REFERENCES repo_paths(id),\n    owner_id INTEGER NOT NULL REFERENCES codeowners_owners(id),\n    tree_owned_files_count INTEGER NOT NULL,\n    updated_at TIMESTAMP NOT NULL,\n    -- We choose a compound primary key as the counts are looked up by either file_path_id only\n    -- or by the pair.\n    PRIMARY KEY (file_path_id, owner_id)\n);\n\nCOMMENT ON TABLE codeowners_individual_stats IS 'Data on how many files in given tree are owned by given owner.\n\nAs opposed to ownership-general `ownership_path_stats` table, the individual \u003cpath x owner\u003e stats\nare stored in CODEOWNERS-specific table `codeowners_individual_stats`. The reason for that is that\nwe are also indexing on owner_id which is CODEOWNERS-specific.';\nCOMMENT ON COLUMN codeowners_individual_stats.tree_owned_files_count IS 'Total owned file count by given owner at given file tree.';\nCOMMENT ON COLUMN codeowners_individual_stats.updated_at IS 'When the last background job updating counts run.';\n\nALTER TABLE IF EXISTS repo_paths\nADD COLUMN IF NOT EXISTS tree_files_count INTEGER NULL,\n    ADD COLUMN IF NOT EXISTS tree_files_counts_updated_at TIMESTAMP NULL;\n\nCOMMENT ON COLUMN repo_paths.tree_files_count IS 'Total count of files in the file tree rooted at the path. 1 for files.';\nCOMMENT ON COLUMN repo_paths.tree_files_counts_updated_at IS 'Timestamp of the job that updated the file counts';",
+				"DownQuery": "ALTER TABLE IF EXISTS repo_paths DROP COLUMN IF EXISTS tree_files_count,\n    DROP COLUMN IF EXISTS tree_files_counts_updated_at;\n\nDROP TABLE IF EXISTS codeowners_individual_stats;\n\nDROP TABLE IF EXISTS ownership_path_stats;\n\nDROP INDEX IF EXISTS codeowners_owners_reference;\nDROP TABLE IF EXISTS codeowners_owners;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685495400,
+					1685525992,
+					1685570436
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685697346,
+				"Name": "add unique constraint to assigned_owners",
+				"UpQuery": "DROP INDEX IF EXISTS assigned_owners_file_path;\n\nCREATE UNIQUE INDEX IF NOT EXISTS assigned_owners_file_path_owner\n    ON assigned_owners\n        USING btree (file_path_id, owner_user_id);",
+				"DownQuery": "DROP INDEX IF EXISTS assigned_owners_file_path_owner;\n\nCREATE INDEX IF NOT EXISTS assigned_owners_file_path\n    ON assigned_owners\n        USING btree (file_path_id);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685495400,
+					1685525992,
+					1685570436
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685727930,
+				"Name": "Junk cleanup",
+				"UpQuery": "WITH\nprogress AS (\n    SELECT graph_key\n    FROM codeintel_ranking_progress\n    ORDER BY mappers_started_at DESC\n    LIMIT 1\n),\ndel_references AS (\n    DELETE FROM codeintel_ranking_references_processed\n    WHERE graph_key NOT IN (SELECT graph_key FROM progress)\n    RETURNING 1\n),\ndel_paths AS (\n    DELETE FROM codeintel_initial_path_ranks_processed\n    WHERE graph_key NOT IN (SELECT graph_key FROM progress)\n    RETURNING 1\n)\nSELECT\n    (SELECT COUNT(*) FROM del_references),\n    (SELECT COUNT(*) FROM del_paths);",
+				"DownQuery": "-- What do you want me to do, put junk *back*??",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685697346
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685712730,
+				"Name": "add_own_analytics_setting",
+				"UpQuery": "INSERT INTO own_signal_configurations (name, enabled, description)\nVALUES (\n        'analytics',\n        FALSE,\n        'Indexes ownership data to present in aggregated views like Admin \u003e Analytics \u003e Own and Repo \u003e Ownership'\n    ) ON CONFLICT DO NOTHING;",
+				"DownQuery": "DELETE FROM own_signal_configurations\nWHERE name = 'analytics';",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685495400,
+					1685525992,
+					1685570436
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685645480,
+				"Name": "normalize_base_url",
+				"UpQuery": "UPDATE github_apps\n-- Add a trailing slash to URNs that don't have one. This mimics the effect of the\n-- extsvc.NormalizeBaseURL method in Go\nSET base_url = CONCAT(base_url, '/')\nWHERE base_url NOT LIKE '%/';",
+				"DownQuery": "-- Up migration only changes data, no down migration necessary.",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684771948,
+					1685105270
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1684858266,
+				"Name": "add queuenames column to executor heartbeat",
+				"UpQuery": "ALTER TABLE executor_heartbeats ALTER COLUMN queue_name DROP NOT NULL;\nALTER TABLE executor_heartbeats ADD COLUMN IF NOT EXISTS queue_names TEXT[];\n\nDO $$\nBEGIN\n    IF NOT EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'one_of_queue_name_queue_names') THEN\n        ALTER TABLE executor_heartbeats\n            ADD CONSTRAINT one_of_queue_name_queue_names\n                CHECK (\n                        (queue_name IS NOT NULL AND queue_names IS NULL)\n                        OR\n                        (queue_names IS NOT NULL AND queue_name IS NULL)\n                    );\n    END IF;\nEND $$;\n\nCOMMENT ON COLUMN executor_heartbeats.queue_names IS 'The list of queue names that the executor polls for work.';",
+				"DownQuery": "-- multi-queue executors are not implemented in the version that this down migration reverts to, so\n-- delete all heartbeats that contain multiple queue names due to queue_name being NULL for those rows\nDO $$\nBEGIN\n    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'executor_heartbeats' AND column_name = 'queue_names') THEN\n        DELETE FROM executor_heartbeats WHERE queue_name IS NULL AND queue_names IS NOT NULL;\n    END IF;\nEND $$;\n\nALTER TABLE executor_heartbeats DROP CONSTRAINT IF EXISTS one_of_queue_name_queue_names;\nALTER TABLE executor_heartbeats DROP COLUMN IF EXISTS queue_names;\nALTER TABLE executor_heartbeats ALTER COLUMN queue_name SET NOT NULL;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684396562,
+					1684398004,
+					1684429687
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685983690,
+				"Name": "Make path count inputs unique by definition_id.",
+				"UpQuery": "UPDATE codeintel_ranking_path_counts_inputs SET processed = true WHERE NOT processed;\n\nCREATE UNIQUE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_unique_definition_id ON codeintel_ranking_path_counts_inputs(graph_key, definition_id) WHERE NOT processed;",
+				"DownQuery": "DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_unique_definition_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684858266,
+					1685695443,
+					1685697346,
+					1685712730
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685984018,
+				"Name": "Drop duplicate index.",
+				"UpQuery": "DROP INDEX IF EXISTS codeintel_ranking_path_counts_inputs_graph_key_definition_id;",
+				"DownQuery": "CREATE INDEX IF NOT EXISTS codeintel_ranking_path_counts_inputs_graph_key_definition_id ON codeintel_ranking_path_counts_inputs(graph_key, definition_id, id) WHERE NOT processed;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685983690
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1685999719,
+				"Name": "Add additional progress tracking for ranking mapper.",
+				"UpQuery": "ALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS reference_cursor_export_deleted_at TIMESTAMP WITH TIME ZONE;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS reference_cursor_export_id INTEGER;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS path_cursor_deleted_export_at TIMESTAMP WITH TIME ZONE;\nALTER TABLE codeintel_ranking_progress ADD COLUMN IF NOT EXISTS path_cursor_export_id INTEGER;",
+				"DownQuery": "ALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS reference_cursor_export_deleted_at;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS reference_cursor_export_id;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS path_cursor_deleted_export_at;\nALTER TABLE codeintel_ranking_progress DROP COLUMN IF EXISTS path_cursor_export_id;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684858266,
+					1685695443,
+					1685697346,
+					1685712730
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686042710,
+				"Name": "add assigned_teams table",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS assigned_teams\n(\n    id                   SERIAL PRIMARY KEY,\n    owner_team_id        INTEGER   NOT NULL REFERENCES teams (id) ON DELETE CASCADE DEFERRABLE,\n    file_path_id         INTEGER   NOT NULL REFERENCES repo_paths (id),\n    who_assigned_team_id INTEGER   NULL REFERENCES users (id) ON DELETE SET NULL DEFERRABLE,\n    assigned_at          TIMESTAMP NOT NULL DEFAULT NOW()\n);\n\nCREATE UNIQUE INDEX IF NOT EXISTS assigned_teams_file_path_owner\n    ON assigned_teams\n        USING btree (file_path_id, owner_team_id);\n\nCOMMENT ON TABLE assigned_teams\n    IS 'Table for team ownership assignments, one entry contains an assigned team ID, which repo_path is assigned and the date and user who assigned the owner team.';",
+				"DownQuery": "DROP TABLE IF EXISTS assigned_teams",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684858266,
+					1685695443,
+					1685697346,
+					1685712730
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686169273,
+				"Name": "add_verification_to_changesets",
+				"UpQuery": "-- Note that we have to regenerate the reconciler_changesets view, as the SELECT\n-- statement in the view definition isn't refreshed when the fields change within the\n-- changesets table.\nDROP VIEW IF EXISTS\n    reconciler_changesets;\n\nALTER TABLE changesets\n    ADD COLUMN IF NOT EXISTS commit_verification jsonb DEFAULT '{}'::jsonb NOT NULL;\n\nCREATE VIEW reconciler_changesets AS\nSELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.commit_verification,\n    c.diff_stat_added,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.computed_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_name,\n    c.external_fork_namespace,\n    c.detached_at,\n    c.previous_failure_message\nFROM changesets c\nJOIN repo r ON r.id = c.repo_id\nWHERE r.deleted_at IS NULL AND EXISTS (\n    SELECT 1\n    FROM batch_changes\n        LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id\n        LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id\n    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL\n    );",
+				"DownQuery": "-- Note that we have to regenerate the reconciler_changesets view, as the SELECT\n-- statement in the view definition isn't refreshed when the fields change within the\n-- changesets table.\nDROP VIEW IF EXISTS\n    reconciler_changesets;\n\nALTER TABLE changesets\n    DROP COLUMN IF EXISTS commit_verification;\n\n\nCREATE VIEW reconciler_changesets AS\nSELECT c.id,\n    c.batch_change_ids,\n    c.repo_id,\n    c.queued_at,\n    c.created_at,\n    c.updated_at,\n    c.metadata,\n    c.external_id,\n    c.external_service_type,\n    c.external_deleted_at,\n    c.external_branch,\n    c.external_updated_at,\n    c.external_state,\n    c.external_review_state,\n    c.external_check_state,\n    c.diff_stat_added,\n    c.diff_stat_deleted,\n    c.sync_state,\n    c.current_spec_id,\n    c.previous_spec_id,\n    c.publication_state,\n    c.owned_by_batch_change_id,\n    c.reconciler_state,\n    c.computed_state,\n    c.failure_message,\n    c.started_at,\n    c.finished_at,\n    c.process_after,\n    c.num_resets,\n    c.closing,\n    c.num_failures,\n    c.log_contents,\n    c.execution_logs,\n    c.syncer_error,\n    c.external_title,\n    c.worker_hostname,\n    c.ui_publication_state,\n    c.last_heartbeat_at,\n    c.external_fork_name,\n    c.external_fork_namespace,\n    c.detached_at,\n    c.previous_failure_message\nFROM changesets c\nJOIN repo r ON r.id = c.repo_id\nWHERE r.deleted_at IS NULL AND EXISTS (\n    SELECT 1\n    FROM batch_changes\n        LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id\n        LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id\n    WHERE c.batch_change_ids ? batch_changes.id::text AND namespace_user.deleted_at IS NULL AND namespace_org.deleted_at IS NULL\n    );",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684207923,
+					1685453088,
+					1685645480,
+					1685727930,
+					1685984018,
+					1685999719,
+					1686042710
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686169626,
+				"Name": "add stats to embeddings jobs",
+				"UpQuery": "CREATE TABLE IF NOT EXISTS repo_embedding_job_stats (\n    job_id INTEGER PRIMARY KEY REFERENCES repo_embedding_jobs(id) ON DELETE CASCADE DEFERRABLE,\n    is_incremental BOOLEAN NOT NULL DEFAULT FALSE,\n    code_files_total INTEGER NOT NULL DEFAULT 0,\n    code_files_embedded INTEGER NOT NULL DEFAULT 0,\n    code_chunks_embedded INTEGER NOT NULL DEFAULT 0,\n    code_files_skipped JSONB NOT NULL DEFAULT '{}',\n    code_bytes_embedded INTEGER NOT NULL DEFAULT 0,\n    text_files_total INTEGER NOT NULL DEFAULT 0,\n    text_files_embedded INTEGER NOT NULL DEFAULT 0,\n    text_chunks_embedded INTEGER NOT NULL DEFAULT 0,\n    text_files_skipped JSONB NOT NULL DEFAULT '{}',\n    text_bytes_embedded INTEGER NOT NULL DEFAULT 0\n);",
+				"DownQuery": "-- Undo the changes made in the up migration\n\nDROP TABLE IF EXISTS repo_embedding_job_stats;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684207923,
+					1685727930,
+					1685984018,
+					1685999719,
+					1686042710
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686208766,
+				"Name": "add revoke reason to product_licenses table",
+				"UpQuery": "ALTER TABLE IF EXISTS product_licenses \n    ADD COLUMN IF NOT EXISTS revoke_reason TEXT;",
+				"DownQuery": "ALTER TABLE IF EXISTS product_licenses \n    DROP COLUMN IF EXISTS revoke_reason;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1684207923,
+					1685727930,
+					1685984018,
+					1685999719,
+					1686042710
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686255261,
+				"Name": "add_own_analytics_setting_again",
+				"UpQuery": "-- This setting was already added in 1685712730. We need to do it again here.\n-- The reason is that own_signal_configurations has id with SERIAL type,\n-- and the migration adding analytics setting, inserted just the row values\n-- hoping ID would be autogenerated.\n-- However two rows inserted previously to this table had hardcoded IDs\n-- so they did not advance the ID sequence. Therefore the insert in 1685712730\n-- generated one of the ID that were hardcoded (since these were 1 and 2),\n-- this generated a conflict, and INSERT failed silently due to ON CONFLICT clause.\n-- Reinsert in order to advance the sequence.\nINSERT INTO own_signal_configurations (name, enabled, description)\nVALUES (\n        'analytics',\n        FALSE,\n        'Indexes ownership data to present in aggregated views like Admin \u003e Analytics \u003e Own and Repo \u003e Ownership'\n    ),\n    (\n        'analytics',\n        FALSE,\n        'Indexes ownership data to present in aggregated views like Admin \u003e Analytics \u003e Own and Repo \u003e Ownership'\n    ) ON CONFLICT DO NOTHING;",
+				"DownQuery": "DELETE FROM own_signal_configurations\nWHERE name = 'analytics';",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686208766
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686415661,
+				"Name": "change product_subscriptions cody_gateway limits to int64",
+				"UpQuery": "ALTER TABLE product_subscriptions\n    ALTER COLUMN cody_gateway_chat_rate_limit TYPE bigint,\n    ALTER COLUMN cody_gateway_code_rate_limit TYPE bigint,\n    ALTER COLUMN cody_gateway_embeddings_api_rate_limit TYPE bigint;",
+				"DownQuery": "ALTER TABLE product_subscriptions\nALTER COLUMN cody_gateway_chat_rate_limit TYPE integer,\n    ALTER COLUMN cody_gateway_code_rate_limit TYPE integer,\n    ALTER COLUMN cody_gateway_embeddings_api_rate_limit TYPE integer;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686255261
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686580819,
+				"Name": "Store symbols as bytes",
+				"UpQuery": "-- Drop reliance on symbol names\nDROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_symbol_search;\n\n-- Add symbol checksums columns\nALTER TABLE codeintel_ranking_references ADD COLUMN IF NOT EXISTS symbol_checksums bytea[] NOT NULL DEFAULT '{}';\nALTER TABLE codeintel_ranking_definitions ADD COLUMN IF NOT EXISTS symbol_checksum bytea NOT NULL DEFAULT ''::bytea;\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_symbol_checksum_search ON codeintel_ranking_definitions(graph_key, symbol_checksum, exported_upload_id, document_path);",
+				"DownQuery": "-- Drop new objects\nDROP INDEX IF EXISTS codeintel_ranking_definitions_graph_key_symbol_checksum_search;\nALTER TABLE codeintel_ranking_references DROP COLUMN IF EXISTS symbol_checksums;\nALTER TABLE codeintel_ranking_definitions DROP COLUMN IF EXISTS symbol_checksum;\n\n-- Recreate old index\nCREATE INDEX IF NOT EXISTS codeintel_ranking_definitions_graph_key_symbol_search ON codeintel_ranking_definitions(graph_key, symbol_name, exported_upload_id, document_path);",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686255261
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686723014,
+				"Name": "own_analytics_assigned_ownership",
+				"UpQuery": "ALTER TABLE IF EXISTS ownership_path_stats\nADD COLUMN IF NOT EXISTS tree_assigned_ownership_files_count INTEGER NULL,\n    ADD COLUMN IF NOT EXISTS tree_any_ownership_files_count INTEGER NULL;",
+				"DownQuery": "ALTER TABLE IF EXISTS ownership_path_stats DROP COLUMN IF EXISTS tree_assigned_ownership_files_count,\n    DROP COLUMN IF EXISTS tree_any_ownership_files_count;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686169626,
+					1686580819
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686749117,
+				"Name": "Add last_indexed_at to zoekt_repos.",
+				"UpQuery": "ALTER TABLE zoekt_repos ADD COLUMN IF NOT EXISTS last_indexed_at TIMESTAMP WITH TIME ZONE;",
+				"DownQuery": "ALTER TABLE zoekt_repos DROP COLUMN IF EXISTS last_indexed_at;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686723014
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686282228,
+				"Name": "add installation metadata",
+				"UpQuery": "ALTER TABLE IF EXISTS github_app_installs\n    ADD COLUMN IF NOT EXISTS url text,\n    ADD COLUMN IF NOT EXISTS account_login text,\n    ADD COLUMN IF NOT EXISTS account_avatar_url text,\n    ADD COLUMN IF NOT EXISTS account_url text,\n    ADD COLUMN IF NOT EXISTS account_type text,\n    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();\n\nCREATE INDEX IF NOT EXISTS github_app_installs_account_login ON github_app_installs (account_login);",
+				"DownQuery": "DROP INDEX IF EXISTS github_app_installs_account_login;\n\nALTER TABLE IF EXISTS github_app_installs\n    DROP COLUMN IF EXISTS url,\n    DROP COLUMN IF EXISTS account_login,\n    DROP COLUMN IF EXISTS account_avatar_url,\n    DROP COLUMN IF EXISTS account_url,\n    DROP COLUMN IF EXISTS account_type,\n    DROP COLUMN IF EXISTS updated_at;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1685453088,
+					1685645480,
+					1686208766
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1686287028,
+				"Name": "add unique github app install constraint",
+				"UpQuery": "ALTER TABLE github_app_installs\n    DROP CONSTRAINT IF EXISTS unique_app_install;\n\nALTER TABLE github_app_installs ADD CONSTRAINT unique_app_install UNIQUE (app_id, installation_id);",
+				"DownQuery": "ALTER TABLE github_app_installs DROP CONSTRAINT IF EXISTS unique_app_install;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1686282228
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1680296731,
+				"Name": "package_repos_package_name_regex_match",
+				"UpQuery": "CREATE INDEX IF NOT EXISTS lsif_dependency_repos_name_gin\nON lsif_dependency_repos\nUSING gin (name gin_trgm_ops)",
+				"DownQuery": "DROP INDEX IF EXISTS lsif_dependency_repos_name_gin;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1679426934,
+					1679432506
+				],
+				"IsCreateIndexConcurrently": false,
+				"IndexMetadata": null
+			},
+			{
+				"ID": 1687792857,
+				"Name": "generate license token for existing v1 product licenses",
+				"UpQuery": "UPDATE product_licenses\nSET license_check_token = sha256(sha256(license_key :: bytea))\nWHERE\n    -- update v1 licenses where token is NULL\n    ((\n        -- only update v1 licenses\n        license_version = 1 -- only update records that don't already have a license check token\n        AND license_check_token IS NULL\n    )\n    -- update v2 licenses where token does not match expectation\n    OR (\n        license_version = 2\n        AND license_check_token != sha256(sha256(license_key :: bytea))\n    ))\n    -- only update non-expired\n    AND license_expires_at \u003e now()\n    -- only update non-revoked\n    AND revoked_at IS NULL;",
+				"DownQuery": "-- There's not really a way to rollback safely, so this is a noop",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1680296731,
+					1683593618,
+					1686169273,
+					1686287028,
+					1686415661,
+					1686749117
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
@@ -9555,6 +10730,13 @@
 				"LeafIDs": [
 					1678899992,
 					1678994673
+				],
+				"PreCreation": false
+			},
+			"v5.1.0": {
+				"RootID": 1648051770,
+				"LeafIDs": [
+					1687792857
 				],
 				"PreCreation": false
 			}

--- a/internal/database/migration/stitch/stitch.go
+++ b/internal/database/migration/stitch/stitch.go
@@ -208,15 +208,31 @@ var allowedOverrideMap = map[int]struct{}{
 	1528395701: {}, // https://github.com/sourcegraph/sourcegraph/pull/16203 - rewritten to avoid * in select
 	1528395730: {}, // https://github.com/sourcegraph/sourcegraph/pull/15972 - drops/re-created view to avoid dependencies
 	1663871069: {}, // https://github.com/sourcegraph/sourcegraph/pull/43390 - fixes malformed published value
+	1648628900: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1652707934: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1655157509: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1667220626: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1670934184: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1674455760: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1675962678: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1677003167: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1676420496: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1677944752: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1678214530: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1678456448: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
 
 	// codeintel
 	1000000020: {}, // https://github.com/sourcegraph/sourcegraph/pull/28772 - rewritten to be idempotent
+	1665531314: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1670365552: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
 
 	// codeiensights
 	1000000002: {}, // https://github.com/sourcegraph/sourcegraph/pull/28713 - fixed SQL error
 	1000000001: {}, // https://github.com/sourcegraph/sourcegraph/pull/30781 - removed timescsaledb
 	1000000004: {}, // https://github.com/sourcegraph/sourcegraph/pull/30781 - removed timescsaledb
 	1000000010: {}, // https://github.com/sourcegraph/sourcegraph/pull/30781 - removed timescsaledb
+	1659572248: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
+	1672921606: {}, // https://github.com/sourcegraph/sourcegraph/pull/52098
 }
 
 func overrideAllowed(id int) bool {


### PR DESCRIPTION
#55237 cleans up the database drift in `5.1`, while this PR does the same for the `main` branch.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Running the `cd internal/database/migration/shared && go run ./data/cmd/generator --write-frozen=false` should update the migration graph.