### PR TITLE
gitserver: Register background routines with recorder

### DIFF
--- a/cmd/gitserver/shared/BUILD.bazel
+++ b/cmd/gitserver/shared/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//internal/extsvc/rubygems",
         "//internal/gitserver/v1:gitserver",
         "//internal/goroutine",
+        "//internal/goroutine/recorder",
         "//internal/grpc",
         "//internal/grpc/defaults",
         "//internal/hostname",


### PR DESCRIPTION
This enables us to see gitserver routines in the background jobs page.



## Test plan

Verified locally that routines show up. 