### PR TITLE
Batch Changes - commit message on stdin (#55657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to Sourcegraph are documented in this file.
 - OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)
 - Bitbucket Cloud code host connections no longer automatically syncs the repository of the username used. The appropriate workspace name will have to be added to the `teams` list if repositories for that account need to be synced. [#55095](https://github.com/sourcegraph/sourcegraph/pull/55095)
 - The gRPC implementation for the Symbol service's `LocalCodeIntel` endpoint has been changed to stream its results. [#55242](https://github.com/sourcegraph/sourcegraph/pull/55242)
+- Pressing `Mod-f` will always select the input value in the file view search [#55546](https://github.com/sourcegraph/sourcegraph/pull/55546)
+- The commit message defined in a batch spec will now be passed to `git commit` on stdin using `--file=-` instead of being included inline with `git commit -m` to improve how the message is interpreted by `git` in certain edge cases, such as when the commit message begins with a dash, and to prevent extra quotes being added to the message. This may mean that previous escaping strategies will behave differently.
 
 ### Fixed
 

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -396,7 +396,6 @@ func (s *Server) repoRemoteRefs(ctx context.Context, remoteURL *vcs.URL, repoNam
 		refs[split[2]] = fields[0]
 	}
 	return refs, nil
->>>>>>> d1202d8735 (Batch Changes - commit message on stdin (#55657))
 }
 
 func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommitFromPatchRequest, patchCommit string, remoteURL *vcs.URL, tmpGitPathEnv, altObjectsEnv string) (string, error) {


### PR DESCRIPTION
Commit messages for batch changes can be arbitrary strings, so passing them inline to the command arguments using `-m` is prone to problems and edge cases.
Solving those problems and edge cases is non-optimal, so pivot to using a different way to specify commit messages: from a file (stdin in this case). This allows commit messages to contain arbitrary characters without needing to worry about escaping or edge cases.

(cherry picked from commit d1202d873566cf93c74833d5574340997a818c06)

## Test plan

in a batch spec, use a commit message that contains newlines (use `message: |` followed by the message on the next line, indented more than `message`). Check the commit message on the code host after the patch has been published.

You can include other characters in the commit message (one edge case we've seen is beginning the commit message with a dash) to ensure they are also handled correctly.