### PR TITLE
fix siteadmin check in users connection endpoint

### DIFF
--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -110,13 +108,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 
 	var l []*UserResolver
 	for _, user := range users {
-		l = append(l, &UserResolver{
-			db:   r.db,
-			user: user,
-			logger: log.Scoped("userResolver", "resolves a specific user").With(
-				log.Object("repo",
-					log.String("user", user.Username))),
-		})
+		l = append(l, NewUserResolver(ctx, r.db, user))
 	}
 	return l, nil
 }


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/50228 introduced a new `actor` field on `UserResolver` to reduce amount of user lookups required.
This wasnt being set in all places (or it was assumed that all instantiation of `UserResolver` was through `NewUserResolver`), resulting in actor being unset for this codepath, and hence nil panic when any of the fields that would reference the new field.

Not sure who to request PR review from, so feel free to stamp

## Test plan

Added unit test coverage and manual testing in API console
