### PR TITLE
Remove properties from requireRestart that don't actually do

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -564,13 +564,9 @@ func resolveLatestSettings(ctx context.Context, user *graphqlbackend.UserResolve
 // configuration that is necessary for the web app and is not sensitive/secret.
 func publicSiteConfiguration() schema.SiteConfiguration {
 	c := conf.Get()
-	updateChannel := c.UpdateChannel
-	if updateChannel == "" {
-		updateChannel = "release"
-	}
 	return schema.SiteConfiguration{
 		AuthPublic:                  c.AuthPublic,
-		UpdateChannel:               updateChannel,
+		UpdateChannel:               conf.UpdateChannel(),
 		AuthzEnforceForSiteAdmins:   c.AuthzEnforceForSiteAdmins,
 		DisableNonCriticalTelemetry: c.DisableNonCriticalTelemetry,
 	}

--- a/doc/admin/config/site_config.md
+++ b/doc/admin/config/site_config.md
@@ -24,11 +24,11 @@ All site configuration options and their default values are shown below.
 The following site configuration options require the server to be restarted for the changes to take effect:
 
 ```
-auth.accessTokens
-auth.sessionExpiry
-git.cloneURLToRepositoryName
-searchScopes
-extensions
+auth.providers
+externalURL
+insights.query.worker.concurrency
+insights.commit.indexer.interval
+permissions.syncUsersMaxConcurrency
 ```
 
 ## Editing your site configuration if you cannot access the web UI

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -41,20 +41,11 @@ func ParseConfig(data conftypes.RawUnified) (*Unified, error) {
 // Experimental features are special in that they are denoted individually
 // via e.g. "experimentalFeatures::myFeatureFlag".
 var requireRestart = []string{
-	"auth.accessTokens",
-	"auth.sessionExpiry",
-	"git.cloneURLToRepositoryName",
-	"searchScopes",
-	"extensions",
-	"auth.userOrgMap",
 	"auth.providers",
 	"externalURL",
-	"update.channel",
 	"insights.query.worker.concurrency",
 	"insights.commit.indexer.interval",
-	"codeIntelAutoIndexing.enabled",
 	"permissions.syncUsersMaxConcurrency",
-	"gitHubApp",
 }
 
 // needRestartToApply determines if a restart is needed to apply the changes

--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -782,6 +782,11 @@ var telemetryHTTPProxy = env.Get("TELEMETRY_HTTP_PROXY", "", "if set, HTTP proxy
 
 // check performs an update check and updates the global state.
 func check(logger log.Logger, db database.DB) {
+	// If the update channel is not set to release, we don't do a check.
+	if channel := conf.UpdateChannel(); channel != "release" {
+		return // no update check
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
@@ -890,10 +895,6 @@ func Start(logger log.Logger, db database.DB) {
 		panic("already started")
 	}
 	started = true
-
-	if channel := conf.UpdateChannel(); channel != "release" {
-		return // no update check
-	}
 
 	const delay = 30 * time.Minute
 	scopedLog := logger.Scoped("updatecheck", "checks for updates of services and updates usage telemetry")


### PR DESCRIPTION
This removes a bunch of properties from the list of ones that will show the site-admin a banner that they need to restart their server, because they don't actually do (anymore). 
This hopefully reduces the number of times an admin has to interrupt their workflow to go into the infra and restart. This will also benefit cloud ops where the customer cannot do it themselves.

Reasoning for removal: **Please help me vet that I am not wrong here!!**

- `gitHubApp`: This property is deprecated and not used anymore.
- `codeIntelAutoIndexing.enabled`: This one does not require a server restart, all the background jobs will be running, but return early. The next run they will just work as expected. It does require a page refresh, but that's handled in the SiteAdminConfigurationPage.
- `extensions`: Property no longer exists.
- `auth.sessionExpiry`: This value is used in conf.ContributeValidator and on the request path for SetActor, it's reading the value dynamically so this should not require a restart.
- `auth.accessTokens`: Always read dynamically in resolvers/http handlers. Requires a page refresh, but not a server restart.
- `auth.userOrgMap`: Just used on the user create request path, read dynamically.
- `update.channel`: Fixed by reading the value on each iteration vs not starting the ticker.
- `git.cloneURLToRepositoryName`: Uses conf.Cached, should not require a server restart. None of the accessors of the value seem to cache it anyhow.
- `searchScopes`: Changelog says this was removed, and it doesn't exist anymore in the site.schema.json file.

Maybe next time we can get rid of the remaining ones and entirely eliminate this mechanism for our admins!

## Test plan

Read code carefully to verify that these properties actually don't require a server restart.