### PR TITLE
codeintel: Prefer higher-star count definition repos

### DIFF
--- a/internal/codeintel/uploads/internal/store/uploads.go
+++ b/internal/codeintel/uploads/internal/store/uploads.go
@@ -585,6 +585,7 @@ ranked_uploads AS (
 		-- within a repository by commit date. We'll choose the oldest commit
 		-- date as the canonical choice used to resolve the current definitions
 		-- request.
+		repo.stars,
 		` + packageRankingQueryFragment + ` AS rank
 	FROM lsif_uploads u
 	JOIN lsif_packages p ON p.dump_id = u.id
@@ -599,7 +600,7 @@ canonical_uploads AS (
 	SELECT ru.id
 	FROM ranked_uploads ru
 	WHERE ru.rank = 1
-	ORDER BY ru.id
+	ORDER BY ru.stars DESC, ru.id
 	LIMIT %s
 )
 SELECT

--- a/internal/codeintel/uploads/internal/store/uploads.go
+++ b/internal/codeintel/uploads/internal/store/uploads.go
@@ -581,10 +581,14 @@ WITH
 ranked_uploads AS (
 	SELECT
 		u.id,
-		-- Rank each upload providing the same package from the same directory
-		-- within a repository by commit date. We'll choose the oldest commit
-		-- date as the canonical choice used to resolve the current definitions
-		-- request.
+		-- First, rank by repo stars (if they are populated on the instance).
+		-- This should give us the most popular (and assumed important) packages
+		-- first. Then, we rank each upload providing the same package from the
+		-- same directory within a repository by commit date. We'll choose the
+		-- oldest commit date from the candidates as the canonical choice used
+		-- to resolve the current definitions request. This alternate sorting is
+		-- the primary sorting outside of dotcom, and breaks ties for repos with
+		-- the same star counts.
 		repo.stars,
 		` + packageRankingQueryFragment + ` AS rank
 	FROM lsif_uploads u


### PR DESCRIPTION
When a SCIP index defines a symbol, we write that index to a metadata table putting it into candidacy for cross-repo j2d on that symbol. We don't have many protections on what indexes can define what symbols (as there are no intuitive rules to apply across all ecosystems). This means that some random repo on GitHub may squat symbol names that should be reserved by a more popular library.

This can happen for repos that embed other repos and get indexed, and will generally happen only on _megainstanaces_ such as sourcegraph.com that does not have a cohesive set of repositories (and owners aware of the Sourcegraph instance).

To get around this name-squatting, we can prefer higher-starred repositories over lower ones. This will generally mean that libraries with lots of uses will be "protected" by this ordering. This applies for standard libraries as well, when indexed from a repository (which is the case for Go).

Original debug thread on slack: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1690492726116199

## Test plan

- [x] Existing unit tests.
- [ ] Hand test the query plan on sourcegraph.com prior to merging to ensure we don't regress in xrepo performance.