### PR TITLE
ensure commands are redacted before saving

### DIFF
--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 )
@@ -102,11 +101,8 @@ func (r *recordedCommandResolver) Duration() float64 {
 	return r.command.Duration
 }
 
-var urlRegex = lazyregexp.New(`((https?|ssh|git)://[^:@]+:)[^@]+(@)`)
-
 func (r *recordedCommandResolver) Command() string {
-	redacted := urlRegex.ReplaceAllString(strings.Join(r.command.Args, " "), "$1<REDACTED>$3")
-	return redacted
+	return strings.Join(r.command.Args, " ")
 }
 
 func (r *recordedCommandResolver) Dir() string {

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/redactor"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -77,7 +79,8 @@ func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, repoName 
 	dir.Set(cmd)
 	output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd), configRemoteOpts, nil)
 	if err != nil {
-		return nil, &common.GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
+		redactedOutput := redactor.NewURLRedactor(remoteURL).Redact(string(output))
+		return nil, &common.GitCommandError{Err: err, Output: redactedOutput}
 	}
 	return output, nil
 }

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/redactor"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -181,7 +183,8 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, _ a
 	// something for p4?
 	output, err := runCommandCombinedOutput(ctx, cmd)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to update with output %q", newURLRedactor(remoteURL).redact(string(output)))
+		redactedOutput := redactor.NewURLRedactor(remoteURL).Redact(string(output))
+		return nil, errors.Wrapf(err, "failed to update with output %q", redactedOutput)
 	}
 
 	if !s.FusionConfig.Enabled {

--- a/internal/redactor/command.go
+++ b/internal/redactor/command.go
@@ -1,0 +1,1 @@
+package redactor

--- a/internal/redactor/command.go
+++ b/internal/redactor/command.go
@@ -1,1 +1,15 @@
 package redactor
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+)
+
+var urlRegex = lazyregexp.New(`((https?|ssh|git)://[^:@]+:)[^@]+(@)`)
+
+func RedactCommandArgs(args []string) []string {
+	var redactedArgs = make([]string, len(args))
+	for i, arg := range args {
+		redactedArgs[i] = urlRegex.ReplaceAllString(arg, "$1<REDACTED>$3")
+	}
+	return redactedArgs
+}

