### PR TITLE
nix: xcompile between aarch64-darwin and x86_64-darwin

### DIFF
--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -1,0 +1,30 @@
+name: universal-ctags
+
+on:
+  push:
+    paths:
+    - 'dev/nix/ctags.nix'
+  workflow_dispatch:
+
+jobs:
+  x86_64-darwin:
+    name: Build ctags
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+      - id: auth
+        name: '🔓 Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+      - id: nix-build
+        name: Run `nix build`
+        run: |
+          nix build .#ctags
+      - id: 'upload-file'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: './result/bin/ctags'
+          destination: 'universal_ctags/x86_64-darwin/ctags'

--- a/dev/nix/comby.nix
+++ b/dev/nix/comby.nix
@@ -20,7 +20,7 @@ let
     });
 in
 if hostPlatform.isMacOS then
-  unNixifyDylibs pkgs (combyBuilder pkgs)
+  unNixifyDylibs { inherit pkgs; } (combyBuilder pkgs)
 else
 # ocaml in pkgsStatic is problematic, so we use it from pkgsMusl instead and just
 # supply pkgsStatic system libraries such as openssl etc

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -18,7 +18,7 @@ let
   stdenv = pkgsStatic.stdenv;
 in
 # yoinked from github.com/nixos/nixpkgs
