### PR TITLE
telemetry: define new telemetry, telemetry-gateway APIs

### DIFF
--- a/cmd/frontend/graphqlbackend/telemetry.graphql
+++ b/cmd/frontend/graphqlbackend/telemetry.graphql
@@ -1,0 +1,116 @@
+extend type Mutation {
+    """
+    Telemetry mutations for "Event Logging Everywhere", aka a version 2 of
+    existing event-logging APIs.
+    """
+    telemetry: TelemetryMutation
+}
+
+type TelemetryMutation {
+    """
+    Log a single telemetry event.
+    """
+    logEvent(event: TelemetryEvent!): EmptyResponse
+    """
+    Log a batch of telemetry events.
+    """
+    logEvents(events: [TelemetryEvent!]): EmptyResponse
+}
+
+type TelemetryEvent {
+    """
+    Name of the event.
+    """
+    name: String!
+
+    """
+    Source client of the event.
+    """
+    client: TelemetryEventClient!
+
+    """
+    Parameters of the event.
+    """
+    parameters: TelemetryEventParameters!
+
+    """
+    Optional user associated with the event.
+    """
+    user: TelemetryEventUser
+
+    """
+    Optional marketing campaign tracking parameters.
+    """
+    marketingTracking: TelemetryEventMarketingTracking
+}
+
+enum TelemetryEventClient {
+    SERVER_WEB
+    APP_WEB
+    MARKETING_WEB
+
+    CHROME_SOURCEGRAPH
+    SAFARI_SOURCEGRAPH
+
+    VSCODE_CODY
+    VSCODE_SOURCEGRAPH
+
+    JETBRAINS_CODY
+
+    NEOVIM_CODY
+}
+
+type TelemetryEventParameters {
+    """
+    Version of the event parameters, used for indicating the "shape" of this
+    event's metadata.
+    """
+    version: Int!
+    """
+    Strictly typed metadata.
+    """
+    metadata: [TelemetryEventMetadata!]
+    """
+    Additional, arbitrarily-shaped metadata (JSON recommended). By default, this
+    metadata is assumed to be unsafe for export from an instance.
+    """
+    additionalMetadata: String
+}
+
+type TelemetryEventMetadata {
+    """
+    Metadata keys must come from a static set of predefined metadata keys.
+    """
+    key: TelemetryEventMetadataKey!
+    """
+    Numeric value associated with the key.
+    """
+    value: Int!
+}
+
+enum TelemetryEventMetadataKey {
+    UNKNOWN
+    # TODO Add allowlisted keys here
+}
+
+type TelemetryEventUser {
+    """
+    Database user ID of signed in user.
+    """
+    userID: String
+    """
+    Randomized unique identifier for client (i.e. stored in localstorage in web
+    client).
+    """
+    anonymousUserID: String
+}
+
+type TelemetryEventMarketingTracking {
+    firstSourceURL: String
+    cohortID: String
+    referrer: String
+    lastSourceURL: String
+    deviceSessionID: String
+    sessionReferrer: String
+    sessionFirstURL: String
+}

