### PR TITLE
cleanup: Simplify Lua sandbox code using generics

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/patterns.go
@@ -35,14 +35,14 @@ func (api patternAPI) LuaAPI() map[string]lua.LGFunction {
 			glob := state.CheckString(1)
 			pathspecTable := state.CheckTable(2)
 
-			values, err := util.DecodeSlice(pathspecTable)
+			pathspecs, err := util.MapSlice(pathspecTable, func(value lua.LValue) (string, error) {
+				if s, ok := value.(lua.LString); ok {
+					return string(s), nil
+				}
+				return "", util.NewTypeError("lua.LString", value)
+			})
 			if err != nil {
 				return err
-			}
-
-			var pathspecs []string
-			for _, v := range values {
-				pathspecs = append(pathspecs, v.String())
 			}
 
 			state.Push(luar.New(state, luatypes.NewPattern(glob, pathspecs)))

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/index_job.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/index_job.go
@@ -8,24 +8,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// IndexJobsFromTable decodes a single index job or slice of index jobs from the given Lua
-// value.
-func IndexJobsFromTable(value lua.LValue) (jobs []config.IndexJob, err error) {
-	err = util.UnwrapSliceOrSingleton(value, func(value lua.LValue) error {
-		job, err := indexJobFromTable(value)
-		if err != nil {
-			return err
-		}
-
-		jobs = append(jobs, job)
-		return nil
-	})
-
-	return
-}
-
-// indexJobFromTable decodes a single Lua table value into an index job instance.
-func indexJobFromTable(value lua.LValue) (config.IndexJob, error) {
+// IndexJobFromTable decodes a single Lua table value into an index job instance.
+func IndexJobFromTable(value lua.LValue) (config.IndexJob, error) {
 	table, ok := value.(*lua.LTable)
 	if !ok {
 		return config.IndexJob{}, util.NewTypeError("table", value)
@@ -77,19 +61,15 @@ func dockerStepFromTable(value lua.LValue) (step config.DockerStep, _ error) {
 // slice value on invocation. For use in luasandbox.DecodeTable.
 func setDockerSteps(ptr *[]config.DockerStep) func(lua.LValue) error {
 	return func(value lua.LValue) (err error) {
-		values, err := util.DecodeSlice(value)
+		table, ok := value.(*lua.LTable)
+		if !ok {
+			return util.NewTypeError("table", value)
+		}
+		steps, err := util.MapSlice(table, dockerStepFromTable)
 		if err != nil {
 			return err
 		}
-
-		for _, v := range values {
-			step, err := dockerStepFromTable(v)
-			if err != nil {
-				return err
-			}
-			*ptr = append(*ptr, step)
-		}
-
+		*ptr = append(*ptr, steps...)
 		return nil
 	}
 }

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/index_job_hint.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/index_job_hint.go
@@ -8,24 +8,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// IndexJobHintsFromTable decodes a single index job hint or slice of index job hints from
-// the given Lua value.
-func IndexJobHintsFromTable(value lua.LValue) (indexJobHints []config.IndexJobHint, err error) {
-	err = util.UnwrapSliceOrSingleton(value, func(value lua.LValue) error {
-		jobHint, err := indexJobHintFromTable(value)
-		if err != nil {
-			return err
-		}
-
-		indexJobHints = append(indexJobHints, jobHint)
-		return nil
-	})
-
-	return
-}
-
-// indexJobHintFromTable decodes a single Lua table value into an index job hint instance.
-func indexJobHintFromTable(value lua.LValue) (config.IndexJobHint, error) {
+// IndexJobHintFromTable decodes a single Lua table value into an index job hint instance.
+func IndexJobHintFromTable(value lua.LValue) (config.IndexJobHint, error) {
 	table, ok := value.(*lua.LTable)
 	if !ok {
 		return config.IndexJobHint{}, util.NewTypeError("table", value)

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/path_patterns.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/path_patterns.go
@@ -72,16 +72,7 @@ func FlattenPattern(pathPattern *PathPattern, inverted bool) (patterns []GlobAnd
 // PathPatternsFromUserData decodes a single path pattern or slice of path patterns from
 // the given Lua value.
 func PathPatternsFromUserData(value lua.LValue) (patterns []*PathPattern, err error) {
-	err = util.UnwrapSliceOrSingleton(value, func(value lua.LValue) error {
-		return util.UnwrapLuaUserData(value, func(value any) error {
-			if pathPattern, ok := value.(*PathPattern); ok {
-				patterns = append(patterns, pathPattern)
-				return nil
-			}
-
-			return util.NewTypeError("*PathPattern", value)
-		})
+	return util.MapSliceOrSingleton(value, func(value lua.LValue) (*PathPattern, error) {
+		return util.TypecheckUserData[*PathPattern](value, "*PathPattern")
 	})
-
-	return
 }

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
@@ -146,15 +146,12 @@ func NamedRecognizersFromUserDataMap(value lua.LValue, allowFalseAsNil bool) (re
 			}
 		}
 
-		return util.UnwrapLuaUserData(value, func(value any) error {
-			recognizer, ok := value.(*Recognizer)
-			if !ok {
-				return util.NewTypeError("*Recognizer", value)
-			}
-
-			recognizers[name] = recognizer
-			return nil
-		})
+		recognizer, err := util.TypecheckUserData[*Recognizer](value, "*Recognizer")
+		if err != nil {
+			return err
+		}
+		recognizers[name] = recognizer
+		return nil
 	})
 
 	return
@@ -163,18 +160,9 @@ func NamedRecognizersFromUserDataMap(value lua.LValue, allowFalseAsNil bool) (re
 // RecognizersFromUserData decodes a single recognize or slice of recognizers from the
 // given Lua value.
 func RecognizersFromUserData(value lua.LValue) (recognizers []*Recognizer, err error) {
-	err = util.UnwrapSliceOrSingleton(value, func(value lua.LValue) error {
-		return util.UnwrapLuaUserData(value, func(value any) error {
-			if recognizer, ok := value.(*Recognizer); ok {
-				recognizers = append(recognizers, recognizer)
-				return nil
-			}
-
-			return util.NewTypeError("*Recognizer", value)
-		})
+	return util.MapSliceOrSingleton(value, func(value lua.LValue) (*Recognizer, error) {
+		return util.TypecheckUserData[*Recognizer](value, "*Recognizer")
 	})
-
-	return
 }
 
 // RecognizerFromTable decodes a single Lua table value into a recognizer instance.

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
@@ -139,11 +139,9 @@ func NamedRecognizersFromUserDataMap(value lua.LValue, allowFalseAsNil bool) (re
 			return nil
 		}
 
-		if value.Type() == lua.LTBool && !lua.LVAsBool(value) {
-			if allowFalseAsNil {
-				recognizers[name] = nil
-				return nil
-			}
+		if allowFalseAsNil && value.Type() == lua.LTBool && !lua.LVAsBool(value) {
+			recognizers[name] = nil
+			return nil
 		}
 
 		recognizer, err := util.TypecheckUserData[*Recognizer](value, "*Recognizer")

--- a/internal/codeintel/autoindexing/internal/inference/service.go
+++ b/internal/codeintel/autoindexing/internal/inference/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/luasandbox"
+	"github.com/sourcegraph/sourcegraph/internal/luasandbox/util"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
@@ -95,7 +96,7 @@ func (s *Service) InferIndexJobs(ctx context.Context, repo api.RepoName, commit,
 		linearize: luatypes.LinearizeGenerator,
 		callback:  func(recognizer *luatypes.Recognizer) *baselua.LFunction { return recognizer.Generator() },
 		scanLuaValue: func(value baselua.LValue) ([]indexJobOrHint, error) {
-			jobs, err := luatypes.IndexJobsFromTable(value)
+			jobs, err := util.MapSliceOrSingleton(value, luatypes.IndexJobFromTable)
 			if err != nil {
 				return nil, err
 			}
@@ -145,7 +146,7 @@ func (s *Service) InferIndexJobHints(ctx context.Context, repo api.RepoName, com
 		linearize: luatypes.LinearizeHinter,
 		callback:  func(recognizer *luatypes.Recognizer) *baselua.LFunction { return recognizer.Hinter() },
 		scanLuaValue: func(value baselua.LValue) ([]indexJobOrHint, error) {
-			jobHints, err := luatypes.IndexJobHintsFromTable(value)
+			jobHints, err := util.MapSliceOrSingleton(value, luatypes.IndexJobHintFromTable)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/luasandbox/util/util.go
+++ b/internal/luasandbox/util/util.go
@@ -98,20 +98,15 @@ func SetString(ptr *string) func(lua.LValue) error {
 // on invocation. For use in DecodeTable.
 func SetStrings(ptr *[]string) func(lua.LValue) error {
 	return func(value lua.LValue) (err error) {
-		values, err := DecodeSlice(value)
+		table, ok := value.(*lua.LTable)
+		if !ok {
+			return NewTypeError("table", value)
+		}
+		strs, err := MapSlice(table, assertLuaString)
 		if err != nil {
 			return err
 		}
-
-		for _, v := range values {
-			str, err := assertLuaString(v)
-			if err != nil {
-				return err
-			}
-
-			*ptr = append(*ptr, str)
-		}
-
+		*ptr = append(*ptr, strs...)
 		return nil
 	}
 }
@@ -125,24 +120,33 @@ func SetLuaFunction(ptr **lua.LFunction) func(lua.LValue) error {
 	}
 }
 
-// DecodeSlice reads the values off of the given table and collects them into a
-// slice. This function returns an error if the value has an unexpected type.
-func DecodeSlice(value lua.LValue) (values []lua.LValue, _ error) {
-	table, ok := value.(*lua.LTable)
-	if !ok {
-		return nil, NewTypeError("table", value)
-	}
+type notArrayError struct {
+	value lua.LValue
+}
 
-	if err := ForEach(table, func(key, value lua.LValue) error {
+func (n *notArrayError) Error() string {
+	return NewTypeError("array", n.value).Error()
+}
+
+var _ error = &notArrayError{}
+
+func MapSlice[T any](table *lua.LTable, f func(lua.LValue) (T, error)) (values []T, _ error) {
+	return MapTableValues(table, func(value lua.LValue) (T, error) {
 		if table.Len() == 0 {
-			// There are key/value pairs but they're associative, not indexed.
-			// Throw here as we're decoding a table that's of an unexpected
-			// shape.
-			return NewTypeError("array", value)
+			var t T
+			return t, &notArrayError{value}
 		}
+		return f(value)
+	})
+}
 
-		values = append(values, value)
-		return nil
+// MapTableValues reads the values off of the given table and collects them into a
+// slice. Returns an error if the callback hits an error.
+func MapTableValues[T any](table *lua.LTable, f func(lua.LValue) (T, error)) (values []T, _ error) {
+	if err := ForEach(table, func(key, value lua.LValue) error {
+		v, err := f(value)
+		values = append(values, v)
+		return err
 	}); err != nil {
 		return nil, err
 	}
@@ -150,34 +154,45 @@ func DecodeSlice(value lua.LValue) (values []lua.LValue, _ error) {
 	return values, nil
 }
 
-// UnwrapLuaUserData invokes the given callback with the value within the given
+// MapUserData invokes the given callback with the value within the given
 // user data value. This function returns an error if the given type is not a
 // pointer to user data.
-func UnwrapLuaUserData(value lua.LValue, f func(any) error) error {
+func MapUserData[T any](value lua.LValue, f func(any) (T, error)) (T, error) {
 	userData, err := assertUserData(value)
 	if err != nil {
-		return err
+		var t T
+		return t, err
 	}
-
 	return f(userData.Value)
 }
 
-// UnwrapSliceOrSingleton attempts to unwrap the given Lua value as a slice, then
+// TypecheckUserData is a specialized version of MapUserData which just performs
+// a type assertion. T should be instantiated to a pointer type
+func TypecheckUserData[T any](value lua.LValue, expectedType string) (T, error) {
+	return MapUserData(value, func(value any) (T, error) {
+		v, ok := value.(T)
+		if !ok {
+			return v, NewTypeError(expectedType, value)
+		}
+		return v, nil
+	})
+}
+
+// MapSliceOrSingleton attempts to unwrap the given Lua value as a slice, then
 // call the given callback over each element of the slice. If the given value does
 // not seem to be a slice, then the callback is invoked once with the entire payload.
-func UnwrapSliceOrSingleton(value lua.LValue, f func(lua.LValue) error) error {
-	values, err := DecodeSlice(value)
-	if err != nil {
-		return f(value)
-	}
-
-	for _, value := range values {
-		if err := f(value); err != nil {
-			return err
+func MapSliceOrSingleton[T any](value lua.LValue, f func(lua.LValue) (T, error)) ([]T, error) {
+	if table, ok := value.(*lua.LTable); ok {
+		ts, err := MapSlice(table, f)
+		if _, ok := err.(*notArrayError); !ok {
+			return ts, err
 		}
 	}
-
-	return nil
+	ret, err := f(value)
+	if err != nil {
+		return nil, err
+	}
+	return []T{ret}, nil
 }
 
 // NewTypeError creates an error with the given expected and actual value type.


### PR DESCRIPTION
There were some APIs which are unwieldy to use (perhaps because
of being written pre-generics), so I've simplified them before doing
more work here.

## Test plan

Covered by existing tests.
