### PR TITLE
Switch package repo paths and use new signing keys

### DIFF
--- a/enterprise/dev/ci/scripts/wolfi/build-repo-index.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-repo-index.sh
@@ -4,10 +4,6 @@ set -eu -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
 
-MAIN_BRANCH="main"
-BRANCH="${BUILDKITE_BRANCH:-'default-branch'}"
-IS_MAIN=$([ "$BRANCH" = "$MAIN_BRANCH" ] && echo "true" || echo "false")
-
 # TODO: Manage these variables properly
 GCP_PROJECT="sourcegraph-ci"
 GCS_BUCKET="package-repository"
@@ -47,7 +43,7 @@ apkindex_build_dir=$(mktemp -d -t apkindex-build.XXXXXXXX)
 pushd "$apkindex_build_dir"
 
 # Fetch all APKINDEX fragments from bucket
-gsutil -u "$GCP_PROJECT" -m cp "gs://$GCS_BUCKET/packages/$BRANCH_PATH/$TARGET_ARCH/*.APKINDEX.fragment" ./
+gsutil -u "$GCP_PROJECT" -m cp "gs://$GCS_BUCKET/$BRANCH_PATH/$TARGET_ARCH/*.APKINDEX.fragment" ./
 
 # Concat all fragments into a single APKINDEX and tar.gz it
 touch placeholder.APKINDEX.fragment
@@ -65,4 +61,4 @@ melange sign-index --signing-key "$key_path" APKINDEX.tar.gz
 
 # Upload signed APKINDEX archive
 # Use no-cache to avoid index/packages getting out of sync
-gsutil -u "$GCP_PROJECT" -h "Cache-Control:no-cache" cp APKINDEX.tar.gz "gs://$GCS_BUCKET/packages/$BRANCH_PATH/$TARGET_ARCH/"
+gsutil -u "$GCP_PROJECT" -h "Cache-Control:no-cache" cp APKINDEX.tar.gz "gs://$GCS_BUCKET/$BRANCH_PATH/$TARGET_ARCH/"

--- a/enterprise/dev/ci/scripts/wolfi/build-repo-index.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-repo-index.sh
@@ -3,8 +3,10 @@
 set -eu -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
-# TODO: This must be replaced with a proper K8s managed secret
-key_path=$(realpath ./wolfi-packages/temporary-keys/)
+
+MAIN_BRANCH="main"
+BRANCH="${BUILDKITE_BRANCH:-'default-branch'}"
+IS_MAIN=$([ "$BRANCH" = "$MAIN_BRANCH" ] && echo "true" || echo "false")
 
 # TODO: Manage these variables properly
 GCP_PROJECT="sourcegraph-ci"
@@ -53,9 +55,13 @@ cat ./*.APKINDEX.fragment >APKINDEX
 touch DESCRIPTION
 tar zcf APKINDEX.tar.gz APKINDEX DESCRIPTION
 
-# Sign index
-# TODO: Use separate keys for staging and prod repos
-melange sign-index --signing-key "$key_path/melange.rsa" APKINDEX.tar.gz
+# Sign index, using separate keys from GCS for staging and prod repos
+if [[ "$IS_MAIN" == "true" ]]; then
+  key_path="/keys/sourcegraph-melange-prod.rsa"
+else
+  key_path="/keys/sourcegraph-melange-dev.rsa"
+fi
+melange sign-index --signing-key "$key_path" APKINDEX.tar.gz
 
 # Upload signed APKINDEX archive
 # Use no-cache to avoid index/packages getting out of sync

--- a/enterprise/dev/ci/scripts/wolfi/upload-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/upload-package.sh
@@ -32,11 +32,11 @@ for apk in "${apks[@]}"; do
   echo " * Processing $apk"
 
   # Generate the branch-specific path to upload the package to
-  dest_path="gs://$GCS_BUCKET/packages/$BRANCH_PATH/$TARGET_ARCH/"
+  dest_path="gs://$GCS_BUCKET/$BRANCH_PATH/$TARGET_ARCH/"
   echo "   -> File path: ${dest_path}${apk}"
 
   # Generate the path to the package file on the main branch
-  dest_path_main="gs://$GCS_BUCKET/packages/$MAIN_BRANCH/$TARGET_ARCH/"
+  dest_path_main="gs://$GCS_BUCKET/$MAIN_BRANCH/$TARGET_ARCH/"
 
   # Generate index fragment for this package
   melange index -o "$apk.APKINDEX.tar.gz" "$apk"
@@ -68,16 +68,14 @@ done
 
 # Show package usage message on branches
 if [[ "$IS_MAIN" != "true" ]]; then
-
-  # TODO: Update keyring when keys change: https://storage.googleapis.com/package-repository/packages/${BRANCH_PATH}/melange.rsa.pub
   if [[ -n "$BUILDKITE" ]]; then
     echo -e "To use this package locally, add the following lines to your base image config:
 \`\`\`
 contents:
   keyring:
-    - https://storage.googleapis.com/package-repository/packages/melange.rsa.pub
+    - https://packages.sgdev.org/sourcegraph-melange-dev.rsa.pub
   repositories:
-    - '@branch https://storage.googleapis.com/package-repository/packages/${BRANCH_PATH}'
+    - '@branch https://packages.sgdev.org/${BRANCH_PATH}'
   packages:
 $package_usage_list
   \`\`\`" | ../../../enterprise/dev/ci/scripts/annotate.sh -s "custom-repo" -m -t "info"

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -2,12 +2,12 @@
 contents:
   keyring:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    - https://storage.googleapis.com/package-repository/packages/melange.rsa.pub
-    - https://storage.googleapis.com/package-repository/chainguard/chainguard-enterprise.rsa.pub
+    - https://packages.sgdev.org/melange.rsa.pub
+    - https://packages.sgdev.org/chainguard/chainguard-enterprise.rsa.pub
   repositories:
     - https://packages.wolfi.dev/os
-    - '@sourcegraph https://storage.googleapis.com/package-repository/packages/main'
-    - '@chainguard https://storage.googleapis.com/package-repository/chainguard'
+    - '@sourcegraph https://packages.sgdev.org/main'
+    - '@chainguard https://packages.sgdev.org/chainguard'
   packages:
     ## Base set of packages
     - wolfi-baselayout

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -2,7 +2,7 @@
 contents:
   keyring:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    - https://packages.sgdev.org/melange.rsa.pub
+    - https://packages.sgdev.org/sourcegraph-melange-prod.rsa.pub
     - https://packages.sgdev.org/chainguard/chainguard-enterprise.rsa.pub
   repositories:
     - https://packages.wolfi.dev/os


### PR DESCRIPTION
* Switch over from a GCS url to the new alias introduced [here](https://github.com/sourcegraph/infrastructure/pull/5304).
* Switch the root package repo path from `gs://package-repo/packages/` to `gs://package-repo/`
* Switch over to the new package signing keys introduced [here](https://github.com/sourcegraph/infrastructure/pull/5305).

Post-merge, this will require a rebuild of {repo index|all packages} with the new signing keys - currently the package repo is signed using the old `melange.rsa` key. Unsure whether this will require a full rebuild of all packages or just the index.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->

- Confirm base images still build locally
- Confirm package upload and reindex works on CI using new keys