### PR TITLE
gRPC: escape utf8 when formatting diff

### DIFF
--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -49,4 +49,37 @@ index dbace57d5f..53357b4971 100644
 		}}
 		require.Equal(t, expectedRanges, ranges)
 	})
+
+	t.Run("invalid utf8", func(t *testing.T) {
+		rawDiff := "diff --git a/.mailmap b/.mailmap\n" +
+			"index dbace57d5f..53357b4971 100644\n" +
+			"--- file with spaces\n" +
+			"+++ new file with spaces and invalid\xC0 utf8\n" +
+			"@@ -59,3 +59,4 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>\n" +
+			" Renovate Bot <bot@renovateapp.com> renovate[bot] <renovate[bot]@users.noreply.github.com>\n" +
+			" Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>\n" +
+			// \xC0 is an invalid UTF8 byte
+			"+Camden Cheek <invalid@utf8.\xC0m> Camden Cheek <camden@ccheek.com>\n"
+
+		parsedDiff, err := diff.NewMultiFileDiffReader(strings.NewReader(rawDiff)).ReadAllFiles()
+		require.NoError(t, err)
+
+		highlights := map[int]MatchedFileDiff{
+			0: {MatchedHunks: map[int]MatchedHunk{
+				0: {MatchedLines: map[int]result.Ranges{
+					2: {{
+						Start: result.Location{Offset: 0, Line: 0, Column: 0},
+						End:   result.Location{Offset: 6, Line: 0, Column: 6},
+					}},
+				}},
+			}},
+		}
+
+		formatted, _ := FormatDiff(parsedDiff, highlights)
+		expectedFormatted := "file\\ with\\ spaces new\\ file\\ with\\ spaces\\ and\\ invalid\xFF\xFD\\ utf8\n" +
+			"@@ -60,1 +60,2 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>\n" +
+			" Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>\n" +
+			"+Camden Cheek <invalid@utf8.\xFF\xFDm> Camden Cheek <camden@ccheek.com>\n"
+		require.Equal(t, expectedFormatted, formatted)
+	})
 }


### PR DESCRIPTION
This fixes one of the invalid UTF8 errors by escaping invalid UTF8 bytes when we format the diff. This error accounts for roughly 80% of the reported instances of this error on sourcegraph.com (based on logs).

## Test plan

Added a unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
