### PR TITLE
source: guard repo settings routes for admins

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -473,12 +473,14 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                                     }
                                 />
                             ))}
-                            <Route
-                                path={repoNameAndRevision + repoSettingsAreaPath}
-                                errorElement={<RouteError />}
-                                // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
-                                element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
-                            />
+                            {props.authenticatedUser?.siteAdmin && (
+                                <Route
+                                    path={repoNameAndRevision + repoSettingsAreaPath}
+                                    errorElement={<RouteError />}
+                                    // Always render the `RepoSettingsArea` even for empty repo to allow side-admins access it.
+                                    element={<RepoSettingsArea {...repoRevisionContainerContext} repoName={repoName} />}
+                                />
+                            )}
                             <Route
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
                                 path={repoNameAndRevision + '/*'}


### PR DESCRIPTION
While working on #55210 I noticed that the repo settings `{repo}/-/settings` route is accessible to non-site-admins (Also raised by Thorsten [here](https://github.com/sourcegraph/sourcegraph/pull/55210#discussion_r1272188597)). 

This PR adds some gating to the repo settings route to ensure they're only registered when the currently authenticated user is a site administrator.

| Before  | <img width="1499" alt="CleanShot 2023-07-31 at 14 16 59@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/348864b9-530d-49cc-9b66-6cba52da8ea1">  |
|---|---|
| After  | ![CleanShot 2023-07-31 at 14 15 44](https://github.com/sourcegraph/sourcegraph/assets/25608335/b6a61c44-0bcf-4a4e-9c28-62487d9043d7)  |

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Sign in to a Sourcegraph instance as a non site-admin
* Navigate to the `{repo}/-/settings` route, and you should be redirected to the Repository page.