### PR TITLE
Don't save inference scripts that fail to parse

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -189,7 +189,7 @@ func (s *Service) inferIndexJobOrHints(
 	overrideScript string,
 	invocationContextMethods invocationFunctionTable,
 ) (_ []indexJobOrHint, logs string, _ error) {
-	sandbox, err := s.createSandbox(ctx)
+	sandbox, err := s.CreateSandbox(ctx)
 	if err != nil {
 		return nil, "", err
 	}
@@ -217,7 +217,7 @@ func (s *Service) inferIndexJobOrHints(
 }
 
 // createSandbox creates a Lua sandbox wih the modules loaded for use with auto indexing inference.
-func (s *Service) createSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err error) {
+func (s *Service) CreateSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err error) {
 	ctx, _, endObservation := s.operations.createSandbox.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -189,7 +189,7 @@ func (s *Service) inferIndexJobOrHints(
 	overrideScript string,
 	invocationContextMethods invocationFunctionTable,
 ) (_ []indexJobOrHint, logs string, _ error) {
-	sandbox, err := s.CreateSandbox(ctx)
+	sandbox, err := s.createSandbox(ctx)
 	if err != nil {
 		return nil, "", err
 	}
@@ -217,7 +217,7 @@ func (s *Service) inferIndexJobOrHints(
 }
 
 // createSandbox creates a Lua sandbox wih the modules loaded for use with auto indexing inference.
-func (s *Service) CreateSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err error) {
+func (s *Service) createSandbox(ctx context.Context) (_ *luasandbox.Sandbox, err error) {
 	ctx, _, endObservation := s.operations.createSandbox.With(ctx, &err, observation.Args{})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/codeintel/autoindexing/internal/store/BUILD.bazel
+++ b/internal/codeintel/autoindexing/internal/store/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "@com_github_lib_pq//:pq",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_yuin_gopher_lua//parse",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/internal/codeintel/autoindexing/internal/store/config_inference.go
+++ b/internal/codeintel/autoindexing/internal/store/config_inference.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
+	luaParse "github.com/yuin/gopher-lua/parse"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -38,6 +39,11 @@ func (s *store) SetInferenceScript(ctx context.Context, script string) (err erro
 		attribute.Int("scriptSize", len(script)),
 	}})
 	defer endObservation(1, observation.Args{})
+
+	_, error := luaParse.Parse(strings.NewReader(script), "<script>")
+	if error != nil {
+		return error
+	}
 
 	return s.db.Exec(ctx, sqlf.Sprintf(setInferenceScriptQuery, script))
 }

--- a/internal/codeintel/autoindexing/internal/store/config_inference.go
+++ b/internal/codeintel/autoindexing/internal/store/config_inference.go
@@ -40,7 +40,7 @@ func (s *store) SetInferenceScript(ctx context.Context, script string) (err erro
 	}})
 	defer endObservation(1, observation.Args{})
 
-	_, error := luaParse.Parse(strings.NewReader(script), "<script>")
+	_, error := luaParse.Parse(strings.NewReader(script), "(inference script)")
 	if error != nil {
 		return error
 	}

--- a/internal/codeintel/autoindexing/internal/store/config_inference_test.go
+++ b/internal/codeintel/autoindexing/internal/store/config_inference_test.go
@@ -1,3 +1,37 @@
 package store
 
-// TODO
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestSetInferenceScript(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	store := New(&observation.TestContext, db)
+
+	for _, testCase := range []struct {
+		script     string
+		shouldFail bool
+	}{
+		{"!!..", true},
+		{"puts(25)", false},
+	} {
+		err := store.SetInferenceScript(context.Background(), testCase.script)
+
+		if testCase.shouldFail && err == nil {
+			t.Fatalf("Expected [%s] script to trigger a parsing error during saving", testCase.script)
+		}
+
+		if !testCase.shouldFail && err != nil {
+
+			t.Fatalf("Expected [%s] script to save successfully, got an error instead: %s", testCase.script, err)
+		}
+	}
+
+}

--- a/internal/codeintel/autoindexing/service.go
+++ b/internal/codeintel/autoindexing/service.go
@@ -25,7 +25,6 @@ import (
 type Service struct {
 	store            store.Store
 	repoStore        database.RepoStore
-	inferenceService inference.Service
 	gitserverClient  gitserver.Client
 	indexEnqueuer    *enqueuer.IndexEnqueuer
 	jobSelector      *jobselector.JobSelector

--- a/internal/codeintel/autoindexing/service.go
+++ b/internal/codeintel/autoindexing/service.go
@@ -23,12 +23,13 @@ import (
 )
 
 type Service struct {
-	store           store.Store
-	repoStore       database.RepoStore
-	gitserverClient gitserver.Client
-	indexEnqueuer   *enqueuer.IndexEnqueuer
-	jobSelector     *jobselector.JobSelector
-	operations      *operations
+	store            store.Store
+	repoStore        database.RepoStore
+	inferenceService inference.Service
+	gitserverClient  gitserver.Client
+	indexEnqueuer    *enqueuer.IndexEnqueuer
+	jobSelector      *jobselector.JobSelector
+	operations       *operations
 }
 
 func newService(

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -33,17 +33,6 @@ func (s *Sandbox) Close() {
 	s.state.Close()
 }
 
-// ValidateScript parses the Lua script in a sandbox, but does not execute it
-func (s *Sandbox) ValidateScript(ctx context.Context, script string) (err error) {
-	ctx, _, endObservation := s.operations.runScript.With(ctx, &err, observation.Args{})
-
-	defer endObservation(1, observation.Args{})
-
-	_, error := s.state.LoadString(script)
-
-	return error
-}
-
 // RunScript runs the given Lua script text in the sandbox.
 func (s *Sandbox) RunScript(ctx context.Context, opts RunOptions, script string) (retValue lua.LValue, err error) {
 	ctx, _, endObservation := s.operations.runScript.With(ctx, &err, observation.Args{})

--- a/internal/luasandbox/sandbox.go
+++ b/internal/luasandbox/sandbox.go
@@ -33,9 +33,21 @@ func (s *Sandbox) Close() {
 	s.state.Close()
 }
 
+// ValidateScript parses the Lua script in a sandbox, but does not execute it
+func (s *Sandbox) ValidateScript(ctx context.Context, script string) (err error) {
+	ctx, _, endObservation := s.operations.runScript.With(ctx, &err, observation.Args{})
+
+	defer endObservation(1, observation.Args{})
+
+	_, error := s.state.LoadString(script)
+
+	return error
+}
+
 // RunScript runs the given Lua script text in the sandbox.
 func (s *Sandbox) RunScript(ctx context.Context, opts RunOptions, script string) (retValue lua.LValue, err error) {
 	ctx, _, endObservation := s.operations.runScript.With(ctx, &err, observation.Args{})
+
 	defer endObservation(1, observation.Args{})
 
 	return s.RunScriptNamed(ctx, opts, singleScriptFS{script}, "main.lua")


### PR DESCRIPTION
We recently had an issue where an invalid Lua script was put into the UI, causing knock off effects in several places.

This ensures that the script at least _parses_ before saving it. Not bulletproof, but should prevent some of the similar situations.

<img width="958" alt="CleanShot 2023-07-28 at 12 19 19@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1052965/ff855c5a-ee79-4646-a6c3-8d60757325a8">


## Test plan

- unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
