### PR TITLE
feat(setup-checklist): add license validity checking logic

### DIFF
--- a/client/web/src/site-admin/setup-checklist/ChecklistNavbarItem.tsx
+++ b/client/web/src/site-admin/setup-checklist/ChecklistNavbarItem.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react'
 
-import { mdiCheck, mdiClose } from '@mdi/js'
+import { mdiCheck, mdiClose, mdiInformation } from '@mdi/js'
 import classNames from 'classnames'
 import MagnifyIcon from 'mdi-react/GearIcon'
 
-import { Icon, Badge } from '@sourcegraph/wildcard'
+import { Icon, Badge, Tooltip } from '@sourcegraph/wildcard'
 
 import { NavDropdown } from '../../nav/NavBar/NavDropdown'
 
@@ -12,7 +12,7 @@ import { useSetupChecklist } from './hooks/useSetupChecklist'
 
 export const ChecklistNavbarItem: React.FC = () => {
     const { data, loading } = useSetupChecklist()
-    const notConfiguredCount = useMemo(() => data.filter(item => !item.configured).length, [data])
+    const notConfiguredCount = useMemo(() => data.filter(item => item.needsSetup).length, [data])
 
     if (loading) {
         return null
@@ -38,17 +38,29 @@ export const ChecklistNavbarItem: React.FC = () => {
             items={data.map(feature => ({
                 content: (
                     <div className="d-flex align-items-center">
-                        <Icon
-                            svgPath={feature.configured ? mdiCheck : mdiClose}
-                            aria-label={feature.configured ? 'configured' : 'not configured'}
-                            className={classNames('mr-1', feature.configured ? 'text-success' : 'text-danger')}
-                        />
+                        {!feature.needsSetup && (
+                            <Icon
+                                svgPath={feature.needsSetup ? mdiClose : mdiCheck}
+                                aria-label={feature.needsSetup ? 'not configured' : 'configured'}
+                                className={classNames('mr-1', feature.needsSetup ? 'text-danger' : 'text-success')}
+                            />
+                        )}
+                        {feature.needsSetup && (
+                            <Tooltip content={feature.needsSetup}>
+                                <Icon
+                                    svgPath={mdiInformation}
+                                    // className="ml-1 text-muted"
+                                    className={classNames('mr-1 text-danger')}
+                                    aria-label={feature.needsSetup}
+                                />
+                            </Tooltip>
+                        )}
                         {feature.name}
                     </div>
                 ),
-                path: feature?.configured
-                    ? feature.path
-                    : `${feature.path}?setup-checklist=${encodeURIComponent(feature.id)}`,
+                path: feature?.needsSetup
+                    ? `${feature.path}?setup-checklist=${encodeURIComponent(feature.id)}`
+                    : feature.path,
             }))}
             name="feedback"
         />

--- a/client/web/src/site-admin/setup-checklist/hooks/__snapshots__/useSetupChecklist.test.tsx.snap
+++ b/client/web/src/site-admin/setup-checklist/hooks/__snapshots__/useSetupChecklist.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useSetupChecklist getLicenseSetupStatus returns reason if exceeded allowed user count 1`] = `"Your user count has exceeded your license limit. Please, get a new license."`;
+
+exports[`useSetupChecklist getLicenseSetupStatus returns reason if expired  1`] = `"The Sourcegraph license expired 1 day ago. Please, get a new license."`;
+
+exports[`useSetupChecklist getLicenseSetupStatus returns reason if expiring soon  1`] = `"The Sourcegraph license will expire in 6 days. Please, renew it soon."`;
+
+exports[`useSetupChecklist getLicenseSetupStatus returns reason if free plan license 1`] = `"You are on a free plan. Please, upgrade your license to unlock more features."`;
+
+exports[`useSetupChecklist getLicenseSetupStatus returns reason if isValid license 1`] = `"The Sourcegraph license key is invalid."`;

--- a/client/web/src/site-admin/setup-checklist/hooks/useSetupChecklist.test.tsx
+++ b/client/web/src/site-admin/setup-checklist/hooks/useSetupChecklist.test.tsx
@@ -1,0 +1,92 @@
+import { add, endOfYear, endOfYesterday, sub } from 'date-fns'
+import { cloneDeep, merge } from 'lodash'
+
+import { getLicenseSetupStatus } from './useSetupChecklist'
+
+type DeepPartial<T> = T extends object
+    ? {
+          [P in keyof T]?: DeepPartial<T[P]>
+      }
+    : T
+
+describe('useSetupChecklist', () => {
+    describe('getLicenseSetupStatus', () => {
+        const now = new Date(2023, 8, 10)
+        const args: Parameters<typeof getLicenseSetupStatus>[0] = {
+            productSubscription: {
+                license: {
+                    __typename: 'ProductLicenseInfo',
+                    isValid: true,
+                    expiresAt: add(now, { days: 100 }).toUTCString(),
+                    tags: [],
+                    userCount: 10,
+                },
+            },
+            users: {
+                totalCount: 9,
+            },
+        }
+        const toArgs = (newArgs: DeepPartial<typeof args>) => merge(cloneDeep(args), newArgs)
+
+        it('returns undefined if license is valid', () => {
+            expect(getLicenseSetupStatus(args, now)).toBeUndefined()
+        })
+
+        it('returns reason if isValid license', () => {
+            const reason = getLicenseSetupStatus(toArgs({ productSubscription: { license: { isValid: false } } }), now)
+            expect(reason).toBeDefined()
+            expect(reason).toMatchSnapshot()
+        })
+
+        it('returns reason if free plan license', () => {
+            const reason = getLicenseSetupStatus(
+                toArgs({ productSubscription: { license: { tags: ['plan:free-1'] } } }),
+                now
+            )
+            expect(reason).toBeDefined()
+            expect(reason).toMatchSnapshot()
+        })
+
+        it('returns reason if exceeded allowed user count', () => {
+            const reason = getLicenseSetupStatus(toArgs({ users: { totalCount: 11 } }), now)
+            expect(reason).toBeDefined()
+            expect(reason).toMatchSnapshot()
+        })
+
+        it('returns undefined if exceeded allowed user count but true-up', () => {
+            const reason = getLicenseSetupStatus(
+                toArgs({ users: { totalCount: 11 }, productSubscription: { license: { tags: ['true-up'] } } }),
+                now
+            )
+            expect(reason).toBeUndefined()
+        })
+
+        it('returns reason if expired ', () => {
+            const reason = getLicenseSetupStatus(
+                toArgs({ productSubscription: { license: { expiresAt: sub(now, { days: 1 }).toUTCString() } } }),
+                now
+            )
+            expect(reason).toBeDefined()
+            expect(reason).toMatchSnapshot()
+        })
+
+        it('returns reason if expiring soon ', () => {
+            const reason = getLicenseSetupStatus(
+                toArgs({ productSubscription: { license: { expiresAt: add(now, { days: 6 }).toUTCString() } } }),
+                now
+            )
+            expect(reason).toBeDefined()
+            expect(reason).toMatchSnapshot()
+        })
+
+        it('returns undefined if dev plan ', () => {
+            const reason = getLicenseSetupStatus(
+                toArgs({
+                    productSubscription: { license: { expiresAt: endOfYesterday().toUTCString(), tags: ['dev'] } },
+                }),
+                now
+            )
+            expect(reason).toBeUndefined()
+        })
+    })
+})

--- a/client/web/src/site-admin/setup-checklist/hooks/useSetupChecklist.tsx
+++ b/client/web/src/site-admin/setup-checklist/hooks/useSetupChecklist.tsx
@@ -1,3 +1,5 @@
+import { add, differenceInDays, formatDistanceStrict } from 'date-fns'
+
 import { gql, useQuery } from '@sourcegraph/http-client'
 import { Code, Link, Text } from '@sourcegraph/wildcard'
 
@@ -12,8 +14,13 @@ const QUERY = gql`
             productSubscription {
                 license {
                     isValid
+                    expiresAt
                     tags
+                    userCount
                 }
+            }
+            users(deletedAt: { empty: true }) {
+                totalCount
             }
         }
     }
@@ -24,36 +31,95 @@ export enum SetupChecklistItem {
 }
 
 interface UseSetupChecklistReturnType {
-    data: { id: SetupChecklistItem; name: string; path: string; info: React.ReactNode; configured?: boolean }[]
+    data: {
+        id: SetupChecklistItem
+        name: string
+        path: string
+        info: React.ReactNode
+        needsSetup?: string
+    }[]
     error?: any
     loading: boolean
+}
+
+const NOTIFY_LICENSE_EXPIRATION_DAYS = 7
+/**
+ * Returns either text of why setup/action is required or undefined if everything is good
+ *
+ * @param args
+ * @param now for testing purposes
+ */
+export const getLicenseSetupStatus = (
+    args?: Pick<SetupChecklistResult['site'], 'users' | 'productSubscription'>,
+    now = new Date()
+): string | undefined => {
+    const license = args?.productSubscription?.license
+
+    if (!license?.isValid) {
+        return 'The Sourcegraph license key is invalid.'
+    }
+
+    if (license?.tags?.includes('dev')) {
+        return
+    }
+
+    const expiresAt = license?.expiresAt ? new Date(license.expiresAt) : undefined
+    if (expiresAt && differenceInDays(expiresAt, now) <= NOTIFY_LICENSE_EXPIRATION_DAYS) {
+        return `The Sourcegraph license ${
+            differenceInDays(expiresAt, now) <= 0
+                ? 'expired ' + formatDistanceStrict(expiresAt, now) + ' ago. Please, get a new license.' // 'Expired two months ago'
+                : 'will expire in ' + formatDistanceStrict(expiresAt, now) + '. Please, renew it soon.' // 'Will expire in two months'
+        }`
+    }
+
+    if (license?.tags?.includes('plan:free-1')) {
+        return 'You are on a free plan. Please, upgrade your license to unlock more features.'
+    }
+
+    const userCount = args?.users?.totalCount
+    const hasExceededUserCount =
+        !!userCount && !!license?.userCount && userCount > license?.userCount && !license?.tags.includes('true-up')
+    if (hasExceededUserCount) {
+        return 'Your user count has exceeded your license limit. Please, get a new license.'
+    }
+
+    return
+}
+
+const getCodehostSetupStatus = (
+    args?: Pick<SetupChecklistResult['site'], 'externalServicesCounts'>
+): string | undefined => {
+    const codeHostsCounts = args?.externalServicesCounts?.remoteExternalServicesCount
+    // todo: add more checks such as valid code host connections
+    if (codeHostsCounts === 0) {
+        return 'Add code host connection'
+    }
+    return
 }
 
 export function useSetupChecklist(): UseSetupChecklistReturnType {
     const { data, loading, error } = useQuery<SetupChecklistResult, SetupChecklistVariables>(QUERY, {})
 
-    const codeHostsCounts = data?.site?.externalServicesCounts?.remoteExternalServicesCount ?? 0
-    const license = data?.site?.productSubscription?.license
     return {
         data: [
             {
                 id: SetupChecklistItem.AddLicense,
                 name: 'Add license',
                 path: '/site-admin/configuration',
+                needsSetup: getLicenseSetupStatus(data?.site),
                 info: (
                     <Text className="m-0">
                         Add a new <Code>licenseKey</Code> json field.{' '}
                         <Link to="/help/admin/config/site_config#licenseKey">Learn more</Link>
                     </Text>
                 ),
-                configured: license?.isValid && !license?.tags?.includes('plan:free-1'),
             },
             {
                 id: SetupChecklistItem.ConnectCodeHost,
-                name: 'Add remote repositories',
+                name: 'Connect codehost(s)',
                 path: '/site-admin/external-services/new',
-                info: <div>Add a codehost and sync its repositories</div>,
-                configured: codeHostsCounts > 0,
+                info: <div>Add codehost connections and sync its repositories</div>,
+                needsSetup: getCodehostSetupStatus(data?.site),
             },
         ],
         loading,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/55665

This PR adds setup checklist license checking logic for cases when the license is 1) invalid/expired 2) or in a free plan 3) or instance exceeds the allowed user count and no 'true-up' is allowed

## Test plan
- Tests added
- Check the diff

## Sreenshots
| Description | After| 
| -- | -- |
| is free plan | <img width="466" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/cbcfdc90-46ab-4081-af39-4e2af3cf1e44"> |
| exceeds user count | <img width="466" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/29284159-b42e-4aa3-8bb2-08f9ebe1d146"> | 
| expired | <img width="466" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/87e855a4-a955-4312-8dce-a35df26ab98e"> | 
| expiring within 7 days | <img width="466" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/a94cc1e6-4fb4-49e3-ada3-c1e0b4a293b1"> | 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles -->
