### PR TITLE
graphql: don't query the DB when `repository.externalServices` are queried only for external services IDs.

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -279,3 +279,63 @@ func TestRepository_DefaultBranch(t *testing.T) {
 		})
 	}
 }
+
+func TestRepository_ExternalServices(t *testing.T) {
+	users := database.NewMockUserStore()
+	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+
+	repos := database.NewMockRepoStore()
+	sources := map[string]*types.SourceInfo{
+		"extSvc1": {ID: "extsvc:github.com:1"},
+		"extSvc2": {ID: "extsvc:github.com:2"},
+		"extSvc3": {ID: "extsvc:gitlab.com:3"},
+	}
+	repos.GetFunc.SetDefaultReturn(&types.Repo{ID: 2, Name: "github.com/gorilla/mux", Sources: sources}, nil)
+	extSvcs := database.NewMockExternalServiceStore()
+	extSvcs.ListFunc.SetDefaultHook(func(_ context.Context, _ database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		t.Fatal("External services table should not be queried during onlyID GraphQL query")
+		return nil, nil
+	})
+	db := database.NewMockDB()
+	db.UsersFunc.SetDefaultReturn(users)
+	db.ReposFunc.SetDefaultReturn(repos)
+	db.ExternalServicesFunc.SetDefaultReturn(extSvcs)
+	expectedID1 := MarshalExternalServiceID(1)
+	expectedID2 := MarshalExternalServiceID(2)
+	expectedID3 := MarshalExternalServiceID(3)
+
+	RunTest(t, &Test{
+		Schema: mustParseGraphQLSchema(t, db),
+		Label:  "Read all external service IDs",
+		Query: `
+			{
+				repository(name: "github.com/gorilla/mux") {
+					externalServices(onlyID: true) {
+						nodes {
+							id
+						}
+					}
+				}
+			}
+		`,
+		ExpectedResult: fmt.Sprintf(`
+			{
+				"repository": {
+					"externalServices": {
+						"nodes": [
+							{
+								"id": "%s"
+							},
+							{
+								"id": "%s"
+							},
+							{
+								"id": "%s"
+							}
+						]
+					}
+				}
+			}
+		`, expectedID1, expectedID2, expectedID3),
+	})
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3730,6 +3730,10 @@ type Repository implements Node & GenericSearchResultInterface {
         Returns the first n external services from the list.
         """
         first: Int
+        """
+        If true, only external service IDs are returned, without querying the database.
+        """
+        onlyID: Boolean = false
     ): ExternalServiceConnection!
     """
     Whether the repository is currently being cloned.


### PR DESCRIPTION
Test plan:
GraphQL test added.

### Objective
We want to skip the DB query when querying only IDs of repo's external services:
```
{
	repository(name: "abc") {
		externalServices {
			nodes {
				id
			}
		}
	}
}
```

Current implementation eagerly fetches all external services from the database by IDs.

### Quick and simple but maybe not the most elegant implementation (done)
Adding an argument to `externalServices` query to fetch only IDs, which will return `ComputedExternalServiceConnectionResolver` with `externalServiceResolver`s containing only IDs without a database query.

### More (maybe unnecessary) bulletproof from user errors but more complicated
The previous approach breaks if a user sets `onlyID` and still requests other `externalService` fields.

To get rid of such a possibility, we should implement lazy loading of external services.
This comes with a couple of caveats: 
- the moment of realization that we need to query the database happens at individual `externalService` resolver level when any field except of an ID is queried
- the query should happen at `ComputedExternalServiceConnectionResolver` resolver level because we don't want to move from one query fetching all the external services to individual queries for each external service. Backfilling the services to every `externalService` resolver may get tricky.
- this is a bug-prone approach because when anyone adds another method to `externalService` resolver, this whole check for external service existence may easily get overlooked


Prerequisite to https://github.com/sourcegraph/sourcegraph/pull/55392