### PR TITLE
gRPC: sanitize utf8 in searcher

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"bytes"
 	"context"
 	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
 	"time"
@@ -348,7 +349,7 @@ func zoektChunkMatches(chunkMatches []zoekt.ChunkMatch) []protocol.ChunkMatch {
 		}
 
 		cms = append(cms, protocol.ChunkMatch{
-			Content: string(cm.Content),
+			Content: string(bytes.ToValidUTF8(cm.Content, []byte("�"))),
 			ContentStart: protocol.Location{
 				Offset: int32(cm.ContentStart.ByteOffset),
 				Line:   int32(cm.ContentStart.LineNumber) - 1,

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -95,7 +95,7 @@ func combyChunkMatchesToFileMatch(combyMatch *comby.FileMatchWithChunks) protoco
 		}
 
 		chunkMatches = append(chunkMatches, protocol.ChunkMatch{
-			Content: cm.Content,
+			Content: strings.ToValidUTF8(cm.Content, "�"),
 			ContentStart: protocol.Location{
 				Offset: int32(cm.Start.Offset),
 				Line:   int32(cm.Start.Line) - 1,
@@ -189,7 +189,7 @@ func chunksToMatches(buf []byte, chunks []rangeChunk) []protocol.ChunkMatch {
 			// NOTE: we must copy the content here because the reference
 			// must not outlive the backing mmap, which may be cleaned
 			// up before the match is serialized for the network.
-			Content: string(buf[firstLineStart:lastLineEnd]),
+			Content: string(bytes.ToValidUTF8(buf[firstLineStart:lastLineEnd], []byte("�"))),
 			ContentStart: protocol.Location{
 				Offset: firstLineStart,
 				Line:   chunk.cover.Start.Line,

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -51,6 +51,7 @@ func TestSearch(t *testing.T) {
 
 Hello world example in go`, typeFile},
 		"file++.plus": {`filename contains regex metachars`, typeFile},
+		"nonutf8.txt": {"file contains invalid utf8 \xC0 characters", typeFile},
 		"main.go": {`package main
 
 import "fmt"
@@ -256,6 +257,7 @@ filename contains regex metachars
 abc.txt
 file++.plus
 milton.png
+nonutf8.txt
 symlink
 `},
 
@@ -264,6 +266,7 @@ abc.txt
 file++.plus
 main.go
 milton.png
+nonutf8.txt
 symlink
 `},
 
@@ -272,6 +275,7 @@ README.md
 abc.txt
 file++.plus
 milton.png
+nonutf8.txt
 symlink
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: true}, `
@@ -285,6 +289,10 @@ abc.txt
 `},
 		{protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: false}, `
 abc.txt
+`},
+		{protocol.PatternInfo{Pattern: "utf8", PatternMatchesPath: false, PatternMatchesContent: true}, `
+nonutf8.txt:1:1:
+file contains invalid utf8 � characters
 `},
 	}
 


### PR DESCRIPTION
This sanitizes sources of the `Content` field of `ChunkMatch` to ensure that it is always valid UTF-8. Example error [here](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-07-27T13:22:16.449412057Z;duration=P1D;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22sourcegraph-dev%22%0Aresource.labels.location%3D%22us-central1-f%22%0Aresource.labels.cluster_name%3D%22cloud%22%0Aresource.labels.namespace_name%3D%22prod%22%0AjsonPayload.InstrumentationScope%3D~%22gRPC.internal.error.reporter%22%0Atimestamp%3D%222023-07-27T13:22:16.449412057Z%22%0AinsertId%3D%22koc2gxbcll0u44uv%22?project=sourcegraph-dev). 

The underlying issue is that searcher does not exclude utf8 files when searching, so we can't guarantee that the contents are valid utf8. However, that's a larger issue, so I opened an issue for it [here](https://github.com/sourcegraph/sourcegraph/issues/55371)

## Test plan

Ensured that the search that triggered this error no longer produces this error. Also added a searcher test.

<img width="890" alt="Screenshot 2023-07-27 at 13 26 21" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/2ebbc709-40d2-4fa7-b04f-2f975ab7b59b">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
