### PR TITLE
embeddings: apply model transformations (backport #54302 to 5.1)

### DIFF
--- a/enterprise/cmd/embeddings/qa/embed_queries/main.go
+++ b/enterprise/cmd/embeddings/qa/embed_queries/main.go
@@ -69,7 +69,7 @@ func embedQueries(queries []string, siteConfigPath string) error {
 		if err != nil {
 			return err
 		}
-		result, err := c.GetEmbeddings(ctx, []string{query})
+		result, err := c.GetQueryEmbedding(ctx, query)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get embeddings for query %s", query)
 		}

--- a/enterprise/cmd/embeddings/shared/main.go
+++ b/enterprise/cmd/embeddings/shared/main.go
@@ -176,8 +176,7 @@ func getQueryEmbedding(ctx context.Context, query string) ([]float32, string, er
 		return nil, "", errors.Wrap(err, "getting embeddings client")
 	}
 
-	embeddings, err := client.GetEmbeddings(ctx, []string{query})
-
+	embeddings, err := client.GetQueryEmbedding(ctx, query)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "getting query embedding")
 	}

--- a/internal/embeddings/embed/client/azureopenai/BUILD.bazel
+++ b/internal/embeddings/embed/client/azureopenai/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//internal/conf/conftypes",
         "//internal/embeddings/embed/client",
+        "//internal/embeddings/embed/client/modeltransformations",
         "//lib/errors",
     ],
 )

--- a/internal/embeddings/embed/client/azureopenai/client_test.go
+++ b/internal/embeddings/embed/client/azureopenai/client_test.go
@@ -17,7 +17,7 @@ func TestAzureOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
 		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
 		invalidTexts := []string{"a", ""} // empty string is invalid
-		_, err := client.GetEmbeddings(context.Background(), invalidTexts)
+		_, err := client.GetDocumentEmbeddings(context.Background(), invalidTexts)
 		require.ErrorContains(t, err, "empty string")
 	})
 
@@ -65,7 +65,7 @@ func TestAzureOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{Dimensions: 1536})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a"})
+		resp, err := client.GetQueryEmbedding(context.Background(), "a")
 		require.NoError(t, err)
 		var expected []float32
 		{
@@ -114,7 +114,7 @@ func TestAzureOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{Dimensions: 1536, ExcludeChunkOnError: true})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err, "expected request to succeed")
 		var expected []float32
 		{
@@ -154,7 +154,7 @@ func TestAzureOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{Dimensions: 1536})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err, "expected request to succeed")
 		var expected []float32
 		{

--- a/internal/embeddings/embed/client/client.go
+++ b/internal/embeddings/embed/client/client.go
@@ -6,8 +6,10 @@ import (
 )
 
 type EmbeddingsClient interface {
-	// GetEmbeddings returns embeddings for the given texts.
-	GetEmbeddings(ctx context.Context, texts []string) (*EmbeddingsResults, error)
+	// GetQueryEmbedding returns embedding for the given query.
+	GetQueryEmbedding(ctx context.Context, query string) (*EmbeddingsResults, error)
+	// GetDocumentEmbeddings returns embeddings for the documents (code, text).
+	GetDocumentEmbeddings(ctx context.Context, documents []string) (*EmbeddingsResults, error)
 	// GetDimensions returns the dimensionality of the embedding space.
 	GetDimensions() (int, error)
 	// GetModelIdentifier returns the identifier of the model used to generate embeddings. The format is

--- a/internal/embeddings/embed/client/modeltransformations/BUILD.bazel
+++ b/internal/embeddings/embed/client/modeltransformations/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "modeltransformations",
+    srcs = ["model_transformations.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/modeltransformations",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "modeltransformations_test",
+    srcs = ["model_transformations_test.go"],
+    embed = [":modeltransformations"],
+    deps = ["@com_github_stretchr_testify//require"],
+)

--- a/internal/embeddings/embed/client/modeltransformations/model_transformations.go
+++ b/internal/embeddings/embed/client/modeltransformations/model_transformations.go
@@ -1,0 +1,46 @@
+package modeltransformations
+
+import "strings"
+
+// Replace newlines for certain (OpenAI) models, because they can negatively affect performance.
+var modelsWithoutNewlines = map[string]struct{}{
+	"openai/text-embedding-ada-002": {},
+}
+
+const E5_QUERY_PREFIX = "query: "
+const E5_DOCUMENT_PREFIX = "passage: "
+
+func isE5LikeModel(model string) bool {
+	parts := strings.Split(model, "/")
+	modelName := parts[len(parts)-1]
+	return strings.HasPrefix(modelName, "scout") || strings.HasPrefix(modelName, "e5")
+}
+
+func ApplyToQuery(query string, model string) string {
+	transformedQuery := query
+	if isE5LikeModel(model) {
+		transformedQuery = E5_QUERY_PREFIX + transformedQuery
+	}
+	_, replaceNewlines := modelsWithoutNewlines[model]
+	if replaceNewlines {
+		transformedQuery = strings.ReplaceAll(transformedQuery, "\n", " ")
+	}
+	return transformedQuery
+}
+
+func ApplyToDocuments(documents []string, model string) []string {
+	_, replaceNewlines := modelsWithoutNewlines[model]
+	hasE5Prefix := isE5LikeModel(model)
+
+	transformedDocuments := make([]string, len(documents))
+	for idx, document := range documents {
+		transformedDocuments[idx] = document
+		if hasE5Prefix {
+			transformedDocuments[idx] = E5_DOCUMENT_PREFIX + transformedDocuments[idx]
+		}
+		if replaceNewlines {
+			transformedDocuments[idx] = strings.ReplaceAll(transformedDocuments[idx], "\n", " ")
+		}
+	}
+	return transformedDocuments
+}

--- a/internal/embeddings/embed/client/modeltransformations/model_transformations_test.go
+++ b/internal/embeddings/embed/client/modeltransformations/model_transformations_test.go
@@ -1,0 +1,38 @@
+package modeltransformations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const query = "query1\nquery2\nquery3"
+
+var documents = []string{
+	"line1\nline2\nline3",
+	"line4\nline5\nline6",
+}
+
+func TestOpenAIModel(t *testing.T) {
+	transformedQuery := ApplyToQuery(query, "openai/text-embedding-ada-002")
+	require.Equal(t, "query1 query2 query3", transformedQuery)
+
+	transformedDocuments := ApplyToDocuments(documents, "openai/text-embedding-ada-002")
+	require.Equal(t, []string{"line1 line2 line3", "line4 line5 line6"}, transformedDocuments)
+}
+
+func TestE5LikeModel(t *testing.T) {
+	transformedQuery := ApplyToQuery(query, "sourcegraph/scout-base-v2")
+	require.Equal(t, "query: query1\nquery2\nquery3", transformedQuery)
+
+	transformedDocuments := ApplyToDocuments(documents, "sourcegraph/scout-base-v2")
+	require.Equal(t, []string{"passage: line1\nline2\nline3", "passage: line4\nline5\nline6"}, transformedDocuments)
+}
+
+func TestModelWithoutTransformations(t *testing.T) {
+	transformedQuery := ApplyToQuery(query, "no-transform")
+	require.Equal(t, query, transformedQuery)
+
+	transformedDocuments := ApplyToDocuments(documents, "no-transform")
+	require.Equal(t, documents, transformedDocuments)
+}

--- a/internal/embeddings/embed/client/openai/BUILD.bazel
+++ b/internal/embeddings/embed/client/openai/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//internal/conf/conftypes",
         "//internal/embeddings/embed/client",
+        "//internal/embeddings/embed/client/modeltransformations",
         "//lib/errors",
     ],
 )

