### PR TITLE
JetBrains: display stop generating button in controls panel to avoid text jumping in the chat

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Removed jumping text effect from the chat when generating response [#55357](https://github.com/sourcegraph/sourcegraph/pull/55357)
 
+- Removed jumping text effect from the chat when generating response [#55357](https://github.com/sourcegraph/sourcegraph/pull/55357)
+
 ### Security
 
 ## [3.0.8]

--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Removed jumping text effect from the chat when generating response [#55357](https://github.com/sourcegraph/sourcegraph/pull/55357)
+- Chat message doesn't jump after finished response generation [#55390](https://github.com/sourcegraph/sourcegraph/pull/55390)
 
 - Removed jumping text effect from the chat when generating response [#55357](https://github.com/sourcegraph/sourcegraph/pull/55357)
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.ColorUtil;
 import com.intellij.ui.components.JBTabbedPane;
 import com.intellij.ui.components.JBTextArea;
 import com.intellij.util.IconUtil;
@@ -73,8 +74,8 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
-import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.plaf.ButtonUI;
 import org.apache.commons.lang3.StringUtils;
@@ -91,6 +92,8 @@ public class CodyToolWindowContent implements UpdatableChat {
   private final @NotNull JBTextArea promptInput;
   private final @NotNull JButton sendButton;
   private final @NotNull Project project;
+  private final JButton stopGeneratingButton =
+      new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
   private @NotNull volatile CancellationToken cancellationToken = new CancellationToken();
   private final JPanel stopGeneratingButtonPanel;
   private @NotNull Transcript transcript = new Transcript();
@@ -149,10 +152,10 @@ public class CodyToolWindowContent implements UpdatableChat {
     // Controls panel
     JPanel controlsPanel = new JPanel();
     controlsPanel.setLayout(new BorderLayout());
-    controlsPanel.setBorder(new EmptyBorder(JBUI.insets(14)));
-    JPanel messagePanel = new JPanel(new BorderLayout());
+    controlsPanel.setBorder(new EmptyBorder(JBUI.insets(0, 14, 14, 14)));
+    JPanel promptPanel = new JPanel(new BorderLayout());
     sendButton = createSendButton(this.project);
-    AutoGrowingTextArea autoGrowingTextArea = new AutoGrowingTextArea(3, 9, messagePanel);
+    AutoGrowingTextArea autoGrowingTextArea = new AutoGrowingTextArea(3, 9, promptPanel);
     promptInput = autoGrowingTextArea.getTextArea();
     /* Submit on enter */
     KeyboardShortcut JUST_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, 0), null);
@@ -166,38 +169,40 @@ public class CodyToolWindowContent implements UpdatableChat {
         };
     sendMessageAction.registerCustomShortcutSet(DEFAULT_SUBMIT_ACTION_SHORTCUT, promptInput);
 
-    messagePanel.add(autoGrowingTextArea.getScrollPane(), BorderLayout.CENTER);
-    messagePanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
-    controlsPanel.add(messagePanel, BorderLayout.NORTH);
+    promptPanel.add(autoGrowingTextArea.getScrollPane(), BorderLayout.CENTER);
+    promptPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
+
+    stopGeneratingButtonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, 0, 5));
+    stopGeneratingButtonPanel.setPreferredSize(
+        new Dimension(Short.MAX_VALUE, stopGeneratingButton.getPreferredSize().height + 10));
+    stopGeneratingButton.addActionListener(
+        e -> {
+          cancellationToken.abort();
+          stopGeneratingButton.setVisible(false);
+          sendButton.setEnabled(true);
+        });
+    stopGeneratingButton.setVisible(false);
+    stopGeneratingButtonPanel.add(stopGeneratingButton);
+    stopGeneratingButtonPanel.setOpaque(false);
+    controlsPanel.add(promptPanel, BorderLayout.NORTH);
     controlsPanel.add(sendButton, BorderLayout.EAST);
     JPanel lowerPanel = new JPanel(new BorderLayout());
+    Color borderColor = ColorUtil.brighter(UIUtil.getPanelBackground(), 3);
+    Border topBorder = BorderFactory.createMatteBorder(1, 0, 0, 0, borderColor);
+    lowerPanel.setBorder(topBorder);
     lowerPanel.setLayout(new BoxLayout(lowerPanel, BoxLayout.Y_AXIS));
+    lowerPanel.add(stopGeneratingButtonPanel);
     lowerPanel.add(controlsPanel);
 
     EmbeddingStatusView embeddingStatusView = new EmbeddingStatusView(project);
+    embeddingStatusView.setBorder(topBorder);
     lowerPanel.add(embeddingStatusView);
 
     // Main content panel
     contentPanel.setLayout(new BorderLayout(0, 0));
     contentPanel.setBorder(BorderFactory.createEmptyBorder(0, 0, 10, 0));
 
-    JLayeredPane layeredPane = new JLayeredPane();
-    layeredPane.setLayout(new BorderLayout());
-    JButton button = new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
-    stopGeneratingButtonPanel = new JPanel();
-    button.addActionListener(
-        e -> {
-          cancellationToken.abort();
-          stopGeneratingButtonPanel.setVisible(false);
-          sendButton.setEnabled(true);
-        });
-    stopGeneratingButtonPanel.add(button);
-    stopGeneratingButtonPanel.setOpaque(false);
-    stopGeneratingButtonPanel.setVisible(false);
-    layeredPane.add(chatPanel, BorderLayout.CENTER);
-    layeredPane.add(stopGeneratingButtonPanel, BorderLayout.SOUTH, JLayeredPane.POPUP_LAYER);
-
-    contentPanel.add(layeredPane, BorderLayout.CENTER);
+    contentPanel.add(chatPanel, BorderLayout.CENTER);
     contentPanel.add(lowerPanel, BorderLayout.SOUTH);
 
     tabbedPane.addChangeListener(e -> this.focusPromptInput());
@@ -449,7 +454,7 @@ public class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
-              stopGeneratingButtonPanel.setVisible(true);
+              stopGeneratingButton.setVisible(true);
               sendButton.setEnabled(false);
             });
   }
