### PR TITLE
file sidebar: don't hide error by turning last file into folder

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -630,10 +630,10 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
             const errorMessage = 'Full list of files is too long to display. Use search to find a specific file.'
             const id = tree.nodes.length
 
-            let entryFolder = ''
-            const lastSlashIndex = entry.path.lastIndexOf('/')
-            if (lastSlashIndex !== -1) {
-                entryFolder = entry.path.slice(0, lastSlashIndex)
+            let entryFolder = dirname(entry.path)
+            if (entryFolder === '.') {
+                // If it's just a . it won't render properly.
+                entryFolder = ''
             }
 
             const node: TreeNode = {
@@ -644,7 +644,7 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
                 children: [],
                 // The path is only used to determine if a node is a parent of
                 // another node so we can use dummy values.
-                path: entryFolder + '/sourcegraph.error',
+                path: entryFolder + '/sourcegraph.error.sidebar-file-tree',
                 entry: null,
                 error: errorMessage,
                 dotdot: null,

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -629,6 +629,13 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
             siblingCount = 0
             const errorMessage = 'Full list of files is too long to display. Use search to find a specific file.'
             const id = tree.nodes.length
+
+            let entryFolder = ''
+            const lastSlashIndex = entry.path.lastIndexOf('/')
+            if (lastSlashIndex !== -1) {
+                entryFolder = entry.path.slice(0, lastSlashIndex)
+            }
+
             const node: TreeNode = {
                 name: errorMessage,
                 id,
@@ -637,7 +644,7 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
                 children: [],
                 // The path is only used to determine if a node is a parent of
                 // another node so we can use dummy values.
-                path: entry.path + '/...sourcegraph.error',
+                path: entryFolder + '/sourcegraph.error',
                 entry: null,
                 error: errorMessage,
                 dotdot: null,


### PR DESCRIPTION
I was looking into #41750 and had to laugh out loud when I got to the last file in the sidebar, though "huh, why is that one a folder?", opened it and was greeted with an error message.

This here fixes the issue by not treating the error message as a child of the previous entry, which turns the previous entry into a folder.

### Before
![image](https://github.com/sourcegraph/sourcegraph/assets/1185253/9026f027-f78a-47a5-83ff-6ff83c40bd46)

### After
<img width="281" alt="screenshot_2023-07-26_14 46 18@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/adc01c9e-c14c-4e92-a6af-56ca03a75186">


## Test plan

- Add https://github.com/sourcegraph-testing/lotta-files to my instance
- Open repo
- Open file sidebar
