### PR TITLE
Improve performance of gitserver_repos store methods

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -160,12 +160,15 @@ func (r *repositoryMirrorInfoResolver) LastError(ctx context.Context) (*string, 
 }
 
 func (r *repositoryMirrorInfoResolver) LastSyncOutput(ctx context.Context) (*string, error) {
-	info, err := r.computeGitserverRepo(ctx)
+	output, ok, err := r.db.GitserverRepos().GetLastSyncOutput(ctx, r.repository.innerRepo.Name)
 	if err != nil {
 		return nil, err
 	}
+	if !ok {
+		return nil, nil
+	}
 
-	return strptr(info.LastSyncOutput), nil
+	return &output, nil
 }
 
 func (r *repositoryMirrorInfoResolver) UpdatedAt(ctx context.Context) (*gqlutil.DateTime, error) {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -932,7 +932,6 @@ var ignoreVolatileGitserverRepoFields = cmpopts.IgnoreFields(
 	"UpdatedAt",
 	"CorruptionLogs",
 	"CloningProgress",
-	"LastSyncOutput",
 )
 
 func TestHandleRepoDelete(t *testing.T) {

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -372,6 +372,16 @@ func TestReposWithLastOutput(t *testing.T) {
 			if err := db.GitserverRepos().SetLastOutput(ctx, testRepo.Name, tr.lastOutput); err != nil {
 				t.Fatal(err)
 			}
+			haveOut, ok, err := db.GitserverRepos().GetLastSyncOutput(ctx, testRepo.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tr.lastOutput == "" && ok {
+				t.Fatalf("last output is not empty")
+			}
+			if have, want := haveOut, tr.lastOutput; have != want {
+				t.Fatalf("wrong last output returned, have=%s want=%s", have, want)
+			}
 		})
 	}
 }

--- a/internal/database/mocks_temp.go
+++ b/internal/database/mocks_temp.go
@@ -35732,6 +35732,9 @@ type MockGitserverRepoStore struct {
 	// GetByNamesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByNames.
 	GetByNamesFunc *GitserverRepoStoreGetByNamesFunc
+	// GetLastSyncOutputFunc is an instance of a mock function object
+	// controlling the behavior of the method GetLastSyncOutput.
+	GetLastSyncOutputFunc *GitserverRepoStoreGetLastSyncOutputFunc
 	// GetPoolRepoNameFunc is an instance of a mock function object
 	// controlling the behavior of the method GetPoolRepoName.
 	GetPoolRepoNameFunc *GitserverRepoStoreGetPoolRepoNameFunc
@@ -35807,6 +35810,11 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 		},
 		GetByNamesFunc: &GitserverRepoStoreGetByNamesFunc{
 			defaultHook: func(context.Context, ...api.RepoName) (r0 map[api.RepoName]*types.GitserverRepo, r1 error) {
+				return
+			},
+		},
+		GetLastSyncOutputFunc: &GitserverRepoStoreGetLastSyncOutputFunc{
+			defaultHook: func(context.Context, api.RepoName) (r0 string, r1 bool, r2 error) {
 				return
 			},
 		},
@@ -35923,6 +35931,11 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.GetByNames")
 			},
 		},
