### PR TITLE
Fix main build due to broken paths in scripts

### DIFF
--- a/cmd/executor/build_binary.sh
+++ b/cmd/executor/build_binary.sh
@@ -2,7 +2,7 @@
 
 # This script builds the executor binary.
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 set -eu
 
 OUTPUT=$(mktemp -d -t sgbuild_XXXXXXX)

--- a/cmd/executor/docker-mirror/build.sh
+++ b/cmd/executor/docker-mirror/build.sh
@@ -18,7 +18,7 @@ echo "--- packer build"
 
 # Copy files into workspace.
 cp -R ./* "$TMR_WORKDIR"
-cp ../../../../.tool-versions "$TMR_WORKDIR"
+cp ../../../.tool-versions "$TMR_WORKDIR"
 
 export PKR_VAR_name
 PKR_VAR_name="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"

--- a/cmd/executor/release_binary.sh
+++ b/cmd/executor/release_binary.sh
@@ -2,7 +2,7 @@
 
 # This script publishes the executor binary.
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
+cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 set -eu
 
 # Copy uploaded binary to 'latest'.

--- a/cmd/executor/vm-image/build.sh
+++ b/cmd/executor/vm-image/build.sh
@@ -2,7 +2,7 @@
 
 # This script builds the executor image as a GCP boot disk image and as an AWS AMI.
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../../..
+cd "$(dirname "${BASH_SOURCE[0]}")"/../../..
 set -eu
 
 OUTPUT=$(mktemp -d -t sgdockerbuild_XXXXXXX)

--- a/enterprise/dev/ci/internal/ci/operations.go
+++ b/enterprise/dev/ci/internal/ci/operations.go
@@ -813,7 +813,7 @@ func buildExecutorVM(c Config, skipHashCompare bool) operations.Operation {
 			bk.Env("EXECUTOR_IS_TAGGED_RELEASE", strconv.FormatBool(c.RunType.Is(runtype.TaggedRelease))),
 		}
 		if !skipHashCompare {
-			compareHashScript := "./dev/ci/scripts/compare-hash.sh"
+			compareHashScript := "./enterprise/dev/ci/scripts/compare-hash.sh"
 			stepOpts = append(stepOpts,
 				// Soft-fail with code 222 if nothing has changed
 				bk.SoftFail(222),


### PR DESCRIPTION
Those steps don't run on not-main so missed those when moving executor from enterprise/cmd to cmd.

## Test plan

main-dry-run. 