### PR TITLE
Docs improvements to the main Cody page

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -1000,6 +1000,8 @@ body.theme-dark .markdown-body .chroma.sgquery .ss { color: #ff6b6b; background-
   color: var(--text-color);
   border-radius: 4px;
   border: 1px solid var(--sidebar-nav-active-bg);
+  padding: 1.5rem;
+  padding-top: 1.25rem;
 }
 
 .markdown-body .getting-started .btn:hover {

--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -1,86 +1,170 @@
-# <picture title="Cody"><img class="theme-dark-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
+<style>
+.limg {
+  list-style: none;
+  margin: 3rem 0 !important;
+  padding: 0 !important;
+}
+.limg li {
+  margin-bottom: 1rem;
+  padding: 0 !important;
+}
 
-<span class="badge badge-beta">Beta</span> Cody is an AI coding assistant that writes code and answers questions for you by reading your entire codebase and the code graph.
+.limg li:last {
+  margin-bottom: 0;
+}
 
-Cody uses a combination of Sourcegraph's code graph and Large Language Models (LLMs) to eliminate toil and keep human devs in flow. You can think of Cody as your coding assistant who has read through all the code in open source, all the questions on StackOverflow, and your own entire codebase, and is always there to answer questions you might have or suggest ways of doing something based on prior knowledge.
+.limg a {
+    display: flex;
+    flex-direction: column;
+    transition-property: all;
+   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+     transition-duration: 350ms;
+     border-radius: 0.75rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
 
-## Get Cody
+}
 
-- **Cody enterprise:** Contact your Sourcegraph technical advisor or [request enterprise access](https://about.sourcegraph.com/cody#cody-for-work) to use Cody on your existing Sourcegraph instance or try Cody with your team.
-- **Cody app:** Download the app to try Cody with the code you have locally for free. [Learn more.](../app/index.md)
+.limg a:hover {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  background: rgb(113 220 232 / 19%);
+}
 
-Cody is also available as an editor extension that can be connected to a Sourcegraph enterprise instance, the Cody app, or Sourcegraph.com (for open source code only):
-  - [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)
-  - [JetBrains extension (Experimental)](https://plugins.jetbrains.com/plugin/9682-sourcegraph)
+.limg p {
+  margin: 0rem;
+}
+.limg a img {
+  width: 1rem;
+}
 
-[Read more about the Cody clients, extensions, and plugins](explanations/cody_clients.md), including a full breakdown of features available by client. 
+.limg h3 {
+  display:flex;
+  gap: 0.6rem;
+  margin-top: 0;
+  margin-bottom: .25rem
 
-<div class="getting-started">
-  <a class="btn btn-primary text-center" href="quickstart">★ Cody quickstart</a>
-  <a class="btn text-center" href="explanations/use_cases">Cody use cases</a>
-  <a class="btn text-center" href="faq">FAQ</a>
-  <a class="btn text-center" href="https://discord.com/servers/sourcegraph-969688426372825169">Join our Discord</a>
-</div>
+}
 
-## Features
+th:first-child,
+td:first-child {
+   min-width: 200px;
+}
+
+.markdown-body table thead tr{
+  border-top:0;
+}
+
+.markdown-body table th, .markdown-body table td {
+    text-align: left;
+    vertical-align: baseline;
+    padding: 0.5714286em;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background: unset;
+}
+
+.markdown-body table th, .markdown-body table td {
+    border: none;
+}
+
+.markdown-body .cards {
+  display: flex;
+  align-items: stretch;
+}
+
+.markdown-body .cards .card {
+  flex: 1;
+  margin: 0.5em;
+  color: var(--text-color);
+  border-radius: 4px;
+  border: 1px solid var(--sidebar-nav-active-bg);
+  padding: 1.5rem;
+  padding-top: 1.25rem;
+}
+
+.markdown-body .cards .card:hover {
+  color: var(--link-color);
+}
+
+.markdown-body .cards .card span {
+  color: var(--link-color);
+  font-weight: bold;
+}
+</style>
+
+# <picture title="Cody"><img class="theme-dark-only" alt="Cody AI" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" alt="Cody AI" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
+
+<aside class="beta">
+<p>
+<span class="badge badge-beta">Beta</span>
+Cody is currently available in beta.
+
+<br />
+We value your feedback! You can <a href="https://about.sourcegraph.com/contact">contact us</a> directly, file an  <a href="https://github.com/sourcegraph/sourcegraph">issue</a>, or <a href="https://twitter.com/sourcegraph">tweet</a> to share feedback.
+</p>
+</aside>
+
+## What is Cody?
+
+Cody is an AI coding assistant that utilizes Sourcegraph's <a href="https://docs.sourcegraph.com/cody/explanations/code_graph_context">code graph</a> and Large Language Models (LLMs) to write code and provide answers based on your codebase.
+
+Think of Cody as your personal dedicated AI coding assistant, equipped with a comprehensive understanding of three crucial elements:
+
+1. Your entire codebase
+2. Vast knowledge of open source code
+3. StackOverflow questions related to common problems you may encounter
+
+Cody helps you answer questions, write code, and offer suggestions for code improvement.
+
+## Getting Started
+
+To start using Cody, pick one of the following:
+
+<ul class="limg">
+  <li>
+    <a class="card text-left" target="_blank" href="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai">
+    <h3><img alt="VS Code" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/vscode.svg"/> Cody: VS Code Extension</h3>
+    <p>Install Cody's free and open source extension for VS Code.</p>
+    </a>
+  </li>
+  <li>
+    <a class="card text-left" target="_blank" href="https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph">
+      <h3><img alt="JetBrains" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/jb_beam.svg" />JetBrains Extension (experimental)</h3>
+      <p>Install Cody's free and open source extension for JetBrains.</p>
+    </a>
+  </li>
+  <li>
+     <a class="card text-left" target="_blank" href="https://sourcegraph.com/get-cody">
+      <h3><img alt="VS Code" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/cody-logomark-default.svg"/>Cody App</h3>
+      <p>Free Cody desktop app to try Cody with your local codebase.</p>
+      </a>
+  </li>
+  <li>
+    <a class="card text-left" target="_blank" href="https://about.sourcegraph.com/cody/pricing">
+      <h3><img alt="JetBrains" src="https://sourcegraph.com/.assets/img/sourcegraph-mark.svg" />Cody Enterprise</h3>
+      <p>Get in touch with our team to try Cody for Sourcegraph Enterprise.</p>
+    </a>
+  </li>
+</ul>
+
+## Main Features
+
+Some of the main Cody features include:
 
 <!-- NOTE: These should stay roughly in sync with client/cody/README.md, although these need to be not specific to VS Code. -->
 
-- **🤖 Chatbot that knows _your_ code:** Writes code and answers questions with knowledge of your entire codebase, following your project's code conventions and architecture better than other AI code chatbots.
-- **✨ Fix code inline:** Interactively writes and refactors code for you, based on quick natural-language instructions.
-- **📖 Recipes:** Generates unit tests, documentation, and more, with full codebase awareness.
-- **Autocomplete:** Get suggestions from Cody as you're coding.
+|     Feature     |                                                                                         Description                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Code chatbot    | Your AI-powered code assistant. It fits your project's coding conventions and architecture, unlike other AI code chatbots. Chat with Cody from your code editor or the Sourcegraph sidebar. |
+| Fix code inline | Cody can help you make interactive edits and refactor code by following natural-language instructions.                                                                                      |
+| Recipes         | Cody uses its codebase awareness to produce unit tests, documentation, and more. Use our pre-built recipes to simplify development with a few clicks.                                       |
+| Autocomplete    | Cody provides context-based code auto-completion while typing. Predictions make coding easier.                                                                                              |
 
-### 🤖 Chatbot that knows _your_ code
+## Join our Community
 
-[**📽️ Demo**](https://twitter.com/beyang/status/1647744307045228544)
-
-You can chat with Cody in the editor or in the Sourcegraph sidebar.
-
-Examples of the kinds of questions Cody can handle:
-
-- How is our app's secret storage implemented on Linux?
-- Where is the CI config for the web integration tests?
-- Write a new GraphQL resolver for the AuditLog.
-- Why is the UserConnectionResolver giving an error `unknown user`, and how do I fix it?
-
-Cody tells you which code files it read to generate its response. (If Cody gives a wrong answer, please share feedback so we can improve it.)
-
-### ✨ Fix code inline
-
-[**📽️ Demo**](https://twitter.com/sqs/status/1647673013343780864)
-
-In your editor, just sprinkle your code with instructions in natural language, select the code, and run `Cody: Fixup` (<kbd>Ctrl+Alt+/</kbd>/<kbd>Ctrl+Opt+/</kbd>). Cody will figure out what edits to make.
-
-Examples of the kinds of fixup instructions Cody can handle:
-
-- "Factor out any common helper functions" (when multiple functions are selected)
-- "Use the imported CSS module's class names"
-- "Extract the list item to a separate React component"
-- "Handle errors better"
-- "Add helpful debug log statements"
-- "Make this work" (seriously, it often works--try it!)
-
-### 📖 Recipes
-
-In your editor, select the recipes tab or  right-click on a selection of code and choose one of the `Ask Cody > ...` recipes, such as:
-
-- Explain code
-- Generate unit test
-- Generate docstring
-- Improve variable names
-- Translate to different language
-- Summarize recent code changes
-- Detect code smells
-- Generate release notes
-
-### Autocomplete
-
-Cody provides real-time code autocompletion as you're typing. As you start coding, or after you type a comment, Cody will look at the context around your open files and file history to predict what you're trying to implement and provide autocomplete. 
-
-## Troubleshooting
-
-See [Cody troubleshooting guide](troubleshooting.md).
+If you have any questions regarding Cody, you can always ask our community on [GitHub Discussions](https://github.com/sourcegraph/sourcegraph/discussions), [Discord](https://discord.com/invite/s2qDtYGnAE), or [Twitter](https://twitter.com/sourcegraph).
 
 ## Explanations
 
@@ -92,3 +176,16 @@ See [Cody troubleshooting guide](troubleshooting.md).
 - [Installing the Jetbrains extension (experimental)](explanations/installing_jetbrains.md)
 - [Configuring code graph context](explanations/code_graph_context.md)
 - [Sourcegraph Cody Gateway](explanations/cody_gateway.md)
+
+## More resources
+
+For more information on what to do next, we recommend the following resources:
+
+<div class="cards">
+  <a class="card text-left" href="quickstart"><b>Cody Quickstart</b><p>This guide recommends first things to try once Cody is up and running.</p></a>
+  <a class="card text-left" href="explanations/use_cases"><b>Cody Use Cases</b><p>Explore some of the handy use cases with Cody and try them yourself.</p></a>
+</div>
+<div class="cards">
+   <a class="card text-left" href="troubleshooting"><b>Cody Troubleshooting Guide</b><p>Having trouble with Cody? Review our troubleshooting guide for help.</p></a>
+  <a class="card text-left" href="faq"><b>FAQs</b><p>Learn about some of the frequently asked questions about Cody.</p></a>
+</div>


### PR DESCRIPTION
This PR ships improvement to the main Cody docs overview page with the following revamped changes:

- Improvements to the page information architecture
- Placement of callouts buttons and user-driven actions
- Simplify brand tone and overall grammar, vocab
- Remove fluff and inconsistent content structures

## Preview Link

- [View here →](https://docs.sourcegraph.com/@cody-docs-pr1/cody)

## Screencast

https://sourcegraph.slack.com/files/U05EH1A6Y3F/F05JWJ0D75Z/sg.mp4

## Test plan

- Check links

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
