### PR TITLE
Update docs to reference `sg wolfi` commands

### DIFF
--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -8,7 +8,7 @@ Wolfi base images are built _from scratch_ using [apko](https://github.com/chain
 
 Base images are defined using an apko YAML configuration file, found under [wolfi-images](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/wolfi-images).
 
-These configuration files can be processed with apko, which will generate a base image. You can build these locally using [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+These configuration files can be processed with apko, which will generate a base image. You can build these locally using `sg wolfi image <image-name>`.
 
 ## How to...
 
@@ -28,7 +28,7 @@ This is currently a two-step process, but will be automated in the future:
 To modify a base image to add packages, users, or directories:
 
 - Update its apko YAML configuration file, which can be found under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/)
-- Build and testing it locally using [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+- Build and testing it locally using `sg wolfi image <image-name>`.
   - You can use this local image in your Dockerfiles, or exec into it directly.
 - Once happy with changes, create a PR and merge to main. Buildkite will detect the changes and rebuild the base image.
 - Update the relevant Dockerfiles with the new base image's `sha256` hash, commit the change, and merge to main.
@@ -44,7 +44,7 @@ Otherwise, you can create a new base image configuration file:
 - Add any required packages, users, directory structure, or metadata.
   - See [apko file format](https://github.com/chainguard-dev/apko/blob/main/docs/apko_file.md) for a full list of supported configuration.
   - See the other images under [`wolfi-images/`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/) and [`chainguard-images/images`](https://github.com/chainguard-images/images/tree/main/images) for examples and best practices.
-- Build your image locally with [`local-build.sh <image-name>.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-images/local-build.sh).
+- Build your image locally with `sg wolfi image <image-name>`.
 - Commit your updated YAML file and merge it to main. Buildkite will build and publish your new image.
 
 Once complete, treat the published image it as a standard base image, and use it in your Dockerfile.

--- a/doc/dev/how-to/wolfi/add_update_packages.md
+++ b/doc/dev/how-to/wolfi/add_update_packages.md
@@ -37,7 +37,7 @@ It's common to need to update a package to the most recent release in order to p
 
 - Depending on the package, this step may download a binary or source code. Projects release code in different ways, so the pipeline may check out a Git repository on a specific branch or download a `.tar.gz` file containing source code.
 
-3. Try building the package locally with the [`local-build.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh) script. If successful, it will generate an `.apk` file under `wolfi-packages/packages/x86_64/`.
+3. Optionally, build the package locally with `sg wolfi package <package-name>`. This will create an `.apk` file under `wolfi-packages/local-repo/packages/x86_64` which you can [inspect](#testing-packages).
 
 4. Push your branch and create a PR. Buildkite will build the new version of the package, which you can [test](#testing-packages). Once merged to `main`, it will be added to the [Sourcegraph package repository](#sourcegraph-package-repository).
 
@@ -52,7 +52,7 @@ When creating a new package, the rough workflow is:
   - If only source releases are available, you'll need to download the source of a versioned release and build it.
   - Projects typically include a Makefile, or building instructions in their README or INSTALL.
 - Add metadata such as the package name, version, and license.
-- Iterate by [building](#building-packages) the package locally using [`local-build.sh <your-package.yaml>`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh)
+- Iterate by [building](#building-packages) the package locally using `sg wolfi package <package-name>`.
 - [Test your new package](#testing-packages)
 - Once confident the package works as expected, create a PR and merge to `main` to add it to the Sourcegraph package repository.
 
@@ -66,12 +66,14 @@ When creating a new package, the rough workflow is:
   - It can also be useful to refer to the [code that these pipelines run](https://github.com/chainguard-dev/melange/tree/main/pkg/build/pipelines).
 - Spin up a dev Wolfi image with and run the build steps manually in there. This is useful for debugging, or for speeding up iteration on slow-building dependencies.
   - `docker run -it --entrypoint /bin/sh  us.gcr.io/sourcegraph-dev/wolfi-sourcegraph-dev-base:latest`
+- You can build packages locally using `sg wolfi package <package-name>`.
 
 ### Testing packages
 
 - `.apk` files are just `.tar.gz` files, so can be extracted with `tar zxvf package.apk`. This is useful for checking their contents.
-  - When building locally with [`local-build.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/wolfi-packages/local-build.sh), packages are built under `wolfi-packages/packages/x86_64/`.
+  - After building locally with `sg wolfi package <package-name>`, packages can be found under `wolfi-packages/local-repo/packages/x86_64/`.
 - Always try installing the package in a container, as this ensures that all runtime dependencies can be satisfied.
+- After building a package locally with `sg wolfi package`, you can test it out in a specific base image by modifying that image's manifest (under `wolfi-images/`) from `package@sourcegraph` to `package@local` and run `sg wolfi image <image-name>`. This will build the base image using the package from your local repository.
 
 ## Sourcegraph package repository
 
@@ -83,3 +85,7 @@ Currently, all packages are uploaded directly to the main Sourcegraph package re
 
 - The `main/` directory only contains packages built from the main branch.
 - Each branch which updates package manifests will have its own `branch-name` repository.
+
+### Local package repository
+
+After building a package locally with `sg wolfi package <package-name>`, it is stored in a local package repository under `wolfi-packages/local-repo/packages/`. Thes packages can be used in locally-built base images by referencing them using `package@local` in the image manifest and running `sg wolfi image <image-name>`.


### PR DESCRIPTION
Update documentation to reference the new `sg wolfi` commands

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Docs only - green CI build