+		GetLastSyncOutputFunc: &GitserverRepoStoreGetLastSyncOutputFunc{
+			defaultHook: func(context.Context, api.RepoName) (string, bool, error) {
+				panic("unexpected invocation of MockGitserverRepoStore.GetLastSyncOutput")
+			},
+		},
 		GetPoolRepoNameFunc: &GitserverRepoStoreGetPoolRepoNameFunc{
 			defaultHook: func(context.Context, api.RepoName) (api.RepoName, bool, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.GetPoolRepoName")
@@ -36029,6 +36042,9 @@ func NewMockGitserverRepoStoreFrom(i GitserverRepoStore) *MockGitserverRepoStore
 		},
 		GetByNamesFunc: &GitserverRepoStoreGetByNamesFunc{
 			defaultHook: i.GetByNames,
+		},
+		GetLastSyncOutputFunc: &GitserverRepoStoreGetLastSyncOutputFunc{
+			defaultHook: i.GetLastSyncOutput,
 		},
 		GetPoolRepoNameFunc: &GitserverRepoStoreGetPoolRepoNameFunc{
 			defaultHook: i.GetPoolRepoName,
@@ -36417,6 +36433,120 @@ func (c GitserverRepoStoreGetByNamesFuncCall) Args() []interface{} {
 // invocation.
 func (c GitserverRepoStoreGetByNamesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// GitserverRepoStoreGetLastSyncOutputFunc describes the behavior when the
+// GetLastSyncOutput method of the parent MockGitserverRepoStore instance is
+// invoked.
+type GitserverRepoStoreGetLastSyncOutputFunc struct {
+	defaultHook func(context.Context, api.RepoName) (string, bool, error)
+	hooks       []func(context.Context, api.RepoName) (string, bool, error)
+	history     []GitserverRepoStoreGetLastSyncOutputFuncCall
+	mutex       sync.Mutex
+}
+
+// GetLastSyncOutput delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) GetLastSyncOutput(v0 context.Context, v1 api.RepoName) (string, bool, error) {
+	r0, r1, r2 := m.GetLastSyncOutputFunc.nextHook()(v0, v1)
+	m.GetLastSyncOutputFunc.appendCall(GitserverRepoStoreGetLastSyncOutputFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the GetLastSyncOutput
+// method of the parent MockGitserverRepoStore instance is invoked and the
+// hook queue is empty.
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) SetDefaultHook(hook func(context.Context, api.RepoName) (string, bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetLastSyncOutput method of the parent MockGitserverRepoStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) PushHook(hook func(context.Context, api.RepoName) (string, bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) SetDefaultReturn(r0 string, r1 bool, r2 error) {
+	f.SetDefaultHook(func(context.Context, api.RepoName) (string, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) PushReturn(r0 string, r1 bool, r2 error) {
+	f.PushHook(func(context.Context, api.RepoName) (string, bool, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) nextHook() func(context.Context, api.RepoName) (string, bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) appendCall(r0 GitserverRepoStoreGetLastSyncOutputFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverRepoStoreGetLastSyncOutputFuncCall
+// objects describing the invocations of this function.
+func (f *GitserverRepoStoreGetLastSyncOutputFunc) History() []GitserverRepoStoreGetLastSyncOutputFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreGetLastSyncOutputFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreGetLastSyncOutputFuncCall is an object that describes
+// an invocation of method GetLastSyncOutput on an instance of
+// MockGitserverRepoStore.
+type GitserverRepoStoreGetLastSyncOutputFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 api.RepoName
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 string
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 bool
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreGetLastSyncOutputFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreGetLastSyncOutputFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // GitserverRepoStoreGetPoolRepoNameFunc describes the behavior when the

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -593,8 +593,6 @@ type GitserverRepo struct {
 	CloningProgress string
 	// The last error that occurred or empty if the last action was successful
 	LastError string
-	// the output of the most recent repo sync job
-	LastSyncOutput string
 	// The last time fetch was called.
 	LastFetched time.Time
 	// The last time a fetch updated the repository.


### PR DESCRIPTION
We recently added a left join on another table holding the gitserver sync logs, which added quite some overhead to the queries. Here's an example query plan from dotcom for the iterate gitserver repos query:

Before

```
SELECT
    gr.repo_id, repo.name, gr.clone_status, gr.cloning_progress, gr.shard_id, gr.last_error, gr.last_fetched, gr.last_changed, gr.repo_size_bytes, gr.updated_at, gr.corrupted_at, gr.corruption_logs, gr.pool_repo_id, go.last_output 
FROM gitserver_repos gr 
JOIN repo ON gr.repo_id = repo.id 
LEFT OUTER JOIN gitserver_repos_sync_output go ON gr.repo_id = go.repo_id 
WHERE gr.repo_id > 0 AND repo.id > 0 
ORDER BY gr.repo_id ASC 
LIMIT 5000 
OFFSET 0;
```

```
                                                                                           QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=4.83..1408.91 rows=5000 width=489) (actual time=0.155..2133.020 rows=5000 loops=1)
   ->  Merge Left Join  (cost=4.83..2619877.12 rows=9329510 width=489) (actual time=0.154..2132.011 rows=5000 loops=1)
         Merge Cond: (gr.repo_id = go.repo_id)
         ->  Merge Join  (cost=4.40..2219410.84 rows=9329510 width=328) (actual time=0.024..47.463 rows=5000 loops=1)
               Merge Cond: (gr.repo_id = repo.id)
               ->  Index Scan using gitserver_repos_pkey on gitserver_repos gr  (cost=0.56..884164.75 rows=9329510 width=285) (actual time=0.008..24.785 rows=5000 loops=1)
                     Index Cond: (repo_id > 0)
               ->  Index Scan using repo_pkey on repo  (cost=0.43..1197363.74 rows=9399073 width=47) (actual time=0.009..16.556 rows=5000 loops=1)
                     Index Cond: (id > 0)
         ->  Index Scan using gitserver_repos_sync_output_pkey on gitserver_repos_sync_output go  (cost=0.43..306938.95 rows=5619062 width=165) (actual time=0.129..2076.751 rows=4738 loops=1)
 Planning Time: 3.811 ms
 Execution Time: 2134.226 ms
(12 rows)
```

After

```
EXPLAIN ANALYZE
SELECT
    gr.repo_id, repo.name, gr.clone_status, gr.cloning_progress, gr.shard_id, gr.last_error, gr.last_fetched, gr.last_changed, gr.repo_size_bytes, gr.updated_at, gr.corrupted_at, gr.corruption_logs, gr.pool_repo_id
FROM gitserver_repos gr 
JOIN repo ON gr.repo_id = repo.id 
WHERE gr.repo_id > 0 AND repo.id > 0 
ORDER BY gr.repo_id ASC 
LIMIT 5000 
OFFSET 0;
```

```
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=4.40..1193.85 rows=5000 width=328) (actual time=0.023..34.821 rows=5000 loops=1)
   ->  Merge Join  (cost=4.40..2219410.84 rows=9329510 width=328) (actual time=0.022..34.156 rows=5000 loops=1)
         Merge Cond: (gr.repo_id = repo.id)
         ->  Index Scan using gitserver_repos_pkey on gitserver_repos gr  (cost=0.56..884164.75 rows=9329510 width=285) (actual time=0.008..20.225 rows=5000 loops=1)
               Index Cond: (repo_id > 0)
         ->  Index Scan using repo_pkey on repo  (cost=0.43..1197363.74 rows=9399073 width=47) (actual time=0.011..10.150 rows=5000 loops=1)
               Index Cond: (id > 0)
 Planning Time: 0.732 ms
 Execution Time: 35.279 ms
(9 rows)
```

Since we only used this field in a single place, I decided to create a separate query function for it, in favor of dealing with complexity of conditionally loading or not loading this field.

## Test plan

Added tests, query plans above.