### PR TITLE
🎨 Docs Design and Structure changes

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -102,16 +102,36 @@ body {
   color: var(--text-color);
   font-size: 16px;
 }
+
 a {
-  color: rgb(161, 161, 161);
   text-decoration: none;
 }
-a:hover {
+
+body.theme-light a,
+body.theme-light .markdown-body a {
+  color: var(--link-color);
+}
+
+body.theme-dark a {
   color:var(--brand-cyan-color);
+
+}
+a:hover {
   opacity:0.8;
   transition: color 0.2s ease-in-out;
   text-decoration: none;
 }
+
+body.theme-light #sidebar a,
+body.theme-light #index a {
+  color: #171717;
+}
+
+body.theme-dark #sidebar a,
+body.theme-dark #index a {
+  color: rgb(161, 161, 161);
+}
+
 /* Nav links */
 nav.links ul {
     padding: 0;
@@ -535,6 +555,8 @@ body > #page > main > #content {
     max-width: 100%;
     height: auto;
     aspect-ratio: attr(width) / attr(height);
+    border-radius: .375rem;
+    /* border: 1px solid rgb(31, 31, 31); */
 }
 .markdown-body a:not([href]) {
   color: inherit;
@@ -546,7 +568,7 @@ body > #page > main > #content {
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  margin-top: 24px;
+  margin-top: 32px;
   margin-bottom: 16px;
   font-weight: 600;
   line-height: 1.25;
@@ -974,7 +996,7 @@ body.theme-dark .markdown-body .chroma.sgquery .ss { color: #ff6b6b; background-
 .markdown-body .getting-started .btn {
   flex: 1;
   margin: 0.5em;
-  padding: 1rem 1.25rem;
+  padding: 0.1rem 0.25rem;
   color: var(--text-color);
   border-radius: 4px;
   border: 1px solid var(--sidebar-nav-active-bg);
@@ -1352,12 +1374,16 @@ markprompt-content.dark {
     padding-bottom: 0.5rem;
 }
 
-.markdown-body p,
-.markdown-body ul,
-.markdown-body li,
-.markdown-body a {
-    color: #ededed;
+body.theme-dark .markdown-body p,
+body.theme-dark .markdown-body ul,
+body.theme-dark .markdown-body li {
     color: #94a5b8;
+}
+
+body.theme-light .markdown-body p,
+body.theme-light .markdown-body ul,
+body.theme-light .markdown-body li {
+    color: #171717;
 }
 
 .toc-bottom {
@@ -1409,6 +1435,9 @@ body.theme-light #content > .breadcrumbs > .active,
 
 body.theme-light > #sidebar .nav-section ul ul li.active-subsection{
     border-left: solid 1px #000018;
+}
+body > #sidebar .current > a  {
+    font-weight: bold;
 }
 
 .hidden {

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -37,6 +37,7 @@ The document content can set class names and IDs on elements (for example, Markd
     --experimental-color: #b200f8;
     --feature-color: #38757F;
     --beta-color: #72dbe8;
+    --brand-cyan-color: #72dbe8;
 
     --table-row-bg-1: var(--body-bg);
 }
@@ -102,12 +103,14 @@ body {
   font-size: 16px;
 }
 a {
-  color: var(--link-color);
+  color: rgb(161, 161, 161);
   text-decoration: none;
 }
 a:hover {
-  color: var(--link-hover-color);
-  text-decoration: underline;
+  color:var(--brand-cyan-color);
+  opacity:0.8;
+  transition: color 0.2s ease-in-out;
+  text-decoration: none;
 }
 /* Nav links */
 nav.links ul {
@@ -172,6 +175,7 @@ body > div#page {
     min-height: 100vh;
     justify-content: space-between;
     overflow-x: hidden; /* Prevent horizontal scrolling */
+    margin-top: calc(2*var(--spacing));
 }
 /* Responsive */
 @media (max-width: 800px /* == var(--sidebar-breakpoint-width) */) {
@@ -180,6 +184,10 @@ body > div#page {
     }
     body > #sidebar {
         border-bottom: solid 1px var(--sidebar-border-color);
+        padding: 2rem;
+        margin: 0 auto !important;
+        width: 100%;
+        text-align: center;
     }
     body > #sidebar nav {
         display: none;
@@ -200,7 +208,6 @@ body > div#page {
         position: sticky;
         top: 0;
         align-self: flex-start;
-        border-right: solid 1px var(--sidebar-border-color);
         width: var(--sidebar-width);
         overflow-y: auto;
         padding-bottom: calc(0.75*var(--spacing));
@@ -222,10 +229,12 @@ body > div#page {
 
 /* SIDEBAR */
 body > #sidebar {
-    background-color: var(--sidebar-bg);
+    background-color: var(--body-bg);
     flex-shrink: 0;
     display: flex;
     flex-direction: column;
+    margin-top: calc(2*var(--spacing));
+    margin-left: calc(6*var(--spacing));
 }
 /* Logo */
 body > #sidebar #logo {
@@ -234,7 +243,7 @@ body > #sidebar #logo {
 body > #sidebar #logo a {
     text-decoration: none;
     display: block;
-    padding: calc(1.25*var(--spacing)) calc(1.25*var(--spacing)) calc(0.5*var(--spacing)) ;
+    padding: 0;
 }
 body > #sidebar #logo img {
     width: 170px;
@@ -252,13 +261,15 @@ body > #sidebar #search-form {
 }
 body > #sidebar #search-form #search {
     color: var(--text-color);
