### PR TITLE
Wrap CommandInput if the field is marked as read only

### DIFF
--- a/client/web/src/enterprise/codeintel/configuration/components/inference-form/CommandInput.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-form/CommandInput.tsx
@@ -67,6 +67,7 @@ export const CommandInput: React.FunctionComponent<CommandInputProps> = React.me
     const extensions = useMemo(
         () => [
             staticExtensions,
+            [EditorView.lineWrapping].filter(() => readOnly),
             EditorState.readOnly.of(readOnly),
             EditorView.updateListener.of(update => {
                 if (update.docChanged) {

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-form/CommandInput.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-form/CommandInput.tsx
@@ -67,7 +67,7 @@ export const CommandInput: React.FunctionComponent<CommandInputProps> = React.me
     const extensions = useMemo(
         () => [
             staticExtensions,
-            [EditorView.lineWrapping].filter(() => readOnly),
+            readOnly ? [EditorView.lineWrapping] : [],
             EditorState.readOnly.of(readOnly),
             EditorView.updateListener.of(update => {
                 if (update.docChanged) {

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-form/InferenceForm.module.scss
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-form/InferenceForm.module.scss
@@ -2,6 +2,7 @@
     padding: 1rem;
     margin-bottom: 1rem;
     flex: 1;
+    min-width: 0;
 }
 
 .inputs {


### PR DESCRIPTION
Before (form stretches to the right into infinity)

![image](https://github.com/sourcegraph/sourcegraph/assets/1052965/31dcc57f-5729-4347-8002-a0b9b9afc393)

After (if the field is read only, we wrap, if not read only, we _don't_ stretch the form anyways)

![image](https://github.com/sourcegraph/sourcegraph/assets/1052965/8cf19173-b095-4b89-a01d-784afd8b1b9b)


## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
