### PR TITLE
[Backport 5.1] httpcli: respect retry-after on all error responses, set retry-after in Cody Gateway responses

### DIFF
--- a/cmd/sitemap/graphql.go
+++ b/cmd/sitemap/graphql.go
@@ -73,7 +73,7 @@ func (c *graphQLClient) requestGraphQL(ctx context.Context, queryName string, qu
 			httpcli.ExternalTransportOpt,
 			httpcli.NewErrorResilientTransportOpt(
 				httpcli.NewRetryPolicy(httpcli.MaxRetries(graphQLRetryMaxAttempts), 2*time.Second),
-				httpcli.ExpJitterDelay(graphQLRetryDelayBase, graphQLRetryDelayMax),
+				httpcli.ExpJitterDelayOrRetryAfterDelay(graphQLRetryDelayBase, graphQLRetryDelayMax),
 			),
 			httpcli.TracedTransportOpt,
 		)

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -91,6 +91,14 @@ func NewAnthropicHandler(
 				return len(lastCompletion)
 			},
 		},
+
+		// Anthropic primarily uses concurrent requests to rate-limit spikes
+		// in requests, so set a default retry-after that is likely to be
+		// acceptable for Sourcegraph clients to retry (the default
+		// SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION) since we might be
+		// able to circumvent concurrents limits without raising an error to the
+		// user.
+		2, // seconds
 	)
 }
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -102,6 +102,12 @@ func NewOpenAIHandler(
 				return len(finalCompletion)
 			},
 		},
+
+		// OpenAI primarily uses tokens-per-minute ("TPM") to rate-limit spikes
+		// in requests, so set a very high retry-after to discourage Sourcegraph
+		// clients from retrying at all since retries are probably not going to
+		// help in a minute-long rate limit window.
+		30, // seconds
 	)
 }
 

