### PR TITLE
sveltekit: Remove faker from production build

### DIFF
--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker'
 import { createPopper, type Instance, type Options } from '@popperjs/core'
 import type { ActionReturn, Action } from 'svelte/action'
 import * as uuid from 'uuid'
@@ -11,7 +10,7 @@ import { highlightNode } from '$lib/common'
  */
 export function uniqueID(prefix = '') {
     if (process.env.VITEST) {
-        return `test-${prefix}-${faker.string.uuid()}`
+        return `test-${prefix}-123`
     }
     return `${prefix}-${uuid.v4()}`
 }


### PR DESCRIPTION
I assumed that faker wouldn't be included in production builds due to tree-shaking but I was wrong. It currently adds > 2MB to the production build files.

I confirmed that the `if` statement is removed in the production build (i.e. faker is not referenced) but the module is still included.

I thought maybe the dead code removal happens after dependencies are processed, so I removed the callsite completel but the module would still be included.

I tried various [`treeshake`](https://rollupjs.org/configuration-options/#treeshake) options, such as `moduleSideEffects: false`, but to no avail.

So for the time being, removing the import alltoghether is the best way to ensure that the module is not included in the production build.



## Test plan

`pnpm build` ... the output listing the generated files confirms that faker isn't included anymore

`pnpm vitest`
