### PR TITLE
sveltekit: Add badge wildcard component

### DIFF
--- a/client/web-sveltekit/src/lib/wildcard/Badge.module.scss
+++ b/client/web-sveltekit/src/lib/wildcard/Badge.module.scss
@@ -1,0 +1,202 @@
+:root {
+    --badge-font-size: 0.75rem;
+    --badge-font-weight: 500;
+    --badge-padding-y: 0.125rem;
+    --badge-padding-x: 0.375rem;
+    --badge-border-radius: 3px;
+    --badge-transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out,
+        box-shadow 0.15s ease-in-out;
+}
+
+.badge {
+    display: inline-block;
+    padding: var(--badge-padding-y) var(--badge-padding-x);
+    font-size: var(--badge-font-size);
+    font-weight: var(--badge-font-weight);
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: var(--badge-border-radius);
+
+    background-color: var(--subtle-bg);
+    color: var(--link-color);
+    border: none;
+    line-height: 1rem;
+
+    &:focus,
+    &.focus {
+        outline: 0;
+    }
+}
+
+// Base Variants
+.primary,
+.secondary,
+.success,
+.danger,
+.info,
+.warning,
+.merged,
+.outline-secondary {
+    background-color: var(--badge-base);
+    color: var(--badge-text);
+    border: var(--badge-border, none);
+}
+
+.primary {
+    --badge-base: var(--primary);
+    --badge-light: var(--primary-2);
+    --badge-dark: var(--primary-3);
+    --badge-text: var(--light-text);
+}
+
+.secondary {
+    --badge-base: var(--secondary);
+    --badge-light: var(--secondary-2);
+    --badge-dark: var(--secondary-3);
+    --badge-text: var(--body-color);
+}
+
+.success {
+    --badge-base: var(--success);
+    --badge-light: var(--success-2);
+    --badge-dark: var(--success-3);
+    --badge-text: var(--light-text);
+}
+
+.danger {
+    --badge-base: var(--danger);
+    --badge-light: var(--danger-2);
+    --badge-dark: var(--danger-3);
+    --badge-text: var(--light-text);
+}
+
+.info {
+    --badge-base: var(--info);
+    --badge-light: var(--info-2);
+    --badge-dark: var(--info-3);
+    --badge-text: var(--dark-text);
+}
+
+.warning {
+    --badge-base: var(--warning);
+    --badge-light: var(--warning-2);
+    --badge-dark: var(--warning-3);
+    --badge-text: var(--dark-text);
+}
+
+.merged {
+    --badge-base: var(--merged);
+    --badge-light: var(--merged-2);
+    --badge-dark: var(--merged-3);
+    --badge-text: var(--light-text);
+}
+
+.outline-secondary {
+    --badge-base: transparent;
+    --badge-light: var(--secondary-2);
+    --badge-dark: var(--secondary-2);
+    --badge-text: var(--text-muted);
+    --badge-border: 1px solid var(--secondary);
+}
+
+a.primary,
+a.secondary,
+a.success,
+a.danger,
+a.info,
+a.warning,
+a.merged,
+a.outline-secondary {
+    background-color: var(--badge-base);
+    color: var(--badge-text);
+
+    &:hover,
+    &:focus,
+    &.focus {
+        color: var(--badge-text);
+        background-color: var(--badge-dark);
+    }
+
+    &:focus,
+    &.focus {
+        outline: 0;
+
+        :global(.theme-light) & {
+            box-shadow: 0 0 0 0.125rem var(--badge-light);
+        }
+
+        :global(.theme-dark) & {
+            box-shadow: 0 0 0 0.125rem var(--badge-dark);
+        }
+    }
+}
+
+:global(.theme-light),
+:global(.theme-dark) {
+    // Update secondary text color and focus state for better contrast
+    a.secondary,
+    a.outline-secondary {
+        &:focus,
+        &.focus {
+            box-shadow: var(--focus-box-shadow);
+        }
+    }
+    a.secondary {
+        &:hover,
+        &:focus,
+        &.focus {
+            color: var(--body-color);
+        }
+    }
+}
+
+// Outline links need slightly different treatment to be more visible on hover
+:global(.theme-light) {
+    a.outline-secondary {
+        &:hover,
+        &:focus,
+        &.focus {
+            border-color: var(--secondary);
+        }
+    }
+}
+
+:global(.theme-dark) {
+    a.outline-secondary {
+        &:hover,
+        &:focus,
+        &.focus {
+            border-color: var(--secondary-4);
+        }
+    }
+}
+
+a.badge {
+    transition: var(--badge-transition);
+}
+
+a.badge:hover,
+a.badge:focus {
+    text-decoration: none;
+}
+
+.badge:empty {
+    display: none;
+}
+
+.pill {
+    // Preserve original Bootstrap padding values
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    padding-right: 0.6em;
+    // stylelint-disable-next-line declaration-property-unit-allowed-list
+    padding-left: 0.6em;
+    border-radius: 10rem;
+}
+
+.small {
+    --badge-font-size: 0.6875rem;
+    --badge-padding-y: 0;
+    --badge-padding-x: 0.25rem;
+    --badge-border-radius: 2px;
+}

