### PR TITLE
emit configuration changes

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -102,6 +102,7 @@ public class CodyAgent implements Disposable {
                       .get();
               logger.info("connected to Cody agent " + info.name);
               server.initialized();
+              server.configurationDidChange(ConfigUtil.getAgentConfiguration(this.project));
               this.subscribeToFocusEvents();
               this.initialized.complete(server);
             } catch (Exception e) {


### PR DESCRIPTION
Goes along with https://github.com/sourcegraph/cody/pull/651

I am sure I'm doing something really silly in this specific PR, I wasn't able to sort out exactly where in the IntelliJ side of things we should be calling `configurationDidChange` but it definitely needs to be called somewhere, and this works for our purposes of hard-coding configuration.

## Test plan

n/a