### PR TITLE
JetBrains: Add more comprehensive autocomplete telemetry

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
@@ -34,11 +34,10 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
     }
 
     /**
-     * Applies the autocomplete to the document at a caret:
-     *   1. Replaces the string between the caret offset and its line end with the current completion
-     *   2. Moves the caret to the start and end offsets with the completion text.
-     * If there are multiple carets, uses the first one.
-     * If there are no completions at the caret, does nothing.
+     * Applies the autocomplete to the document at a caret: 1. Replaces the string between the caret
+     * offset and its line end with the current completion 2. Moves the caret to the start and end
+     * offsets with the completion text. If there are multiple carets, uses the first one. If there
+     * are no completions at the caret, does nothing.
      */
     @Override
     protected void doExecute(

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
@@ -33,6 +33,13 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
           && AutoCompleteText.atCaret(caret).isPresent();
     }
 
+    /**
+     * Applies the autocomplete to the document at a caret:
+     *   1. Replaces the string between the caret offset and its line end with the current completion
+     *   2. Moves the caret to the start and end offsets with the completion text.
+     * If there are multiple carets, uses the first one.
+     * If there are no completions at the caret, does nothing.
+     */
     @Override
     protected void doExecute(
         @NotNull Editor editor, @Nullable Caret maybeCaret, @Nullable DataContext dataContext) {
@@ -60,7 +67,7 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
 
   /**
    * Applies the autocomplete to the document at a caret. This replaces the string between the caret
-   * offset and its line end with the autocompletion String and then moves the caret to the end of
+   * offset and its line end with the autocompletion string and then moves the caret to the end of
    * the autocompletion.
    *
    * @param document the document to apply the autocomplete to
@@ -68,18 +75,27 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
    */
   private static void applyAutoComplete(
       @NotNull Document document, @NotNull AutoCompleteTextAtCaret autoComplete) {
+    // Calculate the end of the line to replace
     int lineEndOffset =
         document.getLineEndOffset(document.getLineNumber(autoComplete.caret.getOffset()));
+
+    // Get autocompletion string
     String autoCompletionString =
         autoComplete.autoCompleteText.getAutoCompletionString(
             document.getText(TextRange.create(autoComplete.caret.getOffset(), lineEndOffset)));
+
+    // If the autocompletion string does not contain the suffix of the line, add it to the end
     String sameLineSuffix =
         document.getText(TextRange.create(autoComplete.caret.getOffset(), lineEndOffset));
     String sameLineSuffixIfMissing =
         autoCompletionString.contains(sameLineSuffix) ? "" : sameLineSuffix;
+
+    // Replace the line with the autocompletion string
     String finalAutoCompletionString = autoCompletionString + sameLineSuffixIfMissing;
     document.replaceString(
         autoComplete.caret.getOffset(), lineEndOffset, finalAutoCompletionString);
+
+    // Move the caret to the end of the autocompletion string
     autoComplete.caret.moveToOffset(
         autoComplete.caret.getOffset() + finalAutoCompletionString.length());
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteTextAtCaret.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteTextAtCaret.java
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.autocomplete;
 import com.intellij.openapi.editor.Caret;
 import org.jetbrains.annotations.NotNull;
 
-class AutoCompleteTextAtCaret {
+public class AutoCompleteTextAtCaret {
   @NotNull public final AutoCompleteText autoCompleteText;
   @NotNull public final Caret caret;
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -2,21 +2,19 @@ package com.sourcegraph.cody.autocomplete;
 
 import org.jetbrains.annotations.NotNull;
 
-/**
- * A class that stores the state and timing information of an autocompletion.
- */
-public class Autocompletion {
+/** A class that stores the state and timing information of an autocompletion. */
+public class AutocompleteTelemetry {
   private long completionTriggeredTimestampMs;
   private long completionDisplayedTimestampMs;
   private long completionHiddenTimestampMs;
 
-  public static @NotNull Autocompletion createAndMarkTriggered() {
-    var autocompletion = new Autocompletion();
+  public static @NotNull AutocompleteTelemetry createAndMarkTriggered() {
+    var autocompletion = new AutocompleteTelemetry();
     autocompletion.completionTriggeredTimestampMs = System.currentTimeMillis();
     return autocompletion;
   }
 
-  private Autocompletion() {}
+  private AutocompleteTelemetry() {}
 
   public void markCompletionDisplayed() {
     this.completionDisplayedTimestampMs = System.currentTimeMillis();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -10,7 +10,8 @@ public class AutocompleteTelemetry {
 
   public static @NotNull AutocompleteTelemetry createAndMarkTriggered() {
     var autocompletion = new AutocompleteTelemetry();
-    // TODO: we could use java.time.Instant.now() and java.time.Duration.between(Instant,Instant) and avoid the "TimestampMs" suffixes
+    // TODO: we could use java.time.Instant.now() and java.time.Duration.between(Instant,Instant)
+    // and avoid the "TimestampMs" suffixes
     autocompletion.completionTriggeredTimestampMs = System.currentTimeMillis();
     return autocompletion;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -10,6 +10,7 @@ public class AutocompleteTelemetry {
 
   public static @NotNull AutocompleteTelemetry createAndMarkTriggered() {
     var autocompletion = new AutocompleteTelemetry();
+    // TODO: we could use java.time.Instant.now() and java.time.Duration.between(Instant,Instant) and avoid the "TimestampMs" suffixes
     autocompletion.completionTriggeredTimestampMs = System.currentTimeMillis();
     return autocompletion;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
@@ -2,6 +2,9 @@ package com.sourcegraph.cody.autocomplete;
 
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A class that stores the state and timing information of an autocompletion.
+ */
 public class Autocompletion {
   private long completionTriggeredTimestampMs;
   private long completionDisplayedTimestampMs;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
@@ -13,8 +13,7 @@ public class Autocompletion {
     return autocompletion;
   }
 
-  private Autocompletion() {
-  }
+  private Autocompletion() {}
 
   public void markCompletionDisplayed() {
     this.completionDisplayedTimestampMs = System.currentTimeMillis();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/Autocompletion.java
@@ -1,0 +1,44 @@
+package com.sourcegraph.cody.autocomplete;
+
+import org.jetbrains.annotations.NotNull;
+
+public class Autocompletion {
+  private long completionTriggeredTimestampMs;
+  private long completionDisplayedTimestampMs;
+  private long completionHiddenTimestampMs;
+
+  public static @NotNull Autocompletion createAndMarkTriggered() {
+    var autocompletion = new Autocompletion();
+    autocompletion.completionTriggeredTimestampMs = System.currentTimeMillis();
+    return autocompletion;
+  }
+
+  private Autocompletion() {
+  }
+
+  public void markCompletionDisplayed() {
+    this.completionDisplayedTimestampMs = System.currentTimeMillis();
+  }
+
+  public long getLatencyMs() {
+    return completionDisplayedTimestampMs - completionTriggeredTimestampMs;
+  }
+
+  public void markCompletionHidden() {
+    this.completionHiddenTimestampMs = System.currentTimeMillis();
+  }
+
+  public long getDisplayDurationMs() {
+    return completionHiddenTimestampMs - completionDisplayedTimestampMs;
+  }
+
+  public @NotNull AutocompletionStatus getStatus() {
+    if (completionDisplayedTimestampMs == 0) {
+      return AutocompletionStatus.TRIGGERED_NOT_DISPLAYED;
+    }
+    if (completionHiddenTimestampMs == 0) {
+      return AutocompletionStatus.DISPLAYED;
+    }
+    return AutocompletionStatus.HIDDEN;
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
@@ -1,8 +1,6 @@
 package com.sourcegraph.cody.autocomplete;
 
-/**
- * The possible states of an autocompletion.
- */
+/** The possible states of an autocompletion. */
 public enum AutocompletionStatus {
   TRIGGERED_NOT_DISPLAYED,
   DISPLAYED,

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody.autocomplete;
+
+public enum AutocompletionStatus {
+  TRIGGERED_NOT_DISPLAYED,
+  DISPLAYED,
+  HIDDEN
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompletionStatus.java
@@ -1,5 +1,8 @@
 package com.sourcegraph.cody.autocomplete;
 
+/**
+ * The possible states of an autocompletion.
+ */
 public enum AutocompletionStatus {
   TRIGGERED_NOT_DISPLAYED,
   DISPLAYED,

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -35,7 +35,7 @@ public class CodyAutoCompleteManager {
   // TODO: figure out how to avoid the ugly nested `Future<CompletableFuture<T>>` type.
   private final AtomicReference<Optional<Future<CompletableFuture<Void>>>> currentJob =
       new AtomicReference<>(Optional.empty());
-  private @Nullable Autocompletion currentAutocompletion = null;
+  private @Nullable AutocompleteTelemetry currentAutocompleteTelemetry = null;
 
   public static @NotNull CodyAutoCompleteManager getInstance() {
     return ApplicationManager.getApplication().getService(CodyAutoCompleteManager.class);
@@ -47,15 +47,15 @@ public class CodyAutoCompleteManager {
     Optional.ofNullable(editor.getProject())
         .ifPresent(
             p -> {
-              if (currentAutocompletion != null
-                  && currentAutocompletion.getStatus()
+              if (currentAutocompleteTelemetry != null
+                  && currentAutocompleteTelemetry.getStatus()
                       != AutocompletionStatus.TRIGGERED_NOT_DISPLAYED) {
-                currentAutocompletion.markCompletionHidden();
+                currentAutocompleteTelemetry.markCompletionHidden();
                 GraphQlLogger.logAutocompleteSuggestedEvent(
                     p,
-                    currentAutocompletion.getLatencyMs(),
-                    currentAutocompletion.getDisplayDurationMs());
-                currentAutocompletion = null;
+                    currentAutocompleteTelemetry.getLatencyMs(),
+                    currentAutocompleteTelemetry.getDisplayDurationMs());
+                currentAutocompleteTelemetry = null;
               }
             });
 
@@ -89,7 +89,7 @@ public class CodyAutoCompleteManager {
     }
 
     // Save autocompletion
-    currentAutocompletion = Autocompletion.createAndMarkTriggered();
+    currentAutocompleteTelemetry = AutocompleteTelemetry.createAndMarkTriggered();
 
     Project project = editor.getProject();
     if (project != null) {
@@ -187,8 +187,8 @@ public class CodyAutoCompleteManager {
                           /* Clear existing completions */
                           this.clearAutoCompleteSuggestions(editor);
 
-                          if (currentAutocompletion != null) {
-                            currentAutocompletion.markCompletionDisplayed();
+                          if (currentAutocompleteTelemetry != null) {
+                            currentAutocompleteTelemetry.markCompletionDisplayed();
                           }
 
                           /* Display autocomplete */

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -131,21 +131,7 @@ public class CodyAutoCompleteManager {
   }
 
   /**
-   * Asynchronously triggers auto-complete for the given editor and offset. Details: - Calls
-   * provideInlineAutoCompleteItems() on the provider to get autocomplete items. - Filters and
-   * processes the results: - Removes undesired characters - Normalizes indentation - Finds the
-   * first non-empty insertText item - If an item is found: - Clears existing autocomplete items -
-   * Logs a "completion suggested" event - Renders the autocomplete item as inline, after line, and
-   * block elements - Adds the rendered elements to the editor's InlayModel - Returns a
-   * CompletableFuture<Void> that completes when the autocomplete is rendered. - Catches any
-   * unexpected exceptions and logs a warning.
-   *
-   * @param editor The editor instance to provide autocomplete for.
-   * @param offset The character offset in the editor to trigger autocomplete at.
-   * @param token The CancellationToken to allow cancelling the autocomplete job.
-   * @param provider The CodyAutoCompleteItemProvider to generate autocomplete items.
-   * @param textDocument The TextDocument representing the editor content.
-   * @param autoCompleteDocumentContext The context for the autocomplete request.
+   * Asynchronously triggers auto-complete for the given editor and offset.
    */
   private CompletableFuture<Void> triggerAutoCompleteAsync(
       @NotNull Editor editor,

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -47,10 +47,14 @@ public class CodyAutoCompleteManager {
     Optional.ofNullable(editor.getProject())
         .ifPresent(
             p -> {
-              if (currentAutocompletion != null && currentAutocompletion.getStatus() != AutocompletionStatus.TRIGGERED_NOT_DISPLAYED) {
+              if (currentAutocompletion != null
+                  && currentAutocompletion.getStatus()
+                      != AutocompletionStatus.TRIGGERED_NOT_DISPLAYED) {
                 currentAutocompletion.markCompletionHidden();
                 GraphQlLogger.logAutocompleteSuggestedEvent(
-                    p, currentAutocompletion.getLatencyMs(), currentAutocompletion.getDisplayDurationMs());
+                    p,
+                    currentAutocompletion.getLatencyMs(),
+                    currentAutocompletion.getDisplayDurationMs());
                 currentAutocompletion = null;
               }
             });
@@ -127,19 +131,14 @@ public class CodyAutoCompleteManager {
   }
 
   /**
-   * Asynchronously triggers auto-complete for the given editor and offset. Details:
-   * - Calls provideInlineAutoCompleteItems() on the provider to get autocomplete items.
-   * - Filters and processes the results:
-   *   - Removes undesired characters
-   *   - Normalizes indentation
-   *   - Finds the first non-empty insertText item
-   * - If an item is found:
-   *   - Clears existing autocomplete items
-   *   - Logs a "completion suggested" event
-   *   - Renders the autocomplete item as inline, after line, and block elements
-   *   - Adds the rendered elements to the editor's InlayModel
-   * - Returns a CompletableFuture<Void> that completes when the autocomplete is rendered.
-   * - Catches any unexpected exceptions and logs a warning.
+   * Asynchronously triggers auto-complete for the given editor and offset. Details: - Calls
+   * provideInlineAutoCompleteItems() on the provider to get autocomplete items. - Filters and
+   * processes the results: - Removes undesired characters - Normalizes indentation - Finds the
+   * first non-empty insertText item - If an item is found: - Clears existing autocomplete items -
+   * Logs a "completion suggested" event - Renders the autocomplete item as inline, after line, and
+   * block elements - Adds the rendered elements to the editor's InlayModel - Returns a
+   * CompletableFuture<Void> that completes when the autocomplete is rendered. - Catches any
+   * unexpected exceptions and logs a warning.
    *
    * @param editor The editor instance to provide autocomplete for.
    * @param offset The character offset in the editor to trigger autocomplete at.

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.autocomplete;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.Editor;
@@ -77,12 +76,14 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
   private static class CodySelectionListener implements SelectionListener {
     @Override
     public void selectionChanged(@NotNull SelectionEvent e) {
-      if (CodyAutoCompleteManager.getInstance().isEnabledForEditor(e.getEditor())
+      if (!ConfigUtil.isCodyEnabled()) {
+        return;
+      }
+      informAgentAboutEditorChange(e.getEditor());
+      CodyAutoCompleteManager suggestions = CodyAutoCompleteManager.getInstance();
+      if (suggestions.isEnabledForEditor(e.getEditor())
           && CodyEditorFactoryListener.isSelectedEditor(e.getEditor())) {
-        informAgentAboutEditorChange(e.getEditor());
-        ApplicationManager.getApplication()
-            .getService(CodyAutoCompleteManager.class)
-            .clearAutoCompleteSuggestions(e.getEditor());
+        suggestions.clearAutoCompleteSuggestions(e.getEditor());
       }
     }
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AutoCompleteProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AutoCompleteProvider.java
@@ -14,16 +14,31 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+/**
+ * Abstract base class for auto-complete providers. Subclasses must implement:
+ *   createPromptPrefix() - Generates prompt prefix messages.
+ *   generateCompletions() - Generates completions for a given context.
+ */
+
 public abstract class AutoCompleteProvider {
+  /** The client for making completion requests */
   protected SourcegraphNodeCompletionsClient completionsClient;
+  /** An executor service for async operations */
   protected final ExecutorService executor =
       Executors.newFixedThreadPool(CodyAutoCompleteItemProvider.nThreads);
+  /** Max chars allowed for prompt */
   protected int promptChars;
+  /** Max tokens to generate in response */
   protected int responseTokens;
+  /** Reference code snippets to include in prompt */
   protected List<ReferenceSnippet> snippets;
+  /** Prefix context before cursor */
   protected String prefix;
+  /** Suffix context after cursor */
   protected String suffix;
+  /** Additional prefix to inject into prompt */
   protected String injectPrefix;
+  /** Default number of completions to generate */
   protected int defaultN;
 
   public AutoCompleteProvider(
@@ -51,12 +66,18 @@ public abstract class AutoCompleteProvider {
   public abstract CompletableFuture<List<Completion>> generateCompletions(
       CancellationToken token, Optional<Integer> n);
 
+  /**
+   * Gets length of prompt without snippets
+   */
   public int emptyPromptLength() {
     String promptNoSnippets =
         createPromptPrefix().stream().map(Message::prompt).collect(Collectors.joining(""));
-    return promptNoSnippets.length() - 10;
+    return promptNoSnippets.length() - 10; // Hunch: The minus 10 is for "Assistant:"?
   }
 
+  /**
+   * Builds full prompt with prefixes and snippets
+   */
   protected List<Message> createPrompt() {
     List<Message> prefixMessages = createPromptPrefix();
     List<Message> referenceSnippetMessages = new ArrayList<>();
@@ -88,6 +109,9 @@ public abstract class AutoCompleteProvider {
     return referenceSnippetMessages;
   }
 
+  /**
+   * Batches multiple completion requests
+   */
   protected CompletableFuture<List<CompletionResponse>> batchCompletions(
       SourcegraphNodeCompletionsClient client, CompletionParameters params, int n) {
     List<CompletableFuture<CompletionResponse>> promises = new ArrayList<>();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AutoCompleteProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/AutoCompleteProvider.java
@@ -15,29 +15,36 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 /**
- * Abstract base class for auto-complete providers. Subclasses must implement:
- *   createPromptPrefix() - Generates prompt prefix messages.
- *   generateCompletions() - Generates completions for a given context.
+ * Abstract base class for auto-complete providers. Subclasses must implement: createPromptPrefix()
+ * - Generates prompt prefix messages. generateCompletions() - Generates completions for a given
+ * context.
  */
-
 public abstract class AutoCompleteProvider {
   /** The client for making completion requests */
   protected SourcegraphNodeCompletionsClient completionsClient;
+
   /** An executor service for async operations */
   protected final ExecutorService executor =
       Executors.newFixedThreadPool(CodyAutoCompleteItemProvider.nThreads);
+
   /** Max chars allowed for prompt */
   protected int promptChars;
+
   /** Max tokens to generate in response */
   protected int responseTokens;
+
   /** Reference code snippets to include in prompt */
   protected List<ReferenceSnippet> snippets;
+
   /** Prefix context before cursor */
   protected String prefix;
+
   /** Suffix context after cursor */
   protected String suffix;
+
   /** Additional prefix to inject into prompt */
   protected String injectPrefix;
+
   /** Default number of completions to generate */
   protected int defaultN;
 
@@ -66,18 +73,14 @@ public abstract class AutoCompleteProvider {
   public abstract CompletableFuture<List<Completion>> generateCompletions(
       CancellationToken token, Optional<Integer> n);
 
-  /**
-   * Gets length of prompt without snippets
-   */
+  /** Gets length of prompt without snippets */
   public int emptyPromptLength() {
     String promptNoSnippets =
         createPromptPrefix().stream().map(Message::prompt).collect(Collectors.joining(""));
     return promptNoSnippets.length() - 10; // Hunch: The minus 10 is for "Assistant:"?
   }
 
-  /**
-   * Builds full prompt with prefixes and snippets
-   */
+  /** Builds full prompt with prefixes and snippets */
   protected List<Message> createPrompt() {
     List<Message> prefixMessages = createPromptPrefix();
     List<Message> referenceSnippetMessages = new ArrayList<>();
@@ -109,9 +112,7 @@ public abstract class AutoCompleteProvider {
     return referenceSnippetMessages;
   }
 
-  /**
-   * Batches multiple completion requests
-   */
+  /** Batches multiple completion requests */
   protected CompletableFuture<List<CompletionResponse>> batchCompletions(
       SourcegraphNodeCompletionsClient client, CompletionParameters params, int n) {
     List<CompletableFuture<CompletionResponse>> promises = new ArrayList<>();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
@@ -86,7 +86,6 @@ public class CodyAutoCompleteItemProvider extends InlineAutoCompleteItemProvider
    * @param context Additional context about the auto-complete invocation.
    * @param token A cancellation token to abort the operation.
    */
-
   private CompletableFuture<InlineAutoCompleteList> provideInlineAutoCompleteItemsInner(
       TextDocument document,
       Position position,

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/prompt_library/CodyAutoCompleteItemProvider.java
@@ -78,16 +78,27 @@ public class CodyAutoCompleteItemProvider extends InlineAutoCompleteItemProvider
     return toks * charsPerToken;
   }
 
+  /**
+   * Provides inline auto-complete items for the given context.
+   *
+   * @param document The text document to provide completions for.
+   * @param position The position in the document to provide completions at.
+   * @param context Additional context about the auto-complete invocation.
+   * @param token A cancellation token to abort the operation.
+   */
+
   private CompletableFuture<InlineAutoCompleteList> provideInlineAutoCompleteItemsInner(
       TextDocument document,
       Position position,
       InlineAutoCompleteContext context,
       CancellationToken token) {
+    // Abort any previously open inline completion requests
     this.abortOpenInlineCompletions.run();
     CancellationToken abortController = new CancellationToken();
     token.onCancellationRequested(abortController::abort);
     this.abortOpenInlineCompletions = abortController::abort;
 
+    // Get the current document context around the position
     DocContext docContext =
         getCurrentDocContext(
             document, position, tokToChar(maxPrefixTokens), tokToChar(maxSuffixTokens));

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/recipes/SimpleRecipeAction.java
@@ -33,7 +33,7 @@ public abstract class SimpleRecipeAction extends BaseRecipeAction {
 
   public void executeRecipeWithPromptProvider(
       @NotNull UpdatableChat updatableChat, @NotNull Project project) {
-    GraphQlLogger.logCodyEvents(project, this.getActionComponentName(), "clicked");
+    GraphQlLogger.logCodyEvent(project, this.getActionComponentName(), "clicked");
     RecipeRunner recipeRunner = new RecipeRunner(project, updatableChat);
     ActionUtil.runIfCodeSelected(
         updatableChat,

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -16,7 +16,8 @@ import org.jetbrains.annotations.Nullable;
 public class GraphQlLogger {
   private static final Logger logger = Logger.getInstance(GraphQlLogger.class);
 
-  public static void logInstallEvent(@NotNull Project project, @NotNull Consumer<Boolean> callback) {
+  public static void logInstallEvent(
+      @NotNull Project project, @NotNull Consumer<Boolean> callback) {
     if (ConfigUtil.getAnonymousUserId() != null) {
       var event = createEvent(project, "CodyInstalled", new JsonObject());
       logEvent(project, event, (responseStatusCode) -> callback.accept(responseStatusCode == 200));
@@ -46,21 +47,21 @@ public class GraphQlLogger {
   }
 
   @NotNull
-  private static Event createEvent(@NotNull Project project, @NotNull String eventName,
-      @NotNull JsonObject eventParameters) {
+  private static Event createEvent(
+      @NotNull Project project, @NotNull String eventName, @NotNull JsonObject eventParameters) {
     var updatedEventParameters = addProjectSpecificEventParameters(eventParameters, project);
     String anonymousUserId = ConfigUtil.getAnonymousUserId();
     return new Event(
-            eventName,
-            anonymousUserId != null ? anonymousUserId : "",
-            "",
-            updatedEventParameters,
-            updatedEventParameters);
+        eventName,
+        anonymousUserId != null ? anonymousUserId : "",
+        "",
+        updatedEventParameters,
+        updatedEventParameters);
   }
 
   @NotNull
-  private static JsonObject addProjectSpecificEventParameters(@NotNull JsonObject eventParameters,
-      @NotNull Project project) {
+  private static JsonObject addProjectSpecificEventParameters(
+      @NotNull JsonObject eventParameters, @NotNull Project project) {
     var updatedEventParameters = eventParameters.deepCopy();
     updatedEventParameters.addProperty("serverEndpoint", ConfigUtil.getSourcegraphUrl(project));
     return updatedEventParameters;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -30,6 +30,15 @@ public class GraphQlLogger {
     }
   }
 
+  public static void logAutocompleteSuggestedEvent(
+      @NotNull Project project, long latencyMs, long displayDurationMs) {
+    String eventName = "CodyJetBrainsPlugin:completion:suggested";
+    JsonObject eventParameters = new JsonObject();
+    eventParameters.addProperty("latency", latencyMs);
+    eventParameters.addProperty("displayDuration", displayDurationMs);
+    logEvent(project, createEvent(project, eventName, eventParameters), null);
+  }
+
   public static void logCodyEvent(
       @NotNull Project project, @NotNull String componentName, @NotNull String action) {
     var eventName = "CodyJetBrainsPlugin:" + componentName + ":" + action;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -16,46 +16,45 @@ import org.jetbrains.annotations.Nullable;
 public class GraphQlLogger {
   private static final Logger logger = Logger.getInstance(GraphQlLogger.class);
 
-  public static void logInstallEvent(Project project, Consumer<Boolean> callback) {
-    String anonymousUserId = ConfigUtil.getAnonymousUserId();
-    JsonObject eventParameters = getEventParameters(project);
-    if (anonymousUserId != null) {
-      Event event =
-          new Event("CodyInstalled", anonymousUserId, "", eventParameters, eventParameters);
+  public static void logInstallEvent(@NotNull Project project, @NotNull Consumer<Boolean> callback) {
+    if (ConfigUtil.getAnonymousUserId() != null) {
+      var event = createEvent(project, "CodyInstalled", new JsonObject());
       logEvent(project, event, (responseStatusCode) -> callback.accept(responseStatusCode == 200));
     }
   }
 
-  public static void logUninstallEvent(Project project) {
-    String anonymousUserId = ConfigUtil.getAnonymousUserId();
-    JsonObject eventParameters = getEventParameters(project);
-    if (anonymousUserId != null) {
-      Event event =
-          new Event("CodyUninstalled", anonymousUserId, "", eventParameters, eventParameters);
+  public static void logUninstallEvent(@NotNull Project project) {
+    if (ConfigUtil.getAnonymousUserId() != null) {
+      Event event = createEvent(project, "CodyUninstalled", new JsonObject());
       logEvent(project, event, null);
     }
   }
 
   public static void logCodyEvent(
       @NotNull Project project, @NotNull String componentName, @NotNull String action) {
-    String anonymousUserId = ConfigUtil.getAnonymousUserId();
-    String eventName = "CodyJetBrainsPlugin:" + componentName + ":" + action;
-    JsonObject eventParameters = getEventParameters(project);
-    Event event =
-        new Event(
-            eventName,
-            anonymousUserId != null ? anonymousUserId : "",
-            "",
-            eventParameters,
-            eventParameters);
-    logEvent(project, event, null);
+    var eventName = "CodyJetBrainsPlugin:" + componentName + ":" + action;
+    logEvent(project, createEvent(project, eventName, new JsonObject()), null);
   }
 
   @NotNull
-  private static JsonObject getEventParameters(@NotNull Project project) {
-    JsonObject eventParameters = new JsonObject();
-    eventParameters.addProperty("serverEndpoint", ConfigUtil.getSourcegraphUrl(project));
-    return eventParameters;
+  private static Event createEvent(@NotNull Project project, @NotNull String eventName,
+      @NotNull JsonObject eventParameters) {
+    var updatedEventParameters = addProjectSpecificEventParameters(eventParameters, project);
+    String anonymousUserId = ConfigUtil.getAnonymousUserId();
+    return new Event(
+            eventName,
+            anonymousUserId != null ? anonymousUserId : "",
+            "",
+            updatedEventParameters,
+            updatedEventParameters);
+  }
+
+  @NotNull
+  private static JsonObject addProjectSpecificEventParameters(@NotNull JsonObject eventParameters,
+      @NotNull Project project) {
+    var updatedEventParameters = eventParameters.deepCopy();
+    updatedEventParameters.addProperty("serverEndpoint", ConfigUtil.getSourcegraphUrl(project));
+    return updatedEventParameters;
   }
 
   private static void callGraphQlService(

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -36,13 +36,6 @@ public class GraphQlLogger {
     }
   }
 
-  public static void logCodyEvents(
-      @NotNull Project project, @NotNull String componentName, String... actions) {
-    for (String action : actions) {
-      logCodyEvent(project, componentName, action);
-    }
-  }
-
   public static void logCodyEvent(
       @NotNull Project project, @NotNull String componentName, @NotNull String action) {
     String anonymousUserId = ConfigUtil.getAnonymousUserId();


### PR DESCRIPTION
Closes https://github.com/sourcegraph/cody/issues/123

Changes:
- Added `latency` and `displayDuration` arguments for `CodyJetBrainsPlugin:completion:suggested` event logging
- Added comments to various places as I discovered the codebase.

The other two completion-related events (`completion:started` and `completion:accepted`) were already in place at the right locations. `completion:suggested` was triggered too early, I had to move it to a much later point where the timing information was available.

Caveats:
- Did not add any other arguments for now. I need to check the dashboard to make sure this is enough, but honestly, I didn't want to do a lot of changes before the Agent-related PRs are merged

Note for the reviewer: if the docs changes are too much, you can review this commit by commit. But it's probably not worth it, so I've left comments on the key points; the rest are just added comments.

## Test plan

Made sure that:
- Autocompletions still work
- We're tracking the latency and display information
- That logging has roughly the same shape as the logs in VS Code (see the [issue](https://github.com/sourcegraph/cody/issues/123) comments for a detailed list)

[3-min Loom](https://www.loom.com/share/703b0c41bbfd4a3c94ea2acd6f432fa1?sid=512b70c4-dd49-46ce-8090-5a6ed6f033f2) where I demo this