### PR TITLE
Fix GitHub Discussions link in Cody docs

### DIFF
--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -164,7 +164,7 @@ Some of the main Cody features include:
 
 ## Join our Community
 
-If you have any questions regarding Cody, you can always ask our community on [GitHub Discussions](https://github.com/sourcegraph/sourcegraph/discussions), [Discord](https://discord.com/invite/s2qDtYGnAE), or [Twitter](https://twitter.com/sourcegraph).
+If you have any questions regarding Cody, you can always ask our community on [GitHub Discussions](sourcegraph/cody/discussions), [Discord](https://discord.com/invite/s2qDtYGnAE), or [Twitter](https://twitter.com/sourcegraph).
 
 ## Explanations
 


### PR DESCRIPTION
A quick fix to GH discussions link.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
