### PR TITLE
Use GetStore to create Stores instead of having to know about mocks

### DIFF
--- a/cmd/frontend/graphqlbackend/access_requests.go
+++ b/cmd/frontend/graphqlbackend/access_requests.go
@@ -50,7 +50,7 @@ type accessRequestConnectionStore struct {
 }
 
 func (s *accessRequestConnectionStore) ComputeTotal(ctx context.Context) (*int32, error) {
-	count, err := accessrequests.NewStore(s.db).Count(ctx, s.args)
+	count, err := database.GetStore(s.db, accessrequests.NewStore).Count(ctx, s.args)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (s *accessRequestConnectionStore) ComputeTotal(ctx context.Context) (*int32
 }
 
 func (s *accessRequestConnectionStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]*accessRequestResolver, error) {
-	accessRequests, err := accessrequests.NewStore(s.db).List(ctx, s.args, args)
+	accessRequests, err := database.GetStore(s.db, accessrequests.NewStore).List(ctx, s.args, args)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (r *schemaResolver) SetAccessRequestStatus(ctx context.Context, args *struc
 	}
 
 	err = r.db.WithTransact(ctx, func(tx database.DB) error {
-		store := accessrequests.NewStore(tx)
+		store := database.GetStore(tx, accessrequests.NewStore)
 
 		accessRequest, err := store.GetByID(ctx, id)
 		if err != nil {
@@ -167,7 +167,7 @@ func accessRequestByID(ctx context.Context, db database.DB, id graphql.ID) (*acc
 	if err != nil {
 		return nil, err
 	}
-	accessRequest, err := accessrequests.NewStore(db).GetByID(ctx, accessRequestID)
+	accessRequest, err := database.GetStore(db, accessrequests.NewStore).GetByID(ctx, accessRequestID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/accessrequest/handlers.go
+++ b/internal/auth/accessrequest/handlers.go
@@ -64,7 +64,7 @@ func handleRequestAccess(logger log.Logger, db database.DB, w http.ResponseWrite
 		Email:          data.Email,
 		AdditionalInfo: data.AdditionalInfo,
 	}
-	accessRequestStore := accessrequests.NewStore(db)
+	accessRequestStore := database.GetStore(db, accessrequests.NewStore)
 
 	_, err := accessRequestStore.Create(r.Context(), &accessRequest)
 	if err == nil {

--- a/internal/auth/accessrequest/handlers_test.go
+++ b/internal/auth/accessrequest/handlers_test.go
@@ -104,7 +104,7 @@ func TestRequestAccess(t *testing.T) {
 		handler(res, req)
 		assert.Equal(t, http.StatusCreated, res.Code)
 
-		_, err = accessrequests.NewStore(db).GetByEmail(context.Background(), newUser.Email)
+		_, err = database.GetStore(db, accessrequests.NewStore).GetByEmail(context.Background(), newUser.Email)
 		require.Error(t, err)
 		require.Equal(t, errcode.IsNotFound(err), true)
 	})
@@ -115,8 +115,8 @@ func TestRequestAccess(t *testing.T) {
 			Name:  "a1",
 			Email: "a1@example.com",
 		}
-		accessrequests.NewStore(db).Create(context.Background(), &accessRequest)
-		_, err := accessrequests.NewStore(db).GetByEmail(context.Background(), accessRequest.Email)
+		database.GetStore(db, accessrequests.NewStore).Create(context.Background(), &accessRequest)
+		_, err := database.GetStore(db, accessrequests.NewStore).GetByEmail(context.Background(), accessRequest.Email)
 		require.NoError(t, err)
 
 		req, err := http.NewRequest(http.MethodPost, "/-/request-access", strings.NewReader(fmt.Sprintf(`{"email": "%s", "name": "%s", "additionalInfo": "%s"}`, accessRequest.Email, accessRequest.Name, accessRequest.AdditionalInfo)))
@@ -135,7 +135,7 @@ func TestRequestAccess(t *testing.T) {
 		handler(res, req)
 		assert.Equal(t, http.StatusCreated, res.Code)
 
-		accessRequest, err := accessrequests.NewStore(db).GetByEmail(context.Background(), "a2@example.com")
+		accessRequest, err := database.GetStore(db, accessrequests.NewStore).GetByEmail(context.Background(), "a2@example.com")
 		require.NoError(t, err)
 		assert.Equal(t, "a2", accessRequest.Name)
 		assert.Equal(t, "a2@example.com", accessRequest.Email)

--- a/internal/database/accessrequests/access_requests.go
+++ b/internal/database/accessrequests/access_requests.go
@@ -92,9 +92,6 @@ type store struct {
 }
 
 func NewStore(db database.DB) Store {
-	if mock := database.GetMock[Store](db); mock != nil {
-		return mock
-	}
 	return &store{Store: basestore.NewWithHandle(db.Handle()), logger: db.Logger()}
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -128,11 +128,16 @@ func GetStore[T basestore.ShareableStore](db DB, f NewStoreFunc[T]) T {
 	return f(db)
 }
 
-func Mock[T basestore.ShareableStore](db DB, val T) *mockedDB {
-	return &mockedDB{
-		DB:          db,
-		mockedStore: reflect.ValueOf(val),
+func Mock[T basestore.ShareableStore](db DB, vals ...T) (mdb *mockedDB) {
+	mdb = &mockedDB{DB: db}
+	for val := range vals {
+		mdb = &mockedDB{
+			DB:          mdb,
+			mockedStore: reflect.ValueOf(val),
+		}
 	}
+
+	return mdb
 }
 
 func (d *db) Logger() log.Logger {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -128,12 +128,16 @@ func GetStore[T basestore.ShareableStore](db DB, f NewStoreFunc[T]) T {
 	return f(db)
 }
 
-func Mock[T basestore.ShareableStore](db DB, vals ...T) (mdb *mockedDB) {
-	mdb = &mockedDB{DB: db}
-	for val := range vals {
+func Mock[T basestore.ShareableStore](db DB, val T, vals ...T) (mdb *mockedDB) {
+	mdb = &mockedDB{
+		DB:          db,
+		mockedStore: reflect.ValueOf(val),
+	}
+
+	for v := range vals {
 		mdb = &mockedDB{
 			DB:          mdb,
-			mockedStore: reflect.ValueOf(val),
+			mockedStore: reflect.ValueOf(v),
 		}
 	}
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -115,15 +115,17 @@ func (mdb *mockedDB) WithTransact(ctx context.Context, f func(tx DB) error) erro
 	})
 }
 
-func GetMock[T basestore.ShareableStore](db DB) (t T) {
+type StoreGetterFunc[T basestore.ShareableStore] func(DB) T
+
+func GetStore[T basestore.ShareableStore](db DB, f StoreGetterFunc[T]) (t T) {
 	switch v := db.(type) {
 	case *mockedDB:
 		if v.mockedStore.Type().Implements(reflect.TypeOf((*T)(nil)).Elem()) {
 			return v.mockedStore.Interface().(T)
 		}
-		return GetMock[T](v.DB)
+		return GetStore[T](v.DB, f)
 	}
-	return t
+	return f(db)
 }
 
 func Mock[T basestore.ShareableStore](db DB, val T) *mockedDB {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -115,9 +115,9 @@ func (mdb *mockedDB) WithTransact(ctx context.Context, f func(tx DB) error) erro
 	})
 }
 
-type StoreGetterFunc[T basestore.ShareableStore] func(DB) T
+type NewStoreFunc[T basestore.ShareableStore] func(DB) T
 
-func GetStore[T basestore.ShareableStore](db DB, f StoreGetterFunc[T]) (t T) {
+func GetStore[T basestore.ShareableStore](db DB, f NewStoreFunc[T]) T {
 	switch v := db.(type) {
 	case *mockedDB:
 		if v.mockedStore.Type().Implements(reflect.TypeOf((*T)(nil)).Elem()) {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -128,20 +128,11 @@ func GetStore[T basestore.ShareableStore](db DB, f NewStoreFunc[T]) T {
 	return f(db)
 }
 
-func Mock[T basestore.ShareableStore](db DB, val T, vals ...T) (mdb *mockedDB) {
-	mdb = &mockedDB{
+func Mock[T basestore.ShareableStore](db DB, val T) *mockedDB {
+	return &mockedDB{
 		DB:          db,
 		mockedStore: reflect.ValueOf(val),
 	}
-
-	for v := range vals {
-		mdb = &mockedDB{
-			DB:          mdb,
-			mockedStore: reflect.ValueOf(v),
-		}
-	}
-
-	return mdb
 }
 
 func (d *db) Logger() log.Logger {


### PR DESCRIPTION
Iterates on @camdencheek 's POC improvement. What I'm trying to do here is see if we can make the development of new stores as easy as possible and remove some room for errors.

I renamed the `database.GetMock` function to `database.GetStore`, and it takes an extra parameter: a function that constructs the Store given a DB.

Now the `GetStore` function always returns a Store of the desired type. If `DB` happened to be a `mockedDB` with a mocked Store embedded, then it will return the mocked store. Otherwise it will create a new Store.

When creating a store, you simply do `database.GetStore(db, storetype.NewStore)` and then all the magic happens away from the caller/implementer.

The idea is to think about the Store creation functions the same way we think about `http.HandlerFunc`s .

For `http.HandlerFunc`s, all you need is a function with the signature `func(w http.ResponseWriter, r *http.Request)`

Similarly, a `NewStoreFunc` is a function with the signature `func[T basestore.ShareableStore](db database.DB) T`. This is what the function `database.GetStore` expects.

So, for simple stores, that's straightforward:

```go
func NewStore(db database.DB) Store {
    return &store{db: db}
}

// ...

store := database.GetStore(db, NewStore)
```

But, just like HTTP handlers, sometimes you need extra dependencies inside the handler, like a database connection. But this is still possible, as long as you return a `NewStoreFunc`:

```go
func NewStore(someDependency Thing) database.NewStoreFunc {
    return func(db database.DB) Store {
        return &store{db: db, someDep: someDependency}
    }
}

// ...

someDep := NewSomeDep()
store := database.GetStore(db, NewStore(someDep))
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
