### PR TITLE
Backend: remove internalClient.ExternalURL

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -238,7 +238,6 @@ func RegisterInternalServices(
 
 	proto.RegisterZoektConfigurationServiceServer(s, &searchIndexerGRPCServer{server: indexer})
 
-	m.Get(apirouter.ExternalURL).Handler(trace.Route(handler(serveExternalURL)))
 	gitService := &gitServiceHandler{
 		Gitserver: gsClient,
 	}

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -43,7 +43,6 @@ const (
 
 	CodeInsightsDataExport = "insights.data.export"
 
-	ExternalURL         = "internal.app-url"
 	GitInfoRefs         = "internal.git.info-refs"
 	GitUploadPack       = "internal.git.upload-pack"
 	ReposIndex          = "internal.repos.index"
@@ -107,7 +106,6 @@ func NewInternal(base *mux.Router) *mux.Router {
 
 	base.StrictSlash(true)
 	// Internal API endpoints should only be served on the internal Handler
-	base.Path("/app-url").Methods("POST").Name(ExternalURL)
 	base.Path("/git/{RepoName:.*}/info/refs").Methods("GET").Name(GitInfoRefs)
 	base.Path("/git/{RepoName:.*}/git-upload-pack").Methods("GET", "POST").Name(GitUploadPack)
 	base.Path("/repos/index").Methods("POST").Name(ReposIndex)

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -41,20 +41,6 @@ var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets: prometheus.DefBuckets,
 }, []string{"category", "code"})
 
-// TODO(slimsag): In the future, once we're no longer using environment
-// variables to build ExternalURL, remove this in favor of services just reading it
-// directly from the configuration file.
-//
-// TODO(slimsag): needs cleanup as part of upcoming configuration refactor.
-func (c *internalClient) ExternalURL(ctx context.Context) (string, error) {
-	var externalURL string
-	err := c.postInternal(ctx, "app-url", nil, &externalURL)
-	if err != nil {
-		return "", err
-	}
-	return externalURL, nil
-}
-
 // MockClientConfiguration mocks (*internalClient).Configuration.
 var MockClientConfiguration func() (conftypes.RawUnified, error)
 

--- a/internal/batches/reconciler/BUILD.bazel
+++ b/internal/batches/reconciler/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//internal/batches/testing",
         "//internal/batches/types",
         "//internal/batches/webhooks",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/encryption/testing",

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -95,8 +95,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 	})
 	defer state.Unmock()
 
-	btypes.MockInternalClientExternalURL("https://sourcegraph.test")
-	t.Cleanup(btypes.ResetInternalClient)
+	mockExternalURL(t, "https://sourcegraph.test")
 
 	githubPR := buildGithubPR(clock(), btypes.ChangesetExternalStateOpen)
 	githubHeadRef := gitdomain.EnsureRefPrefix(githubPR.HeadRefName)
@@ -1216,8 +1215,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 		return &database.Namespace{Name: "my-user", User: user}, nil
 	})
 
-	btypes.MockInternalClientExternalURL("https://sourcegraph.test")
-	t.Cleanup(btypes.ResetInternalClient)
+	mockExternalURL(t, "https://sourcegraph.test")
 
 	fs := &FakeStore{
 		GetBatchChangeMock: func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {

--- a/internal/batches/reconciler/reconciler_test.go
+++ b/internal/batches/reconciler/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	bstore "github.com/sourcegraph/sourcegraph/internal/batches/store"
 	bt "github.com/sourcegraph/sourcegraph/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -43,8 +44,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	})
 	defer state.Unmock()
 
-	btypes.MockInternalClientExternalURL("https://sourcegraph.test")
-	t.Cleanup(btypes.ResetInternalClient)
+	mockExternalURL(t, "https://sourcegraph.test")
 
 	githubPR := buildGithubPR(time.Now(), btypes.ChangesetExternalStateOpen)
 	githubHeadRef := gitdomain.EnsureRefPrefix(githubPR.HeadRefName)
@@ -176,4 +176,12 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 		// Clean up database.
 		bt.TruncateTables(t, db, "changeset_events", "changesets", "batch_changes", "batch_specs", "changeset_specs")
 	}
+}
+
+func mockExternalURL(t *testing.T, url string) {
+	oldConf := conf.Get()
+	newConf := *oldConf
+	newConf.ExternalURL = url
+	conf.Mock(&newConf)
+	t.Cleanup(func() { conf.Mock(oldConf) })
 }

--- a/internal/batches/types/BUILD.bazel
+++ b/internal/batches/types/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api",
-        "//internal/api/internalapi",
         "//internal/batches/sources/azuredevops",
         "//internal/batches/sources/bitbucketcloud",
         "//internal/batches/sources/gerrit",
