### PR TITLE
bazel: run gofmt as part of bazel configure step

### DIFF
--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -30,7 +30,7 @@ END
 fi
 
 echo "--- :bazel::go: Running gofmt"
-unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l . 2>/dev/null)
+unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ $unformatted != "" ]]; then
   mkdir -p ./anntations
@@ -38,7 +38,7 @@ if [[ $unformatted != "" ]]; then
   The following files were found to not be formatted according to `gofmt`:
 
   \`\`\`
-  ${unformatted}
+  "${unformatted}"
   \`\`\`
 
   To automatically format these files run:

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -29,4 +29,26 @@ if [[ $EXIT_CODE -ne 0 ]]; then
 END
 fi
 
+unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l . 2>/dev/null)
+
+if [[ $unformatted != "" ]]; then
+  echo -e "The following files are not formatted:\n$unformatted"
+  mkdir -p ./anntations
+  cat <<-"END" > ./annotations/bazel-gofmt.md
+  The following files were found to not be formatted according to `gofmt`:
+
+  ```
+  ${unformatted}
+  ```
+
+  To automatically format these files run:
+
+  ```
+  bazel run @go_sdk//:bin/gofmt -- -w .
+  ```
+END
+  EXIT_CODE=1
+fi
+
+
 exit "$EXIT_CODE"

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -3,7 +3,7 @@
 set -eu
 
 # We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
-echo "--- Running bazel configure"
+echo "--- :bazel: Running bazel configure"
 bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc configure
 
 # We disable exit on error here, since we want to catch the exit code and interpret it
@@ -29,23 +29,23 @@ if [[ $EXIT_CODE -ne 0 ]]; then
 END
 fi
 
+echo "--- :bazel::go: Running gofmt"
 unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l . 2>/dev/null)
 
 if [[ $unformatted != "" ]]; then
-  echo -e "The following files are not formatted:\n$unformatted"
   mkdir -p ./anntations
-  cat <<-"END" > ./annotations/bazel-gofmt.md
+  cat <<-END > ./annotations/bazel-gofmt.md
   The following files were found to not be formatted according to `gofmt`:
 
-  ```
+  \`\`\`
   ${unformatted}
-  ```
+  \`\`\`
 
   To automatically format these files run:
 
-  ```
+  \`\`\`
   bazel run @go_sdk//:bin/gofmt -- -w .
-  ```
+  \`\`\`
 END
   EXIT_CODE=1
 fi

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -51,7 +51,11 @@ if [[ ${unformatted} != "" ]]; then
   bazel run @go_sdk//:bin/gofmt -- -w .
   \`\`\`
 END
-  EXIT_CODE=1
+
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    # We;re using 100 as a Soft fail exit code, so we only want to use it the exit code isn't a hard fail code ie. not 0
+    EXIT_CODE=100
+  fi
 fi
 
 

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -18,7 +18,7 @@ EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]; then
   mkdir -p ./annotations
   cat <<-'END' > ./annotations/bazel-prechecks.md
-  ### Missing BUILD.bazel files
+  #### Missing BUILD.bazel files
 
   BUILD.bazel files need to be updated to match the repository state. You should run the following command and commit the result
 
@@ -37,7 +37,7 @@ unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l .)
 if [[ ${unformatted} != "" ]]; then
   mkdir -p ./annotations
   tee -a ./annotations/bazel-prechecks.md <<-END
-  ### Unformatted Go files
+  #### Unformatted Go files
 
   The following files were found to not be formatted according to \`gofmt\`:
 

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -32,9 +32,9 @@ fi
 echo "--- :bazel::go: Running gofmt"
 unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l .)
 
-if [[ $unformatted != "" ]]; then
+if [[ ${unformatted} != "" ]]; then
   mkdir -p ./anntations
-  cat <<-END > ./annotations/bazel-gofmt.md
+  cat <<'END' > ./annotations/bazel-gofmt.md
   The following files were found to not be formatted according to `gofmt`:
 
   \`\`\`
@@ -43,9 +43,9 @@ if [[ $unformatted != "" ]]; then
 
   To automatically format these files run:
 
-  \`\`\`
-  bazel run @go_sdk//:bin/gofmt -- -w .
-  \`\`\`
+  # \`\`\`
+  # bazel run @go_sdk//:bin/gofmt -- -w .
+  # \`\`\`
 END
   EXIT_CODE=1
 fi

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -2,9 +2,11 @@
 
 set -eu
 
+bazelrc="--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc"
+
 # We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
 echo "--- :bazel: Running bazel configure"
-bazel --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc configure
+bazel "${bazelrc}" configure
 
 # We disable exit on error here, since we want to catch the exit code and interpret it
 set +e
@@ -32,7 +34,7 @@ END
 fi
 
 echo "--- :bazel::go: Running gofmt"
-unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l .)
+unformatted=$(bazel ${bazelrc} run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ ${unformatted} != "" ]]; then
   mkdir -p ./annotations

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -16,8 +16,10 @@ EXIT_CODE=$?
 
 # if we get a non-zero exit code, bazel configure updated files
 if [[ $EXIT_CODE -ne 0 ]]; then
-  mkdir -p ./anntations
-  cat <<-'END' > ./annotations/bazel-configure.md
+  mkdir -p ./annotations
+  cat <<-'END' > ./annotations/bazel-prechecks.md
+  ### Missing BUILD.bazel files
+
   BUILD.bazel files need to be updated to match the repository state. You should run the following command and commit the result
 
   ```
