### PR TITLE
fix(site-admin-ui): hide disabled feature admin pages

### DIFF
--- a/client/web/src/enterprise/site-admin/routes.tsx
+++ b/client/web/src/enterprise/site-admin/routes.tsx
@@ -183,6 +183,7 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = (
             exact: true,
             path: '/code-insights-jobs',
             render: () => <CodeInsightsJobsPage />,
+            condition: ({ codeInsightsEnabled }) => codeInsightsEnabled,
         },
         {
             exact: true,

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -1,19 +1,18 @@
-import BrainIcon from 'mdi-react/BrainIcon'
-import BriefcaseIcon from 'mdi-react/BriefcaseIcon'
-import PackageVariantIcon from 'mdi-react/PackageVariantIcon'
+import BrainIcon from 'mdi-react/BrainIcon';
+import BriefcaseIcon from 'mdi-react/BriefcaseIcon';
+import PackageVariantIcon from 'mdi-react/PackageVariantIcon';
 
-import { BatchChangesIcon } from '../../batches/icons'
-import { CodyPageIcon } from '../../cody/chat/CodyPageIcon'
-import {
-    apiConsoleGroup,
-    analyticsGroup,
-    configurationGroup as ossConfigurationGroup,
-    maintenanceGroup as ossMaintenanceGroup,
-    repositoriesGroup as ossRepositoriesGroup,
-    usersGroup as ossUsersGroup,
-} from '../../site-admin/sidebaritems'
-import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar'
-import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
+
+
+import { BatchChangesIcon } from '../../batches/icons';
+import { CodyPageIcon } from '../../cody/chat/CodyPageIcon';
+import { apiConsoleGroup, analyticsGroup, configurationGroup as ossConfigurationGroup, maintenanceGroup as ossMaintenanceGroup, repositoriesGroup as ossRepositoriesGroup, usersGroup as ossUsersGroup } from '../../site-admin/sidebaritems';
+import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar';
+import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features';
+
+
+
+
 
 const configurationGroup: SiteAdminSideBarGroup = {
     ...ossConfigurationGroup,

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -1,18 +1,19 @@
-import BrainIcon from 'mdi-react/BrainIcon';
-import BriefcaseIcon from 'mdi-react/BriefcaseIcon';
-import PackageVariantIcon from 'mdi-react/PackageVariantIcon';
+import BrainIcon from 'mdi-react/BrainIcon'
+import BriefcaseIcon from 'mdi-react/BriefcaseIcon'
+import PackageVariantIcon from 'mdi-react/PackageVariantIcon'
 
-
-
-import { BatchChangesIcon } from '../../batches/icons';
-import { CodyPageIcon } from '../../cody/chat/CodyPageIcon';
-import { apiConsoleGroup, analyticsGroup, configurationGroup as ossConfigurationGroup, maintenanceGroup as ossMaintenanceGroup, repositoriesGroup as ossRepositoriesGroup, usersGroup as ossUsersGroup } from '../../site-admin/sidebaritems';
-import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar';
-import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features';
-
-
-
-
+import { BatchChangesIcon } from '../../batches/icons'
+import { CodyPageIcon } from '../../cody/chat/CodyPageIcon'
+import {
+    apiConsoleGroup,
+    analyticsGroup,
+    configurationGroup as ossConfigurationGroup,
+    maintenanceGroup as ossMaintenanceGroup,
+    repositoriesGroup as ossRepositoriesGroup,
+    usersGroup as ossUsersGroup,
+} from '../../site-admin/sidebaritems'
+import { SiteAdminSideBarGroup, SiteAdminSideBarGroups } from '../../site-admin/SiteAdminSidebar'
+import { SHOW_BUSINESS_FEATURES } from '../dotcom/productSubscriptions/features'
 
 const configurationGroup: SiteAdminSideBarGroup = {
     ...ossConfigurationGroup,
@@ -44,7 +45,7 @@ const maintenanceGroup: SiteAdminSideBarGroup = {
         {
             label: 'Code Insights jobs',
             to: '/site-admin/code-insights-jobs',
-            condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
+            condition: ({ isSourcegraphApp, codeInsightsEnabled }) => !isSourcegraphApp && codeInsightsEnabled,
         },
     ],
 }

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -119,6 +119,7 @@ export const routes: RouteObject[] = [
                         routes={props.siteAdminAreaRoutes}
                         sideBarGroups={props.siteAdminSideBarGroups}
                         overviewComponents={props.siteAdminOverviewComponents}
+                        codeInsightsEnabled={window.context.codeInsightsEnabled}
                     />
                 )}
             />

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -56,6 +56,8 @@ export interface SiteAdminAreaRouteContext
 
     /** This property is only used by {@link SiteAdminOverviewPage}. */
     overviewComponents: readonly React.ComponentType<React.PropsWithChildren<{}>>[]
+
+    codeInsightsEnabled: boolean
 }
 
 export interface SiteAdminAreaRoute extends RouteV6Descriptor<SiteAdminAreaRouteContext> {}