--- a/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,6 +63,11 @@ func makeUpstreamHandler[ReqT any](
 	allowedModels []string,
 
 	methods upstreamHandlerMethods[ReqT],
+
+	// defaultRetryAfterSeconds sets the retry-after policy on upstream rate
+	// limit events in case a retry-after is not provided by the upstream
+	// response.
+	defaultRetryAfterSeconds int,
 ) http.Handler {
 	baseLogger = baseLogger.Scoped(upstreamName, fmt.Sprintf("%s upstream handler", upstreamName)).
 		With(log.String("upstream.url", upstreamAPIURL))
@@ -225,14 +231,22 @@ func makeUpstreamHandler[ReqT any](
 			if upstreamStatusCode == http.StatusTooManyRequests {
 				// Rewrite 429 to 503 because we share a quota when talking to upstream,
 				// and a 429 from upstream should NOT indicate to the client that they
-				// should retry. To ensure we are notified when this happens, log this
-				// as an error and record the headers that are provided to us.
+				// should liberally retry until the rate limit is lifted. To ensure we are
+				// notified when this happens, log this as an error and record the headers
+				// that are provided to us.
 				var headers bytes.Buffer
 				_ = resp.Header.Write(&headers)
 				logger.Error("upstream returned 429, rewriting to 503",
 					log.Error(errors.New(resp.Status)), // real error needed for Sentry reporting
 					log.String("resp.headers", headers.String()))
 				resolvedStatusCode = http.StatusServiceUnavailable
+				// Propagate retry-after in case it is handle-able by the client,
+				// or write our default. 503 errors can have retry-after as well.
+				if upstreamRetryAfter := resp.Header.Get("retry-after"); upstreamRetryAfter != "" {
+					w.Header().Set("retry-after", upstreamRetryAfter)
+				} else {
+					w.Header().Set("retry-after", strconv.Itoa(defaultRetryAfterSeconds))
+				}
 			}
 
 			// Write the resolved status code.

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -108,7 +108,13 @@ func NewHandler(
 			usedTokens = ut
 			upstreamFinished = time.Since(upstreamStarted)
 			if err != nil {
-				logger.Error("error from upstream", log.Error(err))
+				// This is an error path, so always set a default retry-after
+				// on errors that discourages Sourcegraph clients from retrying
+				// at all - embeddings will likely be run by embeddings workers
+				// that will eventually retry on a more reasonable schedule.
+				w.Header().Set("retry-after", "60")
+
+				// If a status error is returned, pass through the code and error
 				var statusCodeErr response.HTTPStatusCodeError
 				if errors.As(err, &statusCodeErr) {
 					resolvedStatusCode = statusCodeErr.HTTPStatusCode()

--- a/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
+++ b/enterprise/cmd/cody-gateway/internal/httpapi/embeddings/openai_test.go
@@ -18,7 +18,3 @@ func TestOpenAI(t *testing.T) {
 		require.ErrorContains(t, err, "empty string")
 	})
 }
-
-type roundTripFunc func(r *http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -527,7 +527,7 @@ func NewRetryPolicy(max int, maxRetryAfterDuration time.Duration) rehttp.RetryFn
 
 	return func(a rehttp.Attempt) (retry bool) {
 		tr := trace.TraceFromContext(a.Request.Context())
-		if a.Index == 0 {
+		if tr != nil && a.Index == 0 {
 			// For the initial attempt set it to false in case we never retry,
 			// to make this easier to query in Cloud Trace. This attribute will
 			// get overwritten later if a retry occurs.
@@ -541,7 +541,7 @@ func NewRetryPolicy(max int, maxRetryAfterDuration time.Duration) rehttp.RetryFn
 		defer func() {
 			// Avoid trace log spam if we haven't invoked the retry policy.
 			shouldTraceLog := retry || a.Index > 0
-			if tr := trace.TraceFromContext(a.Request.Context()); tr != nil && shouldTraceLog {
+			if tr != nil && shouldTraceLog {
 				fields := []attribute.KeyValue{
 					attribute.Bool("retry", retry),
 					attribute.Int("attempt", a.Index),

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -148,7 +148,7 @@ func newExternalClientFactory(cache bool, middleware ...Middleware) *Factory {
 		ExternalTransportOpt,
 		NewErrorResilientTransportOpt(
 			NewRetryPolicy(MaxRetries(externalRetryMaxAttempts), externalRetryAfterMaxDuration),
-			ExpJitterDelay(externalRetryDelayBase, externalRetryDelayMax),
+			ExpJitterDelayOrRetryAfterDelay(externalRetryDelayBase, externalRetryDelayMax),
 		),
 		TracedTransportOpt,
 	}
@@ -203,7 +203,7 @@ func NewInternalClientFactory(subsystem string, middleware ...Middleware) *Facto
 		NewMaxIdleConnsPerHostOpt(500),
 		NewErrorResilientTransportOpt(
 			NewRetryPolicy(MaxRetries(internalRetryMaxAttempts), internalRetryAfterMaxDuration),
-			ExpJitterDelay(internalRetryDelayBase, internalRetryDelayMax),
+			ExpJitterDelayOrRetryAfterDelay(internalRetryDelayBase, internalRetryDelayMax),
 		),
 		MeteredTransportOpt(subsystem),
 		ActorTransportOpt,
@@ -520,9 +520,17 @@ func MaxRetries(n int) int {
 	return n
 }
 
+<<<<<<< HEAD
 // NewRetryPolicy returns a retry policy used in any Doer or Client returned
 // by NewExternalClientFactory.
 func NewRetryPolicy(max int, retryAfterMaxSleepDuration time.Duration) rehttp.RetryFn {
+=======
+// NewRetryPolicy returns a retry policy based on some Sourcegraph defaults.
+func NewRetryPolicy(max int, maxRetryAfterDuration time.Duration) rehttp.RetryFn {
+	// Indicates in trace whether or not this request was retried at some point
+	const retriedTraceAttributeKey = "httpcli.retried"
+
+>>>>>>> 76d4077c09 (httpcli: respect retry-after on all error responses, set retry-after in Cody Gateway responses (#55591))
 	return func(a rehttp.Attempt) (retry bool) {
 		status := 0
 		var retryAfterHeader string
@@ -603,52 +611,71 @@ func NewRetryPolicy(max int, retryAfterMaxSleepDuration time.Duration) rehttp.Re
 			return true
 		}
 
-		if status == 0 || (status >= 500 && status != http.StatusNotImplemented) {
-			return true
-		}
-
-		if status == http.StatusTooManyRequests {
-			// If a retry-after header exists, we only want to retry if it might resolve
-			// the issue.
-			if a.Response != nil {
-				retryAfterHeader = a.Response.Header.Get("retry-after")
-				if retryAfterHeader != "" {
-					// There are two valid formats for retry-after headers: seconds
-					// until retry in int, or a RFC1123 date string.
-					// First, see if it is denoted in seconds.
-					s, err := strconv.Atoi(retryAfterHeader)
-					// If denoted in seconds, only retry if we will get access within
-					// the next retryAfterMaxSleepDuration seconds.
-					if err == nil {
-						return s <= int(retryAfterMaxSleepDuration/time.Second)
-					}
-
-					// If we weren't able to parse as seconds, try to parse as RFC1123.
-					if err != nil {
-						after, err := time.Parse(time.RFC1123, retryAfterHeader)
-						if err != nil {
-							// We don't know how to parse this header, so let's just retry.
-							return true
-						}
-						// Check if the date is either in the past, or if within the next
-						// retryAfterMaxSleepDuration we would get access again.
-						in := time.Until(after)
-						return in <= retryAfterMaxSleepDuration
-					}
-				}
-
-				// Otherwise, default to the behavior this function always had: retry 429 errors.
-				return true
-			}
+		// If we have some 5xx response or 429 response that could work after
+		// a few retries, retry the request, as determined by retryWithRetryAfter
+		if status == 0 ||
+			(status >= 500 && status != http.StatusNotImplemented) ||
+			status == http.StatusTooManyRequests {
+			retry, retryAfterHeader = retryWithRetryAfter(a.Response, maxRetryAfterDuration)
+			return retry
 		}
 
 		return false
 	}
 }
 
-// ExpJitterDelay returns a DelayFn that returns a delay between 0 and
-// base * 2^attempt capped at max (an exponential backoff delay with
-// jitter).
+// retryWithRetryAfter always retries, unless we have a non-nil response that
+// indicates a retry-after header as outlined here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+func retryWithRetryAfter(response *http.Response, retryAfterMaxSleepDuration time.Duration) (bool, string) {
+	// If a retry-after header exists, we only want to retry if it might resolve
+	// the issue.
+	retryAfterHeader, retryAfter := extractRetryAfter(response)
+	if retryAfter != nil {
+		// Retry if retry-after is within the maximum sleep duration, otherwise
+		// there's no point retrying
+		return *retryAfter <= retryAfterMaxSleepDuration, retryAfterHeader
+	}
+
+	// Otherwise, default to the behavior we always had: retry.
+	return true, retryAfterHeader
+}
+
+// extractRetryAfter attempts to extract a retry-after time from retryAfterHeader,
+// returning a nil duration if it cannot infer one.
+func extractRetryAfter(response *http.Response) (retryAfterHeader string, retryAfter *time.Duration) {
+	if response != nil {
+		// See  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+		// for retry-after standards.
+		retryAfterHeader = response.Header.Get("retry-after")
+		if retryAfterHeader != "" {
+			// There are two valid formats for retry-after headers: seconds
+			// until retry in int, or a RFC1123 date string.
+			// First, see if it is denoted in seconds.
+			s, err := strconv.Atoi(retryAfterHeader)
+			if err == nil {
+				d := time.Duration(s) * time.Second
+				return retryAfterHeader, &d
+			}
+
+			// If we weren't able to parse as seconds, try to parse as RFC1123.
+			if err != nil {
+				after, err := time.Parse(time.RFC1123, retryAfterHeader)
+				if err != nil {
+					// We don't know how to parse this header
+					return retryAfterHeader, nil
+				}
+				in := time.Until(after)
+				return retryAfterHeader, &in
+			}
+		}
+	}
+	return retryAfterHeader, nil
+}
+
+// ExpJitterDelayOrRetryAfterDelay returns a DelayFn that returns a delay
+// between 0 and base * 2^attempt capped at max (an exponential backoff delay
+// with jitter), unless a 'retry-after' value is provided in the response - then
+// the 'retry-after' duration is used, up to max.
 //
 // See the full jitter algorithm in:
 // http://www.awsarchitectureblog.com/2015/03/backoff.html
@@ -656,20 +683,31 @@ func NewRetryPolicy(max int, retryAfterMaxSleepDuration time.Duration) rehttp.Re
 // This is adapted from rehttp.ExpJitterDelay to not use a non-thread-safe
 // package level PRNG and to be safe against overflows. It assumes that
 // max > base.
-func ExpJitterDelay(base, max time.Duration) rehttp.DelayFn {
+//
+// This retry policy has also been adapted to support using
+func ExpJitterDelayOrRetryAfterDelay(base, max time.Duration) rehttp.DelayFn {
 	var mu sync.Mutex
 	prng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	return func(attempt rehttp.Attempt) time.Duration {
-		exp := math.Pow(2, float64(attempt.Index))
-		top := float64(base) * exp
-		n := int64(math.Min(float64(max), top))
-		if n <= 0 {
-			return base
-		}
+		var delay time.Duration
+		if _, retryAfter := extractRetryAfter(attempt.Response); retryAfter != nil {
+			// Delay by what upstream request tells us. If retry-after is
+			// significantly higher than max, then it should be up to the retry
+			// policy to choose not to retry the request.
+			delay = *retryAfter
+		} else {
+			// Otherwise, generate a delay with some jitter.
+			exp := math.Pow(2, float64(attempt.Index))
+			top := float64(base) * exp
+			n := int64(math.Min(float64(max), top))
+			if n <= 0 {
+				return base
+			}
 
-		mu.Lock()
-		delay := time.Duration(prng.Int63n(n))
-		mu.Unlock()
+			mu.Lock()
+			delay = time.Duration(prng.Int63n(n))
+			mu.Unlock()
+		}
 
 		// Overflow handling
 		switch {

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -526,7 +526,7 @@ func NewRetryPolicy(max int, maxRetryAfterDuration time.Duration) rehttp.RetryFn
 	const retriedTraceAttributeKey = "httpcli.retried"
 
 	return func(a rehttp.Attempt) (retry bool) {
-		tr := trace.FromContext(a.Request.Context())
+		tr := trace.TraceFromContext(a.Request.Context())
 		if a.Index == 0 {
 			// For the initial attempt set it to false in case we never retry,
 			// to make this easier to query in Cloud Trace. This attribute will


### PR DESCRIPTION
Backports https://github.com/sourcegraph/sourcegraph/pull/55591 (manual PR because the automated one failed)