### PR TITLE
Fix ancestors calculation infinite loop

### DIFF
--- a/internal/luasandbox/libs/paths.go
+++ b/internal/luasandbox/libs/paths.go
@@ -41,7 +41,7 @@ func (api pathAPI) LuaAPI() map[string]lua.LGFunction {
 // this function will return an empty string (instead of a `.`) to indicate an empty
 // directory name.
 func dirWithoutDot(path string) string {
-	if dir := filepath.Dir(path); dir != "." {
+	if dir := filepath.Dir(path); dir != "." && dir != "/" {
 		return dir
 	}
 	return ""

--- a/internal/luasandbox/libs/paths.go
+++ b/internal/luasandbox/libs/paths.go
@@ -41,10 +41,15 @@ func (api pathAPI) LuaAPI() map[string]lua.LGFunction {
 // this function will return an empty string (instead of a `.`) to indicate an empty
 // directory name.
 func dirWithoutDot(path string) string {
-	if dir := filepath.Dir(path); dir != "." && dir != "/" {
-		return dir
+	dir := filepath.Dir(path)
+	if dir == "." {
+		return ""
 	}
-	return ""
+	if len(dir) > 0 && dir[0] == '/' {
+		return dir[1:]
+	}
+
+	return dir
 }
 
 // ancestorDirs returns all ancestor dirnames of the given path. The last element of

--- a/internal/luasandbox/libs/paths_test.go
+++ b/internal/luasandbox/libs/paths_test.go
@@ -11,6 +11,7 @@ func TestDirWithoutDot(t *testing.T) {
 		actual   string
 		expected string
 	}{
+		{dirWithoutDot("/"), ""},
 		{dirWithoutDot("foo.txt"), ""},
 		{dirWithoutDot("foo/bar.txt"), "foo"},
 		{dirWithoutDot("foo/baz"), "foo"},
@@ -35,3 +36,17 @@ func TestAncestorDirs(t *testing.T) {
 
 	}
 }
+
+func TestAncestorDirsRoots(t *testing.T) {
+	expectedAncestors := []string{
+		"/foo/bar/baz",
+		"/foo/bar",
+		"/foo",
+		"",
+	}
+	if diff := cmp.Diff(expectedAncestors, ancestorDirs("/foo/bar/baz/bonk.txt")); diff != "" {
+		t.Errorf("unexpected ancestor dirs (-want +got):\n%s", diff)
+
+	}
+}
+

--- a/internal/luasandbox/libs/paths_test.go
+++ b/internal/luasandbox/libs/paths_test.go
@@ -8,45 +8,64 @@ import (
 
 func TestDirWithoutDot(t *testing.T) {
 	testCases := []struct {
-		actual   string
+		input    string
 		expected string
 	}{
-		{dirWithoutDot("/"), ""},
-		{dirWithoutDot("foo.txt"), ""},
-		{dirWithoutDot("foo/bar.txt"), "foo"},
-		{dirWithoutDot("foo/baz"), "foo"},
+		{"file.txt", ""},
+		{"simple/file.txt", "simple"},
+		{"longer/ancestor/paths/file.txt", "longer/ancestor/paths"},
+		{"longer/ancestor/paths/subdir", "longer/ancestor/paths"},
 	}
 
-	for _, testCase := range testCases {
-		if testCase.actual != testCase.expected {
-			t.Errorf("unexpected dirname: want=%s got=%s", testCase.expected, testCase.actual)
+	t.Run("edge cases", func(t *testing.T) {
+		for _, input := range []string{"", "/", "."} {
+			if actual := dirWithoutDot(input); actual != "" {
+				t.Errorf("unexpected dirname: want=%s got=%s", "", actual)
+			}
 		}
-	}
+	})
+
+	t.Run("un-rooted", func(t *testing.T) {
+		for _, testCase := range testCases {
+			if actual := dirWithoutDot(testCase.input); actual != testCase.expected {
+				t.Errorf("unexpected dirname: want=%s got=%s", testCase.expected, actual)
+			}
+		}
+	})
+
+	t.Run("rooted", func(t *testing.T) {
+		for _, testCase := range testCases {
+			if actual := dirWithoutDot("/" + testCase.input); actual != testCase.expected {
+				t.Errorf("unexpected dirname: want=%s got=%s", testCase.expected, actual)
+			}
+		}
+	})
 }
 
 func TestAncestorDirs(t *testing.T) {
-	expectedAncestors := []string{
-		"foo/bar/baz",
-		"foo/bar",
-		"foo",
-		"",
+	testCases := []struct {
+		input    string
+		expected []string
+	}{
+		{"", []string{""}},
+		{"file.txt", []string{""}},
+		{"simple/file.txt", []string{"simple", ""}},
+		{"longer/ancestor/paths/file.txt", []string{"longer/ancestor/paths", "longer/ancestor", "longer", ""}},
 	}
-	if diff := cmp.Diff(expectedAncestors, ancestorDirs("foo/bar/baz/bonk.txt")); diff != "" {
-		t.Errorf("unexpected ancestor dirs (-want +got):\n%s", diff)
 
-	}
+	t.Run("un-rooted", func(t *testing.T) {
+		for _, testCase := range testCases {
+			if diff := cmp.Diff(testCase.expected, ancestorDirs(testCase.input)); diff != "" {
+				t.Errorf("unexpected ancestor for %q dirs (-want +got):\n%s", testCase.input, diff)
+			}
+		}
+	})
+
+	t.Run("rooted", func(t *testing.T) {
+		for _, testCase := range testCases {
+			if diff := cmp.Diff(testCase.expected, ancestorDirs("/"+testCase.input)); diff != "" {
+				t.Errorf("unexpected ancestor for %q dirs (-want +got):\n%s", testCase.input, diff)
+			}
+		}
+	})
 }
-
-func TestAncestorDirsRoots(t *testing.T) {
-	expectedAncestors := []string{
-		"/foo/bar/baz",
-		"/foo/bar",
-		"/foo",
-		"",
-	}
-	if diff := cmp.Diff(expectedAncestors, ancestorDirs("/foo/bar/baz/bonk.txt")); diff != "" {
-		t.Errorf("unexpected ancestor dirs (-want +got):\n%s", diff)
-
-	}
-}
-


### PR DESCRIPTION
A simple `ancestorDirs("/")` causes an infinite loop and then a deadline error in the worker when inferring jobs.

## Test plan

Unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
