### PR TITLE
docs: add cool feature on index page

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,7 @@
 # <img alt="Sourcegraph logo" src="/assets/sourcegraph-logo-dark.svg" width="50%" class="theme-dark-only"><img alt="Sourcegraph logo" src="/assets/sourcegraph-logo-light.svg" width="50%" class="theme-light-only"><span class="sr-only">Sourcegraph</span>
 
+<marquee>Thorsten was here</marquee>
+
 Sourcegraph makes it easy to read, write, and fix code—even in big, complex codebases.
 
 - **Code search:** Search all of your repositories across all branches and all code hosts.

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,9 @@
 # <img alt="Sourcegraph logo" src="/assets/sourcegraph-logo-dark.svg" width="50%" class="theme-dark-only"><img alt="Sourcegraph logo" src="/assets/sourcegraph-logo-light.svg" width="50%" class="theme-light-only"><span class="sr-only">Sourcegraph</span>
 
-<marquee>Thorsten was here</marquee>
+<h1><marquee>Thorsten was here</marquee></h1>
+<h1><marquee>Thorsten was here</marquee></h1>
+
+FOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO
 
 Sourcegraph makes it easy to read, write, and fix code—even in big, complex codebases.
 


### PR DESCRIPTION
This is just to demonstrate that you can preview docs changes by using

```
https://docs.sourcegraph.com/@<branch>
```

NOTE: if you use `/` in a branch name, this won't work.

So, to preview this branch: [https://docs.sourcegraph.com/@mrn-docs-preview](https://docs.sourcegraph.com/@mrn-docs-preview) and you'll see this:

<img width="1284" alt="screenshot_2023-08-09_17 38 03@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/e11ed52c-a1f8-4aa3-b01e-1829ea9f9b85">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
