### PR TITLE
release: fix improper formatting when generating migrator bazel build

### DIFF
--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -293,11 +293,9 @@ export const updateUpgradeGuides = (previous: string, next: string): EditFunc =>
 export const updateMigratorBazelOuts =
     (version: string): EditFunc =>
     (directory: string): void => {
-        const newEntries = [
-            `schema-descriptions/v${version}-internal_database_schema.codeinsights.json`,
-            `schema-descriptions/v${version}-internal_database_schema.codeintel.json`,
-            `schema-descriptions/v${version}-internal_database_schema.json`,
-        ]
+        const newEntries = `        "schema-descriptions/v${version}-internal_database_schema.codeinsights.json",
+        "schema-descriptions/v${version}-internal_database_schema.codeintel.json",
+        "schema-descriptions/v${version}-internal_database_schema.json",`
         const filePath = `${directory}/cmd/migrator/BUILD.bazel`
 
         let inGenrule = false
@@ -322,7 +320,7 @@ export const updateMigratorBazelOuts =
             if (inGenrule && inOuts && line.includes('],')) {
                 inOuts = false
                 inGenrule = false
-                line = `        "${newEntries.join(',\n')}",\n    ` + line
+                line = `${newEntries}\n${line}`
             }
 
             result.push(line)


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Locally tested and it formats the BAZEL file properly.

It is still hacky and in the long run we should probably research a bazel parser that can enable us load this and modify before saving but this works for now.
