### PR TITLE
Update wolfi base images for 5.1.6

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -34,31 +34,31 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 def oci_deps():
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:1f41fbd1ad390a4575d6d4107661372e39b875e0a7221bd9f5475a2dcb375f6c",
+        digest = "sha256:0c318f31e2283606a8638d8f12887c61e1a638c169f3f893138f31e8994138dc",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:aae9ff525dbd2c43dcdfd54f74b011d792db7b611dc40ebf9b17387b63f0b52a",
+        digest = "sha256:461b071e88388d098ecf9229215f93300c65961c1998b15a5ea2e8355e50032b",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:fb906ee43cd89a243aba32efa9c61ccfab50988e2ce220bdcb7da56e59d41026",
+        digest = "sha256:5ee69c6ef578acd7ebe3b5657fd0f7ab1bb7e67ddc3149c487a0304c9ff90a9a",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:c282859aba2866bcb0c504a39e1363df5c29f705890a60f97bf8c112d7eee0b7",
+        digest = "sha256:f169aa4f1dc9a6901a64ae78f195e8040b2b4207a3dfaf234862a963db9dda54",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:9557a0d248fe7afedba820b32096919fc6b12776ca250ee4bd90d5ab931874ca",
+        digest = "sha256:811f6b8236ae26fc300c06700b5a49ab054f7a2637c9fabf3d71549d87a39fbb",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
@@ -70,127 +70,127 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:530bc2c44f357bf0e1134b8107591df7f62135336dfb65406f369edb00c39e46",
+        digest = "sha256:85e95314e514bb1bdaec616d0fc073ccd8d1c586eb05af205e23debadf6e39fd",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:c6d83b0504bd262dfbcdab4fa7c6a728888e270649554376a4077c21073c3a99",
+        digest = "sha256:b073b40468b8154c2caab57bea2a011b60d2a44410e6901c3cec924052337312",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:f72456acb0af84814671f0389ae0aa105b5449a4a991c347009f70aec00ce183",
+        digest = "sha256:9cc8b58db182c460fc7a0cf6bb20fd89051e08c9d202181cd30b2b38c3f9d5b1",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:be1bbdbfd94ea2fad684afd629c5bd8b86e835c2090c92b291366bee2a81973f",
+        digest = "sha256:dec7c57abbd0061d23bb1013c2edbe7f2da5e57a4739b7418916669b4d644384",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:cab23291a0c43c8a47088bdca67ff01ceb1bafe222499b3dda7fa1d45a44a26c",
+        digest = "sha256:3f314fbfec7b6604991eef42138ce4ee75868e4ee7f515f5b72b44a9592c4a10",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:177a494fc657b95738322d17fa56f0547b948c178abab495f8ee160c849a7458",
+        digest = "sha256:878ca09163885c6673f5acd89a1870748faa97e26ef5696297185d4bb2ba2d6c",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:ce524267e2d86a4f5f8b05e825a670f6dd01917686ad20f66b7c34bf212b87a6",
+        digest = "sha256:c3ef437358e36fd1d889997333817777cd67457d1c316ae23e8de5aaebc6afee",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:b263c76f8d3658afe7305ad93b3dead8f37c51ea9ef619f6e80689dd3f350a55",
+        digest = "sha256:ac23e9e74f5ad4f769ea386131832a00baf2d873a4c809d278373b2b9a1f8200",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:8fb353249ed6fa6286568aa12d4dfb7de315292e2455fd790f8387d82c3c4f7c",
+        digest = "sha256:184101e1c3aa4312bf359851c15ae04d8e5cc3441008499e92f784fe1c59a96d",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:aea1f2e51635d20800e19ccf44cb1f18e9988f7a694d51281c0c0cb36a0b5ea9",
+        digest = "sha256:7ccf7dbcf9c6b5d818504857d680bef1c0ac12674d2d61f80d4e45c7c07272c2",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:44cf4d34ef20e48336446bcbcbc3a26769e4dc7a43e64ca2c0c16c931561faeb",
+        digest = "sha256:7f01d45f05f39c8c5c1f9a9010ccd5e1f8ca7f70298ede88e37aa85052715ac2",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:cd3b91225e3aae076567725205d464f1bd0e5049536179f7839b71b27a42864e",
+        digest = "sha256:a11c399dd9880eeba82b22a03185f4896dcfb79963290d7105268f3e5485e7ae",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:02d4681a4f9887e46c37745d726e07e9e991735aa0ff3052f6bd0970cf297219",
+        digest = "sha256:5d453c49f9a49daeabff155251f32c8f6e8157c8263dbe2a2839d45d64549800",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:07dfc9d4654658f3bc783bbec238328cbcbee129edab2b6bede04fcba5b7dd2c",
+        digest = "sha256:d336069d5846f068f00e9404fa64dd2cd36c49869ebc923cdac3d08c1913de3c",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:f5857ce301e98981b1387bc23a59ca7a44487e87a01bcdf010f496e0335e6055",
+        digest = "sha256:14519040dfd547b933d6c345181f9a3a0eaeeb232c2922c7fbee52b05fbbbcdd",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:0f521abae263be472d8049904375c0e48f40ed560088a418b33616a9bb6bacdc",
+        digest = "sha256:1e6c90c133107ef6655f14bdfe5331702465d9734c810c5c58c7ceef26565599",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:b362b9313df22e69214c30fd660b21bfe2354921a0b915efcb51ffc288c099eb",
+        digest = "sha256:82502505d946eda47024f957ea308e7473e7f4ab5d19ca87826c352a683423d3",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:3cd6ae2b9c59c230ae0f65a6aa2e8a030361de82d4273ed64f5cf8052c94f197",
+        digest = "sha256:7a9367238123005c0f794362a012c8f50a84bb614a3a60f761a8c815262f2141",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:9c96f8fb5197ea6a51272cd9d7c7bb479290a2aadd11de950b144882a67392e9",
+        digest = "sha256:52e6c51d0960614132da937907a74e844183bbc9f8c08b427135938469c6cf28",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:8fb353249ed6fa6286568aa12d4dfb7de315292e2455fd790f8387d82c3c4f7c",
+        digest = "sha256:184101e1c3aa4312bf359851c15ae04d8e5cc3441008499e92f784fe1c59a96d",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:09239985070a367d1f1d839bed5326af56d9dcf2133b779456b8255f5053e4c6",
+        digest = "sha256:42ff3ba38633022bfb2d7982e2ad671670b160fdaa04b453368f2098aaf9bf86",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )


### PR DESCRIPTION
Update all Wolfi base images to the latest release, to pick up new patches and fix vulns.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Green CI
- Test on S2 prior to publishing