### PR TITLE
zoekt: update and observe new timing Stats

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6266,8 +6266,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:VWYAOJEy4iCY5ypRui6xgFGyUWhlq2AtPj3J7BYgzQk=",
-        version = "v0.0.0-20230724134010-f9b3ea5dcf46",
+        sum = "h1:RPuTlekup6EQ41utARp+UiR5kc6smGMPQTmor0Rw84w=",
+        version = "v0.0.0-20230801152445-d57235362dca",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -542,7 +542,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46
+	github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2025,8 +2025,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46 h1:VWYAOJEy4iCY5ypRui6xgFGyUWhlq2AtPj3J7BYgzQk=
-github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
+github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca h1:RPuTlekup6EQ41utARp+UiR5kc6smGMPQTmor0Rw84w=
+github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -187,6 +187,8 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		attribute.Int("stats.shards_skipped", statsAgg.ShardsSkipped),
 		attribute.Int("stats.shards_skipped_filter", statsAgg.ShardsSkippedFilter),
 		attribute.Int64("stats.wait_ms", statsAgg.Wait.Milliseconds()),
+		attribute.Int64("stats.match_tree_construction_ms", statsAgg.MatchTreeConstruction.Milliseconds()),
+		attribute.Int64("stats.match_tree_search_ms", statsAgg.MatchTreeSearch.Milliseconds()),
 		attribute.Int("stats.regexps_considered", statsAgg.RegexpsConsidered),
 		attribute.String("stats.flush_reason", statsAgg.FlushReason.String()),
 	}


### PR DESCRIPTION
We introduced some new search stats we want to hook up to our observability. Additionally this bump includes the following changes:

- https://github.com/sourcegraph/zoekt/commit/9923324317 Create buf-breaking-check.yml
- https://github.com/sourcegraph/zoekt/commit/0f6564bdb9 trace: add service.instance.id
- https://github.com/sourcegraph/zoekt/commit/9c20a034e0 fix tracing
- https://github.com/sourcegraph/zoekt/commit/6a428ad677 SearchOptions: add MaxMatchDisplayCount
- https://github.com/sourcegraph/zoekt/commit/626c7d8f51 introduce DisplayTruncator
- https://github.com/sourcegraph/zoekt/commit/eede122967 gofmt -s -w .
- https://github.com/sourcegraph/zoekt/commit/9559422b7f DisplayTruncator: always apply both limits
- https://github.com/sourcegraph/zoekt/commit/63da184a02 stat: introduce timing stats around shard search
- https://github.com/sourcegraph/zoekt/commit/d57235362d remove bazel

Test Plan: CI

Part of #55483
