### PR TITLE
JetBrains: Cody: Removing common suffix when multiline autocomplete is rendered

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineAutoCompleteItem.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineAutoCompleteItem.java
@@ -70,9 +70,7 @@ public class InlineAutoCompleteItem {
         !sameLineSuffix.isEmpty() && sameLineRawAutocomplete.contains(sameLineSuffix);
     int lastSuffixIndex = sameLineRawAutocomplete.lastIndexOf(sameLineSuffix);
     String sameLineBeforeSuffixText =
-        needAfterEndOfLineSuffix
-            ? sameLineRawAutocomplete.substring(0, lastSuffixIndex)
-            : sameLineRawAutocomplete;
+        removeCommonSuffix(sameLineRawAutocomplete, sameLineSuffix);
     String afterEndOfLineSuffix =
         needAfterEndOfLineSuffix
             ? sameLineRawAutocomplete.substring(lastSuffixIndex + sameLineSuffix.length())
@@ -82,5 +80,20 @@ public class InlineAutoCompleteItem {
             ? this.insertText.lines().skip(1).collect(Collectors.joining(System.lineSeparator()))
             : "";
     return new AutoCompleteText(sameLineBeforeSuffixText, afterEndOfLineSuffix, blockText);
+  }
+
+  private String removeCommonSuffix(String str1, String str2) {
+    int len1 = str1.length();
+    int len2 = str2.length();
+    int minLength = Math.min(len1, len2);
+    int i = 1;
+
+    // Iterate from the end and find the first character that differs
+    while (i <= minLength && str1.charAt(len1 - i) == str2.charAt(len2 - i)) {
+      i++;
+    }
+
+    // Remove the common suffix
+    return i > 1 ? str1.substring(0, len1 - i + 1) : str1;
   }
 }


### PR DESCRIPTION
It fixes this issue [JetBrains: Cody: Overwrite the current line suffix when it's not included in multiline autocomplete #253](https://github.com/sourcegraph/cody/issues/253)
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
Prerequisites:
* Cody plugin installed and autocompletion enabled:
![Screenshot 2023-08-04 at 15 57 45](https://github.com/sourcegraph/sourcegraph/assets/9321940/f2f7bbeb-7feb-4d7b-8950-27a9cada7cc3)

Steps:
* Write some code that is most likely to generate multiline autocomplete with same suffix, for example:
<img width="391" alt="Screenshot 2023-08-04 at 16 35 16" src="https://github.com/sourcegraph/sourcegraph/assets/9321940/7e1e71f3-0e3b-47f9-be1e-5997d9816308">