-    border: solid 1px var(--input-border-color);
-    border-radius: 4px;
-    background-color: var(--body-bg);
+    border: none;
+    background-color: var(--border-color);
     width: 100%;
-    justify-self: center;
-    padding: calc(0.5*var(--spacing)) calc(0.25*var(--spacing)) calc(0.5*var(--spacing)) calc(2.2*var(--spacing));
     font-size: 1.0rem;
+    padding: calc(0.5*var(--spacing)) calc(0.6*var(--spacing));
+    box-shadow: inset 0 1px 0 0 #ffffff0d;
+    line-height: 1.5rem;
+    border-radius: .375rem;
+    border: 1px solid transparent;
 }
 body > #sidebar #search-form #search:focus {
     outline: none;
@@ -272,34 +283,42 @@ body > #sidebar #search-form .search-icon {
     top: 10px;
 }
 /* Nav */
-body > #sidebar nav.links {
-    margin-top: calc(0.75*var(--spacing));
-}
+body > #sidebar nav.links {margin-top: calc(2*var(--spacing));}
 body > #sidebar a {
-    padding: calc(0.4*var(--spacing)) calc(1.5*var(--spacing));
+    display: flex;
+    padding: calc(0.4*var(--spacing)) calc(1.5*var(--spacing)) calc(0.4*var(--spacing)) 0;
+    align-items: center;
 }
+
+#sidebar a svg {
+    width:16px;
+    margin-right: 0.5rem;
+}
+
 body > #sidebar nav .current > a {
-    font-weight: bold;
-    color: var(--text-color);
+    color: var(--brand-cyan-color);
 }
 body > #sidebar nav .nav-section  {
-    margin-top: calc(1.5*var(--spacing));
 }
 body > #sidebar .nav-section > ul > li {
     margin-bottom: calc(0.25*var(--spacing));
 }
 body > #sidebar .nav-section > ul > li.expand {
-    background-color: var(--sidebar-nav-active-bg);
+    /* background-color: var(--sidebar-nav-active-bg); */
 }
 body > #sidebar .nav-section ul ul {
     font-size: 90%;
-    padding-left: var(--spacing);
+    border-left: solid 1px var(--border-color);
+    margin-left: 0.2rem;
+    padding-right: .125rem;
 }
 body > #sidebar .nav-section ul ul li.active-subsection {
     font-weight: bold;
+    border-left: solid 1px var(--beta-color);
+    /* margin-left: -1px; */
 }
 body > #sidebar .nav-section ul ul li.active-subsection a {
-    color: var(--text-color);
+    color: var(--brand-cyan-color);
 }
 body > #sidebar .nav-section li.collapse ul {
     display: none;
