### PR TITLE
codygateway: Always return all Sourcegraph access tokens

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -176,7 +176,7 @@ func (r *productSubscription) SourcegraphAccessTokens(ctx context.Context) (toke
 		if !l.AccessTokenEnabled {
 			continue
 		}
-		lt := license.GenerateLicenseKeyBasedAccessToken(r.activeLicense.LicenseKey)
+		lt := license.GenerateLicenseKeyBasedAccessToken(l.LicenseKey)
 		if mainToken == "" || lt != mainToken {
 			tokens = append(tokens, lt)
 		}


### PR DESCRIPTION
Was broken by https://github.com/sourcegraph/sourcegraph/pull/52811 where we switched from `l` to `activeLicense`, we accidentally only returned the most recent access token, causing older tokens to never get a new configuration synced.

## Test plan

Verified all tokens are returned again.