@@ -33,19 +35,21 @@ echo "--- :bazel::go: Running gofmt"
 unformatted=$(bazel run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ ${unformatted} != "" ]]; then
-  mkdir -p ./anntations
-  cat <<'END' > ./annotations/bazel-gofmt.md
-  The following files were found to not be formatted according to `gofmt`:
+  mkdir -p ./annotations
+  tee -a ./annotations/bazel-prechecks.md <<-END
+  ### Unformatted Go files
+
+  The following files were found to not be formatted according to \`gofmt\`:
 
   \`\`\`
-  "${unformatted}"
+  ${unformatted}
   \`\`\`
 
   To automatically format these files run:
 
-  # \`\`\`
-  # bazel run @go_sdk//:bin/gofmt -- -w .
-  # \`\`\`
+  \`\`\`
+  bazel run @go_sdk//:bin/gofmt -- -w .
+  \`\`\`
 END
   EXIT_CODE=1
 fi

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -34,7 +34,7 @@ END
 fi
 
 echo "--- :bazel::go: Running gofmt"
-unformatted=$(bazel ${bazelrc} run @go_sdk//:bin/gofmt -- -l .)
+unformatted=$(bazel "${bazelrc}" run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ ${unformatted} != "" ]]; then
   mkdir -p ./annotations

--- a/doc/dev/background-information/ci/reference.md
+++ b/doc/dev/background-information/ci/reference.md
@@ -15,14 +15,14 @@ For a higher-level overview, please refer to the [continuous integration docs](h
 The default run type.
 
 - Pipeline for `Go` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Client` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
@@ -31,90 +31,90 @@ The default run type.
   - **Pipeline setup**: Trigger async
 
 - Pipeline for `GraphQL` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Client checks**: Upload Storybook to Chromatic, Enterprise build, Build (client/jetbrains), Tests for VS Code extension, Stylelint (all)
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `DatabaseSchema` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Docs` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Dockerfiles` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `ExecutorVMImage` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `ExecutorDockerRegistryMirror` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `CIScripts` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Terraform` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `SVG` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Shell` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `DockerImages` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `WolfiPackages` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `WolfiBaseImages` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Security Scanning**: Sonarcloud Scan
 
 - Pipeline for `Protobuf` changes:
-  - Ensure buildfiles are up to date
+  - Perform bazel prechecks
   - Tests
   - BackCompat Tests
   - **Linters and static analysis**: Run sg lint
