### PR TITLE
Update polling interval for embeddings status indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,5 @@ result-*
 
 # Windows
 /enterprise/cmd/sourcegraph/__debug_bin.exe
+
+/cody

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -53,7 +53,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
 
         loadReposStatus({
             variables: { repoNames, first: repoNames.length, includeJobs: !!window.context.currentUser?.siteAdmin },
-            pollInterval: 5000,
+            pollInterval: 2000,
         }).catch(() => null)
     }, [activeEditor, scope.repositories, loadReposStatus])
 


### PR DESCRIPTION
Reduce polling interval to 2s from 5s for embedding status indicator.


## Test plan

- sg start dotcom
- visit /cody
- add repos to context
- check network tab for repos embeddings status gql request every 2 seconds. 