-unNixifyDylibs pkgs (stdenv.mkDerivation rec {
+unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
   pname = "universal-ctags";
   version = "5.9.20220403.0";
 

--- a/dev/nix/p4-fusion.nix
+++ b/dev/nix/p4-fusion.nix
@@ -9,7 +9,7 @@
 , patchelf
 , pkg-config
 , darwin
-, targetPlatform
+, hostPlatform
 }:
 let
   inherit (import ./util.nix { inherit lib; }) mkStatic unNixifyDylibs;
@@ -31,7 +31,7 @@ let
   # pkgsStatic.zlib.static doesn't exist on linux, but does on macos
   zlib-static = (pkgsStatic.zlib.static or pkgsStatic.zlib);
 in
-unNixifyDylibs pkgs (pkgsStatic.gccStdenv.mkDerivation rec {
+unNixifyDylibs { inherit pkgs; } (pkgsStatic.gccStdenv.mkDerivation rec {
   name = "p4-fusion";
   version = "v1.12";
 
@@ -44,8 +44,8 @@ unNixifyDylibs pkgs (pkgsStatic.gccStdenv.mkDerivation rec {
       hash = "sha256-rUXuBoXuOUanWxutd7dNgjn2vLFvHQ0IgCIn9vG5dgs=";
     })
     (
-      if targetPlatform.isMacOS then
-        if targetPlatform.isAarch64 then
+      if hostPlatform.isMacOS then
+        if hostPlatform.isAarch64 then
           fetchzip
             {
               name = "helix-core-api";
@@ -58,14 +58,14 @@ unNixifyDylibs pkgs (pkgsStatic.gccStdenv.mkDerivation rec {
             url = "https://cdist2.perforce.com/perforce/r22.2/bin.macosx12x86_64/p4api-openssl3.tgz";
             hash = "sha256-E5oK/uvRRNuEC5b8h5zQVdfZOieUgV2T8aPISEWgSY8=";
           }
-      else if targetPlatform.isLinux then
+      else if hostPlatform.isLinux then
         fetchzip
           {
             name = "helix-core-api";
             url = "https://cdist2.perforce.com/perforce/r22.2/bin.linux26x86_64/p4api-glibc2.3-openssl3.tgz";
             hash = "sha256-wovk38lk4cjrC6pTa9dSwmYM1RN1nzmzdl8VIwf2BLY=";
           }
-      else throw "unsupported platform ${stdenv.targetPlatform.parsed.kernel.name}"
+      else throw "unsupported platform ${stdenv.hostPlatform.parsed.kernel.name}"
     )
   ];
 
@@ -82,7 +82,7 @@ unNixifyDylibs pkgs (pkgsStatic.gccStdenv.mkDerivation rec {
     http-parser-static
     pcre-static
     openssl-static
-  ] ++ lib.optional targetPlatform.isMacOS [
+  ] ++ lib.optional hostPlatform.isMacOS [
     # iconv is bundled with glibc and apparently only needed for osx
     # https://sourcegraph.com/github.com/salesforce/p4-fusion@3ee482466464c18e6a635ff4f09cd75a2e1bfe0f/-/blob/vendor/libgit2/README.md?L178:3
     libiconv-static
@@ -91,7 +91,7 @@ unNixifyDylibs pkgs (pkgsStatic.gccStdenv.mkDerivation rec {
   ];
 
   # copy helix-core-api stuff into the expected directories, and statically link libstdc++
-  preBuild = let dir = if targetPlatform.isMacOS then "mac" else "linux"; in
+  preBuild = let dir = if hostPlatform.isMacOS then "mac" else "linux"; in
     ''
       mkdir -p $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}
       cp -R $NIX_BUILD_TOP/helix-core-api/* $NIX_BUILD_TOP/$sourceRoot/vendor/helix-core-api/${dir}

--- a/dev/nix/util.nix
+++ b/dev/nix/util.nix
@@ -22,7 +22,7 @@
     assert lib.assertMsg (lib.isDerivation drv) "unNixifyDylibs expects a derivation, got ${builtins.typeOf drv}";
     assert lib.assertMsg (drv ? "overrideAttrs") "unNixifyDylibs expects an overridable derivation";
 
-    drv.overrideAttrs (oldAttrs: {
+    drv.overrideAttrs (oldAttrs: lib.optionalAttrs pkgs.hostPlatform.isMacOS {
       nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++
         map (drv: drv.__spliced.buildHost or drv)
           (with (pkgs.__splicedPackages or pkgs); [
@@ -32,7 +32,7 @@
             gnugrep
           ]);
 
-      postFixup = (oldAttrs.postFixup or "") + lib.optionalString pkgs.hostPlatform.isMacOS ''
+      postFixup = (oldAttrs.postFixup or "") + ''
         for bin in $(find $out/bin -type f); do
           for lib in $(otool -L $bin | tail -n +2 | cut -d' ' -f1 | grep nix); do
             echo "patching dylib from "$lib" to "@rpath/$(basename $lib)""

--- a/dev/nix/util.nix
+++ b/dev/nix/util.nix
@@ -1,21 +1,27 @@
 { lib }:
 {
   # utility function to add some best-effort flags for emitting static objects instead of dynamic
-  mkStatic = pkg:
+  mkStatic = drv:
+    assert lib.assertMsg (lib.isDerivation drv) "mkStatic expects a derivation, got ${builtins.typeOf drv}";
+    assert lib.assertMsg (drv ? "overrideAttrs") "mkStatic expects an overridable derivation";
+
     let
-      auto = builtins.intersectAttrs pkg.override.__functionArgs { withStatic = true; static = true; enableStatic = true; enableShared = false; };
-      overridden = pkg.overrideAttrs (oldAttrs: {
+      auto = builtins.intersectAttrs drv.override.__functionArgs { withStatic = true; static = true; enableStatic = true; enableShared = false; };
+      overridden = drv.overrideAttrs (oldAttrs: {
         dontDisableStatic = true;
       } // lib.optionalAttrs (!(oldAttrs.dontAddStaticConfigureFlags or false)) {
         configureFlags = (oldAttrs.configureFlags or [ ]) ++ [ "--disable-shared" "--enable-static" "--enable-shared=false" ];
       });
     in
-    if pkg.pname == "openssl" then pkg.override { static = true; } else overridden.override auto;
+    if drv.pname == "openssl" then drv.override { static = true; } else overridden.override auto;
 
   # doesn't actually change anything in practice, just makes otool -L not display nix store paths for libiconv and libxml.
   # they exist in macos dydl cache anyways, so where they point to is irrelevant. worst case, this will let you catch earlier
   # when a library that should be statically linked or that isnt in dydl cache is dynamically linked.
-  unNixifyDylibs = pkgs: drv:
+  unNixifyDylibs = { pkgs }: drv:
+    assert lib.assertMsg (lib.isDerivation drv) "unNixifyDylibs expects a derivation, got ${builtins.typeOf drv}";
+    assert lib.assertMsg (drv ? "overrideAttrs") "unNixifyDylibs expects an overridable derivation";
+
     drv.overrideAttrs (oldAttrs: {
       postFixup = with pkgs; (oldAttrs.postFixup or "") + lib.optionalString pkgs.hostPlatform.isMacOS ''
         for bin in $(${findutils}/bin/find $out/bin -type f); do
@@ -26,11 +32,24 @@
       '';
     });
 
-  # removes packages from a list of packages by name.
-  # Copied from https://sourcegraph.com/github.com/NixOS/nixpkgs@4d924a6b3376c5e3cae3ba8c971007bf736084c5/-/blob/nixos/lib/utils.nix?L219
-  removePackagesByName = packages: packagesToRemove:
-    let
-      namesToRemove = map lib.getName packagesToRemove;
-    in
-    lib.filter (x: !(builtins.elem (lib.getName x) namesToRemove)) packages;
+  # returns a set of unsuffixed derivations for a native target and suffixed derivations for an optional cross-compile target
+  # returned by applying `f` to the passed native & cross-compile package sets.
+  xcompilify = { pkgs, pkgsX }: f: lib.foldl # merge all outputs into a single set
+    (acc: pkgSet: acc //
+      # rename with -${xtarget} if an xtarget package
+      (lib.mapAttrs'
+        (name: drv:
+          assert lib.assertMsg (lib.isDerivation drv) "expected derivation, got ${builtins.typeOf drv}"; {
+            name = (name + lib.optionalString
+              # cant use drv.stdenv.buildPlatform.system here, as
+              # aarch64-darwin.pkgsx86_64Darwin.stdenv.buildPlatform.system == aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.system
+              (pkgs.system != drv.stdenv.hostPlatform.system) "-${drv.stdenv.hostPlatform.system}"
+            );
+            value = drv;
+          })
+        pkgSet)
+    )
+    { }
+    # call f with native pkgs (and, if non-null, cross-compile pkgsx)
+    (builtins.map (pkgs: f pkgs) ([ pkgs ] ++ lib.optional (pkgsX != null) pkgsX));
 }

--- a/dev/nix/util.nix
+++ b/dev/nix/util.nix
@@ -25,8 +25,9 @@
     drv.overrideAttrs (oldAttrs: {
       postFixup = with pkgs; (oldAttrs.postFixup or "") + lib.optionalString pkgs.hostPlatform.isMacOS ''
         for bin in $(${findutils}/bin/find $out/bin -type f); do
-          for lib in $(otool -L $bin | ${coreutils}/bin/tail -n +2 | ${coreutils}/bin/cut -d' ' -f1 | ${gnugrep}/bin/grep nix); do
-            install_name_tool -change "$lib" "@rpath/$(basename $lib)" $bin
+          for lib in $(${darwin.cctools}/bin/otool -L $bin | ${coreutils}/bin/tail -n +2 | ${coreutils}/bin/cut -d' ' -f1 | ${gnugrep}/bin/grep nix); do
+            echo "patching dylib from "$lib" to "@rpath/$(basename $lib)""
+            ${darwin.cctools}/bin/install_name_tool -change "$lib" "@rpath/$(basename $lib)" $bin
           done
         done
       '';

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682268651,
-        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
+        "lastModified": 1690272529,
+        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
+        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690272529,
-        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
+        "lastModified": 1682268651,
+        "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
+        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e78d25df6f1036b3fa76750ed4603dd9d5fe90fc",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Sourcegraph developer environment & packages Nix Flake";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,25 +7,40 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
+    let
+      xcompileTargets = {
+        "aarch64-darwin" = nixpkgs.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
+        "x86_64-darwin" = import nixpkgs { system = "x86_64-darwin"; crossSystem = nixpkgs.lib.systems.examples.aarch64-darwin; };
+      };
+    in
     flake-utils.lib.eachDefaultSystem
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
+          pkgsX = xcompileTargets.${system} or null;
+          xcompilify = f: with nixpkgs; lib.foldl'
+            (acc: val: acc // (lib.mapAttrs'
+              # rename with -${xtarget} if an xtarget package
+              (name: value:
+                lib.nameValuePair
+                  (name + lib.optionalString (value.system != system) "-${value.system}")
+                  value
+              )
+              val))
+            { }
+            (builtins.map (val: f val) ([ pkgs ] ++ lib.optional (pkgsX != null) pkgsX))
+          ;
         in
         {
-          # We set legacyPackages to our custom static binaries so command
-          # like "nix build .#p4-fusion" work.
           legacyPackages = pkgs';
 
-          packages = {
+          packages = (xcompilify (pkgs: {
             ctags = pkgs.callPackage ./dev/nix/ctags.nix { };
             comby = pkgs.callPackage ./dev/nix/comby.nix { };
-            nodejs-16_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
-          }
-          # so we don't get `packages.aarch64-linux.p4-fusion` in nix `flake show` output
-          // pkgs.lib.optionalAttrs (pkgs.targetPlatform.system != "aarch64-linux") {
             p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
+          })) // {
+            nodejs-16_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
           };
 
           # We use pkgs (not pkgs') intentionally to avoid doing extra work of
@@ -36,7 +51,9 @@
           formatter = pkgs.nixpkgs-fmt;
         }) // {
       overlays = {
-        ctags = final: prev: { universal-ctags = self.packages.${prev.system}.ctags; };
+        ctags = final: prev: {
+          universal-ctags = self.packages.${prev.system}.ctags;
+        };
         comby = final: prev: { comby = self.packages.${prev.system}.comby; };
         nodejs-16_x = final: prev: { nodejs-16_x = self.packages.${prev.system}.nodejs-16_x; };
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,11 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     let
-      xcompileTargets = {
+      xcompileTargets = with nixpkgs.lib.systems.examples; {
         "aarch64-darwin" = nixpkgs.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
-        "x86_64-darwin" = import nixpkgs { system = "x86_64-darwin"; crossSystem = nixpkgs.lib.systems.examples.aarch64-darwin; };
+        "x86_64-darwin" = import nixpkgs { system = "x86_64-darwin"; crossSystem = aarch64-darwin; };
       };
+      inherit (import ./dev/nix/util.nix { inherit (nixpkgs) lib; }) xcompilify;
     in
     flake-utils.lib.eachDefaultSystem
       (system:
@@ -19,27 +20,16 @@
           pkgs = nixpkgs.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;
-          xcompilify = f: with nixpkgs; lib.foldl'
-            (acc: val: acc // (lib.mapAttrs'
-              # rename with -${xtarget} if an xtarget package
-              (name: value:
-                lib.nameValuePair
-                  (name + lib.optionalString (value.system != system) "-${value.system}")
-                  value
-              )
-              val))
-            { }
-            (builtins.map (val: f val) ([ pkgs ] ++ lib.optional (pkgsX != null) pkgsX))
-          ;
         in
         {
           legacyPackages = pkgs';
 
-          packages = (xcompilify (pkgs: {
-            ctags = pkgs.callPackage ./dev/nix/ctags.nix { };
-            comby = pkgs.callPackage ./dev/nix/comby.nix { };
-            p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
-          })) // {
+          packages = xcompilify { inherit pkgs pkgsX; }
+            (pkgs: {
+              ctags = pkgs.callPackage ./dev/nix/ctags.nix { };
+              comby = pkgs.callPackage ./dev/nix/comby.nix { };
+              p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
+            }) // {
             nodejs-16_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
           };
 
@@ -51,9 +41,7 @@
           formatter = pkgs.nixpkgs-fmt;
         }) // {
       overlays = {
-        ctags = final: prev: {
-          universal-ctags = self.packages.${prev.system}.ctags;
-        };
+        ctags = final: prev: { universal-ctags = self.packages.${prev.system}.ctags; };
         comby = final: prev: { comby = self.packages.${prev.system}.comby; };
         nodejs-16_x = final: prev: { nodejs-16_x = self.packages.${prev.system}.nodejs-16_x; };
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };


### PR DESCRIPTION
Adds targets for darwin x86_64 to cross-compile comby, p4-fusion and ctags to darwin aarch64, and vice versa

cross-compile targets are suffixed with the target platform and namespaced under the build platform.

**Not working/TODO**:
- `.#packages.aarch64-darwin.comby-x86_64-darwin`
- `.#packages.aarch64-darwin.p4-fusion-x86_64-darwin` has extra libstdc++ dylib
- `.#packages.x86_64-darwin.p4-fusion-aarch64-darwin` due to gcc
- `.#packages.x86_64-darwin.comby-aarch64-darwin` due to ocaml not building

## Test plan

Ran on x86_64 mac VM and aarch64 machine