@@ -370,20 +389,15 @@ body > #sidebar .external a, body > #page > footer .external a {
 		flex-direction: row-reverse;
 	}
 	body > #page > main > #index {
-        margin-top: calc(4.25*var(--spacing));
-        margin-left: calc(2*var(--spacing));
-        width: 30%;
+
+
         /* Note: all ancestors up to <html> (the scrolling element) must be overflow: visible (default) for this to work. */
-		position: sticky;
-		top: calc(2*var(--spacing));
-		max-height: calc(100vh - 4*var(--spacing));
-		padding: var(--spacing);
-        border: solid 1px var(--border-color);
-	}
+        top: calc(2*var(--spacing));
+        max-height: calc(100vh - 4*var(--spacing));
+ }
     body > #page > main > #content {
         flex: 8 4 auto;
         min-width: 0;
-        margin-top: calc(3.25*var(--spacing));
     }
 }
 
@@ -391,7 +405,11 @@ body > #page > main > #index {
 	font-size: 90%;
 	line-height: 24px;
 	overflow-y: auto;
-    align-self: flex-start;
+	align-self: flex-start;
+	position: fixed;
+	min-width: 300px;
+	max-width: 300px;
+	margin-top: calc(3*var(--spacing));
 }
 body > #page > main > #index > h3.version {
 	font-weight: bold;
@@ -401,8 +419,10 @@ body > #page > main > #index > h3.version {
 }
 body > #page > main > #index > h4 {
     margin-top: 0;
-	margin-bottom: 0;
-	padding-bottom: 0;
+    margin-bottom: 0;
+    padding-bottom: 0;
+    line-height: 1.5rem;
+    margin-bottom: 1rem;
 }
 body > #page > main > #index .on-this-page {
     opacity: 0.7;
@@ -430,23 +450,27 @@ body > #page > main > #content {
 	font-size: 90%;
 }
 #content > .breadcrumbs {
-	margin-bottom: 0.75rem;
+	display: flex;
+	align-items: center;
+	color: rgb(143, 143, 143);
+	gap: .5rem;
+	padding: 0 1rem;
+	margin-bottom: 2.5rem;
 }
 #content > .breadcrumbs > .active {
 	color: inherit;
