### PR TITLE
ci: fix pre-exit hook

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -16,10 +16,10 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" == "bazel" ]]; then
   for db in $(psql -c '\l' | grep "sourcegraph-" | cut -d '|' -f 1); do psql -c "drop database \"$db\""; done
 
   # Remove any hanging containers and/or volumes to ensure the next tests are able to run.
-  if $(docker ps -aq | wc -l) -gt 0; then
+  if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
     docker rm -f "$(docker ps -aq)"
   fi
-  if $(docker volume ls -q) -gt 0; then
+  if [[ $(docker volume ls -q) -gt 0 ]]; then
     docker volume rm "$(docker volume ls -q)"
   fi
 


### PR DESCRIPTION
Fixes the error

```
/buildkite/builds/buildkite-agent-bazel-85dff99848-7lgqm-1/sourcegraph/sourcegraph/.buildkite/hooks/pre-exit: line 19: 0: command not found
--
  | /buildkite/builds/buildkite-agent-bazel-85dff99848-7lgqm-1/sourcegraph/sourcegraph/.buildkite/hooks/pre-exit: line 22: -gt: command not found
```
## Test plan

Check the pre-exit output on any bazel agent in this PR