### PR TITLE
Fix headings in Cody docs — Make them sentence cased

### DIFF
--- a/doc/cody/index.md
+++ b/doc/cody/index.md
@@ -118,7 +118,7 @@ Think of Cody as your personal dedicated AI coding assistant, equipped with a co
 
 Cody helps you answer questions, write code, and offer suggestions for code improvement.
 
-## Getting Started
+## Getting started
 
 To start using Cody, pick one of the following:
 
@@ -149,7 +149,7 @@ To start using Cody, pick one of the following:
   </li>
 </ul>
 
-## Main Features
+## Main features
 
 Some of the main Cody features include:
 
@@ -162,7 +162,7 @@ Some of the main Cody features include:
 | Recipes         | Cody uses its codebase awareness to produce unit tests, documentation, and more. Use our pre-built recipes to simplify development with a few clicks.                                       |
 | Autocomplete    | Cody provides context-based code auto-completion while typing. Predictions make coding easier.                                                                                              |
 
-## Join our Community
+## Join our community
 
 If you have any questions regarding Cody, you can always ask our community on [GitHub Discussions](https://github.com/sourcegraph/cody/discussions), [Discord](https://discord.com/invite/s2qDtYGnAE), or [Twitter](https://twitter.com/sourcegraph).
 


### PR DESCRIPTION
Make section headings sentence case in Cody docs.

## Past Context

- [Slack thread](https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1690572986358889?thread_ts=1690566601.403829&cid=C01DXLN3D0T)

## Test plan

- Check links

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
