### PR TITLE
codeintel: limit package filter list modal height

### DIFF
--- a/client/web/src/site-admin/packages/PackagesModal.module.scss
+++ b/client/web/src/site-admin/packages/PackagesModal.module.scss
@@ -2,7 +2,7 @@
     width: 100%;
     max-width: 60rem;
     margin: 5rem 0;
-    top: 45%; // looks fine when overflowing, maybe not when semaller?
+    top: 45%;
 }
 
 .header {

--- a/client/web/src/site-admin/packages/PackagesModal.module.scss
+++ b/client/web/src/site-admin/packages/PackagesModal.module.scss
@@ -2,6 +2,7 @@
     width: 100%;
     max-width: 60rem;
     margin: 5rem 0;
+    top: 45%; // looks fine when overflowing, maybe not when semaller?
 }
 
 .header {

--- a/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
+++ b/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
@@ -7,6 +7,9 @@
 
 .content {
     min-height: 5rem;
+    max-height: 50rem; // TODO adaptive for different screen sizes
+    overflow-y: scroll;
+    padding-right: 1em;
 }
 
 .close-action {

--- a/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
+++ b/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
@@ -7,7 +7,7 @@
 
 .content {
     min-height: 5rem;
-    max-height: 50rem; // TODO adaptive for different screen sizes
+    max-height: 30rem;
     overflow-y: scroll;
     padding-right: 1em;
 }

--- a/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
+++ b/client/web/src/site-admin/packages/modal-content/ManagePackageFiltersModalContent.module.scss
@@ -9,7 +9,7 @@
     min-height: 5rem;
     max-height: 30rem;
     overflow-y: scroll;
-    padding-right: 1em;
+    padding-right: 1rem;
 }
 
 .close-action {


### PR DESCRIPTION
The package repo filter list modal didnt enforce a max height, resulting in it growing beyond the top/bottom of the screen when too many filters were added.

## Test plan

Tested locally with 0-17 filters on 1440p and 1080p screens
