### PR TITLE
ci: fix regex to push images to dockerhub

### DIFF
--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -350,8 +350,7 @@ sg ci build docker-images-candidates-notest
 Base pipeline (more steps might be included based on branch changes):
 
 - **Image builds**: Build Docker images
-- **Publish candidate images**: Push candidate Images
-- **Publish images**: executor-vm, alpine-3.14, codeinsights-db, codeintel-db, postgres-12-alpine, Push final images
+- **Publish images**: Push final images, executor-vm, alpine-3.14, codeinsights-db, codeintel-db, postgres-12-alpine
 
 ### Backend integration tests
 

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -63,7 +63,7 @@ func bazelPushImagesCandidatesNoTest(version string) func(*bk.Pipeline) {
 
 // Used in CandidateNoTest run type
 func bazelPushImagesFinalNoTest(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, false, "bazel-push-images-candidate")
+	return bazelPushImagesCmd(version, false, "pipeline-gen")
 }
 
 func bazelPushImagesCmd(version string, isCandidate bool, depKey string) func(*bk.Pipeline) {

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -57,12 +57,7 @@ func bazelPushImagesFinal(version string) func(*bk.Pipeline) {
 }
 
 // Used in CandidateNoTest run type
-func bazelPushImagesCandidatesNoTest(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, true, "pipeline-gen")
-}
-
-// Used in CandidateNoTest run type
-func bazelPushImagesFinalNoTest(version string) func(*bk.Pipeline) {
+func bazelPushImagesNoTest(version string) func(*bk.Pipeline) {
 	return bazelPushImagesCmd(version, false, "pipeline-gen")
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -224,7 +224,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Add final artifacts
 		publishOps := operations.NewNamedSet("Publish images")
-		publishOps.Append(bazelPushImagesFinalNoTest(c.Version))
+		publishOps.Append(bazelPushImagesNoTest(c.Version))
 
 		for _, dockerImage := range legacyDockerImages {
 			publishOps.Append(publishFinalDockerImage(c, dockerImage))

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -220,21 +220,13 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		imageBuildOps.Append(bazelBuildCandidateDockerImages(legacyDockerImages, c.Version, c.candidateImageTag(), c.RunType))
 		ops.Merge(imageBuildOps)
 
-		publishOpsDev := operations.NewNamedSet("Publish candidate images")
-		publishOpsDev.Append(bazelPushImagesCandidatesNoTest(c.Version))
-		ops.Merge(publishOpsDev)
-
-		ops.Append(wait)
-
 		// Add final artifacts
 		publishOps := operations.NewNamedSet("Publish images")
-		// Add final artifacts
+		publishOps.Append(bazelPushImagesCandidatesNoTest(c.Version))
+
 		for _, dockerImage := range legacyDockerImages {
 			publishOps.Append(publishFinalDockerImage(c, dockerImage))
 		}
-
-		// Final Bazel images
-		publishOps.Append(bazelPushImagesFinalNoTest(c.Version))
 		ops.Merge(publishOps)
 
 	case runtype.ImagePatch:

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -220,6 +220,8 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		imageBuildOps.Append(bazelBuildCandidateDockerImages(legacyDockerImages, c.Version, c.candidateImageTag(), c.RunType))
 		ops.Merge(imageBuildOps)
 
+		ops.Append(wait)
+
 		// Add final artifacts
 		publishOps := operations.NewNamedSet("Publish images")
 		publishOps.Append(bazelPushImagesCandidatesNoTest(c.Version))

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -224,7 +224,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Add final artifacts
 		publishOps := operations.NewNamedSet("Publish images")
-		publishOps.Append(bazelPushImagesCandidatesNoTest(c.Version))
+		publishOps.Append(bazelPushImagesFinalNoTest(c.Version))
 
 		for _, dockerImage := range legacyDockerImages {
 			publishOps.Append(publishFinalDockerImage(c, dockerImage))

--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -62,7 +62,7 @@ push_prod=false
 # ok: main-dry-run
 # ok: main-dry-run-123
 # no: main-foo
-if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]] || [[ "$BUILD_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
+if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]] || [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=true

--- a/enterprise/dev/ci/push_all.sh
+++ b/enterprise/dev/ci/push_all.sh
@@ -62,7 +62,7 @@ push_prod=false
 # ok: main-dry-run
 # ok: main-dry-run-123
 # no: main-foo
-if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run)? ]]; then
+if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]] || [[ "$BUILD_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=true


### PR DESCRIPTION
Follows up from https://github.com/sourcegraph/sourcegraph/pull/55270 and pushes the images to dockerhub

## Test plan

Pushed image from this branch to docker hub https://hub.docker.com/layers/sourcegraph/frontend/docker-images-candidates-notest-dt-fix_regex_235989_2023-07-25_5.1-703c2e35f1dd/images/sha256-df53e963fc404d504d6da491ee5c634c49c2d6d18426a28948c3e737ce2016c4?context=explore