### PR TITLE
[github app] Encode App baseURL in state instead of using Referer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed an issue where GitHub Apps could not be set up using Firefox. [#55305](https://github.com/sourcegraph/sourcegraph/pull/55305)
+
 ### Removed
 
 - indexed-search has removed the deprecated environment variable ZOEKT_ENABLE_LAZY_DOC_SECTIONS [zoekt#620](https://github.com/sourcegraph/zoekt/pull/620)

--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -129,7 +129,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
         setError(undefined)
         try {
             const response = await fetch(
-                `/.auth/githubapp/new-app-state?appName=${name}&webhookURN=${url}&domain=${appDomain}`
+                `/.auth/githubapp/new-app-state?appName=${name}&webhookURN=${url}&domain=${appDomain}&baseURL=${url}`
             )
             if (!response.ok) {
                 if (response.body instanceof ReadableStream) {
@@ -155,7 +155,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                 setError('Unknown error occurred.')
             }
         }
-    }, [submitForm, name, appDomain, url, originURL])
+    }, [submitForm, name, appDomain, url, originURL, url])
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setName(event.target.value)

--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -155,7 +155,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
                 setError('Unknown error occurred.')
             }
         }
-    }, [submitForm, name, appDomain, url, originURL, url])
+    }, [submitForm, name, appDomain, url, originURL])
 
     const handleNameChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setName(event.target.value)

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware_test.go
@@ -260,6 +260,7 @@ func TestGithubAppAuthMiddleware(t *testing.T) {
 			t.Fatalf("unexpected error generating random state: %s", err.Error())
 		}
 		domain := types.BatchesGitHubAppDomain
+		stateBaseURL := "https://github.com"
 
 		t.Run("normal user", func(t *testing.T) {
 			req := httptest.NewRequest("GET", baseURL, nil)
@@ -308,7 +309,6 @@ func TestGithubAppAuthMiddleware(t *testing.T) {
 				return &ghtypes.GitHubApp{}, nil
 			}
 			req := httptest.NewRequest("GET", fmt.Sprintf("%s?state=%s&code=%s", baseURL, state, code), nil)
-			req.Header.Set("Referer", "https://example.com")
 			req = req.WithContext(actor.WithActor(req.Context(), &actor.Actor{
 				UID: 2,
 			}))
@@ -316,6 +316,7 @@ func TestGithubAppAuthMiddleware(t *testing.T) {
 			stateDeets, err := json.Marshal(gitHubAppStateDetails{
 				WebhookUUID: webhookUUID.String(),
 				Domain:      string(domain),
+				BaseURL:     stateBaseURL,
 			})
 			require.NoError(t, err)
 			cache.Set(state, stateDeets)

--- a/enterprise/cmd/frontend/internal/auth/githubappauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githubappauth/middleware_test.go
@@ -187,7 +187,8 @@ func TestGithubAppAuthMiddleware(t *testing.T) {
 		webhookURN := "https://example.com"
 		appName := "TestApp"
 		domain := "batches"
-		req := httptest.NewRequest("GET", fmt.Sprintf("/githubapp/new-app-state?webhookURN=%s&appName=%s&domain=%s", webhookURN, appName, domain), nil)
+		baseURL := "https://ghe.example.org"
+		req := httptest.NewRequest("GET", fmt.Sprintf("/githubapp/new-app-state?webhookURN=%s&appName=%s&domain=%s&baseURL=%s", webhookURN, appName, domain, baseURL), nil)
 
 		t.Run("normal user", func(t *testing.T) {
 			req = req.WithContext(actor.WithActor(req.Context(), &actor.Actor{
@@ -244,6 +245,9 @@ func TestGithubAppAuthMiddleware(t *testing.T) {
 			}
 			if stateDetails.Domain != domain {
 				t.Fatal("expected domain in state details to match request param")
+			}
+			if stateDetails.BaseURL != baseURL {
+				t.Fatal("expected baseURL in state details to match request param")
 			}
 		})
 	})


### PR DESCRIPTION
Firefox's default settings do not forward Referer headers for privacy reasons. This means that GitHub App setups fail when done using Firefox.

This PR adds the GitHub App's base url to the state we store in Redis, so that we no longer rely on the browser sending the Referer header.

## Test plan

Tests updated.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
