### PR TITLE
[Backport 5.1] internal/event_logs: fix timezone handling

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -1789,13 +1789,13 @@ END
 // (and many parts of the world) which start the week on Monday.
 func makeDateTruncExpression(unit, expr string) string {
 	if unit == "week" {
-		return fmt.Sprintf(`TIMEZONE('UTC', (DATE_TRUNC('week', TIMEZONE('UTC', %s) + '1 day'::interval) - '1 day'::interval))`, expr)
+		return fmt.Sprintf(`(DATE_TRUNC('week', TIMEZONE('UTC', %s) + '1 day'::interval) - '1 day'::interval)`, expr)
 	}
 	if unit == "rolling_month" {
-		return fmt.Sprintf(`TIMEZONE('UTC', (DATE_TRUNC('day', TIMEZONE('UTC', %s)) - '1 month'::interval))`, expr)
+		return fmt.Sprintf(`(DATE_TRUNC('day', TIMEZONE('UTC', %s)) - '1 month'::interval)`, expr)
 	}
 
-	return fmt.Sprintf(`TIMEZONE('UTC', DATE_TRUNC('%s', TIMEZONE('UTC', %s)))`, unit, expr)
+	return fmt.Sprintf(`DATE_TRUNC('%s', TIMEZONE('UTC', %s))`, unit, expr)
 }
 
 // RequestsByLanguage returns a map of language names to the number of requests of precise support for that language.


### PR DESCRIPTION
The makeDateTruncExpression converter was truncating dates before converting to UTC. This introduced timezone shift errors for non-UTC dates.

This change updates the converter to first convert the date to UTC, then perform the truncation.

## Test plan

Verified on s2 that makeDateTruncExpression now behaves correctly.