### PR TITLE
Add API version header to Anthropic API requests

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -58,6 +58,7 @@ func NewAnthropicHandler(
 				r.Header.Set("Content-Type", "application/json")
 				r.Header.Set("Client", "sourcegraph-cody-gateway/1.0")
 				r.Header.Set("X-API-Key", accessToken)
+				r.Header.Set("anthropic-version", "2023-01-01")
 			},
 			parseResponse: func(reqBody anthropicRequest, r io.Reader) int {
 				// Try to parse the request we saw, if it was non-streaming, we can simply parse

--- a/internal/completions/client/anthropic/anthropic.go
+++ b/internal/completions/client/anthropic/anthropic.go
@@ -135,6 +135,12 @@ func (a *anthropicClient) makeRequest(ctx context.Context, requestParams types.C
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Client", clientID)
 	req.Header.Set("X-API-Key", a.accessToken)
+	// Set the API version so responses are in the expected format.
+	// NOTE: When changing this here, Cody Gateway currently overwrites this header
+	// with 2023-01-01, so it will not be respected in Gateway usage and we will
+	// have to fall back to the old parser, or implement a mechanism on the Gateway
+	// side that understands the version header we send here and switch out the parser.
+	req.Header.Set("anthropic-version", "2023-01-01")
 
 	resp, err := a.cli.Do(req)
 	if err != nil {


### PR DESCRIPTION
They recently introduced API versioning, so to be safe that we always get the correct API version that we currently support, we should set this header going forward.

Next up we can switch to the new API which allows incremental streaming, but that will take more engineering effort.

## Test plan

Verified Cody still works.