### PR TITLE
bzl: remove from upsteam zoekt repo

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6266,8 +6266,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:VWYAOJEy4iCY5ypRui6xgFGyUWhlq2AtPj3J7BYgzQk=",
-        version = "v0.0.0-20230724134010-f9b3ea5dcf46",
+        sum = "h1:RPuTlekup6EQ41utARp+UiR5kc6smGMPQTmor0Rw84w=",
+        version = "v0.0.0-20230801152445-d57235362dca",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -542,7 +542,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46
+	github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2025,8 +2025,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46 h1:VWYAOJEy4iCY5ypRui6xgFGyUWhlq2AtPj3J7BYgzQk=
-github.com/sourcegraph/zoekt v0.0.0-20230724134010-f9b3ea5dcf46/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
+github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca h1:RPuTlekup6EQ41utARp+UiR5kc6smGMPQTmor0Rw84w=
+github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/third_party/com_github_sourcegraph_zoekt/BUILD.bazel
+++ b/third_party/com_github_sourcegraph_zoekt/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/third_party/com_github_sourcegraph_zoekt/zoekt_archive_index.patch
+++ b/third_party/com_github_sourcegraph_zoekt/zoekt_archive_index.patch
@@ -1,0 +1,13 @@
+diff --git a/cmd/zoekt-archive-index/BUILD.bazel b/cmd/zoekt-archive-index/BUILD.bazel
+index e62a8d2..4b045f7 100644
+--- a/cmd/zoekt-archive-index/BUILD.bazel
++++ b/cmd/zoekt-archive-index/BUILD.bazel
+@@ -22,6 +22,8 @@ go_binary(
+     name = "zoekt-archive-index",
+     embed = [":zoekt-archive-index_lib"],
+     visibility = ["//visibility:public"],
++    pure = "on",
++    static = "on",
+ )
+
+ go_test(

--- a/third_party/com_github_sourcegraph_zoekt/zoekt_git_index.patch
+++ b/third_party/com_github_sourcegraph_zoekt/zoekt_git_index.patch
@@ -1,0 +1,12 @@
+diff --git a/cmd/zoekt-git-index/BUILD.bazel b/cmd/zoekt-git-index/BUILD.bazel
+index 0606281..0ce27ff 100644
+--- a/cmd/zoekt-git-index/BUILD.bazel
++++ b/cmd/zoekt-git-index/BUILD.bazel
+@@ -16,4 +16,6 @@ go_binary(
+     name = "zoekt-git-index",
+     embed = [":zoekt-git-index_lib"],
+     visibility = ["//visibility:public"],
+-)
++    pure = "on",
++    static = "on",
++    )

--- a/third_party/com_github_sourcegraph_zoekt/zoekt_indexserver.patch
+++ b/third_party/com_github_sourcegraph_zoekt/zoekt_indexserver.patch
@@ -1,0 +1,13 @@
+diff --git a/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel b/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel
+index 503fd67..6989a2d 100644
+--- a/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel
++++ b/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel
+@@ -50,6 +50,8 @@ go_binary(
+     name = "zoekt-sourcegraph-indexserver",
+     embed = [":zoekt-sourcegraph-indexserver_lib"],
+     visibility = ["//visibility:public"],
++    pure = "on",
++    static = "on",
+ )
+
+ go_test(

--- a/third_party/com_github_sourcegraph_zoekt/zoekt_webserver.patch
+++ b/third_party/com_github_sourcegraph_zoekt/zoekt_webserver.patch
@@ -1,0 +1,11 @@
+diff --git a/cmd/zoekt-webserver/BUILD.bazel b/cmd/zoekt-webserver/BUILD.bazel
+index 705d454..abb4446 100644
+--- a/cmd/zoekt-webserver/BUILD.bazel
++++ b/cmd/zoekt-webserver/BUILD.bazel
+@@ -83,4 +83,6 @@ go_binary(
+     name = "zoekt-webserver",
+     embed = [":zoekt-webserver_lib"],
+     visibility = ["//visibility:public"],
++    pure = "on",
++    static = "on",
+ )


### PR DESCRIPTION
Updates our reference to the zoekt repo which no longer has bazel. Adds back in the patches we were previously using to ensure we're building statically, as it was observed this affected indexing behaviour in previous testing. 

## Test plan

Tested with images built from this branch on a compose deployment, which no observable issues. 