### PR TITLE
attribution: stop searching as soon as we hit our limit

### DIFF
--- a/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -49,6 +49,22 @@ func TestAttribution(t *testing.T) {
 	if d := cmp.Diff(want, result); d != "" {
 		t.Fatalf("unexpected (-want, +got):\n%s", d)
 	}
+
+	// With a limit of one we expect one of local or dotcom, depending on
+	// which one returns first.
+	result, err = svc.SnippetAttribution(ctx, "test", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.LimitHit {
+		t.Fatal("we expected the limit to be hit")
+	}
+	if len(result.RepositoryNames) != 1 {
+		t.Fatalf("we wanted one result, got %v", result.RepositoryNames)
+	}
+	if name := result.RepositoryNames[0]; name != "localrepo-1" && name != "dotcomrepo-1" {
+		t.Fatalf("we wanted the first result, got %v", result.RepositoryNames)
+	}
 }
 
 func genRepoNames(prefix string, count int) []string {
@@ -106,7 +122,7 @@ func mockDotComClient(t testing.TB, repoNames []string) dotcom.Client {
 			},
 		}
 
-		return nil
+		return ctx.Err()
 	})
 }
 

--- a/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/enterprise/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -122,7 +122,7 @@ func mockDotComClient(t testing.TB, repoNames []string) dotcom.Client {
 			},
 		}
 
-		return ctx.Err()
+		return context.Cause(ctx)
 	})
 }
 


### PR DESCRIPTION
For the implementation of filtering we will always have a limit of 1 when searching attribution. This is an optimization so we can stop searching once we have a result from dotcom or the local instance.

Test Plan: added unit test

Part of https://github.com/sourcegraph/sourcegraph/issues/55451