-	opacity: 0.8;
+	color: #ededed;
 }
 
 .page-btn {
 	display: inline-block;
 	font-size: 90%;
-	color: inherit;
 }
 
 .badge {
     /* Mirrored from product badge styles */
     display: inline-block;
-    padding: 0.125rem 0.375rem;
+    padding: 0.025rem 0.375rem;
     line-height: 1rem;
     border-radius: 4px;
     font-size: 0.75rem;
@@ -466,6 +490,7 @@ body > #page > main > #content {
     color: #000000;
     background-color: var(--beta-color);
     text-transform: uppercase;
+    margin-right: 0.2rem;
 }
 
 .badge-feature {
@@ -491,10 +516,12 @@ body > #page > main > #content {
 /* MARKDOWN */
 .markdown-body {
   text-size-adjust: 100%;
-  line-height: 1.5;
+  line-height: 1.77;
   word-wrap: break-word;
   tab-size: 2;
-
+  max-width: 665px;
+  margin-top: calc(2*var(--spacing));
+  padding: 0 1rem;
 }
 .markdown-body blockquote {
   border-left: solid 5px var(--border-color);
@@ -528,8 +555,11 @@ body > #page > main > #content {
   position: relative;
   z-index: 1;
 }
-.markdown-body h1 { font-size: 32px; }
-.markdown-body h2 { font-size: 24px; }
+.markdown-body h1 {font-size: 36px;margin-bottom: 0.8888889em;line-height: 1.1111111;}
+.markdown-body h2 {
+    font-size: 24px;border-top-style: solid;border-top-width: 1px;
+    border-color: rgb(21 22 50);
+    padding-top: 2.5rem;scroll-margin-top: 11px;margin-top: 2em;margin-bottom: 1em;line-height: 1.3333333;}
 .markdown-body h3 { font-size: 20px; }
 .markdown-body h4 { font-size: 16px; }
 .markdown-body h5 { font-size: 14px; }
@@ -1197,7 +1227,8 @@ body.theme-dark {
     display: flex;
     flex-direction: row;
     gap: 8px;
-    padding: calc(0.5*var(--spacing)) calc(1*var(--spacing));
+    margin-top: calc(2*var(--spacing));
+    justify-content: center;
 }
 
 .MarkpromptSearchAnswerButton:focus,
@@ -1296,10 +1327,138 @@ markprompt-content.dark {
 #markprompt-button {
     background-color: transparent;
     border: 0px;
-    color: var(--link-color);
+    color: var(--markprompt-mutedForeground);
     cursor:pointer;
 }
 
 #markprompt-button:hover {
     color: var(--link-hover-color);
+}
+
+.markdown-body a {
+    color: var(--brand-cyan-color);
+}
+
+#sidebar ul ul li {
+    margin-left: -1px;
+    margin-top: 0.375rem;
+    margin-bottom: 0.375rem;
+}
+
+#sidebar ul ul li a {
+    cursor: pointer;
+    padding-left: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.markdown-body p,
+.markdown-body ul,
+.markdown-body li,
+.markdown-body a {
+    color: #ededed;
+    color: #94a5b8;
+}
+
+.toc-bottom {
+    margin-top: 1.75rem;
+    padding-top: 1.25rem;
+    font-size: .875rem;
+    line-height: 1.25rem;
+    border-top: solid 1px rgb(21 22 50);
+}
+
+::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+  color: rgb(161, 161, 161);
+  opacity: 1; /* Firefox */
+}
+
+:-ms-input-placeholder { /* Internet Explorer 10-11 */
+  color: rgb(161, 161, 161);
+}
+
+::-ms-input-placeholder { /* Microsoft Edge */
+  color: rgb(161, 161, 161);
+}
+
+.markdown-body ul {
+    padding-left: 12px;
+    margin-top: 1.25em;
+    margin-bottom: 1.25em;
+}
+
+.markdown-body li {
+    padding-left: 12px;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+.theme-light .markdown-body h2 {
+    border-color: rgb(21 22 50 / 15%);
+}
+
+.theme-light .toc-bottom {
+    border-top: solid 1px rgb(21 22 50 / 15%);
+}
+body.theme-light > #sidebar .nav-section ul ul li.active-subsection a,
+body.theme-light > #sidebar nav .current > a,
+body.theme-light #content > .breadcrumbs > .active,
+.theme-light a:hover {
+    color: #000018;
+}
+
+body.theme-light > #sidebar .nav-section ul ul li.active-subsection{
+    border-left: solid 1px #000018;
+}
+
+.hidden {
+    display: none;
+}
+
+@media (min-width: 1350px) {
+    .markdown-body {
+        max-width: 665px;
+        margin: unset;
+    }
+}
+
+@media (max-width: 1350px) {
+    .markdown-body {
+        max-width: 600px;
+    }
+}
+
+@media (min-width: 1280px) {
+    .xl\:block {
+        display: block;
+    }
+
+    body > #sidebar {
+        margin-left: calc(6*var(--spacing));
+    }
+
+     #content > .breadcrumbs {
+        display:flex;
+    }
+}
+
+@media (max-width: 1280px) {
+    #index {
+        display:none;
+    }
+    body > #sidebar {
+        margin-left: calc(2*var(--spacing));
+    }
+    #content > .breadcrumbs {
+        display:none;
+    }
+    .markdown-body {
+        margin: 0 auto;
+    }
+}
+
+@media (max-width: 800px) {
+    body > #sidebar {
+        background-color: var(--sidebar-bg);
+    }
 }

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -66,7 +66,7 @@
 
 {{define "content"}}
 	{{with .Content}}
-		<nav id="index">
+		<nav id="index" class="hidden xl:block">
 			{{if .Doc.Title}}{{template "index" .}}{{end}}
 		</nav>
 	{{end}}
@@ -76,11 +76,14 @@
 				{{range $index, $e := .Breadcrumbs}}
 					<a href="{{$e.URL}}" class="{{if $e.IsActive}}active{{end}}">
 						{{- if eq $index 0 -}}
