### PR TITLE
Don't log certain high-volume events in local (postgres) databases

### DIFF
--- a/internal/eventlogger/event_logger.go
+++ b/internal/eventlogger/event_logger.go
@@ -39,6 +39,14 @@ var NonActiveUserEvents = []string{
 	"CodyVSCodeExtension:CodySavedLogin:executed",
 }
 
+// List of events that shouldn't be logged in local (Postgres) databases.
+// These events are high volume and cause a lot of noise and pressure on the backend.
+// Since we only need them for debugging, we don't need to route them to custom instances.
+var OnlyLogRemotelyEvents = []string{
+	"CodyVSCodeExtension:completion:started",
+	"CodyVSCodeExtension:completion:networkRequestStarted",
+}
+
 // LogEvent sends a payload representing an event to the api/telemetry endpoint.
 //
 // This method should be invoked after the frontend service has started. It is

--- a/internal/usagestats/BUILD.bazel
+++ b/internal/usagestats/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//internal/database",
         "//internal/database/basestore",
         "//internal/env",
+        "//internal/eventlogger",
         "//internal/featureflag",
         "//internal/gitserver",
         "//internal/pubsub",


### PR DESCRIPTION
Alternative to https://github.com/sourcegraph/cody/pull/455/files that would also prevent these events from being logged in dotcom's prod db

## Test plan

No errors running locally, but I didn't actually test with these specific events.