### PR TITLE
Update CSS for `subtitle` class

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -696,10 +696,10 @@ body > #page > main > #content {
 }
 
 .markdown-body .subtitle {
-  font-weight: 600;
-  margin-top: -0.5em;
-  font-size: 1.3rem;
-  color: var(--text-muted);
+    font-weight: 250;
+    margin-top: -1em;
+    font-size: 1.1rem;
+    color: var(--text-muted);
 }
 
 .markdown-body .lead {


### PR DESCRIPTION
The current styling for the subtitle class is very thick and dense. This PR adds some CSS updates making it look minimal and visually appealing.

## Preview

- Here

## Before

<img width="674" alt="CleanShot 2023-08-03 at 23 50 26@2x" src="https://github.com/sourcegraph/sourcegraph/assets/12712988/a6551ae8-4513-4d01-acf6-c7ff4e0bbfdb">


## After

<img width="629" alt="CleanShot 2023-08-03 at 23 50 58@2x" src="https://github.com/sourcegraph/sourcegraph/assets/12712988/9618a2cc-676b-4347-b1e6-bfed874b0232">


 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
