### PR TITLE
source: rename "Last repo commands" tab

### DIFF
--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -80,7 +80,7 @@ export const RepoSettingsLogsPage: FC<RepoSettingsLogsPageProps> = ({ repo }) =>
                     onChange={setActiveTab}
                 >
                     <TabList>
-                        <Tab>Last repo commands</Tab>
+                        <Tab>Last executed commands</Tab>
                         <Tab>Last sync output</Tab>
                     </TabList>
 

--- a/client/web/src/enterprise/repo/settings/__snapshots__/RepoSettingsLogsPage.test.tsx.snap
+++ b/client/web/src/enterprise/repo/settings/__snapshots__/RepoSettingsLogsPage.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`RepoSettingsLogsPage should render correctly when there are no recorded
             <span
               class="tabLabel"
             >
-              Last repo commands
+              Last executed commands
             </span>
           </button>
           <button
@@ -180,7 +180,7 @@ exports[`RepoSettingsLogsPage should render correctly when there are recorded co
             <span
               class="tabLabel"
             >
-              Last repo commands
+              Last executed commands
             </span>
           </button>
           <button


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Just a name change to the `Last repo commands` tab.

<img width="928" alt="CleanShot 2023-08-01 at 12 23 00@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/66dda748-277c-4ad3-877d-cb9359c3bfa7">
