### PR TITLE
Fix: Repo embedding scheduler job routine as internal actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed a bug where user account requests could not be approved even though the license would permit user creation otherwise. [#55482](https://github.com/sourcegraph/sourcegraph/pull/55482)
+- Fixed a bug where the background scheduler for embedding jobs based on policies would not schedule jobs for private repositories. [#55698](https://github.com/sourcegraph/sourcegraph/pull/55698)
 
 ### Removed
 

--- a/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
@@ -36,10 +37,9 @@ func (r repoEmbeddingSchedulerJob) Routines(_ context.Context, observationCtx *o
 		return nil, err
 	}
 
-	ctx := context.Background()
-
+	workCtx := actor.WithInternalActor(context.Background())
 	return []goroutine.BackgroundRoutine{
-		newRepoEmbeddingScheduler(ctx, gitserver.NewClient(db), db, repo.NewRepoEmbeddingJobsStore(db)),
+		newRepoEmbeddingScheduler(workCtx, gitserver.NewClient(db), db, repo.NewRepoEmbeddingJobsStore(db)),
 	}, nil
 }
 

--- a/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -2,11 +2,11 @@ package repo
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/embeddings"


### PR DESCRIPTION
We received [reports](https://sourcegraph.slack.com/archives/C03JR7S7KRP/p1691615072530409?thread_ts=1691445779.618029&cid=C03JR7S7KRP) in [slack](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1691505903644939) of repositories never getting scheduled for embedding jobs despite the filter / pattern preview showing repos that match.

In both cases linked private repos appear to be impacted. After fetching repo ids from `GetEmbeddableRepos` we then make another fetch for getting the repo names for those repo ids. This read operation is where we appear to end up missing out on some repos because we are not an internal actor and therefore [we must have permissions](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@5.1/-/blob/internal/database/repos.go?L1242) to the repos that we want `List`ed. When we aren't authorized for any repos then we end up never scheduling those repos since we never got the repo names.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

N/A