### PR TITLE
simple-search: fix the feature flag removing query examples when flag is disabled

### DIFF
--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -126,7 +126,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                     </>
                 )}
             </div>
-            {!simpleSearch && (
+            {(!simpleSearchEnabled || !simpleSearch) && (
                 <div className={classNames(styles.panelsContainer)}>
                     {(!!authenticatedUser || isSourcegraphDotCom) && (
                         <QueryExamples


### PR DESCRIPTION
Fixes a bug where the search page content was getting affected by a disabled simple search flag. Note: this is not live in the 5.0 branch, so only made it to dotcom for a few days.

## Test plan

Flag disabled
<img width="1143" alt="CleanShot 2023-07-27 at 14 20 09@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5090588/48817e31-2870-4ef8-905a-4d4c90df689f">


Flag enabled, toggled off
<img width="1144" alt="CleanShot 2023-07-27 at 14 20 24@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5090588/46b020d3-a099-4f7f-a3a1-08cbf88ce107">


Flag enabled, toggled on
<img width="1178" alt="CleanShot 2023-07-27 at 14 20 29@2x" src="https://github.com/sourcegraph/sourcegraph/assets/5090588/9968141f-de4d-48e6-8cd4-7eb7485b6758">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
