### PR TITLE
grpc: monitoring: fix method label query

### DIFF
--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -11,8 +11,12 @@ import (
 )
 
 func Frontend() *monitoring.Dashboard {
-	// frontend is sometimes called sourcegraph-frontend in various contexts
-	const containerName = "(frontend|sourcegraph-frontend)"
+	const (
+		// frontend is sometimes called sourcegraph-frontend in various contexts
+		containerName = "(frontend|sourcegraph-frontend)"
+
+		grpcZoektConfigurationServiceName = "sourcegraph.zoekt.configuration.v1.ZoektConfigurationService"
+	)
 
 	var sentinelSamplingIntervals []string
 	for _, d := range []time.Duration{
@@ -28,7 +32,7 @@ func Frontend() *monitoring.Dashboard {
 	}
 
 	defaultSamplingInterval := (90 * time.Minute).Round(time.Second)
-	grpcMethodVariable := shared.GRPCMethodVariable("frontend")
+	grpcMethodVariable := shared.GRPCMethodVariable(grpcZoektConfigurationServiceName)
 
 	orgMetricSpec := []struct{ name, route, description string }{
 		{"org_members", "OrganizationMembers", "API requests to list organisation members"},
@@ -405,7 +409,7 @@ func Frontend() *monitoring.Dashboard {
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{
 					HumanServiceName:   "frontend",
-					RawGRPCServiceName: "sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",
+					RawGRPCServiceName: grpcZoektConfigurationServiceName,
 
 					MethodFilterRegex:   fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 					InstanceFilterRegex: `${internalInstance:regex}`,
@@ -413,7 +417,7 @@ func Frontend() *monitoring.Dashboard {
 			shared.NewGRPCInternalErrorMetricsGroup(
 				shared.GRPCInternalErrorMetricsOptions{
 					HumanServiceName:   "frontend",
-					RawGRPCServiceName: "sourcegraph.zoekt.configuration.v1.ZoektConfigurationService",
+					RawGRPCServiceName: grpcZoektConfigurationServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 				}, monitoring.ObservableOwnerSearchCore),

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -9,7 +9,10 @@ import (
 )
 
 func GitServer() *monitoring.Dashboard {
-	const containerName = "gitserver"
+	const (
+		containerName   = "gitserver"
+		grpcServiceName = "gitserver.v1.GitserverService"
+	)
 
 	gitserverHighMemoryNoAlertTransformer := func(observable shared.Observable) shared.Observable {
 		return observable.WithNoAlerts(`Git Server is expected to use up all the memory it is provided.`)
@@ -20,7 +23,7 @@ func GitServer() *monitoring.Dashboard {
 		ShortTermMemoryUsage: gitserverHighMemoryNoAlertTransformer,
 	}
 
-	grpcMethodVariable := shared.GRPCMethodVariable(containerName)
+	grpcMethodVariable := shared.GRPCMethodVariable(grpcServiceName)
 
 	return &monitoring.Dashboard{
 		Name:        "gitserver",
@@ -535,7 +538,7 @@ func GitServer() *monitoring.Dashboard {
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{
 					HumanServiceName:   "gitserver",
-					RawGRPCServiceName: "gitserver.v1.GitserverService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex:   fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 					InstanceFilterRegex: `${shard:regex}`,
@@ -544,7 +547,7 @@ func GitServer() *monitoring.Dashboard {
 			shared.NewGRPCInternalErrorMetricsGroup(
 				shared.GRPCInternalErrorMetricsOptions{
 					HumanServiceName:   "gitserver",
-					RawGRPCServiceName: "gitserver.v1.GitserverService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 				}, monitoring.ObservableOwnerSearchCore),

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -10,7 +10,8 @@ import (
 
 func RepoUpdater() *monitoring.Dashboard {
 	const (
-		containerName = "repo-updater"
+		containerName   = "repo-updater"
+		grpcServiceName = "repoupdater.v1.RepoUpdaterService"
 
 		// This is set a bit longer than maxSyncInterval in internal/repos/syncer.go
 		syncDurationThreshold = 9 * time.Hour
@@ -22,7 +23,7 @@ func RepoUpdater() *monitoring.Dashboard {
 		},
 	}
 
-	grpcMethodVariable := shared.GRPCMethodVariable("repo_updater")
+	grpcMethodVariable := shared.GRPCMethodVariable(grpcServiceName)
 
 	return &monitoring.Dashboard{
 		Name:        "repo-updater",
@@ -577,7 +578,7 @@ func RepoUpdater() *monitoring.Dashboard {
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{
 					HumanServiceName:   "repo_updater",
-					RawGRPCServiceName: "repoupdater.v1.RepoUpdaterService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex:   fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 					InstanceFilterRegex: `${instance:regex}`,
@@ -586,7 +587,7 @@ func RepoUpdater() *monitoring.Dashboard {
 			shared.NewGRPCInternalErrorMetricsGroup(
 				shared.GRPCInternalErrorMetricsOptions{
 					HumanServiceName:   "repo_updater",
-					RawGRPCServiceName: "repoupdater.v1.RepoUpdaterService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 				}, monitoring.ObservableOwnerSource),

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -10,9 +10,12 @@ import (
 )
 
 func Searcher() *monitoring.Dashboard {
-	const containerName = "searcher"
+	const (
+		containerName   = "searcher"
+		grpcServiceName = "searcher.v1.SearcherService"
+	)
 
-	grpcMethodVariable := shared.GRPCMethodVariable(containerName)
+	grpcMethodVariable := shared.GRPCMethodVariable(grpcServiceName)
 
 	// instanceSelector is a helper for inserting the instance selector.
 	// Should be used on strings created via `` since you can't escape in
@@ -221,7 +224,7 @@ regularly above 0 it is a sign for further investigation.`,
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{
 					HumanServiceName:   "searcher",
-					RawGRPCServiceName: "searcher.v1.SearcherService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 
@@ -231,7 +234,7 @@ regularly above 0 it is a sign for further investigation.`,
 			shared.NewGRPCInternalErrorMetricsGroup(
 				shared.GRPCInternalErrorMetricsOptions{
 					HumanServiceName:   "searcher",
-					RawGRPCServiceName: "searcher.v1.SearcherService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 				}, monitoring.ObservableOwnerSearchCore),

--- a/monitoring/definitions/shared/grpc.go
+++ b/monitoring/definitions/shared/grpc.go
@@ -445,11 +445,12 @@ func NewGRPCInternalErrorMetricsGroup(opts GRPCInternalErrorMetricsOptions, owne
 
 // GRPCMethodVariable creates a container variable that contains all the gRPC methods
 // exposed by the given service.
-func GRPCMethodVariable(serviceNamespace string) monitoring.ContainerVariable {
-	query := "grpc_server_started_total"
-	if serviceNamespace != "" {
-		query = fmt.Sprintf("%s_%s", serviceNamespace, query)
-	}
+//
+// services is a list of the full, dot-separated, code-generated gRPC service names that we're gathering metrics for
+// (e.g. "gitserver.v1.GitserverService").
+func GRPCMethodVariable(services ...string) monitoring.ContainerVariable {
+	servicesRegex := fmt.Sprintf(`(%s)`, strings.Join(services, "|"))
+	query := fmt.Sprintf("grpc_server_started_total{grpc_service=~`%s`}", servicesRegex)
 
 	return monitoring.ContainerVariable{
 		Label: "RPC Method",
@@ -459,6 +460,7 @@ func GRPCMethodVariable(serviceNamespace string) monitoring.ContainerVariable {
 			LabelName:     "grpc_method",
 			ExampleOption: "Exec",
 		},
+
 		Multi: true,
 	}
 }

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -8,9 +8,12 @@ import (
 )
 
 func Symbols() *monitoring.Dashboard {
-	const containerName = "symbols"
+	const (
+		containerName   = "symbols"
+		grpcServiceName = "symbols.v1.SymbolsService"
+	)
 
-	grpcMethodVariable := shared.GRPCMethodVariable(containerName)
+	grpcMethodVariable := shared.GRPCMethodVariable(grpcServiceName)
 
 	return &monitoring.Dashboard{
 		Name:        "symbols",
@@ -27,7 +30,7 @@ func Symbols() *monitoring.Dashboard {
 				},
 				Multi: true,
 			},
-			shared.GRPCMethodVariable(containerName),
+			grpcMethodVariable,
 		},
 		Groups: []monitoring.Group{
 			shared.CodeIntelligence.NewSymbolsAPIGroup(containerName),
@@ -39,7 +42,7 @@ func Symbols() *monitoring.Dashboard {
 			shared.NewGRPCServerMetricsGroup(
 				shared.GRPCServerMetricsOptions{
 					HumanServiceName:   containerName,
-					RawGRPCServiceName: "symbols.v1.SymbolsService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex:   fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 					InstanceFilterRegex: `${instance:regex}`,
@@ -48,7 +51,7 @@ func Symbols() *monitoring.Dashboard {
 			shared.NewGRPCInternalErrorMetricsGroup(
 				shared.GRPCInternalErrorMetricsOptions{
 					HumanServiceName:   containerName,
-					RawGRPCServiceName: "symbols.v1.SymbolsService",
+					RawGRPCServiceName: grpcServiceName,
 
 					MethodFilterRegex: fmt.Sprintf("${%s:regex}", grpcMethodVariable.Name),
 				}, monitoring.ObservableOwnerCodeIntel),


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/55498, I removed the extra namespace from all the gRPC service metrics.

However, I missed that the method variable (which we use to be able to filter metrics for an individual method) definition was still referencing the old namespace. This had the inadvertent effect of breaking most of the gRPC dashboards on sourcegraph.com - since the metrics they were looking for didn't exist.

This PR fixes this by replacing the namespace in the definition with a grpc_service label filter.

## Test plan

Local testing
