### PR TITLE
chore: update zoekt to 956d775e32b369708c457dc612fd5b69ba85523e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -543,7 +543,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca
+	github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2027,8 +2027,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca h1:RPuTlekup6EQ41utARp+UiR5kc6smGMPQTmor0Rw84w=
-github.com/sourcegraph/zoekt v0.0.0-20230801152445-d57235362dca/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
+github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3 h1:mi8zKWhOb8dX/wXXkvSwIyOXHWX6E2T3yf5yIGUcmF0=
+github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This updates our zoekt dependency to point to https://github.com/sourcegraph/zoekt/commit/956d775e32b369708c457dc612fd5b69ba85523e.

## Test plan

This is just updating the [github.com/sourcegraph/zoekt](github.com/sourcegraph/zoekt) dependency we have. All CI checks on the original repository are sufficient. 