### PR TITLE
[cody/web] Papercuts: Hide delete & update history icon

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -238,7 +238,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                             </MenuButton>
 
                             <MenuList>
-                                {transcriptHistory[0].interactions.length > 0 && (
+                                {(transcriptHistory.length > 1 || !!transcriptHistory[0]?.interactions?.length) && (
                                     <>
                                         <MenuItem onSelect={clearHistory}>
                                             <Icon aria-hidden={true} svgPath={mdiDelete} /> Clear all chats
@@ -427,7 +427,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                         <Icon aria-hidden={true} svgPath={mdiPlus} />
                                     </Button>
                                 </Tooltip>
-                                {showMobileHistory && transcriptHistory[0].interactions.length > 0 && (
+                                {(transcriptHistory.length > 1 || !!transcriptHistory[0]?.interactions?.length) && (
                                     <Tooltip content="Clear all chats">
                                         <Button
                                             variant="icon"

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -238,10 +238,14 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                             </MenuButton>
 
                             <MenuList>
-                                <MenuItem onSelect={clearHistory}>
-                                    <Icon aria-hidden={true} svgPath={mdiDelete} /> Clear all chats
-                                </MenuItem>
-                                <MenuDivider />
+                                {transcriptHistory[0].interactions.length > 0 && (
+                                    <>
+                                        <MenuItem onSelect={clearHistory}>
+                                            <Icon aria-hidden={true} svgPath={mdiDelete} /> Clear all chats
+                                        </MenuItem>
+                                        <MenuDivider />
+                                    </>
+                                )}
                                 <MenuLink
                                     as={Link}
                                     to={isSourcegraphApp ? 'https://docs.sourcegraph.com/app' : '/help/cody'}
@@ -423,7 +427,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                         <Icon aria-hidden={true} svgPath={mdiPlus} />
                                     </Button>
                                 </Tooltip>
-                                {showMobileHistory && (
+                                {showMobileHistory && transcriptHistory[0].interactions.length > 0 && (
                                     <Tooltip content="Clear all chats">
                                         <Button
                                             variant="icon"

--- a/client/web/src/cody/components/HistoryList/HistoryList.tsx
+++ b/client/web/src/cody/components/HistoryList/HistoryList.tsx
@@ -110,14 +110,16 @@ const HistoryListItem: React.FunctionComponent<{
                 <Text className="mb-1 text-muted" size="small">
                     <Timestamp date={safeTimestampToDate(lastInteractionTimestamp)} />
                 </Text>
-                <Tooltip content="Delete">
-                    <Icon
-                        aria-label="Delete"
-                        svgPath={mdiDelete}
-                        onClick={deleteItem}
-                        className={styles.deleteButton}
-                    />
-                </Tooltip>
+                {!!interactions.length && (
+                    <Tooltip content="Delete">
+                        <Icon
+                            aria-label="Delete"
+                            svgPath={mdiDelete}
+                            onClick={deleteItem}
+                            className={styles.deleteButton}
+                        />
+                    </Tooltip>
+                )}
             </div>
             <Text className="mb-0 truncate text-body">
                 {text.slice(0, truncateMessageLength)}

--- a/client/web/src/cody/sidebar/CodySidebar.module.scss
+++ b/client/web/src/cody/sidebar/CodySidebar.module.scss
@@ -25,3 +25,7 @@
     display: flex;
     flex-direction: column;
 }
+
+.action-buttons {
+    min-width: 52px;
+}

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { mdiClose, mdiHistory, mdiPlus, mdiDelete } from '@mdi/js'
+import classNames from 'classnames'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import { Button, Icon, Tooltip, Badge } from '@sourcegraph/wildcard'
@@ -83,7 +84,7 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
         <div className={styles.mainWrapper}>
             <div className={styles.codySidebar} ref={codySidebarRef} onScroll={handleScroll}>
                 <div className={styles.codySidebarHeader}>
-                    <div className="d-flex col-2 p-0">
+                    <div className={classNames(styles.actionButtons, 'd-flex col-2 p-0')}>
                         <Tooltip content="Chat history">
                             <Button
                                 variant="icon"

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -100,7 +100,7 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
                                 <Icon aria-hidden={true} svgPath={mdiPlus} />
                             </Button>
                         </Tooltip>
-                        {showHistory && (
+                        {showHistory && transcriptHistory[0].interactions.length > 0 && (
                             <Tooltip content="Clear all chats">
                                 <Button
                                     variant="icon"

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { mdiClose, mdiFormatListBulleted, mdiPlus, mdiDelete } from '@mdi/js'
+import { mdiClose, mdiHistory, mdiPlus, mdiDelete } from '@mdi/js'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import { Button, Icon, Tooltip, Badge } from '@sourcegraph/wildcard'
@@ -92,7 +92,7 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
                                 onClick={() => setShowHistory(showing => !showing)}
                                 aria-pressed={showHistory}
                             >
-                                <Icon aria-hidden={true} svgPath={mdiFormatListBulleted} />
+                                <Icon aria-hidden={true} svgPath={mdiHistory} />
                             </Button>
                         </Tooltip>
                         <Tooltip content="Start a new chat">

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -101,18 +101,19 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
                                 <Icon aria-hidden={true} svgPath={mdiPlus} />
                             </Button>
                         </Tooltip>
-                        {showHistory && transcriptHistory[0].interactions.length > 0 && (
-                            <Tooltip content="Clear all chats">
-                                <Button
-                                    variant="icon"
-                                    className="ml-2"
-                                    aria-label="Clear all chats"
-                                    onClick={clearHistory}
-                                >
-                                    <Icon aria-hidden={true} svgPath={mdiDelete} />
-                                </Button>
-                            </Tooltip>
-                        )}
+                        {showHistory &&
+                            (transcriptHistory.length > 1 || !!transcriptHistory[0]?.interactions?.length) && (
+                                <Tooltip content="Clear all chats">
+                                    <Button
+                                        variant="icon"
+                                        className="ml-2"
+                                        aria-label="Clear all chats"
+                                        onClick={clearHistory}
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiDelete} />
+                                    </Button>
+                                </Tooltip>
+                            )}
                     </div>
                     <div className="col-8 d-flex justify-content-center">
                         <div className="d-flex flex-shrink-0 align-items-center">


### PR DESCRIPTION
Closes #55746 - Hides delete chat item or clear all chat history when there are no chat interactions. Updates chat history icon to match [VS Code's](https://github.com/sourcegraph/cody/pull/323)

### Empty chat history
<img width="602" alt="Screenshot 2023-08-10 at 9 20 52 AM" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/eb3a8d18-f0b1-482d-92fa-99d697a8cf17">
<img width="479" alt="Screenshot 2023-08-10 at 9 25 40 AM" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/be229104-b94d-4711-a2c5-10d1a3dc5224">

### Filled chat history
<img width="449" alt="Screenshot 2023-08-10 at 9 21 42 AM" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/c2e4b713-675f-4c43-8483-52e5f63b1c4d">
<img width="632" alt="Screenshot 2023-08-10 at 9 27 22 AM" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/74d45754-abde-4aee-b644-fa32523fbd4e">

## Test plan
- Manual test on cody sidebar & cody chat page: With chat history and without
