### PR TITLE
bazel: replace go:generate with bazel target for schema changes

### DIFF
--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -17,6 +17,7 @@ write_source_files(
         "//doc/dev/background-information/sg:write_cli_reference_doc",
         "//enterprise/cmd/frontend/internal/guardrails/dotcom:write_genql_yaml",
         "//internal/batches/search/syntax:write_token_type",
+        "//lib/batches/schema:write_generated_code",
         "//lib/codeintel/lsif/protocol:write_symbol_kind",
         "//lib/codeintel/lsif/protocol:write_symbol_tag",
     ],

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -176,7 +176,6 @@ genrule(
     srcs = ["//:sg.config.yaml"],
     outs = ["reference.md"],
     cmd = """
-    set -x
     SG_FORCE_REPO_ROOT="$$(pwd)" $(location :sg) \
             --no-dev-private \
             --disable-overwrite \

--- a/lib/batches/schema/BUILD.bazel
+++ b/lib/batches/schema/BUILD.bazel
@@ -6,10 +6,12 @@ GENERATED_FILES = [
     "changeset_spec_stringdata.go",
 ]
 
+# Telling gazelle to ignore here otherwise it wants to add generated files to srcs instead of fetching them
+# gazelle:ignore
 go_library(
     name = "schema",
     srcs = [
-        ":generate_stringdata_code"
+        ":generate_stringdata_code",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/lib/batches/schema",
     visibility = ["//visibility:public"],
@@ -32,14 +34,16 @@ genrule(
     $(location //lib/batches/schema/gen:stringdata) -i $${srcs[1]} -name ChangesetSpecJSON -pkg schema -o $${outs[1]}
     $(location @go_sdk//:bin/gofmt) -s -w $${outs[1]}
     """,
-    tools = ["//lib/batches/schema/gen:stringdata", "@go_sdk//:bin/gofmt"],
-    visibility = ["//visibility:public"]
+    tools = [
+        "//lib/batches/schema/gen:stringdata",
+        "@go_sdk//:bin/gofmt",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 write_generated_to_source_files(
     name = "write_generated_code",
     src = ":generate_stringdata_code",
     files = GENERATED_FILES,
-    tags = ["go_generate"]
-
+    tags = ["go_generate"],
 )

--- a/lib/batches/schema/BUILD.bazel
+++ b/lib/batches/schema/BUILD.bazel
@@ -1,12 +1,45 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
+
+GENERATED_FILES = [
+    "batch_spec_stringdata.go",
+    "changeset_spec_stringdata.go",
+]
 
 go_library(
     name = "schema",
     srcs = [
-        "batch_spec_stringdata.go",
-        "changeset_spec_stringdata.go",
-        "gen.go",
+        ":generate_stringdata_code"
     ],
     importpath = "github.com/sourcegraph/sourcegraph/lib/batches/schema",
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "generate_stringdata_code",
+    srcs = [
+        "//schema:batch_spec.schema.json",
+        "//schema:changeset_spec.schema.json",
+    ],
+    outs = GENERATED_FILES,
+    cmd = """
+    srcs=($(SRCS))
+    outs=($(OUTS))
+
+    $(location //lib/batches/schema/gen:stringdata) -i $${srcs[0]} -name BatchSpecJSON -pkg schema -o $${outs[0]}
+    $(location @go_sdk//:bin/gofmt) -s -w $${outs[0]}
+
+    $(location //lib/batches/schema/gen:stringdata) -i $${srcs[1]} -name ChangesetSpecJSON -pkg schema -o $${outs[1]}
+    $(location @go_sdk//:bin/gofmt) -s -w $${outs[1]}
+    """,
+    tools = ["//lib/batches/schema/gen:stringdata", "@go_sdk//:bin/gofmt"],
+    visibility = ["//visibility:public"]
+)
+
+write_generated_to_source_files(
+    name = "write_generated_code",
+    src = ":generate_stringdata_code",
+    files = GENERATED_FILES,
+    tags = ["go_generate"]
+
 )

--- a/lib/batches/schema/batch_spec_stringdata.go
+++ b/lib/batches/schema/batch_spec_stringdata.go
@@ -2,7 +2,7 @@
 
 package schema
 
-// BatchSpecJSON is the content of the file "../../../schema/batch_spec.schema.json".
+// BatchSpecJSON is the content of the file "schema/batch_spec.schema.json".
 const BatchSpecJSON = `{
   "$id": "batch_spec.schema.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/lib/batches/schema/changeset_spec_stringdata.go
+++ b/lib/batches/schema/changeset_spec_stringdata.go
@@ -2,7 +2,7 @@
 
 package schema
 
-// ChangesetSpecJSON is the content of the file "../../../schema/changeset_spec.schema.json".
+// ChangesetSpecJSON is the content of the file "schema/changeset_spec.schema.json".
 const ChangesetSpecJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ChangesetSpec",

--- a/lib/batches/schema/gen.go
+++ b/lib/batches/schema/gen.go
@@ -1,6 +1,0 @@
-package schema
-
-//go:generate env GO111MODULE=on go run stringdata.go -i ../../../schema/batch_spec.schema.json -name BatchSpecJSON -pkg schema -o batch_spec_stringdata.go
-//go:generate gofmt -s -w batch_spec_stringdata.go
-//go:generate env GO111MODULE=on go run stringdata.go -i ../../../schema/changeset_spec.schema.json -name ChangesetSpecJSON -pkg schema -o changeset_spec_stringdata.go
-//go:generate gofmt -s -w changeset_spec_stringdata.go

--- a/lib/batches/schema/gen/BUILD.bazel
+++ b/lib/batches/schema/gen/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
-
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 # This target is used by //lib/batches/schema:generate_stringdata_code
 # to generate code based on json schemas found in schema/
@@ -11,6 +10,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
 # to it's own package side steps some unneeded complexity
 go_binary(
     name = "stringdata",
+    embed = [":gen_lib"],
+    visibility = ["//lib/batches/schema:__pkg__"],
+)
+
+go_library(
+    name = "gen_lib",
     srcs = ["gen.go"],
-    visibility = [ "//lib/batches/schema:__pkg__"],
+    importpath = "github.com/sourcegraph/sourcegraph/lib/batches/schema/gen",
+    visibility = ["//visibility:private"],
 )

--- a/lib/batches/schema/gen/BUILD.bazel
+++ b/lib/batches/schema/gen/BUILD.bazel
@@ -1,8 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
 
+
+# This target is used by //lib/batches/schema:generate_stringdata_code
+# to generate code based on json schemas found in schema/
+#
+# The reason that this is in it's own folder is to make it easier to invoke
+# from Bazel, otherwise the `//go:build +ignore` directive makes that Bazel
+# can't invoke this binary. Consequently it is very difficult to use `go run`
+# within Bazel as you would have to set GOCACHE, HOME dirs etc - so moving it
+# to it's own package side steps some unneeded complexity
 go_binary(
     name = "stringdata",
     srcs = ["gen.go"],
     visibility = [ "//lib/batches/schema:__pkg__"],
 )
-

--- a/lib/batches/schema/gen/BUILD.bazel
+++ b/lib/batches/schema/gen/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_binary")
+
+go_binary(
+    name = "stringdata",
+    srcs = ["gen.go"],
+    visibility = [ "//lib/batches/schema:__pkg__"],
+)
+

--- a/lib/batches/schema/gen/gen.go
+++ b/lib/batches/schema/gen/gen.go
@@ -1,6 +1,3 @@
-//go:build ignore
-// +build ignore
-
 package main
 
 import (


### PR DESCRIPTION
Moved `stringdata.go` to `gen/gen.go` since that made it a whole lot easier to invoke it. Otherwise I would have had to [this](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/go_stringer.bzl?L22-24)
## Test plan
Executed `bazel run //lib/batches/schema:write_generated_code` locally and `//dev/wrtite_all_generated`

Closes #54825
