### PR TITLE
sveltekit: Enable graphql generation and inspect modes

### DIFF
--- a/client/shared/dev/generateGraphQlOperations.js
+++ b/client/shared/dev/generateGraphQlOperations.js
@@ -72,38 +72,40 @@ const PRETTIER = path.join(path.dirname(require.resolve('prettier')), 'bin-prett
  */
 async function generateGraphQlOperations() {
   try {
-    await _generateGraphQlOperations([
-      {
-        interfaceNameForOperations: 'BrowserGraphQlOperations',
-        outputPath: path.join(BROWSER_FOLDER, './src/graphql-operations.ts'),
-      },
-      {
-        interfaceNameForOperations: 'WebGraphQlOperations',
-        outputPath: path.join(WEB_FOLDER, './src/graphql-operations.ts'),
-      },
-      {
-        interfaceNameForOperations: 'SvelteKitGraphQlOperations',
-        outputPath: path.join(SVELTEKIT_FOLDER, './src/lib/graphql-operations.ts'),
-      },
-      {
-        interfaceNameForOperations: 'SharedGraphQlOperations',
-        outputPath: path.join(SHARED_FOLDER, './src/graphql-operations.ts'),
-      },
-      {
-        interfaceNameForOperations: 'VSCodeGraphQlOperations',
-        outputPath: path.join(VSCODE_FOLDER, './src/graphql-operations.ts'),
-      },
-      {
-        interfaceNameForOperations: 'JetBrainsGraphQlOperations',
-        outputPath: path.join(JETBRAINS_FOLDER, './webview/src/graphql-operations.ts'),
-      },
-    ])
+    await generate(
+      createCodegenConfig([
+        {
+          interfaceNameForOperations: 'BrowserGraphQlOperations',
+          outputPath: path.join(BROWSER_FOLDER, './src/graphql-operations.ts'),
+        },
+        {
+          interfaceNameForOperations: 'WebGraphQlOperations',
+          outputPath: path.join(WEB_FOLDER, './src/graphql-operations.ts'),
+        },
+        {
+          interfaceNameForOperations: 'SvelteKitGraphQlOperations',
+          outputPath: path.join(SVELTEKIT_FOLDER, './src/lib/graphql-operations.ts'),
+        },
+        {
+          interfaceNameForOperations: 'SharedGraphQlOperations',
+          outputPath: path.join(SHARED_FOLDER, './src/graphql-operations.ts'),
+        },
+        {
+          interfaceNameForOperations: 'VSCodeGraphQlOperations',
+          outputPath: path.join(VSCODE_FOLDER, './src/graphql-operations.ts'),
+        },
+        {
+          interfaceNameForOperations: 'JetBrainsGraphQlOperations',
+          outputPath: path.join(JETBRAINS_FOLDER, './webview/src/graphql-operations.ts'),
+        },
+      ])
+    )
   } catch (error) {
     console.log(error)
   }
 }
 
-async function _generateGraphQlOperations(operations) {
+function createCodegenConfig(operations) {
   const generates = operations.reduce((generates, operation) => {
     generates[operation.outputPath] = {
       documents: GLOBS[operation.interfaceNameForOperations],
@@ -121,48 +123,46 @@ async function _generateGraphQlOperations(operations) {
     return generates
   }, {})
 
-  await generate(
-    {
-      schema: SCHEMA_PATH,
-      hooks: {
-        afterOneFileWrite: `${PRETTIER} --write`,
-      },
-      errorsOnly: true,
-      config: {
-        // https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#config-api-reference
-        arrayInputCoercion: false,
-        preResolveTypes: true,
-        operationResultSuffix: 'Result',
-        omitOperationSuffix: true,
-        namingConvention: {
-          typeNames: 'keep',
-          enumValues: 'keep',
-          transformUnderscore: true,
-        },
-        declarationKind: 'interface',
-        avoidOptionals: {
-          field: true,
-          inputValue: false,
-          object: true,
-        },
-        scalars: {
-          DateTime: 'string',
-          JSON: 'object',
-          JSONValue: 'unknown',
-          GitObjectID: 'string',
-          JSONCString: 'string',
-          PublishedValue: "boolean | 'draft'",
-          BigInt: 'string',
-        },
-      },
-      generates,
+  return {
+    schema: SCHEMA_PATH,
+    hooks: {
+      afterOneFileWrite: `${PRETTIER} --write`,
     },
-    true
-  )
+    errorsOnly: true,
+    config: {
+      // https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#config-api-reference
+      arrayInputCoercion: false,
+      preResolveTypes: true,
+      operationResultSuffix: 'Result',
+      omitOperationSuffix: true,
+      namingConvention: {
+        typeNames: 'keep',
+        enumValues: 'keep',
+        transformUnderscore: true,
+      },
+      declarationKind: 'interface',
+      avoidOptionals: {
+        field: true,
+        inputValue: false,
+        object: true,
+      },
+      scalars: {
+        DateTime: 'string',
+        JSON: 'object',
+        JSONValue: 'unknown',
+        GitObjectID: 'string',
+        JSONCString: 'string',
+        PublishedValue: "boolean | 'draft'",
+        BigInt: 'string',
+      },
+    },
+    generates,
+  }
 }
 
 module.exports = {
   generateGraphQlOperations,
+  createCodegenConfig,
   SHARED_DOCUMENTS_GLOB,
   WEB_DOCUMENTS_GLOB,
   ALL_DOCUMENTS_GLOB,
@@ -177,7 +177,7 @@ async function main(args) {
 
   const [interfaceNameForOperations, outputPath] = args
 
-  await _generateGraphQlOperations([{ interfaceNameForOperations, outputPath }])
+  await generate(createCodegenConfig([{ interfaceNameForOperations, outputPath }]))
 }
 
 if (require.main === module) {

--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -51,6 +51,8 @@
     "svelte-check": "^3.4.6",
     "tslib": "2.1.0",
     "vite": "^4.4.7",
+    "vite-plugin-graphql-codegen": "^3.2.3",
+    "vite-plugin-inspect": "^0.7.35",
     "vitest": "^0.33.0"
   },
   "type": "module",

--- a/client/web-sveltekit/svelte.config.js
+++ b/client/web-sveltekit/svelte.config.js
@@ -10,6 +10,13 @@ const config = {
   // for more information about preprocessors
   preprocess: vitePreprocess(),
 
+  vitePlugin: {
+    inspector: {
+      showToggleButton: 'always',
+      toggleButtonPos: 'bottom-right',
+    },
+  },
+
   kit: {
     adapter: adapter({
       fallback: 'index.html',

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -1,8 +1,27 @@
 import { sveltekit } from '@sveltejs/kit/vite'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
+import codegen from 'vite-plugin-graphql-codegen'
+import inspect from 'vite-plugin-inspect'
+
+import operations from '@sourcegraph/shared/dev/generateGraphQlOperations'
+
+function generateGraphQLOperations(): Plugin {
+    const outputPath = './src/lib/graphql-operations.ts'
+    const interfaceNameForOperations = 'SvelteKitGraphQlOperations'
+    const documents = ['src/lib/**/*.ts', '!src/lib/graphql-operations.ts']
+
+    return codegen({
+        config: {
+            ...operations.createCodegenConfig([{ interfaceNameForOperations, outputPath }]),
+            // Top-level documents needs to be expliclity configured, otherwise vite-plugin-graphql-codgen
+            // won't regenerate on change.
+            documents,
+        },
+    })
+}
 
 const config = defineConfig(({ mode }) => ({
-    plugins: [sveltekit()],
+    plugins: [sveltekit(), generateGraphQLOperations(), inspect()],
     define:
         mode === 'test'
             ? {}

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@babel/runtime": "^7.20.6",
     "@gql2ts/types": "^1.9.0",
     "@graphql-codegen/cli": "^2.16.1",
+    "@graphql-codegen/plugin-helpers": "^5.0.1",
     "@graphql-codegen/typescript": "2.8.5",
     "@graphql-codegen/typescript-apollo-client-helpers": "^2.2.6",
     "@graphql-codegen/typescript-operations": "2.5.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -507,6 +507,9 @@ importers:
       '@graphql-codegen/cli':
         specifier: ^2.16.1
         version: 2.16.1(@babel/core@7.21.0)(@types/node@13.13.5)(graphql@15.4.0)(ts-node@10.9.1)(typescript@5.0.2)
+      '@graphql-codegen/plugin-helpers':
+        specifier: ^5.0.1
+        version: 5.0.1(graphql@15.4.0)
       '@graphql-codegen/typescript':
         specifier: 2.8.5
         version: 2.8.5(graphql@15.4.0)
@@ -1750,6 +1753,12 @@ importers:
       vite:
         specifier: ^4.4.7
         version: 4.4.7(@types/node@13.13.5)(sass@1.32.4)
+      vite-plugin-graphql-codegen:
+        specifier: ^3.2.3
+        version: 3.2.3(@graphql-codegen/cli@2.16.1)(graphql@15.4.0)(vite@4.4.7)
+      vite-plugin-inspect:
+        specifier: ^0.7.35
+        version: 0.7.35(vite@4.4.7)
       vitest:
         specifier: ^0.33.0
         version: 0.33.0(jsdom@16.7.0)(sass@1.32.4)
@@ -1783,6 +1792,10 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+
+  /@antfu/utils@0.7.5:
+    resolution: {integrity: sha512-dlR6LdS+0SzOAPx/TPRhnoi7hE251OVeT2Snw0RguNbBSbjUHdWr0l3vcUUDg26rEysT89kCbtw1lVorBXLLCg==}
+    dev: true
 
   /@apidevtools/json-schema-ref-parser@9.0.6:
     resolution: {integrity: sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==}
@@ -2911,6 +2924,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.22.9):
+    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.9
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -5663,6 +5686,61 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@graphql-codegen/cli@2.16.1(@babel/core@7.22.9)(@types/node@13.13.5)(graphql@15.4.0)(ts-node@10.9.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-11z3iSlsNCXcNNkoRKG3wCmT9XpLf7/GZG9bWGXkCoveWVRwnRmo37YakHdNV3hbcJ4iiGbR3Z+MX9gUTEPDVA==}
+    hasBin: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@babel/generator': 7.22.9
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+      '@graphql-codegen/core': 2.6.8(graphql@15.4.0)
+      '@graphql-codegen/plugin-helpers': 3.1.1(graphql@15.4.0)
+      '@graphql-tools/apollo-engine-loader': 7.3.21(graphql@15.4.0)
+      '@graphql-tools/code-file-loader': 7.3.15(@babel/core@7.22.9)(graphql@15.4.0)
+      '@graphql-tools/git-loader': 7.2.15(@babel/core@7.22.9)(graphql@15.4.0)
+      '@graphql-tools/github-loader': 7.3.22(@babel/core@7.22.9)(graphql@15.4.0)
+      '@graphql-tools/graphql-file-loader': 7.5.13(graphql@15.4.0)
+      '@graphql-tools/json-file-loader': 7.4.14(graphql@15.4.0)
+      '@graphql-tools/load': 7.8.0(graphql@15.4.0)
+      '@graphql-tools/prisma-loader': 7.2.46(@types/node@13.13.5)(graphql@15.4.0)
+      '@graphql-tools/url-loader': 7.16.26(@types/node@13.13.5)(graphql@15.4.0)
+      '@graphql-tools/utils': 8.13.1(graphql@15.4.0)
+      '@whatwg-node/fetch': 0.5.3
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 7.0.1
+      cosmiconfig-typescript-loader: 4.1.1(@types/node@13.13.5)(cosmiconfig@7.0.1)(ts-node@10.9.1)(typescript@5.1.3)
+      debounce: 1.2.1
+      detect-indent: 6.1.0
+      graphql: 15.4.0
+      graphql-config: 4.3.6(@types/node@13.13.5)(graphql@15.4.0)(typescript@5.1.3)
+      inquirer: 8.2.5
+      is-glob: 4.0.3
+      json-to-pretty-yaml: 1.2.2
+      listr2: 4.0.5
+      log-symbols: 4.1.0
+      shell-quote: 1.8.1
+      string-env-interpolation: 1.0.1
+      ts-log: 2.2.3
+      tslib: 2.1.0
+      yaml: 1.10.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - enquirer
+      - supports-color
+      - ts-node
+      - typescript
+      - utf-8-validate
+    dev: true
+
   /@graphql-codegen/core@2.6.8(graphql@15.4.0):
     resolution: {integrity: sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==}
     peerDependencies:
@@ -5695,6 +5773,20 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       '@graphql-tools/utils': 8.13.1(graphql@15.4.0)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 15.4.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.1.0
+    dev: true
+
+  /@graphql-codegen/plugin-helpers@5.0.1(graphql@15.4.0):
+    resolution: {integrity: sha512-6L5sb9D8wptZhnhLLBcheSPU7Tg//DGWgc5tQBWX46KYTOTQHGqDpv50FxAJJOyFVJrveN9otWk9UT9/yfY4ww==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/utils': 10.0.4(graphql@15.4.0)
       change-case-all: 1.0.15
       common-tags: 1.8.2
       graphql: 15.4.0
@@ -5846,6 +5938,22 @@ packages:
       - supports-color
     dev: true
 
+  /@graphql-tools/code-file-loader@7.3.15(@babel/core@7.22.9)(graphql@15.4.0):
+    resolution: {integrity: sha512-cF8VNc/NANTyVSIK8BkD/KSXRF64DvvomuJ0evia7tJu4uGTXgDjimTMWsTjKRGOOBSTEbL6TA8e4DdIYq6Udw==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 7.4.2(@babel/core@7.22.9)(graphql@15.4.0)
+      '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
+      globby: 11.1.0
+      graphql: 15.4.0
+      tslib: 2.1.0
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /@graphql-tools/delegate@9.0.20(graphql@15.4.0):
     resolution: {integrity: sha512-m/de++kSxa/JABQ15tyt6SMlc4qfl3MgFFWmwbPcWgJxlAvZ7oIdGXcUvU6VJcXiyXfo6MZ/zr4V2E2UwMehew==}
     peerDependencies:
@@ -5944,6 +6052,23 @@ packages:
       - supports-color
     dev: true
 
+  /@graphql-tools/git-loader@7.2.15(@babel/core@7.22.9)(graphql@15.4.0):
+    resolution: {integrity: sha512-1d5HmeuxhSNjQ2+k2rfKgcKcnZEC6H5FM2pY5lSXHMv8VdBELZd7pYDs5/JxoZarDVYfYOJ5xTeVzxf+Du3VNg==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/graphql-tag-pluck': 7.4.2(@babel/core@7.22.9)(graphql@15.4.0)
+      '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
+      graphql: 15.4.0
+      is-glob: 4.0.3
+      micromatch: 4.0.5
+      tslib: 2.1.0
+      unixify: 1.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
   /@graphql-tools/github-loader@7.3.22(@babel/core@7.21.0)(graphql@15.4.0):
     resolution: {integrity: sha512-JE5F/ObbwknO7+gDfeuKAZtLS831WV8/SsLzQLMGY0hdgTbsAg2/xziAGprNToK4GMSD7ygCer9ZryvxBKMwbQ==}
     peerDependencies:
@@ -5951,6 +6076,23 @@ packages:
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/graphql-tag-pluck': 7.4.2(@babel/core@7.21.0)(graphql@15.4.0)
+      '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
+      '@whatwg-node/fetch': 0.5.3
+      graphql: 15.4.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-tools/github-loader@7.3.22(@babel/core@7.22.9)(graphql@15.4.0):
+    resolution: {integrity: sha512-JE5F/ObbwknO7+gDfeuKAZtLS831WV8/SsLzQLMGY0hdgTbsAg2/xziAGprNToK4GMSD7ygCer9ZryvxBKMwbQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/sync-fetch': 0.0.1
+      '@graphql-tools/graphql-tag-pluck': 7.4.2(@babel/core@7.22.9)(graphql@15.4.0)
       '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
       '@whatwg-node/fetch': 0.5.3
       graphql: 15.4.0
@@ -5981,6 +6123,23 @@ packages:
     dependencies:
       '@babel/parser': 7.22.7
       '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.21.0)
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
+      '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
+      graphql: 15.4.0
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
+
+  /@graphql-tools/graphql-tag-pluck@7.4.2(@babel/core@7.22.9)(graphql@15.4.0):
+    resolution: {integrity: sha512-SXM1wR5TExrxocQTxZK5r74jTbg8GxSYLY3mOPCREGz6Fu7PNxMxfguUzGUAB43Mf44Dn8oVztzd2eitv2Qgww==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@babel/parser': 7.22.7
+      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.22.9)
       '@babel/traverse': 7.22.8
       '@babel/types': 7.22.5
       '@graphql-tools/utils': 9.1.3(graphql@15.4.0)
@@ -6162,6 +6321,18 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
+    dev: true
+
+  /@graphql-tools/utils@10.0.4(graphql@15.4.0):
+    resolution: {integrity: sha512-MF+nZgGROSnFgyOYWhrl2PuJMlIBvaCH48vtnlnDQKSeDc2fUfOzUVloBAQvnYmK9JBmHHks4Pxv25Ybg3r45Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.1.1(graphql@15.4.0)
+      dset: 3.1.2
+      graphql: 15.4.0
+      tslib: 2.1.0
     dev: true
 
   /@graphql-tools/utils@8.12.0(graphql@15.4.0):
@@ -8884,6 +9055,20 @@ packages:
 
   /@repeaterjs/repeater@3.0.4:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
+    dev: true
+
+  /@rollup/pluginutils@5.0.2:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
     dev: true
 
   /@sentry/browser@7.8.1:
@@ -15654,6 +15839,13 @@ packages:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
     dev: false
 
+  /bundle-name@3.0.0:
+    resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
+    engines: {node: '>=12'}
+    dependencies:
+      run-applescript: 5.0.0
+    dev: true
+
   /bundlesize2@0.0.31:
     resolution: {integrity: sha512-MdzJW/u+n+0jH0Uz78g8WENHAW7QNUdLD/c8aLuPB/aCIwt52zMJ4fc2fBU2y1K2iMwE/9+JoR8ojsAF0r0Xjw==}
     hasBin: true
@@ -16852,6 +17044,21 @@ packages:
       typescript: 5.0.2
     dev: true
 
+  /cosmiconfig-typescript-loader@4.1.1(@types/node@13.13.5)(cosmiconfig@7.0.1)(ts-node@10.9.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-9DHpa379Gp0o0Zefii35fcmuuin6q92FnLDffzdZ0l9tVd3nEobG3O+MZ06+kuBvFTSVScvNb/oHA13Nd4iipg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=7'
+      ts-node: '>=10'
+      typescript: '>=3'
+    dependencies:
+      '@types/node': 13.13.5
+      cosmiconfig: 7.0.1
+      ts-node: 10.9.1(@types/node@13.13.5)(typescript@5.1.3)
+      typescript: 5.1.3
+    dev: true
+
   /cosmiconfig-typescript-loader@4.3.0(@types/node@13.13.5)(cosmiconfig@7.0.1)(ts-node@10.9.1)(typescript@5.0.2):
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
@@ -16865,6 +17072,21 @@ packages:
       cosmiconfig: 7.0.1
       ts-node: 10.9.1(@types/node@13.13.5)(typescript@5.0.2)
       typescript: 5.0.2
+    dev: true
+
+  /cosmiconfig-typescript-loader@4.3.0(@types/node@13.13.5)(cosmiconfig@7.0.1)(ts-node@10.9.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=7'
+      ts-node: '>=10'
+      typescript: '>=3'
+    dependencies:
+      '@types/node': 13.13.5
+      cosmiconfig: 7.0.1
+      ts-node: 10.9.1(@types/node@13.13.5)(typescript@5.1.3)
+      typescript: 5.1.3
     dev: true
 
   /cosmiconfig@5.2.1:
@@ -18048,6 +18270,16 @@ packages:
       untildify: 4.0.0
     dev: true
 
+  /default-browser@4.0.0:
+    resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      bundle-name: 3.0.0
+      default-browser-id: 3.0.0
+      execa: 7.2.0
+      titleize: 3.0.0
+    dev: true
+
   /default-compare@1.0.0:
     resolution: {integrity: sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==}
     engines: {node: '>=0.10.0'}
@@ -18089,6 +18321,11 @@ packages:
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+    dev: true
 
   /define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
@@ -19545,6 +19782,10 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  /estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
@@ -19636,6 +19877,21 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  /execa@7.2.0:
+    resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
+    engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 4.3.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
 
   /execall@2.0.0:
     resolution: {integrity: sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==}
@@ -21131,6 +21387,36 @@ packages:
       - utf-8-validate
     dev: true
 
+  /graphql-config@4.3.6(@types/node@13.13.5)(graphql@15.4.0)(typescript@5.1.3):
+    resolution: {integrity: sha512-i7mAPwc0LAZPnYu2bI8B6yXU5820Wy/ArvmOseDLZIu0OU1UTULEuexHo6ZcHXeT9NvGGaUPQZm8NV3z79YydA==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/graphql-file-loader': 7.5.13(graphql@15.4.0)
+      '@graphql-tools/json-file-loader': 7.4.14(graphql@15.4.0)
+      '@graphql-tools/load': 7.8.8(graphql@15.4.0)
+      '@graphql-tools/merge': 8.3.14(graphql@15.4.0)
+      '@graphql-tools/url-loader': 7.16.26(@types/node@13.13.5)(graphql@15.4.0)
+      '@graphql-tools/utils': 8.13.1(graphql@15.4.0)
+      cosmiconfig: 7.0.1
+      cosmiconfig-toml-loader: 1.0.0
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@13.13.5)(cosmiconfig@7.0.1)(ts-node@10.9.1)(typescript@5.1.3)
+      graphql: 15.4.0
+      minimatch: 4.2.1
+      string-env-interpolation: 1.0.1
+      ts-node: 10.9.1(@types/node@13.13.5)(typescript@5.1.3)
+      tslib: 2.1.0
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+    dev: true
+
   /graphql-language-service@5.1.0(graphql@15.4.0):
     resolution: {integrity: sha512-APffigZ/l2me6soek+Yq5Us3HBwmfw4vns4QoqsTePXkK3knVO8rn0uAC6PmTyglb1pmFFPbYaRIzW4wmcnnGQ==}
     hasBin: true
@@ -21862,6 +22148,11 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  /human-signals@4.3.1:
+    resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
+    engines: {node: '>=14.18.0'}
+    dev: true
+
   /humps@2.0.1:
     resolution: {integrity: sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g==}
     dev: true
@@ -22333,6 +22624,12 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  /is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dev: true
+
   /is-dom@1.1.0:
     resolution: {integrity: sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==}
     dependencies:
@@ -22410,6 +22707,14 @@ packages:
 
   /is-hexadecimal@1.0.2:
     resolution: {integrity: sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==}
+    dev: true
+
+  /is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      is-docker: 3.0.0
     dev: true
 
   /is-installed-globally@0.1.0:
@@ -22614,6 +22919,11 @@ packages:
   /is-stream@2.0.0:
     resolution: {integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==}
     engines: {node: '>=8'}
+
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -25708,6 +26018,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -26350,6 +26665,13 @@ packages:
     dependencies:
       path-key: 3.1.1
 
+  /npm-run-path@5.1.0:
+    resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: true
+
   /npmlog@4.1.2:
     resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==}
     dependencies:
@@ -26634,6 +26956,13 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
 
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: true
+
   /open-color@1.8.0:
     resolution: {integrity: sha512-gSHRpWLx83rKlHZIm9ZoUBsSMijhPRMxOOacUETjY8guu9dAwIAbtZgmVqkfglmhs3/pYppGohzp8fUdJ4YBqQ==}
     dev: false
@@ -26659,6 +26988,16 @@ packages:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  /open@9.1.0:
+    resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
+    engines: {node: '>=14.16'}
+    dependencies:
+      default-browser: 4.0.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      is-wsl: 2.2.0
+    dev: true
 
   /opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -27136,6 +27475,11 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -29897,6 +30241,13 @@ packages:
     engines: {node: 0.12.* || 4.* || 6.* || >= 7.*}
     dev: true
 
+  /run-applescript@5.0.0:
+    resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
+    engines: {node: '>=12'}
+    dependencies:
+      execa: 5.1.1
+    dev: true
+
   /run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -30433,6 +30784,15 @@ packages:
 
   /sirv@2.0.2:
     resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mrmime: 1.0.1
+      totalist: 3.0.0
+    dev: true
+
+  /sirv@2.0.3:
+    resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
     engines: {node: '>= 10'}
     dependencies:
       '@polka/url': 1.0.0-next.21
@@ -31254,6 +31614,11 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /strip-indent@1.0.1:
     resolution: {integrity: sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==}
     engines: {node: '>=0.10.0'}
@@ -32038,6 +32403,11 @@ packages:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
       tslib: 2.1.0
+    dev: true
+
+  /titleize@3.0.0:
+    resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /tmp@0.0.33:
@@ -33343,6 +33713,41 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite-plugin-graphql-codegen@3.2.3(@graphql-codegen/cli@2.16.1)(graphql@15.4.0)(vite@4.4.7):
+    resolution: {integrity: sha512-+GeuwDmKduphaX2OEc3fXdL4PIXD2ELncED+iKo6HFjfuBIbeYMX5ODYrfO2wJu5B4ngQ+5SLoG74JEFiVq3xw==}
+    peerDependencies:
+      '@graphql-codegen/cli': ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      vite: ^2.7.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      '@graphql-codegen/cli': 2.16.1(@babel/core@7.22.9)(@types/node@13.13.5)(graphql@15.4.0)(ts-node@10.9.1)(typescript@5.1.3)
+      graphql: 15.4.0
+      vite: 4.4.7(@types/node@13.13.5)(sass@1.32.4)
+    dev: true
+
+  /vite-plugin-inspect@0.7.35(vite@4.4.7):
+    resolution: {integrity: sha512-e5w5dJAj3vDcHTxn8hHbiH+mVqYs17gaW00f3aGuMTXiqUog+T1Lsxr9Jb4WRiip84cpuhR0KFFBT1egtXboiA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': '*'
+      vite: ^3.1.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+    dependencies:
+      '@antfu/utils': 0.7.5
+      '@rollup/pluginutils': 5.0.2
+      debug: 4.3.4
+      fs-extra: 11.1.1
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.3
+      vite: 4.4.7(@types/node@13.13.5)(sass@1.32.4)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
     dev: true
 
   /vite@4.4.7(@types/node@13.13.5)(sass@1.32.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12109,7 +12109,7 @@ packages:
       mime: 3.0.0
       sade: 1.8.1
       set-cookie-parser: 2.6.0
-      sirv: 2.0.2
+      sirv: 2.0.3
       svelte: 4.1.1
       undici: 5.22.1
       vite: 4.4.7(@types/node@13.13.5)(sass@1.32.4)
@@ -30781,15 +30781,6 @@ packages:
       '@polka/url': 1.0.0-next.21
       mime: 2.6.0
       totalist: 1.1.0
-
-  /sirv@2.0.2:
-    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
-    engines: {node: '>= 10'}
-    dependencies:
-      '@polka/url': 1.0.0-next.21
-      mrmime: 1.0.1
-      totalist: 3.0.0
-    dev: true
 
   /sirv@2.0.3:
     resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}


### PR DESCRIPTION
This commit adds a couple of developer workflow improvements:

- GraphQL types are now generated automatically in dev and production mode. No need to run `pnpm generate` anymore (unless the changes happen outside of the SvelteKit app). To make this work I refactored the existing code to be able to reuse the config generation logic.
- Enabled Svelte's "inspect" mode to easily identify components. This also allows you to open the component in your configured editor.
- Enabled inspect mode for Vite plugins. I didn't need this but it's interesting to see how modules are transformed and might come in handy one day. 

Svelte inspect mode (screenshot tool didn't capture the cursor)
![2023-08-07_11-32](https://github.com/sourcegraph/sourcegraph/assets/179026/a764ef0d-1ad2-47de-aace-c707f8051cc7)

Vite inpsect
![2023-08-07_11-35](https://github.com/sourcegraph/sourcegraph/assets/179026/c3b080ca-86c9-4d3c-a94d-9e851d7d7566)




## Test plan

`pnpm dev`
