### PR TITLE
git-debuggability: paginate recorded commands

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlutil/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/graphqlutil/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "doc.go",
         "offset.go",
         "page_info.go",
+        "slice_connection_resolver.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil",
     visibility = ["//visibility:public"],
@@ -22,7 +23,10 @@ go_library(
 go_test(
     name = "graphqlutil_test",
     timeout = "short",
-    srcs = ["connection_resolver_test.go"],
+    srcs = [
+        "connection_resolver_test.go",
+        "slice_connection_resolver_test.go",
+    ],
     embed = [":graphqlutil"],
     deps = [
         "//internal/database",

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
@@ -5,82 +5,39 @@ import (
 	"sync"
 )
 
-type SliceConnectionResolver[T, V any] interface {
-	Nodes(ctx context.Context) ([]V, error)
+type SliceConnectionResolver[T any] interface {
+	Nodes(ctx context.Context) []T
 	TotalCount(ctx context.Context) int32
-	PageInfo(ctx context.Context) (*PageInfo, error)
+	PageInfo(ctx context.Context) *PageInfo
 }
 
-type SliceConnectionTransformer[T, V any] func(item T) (V, error)
-
-func NewSliceConnectionResolver[T, V any](data []T, limit, offset int, transformer SliceConnectionTransformer[T, V]) SliceConnectionResolver[T, V] {
-	return &sliceConnectionResolver[T, V]{
-		data:        data,
-		limit:       limit,
-		offset:      offset,
-		transformer: transformer,
+func NewSliceConnectionResolver[T any](data []T, total, currentEnd int) SliceConnectionResolver[T] {
+	return &sliceConnectionResolver[T]{
+		data:       data,
+		total:      total,
+		currentEnd: currentEnd,
 	}
 }
 
-type sliceConnectionResolver[T, V any] struct {
-	once sync.Once
-
-	data []T
-
-	paginatedData []V
-	hasNextPage   bool
-	transformer   SliceConnectionTransformer[T, V]
-	err           error
-
-	limit  int
-	offset int
+type sliceConnectionResolver[T any] struct {
+	computeOnce sync.Once
+	data        []T
+	total       int
+	currentEnd  int
 }
 
-func (c *sliceConnectionResolver[T, V]) compute(ctx context.Context) ([]V, bool, error) {
-	c.once.Do(func() {
-		if c.offset < 0 || c.offset >= len(c.data) {
-			c.paginatedData = make([]V, 0)
-			return
-		}
-
-		start := c.offset
-		end := start + c.limit
-
-		if end > len(c.data) {
-			end = len(c.data)
-		}
-
-		// rawPaginatedData is a slice containing the current page of items.
-		// It slices the full items slice from the calculated start to end offsets.
-		// hasNextPage is a boolean indicating if there are more pages after this one.
-		// It is true if the length of the full items slice is greater than the end offset.
-		rawPaginatedData := c.data[start:end]
-		var hasNextPage bool
-		if len(c.data) > (start + len(rawPaginatedData)) {
-			hasNextPage = true
-		}
-
-		c.paginatedData = make([]V, len(rawPaginatedData))
-		for i, raw := range rawPaginatedData {
-			c.paginatedData[i], c.err = c.transformer(raw)
-		}
-
-		c.hasNextPage = hasNextPage
-	})
-
-	return c.paginatedData, c.hasNextPage, c.err
+func (c *sliceConnectionResolver[T]) Nodes(ctx context.Context) []T {
+	return c.data
 }
 
-func (c *sliceConnectionResolver[T, V]) Nodes(ctx context.Context) ([]V, error) {
-	data, _, err := c.compute(ctx)
-	return data, err
+func (c *sliceConnectionResolver[T]) TotalCount(ctx context.Context) int32 {
+	return int32(c.total)
 }
 
-func (c *sliceConnectionResolver[T, V]) TotalCount(ctx context.Context) int32 {
-	return int32(len(c.data))
-}
-
-func (c *sliceConnectionResolver[T, V]) PageInfo(ctx context.Context) (*PageInfo, error) {
-	_, hasNextPage, err := c.compute(ctx)
-	return HasNextPage(hasNextPage), err
+func (c *sliceConnectionResolver[T]) PageInfo(ctx context.Context) *PageInfo {
+	var hasNextPage bool
+	if c.total > c.currentEnd {
+		hasNextPage = true
+	}
+	return HasNextPage(hasNextPage)
 }

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
@@ -2,7 +2,6 @@ package graphqlutil
 
 import (
 	"context"
-	"sync"
 )
 
 type SliceConnectionResolver[T any] interface {
@@ -11,6 +10,16 @@ type SliceConnectionResolver[T any] interface {
 	PageInfo(ctx context.Context) *PageInfo
 }
 
+// NewSliceConnectionResolver creates a new sliceConnectionResolver that implements
+// the SliceConnectionResolver interface. This is simply a convenience helper to return
+// paginated slice in graphql-compliant way.
+//
+// data is the slice of nodes for this connection.
+// total is the total number of nodes available.
+// currentEnd is the current end index of the nodes slice.
+//
+// Returns a new sliceConnectionResolver that provides resolver methods for
+// connection fields.
 func NewSliceConnectionResolver[T any](data []T, total, currentEnd int) SliceConnectionResolver[T] {
 	return &sliceConnectionResolver[T]{
 		data:       data,
@@ -19,11 +28,16 @@ func NewSliceConnectionResolver[T any](data []T, total, currentEnd int) SliceCon
 	}
 }
 
+// sliceConnectionResolver implements the SliceConnectionResolver interface
+// to provide resolver functions for a connection backed by a slice.
+//
+// data is the slice of nodes for this connection.
+// total is the total number of nodes available.
+// currentEnd is the current end index of the nodes slice.
 type sliceConnectionResolver[T any] struct {
-	computeOnce sync.Once
-	data        []T
-	total       int
-	currentEnd  int
+	data       []T
+	total      int
+	currentEnd int
 }
 
 func (c *sliceConnectionResolver[T]) Nodes(ctx context.Context) []T {

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
@@ -49,9 +49,5 @@ func (c *sliceConnectionResolver[T]) TotalCount(ctx context.Context) int32 {
 }
 
 func (c *sliceConnectionResolver[T]) PageInfo(ctx context.Context) *PageInfo {
-	var hasNextPage bool
-	if c.total > c.currentEnd {
-		hasNextPage = true
-	}
-	return HasNextPage(hasNextPage)
+	return HasNextPage(c.total > c.currentEnd)
 }

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
@@ -4,6 +4,12 @@ import (
 	"context"
 )
 
+// SliceConnectionResolver defines the interface that slice-based connection
+// resolvers need to implement. It provides resolver functions for connection fields.
+//
+// Nodes returns the slice of nodes for the connection.
+// TotalCount returns the total number of nodes available.
+// PageInfo returns pagination information for the connection.
 type SliceConnectionResolver[T any] interface {
 	Nodes(ctx context.Context) []T
 	TotalCount(ctx context.Context) int32

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver.go
@@ -1,0 +1,86 @@
+package graphqlutil
+
+import (
+	"context"
+	"sync"
+)
+
+type SliceConnectionResolver[T, V any] interface {
+	Nodes(ctx context.Context) ([]V, error)
+	TotalCount(ctx context.Context) int32
+	PageInfo(ctx context.Context) (*PageInfo, error)
+}
+
+type SliceConnectionTransformer[T, V any] func(item T) (V, error)
+
+func NewSliceConnectionResolver[T, V any](data []T, limit, offset int, transformer SliceConnectionTransformer[T, V]) SliceConnectionResolver[T, V] {
+	return &sliceConnectionResolver[T, V]{
+		data:        data,
+		limit:       limit,
+		offset:      offset,
+		transformer: transformer,
+	}
+}
+
+type sliceConnectionResolver[T, V any] struct {
+	once sync.Once
+
+	data []T
+
+	paginatedData []V
+	hasNextPage   bool
+	transformer   SliceConnectionTransformer[T, V]
+	err           error
+
+	limit  int
+	offset int
+}
+
+func (c *sliceConnectionResolver[T, V]) compute(ctx context.Context) ([]V, bool, error) {
+	c.once.Do(func() {
+		if c.offset < 0 || c.offset >= len(c.data) {
+			c.paginatedData = make([]V, 0)
+			return
+		}
+
+		start := c.offset
+		end := start + c.limit
+
+		if end > len(c.data) {
+			end = len(c.data)
+		}
+
+		// rawPaginatedData is a slice containing the current page of items.
+		// It slices the full items slice from the calculated start to end offsets.
+		// hasNextPage is a boolean indicating if there are more pages after this one.
+		// It is true if the length of the full items slice is greater than the end offset.
+		rawPaginatedData := c.data[start:end]
+		var hasNextPage bool
+		if len(c.data) > (start + len(rawPaginatedData)) {
+			hasNextPage = true
+		}
+
+		c.paginatedData = make([]V, len(rawPaginatedData))
+		for i, raw := range rawPaginatedData {
+			c.paginatedData[i], c.err = c.transformer(raw)
+		}
+
+		c.hasNextPage = hasNextPage
+	})
+
+	return c.paginatedData, c.hasNextPage, c.err
+}
+
+func (c *sliceConnectionResolver[T, V]) Nodes(ctx context.Context) ([]V, error) {
+	data, _, err := c.compute(ctx)
+	return data, err
+}
+
+func (c *sliceConnectionResolver[T, V]) TotalCount(ctx context.Context) int32 {
+	return int32(len(c.data))
+}
+
+func (c *sliceConnectionResolver[T, V]) PageInfo(ctx context.Context) (*PageInfo, error) {
+	_, hasNextPage, err := c.compute(ctx)
+	return HasNextPage(hasNextPage), err
+}

--- a/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlutil/slice_connection_resolver_test.go
@@ -1,0 +1,76 @@
+package graphqlutil
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSliceConnectionResolver(t *testing.T) {
+	data := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+		[]byte("d"),
+		[]byte("e"),
+		[]byte("f"),
+		[]byte("g"),
+		[]byte("h"),
+		[]byte("i"),
+		[]byte("j"),
+		[]byte("k"),
+		[]byte("l"),
+	}
+
+	ctx := context.Background()
+	transformer := func(item []byte) (string, error) {
+		return string(item), nil
+	}
+
+	resolver := NewSliceConnectionResolver(data, 2, 0, transformer)
+
+	nodes, err := resolver.Nodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+
+	if nodes[0] != "a" {
+		t.Fatalf("expected first node to be a, got %s", nodes[0])
+	}
+
+	if nodes[1] != "b" {
+		t.Fatalf("expected second node to be b, got %s", nodes[1])
+	}
+
+	totalCount := resolver.TotalCount(ctx)
+	if int(totalCount) != len(data) {
+		t.Fatalf("expected totalCount to be %d, got %d", len(data), totalCount)
+	}
+
+	resolver = NewSliceConnectionResolver(data, 2, 2, transformer)
+
+	nodes, err = resolver.Nodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+
+	if nodes[0] != "c" {
+		t.Fatalf("expected first node to be c, got %s", nodes[0])
+	}
+
+	if nodes[1] != "d" {
+		t.Fatalf("expected second node to be d, got %s", nodes[1])
+	}
+
+	totalCount = resolver.TotalCount(ctx)
+	if int(totalCount) != len(data) {
+		t.Fatalf("expected totalCount to be %d, got %d", len(data), totalCount)
+	}
+}

--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -16,6 +16,15 @@ import (
 // recorded commands. It should always be in sync with the default in `cmd/frontend/graphqlbackend/schema.graphql`
 const recordedCommandMaxLimit = 40
 
+var MockGetRecordedCommandMaxLimit func() int
+
+func GetRecordedCommandMaxLimit() int {
+	if MockGetRecordedCommandMaxLimit != nil {
+		return MockGetRecordedCommandMaxLimit()
+	}
+	return recordedCommandMaxLimit
+}
+
 type RecordedCommandsArgs struct {
 	Limit  int32
 	Offset int32
@@ -24,8 +33,9 @@ type RecordedCommandsArgs struct {
 func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *RecordedCommandsArgs) (graphqlutil.SliceConnectionResolver[RecordedCommandResolver], error) {
 	offset := int(args.Offset)
 	limit := int(args.Limit)
-	if limit == 0 || limit > recordedCommandMaxLimit {
-		limit = recordedCommandMaxLimit
+	maxLimit := GetRecordedCommandMaxLimit()
+	if limit == 0 || limit > maxLimit {
+		limit = maxLimit
 	}
 	currentEnd := offset + limit
 

--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -4,16 +4,23 @@ import (
 	"context"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-func (r *RepositoryResolver) RecordedCommands(ctx context.Context) ([]RecordedCommandResolver, error) {
+const recordedCommandDefaultLimit = 40
+
+func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *struct {
+	Limit  *int32
+	Offset *int32
+}) (graphqlutil.SliceConnectionResolver[[]byte, RecordedCommandResolver], error) {
 	recordingConf := conf.Get().SiteConfig().GitRecorder
 	if recordingConf == nil {
-		return []RecordedCommandResolver{}, nil
+		return graphqlutil.NewSliceConnectionResolver([][]byte{}, 0, 0, recordedCommandTransformer), nil
 	}
 	store := rcache.NewFIFOList(wrexec.GetFIFOListKey(r.Name()), recordingConf.Size)
 	empty, err := store.IsEmpty()
@@ -21,21 +28,30 @@ func (r *RepositoryResolver) RecordedCommands(ctx context.Context) ([]RecordedCo
 		return nil, err
 	}
 	if empty {
-		return []RecordedCommandResolver{}, nil
+		return graphqlutil.NewSliceConnectionResolver([][]byte{}, 0, 0, recordedCommandTransformer), nil
 	}
 	raws, err := store.All(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resolvers := make([]RecordedCommandResolver, len(raws))
-	for i, raw := range raws {
-		command, err := wrexec.UnmarshalCommand(raw)
-		if err != nil {
-			return nil, err
-		}
-		resolvers[i] = NewRecordedCommandResolver(command)
+
+	if args.Limit == nil || *args.Limit > recordedCommandDefaultLimit {
+		args.Limit = pointers.Ptr(int32(recordedCommandDefaultLimit))
 	}
-	return resolvers, nil
+
+	if args.Offset == nil {
+		args.Offset = pointers.Ptr(int32(0))
+	}
+
+	return graphqlutil.NewSliceConnectionResolver(raws, int(*args.Limit), int(*args.Offset), recordedCommandTransformer), nil
+}
+
+func recordedCommandTransformer(raw []byte) (RecordedCommandResolver, error) {
+	command, err := wrexec.UnmarshalCommand(raw)
+	if err != nil {
+		return nil, err
+	}
+	return NewRecordedCommandResolver(command), nil
 }
 
 type RecordedCommandResolver interface {

--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -42,7 +42,10 @@ func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *Recorde
 		return graphqlutil.NewSliceConnectionResolver([]RecordedCommandResolver{}, 0, currentEnd), nil
 	}
 
-	raws, err := store.Slice(ctx, offset, limit)
+	// the FIFO list is zero-indexed, so we need to deduct one from the limit
+	// to be able to get the correct amount of data.
+	to := currentEnd - 1
+	raws, err := store.Slice(ctx, offset, to)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -60,14 +60,6 @@ func (r *RepositoryResolver) RecordedCommands(ctx context.Context, args *Recorde
 	return graphqlutil.NewSliceConnectionResolver(resolvers, size, offset+limit), nil
 }
 
-func recordedCommandTransformer(raw []byte) (RecordedCommandResolver, error) {
-	command, err := wrexec.UnmarshalCommand(raw)
-	if err != nil {
-		return nil, err
-	}
-	return NewRecordedCommandResolver(command), nil
-}
-
 type RecordedCommandResolver interface {
 	Start() gqlutil.DateTime
 	Duration() float64

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -339,8 +339,54 @@ func TestRecordedCommandsResolver(t *testing.T) {
 					`,
 			})
 		})
-	})
 
+		t.Run("valid offset and limit", func(t *testing.T) {
+			RunTest(t, &Test{
+				Schema: mustParseGraphQLSchema(t, db),
+				Query: `
+						{
+							repository(name: "github.com/sourcegraph/sourcegraph") {
+								recordedCommands(offset: 1, limit: 2) {
+									nodes {
+										start
+										duration
+										command
+										dir
+										path
+									}
+									totalCount
+								}
+							}
+						}
+					`,
+				ExpectedResult: `
+						{
+							"repository": {
+								"recordedCommands": {
+									"nodes": [
+										{
+											"command": "git clone",
+											"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+											"duration": 10,
+											"path": "/opt/homebrew/bin/git",
+											"start": "2023-07-20T15:04:05Z"
+										},
+										{
+											"command": "git fetch",
+											"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+											"duration": 100,
+											"path": "/opt/homebrew/bin/git",
+											"start": "2023-07-20T15:04:05Z"
+										}
+									],
+									"totalCount": 3
+								}
+							}
+						}
+					`,
+			})
+		})
+	})
 }
 
 func marshalCmd(t *testing.T, command wrexec.RecordedCommand) []byte {

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -51,6 +51,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 								path
 							}
 							totalCount
+							pageInfo {
+								hasNextPage
+							}
 						}
 					}
 				}
@@ -60,7 +63,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 					"repository": {
 						"recordedCommands": {
 							"nodes": [],
-							"totalCount": 0
+							"totalCount": 0,
+							"pageInfo": {
+								"hasNextPage": false
+							}
 						}
 					}
 				}
@@ -91,6 +97,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 									path
 								}
 								totalCount
+								pageInfo {
+									hasNextPage
+								}
 							}
 						}
 					}
@@ -100,7 +109,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 						"repository": {
 							"recordedCommands": {
 								"nodes": [],
-								"totalCount": 0
+								"totalCount": 0,
+								"pageInfo": {
+									"hasNextPage": false
+								}
 							}
 						}
 					}
@@ -142,6 +154,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 								path
 							}
 							totalCount
+							pageInfo {
+								hasNextPage
+							}
 						}
 					}
 				}
@@ -159,7 +174,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 									"start": "2023-07-20T15:04:05Z"
 								}
 							],
-							"totalCount": 1
+							"totalCount": 1,
+							"pageInfo": {
+								"hasNextPage": false
+							}
 						}
 					}
 				}
@@ -222,6 +240,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 										path
 									}
 									totalCount
+									pageInfo {
+										hasNextPage
+									}
 								}
 							}
 						}
@@ -246,7 +267,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 											"start": "2023-07-20T15:04:05Z"
 										}
 									],
-									"totalCount": 3
+									"totalCount": 3,
+									"pageInfo": {
+										"hasNextPage": true
+									}
 								}
 							}
 						}
@@ -269,6 +293,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 										path
 									}
 									totalCount
+									pageInfo {
+										hasNextPage
+									}
 								}
 							}
 						}
@@ -300,7 +327,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 											"start": "2023-07-20T15:04:05Z"
 										}
 									],
-									"totalCount": 3
+									"totalCount": 3,
+									"pageInfo": {
+										"hasNextPage": false
+									}
 								}
 							}
 						}
@@ -323,6 +353,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 										path
 									}
 									totalCount
+									pageInfo {
+										hasNextPage
+									}
 								}
 							}
 						}
@@ -332,7 +365,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 							"repository": {
 								"recordedCommands": {
 									"nodes": [],
-									"totalCount": 3
+									"totalCount": 3,
+									"pageInfo": {
+										"hasNextPage": false
+									}
 								}
 							}
 						}
@@ -355,6 +391,9 @@ func TestRecordedCommandsResolver(t *testing.T) {
 										path
 									}
 									totalCount
+									pageInfo {
+										hasNextPage
+									}
 								}
 							}
 						}
@@ -379,7 +418,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 											"start": "2023-07-20T15:04:05Z"
 										}
 									],
-									"totalCount": 3
+									"totalCount": 3,
+									"pageInfo": {
+										"hasNextPage": false
+									}
 								}
 							}
 						}

--- a/cmd/frontend/graphqlbackend/recorded_commands_test.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands_test.go
@@ -42,11 +42,14 @@ func TestRecordedCommandsResolver(t *testing.T) {
 				{
 					repository(name: "github.com/sourcegraph/sourcegraph") {
 						recordedCommands {
-							start
-							duration
-							command
-							dir
-							path
+							nodes {
+								start
+								duration
+								command
+								dir
+								path
+							}
+							totalCount
 						}
 					}
 				}
@@ -54,7 +57,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 		ExpectedResult: `
 				{
 					"repository": {
-						"recordedCommands": []
+						"recordedCommands": {
+							"nodes": [],
+							"totalCount": 0
+						}
 					}
 				}
 			`,
@@ -95,11 +101,14 @@ func TestRecordedCommandsResolver(t *testing.T) {
 				{
 					repository(name: "github.com/sourcegraph/sourcegraph") {
 						recordedCommands {
-							start
-							duration
-							command
-							dir
-							path
+							nodes {
+								start
+								duration
+								command
+								dir
+								path
+							}
+							totalCount
 						}
 					}
 				}
@@ -107,7 +116,10 @@ func TestRecordedCommandsResolver(t *testing.T) {
 		ExpectedResult: `
 				{
 					"repository": {
-						"recordedCommands": []
+						"recordedCommands": {
+							"nodes": [],
+							"totalCount": 0
+						}
 					}
 				}
 			`,
@@ -123,11 +135,14 @@ func TestRecordedCommandsResolver(t *testing.T) {
 				{
 					repository(name: "github.com/sourcegraph/sourcegraph") {
 						recordedCommands {
-							start
-							duration
-							command
-							dir
-							path
+							nodes {
+								start
+								duration
+								command
+								dir
+								path
+							}
+							totalCount
 						}
 					}
 				}
@@ -135,15 +150,18 @@ func TestRecordedCommandsResolver(t *testing.T) {
 		ExpectedResult: `
 				{
 					"repository": {
-						"recordedCommands": [
-							{
-								"command": "git fetch",
-								"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
-								"duration": 100,
-								"path": "/opt/homebrew/bin/git",
-								"start": "2023-07-20T15:04:05Z"
-							}
-						]
+						"recordedCommands": {
+							"nodes": [
+								{
+									"command": "git fetch",
+									"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+									"duration": 100,
+									"path": "/opt/homebrew/bin/git",
+									"start": "2023-07-20T15:04:05Z"
+								}
+							],
+							"totalCount": 1
+						}
 					}
 				}
 			`,
@@ -160,11 +178,14 @@ func TestRecordedCommandsResolver(t *testing.T) {
 				{
 					repository(name: "github.com/sourcegraph/sourcegraph") {
 						recordedCommands {
-							start
-							duration
-							command
-							dir
-							path
+							nodes {
+								start
+								duration
+								command
+								dir
+								path
+							}
+							totalCount
 						}
 					}
 				}
@@ -172,29 +193,32 @@ func TestRecordedCommandsResolver(t *testing.T) {
 		ExpectedResult: `
 				{
 					"repository": {
-						"recordedCommands": [
-							{
-								"command": "git ls-files",
-								"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
-								"duration": 5,
-								"path": "/opt/homebrew/bin/git",
-								"start": "2023-07-20T15:04:05Z"
-							},
-							{
-								"command": "git clone",
-								"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
-								"duration": 10,
-								"path": "/opt/homebrew/bin/git",
-								"start": "2023-07-20T15:04:05Z"
-							},
-							{
-								"command": "git fetch",
-								"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
-								"duration": 100,
-								"path": "/opt/homebrew/bin/git",
-								"start": "2023-07-20T15:04:05Z"
-							}
-						]
+						"recordedCommands": {
+							"nodes": [
+								{
+									"command": "git ls-files",
+									"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+									"duration": 5,
+									"path": "/opt/homebrew/bin/git",
+									"start": "2023-07-20T15:04:05Z"
+								},
+								{
+									"command": "git clone",
+									"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+									"duration": 10,
+									"path": "/opt/homebrew/bin/git",
+									"start": "2023-07-20T15:04:05Z"
+								},
+								{
+									"command": "git fetch",
+									"dir": "/.sourcegraph/repos_1/github.com/sourcegraph/sourcegraph/.git",
+									"duration": 100,
+									"path": "/opt/homebrew/bin/git",
+									"start": "2023-07-20T15:04:05Z"
+								}
+							],
+							"totalCount": 3
+						}
 					}
 				}
 			`,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3896,12 +3896,14 @@ type Repository implements Node & GenericSearchResultInterface {
     recordedCommands(
         """
         Returns the "limit" number recorded commands from the list.
+        (Default: 40)
         """
-        limit: Int
+        limit: Int = 40
         """
         Skips initial "offset" number of recorded commands.
+        (Default: 0)
         """
-        offset: Int
+        offset: Int = 0
     ): RecordedCommandConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3893,7 +3893,36 @@ type Repository implements Node & GenericSearchResultInterface {
     """
     Returns a list of all recorded commands for given repository.
     """
-    recordedCommands: [RecordedCommand!]!
+    recordedCommands(
+        """
+        Returns the "limit" number recorded commands from the list.
+        """
+        limit: Int
+        """
+        Skips initial "offset" number of recorded commands.
+        """
+        offset: Int
+    ): RecordedCommandConnection!
+}
+
+"""
+RecordedCommandConnection is a connection containing a list of RecordedCommand nodes.
+"""
+type RecordedCommandConnection {
+    """
+    A list of recorded commands for given repository.
+    """
+    nodes: [RecordedCommand!]!
+
+    """
+    The total number of recorded commands for given repository in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3895,7 +3895,7 @@ type Repository implements Node & GenericSearchResultInterface {
     """
     recordedCommands(
         """
-        Returns the "limit" number recorded commands from the list.
+        Maximum number of recorded commands returned.
         (Default: 40)
         """
         limit: Int = 40

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3896,7 +3896,9 @@ type Repository implements Node & GenericSearchResultInterface {
     recordedCommands(
         """
         Maximum number of recorded commands returned.
-        (Default: 40)
+        If a query specifies a limit higher than 40, it will be capped at 40.
+        The default value is 40. This prevents returning an excessive number
+        of recorded commands for performance reasons.
         """
         limit: Int = 40
         """


### PR DESCRIPTION
[Walkthrough](https://www.loom.com/share/8278ed0143af4f3d8734a69dafce91b8)

This PR introduces a slice connection resolver that can be used to paginate slices. I added this under the `graphqlutil` package because it fulfills an interface similar to that of the `ConnectionResolver`.

```graphql
type SliceConnectionResolver[T, any] interface {
	Nodes(ctx context.Context) []T
	TotalCount(ctx context.Context) int32
	PageInfo(ctx context.Context) *PageInfo
}
```

This ensures we can adequately paginate the `RecordedCommands` field on the `RepositoryResolver`.

This is particularly useful because we get a slice of byte slice from redis and need to transform that into `RecordedCommandResolver`.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Navigate to the API console
* Run a GraphQL query to fetch the recorded commands for any repository of your choosing.
```graphql
query {
  repository(name:  <REPOSITORY_NAME>) {
    id
    name
    mirrorInfo {
      shard
    }
    recordedCommands(limit: 100) {
      totalCount
      pageInfo {
        hasNextPage
      }
      nodes {
        dir
        command
        duration
        start
      }
    }
  }
}
```

* You should be able to retrieve the nodes, pageInfo and totalCount of the recorded commands.