### PR TITLE
Linting: add `unused` lint

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -317,6 +317,7 @@ nogo(
             "//dev/linters/gocritic",
             "//dev/linters/ineffassign",
             "//dev/linters/unparam",
+            "//dev/linters/unused",
         ] + STATIC_CHECK_ANALYZERS,
     }),
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -317,7 +317,8 @@ nogo(
             "//dev/linters/gocritic",
             "//dev/linters/ineffassign",
             "//dev/linters/unparam",
-            "//dev/linters/unused",
+            # Disabled because we currently have a lot of unused code
+            # "//dev/linters/unused",
         ] + STATIC_CHECK_ANALYZERS,
     }),
 )

--- a/dev/linters/unused/BUILD.bazel
+++ b/dev/linters/unused/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/linters/unused",
     visibility = ["//visibility:public"],
     deps = [
+        "//dev/linters/nolint",
         "@co_honnef_go_tools//unused",
         "@org_golang_x_tools//go/analysis",
     ],

--- a/dev/linters/unused/BUILD.bazel
+++ b/dev/linters/unused/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "unused",
+    srcs = ["unused.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/unused",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@co_honnef_go_tools//unused",
+        "@org_golang_x_tools//go/analysis",
+    ],
+)

--- a/dev/linters/unused/unused.go
+++ b/dev/linters/unused/unused.go
@@ -1,0 +1,31 @@
+package unused
+
+import (
+	"fmt"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+	"honnef.co/go/tools/unused"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name: "unused",
+	Doc:  unused.Analyzer.Analyzer.Doc,
+	Run: func(pass *analysis.Pass) (interface{}, error) {
+		res, err := unused.Analyzer.Analyzer.Run(pass)
+		if err != nil {
+			return res, err
+		}
+		allUnused := res.(unused.Result).Unused
+		for _, u := range allUnused {
+			pass.Report(analysis.Diagnostic{
+				Pos:     token.Pos(u.Position.Offset),
+				Message: fmt.Sprintf("%s is unused", u.Name),
+			})
+		}
+		return res, err
+	},
+	Requires:   unused.Analyzer.Analyzer.Requires,
+	ResultType: unused.Analyzer.Analyzer.ResultType,
+	FactTypes:  []analysis.Fact{},
+}

--- a/dev/linters/unused/unused.go
+++ b/dev/linters/unused/unused.go
@@ -3,29 +3,29 @@ package unused
 import (
 	"fmt"
 	"go/token"
+	"reflect"
 
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
 	"golang.org/x/tools/go/analysis"
 	"honnef.co/go/tools/unused"
 )
 
-var Analyzer = &analysis.Analyzer{
+var Analyzer = nolint.Wrap(&analysis.Analyzer{
 	Name: "unused",
-	Doc:  unused.Analyzer.Analyzer.Doc,
+	Doc:  "Unused code",
 	Run: func(pass *analysis.Pass) (interface{}, error) {
-		res, err := unused.Analyzer.Analyzer.Run(pass)
-		if err != nil {
-			return res, err
-		}
-		allUnused := res.(unused.Result).Unused
+		// This is just a lightweight wrapper around the default unused
+		// analyzer that reports a diagnostic error rather than just returning
+		// a result
+		allUnused := pass.ResultOf[unused.Analyzer.Analyzer].(unused.Result).Unused
 		for _, u := range allUnused {
 			pass.Report(analysis.Diagnostic{
 				Pos:     token.Pos(u.Position.Offset),
 				Message: fmt.Sprintf("%s is unused", u.Name),
 			})
 		}
-		return res, err
+		return nil, nil
 	},
-	Requires:   unused.Analyzer.Analyzer.Requires,
-	ResultType: unused.Analyzer.Analyzer.ResultType,
-	FactTypes:  []analysis.Fact{},
-}
+	Requires:   []*analysis.Analyzer{unused.Analyzer.Analyzer},
+	ResultType: reflect.TypeOf(nil),
+})


### PR DESCRIPTION
This adds the `unused` lint to the set of linters supported by `nogo`. This PR leaves it disabled because we currently have a _lot_ of dead code lying around. 

For anyone who wants to work on sniping some unused code, just uncomment the line in `BUILD.bazel`

## Test plan

```bash
❯ bazel build //cmd/frontend/internal/httpapi
...
compilepkg: nogo: errors found by nogo during build-time code analysis:
internal/extsvc/types.go:319:87: bbsLower is unused (unused)
internal/extsvc/types.go:320:62: bbcLower is unused (unused)
internal/extsvc/types.go:321:24: jvmLower is unused (unused)
internal/extsvc/types.go:322:22: npmLower is unused (unused)
internal/extsvc/types.go:324:30: goLower is unused (unused)
internal/extsvc/types.go:324:89: pythonLower is unused (unused)
internal/extsvc/types.go:325:45: rustLower is unused (unused)
internal/extsvc/types.go:326:36: rubyLower is unused (unused)
internal/extsvc/types.go:339:74: supportsRepoExclusion is unused (unused)
Target //cmd/frontend/internal/httpapi:httpapi failed to build
```