--- a/internal/telemetrygateway/v1/telemetrygateway.proto
+++ b/internal/telemetrygateway/v1/telemetrygateway.proto
@@ -28,9 +28,9 @@ message Event {
   // Parameters of the event.
   EventParameters parameters = 4;
   // Optional user associated with the event.
-  EventUser user = 5;
+  optional EventUser user = 5;
   // Optional marketing campaign tracking parameters.
-  EventMarketingTracking marketingTracking = 6;
+  optional EventMarketingTracking marketingTracking = 6;
 }
 
 message EventParameters {
@@ -42,7 +42,7 @@ message EventParameters {
   // Additional, arbitrarily-shaped metadata (JSON recommended). By default,
   // this metadata should not be assumed to be unsafe for export from an
   // instance, and should only be exported on an allowlist basis.
-  string additionalMetadata = 3;
+  optional string additionalMetadata = 3;
 }
 
 message EventUser {

--- a/internal/telemetrygateway/v1/telemetrygateway.proto
+++ b/internal/telemetrygateway/v1/telemetrygateway.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package telemetrygateway.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1";
+
+service TelemeteryGatewayService {
+  rpc LogEvents(LogEventsRequest) returns (LogEventsResponse) {}
+}
+
+message LogEventsRequest {
+  repeated Event events = 1;
+
+  // License key hashed for analytics purposes (hashed value should include the
+  // appropriate prefix).
+  string analytics_hashed_license_key = 2;
+}
+
+message Event {
+  // Timestamp of when the original event was recorded.
+  google.protobuf.Timestamp timestamp = 1;
+  // Name of the event.
+  string name = 2;
+  // Source client of the event.
+  string client = 3;
+  // Parameters of the event.
+  EventParameters parameters = 4;
+  // Optional user associated with the event.
+  EventUser user = 5;
+  // Optional marketing campaign tracking parameters.
+  EventMarketingTracking marketingTracking = 6;
+}
+
+message EventParameters {
+  // Version of the event parameters, used for indicating the "shape" of this
+  // event's metadata.
+  int32 version = 1;
+  // Strictly typed metadata, restricted to integer values.
+  map<string, int32> metadata = 2;
+  // Additional, arbitrarily-shaped metadata (JSON recommended). By default,
+  // this metadata should not be assumed to be unsafe for export from an
+  // instance, and should only be exported on an allowlist basis.
+  string additionalMetadata = 3;
+}
+
+message EventUser {
+  // Database user ID of signed in user.
+  string userID = 1;
+  // Randomized unique identifier for client (i.e. stored in localstorage in web
+  // client).
+  string anonymousUserID = 2;
+}
+
+message EventMarketingTracking {
+  string firstSourceURL = 1;
+  string cohortID = 2;
+  string referrer = 3;
+  string lastSourceURL = 4;
+  string deviceSessionID = 5;
+  string sessionReferrer = 6;
+  string sessionFirstURL = 7;
+}


### PR DESCRIPTION
This PR lays out new APIs for the Event Logging Everywhere projects, as outlined in the [core services implementation plan document](https://docs.google.com/document/d/14WBt80sbmVm73B-R1Srs5cSunZo2IhDMtKiyAgkYujU/edit#heading=h.pjzp9tym0hxu) and [event data structure updates](https://docs.google.com/document/d/1F6yFUVX_DZ_tT76NpGJL6_jlm_THQyVikRRRjNDNsyg/edit#heading=h.qnigiquexsi). There are two parts to this:

1. `mutation { telemetry { ... } }` - these are the "v2" of the existing `logEvent` and `logEvents` mutations. Some key features here include:
    - grouping event fields for ease of use
    - event metadata is now strictly typed, in the interests of preventing accidental sensitive data/PII leakage. See [events sanitization](https://docs.google.com/document/d/14WBt80sbmVm73B-R1Srs5cSunZo2IhDMtKiyAgkYujU/edit#bookmark=id.t2azqrzegw38)
2. A protobuf API spec for a new [Telemetry Gateway for exporting events](https://docs.google.com/document/d/14WBt80sbmVm73B-R1Srs5cSunZo2IhDMtKiyAgkYujU/edit#bookmark=id.gm97tmnvqp2t)
    - the shape of API anticipates Sourcegraph instances adding more metadata (instance identifier, timestamps, etc) before exporting to Telemetry Gateway, and for Telemetry Gateway itself to be able to add additional metadata if needed based on product subscriptions, etc.
    - the types here are looser than exposed in the GraphQL API (e.g. no enums), as we will rely on type checks to validate fields in-Sourcegraph before exports - this will help us avoid breaking old Sourcegraph events, etc.

Telemetry Gateway can later flatten received events into a single-level JSON object for BigQuery, or whatever format is helpful for data pipelines. Having a stable API from Sourcegraph to the Telemetry Gateway helps us ensure compatibility, validate data, and encode large volumes of events more efficiently, in anticipation of very high traffic.

TODO:

- [ ] Add stub implementations, etc once API shape is ok 👌 

## Test plan