### PR TITLE
gRPC: fix replacement char encoding

### DIFF
--- a/cmd/symbols/squirrel/hover.go
+++ b/cmd/symbols/squirrel/hover.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-const utf8ReplacementChar = "\xFF\xFD"
-
 // Returns the markdown hover message for the given node if it exists.
 func findHover(node Node) string {
 	style := node.LangSpec.commentStyle
@@ -80,5 +78,5 @@ func findHover(node Node) string {
 		hover = hover + "\n\n---\n\n" + strings.Join(comments, "\n") + "\n"
 	}
 
-	return strings.ToValidUTF8(hover, utf8ReplacementChar)
+	return strings.ToValidUTF8(hover, "�")
 }

--- a/cmd/symbols/squirrel/local_code_intel.go
+++ b/cmd/symbols/squirrel/local_code_intel.go
@@ -55,8 +55,7 @@ func (s *SquirrelService) LocalCodeIntel(ctx context.Context, repoCommitPath typ
 					// Found the scope.
 					if scope, ok := scopes[nodeId(cur)]; ok {
 						// Get the symbol name.
-						const utf8ReplacementChar = "\xFF\xFD"
-						symbolName := SymbolName(strings.ToValidUTF8(node.Content(node.Contents), utf8ReplacementChar))
+						symbolName := SymbolName(strings.ToValidUTF8(node.Content(node.Contents), "�"))
 
 						// Skip the symbol if it's already defined.
 						if _, ok := scope[symbolName]; ok {

--- a/internal/gitserver/search/diff_format.go
+++ b/internal/gitserver/search/diff_format.go
@@ -20,10 +20,8 @@ const (
 
 var escaper = strings.NewReplacer(" ", `\ `)
 
-const utf8ReplacementChar = "\xFF\xFD"
-
 func escapeUTF8AndSpaces(s string) string {
-	return escaper.Replace(strings.ToValidUTF8(s, utf8ReplacementChar))
+	return escaper.Replace(strings.ToValidUTF8(s, "�"))
 }
 
 func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (string, result.Ranges) {
@@ -102,7 +100,7 @@ func FormatDiff(rawDiff []*diff.FileDiff, highlights map[int]MatchedFileDiff) (s
 					ranges = append(ranges, lineHighlights.Add(loc)...)
 				}
 
-				buf.Write(bytes.ToValidUTF8(lineWithoutPrefix, []byte(utf8ReplacementChar)))
+				buf.Write(bytes.ToValidUTF8(lineWithoutPrefix, []byte("�")))
 				buf.WriteByte('\n')
 				loc.Offset = buf.Len()
 				loc.Line++

--- a/internal/gitserver/search/diff_format_test.go
+++ b/internal/gitserver/search/diff_format_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/stretchr/testify/require"
@@ -76,10 +77,11 @@ index dbace57d5f..53357b4971 100644
 		}
 
 		formatted, _ := FormatDiff(parsedDiff, highlights)
-		expectedFormatted := "file\\ with\\ spaces new\\ file\\ with\\ spaces\\ and\\ invalid\xFF\xFD\\ utf8\n" +
+		expectedFormatted := "file\\ with\\ spaces new\\ file\\ with\\ spaces\\ and\\ invalid�\\ utf8\n" +
 			"@@ -60,1 +60,2 @@ Unknown <u@gogs.io> 无闻 <u@gogs.io>\n" +
 			" Matt King <kingy895@gmail.com> Matthew King <kingy895@gmail.com>\n" +
-			"+Camden Cheek <invalid@utf8.\xFF\xFDm> Camden Cheek <camden@ccheek.com>\n"
+			"+Camden Cheek <invalid@utf8.�m> Camden Cheek <camden@ccheek.com>\n"
 		require.Equal(t, expectedFormatted, formatted)
+		require.True(t, utf8.ValidString(formatted))
 	})
 }


### PR DESCRIPTION
The byte sequence I used to replace invalid byte sequences was itself an invalid byte sequence 🤦 . `0xFFFD` is the code point for the unicode replacement character, not the byte sequence in UTF8. Go supports utf8 characters in strings, so to avoid the error, I just pasted the raw character itself.

## Test plan

Added a test that the output is, in fact, valid UTF8.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