--- a/client/web-sveltekit/src/lib/wildcard/Badge.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/Badge.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" context="module">
+    import classNames from "classnames"
+    import styles from './Badge.module.scss'
+
+    export const BADGE_VARIANTS = [
+        'primary',
+        'secondary',
+        'success',
+        'danger',
+        'warning',
+        'info',
+        'merged',
+        'outlineSecondary',
+    ] as const
+
+    export type BadgeVariantType = typeof BADGE_VARIANTS[number]
+
+    export function badgeClassName(variant: BadgeVariantType, small?: boolean, pill?: boolean): string {
+        return classNames(styles.badge, styles[variant], {[styles.small]: small, [styles.pill]: pill})
+    }
+</script>
+
+<script lang="ts">
+    /**
+     * The variant style of the badge.
+     */
+    export let variant: BadgeVariantType
+    /**
+     * Allows modifying the size of the badge. Supports a smaller variant.
+     */
+    export let small: boolean|undefined = undefined
+    /**
+     * Render the badge as a rounded pill
+     */
+    export let pill: boolean|undefined = undefined
+
+    $: cls = badgeClassName(variant, small, pill)
+</script>
+
+<!--TODO: support non-branded badges -->
+<slot name="custom" class={cls}>
+    <span class={cls}>
+        <slot />
+    </span>
+</slot>

--- a/client/web-sveltekit/src/lib/wildcard/index.ts
+++ b/client/web-sveltekit/src/lib/wildcard/index.ts
@@ -4,3 +4,4 @@
 export { default as Button } from './Button.svelte'
 export { default as ButtonGroup } from './ButtonGroup.svelte'
 export { WildcardThemeContext, type WildcardTheme } from '@sourcegraph/wildcard/src/hooks/useWildcardTheme'
+export { default as Badge } from './Badge.svelte'

--- a/client/web-sveltekit/src/stories/Badge.stories.ts
+++ b/client/web-sveltekit/src/stories/Badge.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+
+import BadgeExample from './BadgeExample.svelte'
+
+const meta: Meta<typeof BadgeExample> = {
+    title: 'wildcard/Badge',
+    component: BadgeExample,
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Badge: Story = {}

--- a/client/web-sveltekit/src/stories/BadgeExample.svelte
+++ b/client/web-sveltekit/src/stories/BadgeExample.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import Badge, { BADGE_VARIANTS } from "$lib/wildcard/Badge.svelte"
+</script>
+
+<h2>Default</h2>
+<table>
+    <thead>
+        <tr><th>Variant</th><th></th><th>pill=true</th><th>small=true</th><th>pill=true small=true</tr>
+    </thead>
+    <tbody>
+    {#each BADGE_VARIANTS as variant}
+        <tr>
+            <th>{variant}</th>
+            <td><Badge {variant}>Badge</Badge> </td>
+            <td><Badge {variant} pill>Badge</Badge></td>
+            <td><Badge {variant} small>Badge</Badge></td>
+            <td><Badge {variant} pill small>Badge</Badge></td>
+        </tr>
+    {/each}
+    </tbody>
+</table>
+
+<h2 id="custom">Custom elements</h2>
+<Badge variant="primary">
+    <a slot="custom" let:class={cls} class={cls} href="#custom">I'm a link</a>
+</Badge>
+
+<style lang="scss">
+    td, th {
+        padding: 0.5rem;
+    }
+</style>


### PR DESCRIPTION
This PR adds the bade wildcard component to the prototype.

Whenever styles should be "shareable" it's easier to use CSS modules rather than Svelte `<style>` tags. This time I copied the module but I could also reuse the existing one from the wildcard library (still trying to figure out how to do that properly going forward).
Similar to Button, this component allows to customize the DOM structure via a "custom" slot which gets passed the generated class names. (whether or not that's a good approach remains to be seen)

Additionally customization could also be done by using `badgeClassName` directly.


![2023-08-01_12-32](https://github.com/sourcegraph/sourcegraph/assets/179026/750cc4dd-e9f4-4f1a-ba08-5e47393118d9)


## Test plan

Storybook
