### PR TITLE
git-debuggability: allow site-admins configure recorded commands on all repositories

### DIFF
--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -642,14 +642,6 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 		ignoredGitCommands = append(ignoredGitCommands, defaultIgnoredGitCommands...)
 	}
 
-	// If repos contains a single "*" element, it means to record commands
-	// for all repositories. In that case, always return true.
-	if len(repos) == 1 && repos[0] == "*" {
-		return func(ctx context.Context, c *exec.Cmd) bool {
-			return true
-		}
-	}
-
 	// we won't record any git commands with these commands since they are considered to be not destructive
 	var ignoredGitCommandsMap = collections.NewSet(ignoredGitCommands...)
 
@@ -660,14 +652,20 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 		}
 
 		repoMatch := false
-		for _, repo := range repos {
-			// We need to check the suffix, because we can have some common parts in
-			// different repo names. E.g. "sourcegraph/sourcegraph" and
-			// "sourcegraph/sourcegraph-code-ownership" will both be allowed even if only the
-			// first name is included in the config.
-			if strings.HasSuffix(cmd.Dir, repo+"/.git") {
-				repoMatch = true
-				break
+		// If repos contains a single "*" element, it means to record commands
+		// for all repositories. In that case, always return true.
+		if len(repos) == 1 && repos[0] == "*" {
+			repoMatch = true
+		} else {
+			for _, repo := range repos {
+				// We need to check the suffix, because we can have some common parts in
+				// different repo names. E.g. "sourcegraph/sourcegraph" and
+				// "sourcegraph/sourcegraph-code-ownership" will both be allowed even if only the
+				// first name is included in the config.
+				if strings.HasSuffix(cmd.Dir, repo+"/.git") {
+					repoMatch = true
+					break
+				}
 			}
 		}
 

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -642,6 +642,14 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 		ignoredGitCommands = append(ignoredGitCommands, defaultIgnoredGitCommands...)
 	}
 
+	// If repos contains a single "*" element, it means to record commands
+	// for all repositories. In that case, always return true.
+	if len(repos) == 1 && repos[0] == "*" {
+		return func(ctx context.Context, c *exec.Cmd) bool {
+			return true
+		}
+	}
+
 	// we won't record any git commands with these commands since they are considered to be not destructive
 	var ignoredGitCommandsMap = collections.NewSet(ignoredGitCommands...)
 

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -653,7 +653,7 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 
 		repoMatch := false
 		// If repos contains a single "*" element, it means to record commands
-		// for all repositories. In that case, always return true.
+		// for all repositories.
 		if len(repos) == 1 && repos[0] == "*" {
 			repoMatch = true
 		} else {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1312,11 +1312,11 @@ type GitLabWebhook struct {
 	Secret string `json:"secret"`
 }
 
-// GitRecorder description: Record git operations that are executed on configured repositories. The following commands are not recorded: show, log, rev-parse and diff.
+// GitRecorder description: Record git operations that are executed on configured repositories.
 type GitRecorder struct {
 	// IgnoredGitCommands description: List of git commands that should be ignored and not recorded.
 	IgnoredGitCommands []string `json:"ignoredGitCommands,omitempty"`
-	// Repos description: List of repositories whose git operations should be recorded.
+	// Repos description: List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in a wildcard as the only item in the array.
 	Repos []string `json:"repos,omitempty"`
 	// Size description: Defines how many recordings to keep. Once this size is reached, the oldest entry will be removed.
 	Size int `json:"size,omitempty"`
@@ -2548,7 +2548,7 @@ type SiteConfiguration struct {
 	GitMaxCodehostRequestsPerSecond *int `json:"gitMaxCodehostRequestsPerSecond,omitempty"`
 	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
-	// GitRecorder description: Record git operations that are executed on configured repositories. The following commands are not recorded: show, log, rev-parse and diff.
+	// GitRecorder description: Record git operations that are executed on configured repositories.
 	GitRecorder *GitRecorder `json:"gitRecorder,omitempty"`
 	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.
 	GitUpdateInterval []*UpdateIntervalRule `json:"gitUpdateInterval,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1316,7 +1316,7 @@ type GitLabWebhook struct {
 type GitRecorder struct {
 	// IgnoredGitCommands description: List of git commands that should be ignored and not recorded.
 	IgnoredGitCommands []string `json:"ignoredGitCommands,omitempty"`
-	// Repos description: List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in a wildcard as the only item in the array.
+	// Repos description: List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in an asterisk as the only item in the array.
 	Repos []string `json:"repos,omitempty"`
 	// Size description: Defines how many recordings to keep. Once this size is reached, the oldest entry will be removed.
 	Size int `json:"size,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1935,7 +1935,7 @@
           "maximum": 10000
         },
         "repos": {
-          "description": "List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in a wildcard as the only item in the array.",
+          "description": "List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in an asterisk as the only item in the array.",
           "type": "array",
           "items": {
             "type": "string"

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1924,7 +1924,7 @@
       ]
     },
     "gitRecorder": {
-      "description": "Record git operations that are executed on configured repositories. The following commands are not recorded: show, log, rev-parse and diff.",
+      "description": "Record git operations that are executed on configured repositories.",
       "type": "object",
       "properties": {
         "size": {
@@ -1935,7 +1935,7 @@
           "maximum": 10000
         },
         "repos": {
-          "description": "List of repositories whose git operations should be recorded.",
+          "description": "List of repositories whose git operations should be recorded. To record commands on all repositories, simply pass in a wildcard as the only item in the array.",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
I have pretty several repos on my local Sourcegraph instance, and I'll like to record commands on all of them instead of adding each of them one at a time to the site config.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
* Update your site-config to include the `gitRecorder` configuration. 
* Update the `repos` array to include a wildcard

```json
"gitRecorder": {
    "size": 200,
    "repos": ["*"]
  },
```

* Recorded commands will be stored on all repos.