### PR TITLE
executors: Be able to add annotations to job pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Experimental support for Azure OpenAI for the completions and embeddings provider has been added. [#55178](https://github.com/sourcegraph/sourcegraph/pull/55178)
 - Added a feature flag for alternate GitLab project visibility resolution. This may solve some weird cases with not being able to see GitLab internal projects. [#54426](https://github.com/sourcegraph/sourcegraph/pull/54426)
   - To use this feature flag, create a Boolean feature flag named "gitLabProjectVisibilityExperimental" and set the value to True.
+- It is now possible to add annotations to pods spawned by jobs created by the Kubernetes executor. [#55361](https://github.com/sourcegraph/sourcegraph/pull/55361)
 
 ### Changed
 

--- a/doc/admin/executors/deploy_executors_kubernetes.md
+++ b/doc/admin/executors/deploy_executors_kubernetes.md
@@ -75,6 +75,7 @@ set on the Executor `Deployment` and will configure the `Job`s that it spawns.
 | KUBERNETES_FS_GROUP                                          | `1000`            | The group ID to run all containers in the Kubernetes jobs as.                                                                                                                                          |
 | KUBERNETES_KEEP_JOBS                                         | `false`           | If true, Kubernetes jobs will not be deleted after they complete. Useful for debugging.                                                                                                                |
 | KUBERNETES_JOB_ANNOTATIONS                                   | N/A               | The JSON encoded annotations to add to the Kubernetes Jobs. e.g. `{"foo": "bar", "faz": "baz"}`                                                                                                        |
+| KUBERNETES_JOB_POD_ANNOTATIONS                               | N/A               | The JSON encoded annotations to add to the Kubernetes Job Pods. e.g. `{"foo": "bar", "faz": "baz"}`                                                                                                    |
 | KUBERNETES_IMAGE_PULL_SECRETS                                | N/A               | The names of Kubernetes image pull secrets to use for pulling images. e.g. my-secret,my-other-secret                                                                                                   |
 
 <!--

--- a/enterprise/cmd/executor/internal/config/config.go
+++ b/enterprise/cmd/executor/internal/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	KubernetesSecurityContextRunAsGroup            int
 	KubernetesSecurityContextFSGroup               int
 	KubernetesJobAnnotations                       map[string]string
+	KubernetesJobPodAnnotations                    map[string]string
 	KubernetesImagePullSecrets                     string
 	// TODO remove in 5.2
 	KubernetesSingleJobPod              bool
@@ -104,6 +105,8 @@ type Config struct {
 	kubernetesAdditionalJobVolumesUnmarshalError                 error
 	kubernetesJobAnnotations                                     string
 	kubernetesJobAnnotationsUnmarshalError                       error
+	kubernetesJobPodAnnotations                                  string
+	kubernetesJobPodAnnotationsUnmarshalError                    error
 
 	defaultFrontendPassword string
 }
@@ -170,6 +173,7 @@ func (c *Config) Load() {
 	c.KubernetesSingleJobStepImage = c.Get("KUBERNETES_SINGLE_JOB_STEP_IMAGE", "sourcegraph/batcheshelper:insiders", "The image to use for intermediate steps in the single job. Defaults to sourcegraph/batcheshelper:latest.")
 	c.KubernetesGitCACert = c.GetOptional("KUBERNETES_GIT_CA_CERT", "The CA certificate to use for git operations. If not set, the system CA bundle will be used. e.g. /path/to/ca.crt")
 	c.kubernetesJobAnnotations = c.GetOptional("KUBERNETES_JOB_ANNOTATIONS", "The JSON encoded annotations to add to the Kubernetes Jobs. e.g. {\"foo\": \"bar\"}")
+	c.kubernetesJobPodAnnotations = c.GetOptional("KUBERNETES_JOB_POD_ANNOTATIONS", "The JSON encoded annotations to add to the Kubernetes Job Pods. e.g. {\"foo\": \"bar\"}")
 	c.KubernetesImagePullSecrets = c.GetOptional("KUBERNETES_IMAGE_PULL_SECRETS", "The names of Kubernetes image pull secrets to use for pulling images. e.g. my-secret,my-other-secret")
 
 	if c.QueueNamesStr != "" {
@@ -203,6 +207,9 @@ func (c *Config) Load() {
 	}
 	if c.kubernetesJobAnnotations != "" {
 		c.kubernetesJobAnnotationsUnmarshalError = json.Unmarshal([]byte(c.kubernetesJobAnnotations), &c.KubernetesJobAnnotations)
+	}
+	if c.kubernetesJobPodAnnotations != "" {
+		c.kubernetesJobPodAnnotationsUnmarshalError = json.Unmarshal([]byte(c.kubernetesJobPodAnnotations), &c.KubernetesJobPodAnnotations)
 	}
 
 	if c.KubernetesConfigPath == "" {
@@ -276,6 +283,10 @@ func (c *Config) Validate() error {
 
 	if c.kubernetesJobAnnotationsUnmarshalError != nil {
 		c.AddError(errors.Wrap(c.kubernetesJobAnnotationsUnmarshalError, "invalid KUBERNETES_JOB_ANNOTATIONS, failed to parse"))
+	}
+
+	if c.kubernetesJobPodAnnotationsUnmarshalError != nil {
+		c.AddError(errors.Wrap(c.kubernetesJobPodAnnotationsUnmarshalError, "invalid KUBERNETES_JOB_POD_ANNOTATIONS, failed to parse"))
 	}
 
 	if c.KubernetesJobVolumeType != "emptyDir" && c.KubernetesJobVolumeType != "pvc" {

--- a/enterprise/cmd/executor/internal/config/config_test.go
+++ b/enterprise/cmd/executor/internal/config/config_test.go
@@ -70,6 +70,8 @@ func TestConfig_Load(t *testing.T) {
 			return "sourcegraph/step-image:latest"
 		case "KUBERNETES_JOB_ANNOTATIONS":
 			return `{"foo": "bar", "faz": "baz"}`
+		case "KUBERNETES_JOB_POD_ANNOTATIONS":
+			return `{"foo": "bar", "faz": "baz"}`
 		case "KUBERNETES_IMAGE_PULL_SECRETS":
 			return "foo,bar"
 		default:
@@ -172,9 +174,15 @@ func TestConfig_Load(t *testing.T) {
 		cfg.KubernetesAdditionalJobVolumeMounts,
 	)
 	assert.Equal(t, "sourcegraph/step-image:latest", cfg.KubernetesSingleJobStepImage)
+
 	assert.Len(t, cfg.KubernetesJobAnnotations, 2)
 	assert.Equal(t, "bar", cfg.KubernetesJobAnnotations["foo"])
 	assert.Equal(t, "baz", cfg.KubernetesJobAnnotations["faz"])
+
+	assert.Len(t, cfg.KubernetesJobPodAnnotations, 2)
+	assert.Equal(t, "bar", cfg.KubernetesJobPodAnnotations["foo"])
+	assert.Equal(t, "baz", cfg.KubernetesJobPodAnnotations["faz"])
+
 	assert.Equal(t, "foo,bar", cfg.KubernetesImagePullSecrets)
 }
 
@@ -229,6 +237,7 @@ func TestConfig_Load_Defaults(t *testing.T) {
 	assert.Empty(t, cfg.KubernetesAdditionalJobVolumeMounts)
 	assert.Equal(t, "sourcegraph/batcheshelper:insiders", cfg.KubernetesSingleJobStepImage)
 	assert.Nil(t, cfg.KubernetesJobAnnotations)
+	assert.Nil(t, cfg.KubernetesJobPodAnnotations)
 	assert.Empty(t, cfg.KubernetesImagePullSecrets)
 }
 

--- a/enterprise/cmd/executor/internal/run/util.go
+++ b/enterprise/cmd/executor/internal/run/util.go
@@ -227,7 +227,8 @@ func kubernetesOptions(c *config.Config) runner.KubernetesOptions {
 			},
 			NodeName:         c.KubernetesNodeName,
 			NodeSelector:     nodeSelector,
-			Annotations:      c.KubernetesJobAnnotations,
+			JobAnnotations:   c.KubernetesJobAnnotations,
+			PodAnnotations:   c.KubernetesJobPodAnnotations,
 			ImagePullSecrets: imagePullSecrets,
 			RequiredNodeAffinity: command.KubernetesNodeAffinity{
 				MatchExpressions: c.KubernetesNodeRequiredAffinityMatchExpressions,

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes.go
@@ -44,7 +44,8 @@ const (
 type KubernetesContainerOptions struct {
 	CloneOptions          KubernetesCloneOptions
 	Namespace             string
-	Annotations           map[string]string
+	JobAnnotations        map[string]string
+	PodAnnotations        map[string]string
 	NodeName              string
 	NodeSelector          map[string]string
 	ImagePullSecrets      []corev1.LocalObjectReference
@@ -439,13 +440,16 @@ func NewKubernetesJob(name string, image string, spec Spec, path string, options
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: options.Annotations,
+			Annotations: options.JobAnnotations,
 		},
 		Spec: batchv1.JobSpec{
 			// Prevent K8s from retrying. This will lead to the retried jobs always failing as the workspace will get
 			// cleaned up from the first failure.
 			BackoffLimit: pointer.Int32(0),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: options.PodAnnotations,
+				},
 				Spec: corev1.PodSpec{
 					NodeName:         options.NodeName,
 					NodeSelector:     options.NodeSelector,
@@ -658,13 +662,16 @@ func NewKubernetesSingleJob(
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: options.Annotations,
+			Annotations: options.JobAnnotations,
 		},
 		Spec: batchv1.JobSpec{
 			// Prevent K8s from retrying. This will lead to the retried jobs always failing as the workspace will get
 			// cleaned up from the first failure.
 			BackoffLimit: pointer.Int32(0),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: options.PodAnnotations,
+				},
 				Spec: corev1.PodSpec{
 					NodeName:              options.NodeName,
 					NodeSelector:          options.NodeSelector,

--- a/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
+++ b/enterprise/cmd/executor/internal/worker/command/kubernetes_test.go
@@ -548,9 +548,9 @@ func TestNewKubernetesJob(t *testing.T) {
 		Env:     []string{"FOO=bar"},
 	}
 	options := command.KubernetesContainerOptions{
-		Namespace:   "default",
-		NodeName:    "my-node",
-		Annotations: map[string]string{"foo": "bar"},
+		Namespace:      "default",
+		NodeName:       "my-node",
+		JobAnnotations: map[string]string{"foo": "bar"},
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{Name: "my-secret"},
 		},
@@ -655,9 +655,9 @@ func TestNewKubernetesSingleJob(t *testing.T) {
 		CloneOptions: command.KubernetesCloneOptions{
 			ExecutorName: "my-executor",
 		},
-		Namespace:   "default",
-		NodeName:    "my-node",
-		Annotations: map[string]string{"foo": "bar"},
+		Namespace:      "default",
+		NodeName:       "my-node",
+		JobAnnotations: map[string]string{"foo": "bar"},
 		ImagePullSecrets: []corev1.LocalObjectReference{
 			{Name: "my-secret"},
 		},


### PR DESCRIPTION
Be able to add annotations to Pods spawned by Jobs.

## Test plan

Unit tests and manual testing.

![Screenshot 2023-07-27 at 09 11 23](https://github.com/sourcegraph/sourcegraph/assets/38407415/eb267a71-4793-46fa-8988-e8ff56de3a39)
