### PR TITLE
[Backport 5.1]: remove unnecessary internal API for external services (#55450)

### DIFF
--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -53,7 +53,6 @@ go_library(
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/httpcli",
-        "//internal/jsonc",
         "//internal/repoupdater",
         "//internal/search",
         "//internal/search/backend",

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -214,8 +214,6 @@ func RegisterInternalServices(
 		WriteErrBody: true,
 	})
 
-	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs(db))))
-
 	// zoekt-indexserver endpoints
 	gsClient := gitserver.NewClient()
 	indexer := &searchIndexerServer{

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -7,71 +7,14 @@ import (
 	"path"
 
 	"github.com/gorilla/mux"
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// serveExternalServiceConfigs serves a JSON response that is an array of all
-// external service configs that match the requested kind.
-func serveExternalServiceConfigs(db database.DB) func(w http.ResponseWriter, r *http.Request) error {
-	return func(w http.ResponseWriter, r *http.Request) error {
-		var req api.ExternalServiceConfigsRequest
-		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil {
-			return err
-		}
-
-		options := database.ExternalServicesListOptions{
-			Kinds:   []string{req.Kind},
-			AfterID: int64(req.AfterID),
-		}
-		if req.Limit > 0 {
-			options.LimitOffset = &database.LimitOffset{
-				Limit: req.Limit,
-			}
-		}
-
-		services, err := db.ExternalServices().List(r.Context(), options)
-		if err != nil {
-			return err
-		}
-
-		// Instead of returning an intermediate response type, we directly return
-		// the array of configs (which are themselves JSON objects).
-		// This makes it possible for the caller to directly unmarshal the response into
-		// a slice of connection configurations for this external service kind.
-		configs := make([]map[string]any, 0, len(services))
-		for _, service := range services {
-			var config map[string]any
-			// Raw configs may have comments in them so we have to use a json parser
-			// that supports comments in json.
-			rawConfig, err := service.Config.Decrypt(r.Context())
-			if err != nil {
-				return err
-			}
-			if jsonc.Unmarshal(rawConfig, &config); err != nil {
-				log15.Error(
-					"ignoring external service config that has invalid json",
-					"id", service.ID,
-					"displayName", service.DisplayName,
-					"config", rawConfig,
-					"err", err,
-				)
-				continue
-			}
-			configs = append(configs, config)
-		}
-		return json.NewEncoder(w).Encode(configs)
-	}
-}
 
 func serveConfiguration(w http.ResponseWriter, _ *http.Request) error {
 	raw := conf.Raw()

--- a/internal/api/internalapi/BUILD.bazel
+++ b/internal/api/internalapi/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/actor",
-        "//internal/api",
         "//internal/conf/conftypes",
         "//internal/conf/deploy",
         "//internal/env",

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -82,19 +81,6 @@ func (c *internalClient) Configuration(ctx context.Context) (conftypes.RawUnifie
 	var cfg conftypes.RawUnified
 	err := c.postInternal(ctx, "configuration", nil, &cfg)
 	return cfg, err
-}
-
-var MockExternalServiceConfigs func(kind string, result any) error
-
-// ExternalServiceConfigs fetches external service configs of a single kind into the result parameter,
-// which should be a slice of the expected config type.
-func (c *internalClient) ExternalServiceConfigs(ctx context.Context, kind string, result any) error {
-	if MockExternalServiceConfigs != nil {
-		return MockExternalServiceConfigs(kind, result)
-	}
-	return c.postInternal(ctx, "external-services/configs", api.ExternalServiceConfigsRequest{
-		Kind: kind,
-	}, &result)
 }
 
 func (c *internalClient) LogTelemetry(ctx context.Context, reqBody any) error {

--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "//internal/conf/deploy",
         "//internal/dotcomuser",
         "//internal/env",
-        "//internal/extsvc",
         "//internal/hashutil",
         "//internal/httpcli",
         "//internal/jsonc",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1,7 +1,6 @@
 package conf
 
 import (
-	"context"
 	"encoding/base64"
 	"log"
 	"strings"
@@ -10,12 +9,10 @@ import (
 	"github.com/hashicorp/cronexpr"
 
 	licensing "github.com/sourcegraph/sourcegraph/internal/accesstoken"
-	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/dotcomuser"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
 	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -53,46 +50,6 @@ func ExecutorsAccessToken() string {
 		return confdefaults.AppInMemoryExecutorPassword
 	}
 	return Get().ExecutorsAccessToken
-}
-
-func BitbucketServerConfigs(ctx context.Context) ([]*schema.BitbucketServerConnection, error) {
-	var config []*schema.BitbucketServerConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindBitbucketServer, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func GitHubConfigs(ctx context.Context) ([]*schema.GitHubConnection, error) {
-	var config []*schema.GitHubConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindGitHub, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func GitLabConfigs(ctx context.Context) ([]*schema.GitLabConnection, error) {
-	var config []*schema.GitLabConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindGitLab, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func GitoliteConfigs(ctx context.Context) ([]*schema.GitoliteConnection, error) {
-	var config []*schema.GitoliteConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindGitolite, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-func PhabricatorConfigs(ctx context.Context) ([]*schema.PhabricatorConnection, error) {
-	var config []*schema.PhabricatorConnection
-	if err := internalapi.Client.ExternalServiceConfigs(ctx, extsvc.KindPhabricator, &config); err != nil {
-		return nil, err
-	}
-	return config, nil
 }
 
 func GitHubAppEnabled() bool {


### PR DESCRIPTION
This removes an unnecessary internal endpoint. Basically, `schema.ClientConfiguration` is the only consumer of `conf.*Configs()`, which are the only consumers of `internalClient.ExternalServiceConfigs`, which just hits the database and pulls the URL off the config.

So, rather than calling an internal API from `frontend`, which is just served by `frontend`, this PR updates `schema.ClientConfiguration` to just hit the database directly for this information, allowing us to get rid of one of the few remaining internal APIs.

This is an API that was slated to be converted to gRPC, so I'd rather not convert things we can just delete.

(cherry picked from commit 7265e0428e0854bb5ff41004a77c1d06dfac5efc)



## Test plan

Tested on merge to main
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
