### PR TITLE
grpc: move localcodeintel changelog entry from unreleased to 5.1.5 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - The "Files" tab of the fuzzy finder now allows you to navigate directly to a line number by appending `:NUMBER`. For example, the fuzzy query `main.ts:100` opens line 100 in the file `main.ts`. [#55064](https://github.com/sourcegraph/sourcegraph/pull/55064)
+- The gRPC implementation for the Symbol service's `LocalCodeIntel` endpoint has been changed to stream its results. [#55242](https://github.com/sourcegraph/sourcegraph/pull/55242)
 
 ### Added
 


### PR DESCRIPTION
See https://github.com/sourcegraph/sourcegraph/pull/55292



## Test plan

N/A