@@ -145,7 +145,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
@@ -207,7 +207,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
@@ -225,7 +225,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary, Build docker registry mirror image
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
@@ -266,7 +266,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
@@ -289,7 +289,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images, Build executor image, Build executor binary
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint
@@ -365,7 +365,7 @@ Base pipeline (more steps might be included based on branch changes):
 
 - **Pipeline setup**: Trigger async
 - **Image builds**: Build Docker images
-- Ensure buildfiles are up to date
+- Perform bazel prechecks
 - Tests
 - BackCompat Tests
 - **Linters and static analysis**: Run sg lint

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -127,6 +127,7 @@ func bazelPrechecks() func(*bk.Pipeline) {
 	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-prechecks"),
+		bk.SoftFail(100),
 		bk.Agent("queue", "bazel"),
 		bk.AnnotatedCmd("dev/ci/bazel-prechecks.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -138,7 +138,7 @@ func bazelPrechecks() func(*bk.Pipeline) {
 	}
 
 	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(":bazel: Ensure buildfiles are up to date",
+		pipeline.AddStep(":bazel: Perform bazel prechecks",
 			cmds...,
 		)
 	}

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -17,7 +17,7 @@ import (
 
 func BazelOperations(isMain bool) []operations.Operation {
 	ops := []operations.Operation{}
-	ops = append(ops, bazelConfigure())
+	ops = append(ops, bazelPrechecks())
 	if isMain {
 		ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
 	} else {
@@ -105,7 +105,6 @@ func bazelStampedCmd(args ...string) string {
 // bazelAnalysisPhase only runs the analasys phase, ensure that the buildfiles
 // are correct, but do not actually build anything.
 func bazelAnalysisPhase() func(*bk.Pipeline) {
-	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmd := bazelCmd(
 		"build",
 		"--nobuild", // this is the key flag to enable this.
@@ -124,12 +123,12 @@ func bazelAnalysisPhase() func(*bk.Pipeline) {
 		)
 	}
 }
-func bazelConfigure() func(*bk.Pipeline) {
+func bazelPrechecks() func(*bk.Pipeline) {
 	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmds := []bk.StepOpt{
-		bk.Key("bazel-configure"),
+		bk.Key("bazel-prechecks"),
 		bk.Agent("queue", "bazel"),
-		bk.AnnotatedCmd("dev/ci/bazel-configure.sh", bk.AnnotatedCmdOpts{
+		bk.AnnotatedCmd("dev/ci/bazel-prechecks.sh", bk.AnnotatedCmdOpts{
 			Annotations: &bk.AnnotationOpts{
 				Type:         bk.AnnotationTypeWarning,
 				IncludeNames: false,
@@ -151,7 +150,7 @@ func bazelAnnouncef(format string, args ...any) bk.StepOpt {
 
 func bazelTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.DependsOn("bazel-configure"),
+		bk.DependsOn("bazel-prechecks"),
 		bk.Agent("queue", "bazel"),
 		bk.Key("bazel-tests"),
 		bk.ArtifactPaths("./bazel-testlogs/enterprise/cmd/embeddings/shared/shared_test/*.log", "./command.profile.gz"),
@@ -185,7 +184,7 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 
 func bazelBackCompatTest(targets ...string) func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
-		bk.DependsOn("bazel-configure"),
+		bk.DependsOn("bazel-prechecks"),
 		bk.Agent("queue", "bazel"),
 
 		// Generate a patch that backports the migration from the new code into the old one.


### PR DESCRIPTION
I think this work will be superseded by https://github.com/sourcegraph/sourcegraph/issues/54822 but for now:

* Run `gofmt` via bazel to get the list of files that are not formatted and add it to the warning annotation 👇🏼 
![Screenshot 2023-08-01 at 12 20 48](https://github.com/sourcegraph/sourcegraph/assets/1001709/2aa21a89-6cb4-4b9c-b70a-87c8aaaef98a)

* The step will soft fail if files are not formatted
## Test plan
Test locally and CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