--- a/internal/redactor/url.go
+++ b/internal/redactor/url.go
@@ -6,8 +6,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
-// urlRedactor redacts all sensitive strings from a message.
-type urlRedactor struct {
+// UrlRedactor redacts all sensitive strings from a message.
+type UrlRedactor struct {
 	// sensitive are sensitive strings to be redacted.
 	// The strings should not be empty.
 	sensitive []string
@@ -15,7 +15,7 @@ type urlRedactor struct {
 
 // NewURLRedactor returns a new urlRedactor that redacts
 // credentials found in rawurl, and the rawurl itself.
-func NewURLRedactor(parsedURL *vcs.URL) *urlRedactor {
+func NewURLRedactor(parsedURL *vcs.URL) *UrlRedactor {
 	var sensitive []string
 	pw, _ := parsedURL.User.Password()
 	u := parsedURL.User.Username()
@@ -32,12 +32,12 @@ func NewURLRedactor(parsedURL *vcs.URL) *urlRedactor {
 		}
 	}
 	sensitive = append(sensitive, parsedURL.String())
-	return &urlRedactor{sensitive: sensitive}
+	return &UrlRedactor{sensitive: sensitive}
 }
 
 // redact returns a redacted version of message.
 // Sensitive strings are replaced with "<redacted>".
-func (r *urlRedactor) Redact(message string) string {
+func (r *UrlRedactor) Redact(message string) string {
 	for _, s := range r.sensitive {
 		message = strings.ReplaceAll(message, s, "<redacted>")
 	}

--- a/internal/redactor/url.go
+++ b/internal/redactor/url.go
@@ -1,0 +1,45 @@
+package redactor
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+)
+
+// urlRedactor redacts all sensitive strings from a message.
+type urlRedactor struct {
+	// sensitive are sensitive strings to be redacted.
+	// The strings should not be empty.
+	sensitive []string
+}
+
+// NewURLRedactor returns a new urlRedactor that redacts
+// credentials found in rawurl, and the rawurl itself.
+func NewURLRedactor(parsedURL *vcs.URL) *urlRedactor {
+	var sensitive []string
+	pw, _ := parsedURL.User.Password()
+	u := parsedURL.User.Username()
+	if pw != "" && u != "" {
+		// Only block password if we have both as we can
+		// assume that the username isn't sensitive in this case
+		sensitive = append(sensitive, pw)
+	} else {
+		if pw != "" {
+			sensitive = append(sensitive, pw)
+		}
+		if u != "" {
+			sensitive = append(sensitive, u)
+		}
+	}
+	sensitive = append(sensitive, parsedURL.String())
+	return &urlRedactor{sensitive: sensitive}
+}
+
+// redact returns a redacted version of message.
+// Sensitive strings are replaced with "<redacted>".
+func (r *urlRedactor) Redact(message string) string {
+	for _, s := range r.sensitive {
+		message = strings.ReplaceAll(message, s, "<redacted>")
+	}
+	return message
+}

--- a/internal/redactor/url_test.go
+++ b/internal/redactor/url_test.go
@@ -1,0 +1,47 @@
+package redactor
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+)
+
+func TestUrlRedactor(t *testing.T) {
+	testCases := []struct {
+		url      string
+		message  string
+		redacted string
+	}{
+		{
+			url:      "http://token@github.com/foo/bar/",
+			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://user:password@github.com/foo/bar/",
+			message:  "fatal: repository 'http://user:password@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://user:<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://git:password@github.com/foo/bar/",
+			message:  "fatal: repository 'http://git:password@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://git:<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://token@github.com///repo//nick/",
+			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			remoteURL, err := vcs.ParseURL(testCase.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual := NewURLRedactor(remoteURL).Redact(testCase.message); actual != testCase.redacted {
+				t.Fatalf("newUrlRedactor(%q).redact(%q) got %q; want %q", testCase.url, testCase.message, actual, testCase.redacted)
+			}
+		})
+	}
+}

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -111,7 +111,7 @@ func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cm
 	val := RecordedCommand{
 		Start:    rc.start,
 		Duration: time.Since(rc.start).Seconds(),
-		Args:     cmd.Args,
+		Args:     redactor.RedactCommandArgs(cmd.Args),
 		Dir:      cmd.Dir,
 		Path:     cmd.Path,
 	}
@@ -157,9 +157,7 @@ func (rf *RecordingCommandFactory) Disable() {
 // Command returns a new RecordingCommand with the ShouldRecordFunc already set.
 func (rf *RecordingCommandFactory) Command(ctx context.Context, logger log.Logger, repoName, cmdName string, args ...string) *RecordingCmd {
 	store := rcache.NewFIFOList(GetFIFOListKey(repoName), rf.maxSize)
-	fmt.Println("args =====> ", args)
-	redactedArgs := redactor.RedactCommandArgs(args)
-	return RecordingCommand(ctx, logger, rf.shouldRecord, store, cmdName, redactedArgs...)
+	return RecordingCommand(ctx, logger, rf.shouldRecord, store, cmdName, args...)
 }
 
 // Wrap constructs a new RecordingCommand based of an existing os/exec.Cmd, while also setting up the ShouldRecordFunc


### PR DESCRIPTION
This PR ensures the commands saved in Redis are redacted; we initially added a redaction function to the Resolver for RecordedCommands.

<img width="989" alt="CleanShot 2023-08-01 at 16 27 35@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/d63f7472-37fa-4a59-8bfd-661122836fd8">

The PR also moves the URLRedactor into a `redactor` package. This makes it usable outside of `gitserver`.
I'm going to leave it as a draft for now for two reasons:

* Get feedback on the downsides to having a `redactor` package.
* Testing this on a perforce connection so I'm certain the `CommandRedactor` function works. 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

* Added unit tests (and will add more as soon as I confirm how the command redactor works for p4 commands).
