### PR TITLE
Docs: fix link colors

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -103,10 +103,6 @@ body {
 
 a {
   text-decoration: none;
-}
-
-body.theme-light a,
-body.theme-light .markdown-body a {
   color: var(--link-color);
 }
 
@@ -115,14 +111,14 @@ a:hover {
   transition: color 0.2s ease-in-out;
 }
 
-body.theme-light #sidebar a,
-body.theme-light #index a {
-  color: #171717;
+body.theme-light #sidebar,
+body.theme-light #index {
+  --link-color: #171717
 }
 
-body.theme-dark #sidebar a,
-body.theme-dark #index a {
-  color: rgb(161, 161, 161);
+body.theme-dark #sidebar,
+body.theme-dark #index {
+  --link-color: rgb(161, 161, 161);
 }
 
 /* Nav links */

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -247,6 +247,7 @@ body > #sidebar {
     flex-direction: column;
     padding-top: calc(2*var(--spacing));
     margin-left: calc(6*var(--spacing));
+    padding-right: var(--spacing);
 }
 /* Logo */
 body > #sidebar #logo {
@@ -342,7 +343,7 @@ body > #sidebar #theme {
     gap: 0.5rem;
     align-items: center;
 }
-body > #sidebar svg {
+body > #sidebar #theme svg {
     width: 16px;
     margin-right: 0.25rem;
     fill: var(--text-muted);
@@ -1356,18 +1357,20 @@ markprompt-content.dark {
 }
 
 #markprompt-button {
-    background-color: transparent;
-    border: 0px;
+    all: unset;
     color: var(--markprompt-mutedForeground);
-    cursor:pointer;
+    cursor: pointer;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
 }
 
 #markprompt-button:hover {
     color: var(--link-color);
 }
 
-.markdown-body a {
-    color: var(--brand-cyan-color);
+body > #markprompt-button svg {
+    margin-right: 0;
 }
 
 #sidebar ul ul li {

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -1172,7 +1172,7 @@ body {
     --markprompt-secondaryForeground: #171717;
     --markprompt-primaryHighlight: #A112FF;
     --markprompt-secondaryHighlight: #00CBEC;
-    --markprompt-overlay: #00000010;
+    --markprompt-overlay: #00000090;
     --markprompt-ring: #00CBEC;
     --markprompt-radius: 8px;
     --markprompt-text-size: .875rem;
@@ -1265,6 +1265,10 @@ body.theme-dark {
 .MarkpromptSearchAnswerButton:focus,
 .MarkpromptSearchAnswerButton:focus kbd svg {
     color: #ffffff;
+}
+
+.MarkpromptOverlay {
+    z-index: 99 !important;
 }
 
 .MarkpromptContentDialog {

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -53,7 +53,6 @@ body.theme-light {
   --input-border-color: var(--sidebar-border-color);
   --input-focus-border-color: #1986ea;
   --link-color: #0055c5;
-  --link-hover-color: #1986ea;
   --anchor-inline-bg: yellow;
   --anchor-inline-border-color: #eecc11;
   --code-bg: #f4f7fb;
@@ -81,7 +80,6 @@ body.theme-dark {
   --input-border-color: var(--sidebar-border-color);
   --input-focus-border-color: #1986ea;
   --link-color: var(--brand-cyan-color);
-  --link-hover-color: #77bbff;
   --anchor-inline-bg: yellow;
   --anchor-inline-border-color: #eecc11;
   --code-bg: #191929;
@@ -795,9 +793,6 @@ body > #page > main > #content {
     color: var(--link-color);
     font-size: 1.5rem;
 }
-.copy-text:hover {
-    color: var(--link-hover-color);
-}
 
 /* Display hash on hover for schema doc key. */
 .markdown-body .json-schema-doc-heading {
@@ -1368,7 +1363,7 @@ markprompt-content.dark {
 }
 
 #markprompt-button:hover {
-    color: var(--link-hover-color);
+    color: var(--link-color);
 }
 
 .markdown-body a {

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -190,7 +190,7 @@ Answer (including related code snippets if available):`
                             <button id="search-button" type="submit" aria-label="Search" class="sr-only">Search</button>
                         </form>
                         <button id="markprompt-button" aria-label="Open prompt" onclick="showMarkprompt()">
-                            <svg id="markprompt-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-square"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
+                            <svg id="markprompt-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-message-square"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path></svg>
                         </button>
                         <div id="markprompt" style="display: none" />
                     </div>


### PR DESCRIPTION
Fixes the search and breadcrumb link colors to match the rest of the doc, as well as fixing some colours and display issues with the markprompt button and overlay.

| Before | After |
| - | - |
| <img width="1418" alt="Screenshot 2023-08-08 at 11 34 39 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/fb1f3886-abff-4e9e-bd33-e7b0d509c2d0"> | <img width="1418" alt="Screenshot 2023-08-08 at 11 34 19 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/22cc4bd5-6a61-4ae6-a29a-cd24083461b4"> |
| <img width="1418" alt="Screenshot 2023-08-08 at 11 34 30 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/0906192b-fffd-4cfd-9130-43dfa9f9c88b"> | <img width="1418" alt="Screenshot 2023-08-08 at 11 34 14 am" src="https://github.com/sourcegraph/sourcegraph/assets/153/2cc47fac-148a-472f-adb3-803be87fcfb4"> |

## Test plan

- Viewed various pages
- Switched themes
