### PR TITLE
IntelliJ extension send configuration to agent for experimental providers

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
@@ -7,6 +7,10 @@ public class ConnectionConfiguration {
   public String serverEndpoint;
   public String accessToken;
   public Map<String, String> customHeaders;
+  public String autocompleteAdvancedProvider;
+  public String autocompleteAdvancedServerEndpoint;
+  public String autocompleteAdvancedAccessToken;
+  public boolean autocompleteAdvancedEmbeddings;
 
   public ConnectionConfiguration setServerEndpoint(String serverEndpoint) {
     this.serverEndpoint = serverEndpoint;
@@ -22,4 +26,24 @@ public class ConnectionConfiguration {
     this.customHeaders = customHeaders;
     return this;
   }
+
+    public ConnectionConfiguration setAutocompleteAdvancedProvider(String autocompleteAdvancedProvider) {
+        this.autocompleteAdvancedProvider = autocompleteAdvancedProvider;
+        return this;
+    }
+
+    public ConnectionConfiguration setAutocompleteAdvancedServerEndpoint(String autocompleteAdvancedServerEndpoint) {
+        this.autocompleteAdvancedServerEndpoint = autocompleteAdvancedServerEndpoint;
+        return this;
+    }
+
+    public ConnectionConfiguration setAutocompleteAdvancedAccessToken(String autocompleteAdvancedAccessToken) {
+        this.autocompleteAdvancedAccessToken = autocompleteAdvancedAccessToken;
+        return this;
+    }
+
+    public ConnectionConfiguration setAutocompleteAdvancedEmbeddings(boolean autocompleteAdvancedEmbeddings) {
+        this.autocompleteAdvancedEmbeddings = autocompleteAdvancedEmbeddings;
+        return this;
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteProviderType.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteProviderType.java
@@ -6,7 +6,8 @@ import org.jetbrains.annotations.NotNull;
 
 public enum AutoCompleteProviderType {
   ANTHROPIC,
-  UNSTABLE_CODEGEN;
+  UNSTABLE_CODEGEN,
+  UNSTABLE_AZURE_OPENAI;
 
   public static final AutoCompleteProviderType DEFAULT_AUTOCOMPLETE_PROVIDER_TYPE = ANTHROPIC;
   private static final Logger logger = Logger.getInstance(AutoCompleteProviderType.class);
@@ -21,4 +22,8 @@ public enum AutoCompleteProviderType {
       return Optional.empty();
     }
   }
+
+    public String toString() {
+        return super.toString().toLowerCase().replace('_', '-');
+    }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -25,7 +25,11 @@ public class ConfigUtil {
     return new ConnectionConfiguration()
         .setServerEndpoint(getSourcegraphUrl(project))
         .setAccessToken(getProjectAccessToken(project))
-        .setCustomHeaders(getCustomRequestHeadersAsMap(project));
+        .setCustomHeaders(getCustomRequestHeadersAsMap(project))
+        .setAutocompleteAdvancedProvider(UserLevelConfig.getAutoCompleteProviderType().toString())
+        .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutoCompleteServerEndpoint())
+        .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutoCompleteAccessToken())
+        .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings());
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -32,6 +32,11 @@ public class UserLevelConfig {
         .orElse(AutoCompleteProviderType.DEFAULT_AUTOCOMPLETE_PROVIDER_TYPE); // or default
   }
 
+    public static boolean getAutocompleteAdvancedEmbeddings() {
+        Properties properties = readProperties();
+        return Boolean.parseBoolean(properties.getProperty("cody.autocomplete.advanced.embeddings", "true"));
+    }
+
   /**
    * Overrides the server endpoint used for generating autocomplete suggestions. This is only
    * supported with the `unstable-codegen` provider right now.
@@ -45,6 +50,12 @@ public class UserLevelConfig {
     return Optional.ofNullable(properties.getProperty(currentKey, null))
         .orElse(properties.getProperty(oldKey, null)); // fallback to the old key
   }
+
+    @Nullable
+    public static String getAutoCompleteAccessToken() {
+        Properties properties = readProperties();
+        return properties.getProperty("cody.completions.advanced.accessToken", null);
+    }
 
   @Nullable
   public static String getDefaultBranchName() {


### PR DESCRIPTION
This adds the extra agent configuration used with experimental autocomplete providers.  It is paired with https://github.com/sourcegraph/cody/pull/652 

I also added `UNSTABLE_AZURE_OPENAI` because it was easier to test against.