### PR TITLE
Add license tag checks for true-up on AccessRequests page

### DIFF
--- a/client/web/src/site-admin/AccessRequestsPage/index.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/index.tsx
@@ -92,7 +92,13 @@ function useHasRemainingSeats(): boolean {
 
     const licenseSeatsCount = data?.site?.productSubscription?.license?.userCount
     const usersCount = data?.site?.users?.totalCount
-    return typeof licenseSeatsCount !== 'number' || typeof usersCount !== 'number' || licenseSeatsCount > usersCount
+    const tags = data?.site?.productSubscription?.license?.tags ?? []
+    return (
+        typeof licenseSeatsCount !== 'number' ||
+        typeof usersCount !== 'number' ||
+        licenseSeatsCount > usersCount ||
+        tags.includes('true-up')
+    )
 }
 
 const TableColumns: IColumn<AccessRequestNode>[] = [

--- a/client/web/src/site-admin/AccessRequestsPage/queries.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/queries.tsx
@@ -37,6 +37,7 @@ export const HAS_LICENSE_SEATS = gql`
         site {
             productSubscription {
                 license {
+                    tags
                     userCount
                 }
             }


### PR DESCRIPTION
Closes #55470 

The access requests page is not aware that users can still be created when the `true-up` license tag is applied.

Before:
<img width="1102" alt="Screenshot 2023-08-01 at 12 30 51" src="https://github.com/sourcegraph/sourcegraph/assets/6427795/a3d3230e-c81f-4e8e-a5df-1b040962736f">


After:

<img width="1159" alt="Screenshot 2023-08-01 at 12 31 27" src="https://github.com/sourcegraph/sourcegraph/assets/6427795/9c0af392-98c9-4170-ace5-8a7327c30d17">

## Test plan

UI change

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
