### PR TITLE
Wb/sg/rfc fixups

### DIFF
--- a/dev/sg/internal/rfc/rfc_create.go
+++ b/dev/sg/internal/rfc/rfc_create.go
@@ -13,14 +13,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type RfcTemplate string
+type Template struct {
+	Name    string
+	DriveID string
+}
 
 // Template: RFC to frame a problem, propose a solution, and drive a decision.
 // https://docs.google.com/document/d/1FJ6AhHmVInSE22EHcDZnzvvAd9KfwOkKvFpx7e346z4
-const ProblemSolutionDriveTemplate = RfcTemplate("1FJ6AhHmVInSE22EHcDZnzvvAd9KfwOkKvFpx7e346z4")
+var ProblemSolutionDriveTemplate = Template{Name: "solution", DriveID: "1FJ6AhHmVInSE22EHcDZnzvvAd9KfwOkKvFpx7e346z4"}
 
-func Create(ctx context.Context, rfcType RfcTemplate, title string, driveSpec DriveSpec, out *std.Output) error {
-	newFile, newRfcID, err := createMainDoc(ctx, title, rfcType, driveSpec, out)
+// AllTemplates contains all the RFC temaplates that one can use when creating a new RFC
+var AllTemplates = []Template{ProblemSolutionDriveTemplate}
+
+func Create(ctx context.Context, template Template, title string, driveSpec DriveSpec, out *std.Output) error {
+	newFile, newRfcID, err := createMainDoc(ctx, title, template, driveSpec, out)
 	if err != nil {
 		return errors.Wrap(err, "cannot create RFC")
 	}
@@ -207,14 +213,14 @@ func updateContent(ctx context.Context, newFile *drive.File, nextRfcID int, titl
 	return nil
 }
 
-func createMainDoc(ctx context.Context, title string, rfcTemplate RfcTemplate, driveSpec DriveSpec,
+func createMainDoc(ctx context.Context, title string, template Template, driveSpec DriveSpec,
 	out *std.Output) (*drive.File, int, error) {
 	srv, err := getService(ctx, ScopePermissionsReadWrite, out)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	template, err := srv.Files.Get(string(rfcTemplate)).
+	templateFile, err := srv.Files.Get(template.DriveID).
 		Context(ctx).
 		SupportsTeamDrives(true).
 		SupportsAllDrives(true).
@@ -222,7 +228,7 @@ func createMainDoc(ctx context.Context, title string, rfcTemplate RfcTemplate, d
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "failed to get template")
 	}
-	out.Write(fmt.Sprintf("Using template: %s", template.Name))
+	out.Write(fmt.Sprintf("Using template: %s", templateFile.Name))
 
 	nextRfcID, err := findNextRfcID(ctx, out)
 	if err != nil {
@@ -238,7 +244,7 @@ func createMainDoc(ctx context.Context, title string, rfcTemplate RfcTemplate, d
 		Parents: []string{driveSpec.FolderID},
 	}
 
-	newFile, err := srv.Files.Copy(template.Id, &newFileDetails).
+	newFile, err := srv.Files.Copy(templateFile.Id, &newFileDetails).
 		SupportsAllDrives(true).
 		SupportsTeamDrives(true).
 		Do()

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -116,22 +116,22 @@ sg rfc --private create --type <type> "title"
 
 				rfcType := c.String("type")
 
-				var template *rfc.Template
+				var template rfc.Template
 				// Search for the rfcType and assign it to template
 				for _, tpl := range rfc.AllTemplates {
 					if tpl.Name == rfcType {
-						template = &tpl
+						template = tpl
 						break
 					}
 				}
-				if template == nil {
+				if template.Name == "" {
 					return errors.New(fmt.Sprintf("Unknown RFC type: %s", rfcType))
 				}
 
 				if c.Args().Len() == 0 {
 					return errors.New("no title given")
 				}
-				return rfc.Create(c.Context, *template, strings.Join(c.Args().Slice(), " "),
+				return rfc.Create(c.Context, template, strings.Join(c.Args().Slice(), " "),
 					driveSpec, std.Out)
 			},
 		},

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -99,12 +99,12 @@ sg rfc --private create --type <type> "title"
 		},
 		{
 			Name:      "create",
-			ArgsUsage: "--type <type> <title...>",
+			ArgsUsage: "--type <type> [title...]",
 			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:     "type",
-					Usage:    "the type of the RFC to create (valid: solution)",
-					Required: true,
+					Name:  "type",
+					Usage: "the type of the RFC to create (valid: solution)",
+					Value: rfc.ProblemSolutionDriveTemplate.Name,
 				},
 			},
 			Usage: "Create Sourcegraph RFCs",
@@ -113,18 +113,25 @@ sg rfc --private create --type <type> "title"
 				if c.Bool("private") {
 					driveSpec = rfc.PrivateDrive
 				}
+
 				rfcType := c.String("type")
-				var rfcTemplate rfc.RfcTemplate
-				switch rfcType {
-				case "solution":
-					rfcTemplate = rfc.ProblemSolutionDriveTemplate
-				default:
+
+				var template *rfc.Template
+				// Search for the rfcType and assign it to template
+				for _, tpl := range rfc.AllTemplates {
+					if tpl.Name == rfcType {
+						template = &tpl
+						break
+					}
+				}
+				if template == nil {
 					return errors.New(fmt.Sprintf("Unknown RFC type: %s", rfcType))
 				}
+
 				if c.Args().Len() == 0 {
 					return errors.New("no title given")
 				}
-				return rfc.Create(c.Context, rfcTemplate, strings.Join(c.Args().Slice(), " "),
+				return rfc.Create(c.Context, *template, strings.Join(c.Args().Slice(), " "),
 					driveSpec, std.Out)
 			},
 		},

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1517,12 +1517,12 @@ Flags:
 
 Create Sourcegraph RFCs.
 
-Arguments: `--type <type> <title...>`
+Arguments: `--type <type> [title...]`
 
 Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
-* `--type="<value>"`: the type of the RFC to create (valid: solution)
+* `--type="<value>"`: the type of the RFC to create (valid: solution) (default: solution)
 
 ## sg adr
 


### PR DESCRIPTION
- There is only one template currently so make that the default for when creating an RFC
- Change the RFC Template type into a struct so that we can assign names to templates and refer to them else where

## Test plan
Tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
