### PR TITLE
internal/gitserver: Remove ConnForRepo from ClientSource interface

### DIFF
--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -141,10 +141,6 @@ func (c *testGitserverConns) ClientForRepo(ctx context.Context, userAgent string
 	return c.clientFunc(conn), nil
 }
 
-func (c *testGitserverConns) ConnForRepo(ctx context.Context, userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
-	return c.conns.ConnForRepo(ctx, userAgent, repo)
-}
-
 type testConnAndErr struct {
 	address    string
 	conn       *grpc.ClientConn
@@ -378,10 +374,6 @@ func (a *atomicGitServerConns) ClientForRepo(ctx context.Context, userAgent stri
 		return nil, err
 	}
 	return proto.NewGitserverServiceClient(conn), nil
-}
-
-func (a *atomicGitServerConns) ConnForRepo(ctx context.Context, userAgent string, repo api.RepoName) (*grpc.ClientConn, error) {
-	return a.get().ConnForRepo(ctx, userAgent, repo)
 }
 
 func (a *atomicGitServerConns) Addresses() []AddressWithClient {

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -91,8 +90,6 @@ var _ Client = &clientImplementor{}
 type ClientSource interface {
 	// ClientForRepo returns a Client for the given repo.
 	ClientForRepo(ctx context.Context, userAgent string, repo api.RepoName) (proto.GitserverServiceClient, error)
-	// ConnForRepo returns a grpc.ClientConn for the given repo.
-	ConnForRepo(ctx context.Context, userAgent string, repo api.RepoName) (*grpc.ClientConn, error)
 	// AddrForRepo returns the address of the gitserver for the given repo.
 	AddrForRepo(ctx context.Context, userAgent string, repo api.RepoName) string
 	// Address the current list of gitserver addresses.


### PR DESCRIPTION
It is not used.

Follow up to #55078.



## Test plan

- CI with main-dry-run
- Local testing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
