### PR TITLE
blob: Always select search input value when pressing Mod-f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Sourcegraph are documented in this file.
 - OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)
 - Bitbucket Cloud code host connections no longer automatically syncs the repository of the username used. The appropriate workspace name will have to be added to the `teams` list if repositories for that account need to be synced. [#55095](https://github.com/sourcegraph/sourcegraph/pull/55095)
 - The gRPC implementation for the Symbol service's `LocalCodeIntel` endpoint has been changed to stream its results. [#55242](https://github.com/sourcegraph/sourcegraph/pull/55242)
+- Pressing `Mod-f` will always select the input value in the file view search [#55546](https://github.com/sourcegraph/sourcegraph/pull/55546)
 
 ### Fixed
 


### PR DESCRIPTION
Resolves #54810

Browsers' built-in search input will select the input value when pressing Mod-f, even when the focus is already on the search input.

The default CodeMirror behavior will only select the input value when the input is not already focused. This PR changes the behavior to match the browser's behavior.



## Test plan

- Open file page
- Press `Mod-f` to open file search
- Type any input value
- Press `Mod-f` again -> input value is selected