### PR TITLE
Build bundled-executor with shell build tag again

### DIFF
--- a/enterprise/cmd/bundled-executor/BUILD.bazel
+++ b/enterprise/cmd/bundled-executor/BUILD.bazel
@@ -6,7 +6,6 @@ load("//cmd/server:macro.bzl", "container_dependencies", "dependencies_tars")
 
 DEPS = [
     "//cmd/batcheshelper",
-    "//enterprise/cmd/executor",
 ]
 
 container_dependencies(DEPS)
@@ -14,6 +13,13 @@ container_dependencies(DEPS)
 pkg_tar(
     name = "tar_src-cli",
     srcs = ["@src-cli-linux-amd64//:src-cli-linux-amd64"],
+    package_dir = "/usr/local/bin",
+)
+
+# Include the executor binary built with gotags
+pkg_tar(
+    name = "tar_executor",
+    srcs = ["//enterprise/cmd/executor:executor_sh"],
     package_dir = "/usr/local/bin",
 )
 
@@ -30,7 +36,10 @@ oci_image(
         "EXECUTOR_MAXIMUM_NUM_JOBS": "1",  # Preconfigure bundled-executor to take 1 parallel job and restart afterwards, this is to keep the environment clean-ish
         "EXECUTOR_NUM_TOTAL_JOBS": "1",
     },
-    tars = dependencies_tars(DEPS) + [":tar_src-cli"],
+    tars = dependencies_tars(DEPS) + [
+        ":tar_executor",
+        ":tar_src-cli",
+    ],
     user = "sourcegraph",
 )
 

--- a/enterprise/cmd/executor/BUILD.bazel
+++ b/enterprise/cmd/executor/BUILD.bazel
@@ -33,9 +33,24 @@ go_binary(
     },
 )
 
+go_binary(
+    name = "executor_sh",
+    basename = "executor",
+    embed = [":executor_lib"],
+    gotags = [
+        "shell",
+    ],
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
+)
+
 pkg_tar(
     name = "tar_executor",
     srcs = [":executor"],
+    visibility = ["//cmd/bundled-executor:__pkg__"],
 )
 
 pkg_tar(

--- a/enterprise/cmd/executor/internal/util/BUILD.bazel
+++ b/enterprise/cmd/executor/internal/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "util",
     srcs = [
         "buildtag.go",
+        "buildtag_shell.go",  # keep
         "exec.go",
         "srccli.go",
         "tools.go",


### PR DESCRIPTION
We seem to have lost this special build tag somewhere in migrations, causing the bundled-executor to no longer have the shell runtime code in it.

Manual backport of https://github.com/sourcegraph/sourcegraph/pull/55792.

## Test plan

Verified the image builds and has the correct build tag.