### PR TITLE
Backend: remove unnecessary internal API for external services

### DIFF
--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -54,7 +54,6 @@ go_library(
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/httpcli",
-        "//internal/jsonc",
         "//internal/repoupdater",
         "//internal/search",
         "//internal/search/backend",

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -216,8 +216,6 @@ func RegisterInternalServices(
 		WriteErrBody: true,
 	})
 
-	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
-
 	// zoekt-indexserver endpoints
 	gsClient := gitserver.NewClient(db)
 	indexer := &searchIndexerServer{

--- a/internal/api/internalapi/BUILD.bazel
+++ b/internal/api/internalapi/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/actor",
-        "//internal/api",
         "//internal/conf/conftypes",
         "//internal/conf/deploy",
         "//internal/env",

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -82,19 +81,6 @@ func (c *internalClient) Configuration(ctx context.Context) (conftypes.RawUnifie
 	var cfg conftypes.RawUnified
 	err := c.postInternal(ctx, "configuration", nil, &cfg)
 	return cfg, err
-}
-
-var MockExternalServiceConfigs func(kind string, result any) error
-
-// ExternalServiceConfigs fetches external service configs of a single kind into the result parameter,
-// which should be a slice of the expected config type.
-func (c *internalClient) ExternalServiceConfigs(ctx context.Context, kind string, result any) error {
-	if MockExternalServiceConfigs != nil {
-		return MockExternalServiceConfigs(kind, result)
-	}
-	return c.postInternal(ctx, "external-services/configs", api.ExternalServiceConfigsRequest{
-		Kind: kind,
-	}, &result)
 }
 
 func (c *internalClient) LogTelemetry(ctx context.Context, reqBody any) error {

--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//internal/conf/deploy",
         "//internal/dotcomuser",
         "//internal/env",
-        "//internal/extsvc",
         "//internal/hashutil",
         "//internal/httpcli",
         "//internal/jsonc",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"context"
 	"encoding/hex"
 	"log"
 	"strings"
@@ -9,13 +8,11 @@ import (
 
 	"github.com/hashicorp/cronexpr"
 
-	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/dotcomuser"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
@@ -54,38 +51,6 @@ func ExecutorsAccessToken() string {
 		return confdefaults.AppInMemoryExecutorPassword
 	}
 	return Get().ExecutorsAccessToken
-}
-
-func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
-	var config []*schema.BitbucketServerConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindBitbucketServer, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
-	var config []*schema.GitHubConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindGitHub, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
-	var config []*schema.GitLabConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindGitLab, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func PhabricatorConfigs(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
-	var config []*schema.PhabricatorConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindPhabricator, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
 }
 
 type AccessTokenAllow string
@@ -605,7 +570,7 @@ func HashedLicenseKeyForAnalytics(licenseKey string) string {
 
 // HashedLicenseKeyWithPrefix provides a sha256 hashed license key with a prefix (to ensure unique hashed values by use case).
 func HashedLicenseKeyWithPrefix(licenseKey string, prefix string) string {
-	return hex.EncodeToString(hashutil.ToSHA256Bytes([]byte(prefix+licenseKey)))
+	return hex.EncodeToString(hashutil.ToSHA256Bytes([]byte(prefix + licenseKey)))
 }
 
 func GetDeduplicatedForksIndex() collections.Set[string] {


### PR DESCRIPTION
This removes an unnecessary internal endpoint. Basically, `schema.ClientConfiguration` is the only consumer of `conf.*Configs()`, which are the only consumers of `internalClient.ExternalServiceConfigs`, which just hits the database and pulls the URL off the config.

So, rather than calling an internal API from `frontend`, which is just served by `frontend`, this PR updates `schema.ClientConfiguration` to just hit the database directly for this information, allowing us to get rid of one of the few remaining internal APIs.

This is an API that was slated to be converted to gRPC, so I'd rather not convert things we can just delete.

## Test plan

Tested locally that the API call worked as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
