### PR TITLE
JetBrains: Add java install instructions

### DIFF
--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -27,8 +27,11 @@ New issues and feature requests can be filed through our [issue tracker](https:/
   1. CLI: [SDKMAN!](https://github.com/sdkman/homebrew-tap):
      - `brew tap sdkman/tap`
      - `brew install sdkman-cli`
-     - Add this to your `.zprofile`: `export SDKMAN_DIR=$(brew --prefix sdkman-cli)/libexec
-[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"`
+     - Add this to your `.zprofile`:
+       ```sh
+       export SDKMAN_DIR=$(brew --prefix sdkman-cli)/libexec
+       [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+       ```
      - Try it with `sdk version` in a new terminal. It should work.
      - Run `sdk install java 11.0.20-amzn`
   2. GUI:

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -23,8 +23,21 @@ New issues and feature requests can be filed through our [issue tracker](https:/
 - Run `pnpm generate` in the root directory to generate graphql files
 - Go to `client/jetbrains/` and run `pnpm build` to generate the JS files, or `pnpm watch` to watch for changes and regenerate on the fly
 - You can test the “Find with Sourcegraph” window by running `pnpm standalone` in the `client/jetbrains/` directory and opening [http://localhost:3000/](http://localhost:3000/) in your browser.
-- Run the plugin in a sandboxed IDE by running `./gradlew :runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
-  - Note: 2021.3 or later is required for Macs with Apple Silicon chips.
+- Make sure you have Java 11 installed. Two ways to do that:
+  1. CLI: [SDKMAN!](https://github.com/sdkman/homebrew-tap):
+     - `brew tap sdkman/tap`
+     - `brew install sdkman-cli`
+     - Add this to your `.zprofile`: `export SDKMAN_DIR=$(brew --prefix sdkman-cli)/libexec
+       [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"`
+     - Try it with `sdk version` in a new terminal. It should work.
+     - Run `sdk install java 11.0.20-amzn`
+  2. GUI:
+     - Open your clone of the repo in IntelliJ
+     - Go to Project Structure (`⌘;`) | Platform Settings | SDK | Plus sign | Download JDK... | set version to 11 | pick Amazon Corretto aarch64
+- Run the plugin in a sandboxed IDE. Two ways to do that:
+  1. CLI: run `./gradlew :runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
+  2. Run | Run... (`⌃⌥R`) | Edit Configurations... | Plus sign | Gradle | set Tasks to `runIde` | set Gradle project to `jetbrains` | name it `runIde` | OK | Run it with the green play button at the top right of the IDE. 
+  - Note: IntelliJ version 2021.3 or later is required for Macs with Apple Silicon chips.
 - Build a deployable plugin artifact by running `./gradlew buildPlugin`. The output file is `build/distributions/Sourcegraph.zip`.
 - Reformat the codebase with `./gradlew spotlessApply`.
 - Install the google-java-format plugin

--- a/client/jetbrains/CONTRIBUTING.md
+++ b/client/jetbrains/CONTRIBUTING.md
@@ -28,7 +28,7 @@ New issues and feature requests can be filed through our [issue tracker](https:/
      - `brew tap sdkman/tap`
      - `brew install sdkman-cli`
      - Add this to your `.zprofile`: `export SDKMAN_DIR=$(brew --prefix sdkman-cli)/libexec
-       [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"`
+[[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"`
      - Try it with `sdk version` in a new terminal. It should work.
      - Run `sdk install java 11.0.20-amzn`
   2. GUI:
@@ -36,7 +36,7 @@ New issues and feature requests can be filed through our [issue tracker](https:/
      - Go to Project Structure (`⌘;`) | Platform Settings | SDK | Plus sign | Download JDK... | set version to 11 | pick Amazon Corretto aarch64
 - Run the plugin in a sandboxed IDE. Two ways to do that:
   1. CLI: run `./gradlew :runIde`. This will start the platform with the versions defined in `gradle.properties`, [here](https://github.com/sourcegraph/sourcegraph/blob/main/client/jetbrains/gradle.properties#L14-L16).
-  2. Run | Run... (`⌃⌥R`) | Edit Configurations... | Plus sign | Gradle | set Tasks to `runIde` | set Gradle project to `jetbrains` | name it `runIde` | OK | Run it with the green play button at the top right of the IDE. 
+  2. Run | Run... (`⌃⌥R`) | Edit Configurations... | Plus sign | Gradle | set Tasks to `runIde` | set Gradle project to `jetbrains` | name it `runIde` | OK | Run it with the green play button at the top right of the IDE.
   - Note: IntelliJ version 2021.3 or later is required for Macs with Apple Silicon chips.
 - Build a deployable plugin artifact by running `./gradlew buildPlugin`. The output file is `build/distributions/Sourcegraph.zip`.
 - Reformat the codebase with `./gradlew spotlessApply`.


### PR DESCRIPTION
Bumped into this for the second time in two days, so adding more docs.

Added two ways to install Java 11 (CLI and GUI) and run the plugin.
Not saying that it's perfect, and I didn't test it thoroughly (but we tested the CLI commands on @chwarwick's machine while screen sharing, and I used the GUI method earlier), but it should be 90% correct.

## Test plan

Only docs change.