### PR TITLE
gRPC: sanitize utf8 for commit parsing

### DIFF
--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -22,4 +22,5 @@ go_test(
     timeout = "short",
     srcs = ["api_test.go"],
     embed = [":api"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//internal/gitserver/v1:gitserver",
         "//internal/lazyregexp",
+        "//lib/errors",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -9,8 +9,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
-
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // RepoID is the unique identifier for a repository.
@@ -39,6 +39,17 @@ var deletedRegex = lazyregexp.New("DELETED-[0-9]+\\.[0-9]+-")
 // name.
 func UndeletedRepoName(name RepoName) RepoName {
 	return RepoName(deletedRegex.ReplaceAllString(string(name), ""))
+}
+
+var validCommitIDRegexp = lazyregexp.New(`^[a-fA-F0-9]{40}$`)
+
+// NewCommitID creates a new CommitID and validates that it conforms to the
+// requirements of the type.
+func NewCommitID(s string) (CommitID, error) {
+	if validCommitIDRegexp.MatchString(s) {
+		return CommitID(s), nil
+	}
+	return "", errors.Newf("invalid CommitID %q", s)
 }
 
 // CommitID is the 40-character SHA-1 hash for a Git commit.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUndeletedRepoName(t *testing.T) {
@@ -37,5 +39,31 @@ func TestUndeletedRepoName(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewCommitID(t *testing.T) {
+	noErrorCases := []string{
+		"8b25feac0dda3bbe66851794d0552773b6b5aa2b",
+		"8B25FEAC0DDA3BBE66851794D0552773B6B5AA2B",
+	}
+
+	for _, s := range noErrorCases {
+		_, err := NewCommitID(s)
+		require.NoError(t, err)
+	}
+
+	errorCases := []string{
+		"",
+		"8B25FEA",
+		"ZZZ5FEAC0DDA3BBE66851794D0552773B6B5AA2B",
+		"8b25feac0dda3bbe66851794d0552773b6b5aa2b 8b25feac0dda3bbe66851794d0552773b6b5aa2b",
+		" 8b25feac0dda3bbe66851794d0552773b6b5aa2b",
+		"8b25feac0dda3bbe66851794d0552773b6b5aa2b ",
+	}
+
+	for _, s := range errorCases {
+		_, err := NewCommitID(s)
+		require.Error(t, err)
 	}
 }

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -68,21 +68,25 @@ func (l *LazyCommit) Diff() ([]*godiff.FileDiff, error) {
 	return diff, nil
 }
 
-func (l *LazyCommit) ParentIDs() []api.CommitID {
+func (l *LazyCommit) ParentIDs() ([]api.CommitID, error) {
 	strs := strings.Split(string(l.ParentHashes), " ")
 	commitIDs := make([]api.CommitID, 0, len(strs))
 	for _, str := range strs {
-		commitIDs = append(commitIDs, api.CommitID(str))
+		commitID, err := api.NewCommitID(str)
+		if err != nil {
+			return nil, err
+		}
+		commitIDs = append(commitIDs, commitID)
 	}
-	return commitIDs
+	return commitIDs, nil
 }
 
 func (l *LazyCommit) RefNames() []string {
-	return strings.Split(string(l.RawCommit.RefNames), ", ")
+	return strings.Split(utf8String(l.RawCommit.RefNames), ", ")
 }
 
 func (l *LazyCommit) SourceRefs() []string {
-	return strings.Split(string(l.RawCommit.SourceRefs), ", ")
+	return strings.Split(utf8String(l.RawCommit.SourceRefs), ", ")
 }
 
 func (l *LazyCommit) ModifiedFiles() []string {
@@ -100,8 +104,8 @@ func (l *LazyCommit) ModifiedFiles() []string {
 				return files
 			}
 			// A rename entry will be followed by two file names
-			files = append(files, string(l.RawCommit.ModifiedFiles[i+1]))
-			files = append(files, string(l.RawCommit.ModifiedFiles[i+2]))
+			files = append(files, utf8String(l.RawCommit.ModifiedFiles[i+1]))
+			files = append(files, utf8String(l.RawCommit.ModifiedFiles[i+2]))
 			i += 3
 		default:
 			// SAFETY: don't assume that we have the right number of things
@@ -109,7 +113,7 @@ func (l *LazyCommit) ModifiedFiles() []string {
 				return files
 			}
 			// Any entry that is not a rename entry will only be followed by one file name
-			files = append(files, string(l.RawCommit.ModifiedFiles[i+1]))
+			files = append(files, utf8String(l.RawCommit.ModifiedFiles[i+1]))
 			i += 2
 		}
 	}

--- a/internal/gitserver/search/lazy_commit.go
+++ b/internal/gitserver/search/lazy_commit.go
@@ -69,6 +69,9 @@ func (l *LazyCommit) Diff() ([]*godiff.FileDiff, error) {
 }
 
 func (l *LazyCommit) ParentIDs() ([]api.CommitID, error) {
+	if len(l.ParentHashes) == 0 {
+		return nil, nil
+	}
 	strs := strings.Split(string(l.ParentHashes), " ")
 	commitIDs := make([]api.CommitID, 0, len(strs))
 	for _, str := range strs {

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -413,28 +413,42 @@ func CreateCommitMatch(lc *LazyCommit, hc MatchedCommit, includeDiff bool, filte
 		diff.Content, diff.MatchedRanges = FormatDiff(rawDiff, hc.Diff)
 	}
 
+	commitID, err := api.NewCommitID(string(lc.Hash))
+	if err != nil {
+		return nil, err
+	}
+
+	parentIDs, err := lc.ParentIDs()
+	if err != nil {
+		return nil, err
+	}
+
 	return &protocol.CommitMatch{
-		Oid: api.CommitID(lc.Hash),
+		Oid: commitID,
 		Author: protocol.Signature{
-			Name:  string(lc.AuthorName),
-			Email: string(lc.AuthorEmail),
+			Name:  utf8String(lc.AuthorName),
+			Email: utf8String(lc.AuthorEmail),
 			Date:  authorDate,
 		},
 		Committer: protocol.Signature{
-			Name:  string(lc.CommitterName),
-			Email: string(lc.CommitterEmail),
+			Name:  utf8String(lc.CommitterName),
+			Email: utf8String(lc.CommitterEmail),
 			Date:  committerDate,
 		},
-		Parents:    lc.ParentIDs(),
+		Parents:    parentIDs,
 		SourceRefs: lc.SourceRefs(),
 		Refs:       lc.RefNames(),
 		Message: result.MatchedString{
-			Content:       string(lc.Message),
+			Content:       utf8String(lc.Message),
 			MatchedRanges: hc.Message,
 		},
 		Diff:          diff,
 		ModifiedFiles: lc.ModifiedFiles(),
 	}, nil
+}
+
+func utf8String(b []byte) string {
+	return string(bytes.ToValidUTF8(b, []byte("�")))
 }
 
 func filterRawDiff(rawDiff []*godiff.FileDiff, filterFunc func(string) (bool, error)) []*godiff.FileDiff {

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -257,6 +257,7 @@ func TestSearch(t *testing.T) {
 		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
 			matches = append(matches, match)
 		})
+		require.NoError(t, err)
 
 		require.Len(t, matches, 1)
 		match := matches[0]

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
+	"unicode/utf8"
 
 	"github.com/sourcegraph/go-diff/diff"
 	"github.com/stretchr/testify/require"
@@ -228,6 +229,41 @@ func TestSearch(t *testing.T) {
 		require.Equal(t, []string{"file1", "file1a"}, matches[0].ModifiedFiles)
 		require.Equal(t, []string{"file2", "file3"}, matches[1].ModifiedFiles)
 		require.Equal(t, []string{"file1"}, matches[2].ModifiedFiles)
+	})
+
+	t.Run("non utf8 elements", func(t *testing.T) {
+		cmds := []string{
+			"echo lorem ipsum dolor sit amet > file1",
+			"git add -A",
+			"GIT_COMMITTER_NAME=camden1 " +
+				"GIT_COMMITTER_EMAIL=camden1@ccheek.com " +
+				"GIT_COMMITTER_DATE=2006-01-02T15:04:05Z " +
+				"GIT_AUTHOR_NAME=\xc0mden " +
+				"GIT_AUTHOR_EMAIL=\xc0mden1@ccheek.com " +
+				"GIT_AUTHOR_DATE=2006-01-02T15:04:05Z " +
+				"git commit -m \xc0mmit1 ",
+		}
+		dir := initGitRepository(t, cmds...)
+
+		query := &protocol.AuthorMatches{Expr: "c"}
+		tree, err := ToMatchTree(query)
+		require.NoError(t, err)
+		searcher := &CommitSearcher{
+			RepoDir:              dir,
+			Query:                tree,
+			IncludeModifiedFiles: true,
+		}
+		var matches []*protocol.CommitMatch
+		err = searcher.Search(context.Background(), func(match *protocol.CommitMatch) {
+			matches = append(matches, match)
+		})
+
+		require.Len(t, matches, 1)
+		match := matches[0]
+		require.True(t, utf8.ValidString(match.Author.Name))
+		require.True(t, utf8.ValidString(match.Author.Email))
+		require.True(t, utf8.ValidString(match.Message.Content))
+
 	})
 }
 
@@ -480,9 +516,9 @@ index 0000000000..7e54670557
 	require.True(t, mergedResult.Satisfies())
 
 	formatted, ranges := FormatDiff(parsedDiff, highlights.Diff)
-	expectedFormatted := `/dev/null internal/compute/match.go
-@@ -0,0 +6,6 @@ 
-+
+	expectedFormatted := "/dev/null internal/compute/match.go\n" +
+		"@@ -0,0 +6,6 @@ \n" +
+		`+
 +       "github.com/sourcegraph/sourcegraph/internal/search/result"
 +)
 +
@@ -526,9 +562,9 @@ index 0000000000..7e54670557
 	// check formatting w/ sub-repo perms filtering
 	filteredDiff := filterRawDiff(parsedDiff, setupSubRepoFilterFunc())
 	formattedWithFiltering, ranges := FormatDiff(filteredDiff, highlights.Diff)
-	expectedFormatted = `/dev/null internal/compute/match.go
-@@ -0,0 +6,6 @@ 
-+
+	expectedFormatted = "/dev/null internal/compute/match.go\n" +
+		"@@ -0,0 +6,6 @@ \n" +
+		`+
 +       "github.com/sourcegraph/sourcegraph/internal/search/result"
 +)
 +


### PR DESCRIPTION
This sanitizes the output of `git` for search so that invalid utf8 is converted to valid utf8. This fixes some more errors that were showing up on sourcegraph.com.

## Test plan

Tested that the two sources of the errors no longer error. Existing unit tests for regressions. Added a test for NewCommitID. Added an integration test.

<img width="878" alt="Screenshot 2023-07-31 at 12 35 08" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/04f82f44-7b3c-4998-9969-a73414f7ebcf">
<img width="681" alt="Screenshot 2023-07-31 at 13 23 25" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/6d98baf8-886e-48e6-8c66-88033bc8d02b">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
