### PR TITLE
[SG-54465] : Simplify post signup flow SG-54465

### DIFF
--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -43,6 +43,7 @@ export const currentAuthStateQuery = gql`
             tosAccepted
             searchable
             hasVerifiedEmail
+            completedPostSignup
             emails {
                 email
                 verified

--- a/client/shared/src/testing/integration/graphQlResults.ts
+++ b/client/shared/src/testing/integration/graphQlResults.ts
@@ -22,6 +22,7 @@ export const currentUserMock = {
     emails: [{ email: 'felix@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
     hasVerifiedEmail: true,
+    completedPostSignup: true,
     permissions: {
         __typename: 'PermissionConnection',
         nodes: [

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -175,6 +175,7 @@ ts_project(
         "src/auth.ts",
         "src/auth/CloudSignUpPage.tsx",
         "src/auth/OrDivider.tsx",
+        "src/auth/PostSignUpPage.tsx",
         "src/auth/RequestAccessPage.tsx",
         "src/auth/ResetPasswordPage.tsx",
         "src/auth/SignInPage.tsx",
@@ -1854,6 +1855,7 @@ ts_project(
     testonly = True,
     srcs = [
         "src/__mocks__/zustand.ts",
+        "src/auth/PostSignUpPage.test.tsx",
         "src/auth/RequestAccessPage.test.tsx",
         "src/auth/SignInPage.test.tsx",
         "src/auth/SignUpPage.test.tsx",

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -23,7 +23,7 @@ import { useFeatureFlag } from './featureFlags/useFeatureFlag'
 import { GlobalAlerts } from './global/GlobalAlerts'
 import { useHandleSubmitFeedback } from './hooks'
 import { LegacyLayoutRouteContext } from './LegacyRouteContext'
-import { CodySurveyToast, SurveyToast } from './marketing/toast'
+import { SurveyToast } from './marketing/toast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
 import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
 import { parseSearchURLQuery } from './search'
@@ -106,6 +106,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
             PageRoutes.RequestAccess,
         ].includes(routeMatch as PageRoutes)
     const isGetCodyPage = location.pathname === PageRoutes.GetCody
+    const isPostSignUpPage = location.pathname === PageRoutes.PostSignUp
 
     const [enableContrastCompliantSyntaxHighlighting] = useFeatureFlag('contrast-compliant-syntax-highlighting')
 
@@ -196,6 +197,15 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
         return <ApplicationRoutes routes={props.routes} />
     }
 
+    if (
+        props.isSourcegraphDotCom &&
+        props.authenticatedUser &&
+        !props.authenticatedUser.completedPostSignup &&
+        !isPostSignUpPage
+    ) {
+        return <Navigate to={PageRoutes.PostSignUp} replace={true} />
+    }
+
     return (
         <div
             className={classNames(
@@ -231,13 +241,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                 !props.isSourcegraphDotCom &&
                 !disableFeedbackSurvey &&
                 !props.isSourcegraphApp && <SurveyToast authenticatedUser={props.authenticatedUser} />}
-            {props.isSourcegraphDotCom && props.authenticatedUser && (
-                <CodySurveyToast
-                    authenticatedUser={props.authenticatedUser}
-                    telemetryService={props.telemetryService}
-                />
-            )}
-            {!isSiteInit && !isSignInOrUp && !isGetCodyPage && (
+            {!isSiteInit && !isSignInOrUp && !isGetCodyPage && !isPostSignUpPage && (
                 <GlobalNavbar
                     {...props}
                     showSearchBox={

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -12,7 +12,6 @@ import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../graphql-operations'
 import { AuthProvider, SourcegraphContext } from '../jscontext'
-import { useCodySurveyToast } from '../marketing/toast/CodySurveyToast'
 import { USER_AREA_USER_PROFILE } from '../user/area/UserArea'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
@@ -59,7 +58,6 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     isSourcegraphDotCom,
 }) => {
     const location = useLocation()
-    const { setShouldShowCodySurvey } = useCodySurveyToast()
 
     const queryWithUseEmailToggled = new URLSearchParams(location.search)
     if (showEmailForm) {
@@ -81,7 +79,6 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const invitedByUser = data?.user
 
     const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
-        setShouldShowCodySurvey(true)
         const eventType = type === 'builtin' ? 'form' : type
         telemetryService.log('SignupInitiated', { type: eventType }, { type: eventType })
     }

--- a/client/web/src/auth/PostSignUpPage.module.scss
+++ b/client/web/src/auth/PostSignUpPage.module.scss
@@ -1,0 +1,15 @@
+.page-wrapper {
+    background: radial-gradient(133.29% 34.62% at 100% -0%, rgba(161, 18, 255, 0.4) 0%, rgba(15, 17, 26, 0) 100%),
+        var(--black);
+    height: 100%;
+    width: 100%;
+
+    .page {
+        max-width: var(--viewport-xl);
+    }
+
+    .logo {
+        height: 3rem;
+        width: 3rem;
+    }
+}

--- a/client/web/src/auth/PostSignUpPage.story.tsx
+++ b/client/web/src/auth/PostSignUpPage.story.tsx
@@ -1,0 +1,27 @@
+import { Meta, Story } from '@storybook/react'
+
+import { AuthenticatedUser } from '../auth'
+import { WebStory } from '../components/WebStory'
+
+import { PostSignUpPage } from './PostSignUpPage'
+
+const config: Meta = {
+    title: 'web/src/auth/PostSignUpPage',
+}
+
+export default config
+
+const mockUser = {
+    __typename: 'User',
+    id: '1',
+    username: 'user',
+    emails: [{ email: 'user@me.com', isPrimary: true, verified: false }],
+    hasVerifiedEmail: false,
+    completedPostSignup: false,
+} as AuthenticatedUser
+
+export const UnverifiedEmail: Story = () => <WebStory>{() => <PostSignUpPage authenticatedUser={mockUser} />}</WebStory>
+
+export const VerifiedEmail: Story = () => (
+    <WebStory>{() => <PostSignUpPage authenticatedUser={{ ...mockUser, hasVerifiedEmail: true }} />}</WebStory>
+)

--- a/client/web/src/auth/PostSignUpPage.test.tsx
+++ b/client/web/src/auth/PostSignUpPage.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { Route, Routes } from 'react-router-dom'
+
+import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
+import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
+
+import { AuthenticatedUser } from '../auth'
+import { GetCodyPage } from '../get-cody/GetCodyPage'
+
+import { PostSignUpPage } from './PostSignUpPage'
+
+function renderPage({
+    hasVerifiedEmail,
+    completedPostSignup,
+}: {
+    hasVerifiedEmail: boolean
+    completedPostSignup: boolean
+}) {
+    const mockUser = {
+        id: 'userID',
+        username: 'username',
+        hasVerifiedEmail,
+        completedPostSignup,
+    } as AuthenticatedUser
+
+    return renderWithBrandedContext(
+        <MockedTestProvider mocks={[]}>
+            <Routes>
+                <Route path="/post-sign-up" element={<PostSignUpPage authenticatedUser={mockUser} />} />
+                <Route
+                    path="/get-cody"
+                    element={<GetCodyPage authenticatedUser={mockUser} context={{ authProviders: [] }} />}
+                />
+            </Routes>
+        </MockedTestProvider>,
+        { route: '/post-sign-up' }
+    )
+}
+
+describe('PostSignUpPage', () => {
+    test('renders post signup page - with email verification', () => {
+        const { asFragment } = renderPage({ completedPostSignup: false, hasVerifiedEmail: false })
+        expect(document.title).toBe('Post signup - Sourcegraph')
+        expect(asFragment()).toMatchSnapshot()
+
+        // Renders email verification modal.
+        expect(screen.getByText('Verify your email address')).toBeVisible()
+
+        // Render cody survery when next button is clicked
+        const nextButton = screen.getByRole('button', { name: 'Next' })
+        fireEvent.click(nextButton)
+
+        expect(screen.queryByText('Verify your email address')).not.toBeInTheDocument()
+        expect(screen.getByText('How will you be using Cody, our AI assistant?')).toBeVisible()
+    })
+
+    test('renders post signup page - with cody survey', () => {
+        const { asFragment } = renderPage({ completedPostSignup: false, hasVerifiedEmail: true })
+        expect(document.title).toBe('Post signup - Sourcegraph')
+        expect(screen.getByText('How will you be using Cody, our AI assistant?')).toBeVisible()
+        expect(asFragment()).toMatchSnapshot()
+    })
+
+    test('renders redirect when user has completed post signup flow', () => {
+        const { asFragment } = renderPage({ completedPostSignup: true, hasVerifiedEmail: true })
+        expect(document.title).toBe('Sourcegraph')
+        expect(asFragment()).toMatchSnapshot()
+    })
+})

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { Navigate } from 'react-router-dom'
+
+import { AuthenticatedUser } from '../auth'
+import { Page } from '../components/Page'
+import { PageTitle } from '../components/PageTitle'
+import { CodySurveyToast } from '../marketing/toast/CodySurveyToast'
+import { eventLogger } from '../tracking/eventLogger'
+
+import { withAuthenticatedUser } from './withAuthenticatedUser'
+
+import styles from './PostSignUpPage.module.scss'
+
+interface PostSignUpPageProps {
+    authenticatedUser: AuthenticatedUser
+}
+
+const PostSignUp: React.FunctionComponent<PostSignUpPageProps> = ({ authenticatedUser }) => {
+    // Redirects to /search page, if user has already completed post signup flow
+    if (authenticatedUser.completedPostSignup) {
+        return <Navigate to="/search" replace={true} />
+    }
+
+    return (
+        <div className={styles.pageWrapper}>
+            <PageTitle title="Post signup" />
+            <Page className={styles.page}>
+                <img src="/.assets/img/sourcegraph-mark.svg?v2" alt="Sourcegraph logo" className={styles.logo} />
+
+                <CodySurveyToast telemetryService={eventLogger} authenticatedUser={authenticatedUser} />
+            </Page>
+        </div>
+    )
+}
+
+export const PostSignUpPage = withAuthenticatedUser(PostSignUp)

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -134,10 +134,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                     /* eslint-disable react/no-array-index-key */
                     <div className="mb-2" key={index}>
                         <Button
-                            to={
-                                provider.authenticationURL +
-                                (context.sourcegraphDotComMode && returnTo === '/search' ? '&redirect=/get-cody' : '')
-                            }
+                            to={provider.authenticationURL}
                             display="block"
                             variant={showMoreProviders ? 'secondary' : 'primary'}
                             as={AnchorLink}

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -46,7 +46,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     const [searchParams, setSearchParams] = useSearchParams()
     const isRequestAccessAllowed = checkRequestAccessAllowed(props.context)
 
-    let returnTo = getReturnTo(location)
+    const returnTo = getReturnTo(location)
     if (authenticatedUser) {
         return <Navigate to={returnTo} replace={true} />
     }

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -48,9 +48,6 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     let returnTo = getReturnTo(location)
     if (authenticatedUser) {
-        if (context.sourcegraphDotComMode && returnTo === '/search') {
-            returnTo = '/get-cody'
-        }
         return <Navigate to={returnTo} replace={true} />
     }
 

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -11,6 +11,7 @@ import { AuthenticatedUser } from '../auth'
 import { HeroPage } from '../components/HeroPage'
 import { PageTitle } from '../components/PageTitle'
 import { SourcegraphContext } from '../jscontext'
+import { PageRoutes } from '../routes.constants'
 import { eventLogger } from '../tracking/eventLogger'
 
 import { CloudSignUpPage, ShowEmailFormQueryParameter } from './CloudSignUpPage'
@@ -81,7 +82,8 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 return response.text().then(text => Promise.reject(new Error(text)))
             }
 
-            window.location.replace(returnTo)
+            // Redirects to the /post-sign-up after successful signup on sourcegraphDotCom.
+            window.location.replace(context.sourcegraphDotComMode ? PageRoutes.PostSignUp : returnTo)
 
             return Promise.resolve()
         })

--- a/client/web/src/auth/__snapshots__/PostSignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/PostSignUpPage.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PostSignUpPage renders post signup page - with cody survey 1`] = `
+<DocumentFragment>
+  <div
+    class="pageWrapper"
+  >
+    <div
+      class="container py-4 page"
+    >
+      <img
+        alt="Sourcegraph logo"
+        class="logo"
+        src="/.assets/img/sourcegraph-mark.svg?v2"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostSignUpPage renders post signup page - with email verification 1`] = `
+<DocumentFragment>
+  <div
+    class="pageWrapper"
+  >
+    <div
+      class="container py-4 page"
+    >
+      <img
+        alt="Sourcegraph logo"
+        class="logo"
+        src="/.assets/img/sourcegraph-mark.svg?v2"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`PostSignUpPage renders redirect when user has completed post signup flow 1`] = `<DocumentFragment />`;

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -415,7 +415,7 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
           >
             <a
               class="anchorLink btn btnPrimary btnBlock"
-              href="/.auth/github/login?pc=f00bar&redirect=/get-cody"
+              href="/.auth/github/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"
@@ -438,7 +438,7 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
           >
             <a
               class="anchorLink btn btnPrimary btnBlock"
-              href="/.auth/gitlab/login?pc=f00bar&redirect=/get-cody"
+              href="/.auth/gitlab/login?pc=f00bar"
             >
               <svg
                 aria-hidden="true"

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -164,7 +164,6 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                                 onClick={onClickCTAButton}
                                 ctaClassName={styles.authButton}
                                 iconClassName={styles.buttonIcon}
-                                redirect="/get-cody"
                             />
                         </div>
                         <Link to="https://sourcegraph.com/sign-up?showEmail=true">Or, continue with email</Link>

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -61,6 +61,7 @@ const authUser: AuthenticatedUser = {
     },
     viewerCanAdminister: true,
     hasVerifiedEmail: true,
+    completedPostSignup: true,
     databaseID: 0,
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -22,6 +22,7 @@ export const mockUser: AuthenticatedUser = {
         nodes: [],
     },
     hasVerifiedEmail: true,
+    completedPostSignup: true,
     session: { __typename: 'Session', canSignOut: true },
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -83,6 +83,7 @@ const authUser: AuthenticatedUser = {
     },
     viewerCanAdminister: true,
     hasVerifiedEmail: true,
+    completedPostSignup: true,
     databaseID: 0,
     tosAccepted: true,
     searchable: true,

--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -98,7 +98,6 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                                         onClick={onClickCTAButton}
                                         ctaClassName={styles.authButton}
                                         iconClassName={styles.buttonIcon}
-                                        redirect="/get-cody"
                                     />
                                 </div>
                                 <Link

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -81,6 +81,7 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 url: '/users/test',
                 settingsURL: '/users/test/settings',
                 hasVerifiedEmail: true,
+                completedPostSignup: true,
                 organizations: {
                     nodes: [
                         {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -58,6 +58,7 @@ export type SourcegraphContextCurrentUser = Pick<
     | 'latestSettings'
     | 'permissions'
     | 'hasVerifiedEmail'
+    | 'completedPostSignup'
 >
 
 /**

--- a/client/web/src/marketing/toast/CodySurveyToast.module.scss
+++ b/client/web/src/marketing/toast/CodySurveyToast.module.scss
@@ -11,6 +11,18 @@
         border-radius: 0.3125rem;
         color: var(--white);
         border: none;
+
+        &:not(:disabled):not([aria-disabled='true']) {
+            &:hover,
+            &:focus {
+                background: var(--violet-05) !important;
+            }
+        }
+
+        &:disabled,
+        &[aria-disabled='true'] {
+            background: var(--violet-03);
+        }
     }
 
     label {
@@ -36,6 +48,10 @@
 
 .resend-button {
     color: var(--violet-05);
+}
+
+.modal-overlay {
+    background-color: unset;
 }
 
 .modal-checkbox[type='checkbox'] {

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { gql, useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Checkbox, Form, H3, Modal, Text, Button, Icon, Link } from '@sourcegraph/wildcard'
+import { Checkbox, Form, H3, Modal, Text, Button, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodyColorIcon } from '../../cody/chat/CodyPageIcon'

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { gql, useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Checkbox, Form, H3, Modal, Text, Button, Icon } from '@sourcegraph/wildcard'
+import { Checkbox, Form, H3, Modal, Text, Button, Icon, Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodyColorIcon } from '../../cody/chat/CodyPageIcon'
@@ -222,6 +222,9 @@ const CodyVerifyEmailToast: React.FC<{ onNext: () => void; authenticatedUser: Au
             )}
             {resendEmailError && <Text>{resendEmailError.message}.</Text>}
             <div className="d-flex justify-content-end mt-4">
+                <a className="mr-3 mt-auto mb-auto" href="/-/sign-out">
+                    Sign out
+                </a>
                 <Button className={styles.codySurveyToastModalButton} variant="primary" onClick={onNext}>
                     Next
                 </Button>

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { gql, useMutation } from '@sourcegraph/http-client'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Checkbox, Form, H3, Modal, Text, Button, Icon } from '@sourcegraph/wildcard'
+import { Checkbox, Form, H3, Modal, Text, Button, Icon, AnchorLink } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodyColorIcon } from '../../cody/chat/CodyPageIcon'
@@ -222,9 +222,9 @@ const CodyVerifyEmailToast: React.FC<{ onNext: () => void; authenticatedUser: Au
             )}
             {resendEmailError && <Text>{resendEmailError.message}.</Text>}
             <div className="d-flex justify-content-end mt-4">
-                <a className="mr-3 mt-auto mb-auto" href="/-/sign-out">
+                <AnchorLink className="mr-3 mt-auto mb-auto" to="/-/sign-out">
                     Sign out
-                </a>
+                </AnchorLink>
                 <Button className={styles.codySurveyToastModalButton} variant="primary" onClick={onNext}>
                     Next
                 </Button>

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -5,15 +5,19 @@ import classNames from 'classnames'
 
 import { asError, ErrorLike } from '@sourcegraph/common'
 import { gql, useMutation } from '@sourcegraph/http-client'
-import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Checkbox, Form, H3, Modal, Text, Button, Icon, useCookieStorage } from '@sourcegraph/wildcard'
+import { Checkbox, Form, H3, Modal, Text, Button, Icon } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../auth'
 import { CodyColorIcon } from '../../cody/chat/CodyPageIcon'
-import { isEmailVerificationNeededForCody } from '../../cody/isCodyEnabled'
 import { LoaderButton } from '../../components/LoaderButton'
-import { SubmitCodySurveyResult, SubmitCodySurveyVariables } from '../../graphql-operations'
+import {
+    SubmitCodySurveyResult,
+    SubmitCodySurveyVariables,
+    SetCompletedPostSignupVariables,
+    SetCompletedPostSignupResult,
+} from '../../graphql-operations'
+import { PageRoutes } from '../../routes.constants'
 import { resendVerificationEmail } from '../../user/settings/emails/UserEmail'
 
 import styles from './CodySurveyToast.module.scss'
@@ -26,10 +30,17 @@ const SUBMIT_CODY_SURVEY = gql`
     }
 `
 
-const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void } & TelemetryProps> = ({
-    onSubmitEnd,
-    telemetryService,
-}) => {
+const SET_COMPLETED_POST_SIGNUP = gql`
+    mutation SetCompletedPostSignup($userID: ID!) {
+        setCompletedPostSignup(userID: $userID) {
+            alwaysNil
+        }
+    }
+`
+
+const CodySurveyToastInner: React.FC<
+    { onSubmitEnd: () => void; userId: string; hasVerifiedEmail: boolean } & TelemetryProps
+> = ({ userId, onSubmitEnd, telemetryService, hasVerifiedEmail }) => {
     const [isCodyForWork, setIsCodyForWork] = useState(false)
     const [isCodyForPersonalStuff, setIsCodyForPersonalStuff] = useState(false)
 
@@ -40,25 +51,56 @@ const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void } & TelemetryProp
         setIsCodyForPersonalStuff(event.target.checked)
     }, [])
 
-    const [submitCodySurvey, { loading }] = useMutation<SubmitCodySurveyResult, SubmitCodySurveyVariables>(
-        SUBMIT_CODY_SURVEY,
-        {
-            variables: {
-                isForWork: isCodyForWork,
-                isForPersonal: isCodyForPersonalStuff,
-            },
-        }
-    )
+    const [submitCodySurvey, { loading: loadingCodySurvey, error: submitSurveyError }] = useMutation<
+        SubmitCodySurveyResult,
+        SubmitCodySurveyVariables
+    >(SUBMIT_CODY_SURVEY, {
+        variables: {
+            isForWork: isCodyForWork,
+            isForPersonal: isCodyForPersonalStuff,
+        },
+    })
+
+    const [updatePostSignupCompletion, { loading: loadingPostSignup, error: setPostSignupError }] = useMutation<
+        SetCompletedPostSignupResult,
+        SetCompletedPostSignupVariables
+    >(SET_COMPLETED_POST_SIGNUP, {
+        variables: {
+            userID: userId,
+        },
+    })
+
+    const loading = loadingCodySurvey || loadingPostSignup
+    const error = !!submitSurveyError || !!setPostSignupError
 
     const handleSubmit = useCallback(
-        (event: React.FormEvent<HTMLFormElement>) => {
+        async (event: React.FormEvent<HTMLFormElement>) => {
             const eventParams = { isCodyForPersonalStuff, isCodyForWork }
             telemetryService.log('CodyUsageToastSubmitted', eventParams, eventParams)
             event.preventDefault()
-            // eslint-disable-next-line no-console
-            submitCodySurvey().catch(console.error).finally(onSubmitEnd)
+
+            try {
+                await submitCodySurvey()
+
+                if (hasVerifiedEmail) {
+                    await updatePostSignupCompletion()
+                }
+
+                onSubmitEnd()
+            } catch (error) {
+                /* eslint-disable no-console */
+                console.error(error)
+            }
         },
-        [isCodyForPersonalStuff, isCodyForWork, onSubmitEnd, submitCodySurvey, telemetryService]
+        [
+            hasVerifiedEmail,
+            isCodyForPersonalStuff,
+            isCodyForWork,
+            onSubmitEnd,
+            submitCodySurvey,
+            updatePostSignupCompletion,
+            telemetryService,
+        ]
     )
 
     useEffect(() => {
@@ -66,7 +108,12 @@ const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void } & TelemetryProp
     }, [telemetryService])
 
     return (
-        <Modal className={styles.codySurveyToastModal} position="center" aria-label="Welcome message">
+        <Modal
+            className={styles.codySurveyToastModal}
+            position="center"
+            aria-label="Welcome message"
+            containerClassName={styles.modalOverlay}
+        >
             <H3 className="mb-4 d-flex align-items-center">
                 <CodyColorIcon className={styles.codyIcon} />
                 <span>Just one more thing...</span>
@@ -91,12 +138,19 @@ const CodySurveyToastInner: React.FC<{ onSubmitEnd: () => void } & TelemetryProp
                     onChange={handleCodyForPersonalStuffChange}
                     className={styles.modalCheckbox}
                 />
+                {error && (
+                    <Text size="small" className="text-danger mt-3 mb-2">
+                        An error occurred. Please reload the page and try again. If this persists, contact support at
+                        support@sourcegraph.com
+                    </Text>
+                )}
                 <div className="d-flex justify-content-end">
                     <LoaderButton
                         className={styles.codySurveyToastModalButton}
                         type="submit"
                         loading={loading}
                         label="Get started"
+                        disabled={!(isCodyForPersonalStuff || isCodyForWork)}
                     />
                 </div>
             </Form>
@@ -136,7 +190,12 @@ const CodyVerifyEmailToast: React.FC<{ onNext: () => void; authenticatedUser: Au
     }, [telemetryService])
 
     return (
-        <Modal className={styles.codySurveyToastModal} position="center" aria-label="Welcome message">
+        <Modal
+            className={styles.codySurveyToastModal}
+            position="center"
+            aria-label="Welcome message"
+            containerClassName={styles.modalOverlay}
+        >
             <H3 className="mb-4">
                 <Icon svgPath={mdiEmail} className={classNames('mr-2', styles.emailIcon)} aria-hidden={true} />
                 Verify your email address
@@ -171,53 +230,24 @@ const CodyVerifyEmailToast: React.FC<{ onNext: () => void; authenticatedUser: Au
     )
 }
 
-export const useCodySurveyToast = (): {
-    show: boolean
-    dismiss: () => void
-    setShouldShowCodySurvey: (show: boolean) => void
-} => {
-    // we specifically use cookie storage as we want consistent value between when user is logged out and logged in / signed up
-    // as well as cross-domain such about.sourcegraph.com
-    const [shouldShowCodySurvey, setShouldShowCodySurvey] = useCookieStorage<boolean>('cody.survey.show', false, {
-        expires: 365,
-    })
-    const [hasSubmitted, setHasSubmitted] = useTemporarySetting('cody.survey.submitted', false)
-    const dismiss = useCallback(() => {
-        setHasSubmitted(true)
-        setShouldShowCodySurvey(false)
-    }, [setHasSubmitted, setShouldShowCodySurvey])
-
-    useEffect(() => {
-        if (shouldShowCodySurvey && hasSubmitted) {
-            setShouldShowCodySurvey(false)
-        }
-    }, [shouldShowCodySurvey, hasSubmitted, setShouldShowCodySurvey])
-
-    return {
-        // we calculate "show" value based whether this a new signup and whether they already have submitted survey
-        show: !hasSubmitted && !!shouldShowCodySurvey,
-        dismiss,
-        setShouldShowCodySurvey,
-    }
-}
-
 export const CodySurveyToast: React.FC<
     {
-        authenticatedUser?: AuthenticatedUser
+        authenticatedUser: AuthenticatedUser
     } & TelemetryProps
 > = ({ authenticatedUser, telemetryService }) => {
-    const { show, dismiss } = useCodySurveyToast()
-    const [showVerifyEmail, setShowVerifyEmail] = useState(show && isEmailVerificationNeededForCody())
+    const [showVerifyEmail, setShowVerifyEmail] = useState(!authenticatedUser.hasVerifiedEmail)
+
+    const handleSubmitEnd = (): void => {
+        // Redirects to /get-cody page, once user submits the post-sign-up form
+        window.location.replace(PageRoutes.GetCody)
+    }
+
     const dismissVerifyEmail = useCallback(() => {
         telemetryService.log('VerifyEmailToastDismissed')
         setShowVerifyEmail(false)
     }, [telemetryService])
 
-    if (!show) {
-        return null
-    }
-
-    if (showVerifyEmail && authenticatedUser) {
+    if (showVerifyEmail) {
         return (
             <CodyVerifyEmailToast
                 onNext={dismissVerifyEmail}
@@ -227,5 +257,12 @@ export const CodySurveyToast: React.FC<
         )
     }
 
-    return <CodySurveyToastInner onSubmitEnd={dismiss} telemetryService={telemetryService} />
+    return (
+        <CodySurveyToastInner
+            telemetryService={telemetryService}
+            onSubmitEnd={handleSubmitEnd}
+            userId={authenticatedUser.id}
+            hasVerifiedEmail={authenticatedUser.hasVerifiedEmail}
+        />
+    )
 }

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -89,7 +89,6 @@ const NoAuthWidgetContent: React.FC<NoAuhWidgetContentProps> = ({ type, telemetr
                         onClick={logEvent}
                         ctaClassName={styles.authButton}
                         iconClassName={styles.buttonIcon}
-                        redirect="/get-cody"
                     />
                     <Link
                         to="https://sourcegraph.com/sign-up?showEmail=true"

--- a/client/web/src/routes.constants.ts
+++ b/client/web/src/routes.constants.ts
@@ -4,6 +4,7 @@ export enum PageRoutes {
     SearchConsole = '/search/console',
     SignIn = '/sign-in',
     SignUp = '/sign-up',
+    PostSignUp = '/post-sign-up',
     UnlockAccount = '/unlock-account/:token',
     Welcome = '/welcome',
     Settings = '/settings',

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -35,6 +35,7 @@ const RepoContainer = lazyComponent(() => import('./repo/RepoContainer'), 'RepoC
 const TeamsArea = lazyComponent(() => import('./team/TeamsArea'), 'TeamsArea')
 const CodySidebarStoreProvider = lazyComponent(() => import('./cody/sidebar/Provider'), 'CodySidebarStoreProvider')
 const GetCodyPage = lazyComponent(() => import('./get-cody/GetCodyPage'), 'GetCodyPage')
+const PostSignUpPage = lazyComponent(() => import('./auth/PostSignUpPage'), 'PostSignUpPage')
 
 // Force a hard reload so that we delegate to the serverside HTTP handler for a route.
 const PassThroughToServer: React.FC = () => {
@@ -168,6 +169,10 @@ export const routes: RouteObject[] = [
     {
         path: PageRoutes.GetCody,
         element: <LegacyRoute render={props => <GetCodyPage {...props} context={window.context} />} />,
+    },
+    {
+        path: PageRoutes.PostSignUp,
+        element: <LegacyRoute render={props => <PostSignUpPage {...props} />} />,
     },
 ]
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -108,6 +108,7 @@ type CurrentUser struct {
 	TosAccepted         bool       `json:"tosAccepted"`
 	Searchable          bool       `json:"searchable"`
 	HasVerifiedEmail    bool       `json:"hasVerifiedEmail"`
+	CompletedPostSignUp bool       `json:"completedPostSignup"`
 
 	Organizations  *UserOrganizationsConnection `json:"organizations"`
 	Session        *UserSession                 `json:"session"`
@@ -437,6 +438,11 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		return nil
 	}
 
+	completedPostSignup, err := userResolver.CompletedPostSignup(ctx)
+	if err != nil {
+		return nil
+	}
+
 	return &CurrentUser{
 		GraphQLTypename:     "User",
 		AvatarURL:           userResolver.AvatarURL(),
@@ -456,6 +462,7 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		ViewerCanAdminister: canAdminister,
 		Permissions:         resolveUserPermissions(ctx, userResolver),
 		HasVerifiedEmail:    hasVerifiedEmail,
+		CompletedPostSignUp: completedPostSignup,
 	}
 }
 

--- a/cmd/frontend/internal/app/verify_email.go
+++ b/cmd/frontend/internal/app/verify_email.go
@@ -71,7 +71,7 @@ func serveVerifyEmail(db database.DB) http.HandlerFunc {
 			log15.Error("Failed to grant user pending permissions", "userID", usr.ID, "error", err)
 		}
 
-		http.Redirect(w, r, "/user/settings/emails", http.StatusFound)
+		http.Redirect(w, r, "/", http.StatusFound)
 	}
 }
 


### PR DESCRIPTION
## Description
Implements `post-sign-up` flow on `sourcegraphDotCom`, mandating user to verify their email and fill up the cody survey before proceeding with using app.
  
[Figma](https://www.figma.com/file/DIk3eGdgKszigQVec7Y8SD/Frictionless-Cody?type=design&node-id=1617-37199&mode=design)

## Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/54465)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-54465)


## Test Plan
1. Run the sourcegraph app
2. Sign up for a sourcegraph account and it should redirect to the `/post-sign-up` page
3. In the `post-sign-up` page after validating email and filling the survey form it should take you to `/get-cody` page
4. Until the user has validated email and completed the survey form they are blocked in `/post-sign-up` page

## DEMO

<img width="1504" alt="Screenshot 2023-07-22 at 7 13 35 PM" src="https://github.com/sourcegraph/sourcegraph/assets/89894075/a967c1d7-99d1-4f51-a0a9-896a10795a90">
