### PR TITLE
Search: fix tracing so "first results" is an event

### DIFF
--- a/internal/search/job/observe.go
+++ b/internal/search/job/observe.go
@@ -45,7 +45,7 @@ func (o *observingStream) Send(event streaming.SearchEvent) {
 		// Only log the first results once. We can rely on reusing the atomic
 		// int64 as a "sync.Once" since it is only ever incremented.
 		if newTotal == int64(l) {
-			o.tr.SetAttributes(attribute.String("event", "first results"))
+			o.tr.AddEvent("first results")
 		}
 	}
 	o.parent.Send(event)


### PR DESCRIPTION
The "first results" event got switched to an attribute at some point, but the timestamp is actually the interesting part of this event. This just switches it back from an attribute to an event.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