-							Home
+							Docs
 						{{- else -}}
 							{{$e.Label}}
 						{{- end -}}
-					</a> {{if not $e.IsActive}}/{{end}}
+					{{/*  </a> {{if not $e.IsActive}}/{{end}}  */}}
+					</a> {{if not $e.IsActive}}
+                        <svg fill="none" height="24" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="24" style="color: currentcolor; width: 18px; height: 18px;"><path d="M9 18l6-6-6-6"></path></svg>
+                    {{end}}
 				{{end}}
 			</nav>
 			<div class="markdown-body">{{markdown .}}</div>
@@ -103,11 +106,13 @@
 
 {{define "index"}}
 	{{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
-		<h4>{{$.Doc.Title}}</h4>
-		<p class="on-this-page">On this page:</p>
+		{{/*  <h4>{{$.Doc.Title}}</h4>  */}}
+		{{/*  <p class="on-this-page">On this page:</p>  */}}
+		<h4>On this page</h4>
 		<ul>{{template "doc_nav" .}}</ul>
 	{{end}}
-    <a class="page-btn" href="https://github.com/sourcegraph/sourcegraph/edit/main/doc/{{.FilePath}}">Edit this page</a>
+    <div class="toc-bottom"></div>
+    <a class="page-btn" href="https://github.com/sourcegraph/sourcegraph/edit/main/doc/{{.FilePath}}" target="_blank" >Edit this page on GitHub <svg class="with-icon_icon__MHUeb" data-testid="geist-icon" fill="none" height="24" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" viewBox="0 0 24 24" width="24" style="color: currentcolor; width: 14px; height: 14px;"><path d="M7 17L17 7"></path><path d="M7 7h10v10"></path></svg></a>
 {{end}}
 {{define "doc_nav"}}
 	{{range .}}

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -174,8 +174,9 @@ Answer (including related code snippets if available):`
                     </a></h1>
                     <div class="markprompt-search-container">
                         <form id="search-form" method="get" action="/search">
-                            <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>
-                            <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="" spellcheck="false" aria-label="Query" />
+                            {{/*  <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"><path fill="currentColor" d="M21.172 24l-7.387-7.387c-1.388.874-3.024 1.387-4.785 1.387-4.971 0-9-4.029-9-9s4.029-9 9-9 9 4.029 9 9c0 1.761-.514 3.398-1.387 4.785l7.387 7.387-2.828 2.828zm-12.172-8c3.859 0 7-3.14 7-7s-3.141-7-7-7-7 3.14-7 7 3.141 7 7 7z"/></svg>  */}}
+                            {{/*  <svg width="24" height="24" fill="none" aria-hidden="true" class="search-icon"><path d="m19 19-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><circle cx="11" cy="11" r="6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></circle></svg>  */}}
+                            <input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="Search docs..." spellcheck="false" aria-label="Query" />
                             <input type="hidden" name="v" value="{{block "version" .}}{{end}}">
                             <button id="search-button" type="submit" aria-label="Search" class="sr-only">Search</button>
                         </form>
@@ -188,6 +189,31 @@ Answer (including related code snippets if available):`
                 <nav id="sections" class="links sidebar">
                     <div class="nav-section tree">
                         <h2 class="sr-only">Sections</h2>
+                        <ul>
+                            <li>
+                                <a href="/getting-started">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"
+                                        class="lucide lucide-book-open">
+                                        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+                                        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+                                    </svg>
+                                    Getting Started
+                                </a>
+                            </li>
+                            <li>
+                                <a href="/tutorials">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"
+                                        class="lucide lucide-shapes">
+                                        <path d="M8.3 10a.7.7 0 0 1-.626-1.079L11.4 3a.7.7 0 0 1 1.198-.043L16.3 8.9a.7.7 0 0 1-.572 1.1Z" />
+                                        <rect x="3" y="14" width="7" height="7" rx="1" />
+                                        <circle cx="17.5" cy="17.5" r="3.5" />
+                                    </svg>
+                                    Tutorials
+                                </a>
+                            </li>
+                        </ul>
                         {{if (contentFileExists .ContentVersion "sidebar.md")}}
                             {{renderMarkdownContentFile .ContentVersion "sidebar.md"}}
                         {{else}}

--- a/doc/getting-started/index.md
+++ b/doc/getting-started/index.md
@@ -1,6 +1,6 @@
 # Using Sourcegraph
 
-Welcome to Sourcegraph!
+Welcome to Sourcegraph docs!
 
 ## What is Sourcegraph?
 
@@ -53,21 +53,19 @@ Sourcegraph's main features are:
 
 You can also try [Sourcegraph.com](https://sourcegraph.com/search), which is a public instance of Sourcegraph for use on open-source code only.
 
-## How is Sourcegraph licensed? 
+## How is Sourcegraph licensed?
 
 Sourcegraph Enterprise is Sourcegraph’s primary offering and includes all code intelligence platform features. Sourcegraph Enterprise is the best solution for enterprises who want to use Sourcegraph with their organization’s code.
 
-[Cody](https://docs.sourcegraph.com/cody), Sourcegraph's AI-enabled editor assistant, is free and [open source](https://about.sourcegraph.com/blog/open-sourcing-cody) and is licensed under the Apache 2.0 license. 
+[Cody](https://docs.sourcegraph.com/cody), Sourcegraph's AI-enabled editor assistant, is free and [open source](https://about.sourcegraph.com/blog/open-sourcing-cody) and is licensed under the Apache 2.0 license.
 
 Sourcegraph extensions are also OSS licensed (Apache 2), such as:
 1. [Sourcegraph browser extension](https://github.com/sourcegraph/sourcegraph/tree/master/client/browser)
 2. [Sourcegraph VS Code extension](https://github.com/sourcegraph/sourcegraph/tree/main/client/vscode)
 3. [Sourcegraph Jetbrains extension](https://github.com/sourcegraph/sourcegraph/tree/main/client/jetbrains)
 
-## How is Sourcegraph different than GitHub code search? 
+## How is Sourcegraph different than GitHub code search?
 - [See how GitHub code search compares to Sourcegraph](./github-vs-sourcegraph.md)
-
----
 
 ## Code search
 
@@ -83,8 +81,6 @@ Sourcegraph code search is fast, works across all your repositories at any commi
 Read the [code search documentation](../code_search/index.md) to learn more and discover the full feature set. Here's a video to help you get started:
 - [How to Search commits and diffs with Sourcegraph](https://youtu.be/w-RrDz9hyGI)
 - [Search Examples](https://sourcegraph.github.io/sourcegraph-search-examples/)
-
----
 
 ## Code navigation
 
@@ -111,15 +107,11 @@ Sourcegraph gives you code navigation in:
 
 Read the [code navigation documentation](../code_navigation/index.md) to learn more and to set it up.
 
----
-
 ## Cody
 
 Cody is an AI code assistant that uses Sourcegraph code search, the code graph, and LLMs to provide context-aware answers about your codebase. Cody can explain code, refactor code, and write code, all within the context of your existing codebase.
 
 [Learn more about about Cody](../cody/index.md).
-
----
 
 ## Notebooks
 _Note: GA in version 3.39 or later_
@@ -128,16 +120,12 @@ Increase dev collaboration and self-service through live documentation covering 
 
 Read the [Notebooks documentation](../notebooks/index.md) to learn more, and check out these [publicly available notebooks](https://sourcegraph.com/notebooks?_ga=2.9922293.1906238367.1667257632-528424761.1615652680&_gl=1*1xalma3*_ga*NTI4NDI0NzYxLjE2MTU2NTI2ODA.*_ga_E82CCDYYS1*MTY2NzI1NzYzMi41NS4xLjE2NjcyNjA3NjIuMC4wLjA.).
 
----
-
 ## Batch Changes
 _Note: Enterprise Feature_
 
 Automate changes to your codebase. Reduce effort, reduce errors and enable developers to focus on high value work.
 
 Read the [batch changes documentation](../batch_changes/index.md) to learn more, including useful how-to guides. Want a video tutorial? Check out this [batch change tutorial](https://www.youtube.com/watch?v=eOmiyXIWTCw)
-
----
 
 ## Code Insights
 _Note: Enterprise Feature_
@@ -146,11 +134,9 @@ Sourcegraph lets you understand and analyze code trends by visualizing how the c
 
 Read the [code insights documentation](../code_insights/index.md) to learn more, including useful how-to guides.
 
----
-
 ## Integrations
 
-Sourcegraph allows you to get code navigation and code search on code files and code review diffs in your code host and review tool or from your IDE. 
+Sourcegraph allows you to get code navigation and code search on code files and code review diffs in your code host and review tool or from your IDE.
 
 ### IDE integration
 Sourcegraph’s editor integrations allow you search and navigate across all of your repositories without ever leaving your IDE or checking them out locally. Learn more about how to set them up [here](../integration/editor.md).

--- a/doc/index.md
+++ b/doc/index.md
@@ -3,9 +3,9 @@
 Sourcegraph makes it easy to read, write, and fix code—even in big, complex codebases.
 
 - **Code search:** Search all of your repositories across all branches and all code hosts.
-- **Code intelligence:** Navigate code, find references, see code owners, trace history, and more.
-- **Fix and refactor:** Roll out large-scale changes to many repositories at once and track big migrations.
-- **AI code assistant:** Use Cody to read, write, and understand code faster.
+- **Code intelligence:** Navigate code, find references, see code owners, trace history, & more.
+- **Fix & refactor:** Roll out & track large-scale changes & migrations across repos at once.
+- **AI code assistant:** Use Cody to read, write, and understand entire codebas faster.
 
 ## Usage
 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -10,9 +10,10 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
 
 -->
 
-- [Home](index.md)
-- [Getting started](getting-started/index.md)
-- [Tutorials](tutorials/index.md)
+<!-- - [Home](index.md) -->
+
+<!-- - [Getting Started](getting-started/index.md) -->
+<!-- - [Tutorials](tutorials/index.md) -->
 - [Cody (beta)](cody/index.md)
   - [Quickstart](cody/quickstart.md)
   - [Explanations](cody/explanations/index.md)


### PR DESCRIPTION
Our documentation site requires a significant design and structural overhaul. While I am diligently working on the progress toward achieving that goal, I am currently implementing some preliminary design and structural changes. These changes are aimed at rendering our documentation visually appealing, contemporary, clean, and well-organized in the interim period.

This PR ships the following design and structural changes to our docs website:

### Docs landing:
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/5e5593b8-74ec-46cf-b087-390d4faf0e3a)
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/149e4f92-f12c-4264-b786-2b6559119172)

### Docs Cody landing page with improved sidebar design to show sub-level docs
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/6f8999c4-7df7-4eba-9ac9-47e9dffbd769)

### Improved small screens' whitespace and removed TOC on small screens, which isn't required.
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/05d4d5df-8785-4515-aa7b-fce1ee2d8470)

### Improved sidebar highlighting and sub-level design.
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/6f6f7aaf-ecb4-4639-a34c-a4e6a3772cae)

### Modern search bar UI
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/4d786c68-7680-4a7c-afdd-b1060416cc60)

### Experimental menu icons, more to come
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/23ceda76-ea8a-43fb-8681-04f06ac64ee8)

### `h2` level headings come with a border-top to separate segments; no need to use <hr /> elements
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/51225009-b029-49eb-9f17-14ed54158fab)

### TOC redesign, white-space, `On this page` semantics, and clear `Edit this page on GitHub` CTA with SVG Icon
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/cfc8d561-3e78-4199-be65-4beb06992305)

### Improved breadcrumbs design
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/dc44aa0e-2bbd-40fb-825d-c99c9db08dfa)

### Dark mode link color
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/349c6fb2-098a-4185-ac41-184ec9b09555)

### Light mode link color
![image](https://github.com/sourcegraph/sourcegraph/assets/12712988/b4a74bbe-2a69-4c59-b7a6-5c5d02e6e40d)

## Test plan

* Check links

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