@@ -67,6 +69,7 @@ interface SiteAdminAreaProps extends PlatformContextProps, SettingsCascadeProps,
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
+    codeInsightsEnabled: boolean
 }
 
 const sourcegraphOperatorSiteAdminMaintenanceBlockItems = new Set([
@@ -130,6 +133,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         site: { __typename: 'Site' as const, id: window.context.siteGQLID },
         overviewComponents: props.overviewComponents,
         telemetryService: props.telemetryService,
+        codeInsightsEnabled: props.codeInsightsEnabled,
     }
 
     return (
@@ -150,6 +154,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                     batchChangesEnabled={props.batchChangesEnabled}
                     batchChangesExecutionEnabled={props.batchChangesExecutionEnabled}
                     batchChangesWebhookLogsEnabled={props.batchChangesWebhookLogsEnabled}
+                    codeInsightsEnabled={props.codeInsightsEnabled}
                 />
                 <div className="flex-bounded">
                     <React.Suspense fallback={<LoadingSpinner className="m-2" />}>

--- a/client/web/src/site-admin/SiteAdminSidebar.story.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.story.tsx
@@ -1,8 +1,10 @@
 import { DecoratorFn, Meta, Story } from '@storybook/react'
 
-import { WebStory } from '../components/WebStory'
+import { Grid } from '@sourcegraph/wildcard'
 
-import { siteAdminSidebarGroups } from './sidebaritems'
+import { WebStory } from '../components/WebStory'
+import { enterpriseSiteAdminSidebarGroups } from '../enterprise/site-admin/sidebaritems'
+
 import { SiteAdminSidebar } from './SiteAdminSidebar'
 
 const decorator: DecoratorFn = story => <div style={{ width: '192px' }}>{story()}</div>
@@ -10,6 +12,11 @@ const decorator: DecoratorFn = story => <div style={{ width: '192px' }}>{story()
 const config: Meta = {
     title: 'web/site-admin/AdminSidebar',
     decorators: [decorator],
+    parameters: {
+        chromatic: {
+            disableSnapshot: false,
+        },
+    },
 }
 
 export default config
@@ -17,15 +24,63 @@ export default config
 export const AdminSidebarItems: Story = () => (
     <WebStory>
         {webProps => (
-            <SiteAdminSidebar
-                {...webProps}
-                groups={siteAdminSidebarGroups}
-                isSourcegraphDotCom={false}
-                isSourcegraphApp={false}
-                batchChangesEnabled={false}
-                batchChangesExecutionEnabled={false}
-                batchChangesWebhookLogsEnabled={false}
-            />
+            <Grid columnCount={5}>
+                <code>isSourcegraphApp=true</code>
+                <code>default</code>
+                <code>isSourcegraphDotCom=true</code>
+                <code>batchChangesEnabled=false</code>
+                <code>codeInsightsEnabled=false</code>
+                <SiteAdminSidebar
+                    {...webProps}
+                    groups={enterpriseSiteAdminSidebarGroups}
+                    isSourcegraphDotCom={false}
+                    isSourcegraphApp={true}
+                    batchChangesEnabled={true}
+                    batchChangesExecutionEnabled={true}
+                    batchChangesWebhookLogsEnabled={true}
+                    codeInsightsEnabled={true}
+                />
+                <SiteAdminSidebar
+                    {...webProps}
+                    groups={enterpriseSiteAdminSidebarGroups}
+                    isSourcegraphDotCom={false}
+                    isSourcegraphApp={false}
+                    batchChangesEnabled={true}
+                    batchChangesExecutionEnabled={true}
+                    batchChangesWebhookLogsEnabled={true}
+                    codeInsightsEnabled={true}
+                />
+                <SiteAdminSidebar
+                    {...webProps}
+                    groups={enterpriseSiteAdminSidebarGroups}
+                    isSourcegraphDotCom={true}
+                    isSourcegraphApp={false}
+                    batchChangesEnabled={true}
+                    batchChangesExecutionEnabled={true}
+                    batchChangesWebhookLogsEnabled={true}
+                    codeInsightsEnabled={true}
+                />
+                <SiteAdminSidebar
+                    {...webProps}
+                    groups={enterpriseSiteAdminSidebarGroups}
+                    isSourcegraphDotCom={false}
+                    isSourcegraphApp={false}
+                    batchChangesEnabled={false}
+                    batchChangesExecutionEnabled={false}
+                    batchChangesWebhookLogsEnabled={false}
+                    codeInsightsEnabled={true}
+                />
+                <SiteAdminSidebar
+                    {...webProps}
+                    groups={enterpriseSiteAdminSidebarGroups}
+                    isSourcegraphDotCom={false}
+                    isSourcegraphApp={false}
+                    batchChangesEnabled={true}
+                    batchChangesExecutionEnabled={true}
+                    batchChangesWebhookLogsEnabled={true}
+                    codeInsightsEnabled={false}
+                />
+            </Grid>
         )}
     </WebStory>
 )

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -14,15 +14,14 @@ import styles from './SiteAdminSidebar.module.scss'
 export interface SiteAdminSideBarGroupContext extends BatchChangesProps {
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
+    codeInsightsEnabled: boolean
 }
 
 export interface SiteAdminSideBarGroup extends NavGroupDescriptor<SiteAdminSideBarGroupContext> {}
 
 export type SiteAdminSideBarGroups = readonly SiteAdminSideBarGroup[]
 
-export interface SiteAdminSidebarProps extends BatchChangesProps {
-    isSourcegraphDotCom: boolean
-    isSourcegraphApp: boolean
+export interface SiteAdminSidebarProps extends SiteAdminSideBarGroupContext {
     /** The items for the side bar, by group */
     groups: SiteAdminSideBarGroups
     className?: string

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -119,10 +119,12 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/analytics/code-insights',
         render: () => <AnalyticsCodeInsightsPage />,
+        condition: ({ codeInsightsEnabled }) => codeInsightsEnabled,
     },
     {
         path: '/analytics/batch-changes',
         render: () => <AnalyticsBatchChangesPage />,
+        condition: ({ batchChangesEnabled }) => batchChangesEnabled,
     },
     {
         path: '/analytics/notebooks',

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -37,10 +37,12 @@ export const analyticsGroup: SiteAdminSideBarGroup = {
         {
             label: 'Insights',
             to: '/site-admin/analytics/code-insights',
+            condition: ({ codeInsightsEnabled }) => codeInsightsEnabled,
         },
         {
             label: 'Batch changes',
             to: '/site-admin/analytics/batch-changes',
+            condition: ({ batchChangesEnabled }) => batchChangesEnabled,
         },
         {
             label: 'Notebooks',


### PR DESCRIPTION
This PR fixes to hide `analytics /  insights`, `analytics / batches` and `maintenance / code insights jobs` pages and sidebar nav items if the corresponding features are disabled

## Test plan
- Sidebar component snapshot enabled
- `sg start` and open site admin
- Check above nav items and pages are still on there
- `sg start dotcom` restart in dotcom mode (currently dotcom mode has insights and batches disabled)
- Check that no insights or batches sidebar items are shown on the site admin

## Screenshots
| Before | After |
| --: | :-- |
| <img width="524" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/95f97c87-fafd-43fd-ab6e-b3e176ace089"> |  <img width="524" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/c70dc8d9-2176-4543-8fbb-a865c2e996bc"> |
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