@@ -76,6 +75,7 @@ go_test(
         "//internal/batches/sources/azuredevops",
         "//internal/batches/sources/bitbucketcloud",
         "//internal/batches/sources/gerrit",
+        "//internal/conf",
         "//internal/database",
         "//internal/executor",
         "//internal/extsvc",
@@ -87,7 +87,6 @@ go_test(
         "//internal/extsvc/gitlab",
         "//internal/timeutil",
         "//lib/batches",
-        "//lib/errors",
         "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_go_diff//diff",

--- a/internal/batches/types/batch_change.go
+++ b/internal/batches/types/batch_change.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -92,36 +91,4 @@ func namespaceURL(orgID int32, namespaceName string) string {
 	}
 
 	return prefix + namespaceName
-}
-
-type InternalClient interface {
-	ExternalURL(context.Context) (string, error)
-}
-
-// internalClient is here for mocking reasons.
-var internalClient InternalClient = internalapi.Client
-
-func MockInternalClient(mock InternalClient) {
-	internalClient = mock
-}
-
-func MockInternalClientError(err error) {
-	internalClient = &mockInternalClient{err: err}
-}
-
-func MockInternalClientExternalURL(url string) {
-	internalClient = &mockInternalClient{externalURL: url}
-}
-
-func ResetInternalClient() {
-	internalClient = internalapi.Client
-}
-
-type mockInternalClient struct {
-	externalURL string
-	err         error
-}
-
-func (c *mockInternalClient) ExternalURL(ctx context.Context) (string, error) {
-	return c.externalURL, c.err
 }

--- a/internal/batches/types/batch_change.go
+++ b/internal/batches/types/batch_change.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -67,12 +68,7 @@ func (c *BatchChange) State() BatchChangeState {
 
 func (c *BatchChange) URL(ctx context.Context, namespaceName string) (string, error) {
 	// To build the absolute URL, we need to know where Sourcegraph is!
-	extStr, err := internalClient.ExternalURL(ctx)
-	if err != nil {
-		return "", errors.Wrap(err, "getting external Sourcegraph URL")
-	}
-
-	extURL, err := url.Parse(extStr)
+	extURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing external Sourcegraph URL")
 	}

--- a/internal/batches/types/batch_change_test.go
+++ b/internal/batches/types/batch_change_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestBatchChange_URL(t *testing.T) {
@@ -13,14 +13,11 @@ func TestBatchChange_URL(t *testing.T) {
 	bc := &BatchChange{Name: "bar", NamespaceOrgID: 123}
 
 	t.Run("errors", func(t *testing.T) {
-		for name, tc := range map[string]*mockInternalClient{
-			"ExternalURL error": {err: errors.New("foo")},
-			"invalid URL":       {externalURL: "foo://:bar"},
+		for name, url := range map[string]string{
+			"invalid URL": "foo://:bar",
 		} {
 			t.Run(name, func(t *testing.T) {
-				MockInternalClient(tc)
-				t.Cleanup(ResetInternalClient)
-
+				mockExternalURL(t, url)
 				if _, err := bc.URL(ctx, "namespace"); err == nil {
 					t.Error("unexpected nil error")
 				}
@@ -29,8 +26,7 @@ func TestBatchChange_URL(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		MockInternalClientExternalURL("https://sourcegraph.test")
-		t.Cleanup(ResetInternalClient)
+		mockExternalURL(t, "https://sourcegraph.test")
 
 		url, err := bc.URL(
 			ctx,
@@ -71,4 +67,12 @@ func TestNamespaceURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mockExternalURL(t *testing.T, url string) {
+	oldConf := conf.Get()
+	newConf := *oldConf
+	newConf.ExternalURL = url
+	conf.Mock(&newConf)
+	t.Cleanup(func() { conf.Mock(oldConf) })
 }

--- a/internal/codemonitors/background/BUILD.bazel
+++ b/internal/codemonitors/background/BUILD.bazel
@@ -22,8 +22,8 @@ go_library(
     deps = [
         "//internal/actor",
         "//internal/api",
-        "//internal/api/internalapi",
         "//internal/codemonitors",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/errcode",

--- a/internal/codemonitors/background/email.go
+++ b/internal/codemonitors/background/email.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/internal/api/internalapi"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -166,11 +166,7 @@ func getExternalURL(ctx context.Context) (*url.URL, error) {
 	}
 
 	externalURLOnce.Do(func() {
-		externalURLStr, err := internalapi.Client.ExternalURL(ctx)
-		if err != nil {
-			externalURLError = err
-			return
-		}
+		externalURLStr := conf.Get().ExternalURL
 		externalURLValue, externalURLError = url.Parse(externalURLStr)
 	})
 	return externalURLValue, externalURLError

--- a/internal/codemonitors/background/email.go
+++ b/internal/codemonitors/background/email.go
@@ -160,7 +160,7 @@ var (
 	externalURLError error
 )
 
-func getExternalURL(ctx context.Context) (*url.URL, error) {
+func getExternalURL() (*url.URL, error) {
 	if MockExternalURL != nil {
 		return MockExternalURL(), nil
 	}

--- a/internal/codemonitors/background/workers.go
+++ b/internal/codemonitors/background/workers.go
@@ -254,7 +254,7 @@ func (r *actionRunner) handleEmail(ctx context.Context, j *database.ActionJob) e
 		return errors.Wrap(err, "ListRecipients")
 	}
 
-	externalURL, err := getExternalURL(ctx)
+	externalURL, err := getExternalURL()
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func (r *actionRunner) handleWebhook(ctx context.Context, j *database.ActionJob)
 		return errors.Wrap(err, "GetWebhookAction")
 	}
 
-	externalURL, err := getExternalURL(ctx)
+	externalURL, err := getExternalURL()
 	if err != nil {
 		return err
 	}
@@ -343,7 +343,7 @@ func (r *actionRunner) handleSlackWebhook(ctx context.Context, j *database.Actio
 		return errors.Wrap(err, "GetSlackWebhookAction")
 	}
 
-	externalURL, err := getExternalURL(ctx)
+	externalURL, err := getExternalURL()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This removes the `internalClient.ExternalURL` method, which can be replaced with a simple call to `conf.Get()`

## Test plan

Tested that the links in a code monitor still point to the right external URL

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
