### PR TITLE
gitserver: Start cleaning up server struct

### DIFF
--- a/cmd/gitserver/server/BUILD.bazel
+++ b/cmd/gitserver/server/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//internal/gitserver/protocol",
         "//internal/gitserver/search",
         "//internal/gitserver/v1:gitserver",
+        "//internal/goroutine",
         "//internal/grpc/streamio",
         "//internal/honey",
         "//internal/hostname",

--- a/cmd/gitserver/server/clone.go
+++ b/cmd/gitserver/server/clone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -28,7 +29,7 @@ func (s *Server) maybeStartClone(ctx context.Context, logger log.Logger, repo ap
 		}, false
 	}
 
-	cloneProgress, err := s.cloneRepo(ctx, repo, nil)
+	cloneProgress, err := s.CloneRepo(ctx, repo, CloneOptions{})
 	if err != nil {
 		logger.Debug("error starting repo clone", log.String("repo", string(repo)), log.Error(err))
 		return &protocol.NotFoundPayload{CloneInProgress: false}, false

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -129,7 +130,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}()
 
 	// Ensure tmp directory exists
-	tmpRepoDir, err := s.tempDir("patch-repo-")
+	tmpRepoDir, err := tempDir(s.ReposDir, "patch-repo-")
 	if err != nil {
 		resp.SetError(repo, "", "", errors.Wrap(err, "gitserver: make tmp repo"))
 		return http.StatusInternalServerError, resp
@@ -437,7 +438,7 @@ func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommit
 	p4client := strings.TrimPrefix(req.TargetRef, "refs/heads/")
 
 	// do all work in (another) temporary directory
-	tmpClientDir, err := s.tempDir("perforce-client-")
+	tmpClientDir, err := tempDir(s.ReposDir, "perforce-client-")
 	if err != nil {
 		return "", errors.Wrap(err, "gitserver: make tmp repo for Perforce client")
 	}

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -92,7 +92,7 @@ func (s *Server) handleRepoDelete(w http.ResponseWriter, r *http.Request) {
 func (s *Server) deleteRepo(ctx context.Context, repo api.RepoName) error {
 	// The repo may be deleted in the database, in this case we need to get the
 	// original name in order to find it on disk
-	err := s.removeRepoDirectory(s.dir(api.UndeletedRepoName(repo)), s.Logger, true)
+	err := removeRepoDirectory(ctx, s.Logger, s.DB, s.Hostname, s.ReposDir, s.dir(api.UndeletedRepoName(repo)), true)
 	if err != nil {
 		return errors.Wrap(err, "removing repo directory")
 	}

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -342,7 +342,7 @@ func (gs *GRPCServer) RepoClone(ctx context.Context, in *proto.RepoCloneRequest)
 
 	repo := protocol.NormalizeRepo(api.RepoName(in.GetRepo()))
 
-	if _, err := gs.Server.cloneRepo(ctx, repo, &cloneOptions{Block: false}); err != nil {
+	if _, err := gs.Server.CloneRepo(ctx, repo, CloneOptions{Block: false}); err != nil {
 
 		return &proto.RepoCloneResponse{Error: err.Error()}, nil
 	}

--- a/cmd/gitserver/shared/BUILD.bazel
+++ b/cmd/gitserver/shared/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//internal/grpc/defaults",
         "//internal/hostname",
         "//internal/httpcli",
+        "//internal/httpserver",
         "//internal/instrumentation",
         "//internal/jsonc",
         "//internal/observation",

--- a/cmd/gitserver/shared/debug.go
+++ b/cmd/gitserver/shared/debug.go
@@ -6,7 +6,6 @@ import (
 
 // GRPCWebUIDebugEndpoint returns a debug endpoint that serves the GRPCWebUI that targets
 // this gitserver instance.
-func GRPCWebUIDebugEndpoint() debugserver.Endpoint {
-	addr := getAddr()
+func GRPCWebUIDebugEndpoint(addr string) debugserver.Endpoint {
 	return debugserver.NewGRPCWebUIEndpoint("gitserver", addr)
 }

--- a/cmd/gitserver/shared/service.go
+++ b/cmd/gitserver/shared/service.go
@@ -16,7 +16,7 @@ func (svc) Name() string { return "gitserver" }
 func (svc) Configure() (env.Config, []debugserver.Endpoint) {
 	c := LoadConfig()
 	endpoints := []debugserver.Endpoint{
-		GRPCWebUIDebugEndpoint(),
+		GRPCWebUIDebugEndpoint(c.ListenAddress),
 	}
 
 	return c, endpoints

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -5,14 +5,12 @@ import (
 	"container/list"
 	"context"
 	"database/sql"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -34,7 +32,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	connections "github.com/sourcegraph/sourcegraph/internal/database/connections/live"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/crates"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gomodproxy"
@@ -45,8 +42,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
-	"github.com/sourcegraph/sourcegraph/internal/hostname"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -66,68 +63,85 @@ type EnterpriseInit func(db database.DB, keyring keyring.Ring)
 func Main(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, config *Config, enterpriseInit EnterpriseInit) error {
 	logger := observationCtx.Logger
 
+	// Load and validate configuration.
 	if err := config.Validate(); err != nil {
 		return errors.Wrap(err, "failed to validate configuration")
 	}
 
-	// Ensure the ReposDir exists.
-	if err := os.MkdirAll(config.ReposDir, os.ModePerm); err != nil {
-		return errors.Wrap(err, "creating SRC_REPOS_DIR")
+	// Prepare the file system.
+	{
+		// Ensure the ReposDir exists.
+		if err := os.MkdirAll(config.ReposDir, os.ModePerm); err != nil {
+			return errors.Wrap(err, "creating SRC_REPOS_DIR")
+		}
+		// Ensure the Perforce Dir exists.
+		p4Home := filepath.Join(config.ReposDir, server.P4HomeName)
+		if err := os.MkdirAll(p4Home, os.ModePerm); err != nil {
+			return errors.Wrapf(err, "ensuring p4Home exists: %q", p4Home)
+		}
+		// Ensure the tmp dir exists, is cleaned up, and TMP_DIR is set properly.
+		tmpDir, err := setupAndClearTmp(logger, config.ReposDir)
+		if err != nil {
+			return errors.Wrap(err, "failed to setup temporary directory")
+		}
+		// Additionally, set TMP_DIR so other temporary files we may accidentally
+		// create are on the faster RepoDir mount.
+		if err := os.Setenv("TMP_DIR", tmpDir); err != nil {
+			return errors.Wrap(err, "setting TMP_DIR")
+		}
 	}
 
+	// Create a database connection.
 	sqlDB, err := getDB(observationCtx)
 	if err != nil {
 		return errors.Wrap(err, "initializing database stores")
 	}
 	db := database.NewDB(observationCtx.Logger, sqlDB)
 
-	repoStore := db.Repos()
-	dependenciesSvc := dependencies.NewService(observationCtx, db)
-	externalServiceStore := db.ExternalServices()
-
+	// Initialize the keyring.
 	err = keyring.Init(ctx)
 	if err != nil {
 		return errors.Wrap(err, "initializing keyring")
 	}
 
+	// Possibly run enterprise hooks.
 	if enterpriseInit != nil {
 		enterpriseInit(db, keyring.Default())
 	}
 
-	if err != nil {
-		return errors.Wrap(err, "creating sub-repo client")
-	}
-
+	// Setup our server megastruct.
 	recordingCommandFactory := wrexec.NewRecordingCommandFactory(nil, 0)
+	cloneQueue := server.NewCloneQueue(observationCtx, list.New())
 	gitserver := server.Server{
-		Logger:             logger,
-		ObservationCtx:     observationCtx,
-		ReposDir:           config.ReposDir,
-		DesiredPercentFree: config.JanitorReposDesiredPercentFree,
+		Logger:         logger,
+		ObservationCtx: observationCtx,
+		ReposDir:       config.ReposDir,
 		GetRemoteURLFunc: func(ctx context.Context, repo api.RepoName) (string, error) {
-			return getRemoteURLFunc(ctx, db, repoStore, repo)
+			return getRemoteURLFunc(ctx, logger, db, repo)
 		},
 		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
 			return getVCSSyncer(ctx, &newVCSSyncerOpts{
-				externalServiceStore:    externalServiceStore,
-				repoStore:               repoStore,
-				depsSvc:                 dependenciesSvc,
+				externalServiceStore:    db.ExternalServices(),
+				repoStore:               db.Repos(),
+				depsSvc:                 dependencies.NewService(observationCtx, db),
 				repo:                    repo,
 				reposDir:                config.ReposDir,
 				coursierCacheDir:        config.CoursierCacheDir,
 				recordingCommandFactory: recordingCommandFactory,
 			})
 		},
-		Hostname:                externalAddress(),
+		Hostname:                config.ExternalAddress,
 		DB:                      db,
-		CloneQueue:              server.NewCloneQueue(observationCtx, list.New()),
+		CloneQueue:              cloneQueue,
 		GlobalBatchLogSemaphore: semaphore.NewWeighted(int64(config.BatchLogGlobalConcurrencyLimit)),
 		Perforce:                perforce.NewService(ctx, observationCtx, logger, db, list.New()),
 		RecordingCommandFactory: recordingCommandFactory,
 		DeduplicatedForksSet:    types.NewRepoURICache(conf.GetDeduplicatedForksIndex()),
 	}
 
-	conf.Watch(func() {
+	// Make sure we watch for config updates that affect DeduplicatedForksSet or
+	// the recordingCommandFactory.
+	go conf.Watch(func() {
 		gitserver.DeduplicatedForksSet.Overwrite(conf.GetDeduplicatedForksIndex())
 
 		// We update the factory with a predicate func. Each subsequent recordable command will use this predicate
@@ -140,6 +154,75 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		recordingCommandFactory.Update(recordCommandsOnRepos(recordingConf.Repos, recordingConf.IgnoredGitCommands), recordingConf.Size)
 	})
 
+	gitserver.RegisterMetrics(observationCtx, db)
+
+	// Create Handler now since it also initializes state
+	// TODO: Why do we set server state as a side effect of creating our handler?
+	handler := gitserver.Handler()
+	handler = actor.HTTPMiddleware(logger, handler)
+	handler = requestclient.InternalHTTPMiddleware(handler)
+	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
+	handler = instrumentation.HTTPMiddleware("", handler)
+	handler = internalgrpc.MultiplexHandlers(makeGRPCServer(logger, &gitserver), handler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Best effort attempt to sync rate limiters for external services early on. If
+	// it fails, we'll try again in the background syncer.
+	if err := syncExternalServiceRateLimiters(ctx, db.ExternalServices()); err != nil {
+		logger.Warn("error performing initial rate limit sync", log.Error(err))
+	}
+
+	routines := []goroutine.BackgroundRoutine{
+		httpserver.NewFromAddr(config.ListenAddress, &http.Server{
+			Handler: handler,
+		}),
+		gitserver.NewClonePipeline(logger, cloneQueue),
+		newRateLimitSyncer(ctx, db, config.RateLimitSyncerLimitPerSecond),
+		gitserver.NewRepoStateSyncer(ctx, config.SyncRepoStateInterval, config.SyncRepoStateBatchSize, config.SyncRepoStateUpdatePerSecond),
+	}
+
+	if runtime.GOOS == "windows" {
+		// See https://github.com/sourcegraph/sourcegraph/issues/54317 for details.
+		logger.Warn("Janitor is disabled on windows")
+	} else {
+		routines = append(
+			routines,
+			server.NewJanitor(
+				ctx,
+				server.JanitorConfig{
+					ShardID:            gitserver.Hostname,
+					JanitorInterval:    config.JanitorInterval,
+					ReposDir:           config.ReposDir,
+					DesiredPercentFree: config.JanitorReposDesiredPercentFree,
+				},
+				db,
+				recordingCommandFactory,
+				gitserver.CloneRepo,
+				logger,
+			),
+		)
+	}
+
+	logger.Info("git-server: listening", log.String("addr", config.ListenAddress))
+
+	// We're ready!
+	ready()
+
+	// Launch all routines!
+	goroutine.MonitorBackgroundRoutines(ctx, routines...)
+
+	// The most important thing this does is kill all our clones. If we just
+	// shutdown they will be orphaned and continue running.
+	gitserver.Stop()
+
+	return nil
+}
+
+// makeGRPCServer creates a new *grpc.Server for the gitserver endpoints and registers
+// it with methods on the given server.
+func makeGRPCServer(logger log.Logger, s *server.Server) *grpc.Server {
 	configurationWatcher := conf.DefaultClient()
 
 	var additionalServerOptions []grpc.ServerOption
@@ -160,89 +243,11 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	}
 
 	grpcServer := defaults.NewServer(logger, additionalServerOptions...)
-
 	proto.RegisterGitserverServiceServer(grpcServer, &server.GRPCServer{
-		Server: &gitserver,
+		Server: s,
 	})
 
-	gitserver.RegisterMetrics(observationCtx, db)
-
-	if tmpDir, err := gitserver.SetupAndClearTmp(); err != nil {
-		return errors.Wrap(err, "failed to setup temporary directory")
-	} else if err := os.Setenv("TMP_DIR", tmpDir); err != nil {
-		// Additionally, set TMP_DIR so other temporary files we may accidentally
-		// create are on the faster RepoDir mount.
-		return errors.Wrap(err, "setting TMP_DIR")
-	}
-
-	// Create Handler now since it also initializes state
-	// TODO: Why do we set server state as a side effect of creating our handler?
-	handler := gitserver.Handler()
-	handler = actor.HTTPMiddleware(logger, handler)
-	handler = requestclient.InternalHTTPMiddleware(handler)
-	handler = trace.HTTPMiddleware(logger, handler, conf.DefaultClient())
-	handler = instrumentation.HTTPMiddleware("", handler)
-	handler = internalgrpc.MultiplexHandlers(grpcServer, handler)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Best effort attempt to sync rate limiters for external services early on. If
-	// it fails, we'll try again in the background sync below.
-	if err := syncExternalServiceRateLimiters(ctx, externalServiceStore); err != nil {
-		logger.Warn("error performing initial rate limit sync", log.Error(err))
-	}
-
-	// Ready immediately
-	ready()
-
-	go syncRateLimiters(ctx, logger, externalServiceStore, config.RateLimitSyncerLimitPerSecond)
-	go gitserver.Janitor(actor.WithInternalActor(ctx), config.JanitorInterval)
-	go gitserver.SyncRepoState(config.SyncRepoStateInterval, config.SyncRepoStateBatchSize, config.SyncRepoStateUpdatePerSecond)
-
-	gitserver.StartClonePipeline(ctx)
-
-	addr := getAddr()
-	srv := &http.Server{
-		Addr:    addr,
-		Handler: handler,
-	}
-	logger.Info("git-server: listening", log.String("addr", srv.Addr))
-
-	go func() {
-		err := srv.ListenAndServe()
-		if err != http.ErrServerClosed {
-			logger.Fatal(err.Error())
-		}
-	}()
-
-	// Listen for shutdown signals. When we receive one attempt to clean up,
-	// but do an insta-shutdown if we receive more than one signal.
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
-
-	// Once we receive one of the signals from above, continues with the shutdown
-	// process.
-	<-c
-	go func() {
-		// If a second signal is received, exit immediately.
-		<-c
-		os.Exit(0)
-	}()
-
-	// Wait for at most for the configured shutdown timeout.
-	ctx, cancel = context.WithTimeout(ctx, goroutine.GracefulShutdownTimeout)
-	defer cancel()
-	// Stop accepting requests.
-	if err := srv.Shutdown(ctx); err != nil {
-		logger.Error("shutting down http server", log.Error(err))
-	}
-
-	// The most important thing this does is kill all our clones. If we just
-	// shutdown they will be orphaned and continue running.
-	gitserver.Stop()
-
-	return nil
+	return grpcServer
 }
 
 func configureFusionClient(conn schema.PerforceConnection) server.FusionConfig {
@@ -308,13 +313,16 @@ func getDB(observationCtx *observation.Context) (*sql.DB, error) {
 	return connections.EnsureNewFrontendDB(observationCtx, dsn, "gitserver")
 }
 
+// getRemoteURLFunc returns a remote URL for the given repo, if any external service
+// connections reference it. The first external service mentioned in repo.Sources
+// will be used to construct the URL and get credentials.
 func getRemoteURLFunc(
 	ctx context.Context,
+	logger log.Logger,
 	db database.DB,
-	repoStore database.RepoStore,
 	repo api.RepoName,
 ) (string, error) {
-	r, err := repoStore.GetByName(ctx, repo)
+	r, err := db.Repos().GetByName(ctx, repo)
 	if err != nil {
 		return "", err
 	}
@@ -332,10 +340,11 @@ func getRemoteURLFunc(
 			// if a repo moves from being public to private while belonging to both a cloud
 			// default external service and another external service with a token that has
 			// access to the private repo.
+			// TODO: This should not be possible anymore, can we remove this check?
 			continue
 		}
 
-		return repos.EncryptableCloneURL(ctx, log.Scoped("repos.CloneURL", ""), db, svc.Kind, svc.Config, r)
+		return repos.EncryptableCloneURL(ctx, logger.Scoped("repos.CloneURL", ""), db, svc.Kind, svc.Config, r)
 	}
 	return "", errors.Errorf("no sources for %q", repo)
 }
@@ -473,74 +482,50 @@ func syncExternalServiceRateLimiters(ctx context.Context, store database.Externa
 
 // Sync rate limiters from config. Since we don't have a trigger that watches for
 // changes to rate limits we'll run this periodically in the background.
-func syncRateLimiters(ctx context.Context, logger log.Logger, store database.ExternalServiceStore, perSecond int) {
-	backoff := 5 * time.Second
+func newRateLimitSyncer(ctx context.Context, db database.DB, perSecond int) goroutine.BackgroundRoutine {
 	batchSize := 50
-	logger = logger.Scoped("syncRateLimiters", "sync rate limiters from config")
 
-	// perSecond should be spread across all gitserver instances and we want to wait
-	// until we know about at least one instance.
-	var instanceCount int
-	for {
-		instanceCount = len(conf.Get().ServiceConnectionConfig.GitServers)
-		if instanceCount > 0 {
-			break
-		}
-
-		logger.Warn("found zero gitserver instance, trying again after backoff", log.Duration("backoff", backoff))
+	// perSecond should be spread across all gitserver instances. If we cannot
+	// get the number of gitservers initially, we just continue, this limiter
+	// is not very critical as it just means how many external services we fetch
+	// in a given second, and most instances have a handful at most.
+	instanceCount := len(conf.Get().ServiceConnectionConfig.GitServers)
+	if instanceCount <= 0 {
+		instanceCount = 1
 	}
 
-	limiter := ratelimit.NewInstrumentedLimiter("RateLimitSyncer", rate.NewLimiter(rate.Limit(float64(perSecond)/float64(instanceCount)), batchSize))
-	syncer := repos.NewRateLimitSyncer(ratelimit.DefaultRegistry, store, repos.RateLimitSyncerOpts{
+	limiter := ratelimit.NewInstrumentedLimiter(
+		"RateLimitSyncer",
+		rate.NewLimiter(rate.Limit(float64(perSecond)/float64(instanceCount)), batchSize),
+	)
+	syncer := repos.NewRateLimitSyncer(ratelimit.DefaultRegistry, db.ExternalServices(), repos.RateLimitSyncerOpts{
 		PageSize: batchSize,
 		Limiter:  limiter,
 	})
 
 	var lastSuccessfulSync time.Time
-	ticker := time.NewTicker(1 * time.Minute)
-	for {
-		start := time.Now()
-		if err := syncer.SyncLimitersSince(ctx, lastSuccessfulSync); err != nil {
-			logger.Warn("syncRateLimiters: error syncing rate limits", log.Error(err))
-		} else {
+	return goroutine.NewPeriodicGoroutine(
+		actor.WithInternalActor(ctx),
+		goroutine.HandlerFunc(func(ctx context.Context) error {
+			// Get the latest configuration for the rate limiter and update it.
+			instanceCount := len(conf.Get().ServiceConnectionConfig.GitServers)
+			if instanceCount <= 0 {
+				instanceCount = 1
+			}
+			limiter.SetLimit(rate.Limit(float64(perSecond) / float64(instanceCount)))
+
+			start := time.Now()
+			if err := syncer.SyncLimitersSince(ctx, lastSuccessfulSync); err != nil {
+				return errors.Wrap(err, "syncRateLimiters: error syncing rate limits")
+			}
 			lastSuccessfulSync = start
-		}
 
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-	}
-}
-
-// externalAddress calculates the name of this gitserver as it would appear in
-// SRC_GIT_SERVERS.
-//
-// Note: we can't just rely on the listen address since more than likely
-// gitserver is behind a k8s service.
-func externalAddress() string {
-	// First we check for it being explicitly set. This should only be
-	// happening in environments were we run gitserver on localhost.
-	if addr := os.Getenv("GITSERVER_EXTERNAL_ADDR"); addr != "" {
-		return addr
-	}
-	// Otherwise we assume we can reach gitserver via its hostname / its
-	// hostname is a prefix of the reachable address (see hostnameMatch).
-	return hostname.Get()
-}
-
-func getAddr() string {
-	addr := os.Getenv("GITSERVER_ADDR")
-	if addr == "" {
-		port := "3178"
-		host := ""
-		if env.InsecureDev {
-			host = "127.0.0.1"
-		}
-		addr = net.JoinHostPort(host, port)
-	}
-	return addr
+			return nil
+		}),
+		goroutine.WithName("gitserver.rate-limit-syncer"),
+		goroutine.WithDescription("syncs rate limit configurations from external services into memory"),
+		goroutine.WithInterval(time.Minute),
+	)
 }
 
 // methodSpecificStreamInterceptor returns a gRPC stream server interceptor that only calls the next interceptor if the method matches.
@@ -631,4 +616,57 @@ func recordCommandsOnRepos(repos []string, ignoredGitCommands []string) wrexec.S
 		}
 		return true
 	}
+}
+
+// setupAndClearTmp sets up the tempdir for reposDir as well as clearing it
+// out. It returns the temporary directory location.
+func setupAndClearTmp(logger log.Logger, reposDir string) (string, error) {
+	logger = logger.Scoped("setupAndClearTmp", "sets up the the tempdir for ReposDir as well as clearing it out")
+
+	// Additionally, we create directories with the prefix .tmp-old which are
+	// asynchronously removed. We do not remove in place since it may be a
+	// slow operation to block on. Our tmp dir will be ${s.ReposDir}/.tmp
+	dir := filepath.Join(reposDir, server.TempDirName) // .tmp
+	oldPrefix := server.TempDirName + "-old"
+	if _, err := os.Stat(dir); err == nil {
+		// Rename the current tmp file, so we can asynchronously remove it. Use
+		// a consistent pattern so if we get interrupted, we can clean it
+		// another time.
+		oldTmp, err := os.MkdirTemp(reposDir, oldPrefix)
+		if err != nil {
+			return "", err
+		}
+		// oldTmp dir exists, so we need to use a child of oldTmp as the
+		// rename target.
+		if err := os.Rename(dir, filepath.Join(oldTmp, server.TempDirName)); err != nil {
+			return "", err
+		}
+	}
+
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return "", err
+	}
+
+	// Asynchronously remove old temporary directories.
+	// TODO: Why async?
+	files, err := os.ReadDir(reposDir)
+	if err != nil {
+		logger.Error("failed to do tmp cleanup", log.Error(err))
+	} else {
+		for _, f := range files {
+			// Remove older .tmp directories as well as our older tmp-
+			// directories we would place into ReposDir. In September 2018 we
+			// can remove support for removing tmp- directories.
+			if !strings.HasPrefix(f.Name(), oldPrefix) && !strings.HasPrefix(f.Name(), "tmp-") {
+				continue
+			}
+			go func(path string) {
+				if err := os.RemoveAll(path); err != nil {
+					logger.Error("failed to remove old temporary directory", log.String("path", path), log.Error(err))
+				}
+			}(filepath.Join(reposDir, f.Name()))
+		}
+	}
+
+	return dir, nil
 }

--- a/cmd/gitserver/shared/shared_test.go
+++ b/cmd/gitserver/shared/shared_test.go
@@ -3,10 +3,14 @@ package shared
 import (
 	"context"
 	"flag"
-	"net/http"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
@@ -27,14 +31,6 @@ func TestMain(m *testing.M) {
 		logtest.InitWithLevel(m, log.LevelNone)
 	}
 	os.Exit(m.Run())
-}
-
-type mockDoer struct {
-	do func(*http.Request) (*http.Response, error)
-}
-
-func (c *mockDoer) Do(r *http.Request) (*http.Response, error) {
-	return c.do(r)
 }
 
 func TestGetVCSSyncer(t *testing.T) {
@@ -206,5 +202,159 @@ func TestMethodSpecificUnaryInterceptor(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func TestSetupAndClearTmp(t *testing.T) {
+	root := t.TempDir()
+
+	// All non .git paths should become .git
+	mkFiles(t, root,
+		"github.com/foo/baz/.git/HEAD",
+		"example.org/repo/.git/HEAD",
+
+		// Needs to be deleted
+		".tmp/foo",
+		".tmp/baz/bam",
+
+		// Older tmp cleanups that failed
+		".tmp-old123/foo",
+	)
+
+	tmp, err := setupAndClearTmp(logtest.Scoped(t), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Straight after cleaning .tmp should be empty
+	assertPaths(t, filepath.Join(root, ".tmp"), ".")
+
+	// tmp should exist
+	if info, err := os.Stat(tmp); err != nil {
+		t.Fatal(err)
+	} else if !info.IsDir() {
+		t.Fatal("tmpdir is not a dir")
+	}
+
+	// tmp should be on the same mount as root, ie root is parent.
+	if filepath.Dir(tmp) != root {
+		t.Fatalf("tmp is not under root: tmp=%s root=%s", tmp, root)
+	}
+
+	// Wait until async cleaning is done
+	for i := 0; i < 1000; i++ {
+		found := false
+		files, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range files {
+			found = found || strings.HasPrefix(f.Name(), ".tmp-old")
+		}
+		if !found {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Only files should be the repo files
+	assertPaths(
+		t,
+		root,
+		"github.com/foo/baz/.git/HEAD",
+		"example.org/repo/.git/HEAD",
+		".tmp",
+	)
+}
+
+func TestSetupAndClearTmp_Empty(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := setupAndClearTmp(logtest.Scoped(t), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No files, just the empty .tmp dir should exist
+	assertPaths(t, root, ".tmp")
+}
+
+// assertPaths checks that all paths under want exist. It excludes non-empty directories
+func assertPaths(t *testing.T, root string, want ...string) {
+	t.Helper()
+	notfound := make(map[string]struct{})
+	for _, p := range want {
+		notfound[p] = struct{}{}
+	}
+	var unwanted []string
+	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if empty, err := isEmptyDir(path); err != nil {
+				t.Fatal(err)
+			} else if !empty {
+				return nil
+			}
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if _, ok := notfound[rel]; ok {
+			delete(notfound, rel)
+		} else {
+			unwanted = append(unwanted, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(notfound) > 0 {
+		var paths []string
+		for p := range notfound {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		t.Errorf("did not find expected paths: %s", strings.Join(paths, " "))
+	}
+	if len(unwanted) > 0 {
+		sort.Strings(unwanted)
+		t.Errorf("found unexpected paths: %s", strings.Join(unwanted, " "))
+	}
+}
+
+func isEmptyDir(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
+func mkFiles(t *testing.T, root string, paths ...string) {
+	t.Helper()
+	for _, p := range paths {
+		if err := os.MkdirAll(filepath.Join(root, filepath.Dir(p)), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(root, p), nil)
+	}
+}
+
+func writeFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	err := os.WriteFile(path, content, 0o666)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/enterprise/cmd/gitserver/shared/service.go
+++ b/enterprise/cmd/gitserver/shared/service.go
@@ -17,7 +17,7 @@ func (svc) Name() string { return "gitserver" }
 func (svc) Configure() (env.Config, []debugserver.Endpoint) {
 	c := shared.LoadConfig()
 	endpoints := []debugserver.Endpoint{
-		shared.GRPCWebUIDebugEndpoint(),
+		shared.GRPCWebUIDebugEndpoint(c.ListenAddress),
 	}
 	return c, endpoints
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -50,6 +50,7 @@ const git = "git"
 var (
 	clientFactory  = httpcli.NewInternalClientFactory("gitserver")
 	defaultDoer, _ = clientFactory.Doer()
+	// defaultLimiter limits concurrent HTTP requests per running process to gitserver.
 	defaultLimiter = limiter.New(500)
 )
 


### PR DESCRIPTION
This PR starts moving some things off of the server struct that don't actually need it. 

## What do we gain? 

In tests, we don't need to construct the entire server each time, of which we have no clue what of the fields are actually required in a test. This makes the individual functions much easier to test. 

Also, the server struct with about 100 receiver methods smells like a huge anti-pattern. It's very hard to reason about what this monstrosity is all doing, or maybe also.. not doing. I'm hoping this is slowly becoming clearer as the individual subcomponents of the server become more obvious by such refactors.

As a side effect of some of these things becoming standalone routines vs being part of Server, we get:
- Them being goroutines they are tracked in the background routines in our site-admin area
- And I personally find the Main function already much easier to read and reason about

Most of these changes are extremely mechanical, because we now pass down more arguments to functions instead of having everything on the server. That causes a bunch of added diff, but should be fairly easy to scroll past.

## Test plan

Tests are still passing, awaiting CI for integration tests, and started a fresh gitserver installation and ended up with repos properly cloned.