### PR TITLE
gRPC: sanitize symbols strings

### DIFF
--- a/cmd/symbols/squirrel/hover.go
+++ b/cmd/symbols/squirrel/hover.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const utf8ReplacementChar = "\xFF\xFD"
+
 // Returns the markdown hover message for the given node if it exists.
 func findHover(node Node) string {
 	style := node.LangSpec.commentStyle
@@ -78,5 +80,5 @@ func findHover(node Node) string {
 		hover = hover + "\n\n---\n\n" + strings.Join(comments, "\n") + "\n"
 	}
 
-	return hover
+	return strings.ToValidUTF8(hover, utf8ReplacementChar)
 }

--- a/cmd/symbols/squirrel/local_code_intel.go
+++ b/cmd/symbols/squirrel/local_code_intel.go
@@ -55,7 +55,8 @@ func (s *SquirrelService) LocalCodeIntel(ctx context.Context, repoCommitPath typ
 					// Found the scope.
 					if scope, ok := scopes[nodeId(cur)]; ok {
 						// Get the symbol name.
-						symbolName := SymbolName(node.Content(node.Contents))
+						const utf8ReplacementChar = "\xFF\xFD"
+						symbolName := SymbolName(strings.ToValidUTF8(node.Content(node.Contents), utf8ReplacementChar))
 
 						// Skip the symbol if it's already defined.
 						if _, ok := scope[symbolName]; ok {


### PR DESCRIPTION
This sanitizes the two string fields we get from symbols, which are possible to be invalid utf8. We should likely skip symbols processing for non-utf8 files entirely since they are skipped in search, but that's a larger change.

## Test plan

I couldn't reproduce this locally because sg uses a weird configuration for symbols, but the change seems minimal and low risk, so the plan is to just make sure the errors go away.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
