### PR TITLE
Batch Changes - commit message on stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Sourcegraph are documented in this file.
 - OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)
 - Bitbucket Cloud code host connections no longer automatically syncs the repository of the username used. The appropriate workspace name will have to be added to the `teams` list if repositories for that account need to be synced. [#55095](https://github.com/sourcegraph/sourcegraph/pull/55095)
 - Pressing `Mod-f` will always select the input value in the file view search [#55546](https://github.com/sourcegraph/sourcegraph/pull/55546)
+- The commit message defined in a batch spec will now be passed to `git commit` on stdin using `--file=-` instead of being included inline with `git commit -m` to improve how the message is interpreted by the shell in certain edge cases, such as when the commit message begins with a dash, and to prevent extra uotes being added to the message. This may mean that previous escaping strategies will behave differently.
 
 ### Fixed
 


### PR DESCRIPTION
Commit messages for batch changes can be arbitrary strings, so passing them inline to the command arguments using `-m` is prone to problems and edge cases.
Solving those problems and edge cases is non-optimal, so pivot to using a different way to specify commit messages: from a file (stdin in this case). This allows commit messages to contain arbitrary characters without needing to worry about escaping or edge cases.



## Test plan
in a batch spec, use a commit message that contains newlines (use `message: |` followed by the message on the next line, indented more than `message`). Check the commit message on the code host after the patch has been published.

You can include other characters in the commit message (one edge case we've seen is beginning the commit message with a dash) to ensure they are also handled correctly.
