### PR TITLE
source: reword text displayed when there's no output from the last sync

### DIFF
--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -179,7 +179,7 @@ const LastSyncOutput: FC<LastSyncOutputProps> = props => {
     const output =
         (props.mirrorInfo.cloneInProgress && 'Cloning in progress...') ||
         props.mirrorInfo.lastSyncOutput ||
-        "Last sync command didn't produce any output"
+        "Last sync command did not produce any output"
     return (
         <div className="mt-2">
             <Text>Output from this repository's most recent sync</Text>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -86,7 +86,7 @@ export const RepoSettingsLogsPage: FC<RepoSettingsLogsPageProps> = ({ repo }) =>
 
                     <TabPanels>
                         <TabPanel>
-                            <LastRepoCommands repo={repo} />
+                            <LastExecutedCommands repo={repo} />
                         </TabPanel>
 
                         <TabPanel>
@@ -99,11 +99,11 @@ export const RepoSettingsLogsPage: FC<RepoSettingsLogsPageProps> = ({ repo }) =>
     )
 }
 
-interface LastRepoCommandsProps {
+interface LastExecutedCommandsProps {
     repo: SettingsAreaRepositoryFields
 }
 
-const LastRepoCommands: FC<LastRepoCommandsProps> = ({ repo }) => {
+const LastExecutedCommands: FC<LastExecutedCommandsProps> = ({ repo }) => {
     const { recordedCommands, loading, error, fetchMore, hasNextPage } = useFetchRecordedCommands(repo.id)
 
     return (
@@ -116,7 +116,7 @@ const LastRepoCommands: FC<LastRepoCommandsProps> = ({ repo }) => {
                     // of IDs and there's nothing really unique about each command.
                     //
                     // eslint-disable-next-line react/no-array-index-key
-                    <LastRepoCommandNode mirrorInfo={repo.mirrorInfo} command={command} key={index} />
+                    <LastExecutedCommandNode mirrorInfo={repo.mirrorInfo} command={command} key={index} />
                 ))}
             </div>
             {loading && <LoadingSpinner />}
@@ -129,12 +129,12 @@ const LastRepoCommands: FC<LastRepoCommandsProps> = ({ repo }) => {
     )
 }
 
-interface LastRepoCommandNodeProps {
+interface LastExecutedCommandNodeProps {
     command: RepositoryRecordedCommandFields
     mirrorInfo: SettingsAreaRepositoryFields['mirrorInfo']
 }
 
-const LastRepoCommandNode: FC<LastRepoCommandNodeProps> = ({ command, mirrorInfo }) => {
+const LastExecutedCommandNode: FC<LastExecutedCommandNodeProps> = ({ command, mirrorInfo }) => {
     const startDate = parseISO(command.start)
     const duration = formatDuration(command.duration)
 
@@ -179,7 +179,7 @@ const LastSyncOutput: FC<LastSyncOutputProps> = props => {
     const output =
         (props.mirrorInfo.cloneInProgress && 'Cloning in progress...') ||
         props.mirrorInfo.lastSyncOutput ||
-        'No logs yet'
+        "Last sync command didn't produce any output"
     return (
         <div className="mt-2">
             <Text>Output from this repository's most recent sync</Text>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -179,7 +179,7 @@ const LastSyncOutput: FC<LastSyncOutputProps> = props => {
     const output =
         (props.mirrorInfo.cloneInProgress && 'Cloning in progress...') ||
         props.mirrorInfo.lastSyncOutput ||
-        "Last sync command did not produce any output"
+        'Last sync command did not produce any output'
     return (
         <div className="mt-2">
             <Text>Output from this repository's most recent sync</Text>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -179,7 +179,7 @@ const LastSyncOutput: FC<LastSyncOutputProps> = props => {
     const output =
         (props.mirrorInfo.cloneInProgress && 'Cloning in progress...') ||
         props.mirrorInfo.lastSyncOutput ||
-        'No logs yet.'
+        'No logs yet'
     return (
         <div className="mt-2">
             <Text>Output from this repository's most recent sync</Text>

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1939,8 +1939,11 @@ func (s *Server) setLastErrorNonFatal(ctx context.Context, name api.RepoName, er
 }
 
 func (s *Server) setLastOutput(ctx context.Context, name api.RepoName, output string) {
-	if err := s.DB.GitserverRepos().SetLastOutput(ctx, name, output); err != nil {
-		s.Logger.Warn("Setting last output in DB", log.Error(err))
+	// If there are no new changes, we don't want to overwrite the last output.
+	if output != "" {
+		if err := s.DB.GitserverRepos().SetLastOutput(ctx, name, output); err != nil {
+			s.Logger.Warn("Setting last output in DB", log.Error(err))
+		}
 	}
 }
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1939,11 +1939,8 @@ func (s *Server) setLastErrorNonFatal(ctx context.Context, name api.RepoName, er
 }
 
 func (s *Server) setLastOutput(ctx context.Context, name api.RepoName, output string) {
-	// If there are no new changes, we don't want to overwrite the last output.
-	if output != "" {
-		if err := s.DB.GitserverRepos().SetLastOutput(ctx, name, output); err != nil {
-			s.Logger.Warn("Setting last output in DB", log.Error(err))
-		}
+	if err := s.DB.GitserverRepos().SetLastOutput(ctx, name, output); err != nil {
+		s.Logger.Warn("Setting last output in DB", log.Error(err))
 	}
 }
 


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C05HF5XGMFF/p1690878610936729)

> If a repo syncs and there are no new commits, the last sync output updates to show No logs yet.  This can be misleading and gives a false impression to the user that the repo wasn’t synced at all. 

Right now, this PR updates the text displayed in the UI.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

When the last sync doesn't produce an output, we display the text `Last sync command did not produce any output` in the UI.

<img width="920" alt="CleanShot 2023-08-01 at 15 33 36@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/91d2e54b-321e-467e-8548-4aafa39b239c">
