### PR TITLE
metrics/RequestMeter: add label for X-From-Cache

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -35,10 +35,11 @@ type RequestMeter struct {
 }
 
 const (
-	labelCategory = "category"
-	labelCode     = "code"
-	labelHost     = "host"
-	labelTask     = "task"
+	labelCategory  = "category"
+	labelCode      = "code"
+	labelHost      = "host"
+	labelTask      = "task"
+	labelFromCache = "from_cache"
 )
 
 var taskKey struct{}
@@ -64,7 +65,7 @@ func NewRequestMeter(subsystem, help string) *RequestMeter {
 		Subsystem: subsystem,
 		Name:      "requests_total",
 		Help:      help,
-	}, []string{labelCategory, labelCode, labelHost, labelTask})
+	}, []string{labelCategory, labelCode, labelHost, labelTask, labelFromCache})
 	registerer.MustRegister(requestCounter)
 
 	// TODO(uwedeportivo):
@@ -136,12 +137,20 @@ func (t *requestCounterMiddleware) RoundTrip(r *http.Request) (resp *http.Respon
 		code = strconv.Itoa(resp.StatusCode)
 	}
 
+	// X-From-Cache=1 if the returned response is from the cache created by
+	// httpcli.NewCachedTransportOpt
+	var fromCache = "false"
+	if resp != nil && resp.Header.Get("X-From-Cache") != "" {
+		fromCache = "true"
+	}
+
 	d := time.Since(start)
 	t.meter.counter.With(map[string]string{
-		labelCategory: category,
-		labelCode:     code,
-		labelHost:     r.URL.Host,
-		labelTask:     TaskFromContext(r.Context()),
+		labelCategory:  category,
+		labelCode:      code,
+		labelHost:      r.URL.Host,
+		labelTask:      TaskFromContext(r.Context()),
+		labelFromCache: fromCache,
 	}).Inc()
 
 	t.meter.duration.WithLabelValues(category, code, r.URL.Host).Observe(d.Seconds())

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -68,7 +68,13 @@ func TestRequestMeterTransport(t *testing.T) {
 		t.Error(err)
 	}
 
-	c, err := rm.counter.GetMetricWith(map[string]string{labelCategory: "/apiCallA", labelCode: "200", labelHost: "foosystem.com", labelTask: "unknown"})
+	c, err := rm.counter.GetMetricWith(map[string]string{
+		labelCategory:  "/apiCallA",
+		labelCode:      "200",
+		labelHost:      "foosystem.com",
+		labelTask:      "unknown",
+		labelFromCache: "false",
+	})
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This will allow us to measure the usefulness of our request caching

## Test plan

n/a