### PR TITLE
database: sample 4x less events for honeycomb database-batch

### DIFF
--- a/internal/database/batch/observability.go
+++ b/internal/database/batch/observability.go
@@ -45,7 +45,7 @@ func getOperations(logger log.Logger) *operations {
 	opsOnce.Do(func() {
 		observationCtx := observation.NewContext(logger, observation.Honeycomb(&honey.Dataset{
 			Name:       "database-batch",
-			SampleRate: 5,
+			SampleRate: 20,
 		}))
 
 		ops = newOperations(observationCtx)


### PR DESCRIPTION
This may be indicative of a bigger problem in sourcegraph given the volume increase in events. I haven't investigated, but instead I am just getting ahead of us getting rate limited. 4x was chosen since my eyeballs make it look more like the event count from a while ago.

Test Plan: n/a

count of events
<img width="1163" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/187831/93f3c0dd-1f45-492f-bffb-9ca649e9023c">

count of events by table. Seems to be an increase in usage of event logs
<img width="1167" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/187831/23cbfd49-60e5-4eac-832a-dcf96421c11b">