--- a/internal/embeddings/embed/client/openai/client_test.go
+++ b/internal/embeddings/embed/client/openai/client_test.go
@@ -8,15 +8,16 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 
 func TestOpenAI(t *testing.T) {
 	t.Run("errors on empty embedding string", func(t *testing.T) {
 		client := NewClient(http.DefaultClient, &conftypes.EmbeddingsConfig{})
 		invalidTexts := []string{"a", ""} // empty string is invalid
-		_, err := client.GetEmbeddings(context.Background(), invalidTexts)
+		_, err := client.GetDocumentEmbeddings(context.Background(), invalidTexts)
 		require.ErrorContains(t, err, "empty string")
 	})
 
@@ -67,7 +68,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err)
 		var expected []float32
 		{
@@ -123,7 +124,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b", "c"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b", "c"})
 		require.NoError(t, err)
 		var expected []float32
 		{

--- a/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
+++ b/internal/embeddings/embed/client/sourcegraph/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//internal/codygateway",
         "//internal/conf/conftypes",
         "//internal/embeddings/embed/client",
+        "//internal/embeddings/embed/client/modeltransformations",
         "//lib/errors",
     ],
 )

--- a/internal/embeddings/embed/client/sourcegraph/client_test.go
+++ b/internal/embeddings/embed/client/sourcegraph/client_test.go
@@ -8,9 +8,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOpenAI(t *testing.T) {
@@ -61,7 +62,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(httpClient, &conftypes.EmbeddingsConfig{Dimensions: 1536})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b"})
 		require.NoError(t, err)
 		var expected []float32
 		{
@@ -119,7 +120,7 @@ func TestOpenAI(t *testing.T) {
 		})
 
 		client := NewClient(s.Client(), &conftypes.EmbeddingsConfig{Dimensions: dimensions})
-		resp, err := client.GetEmbeddings(context.Background(), []string{"a", "b", "c"})
+		resp, err := client.GetDocumentEmbeddings(context.Background(), []string{"a", "b", "c"})
 		require.NoError(t, err)
 		var expected []float32
 		{

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -243,7 +243,7 @@ func embedFiles(
 			batchChunks[idx] = chunk.Content
 		}
 
-		batchEmbeddings, err := embeddingsClient.GetEmbeddings(ctx, batchChunks)
+		batchEmbeddings, err := embeddingsClient.GetDocumentEmbeddings(ctx, batchChunks)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while getting embeddings")
 		}


### PR DESCRIPTION
Add support for model-specific transformations. We have to:

* replace newlines with spaces for OpenAI (already implemented)
* add query-specific and document (code chunk)-specific prefixes for the E5 family of models.

* Embed with the OpenAI model and confirm the search still works.
* Embed with the Scout model and confirm the search still works.

(cherry picked from commit c022d9411cdb8953d3c9fc9613fd60b70c92c08d)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
