### PR TITLE
sg gen / bazel: port generation of reference from go to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -323,6 +323,7 @@ nogo(
 
 exports_files([
     "go.mod",
+    "sg.config.yaml",
     # Used for when copy_to_directory might reference an empty filegroup
     # under certain conditions. See //ui/assets/...
     "CONTRIBUTING.md",

--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -14,6 +14,7 @@ write_source_files(
         "//cmd/cody-gateway/internal/dotcom:write_genql_yaml",
         "//doc/admin/observability:write_monitoring_docs",
         "//doc/cli/references:write_doc_files",
+        "//doc/dev/background-information/sg:write_cli_reference_doc",
         "//enterprise/cmd/frontend/internal/guardrails/dotcom:write_genql_yaml",
         "//internal/batches/search/syntax:write_token_type",
         "//lib/codeintel/lsif/protocol:write_symbol_kind",

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -177,8 +177,13 @@ genrule(
     outs = ["reference.md"],
     cmd = """
     set -x
-    $(location :sg) --disable-overwrite --disable-analytics --skip-auto-update --config sg.config.yaml \
-            help --use-cwd --full --output $@
+    SG_FORCE_REPO_ROOT="$$(pwd)" $(location :sg) \
+            --no-dev-private \
+            --disable-overwrite \
+            --disable-analytics \
+            --skip-auto-update \
+            --config sg.config.yaml \
+            help --full --output $@
     """,
     tools = [":sg"],
     visibility = ["//visibility:public"],

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -165,3 +165,21 @@ go_test(
         "@com_github_urfave_cli_v2//:cli",
     ],
 )
+
+# Refer to /doc/dev/background-information/sg/BUILD.bazel to see how this target is used to copy the
+# reference.md to the correct directory.
+#
+# Alternatively, if you just want to generate the doc:
+# bazel run /doc/dev/background-information/sg:write_cli_reference_doc
+genrule(
+    name = "generate_reference_doc",
+    srcs = ["//:sg.config.yaml"],
+    outs = ["reference.md"],
+    cmd = """
+    set -x
+    $(location :sg) --disable-overwrite --disable-analytics --skip-auto-update --config sg.config.yaml \
+            help --use-cwd --full --output $@
+    """,
+    tools = [":sg"],
+    visibility = ["//visibility:public"],
+)

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -48,7 +48,7 @@ func main() {
 var (
 	BuildCommit = "dev"
 
-	DisableDevPrivateCheck = false
+	NoDevPrivateCheck = false
 
 	// configFile is the path to use with sgconf.Get - it must not be used before flag
 	// initialization.
@@ -144,8 +144,8 @@ var sg = &cli.App{
 			Name:        "no-dev-private",
 			Usage:       "disable checking for dev-private - only useful for automation or ci",
 			EnvVars:     []string{"SG_NO_DEV_PRIVATE"},
-			Value:       true,
-			Destination: &DisableDevPrivateCheck,
+			Value:       false,
+			Destination: &NoDevPrivateCheck,
 		},
 	},
 	Before: func(cmd *cli.Context) (err error) {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -79,7 +79,8 @@ const sgBugReportTemplate = "https://github.com/sourcegraph/sourcegraph/issues/n
 
 // sg is the main sg CLI application.
 //
-//go:generate go run . -disable-overwrite help -full -output ./doc/dev/background-information/sg/reference.md
+// To generate the reference.md (previously done with go generate) do:
+// bazel run /doc/dev/background-information/sg:write_cli_reference_doc
 var sg = &cli.App{
 	Usage:       "The Sourcegraph developer tool!",
 	Description: "Learn more: https://docs.sourcegraph.com/dev/background-information/sg",

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -48,6 +48,8 @@ func main() {
 var (
 	BuildCommit = "dev"
 
+	DisableDevPrivateCheck = false
+
 	// configFile is the path to use with sgconf.Get - it must not be used before flag
 	// initialization.
 	configFile string
@@ -137,6 +139,13 @@ var sg = &cli.App{
 			Usage:       "use fixed output configuration instead of detecting terminal capabilities",
 			EnvVars:     []string{"SG_DISABLE_OUTPUT_DETECTION"},
 			Destination: &std.DisableOutputDetection,
+		},
+		&cli.BoolFlag{
+			Name:        "no-dev-private",
+			Usage:       "disable checking for dev-private - only useful for automation or ci",
+			EnvVars:     []string{"SG_NO_DEV_PRIVATE"},
+			Value:       true,
+			Destination: &DisableDevPrivateCheck,
 		},
 	},
 	Before: func(cmd *cli.Context) (err error) {

--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -21,20 +21,17 @@ var ErrNotInsideSourcegraph = errors.New("not running inside sourcegraph/sourceg
 
 // RepositoryRoot caches and returns the value of findRoot.
 func RepositoryRoot() (string, error) {
-	// If the repositoryRootValue
-	if repositoryRootValue == "" {
-		once.Do(func() {
-			// This effectively disables automatic repo detection. This is useful in select automation
-			// cases where we really do not need to be sourcegraph/sourcegraph repo ie. generate help docs.
-			// Some commands call RepositoryRoot at init time. So we use the environment variable here to allow us
-			// to set the repo root as early as possible.
-			if forcedRoot := os.Getenv("SG_FORCE_REPO_ROOT"); forcedRoot != "" {
-				repositoryRootValue = forcedRoot
-			} else {
-				repositoryRootValue, repositoryRootError = findRootFromCwd()
-			}
-		})
-	}
+	once.Do(func() {
+		// This effectively disables automatic repo detection. This is useful in select automation
+		// cases where we really do not need to be sourcegraph/sourcegraph repo ie. generate help docs.
+		// Some commands call RepositoryRoot at init time. So we use the environment variable here to allow us
+		// to set the repo root as early as possible.
+		if forcedRoot := os.Getenv("SG_FORCE_REPO_ROOT"); forcedRoot != "" {
+			repositoryRootValue = forcedRoot
+		} else {
+			repositoryRootValue, repositoryRootError = findRootFromCwd()
+		}
+	})
 	return repositoryRootValue, repositoryRootError
 }
 

--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -21,7 +21,16 @@ var ErrNotInsideSourcegraph = errors.New("not running inside sourcegraph/sourceg
 
 // RepositoryRoot caches and returns the value of findRoot.
 func RepositoryRoot() (string, error) {
-	once.Do(func() { repositoryRootValue, repositoryRootError = findRootFromCwd() })
+	// If the repositoryRootValue
+	if repositoryRootValue == "" {
+		once.Do(func() {
+			if forcedRoot := os.Getenv("SG_FORCE_REPO_ROOT"); forcedRoot != "" {
+				repositoryRootValue = forcedRoot
+			} else {
+				repositoryRootValue, repositoryRootError = findRootFromCwd()
+			}
+		})
+	}
 	return repositoryRootValue, repositoryRootError
 }
 

--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -24,6 +24,10 @@ func RepositoryRoot() (string, error) {
 	// If the repositoryRootValue
 	if repositoryRootValue == "" {
 		once.Do(func() {
+			// This effectively disables automatic repo detection. This is useful in select automation
+			// cases where we really do not need to be sourcegraph/sourcegraph repo ie. generate help docs.
+			// Some commands call RepositoryRoot at init time. So we use the environment variable here to allow us
+			// to set the repo root as early as possible.
 			if forcedRoot := os.Getenv("SG_FORCE_REPO_ROOT"); forcedRoot != "" {
 				repositoryRootValue = forcedRoot
 			} else {

--- a/dev/sg/sg_help.go
+++ b/dev/sg/sg_help.go
@@ -24,12 +24,12 @@ var helpCommand = &cli.Command{
 		&cli.BoolFlag{
 			Name:    "full",
 			Aliases: []string{"f"},
-			Usage:   "Generate full markdown sg reference",
+			Usage:   "generate full markdown sg reference",
 		},
 		&cli.StringFlag{
 			Name:      "output",
 			TakesFile: true,
-			Usage:     "Write reference to `file`",
+			Usage:     "write reference to `file`",
 		},
 	},
 	Action: func(cmd *cli.Context) error {

--- a/dev/sg/sg_help.go
+++ b/dev/sg/sg_help.go
@@ -31,10 +31,6 @@ var helpCommand = &cli.Command{
 			TakesFile: true,
 			Usage:     "Write reference to `file`",
 		},
-		&cli.BoolFlag{
-			Name:  "use-cwd",
-			Usage: "Use the current directory instead of checking that we're in sourcegraph/sourcegraph repository.",
-		},
 	},
 	Action: func(cmd *cli.Context) error {
 		if cmd.NArg() != 0 {
@@ -56,7 +52,7 @@ var helpCommand = &cli.Command{
 			return err
 		}
 
-		rootDir, err := determineRootDir(cmd)
+		rootDir, err := root.RepositoryRoot()
 		if err != nil {
 			return err
 		}
@@ -72,23 +68,4 @@ var helpCommand = &cli.Command{
 
 		return std.Out.WriteMarkdown(doc)
 	},
-}
-
-func determineRootDir(cmd *cli.Context) (string, error) {
-	var dir string
-	if cmd.Bool("use-cwd") {
-		wd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		dir = wd
-	} else {
-		repoRoot, err := root.RepositoryRoot()
-		if err != nil {
-			return "", err
-		}
-		dir = repoRoot
-	}
-
-	return dir, nil
 }

--- a/dev/sg/sg_help.go
+++ b/dev/sg/sg_help.go
@@ -52,12 +52,11 @@ var helpCommand = &cli.Command{
 			return err
 		}
 
-		rootDir, err := root.RepositoryRoot()
-		if err != nil {
-			return err
-		}
-
 		if output := cmd.String("output"); output != "" {
+			rootDir, err := root.RepositoryRoot()
+			if err != nil {
+				return err
+			}
 			output = filepath.Join(rootDir, output)
 
 			if err := os.WriteFile(output, []byte(generatedSgReferenceHeader+"\n\n"+doc), 0644); err != nil {

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -221,7 +221,7 @@ func startExec(ctx *cli.Context) error {
 
 	// If the commandset requires the dev-private repository to be cloned, we
 	// check that it's at the right location here.
-	if set.RequiresDevPrivate {
+	if set.RequiresDevPrivate && DisableDevPrivateCheck {
 		repoRoot, err := root.RepositoryRoot()
 		if err != nil {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "Failed to determine repository root location: %s", err))

--- a/dev/sg/sg_start.go
+++ b/dev/sg/sg_start.go
@@ -221,7 +221,7 @@ func startExec(ctx *cli.Context) error {
 
 	// If the commandset requires the dev-private repository to be cloned, we
 	// check that it's at the right location here.
-	if set.RequiresDevPrivate && DisableDevPrivateCheck {
+	if set.RequiresDevPrivate && !NoDevPrivateCheck {
 		repoRoot, err := root.RepositoryRoot()
 		if err != nil {
 			std.Out.WriteLine(output.Styledf(output.StyleWarning, "Failed to determine repository root location: %s", err))

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -8,6 +8,7 @@ sh_test(
         "//dev/tools:docsite",
         "//doc/admin/observability:doc_files",
         "//doc/cli/references:doc_files",
+        "//doc/dev/background-information/sg:doc_files",
     ] + glob(
         ["**/*"],
         ["test.sh"],

--- a/doc/dev/background-information/sg/BUILD.bazel
+++ b/doc/dev/background-information/sg/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
+
+filegroup(
+    name = "doc_files",
+    srcs = glob(
+        ["**/*"],
+    ),
+    visibility = ["//doc:__pkg__"],
+)
+
+write_generated_to_source_files(
+    name = "write_cli_reference_doc",
+    src = "//dev/sg:generate_reference_doc",
+    # :generate_config creates an outputs folder with:
+    # - grafana dashboards
+    # - prometheus config
+    # - docs describing dashboards and alerts
+    files = [
+        "dev/sg/reference.md",
+    ],
+    strip_prefix = "dev/sg/",
+    tags = ["go_generate"],
+)

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -16,6 +16,7 @@ Global flags:
 * `--disable-analytics`: disable event logging (logged to '~/.sourcegraph/events')
 * `--disable-output-detection`: use fixed output configuration instead of detecting terminal capabilities
 * `--disable-overwrite`: disable loading additional sg configuration from overwrite file (see -overwrite)
+* `--no-dev-private`: disable checking for dev-private - only useful for automation or ci
 * `--overwrite, -o="<value>"`: load sg configuration from `file` that is gitignored and can be used to, for example, add credentials (default: sg.config.overwrite.yaml)
 * `--skip-auto-update`: prevent sg from automatically updating itself
 * `--verbose, -v`: toggle verbose mode


### PR DESCRIPTION
This removes the `go:generate` directive to generate `reference.md` to instead be generated with bazel ie. `bazel run //doc/dev/background-information/sg:write_cli_reference_doc` or `bazel run //dev:write_all_generated`

## Changes
- Added flag `--no-dev-private` to disable checking for `dev-private` ... since in bazel we don't have access to it __easily__
- Added environment flag `SG_FORCE_REPO_ROOT` to set the repo root to a directory. This circumvents the auto repo detection since .. again ... in bazel there isn't an easy way to make the whole repo available. And for this command (generating help) it shouldn't be required, but a few commands determine the repo root at init time.
## Test plan
Executed locally + green ci
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->


Closes #54834