### PR TITLE
[Backport 5.1] Implement experimental Azure OpenAI provider for completions and embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,40 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Experimental support for Azure OpenAI for the completions and embeddings provider has been added. [#55178](https://github.com/sourcegraph/sourcegraph/pull/55178)
+
+### Changed
+
+- OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)
+- Bitbucket Cloud code host connections no longer automatically syncs the repository of the username used. The appropriate workspace name will have to be added to the `teams` list if repositories for that account need to be synced. [#55095](https://github.com/sourcegraph/sourcegraph/pull/55095)
+- The gRPC implementation for the Symbol service's `LocalCodeIntel` endpoint has been changed to stream its results. [#55242](https://github.com/sourcegraph/sourcegraph/pull/55242)
+
+### Fixed
+
+### Removed
+
+- indexed-search has removed the deprecated environment variable ZOEKT_ENABLE_LAZY_DOC_SECTIONS [zoekt#620](https://github.com/sourcegraph/zoekt/pull/620)
+- The federation feature that could redirect users from their own Sourcegraph instance to public repositories on Sourcegraph.com has been removed. It allowed users to open a repository URL on their own Sourcegraph instance and, if the repository wasn't found on that instance, the user would be redirect to the repository on Sourcegraph.com, where it was possibly found. The feature has been broken for over a year though and we don't know that it was used. If you want to use it, please open a feature-request issue and tag the `@sourcegraph/source` team. [#55161](https://github.com/sourcegraph/sourcegraph/pull/55161)
+
+## 5.1.5
+
+### Fixed
+
+- Fixed an embeddings job scheduler bug where if we cannot resolve one of the repositories or its default branch then all repositories submitted will not have their respective embeddings job enqueued. Embeddings job scheduler will now continue to schedule jobs for subsequent repositories in the submitted repositories set. [#54701](https://github.com/sourcegraph/sourcegraph/pull/54701)
+- Creation of GitHub Apps will now respect system certificate authorities when specifying certificates for the tls.external site configuration. [#55084](https://github.com/sourcegraph/sourcegraph/pull/55084)
+- Passing multi-line Coursier credentials in JVM packages configuration should now work correctly. [#55113](https://github.com/sourcegraph/sourcegraph/pull/55113)
+- SCIP indexes are now ingested in a streaming fashion, eliminating out-of-memory errors in most cases, even when uploading very large indexes (1GB+ uncompressed). [#53828](https://github.com/sourcegraph/sourcegraph/pull/53828)
+- Moved the license checks to worker service. We make sure to run only 1 instance of license checks this way. [54854](https://github.com/sourcegraph/sourcegraph/pull/54854)
+- The default message size limit for gRPC clients has been raised from 4MB to 90MB. [#55209](https://github.com/sourcegraph/sourcegraph/pull/55209)
+- The message printing feature for the custom gRPC internal error interceptor now supports logging all internal error types, instead of just non-utf 8 errors. [#55130](https://github.com/sourcegraph/sourcegraph/pull/55130)
+
+### Changed
+
+- The "Files" tab of the fuzzy finder now allows you to navigate directly to a line number by appending `:NUMBER`. For example, the fuzzy query `main.ts:100` opens line 100 in the file `main.ts`. [#55064](https://github.com/sourcegraph/sourcegraph/pull/55064)
+- The gRPC implementation for the Symbol service's `LocalCodeIntel` endpoint has been changed to stream its results. [#55242](https://github.com/sourcegraph/sourcegraph/pull/55242)
+
+### Added
+
 -
 
 ### Changed

--- a/doc/cody/explanations/code_graph_context.md
+++ b/doc/cody/explanations/code_graph_context.md
@@ -156,16 +156,45 @@ Supported time units are h (hours), m ( minutes), and s (seconds).
 
 ### Using a third-party embeddings provider directly
 
-Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly for embeddings. Currently, this can only be OpenAI embeddings.
+Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly for embeddings. Currently, this can be one of
+- OpenAI
+- Azure OpenAI <span class="badge badge-experimental">Experimental</span>
 
-You must create your own key with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+#### OpenAI
+
+First, you must create your own key with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+```jsonc
+{
+  // [...]
+  "cody.enabled": true,
+  "embeddings": {
+    "provider": "openai",
+    "accessToken": "<token>",
+    "excludedFilePathPatterns": []
+  }
+}
+```
+
+#### Azure OpenAI <span class="badge badge-experimental">Experimental</span>
+
+First, make sure you created a project in the Azure OpenAI portal. 
+
+From the project overview, go to **Keys and Endpoint** and grab **one of the keys** on that page, and the **endpoint**.
+
+Next, under **Model deployments** click "manage deployments" and make sure you deploy the models you want to use. For example, `text-embedding-ada-002`. Take note of the **deployment name**.
+
+Once done, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
 
 ```jsonc
 {
   "cody.enabled": true,
   "embeddings": {
-    "provider": "openai",
-    "accessToken": "<token>",
+    "provider": "azure-openai",
+    "model": "<deployment name of the model>",
+    "endpoint": "<endpoint>",
+    "accessToken": "<key>",
+    "dimensions": 1536,
     "excludedFilePathPatterns": []
   }
 }

--- a/doc/cody/explanations/enabling_cody_enterprise.md
+++ b/doc/cody/explanations/enabling_cody_enterprise.md
@@ -137,20 +137,74 @@ To do so:
 
 ## Using a third-party LLM provider directly
 
-Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly. Currently, this can only be Anthropic or OpenAI.
+Instead of [Sourcegraph Cody Gateway](./cody_gateway.md), you can configure Sourcegraph to use a third-party provider directly. Currently, this can be one of
+- Anthropic
+- OpenAI
+- Azure OpenAI <span class="badge badge-experimental">Experimental</span>
 
-You must create your own key with Anthropic [here](https://console.anthropic.com/account/keys) or with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+### Anthropic
+
+First, you must create your own key with Anthropic [here](https://console.anthropic.com/account/keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
 
 ```jsonc
 {
   // [...]
   "cody.enabled": true,
   "completions": {
-    "provider": "anthropic", // or "openai" if you use OpenAI
-    "model": "claude-2", // or one of the models listed [here](https://platform.openai.com/docs/models) if you use OpenAI
+    "provider": "anthropic",
+    "chatModel": "claude-2", // Or any other model you would like to use
+    "fastChatModel": "claude-instant-1", // Or any other model you would like to use
+    "completionModel": "claude-instant-1", // Or any other model you would like to use
     "accessToken": "<key>"
   }
 }
 ```
 
-Similarly, you can also [use a third-party LLM provider directly for embeddings](./code_graph_context.md#using-a-third-party-llm-directly).
+### OpenAI
+
+First, you must create your own key with OpenAI [here](https://beta.openai.com/account/api-keys). Once you have the key, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+```jsonc
+{
+  // [...]
+  "cody.enabled": true,
+  "completions": {
+    "provider": "openai",
+    "chatModel": "gpt-4", // Or any other model you would like to use
+    "fastChatModel": "gpt-35-turbo", // Or any other model you would like to use
+    "completionModel": "gpt-35-turbo", // Or any other model you would like to use
+    "accessToken": "<key>"
+  }
+}
+```
+
+_[*OpenAI models supported](https://platform.openai.com/docs/models)_
+
+### Azure OpenAI <span class="badge badge-experimental">Experimental</span>
+
+First, make sure you created a project in the Azure OpenAI portal. 
+
+From the project overview, go to **Keys and Endpoint** and grab **one of the keys** on that page, and the **endpoint**.
+
+Next, under **Model deployments** click "manage deployments" and make sure you deploy the models you want to use. For example, `gpt-35-turbo`. Take note of the **deployment name**.
+
+Once done, go to **Site admin > Site configuration** (`/site-admin/configuration`) on your instance and set:
+
+```jsonc
+{
+  // [...]
+  "cody.enabled": true,
+  "completions": {
+    "provider": "azure-openai",
+    "chatModel": "<deployment name of the model>",
+    "fastChatModel": "<deployment name of the model>",
+    "completionModel": "<deployment name of the model>",
+    "endpoint": "<endpoint>",
+    "accessToken": "<key>"
+  }
+}
+```
+
+---
+
+Similarly, you can also [use a third-party LLM provider directly for embeddings](./code_graph_context.md#using-a-third-party-embeddings-provider-directly).

--- a/internal/completions/client/BUILD.bazel
+++ b/internal/completions/client/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/completions/client/anthropic",
+        "//internal/completions/client/azureopenai",
         "//internal/completions/client/codygateway",
         "//internal/completions/client/openai",
         "//internal/completions/types",

--- a/internal/completions/client/azureopenai/BUILD.bazel
+++ b/internal/completions/client/azureopenai/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "azureopenai",
+    srcs = ["openai.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/completions/client/azureopenai",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/completions/client/openai",
+        "//internal/completions/types",
+        "//internal/httpcli",
+        "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "azureopenai_test",
+    srcs = ["openai_test.go"],
+    embed = [":azureopenai"],
+    deps = [
+        "//internal/completions/types",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -1,0 +1,219 @@
+package azureopenai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {
+	return &azureCompletionClient{
+		cli:         cli,
+		accessToken: accessToken,
+		endpoint:    endpoint,
+	}
+}
+
+type azureCompletionClient struct {
+	cli         httpcli.Doer
+	accessToken string
+	endpoint    string
+}
+
+func (c *azureCompletionClient) Complete(
+	ctx context.Context,
+	feature types.CompletionsFeature,
+	requestParams types.CompletionRequestParameters,
+) (*types.CompletionResponse, error) {
+	resp, err := c.makeRequest(ctx, requestParams, false)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var response openaiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	if len(response.Choices) == 0 {
+		// Empty response.
+		return &types.CompletionResponse{}, nil
+	}
+
+	return &types.CompletionResponse{
+		Completion: response.Choices[0].Content,
+		StopReason: response.Choices[0].FinishReason,
+	}, nil
+}
+
+func (c *azureCompletionClient) Stream(
+	ctx context.Context,
+	feature types.CompletionsFeature,
+	requestParams types.CompletionRequestParameters,
+	sendEvent types.SendCompletionEvent,
+) error {
+	resp, err := c.makeRequest(ctx, requestParams, true)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	dec := openai.NewDecoder(resp.Body)
+	var content string
+	for dec.Scan() {
+		if ctx.Err() != nil && ctx.Err() == context.Canceled {
+			return nil
+		}
+
+		data := dec.Data()
+		// Gracefully skip over any data that isn't JSON-like.
+		if !bytes.HasPrefix(data, []byte("{")) {
+			continue
+		}
+
+		var event openaiResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			return errors.Errorf("failed to decode event payload: %w - body: %s", err, string(data))
+		}
+
+		if len(event.Choices) > 0 {
+			content += event.Choices[0].Delta.Content
+			ev := types.CompletionResponse{
+				Completion: content,
+				StopReason: event.Choices[0].FinishReason,
+			}
+			err = sendEvent(ev)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return dec.Err()
+}
+
+func (c *azureCompletionClient) makeRequest(ctx context.Context, requestParams types.CompletionRequestParameters, stream bool) (*http.Response, error) {
+	if requestParams.TopK < 0 {
+		requestParams.TopK = 0
+	}
+	if requestParams.TopP < 0 {
+		requestParams.TopP = 0
+	}
+
+	// TODO(sqs): make CompletionRequestParameters non-anthropic-specific
+	payload := azureChatCompletionsRequestParameters{
+		Temperature: requestParams.Temperature,
+		TopP:        requestParams.TopP,
+		// TODO(sqs): map requestParams.TopK to openai
+		N:         1,
+		Stream:    stream,
+		MaxTokens: requestParams.MaxTokensToSample,
+		// TODO: Our clients are currently heavily biased towards Anthropic,
+		// so the stop sequences we send might not actually be very useful
+		// for OpenAI.
+		Stop: requestParams.StopSequences,
+	}
+	for _, m := range requestParams.Messages {
+		// TODO(sqs): map these 'roles' to openai system/user/assistant
+		var role string
+		switch m.Speaker {
+		case types.HUMAN_MESSAGE_SPEAKER:
+			role = "user"
+		case types.ASISSTANT_MESSAGE_SPEAKER:
+			role = "assistant"
+			//
+		default:
+			role = strings.ToLower(role)
+		}
+		payload.Messages = append(payload.Messages, message{
+			Role:    role,
+			Content: m.Text,
+		})
+	}
+
+	reqBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse configured endpoint")
+	}
+	q := url.Query()
+	q.Add("api-version", "2023-05-15")
+	url.RawQuery = q.Encode()
+	url.Path = fmt.Sprintf("/openai/deployments/%s/chat/completions", requestParams.Model)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url.String(), bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("api-key", c.accessToken)
+
+	resp, err := c.cli.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, types.NewErrStatusNotOK("AzureOpenAI", resp)
+	}
+
+	return resp, nil
+}
+
+type azureChatCompletionsRequestParameters struct {
+	Messages         []message          `json:"messages"`
+	Temperature      float32            `json:"temperature,omitempty"`
+	TopP             float32            `json:"top_p,omitempty"`
+	N                int                `json:"n,omitempty"`
+	Stream           bool               `json:"stream,omitempty"`
+	Stop             []string           `json:"stop,omitempty"`
+	MaxTokens        int                `json:"max_tokens,omitempty"`
+	PresencePenalty  float32            `json:"presence_penalty,omitempty"`
+	FrequencyPenalty float32            `json:"frequency_penalty,omitempty"`
+	LogitBias        map[string]float32 `json:"logit_bias,omitempty"`
+	User             string             `json:"user,omitempty"`
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type azure struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type openaiChoiceDelta struct {
+	Content string `json:"content"`
+}
+
+type openaiChoice struct {
+	Delta        openaiChoiceDelta `json:"delta"`
+	Role         string            `json:"role"`
+	Content      string            `json:"content"`
+	FinishReason string            `json:"finish_reason"`
+}
+
+type openaiResponse struct {
+	// Usage is only available for non-streaming requests.
+	Usage   azure          `json:"usage"`
+	Model   string         `json:"model"`
+	Choices []openaiChoice `json:"choices"`
+}

--- a/internal/completions/client/azureopenai/openai_test.go
+++ b/internal/completions/client/azureopenai/openai_test.go
@@ -1,0 +1,53 @@
+package azureopenai
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+)
+
+type mockDoer struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
+	return c.do(r)
+}
+
+func TestErrStatusNotOK(t *testing.T) {
+	mockClient := NewClient(&mockDoer{
+		func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(bytes.NewReader([]byte("oh no, please slow down!"))),
+			}, nil
+		},
+	}, "", "")
+
+	t.Run("Complete", func(t *testing.T) {
+		resp, err := mockClient.Complete(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{})
+		require.Error(t, err)
+		assert.Nil(t, resp)
+
+		autogold.Expect("AzureOpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		err := mockClient.Stream(context.Background(), types.CompletionsFeatureChat, types.CompletionRequestParameters{}, func(event types.CompletionResponse) error { return nil })
+		require.Error(t, err)
+
+		autogold.Expect("AzureOpenAI: unexpected status code 429: oh no, please slow down!").Equal(t, err.Error())
+		_, ok := types.IsErrStatusNotOK(err)
+		assert.True(t, ok)
+	})
+}

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/azureopenai"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
@@ -24,6 +25,8 @@ func getBasic(endpoint string, provider conftypes.CompletionsProviderName, acces
 		return anthropic.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameOpenAI:
 		return openai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+	case conftypes.CompletionsProviderNameAzureOpenAI:
+		return azureopenai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameSourcegraph:
 		return codygateway.NewClient(httpcli.ExternalDoer, endpoint, accessToken)
 	default:

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -772,6 +772,31 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 		if completionsConfig.CompletionModel == "" {
 			completionsConfig.CompletionModel = "claude-instant-1"
 		}
+	} else if completionsConfig.Provider == string(conftypes.CompletionsProviderNameAzureOpenAI) {
+		// If no endpoint is configured, this provider is misconfigured.
+		if completionsConfig.Endpoint == "" {
+			return nil
+		}
+
+		// If not access token is set, we cannot talk to Azure OpenAI. Bail.
+		if completionsConfig.AccessToken == "" {
+			return nil
+		}
+
+		// If not chat model is set, we cannot talk to Azure OpenAI. Bail.
+		if completionsConfig.ChatModel == "" {
+			return nil
+		}
+
+		// If not fast chat model is set, we fall back to the Chat Model.
+		if completionsConfig.FastChatModel == "" {
+			completionsConfig.FastChatModel = completionsConfig.ChatModel
+		}
+
+		// If not completions model is set, we cannot talk to Azure OpenAI. Bail.
+		if completionsConfig.CompletionModel == "" {
+			return nil
+		}
 	}
 
 	// Make sure models are always treated case-insensitive.
@@ -936,6 +961,24 @@ func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.Embeddi
 		if embeddingsConfig.Dimensions <= 0 && embeddingsConfig.Model == "text-embedding-ada-002" {
 			embeddingsConfig.Dimensions = 1536
 		}
+	} else if embeddingsConfig.Provider == string(conftypes.EmbeddingsProviderNameAzureOpenAI) {
+		// If no endpoint is configured, we cannot talk to Azure OpenAI.
+		if embeddingsConfig.Endpoint == "" {
+			return nil
+		}
+
+		// If not access token is set, we cannot talk to OpenAI. Bail.
+		if embeddingsConfig.AccessToken == "" {
+			return nil
+		}
+
+		// If no model is set, we cannot do anything here.
+		if embeddingsConfig.Model == "" {
+			return nil
+		}
+		// Make sure models are always treated case-insensitive.
+		// TODO: Are model names on azure case insensitive?
+		embeddingsConfig.Model = strings.ToLower(embeddingsConfig.Model)
 	} else {
 		// Unknown provider value.
 		return nil
@@ -1029,6 +1072,10 @@ func defaultMaxPromptTokens(provider conftypes.CompletionsProviderName, model st
 		return anthropicDefaultMaxPromptTokens(model)
 	case conftypes.CompletionsProviderNameOpenAI:
 		return openaiDefaultMaxPromptTokens(model)
+	case conftypes.CompletionsProviderNameAzureOpenAI:
+		// We cannot know based on the model name what model is actually used,
+		// this is a sane default for GPT in general.
+		return 8_000
 	}
 
 	// Should be unreachable.

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -546,6 +546,32 @@ func TestGetCompletionsConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Azure OpenAI completions completions",
+			siteConfig: schema.SiteConfiguration{
+				CodyEnabled: pointers.Ptr(true),
+				LicenseKey:  licenseKey,
+				Completions: &schema.Completions{
+					Provider:        "azure-openai",
+					AccessToken:     "asdf",
+					Endpoint:        "https://acmecorp.openai.azure.com",
+					ChatModel:       "gpt4-deployment",
+					FastChatModel:   "gpt35-turbo-deployment",
+					CompletionModel: "gpt35-turbo-deployment",
+				},
+			},
+			wantConfig: &conftypes.CompletionsConfig{
+				ChatModel:                "gpt4-deployment",
+				ChatModelMaxTokens:       8000,
+				FastChatModel:            "gpt35-turbo-deployment",
+				FastChatModelMaxTokens:   8000,
+				CompletionModel:          "gpt35-turbo-deployment",
+				CompletionModelMaxTokens: 8000,
+				AccessToken:              "asdf",
+				Provider:                 "azure-openai",
+				Endpoint:                 "https://acmecorp.openai.azure.com",
+			},
+		},
+		{
 			name: "zero-config cody gateway completions without license key",
 			siteConfig: schema.SiteConfiguration{
 				CodyEnabled: pointers.Ptr(true),
@@ -889,6 +915,35 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 				},
 			},
 			wantDisabled: true,
+		},
+		{
+			name: "Azure OpenAI provider",
+			siteConfig: schema.SiteConfiguration{
+				CodyEnabled: pointers.Ptr(true),
+				LicenseKey:  licenseKey,
+				Embeddings: &schema.Embeddings{
+					Provider:    "azure-openai",
+					AccessToken: "asdf",
+					Endpoint:    "https://acmecorp.openai.azure.com",
+					Dimensions:  1536,
+					Model:       "the-model",
+				},
+			},
+			wantConfig: &conftypes.EmbeddingsConfig{
+				Provider:                   "azure-openai",
+				AccessToken:                "asdf",
+				Model:                      "the-model",
+				Endpoint:                   "https://acmecorp.openai.azure.com",
+				Dimensions:                 1536,
+				Incremental:                true,
+				MinimumInterval:            24 * time.Hour,
+				MaxCodeEmbeddingsPerRepo:   3_072_000,
+				MaxTextEmbeddingsPerRepo:   512_000,
+				PolicyRepositoryMatchLimit: pointers.Ptr(5000),
+				FileFilters: conftypes.EmbeddingsFileFilters{
+					MaxFileSizeBytes: 1000000,
+				},
+			},
 		},
 		{
 			name:       "App default config",

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -24,6 +24,7 @@ type CompletionsProviderName string
 const (
 	CompletionsProviderNameAnthropic   CompletionsProviderName = "anthropic"
 	CompletionsProviderNameOpenAI      CompletionsProviderName = "openai"
+	CompletionsProviderNameAzureOpenAI CompletionsProviderName = "azure-openai"
 	CompletionsProviderNameSourcegraph CompletionsProviderName = "sourcegraph"
 )
 
@@ -45,6 +46,7 @@ type EmbeddingsProviderName string
 
 const (
 	EmbeddingsProviderNameOpenAI      EmbeddingsProviderName = "openai"
+	EmbeddingsProviderNameAzureOpenAI EmbeddingsProviderName = "azure-openai"
 	EmbeddingsProviderNameSourcegraph EmbeddingsProviderName = "sourcegraph"
 )
 

--- a/internal/embeddings/embed/BUILD.bazel
+++ b/internal/embeddings/embed/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/embeddings",
         "//internal/embeddings/background/repo",
         "//internal/embeddings/embed/client",
+        "//internal/embeddings/embed/client/azureopenai",
         "//internal/embeddings/embed/client/openai",
         "//internal/embeddings/embed/client/sourcegraph",
         "//internal/httpcli",

--- a/internal/embeddings/embed/client/azureopenai/BUILD.bazel
+++ b/internal/embeddings/embed/client/azureopenai/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "azureopenai",
+    srcs = ["client.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/azureopenai",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/conf/conftypes",
+        "//internal/embeddings/embed/client",
+        "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "azureopenai_test",
+    srcs = ["client_test.go"],
+    embed = [":azureopenai"],
+    deps = [
+        "//internal/conf/conftypes",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/embeddings/embed/client/azureopenai/client.go
+++ b/internal/embeddings/embed/client/azureopenai/client.go
@@ -1,0 +1,144 @@
+package azureopenai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func NewClient(httpClient *http.Client, config *conftypes.EmbeddingsConfig) *azureOpenaiEmbeddingsClient {
+	return &azureOpenaiEmbeddingsClient{
+		httpClient:  httpClient,
+		dimensions:  config.Dimensions,
+		accessToken: config.AccessToken,
+		model:       config.Model,
+		endpoint:    config.Endpoint,
+	}
+}
+
+type azureOpenaiEmbeddingsClient struct {
+	httpClient  *http.Client
+	model       string
+	dimensions  int
+	endpoint    string
+	accessToken string
+}
+
+func (c *azureOpenaiEmbeddingsClient) GetDimensions() (int, error) {
+	if c.dimensions <= 0 {
+		return 0, errors.New("invalid config for embeddings.dimensions, must be > 0")
+	}
+	return c.dimensions, nil
+}
+
+func (c *azureOpenaiEmbeddingsClient) GetModelIdentifier() string {
+	return fmt.Sprintf("azure-openai/%s", c.model)
+}
+
+// GetEmbeddings tries to embed the given texts using the external service specified in the config.
+func (c *azureOpenaiEmbeddingsClient) GetEmbeddings(ctx context.Context, texts []string) ([]float32, error) {
+	for _, text := range texts {
+		if text == "" {
+			// The Azure OpenAI API will return an error if any of the strings in texts is an empty string,
+			// so fail fast to avoid making tons of retryable requests.
+			return nil, errors.New("cannot generate embeddings for an empty string")
+		}
+	}
+
+	// For now, we assume all Azure OpenAI models will benefit from stripping out newlines.
+	augmentedTexts := make([]string, len(texts))
+	// Replace newlines for certain (OpenAI) models, because they can negatively affect performance.
+	for idx, text := range texts {
+		augmentedTexts[idx] = strings.ReplaceAll(text, "\n", " ")
+	}
+
+	embeddings := make([]float32, 0, len(augmentedTexts)*c.dimensions)
+	for i, input := range augmentedTexts {
+		// This is a difference to the OpenAI implementation: Azure OpenAI currently
+		// only supports a single input at a time, so we will need to fire off a request
+		// for each of the texts individually.
+		resp, err := c.requestSingleEmbeddingWithRetryOnNull(ctx, input, 3)
+		if err != nil {
+			return nil, client.PartialError{Err: err, Index: i}
+		}
+		embeddings = append(embeddings, resp.Data[0].Embedding...)
+	}
+
+	return embeddings, nil
+}
+
+func (c *azureOpenaiEmbeddingsClient) requestSingleEmbeddingWithRetryOnNull(ctx context.Context, input string, retries int) (*openaiEmbeddingAPIResponse, error) {
+	for i := 0; i < retries; i++ {
+		response, err := c.do(ctx, c.model, openaiEmbeddingAPIRequest{Input: input})
+		if err != nil {
+			return nil, err
+		}
+		if len(response.Data) != 1 || len(response.Data[0].Embedding) == 0 {
+			continue
+		}
+		return response, nil
+	}
+	return nil, errors.Newf("null response for embedding after %d retries", retries)
+}
+
+func (c *azureOpenaiEmbeddingsClient) do(ctx context.Context, model string, request openaiEmbeddingAPIRequest) (*openaiEmbeddingAPIResponse, error) {
+	bodyBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse configured endpoint")
+	}
+	q := url.Query()
+	q.Add("api-version", "2023-05-15")
+	url.RawQuery = q.Encode()
+	url.Path = fmt.Sprintf("/openai/deployments/%s/embeddings", model)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("api-key", c.accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, errors.Errorf("embeddings: %s %q: failed with status %d: %s", req.Method, req.URL.String(), resp.StatusCode, string(respBody))
+	}
+
+	var response openaiEmbeddingAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+type openaiEmbeddingAPIRequest struct {
+	Input string `json:"input"`
+}
+
+type openaiEmbeddingAPIResponse struct {
+	Data []openaiEmbeddingAPIResponseData `json:"data"`
+}
+
+type openaiEmbeddingAPIResponseData struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
+}

--- a/internal/embeddings/embed/client/azureopenai/client_test.go
+++ b/internal/embeddings/embed/client/azureopenai/client_test.go
@@ -1,0 +1,156 @@
+package azureopenai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+)
+
+func TestAzureOpenAI(t *testing.T) {
+	t.Run("errors on empty embedding string", func(t *testing.T) {
+		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
+		invalidTexts := []string{"a", ""} // empty string is invalid
+		_, err := client.GetEmbeddings(context.Background(), invalidTexts)
+		require.ErrorContains(t, err, "empty string")
+	})
+
+	t.Run("retry on empty embedding", func(t *testing.T) {
+		gotRequest1 := false
+		gotRequest2 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// The client should try that embedding once more. This time, actually return a value.
+			if !gotRequest2 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: append(make([]float32, 1535), 1),
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest2 = true
+				return
+			}
+
+			panic("only expected 2 responses")
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+
+		// HACK: override the URL to always go to the test server
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		resp, err := client.GetEmbeddings(context.Background(), []string{"a"})
+		require.NoError(t, err)
+		var expected []float32
+		{
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 1)
+		}
+		require.Equal(t, expected, resp)
+		require.True(t, gotRequest1)
+		require.True(t, gotRequest2)
+	})
+
+	t.Run("retry on empty embedding fails", func(t *testing.T) {
+		gotRequest1 := false
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// On the first request, respond with a null embedding
+			if !gotRequest1 {
+				resp := openaiEmbeddingAPIResponse{
+					Data: []openaiEmbeddingAPIResponseData{{
+						Index:     0,
+						Embedding: nil,
+					}},
+				}
+				json.NewEncoder(w).Encode(resp)
+				gotRequest1 = true
+				return
+			}
+
+			// Always return an invalid response to all the retry requests
+			resp := openaiEmbeddingAPIResponse{
+				Data: []openaiEmbeddingAPIResponseData{{
+					Index:     0,
+					Embedding: nil,
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		_, err := client.GetEmbeddings(context.Background(), []string{"a"})
+		require.Error(t, err, "expected request to error on failed retry")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		requestCount := 0
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requestCount++
+			resp := openaiEmbeddingAPIResponse{
+				Data: []openaiEmbeddingAPIResponseData{{
+					Index:     0,
+					Embedding: append(make([]float32, 1535), float32(requestCount)),
+				}},
+			}
+			json.NewEncoder(w).Encode(resp)
+		}))
+		defer s.Close()
+
+		httpClient := s.Client()
+		oldTransport := httpClient.Transport
+		httpClient.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			r.URL, _ = url.Parse(s.URL)
+			return oldTransport.RoundTrip(r)
+		})
+
+		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
+		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		require.NoError(t, err, "expected request to succeed")
+		var expected []float32
+		{
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 1)
+			expected = append(expected, make([]float32, 1535)...)
+			expected = append(expected, 2)
+		}
+		require.Equal(t, expected, resp)
+	})
+}
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/embeddings"
 	bgrepo "github.com/sourcegraph/sourcegraph/internal/embeddings/background/repo"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client"
+	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/azureopenai"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/openai"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/sourcegraph"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -21,10 +22,12 @@ import (
 
 func NewEmbeddingsClient(config *conftypes.EmbeddingsConfig) (client.EmbeddingsClient, error) {
 	switch config.Provider {
-	case "sourcegraph":
+	case conftypes.EmbeddingsProviderNameSourcegraph:
 		return sourcegraph.NewClient(httpcli.ExternalClient, config), nil
-	case "openai":
+	case conftypes.EmbeddingsProviderNameOpenAI:
 		return openai.NewClient(httpcli.ExternalClient, config), nil
+	case conftypes.EmbeddingsProviderNameAzureOpenAI:
+		return azureopenai.NewClient(httpcli.ExternalClient, config), nil
 	default:
 		return nil, errors.Newf("invalid provider %q", config.Provider)
 	}

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2429,7 +2429,7 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": ["openai", "sourcegraph"]
+          "enum": ["openai", "azure-openai", "sourcegraph"]
         },
         "endpoint": {
           "type": "string",
@@ -2592,7 +2592,7 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "anthropic",
-          "enum": ["anthropic", "openai", "sourcegraph"]
+          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai"]
         },
         "endpoint": {
           "type": "string",


### PR DESCRIPTION
This adds experimental support for Azure OpenAI as an embeddings and completions provider.

I added some experimental docs for it, and ran through it with a bunch of repos and queries, seems to be on-par with the OpenAI providers mostly. Only thing is that we make more requests for embeddings, because Azure doesn't yet support the batch API.

Test plan
Verified manually using our Azure deployment.