@@ -459,7 +464,7 @@ public class CodyToolWindowContent implements UpdatableChat {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
-              stopGeneratingButtonPanel.setVisible(false);
+              stopGeneratingButton.setVisible(false);
               sendButton.setEnabled(true);
             });
   }
@@ -471,7 +476,7 @@ public class CodyToolWindowContent implements UpdatableChat {
         .invokeLater(
             () -> {
               cancellationToken.abort();
-              stopGeneratingButtonPanel.setVisible(false);
+              stopGeneratingButton.setVisible(false);
               sendButton.setEnabled(true);
               messagesPanel.removeAll();
               addWelcomeMessage();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -7,24 +7,20 @@ import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.serviceContainer.AlreadyDisposedException;
-import com.intellij.ui.ColorUtil;
 import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.concurrency.EdtExecutorService;
 import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.UIUtil;
 import com.sourcegraph.cody.context.embeddings.EmbeddingsStatusLoader;
 import com.sourcegraph.cody.editor.EditorUtil;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.vcs.RepoUtil;
 import java.awt.FlowLayout;
 import java.util.concurrent.TimeUnit;
-import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.JPanel;
-import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -41,10 +37,6 @@ public class EmbeddingStatusView extends JPanel {
     super();
     this.project = project;
     this.setLayout(new FlowLayout(FlowLayout.LEFT));
-    Border topBorder =
-        BorderFactory.createMatteBorder(
-            1, 0, 0, 0, ColorUtil.brighter(UIUtil.getPanelBackground(), 3));
-    this.setBorder(topBorder);
     Box innerPanel = Box.createHorizontalBox();
     embeddingStatusContent = new SimpleColoredComponent();
     openedFileContent = new JBLabel();


### PR DESCRIPTION
Stop generating button moved to controls panel from chat panel to avoid text jumping when finished generation of the message. Button is displayed always in the same place

## Test plan

- Text in the chat should not jump when stop generating button is hidden after finished message generation

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
