### PR TITLE
JetBrains: add settings for debugging agent 

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -18,8 +18,7 @@ public class CodyAgentClient {
   private static final Logger logger = Logger.getInstance(CodyAgentClient.class);
   @Nullable public CodyAgentServer server;
   @Nullable public CodyAgentDocuments documents;
-  // Callback that is invoked when the agent sends a
-  // "chat/updateMessageInProgress" notification.
+  // Callback that is invoked when the agent sends a "chat/updateMessageInProgress" notification.
   @Nullable public Consumer<ChatMessage> onChatUpdateMessageInProgress;
   @Nullable public Editor editor;
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -55,6 +55,6 @@ public class CodyAgentClient {
 
   @JsonNotification("debug/message")
   public void debugMessage(DebugMessage msg) {
-    logger.info(String.format("%s: %s", msg.channel, msg.message));
+    logger.warn(String.format("%s: %s", msg.channel, msg.message));
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -1,8 +1,10 @@
 package com.sourcegraph.cody.agent;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.sourcegraph.cody.agent.protocol.ChatMessage;
+import com.sourcegraph.cody.agent.protocol.DebugMessage;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -13,9 +15,11 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("unused")
 public class CodyAgentClient {
 
+  private static final Logger logger = Logger.getInstance(CodyAgentClient.class);
   @Nullable public CodyAgentServer server;
   @Nullable public CodyAgentDocuments documents;
-  // Callback that is invoked when the agent sends a "chat/updateMessageInProgress" notification.
+  // Callback that is invoked when the agent sends a
+  // "chat/updateMessageInProgress" notification.
   @Nullable public Consumer<ChatMessage> onChatUpdateMessageInProgress;
   @Nullable public Editor editor;
 
@@ -48,5 +52,10 @@ public class CodyAgentClient {
       ApplicationManager.getApplication()
           .invokeLater(() -> onChatUpdateMessageInProgress.accept(params));
     }
+  }
+
+  @JsonNotification("debug/message")
+  public void debugMessage(DebugMessage msg) {
+    logger.info(String.format("%s: %s", msg.channel, msg.message));
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -52,4 +52,7 @@ public interface CodyAgentServer {
 
   @JsonNotification("textDocument/didClose")
   void textDocumentDidClose(TextDocument document);
+
+  @JsonNotification("debug/message")
+  void debugMessage(DebugMessage message);
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
@@ -11,6 +11,8 @@ public class ConnectionConfiguration {
   public String autocompleteAdvancedServerEndpoint;
   public String autocompleteAdvancedAccessToken;
   public boolean autocompleteAdvancedEmbeddings;
+  public boolean codyDebug;
+  public boolean codyVerboseDebug;
 
   public ConnectionConfiguration setServerEndpoint(String serverEndpoint) {
     this.serverEndpoint = serverEndpoint;
@@ -51,6 +53,16 @@ public class ConnectionConfiguration {
     return this;
   }
 
+  public ConnectionConfiguration setCodyDebug(boolean codyDebug) {
+    this.codyDebug = codyDebug;
+    return this;
+  }
+
+  public ConnectionConfiguration setCodyVerboseDebug(boolean codyVerboseDebug) {
+    this.codyVerboseDebug = codyVerboseDebug;
+    return this;
+  }
+
   @Override
   public String toString() {
     return "ConnectionConfiguration{"
@@ -73,6 +85,12 @@ public class ConnectionConfiguration {
         + '\''
         + ", autocompleteAdvancedEmbeddings="
         + autocompleteAdvancedEmbeddings
+        + '\''
+        + ", codyDebug="
+        + codyDebug
+        + '\''
+        + ", codyVerboseDebug="
+        + codyVerboseDebug
         + '}';
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ConnectionConfiguration.java
@@ -11,8 +11,8 @@ public class ConnectionConfiguration {
   public String autocompleteAdvancedServerEndpoint;
   public String autocompleteAdvancedAccessToken;
   public boolean autocompleteAdvancedEmbeddings;
-  public boolean codyDebug;
-  public boolean codyVerboseDebug;
+  public boolean debug;
+  public boolean verboseDebug;
 
   public ConnectionConfiguration setServerEndpoint(String serverEndpoint) {
     this.serverEndpoint = serverEndpoint;
@@ -53,13 +53,13 @@ public class ConnectionConfiguration {
     return this;
   }
 
-  public ConnectionConfiguration setCodyDebug(boolean codyDebug) {
-    this.codyDebug = codyDebug;
+  public ConnectionConfiguration setDebug(boolean debug) {
+    this.debug = debug;
     return this;
   }
 
-  public ConnectionConfiguration setCodyVerboseDebug(boolean codyVerboseDebug) {
-    this.codyVerboseDebug = codyVerboseDebug;
+  public ConnectionConfiguration setVerboseDebug(boolean verboseDebug) {
+    this.verboseDebug = verboseDebug;
     return this;
   }
 
@@ -86,11 +86,11 @@ public class ConnectionConfiguration {
         + ", autocompleteAdvancedEmbeddings="
         + autocompleteAdvancedEmbeddings
         + '\''
-        + ", codyDebug="
-        + codyDebug
+        + ", debug="
+        + debug
         + '\''
-        + ", codyVerboseDebug="
-        + codyVerboseDebug
+        + ", verboseDebug="
+        + verboseDebug
         + '}';
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/DebugMessage.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/DebugMessage.java
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.agent.protocol;
+
+public class DebugMessage {
+  public String channel;
+  public String message;
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -18,16 +18,14 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable public String instanceType;
   @Nullable public String url;
 
-  // Remove this after 2024-08-01 when surely everyone migrated to the secure
-  // storage.
+  // Remove this after 2024-08-01 when surely everyone migrated to the secure storage.
   @Deprecated(since = "3.0.7")
   @Nullable
   public String dotComAccessToken;
 
   public boolean isDotComAccessTokenSet;
 
-  // Remove this after 2024-08-01 when surely everyone migrated to the secure
-  // storage.
+  // Remove this after 2024-08-01 when surely everyone migrated to the secure storage.
   @Deprecated(since = "3.0.7")
   @Nullable
   public String enterpriseAccessToken;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -18,14 +18,16 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable public String instanceType;
   @Nullable public String url;
 
-  // Remove this after 2024-08-01 when surely everyone migrated to the secure storage.
+  // Remove this after 2024-08-01 when surely everyone migrated to the secure
+  // storage.
   @Deprecated(since = "3.0.7")
   @Nullable
   public String dotComAccessToken;
 
   public boolean isDotComAccessTokenSet;
 
-  // Remove this after 2024-08-01 when surely everyone migrated to the secure storage.
+  // Remove this after 2024-08-01 when surely everyone migrated to the secure
+  // storage.
   @Deprecated(since = "3.0.7")
   @Nullable
   public String enterpriseAccessToken;
@@ -47,6 +49,8 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable public Boolean isCodyAutoCompleteEnabled;
   public boolean isAccessTokenNotificationDismissed;
   @Nullable public Boolean authenticationFailedLastTime;
+  @Nullable public Boolean isCodyDebugEnabled;
+  @Nullable public Boolean isCodyVerboseDebugEnabled;
 
   @Nullable
   public String
@@ -124,6 +128,14 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
         .orElse(false);
   }
 
+  public boolean isCodyDebugEnabled() {
+    return Optional.ofNullable(isCodyDebugEnabled).orElse(false);
+  }
+
+  public boolean isCodyVerboseDebugEnabled() {
+    return Optional.ofNullable(isCodyVerboseDebugEnabled).orElse(false);
+  }
+
   public boolean isAccessTokenNotificationDismissed() {
     return isAccessTokenNotificationDismissed;
   }
@@ -166,5 +178,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     this.isAccessTokenNotificationDismissed = settings.isAccessTokenNotificationDismissed;
     this.authenticationFailedLastTime = settings.authenticationFailedLastTime;
     this.lastUpdateNotificationPluginVersion = settings.lastUpdateNotificationPluginVersion;
+    this.isCodyDebugEnabled = settings.isCodyDebugEnabled;
+    this.isCodyVerboseDebugEnabled = settings.isCodyVerboseDebugEnabled;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -30,7 +30,9 @@ public class ConfigUtil {
             UserLevelConfig.getAutoCompleteProviderType().vscodeSettingString())
         .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutoCompleteServerEndpoint())
         .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutoCompleteAccessToken())
-        .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings());
+        .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
+        .setCodyDebug(isCodyDebugEnabled())
+        .setCodyVerboseDebug(isCodyVerboseDebugEnabled());
   }
 
   @NotNull
@@ -223,6 +225,14 @@ public class ConfigUtil {
     return getApplicationLevelConfig().isCodyEnabled;
   }
 
+  public static boolean isCodyDebugEnabled() {
+    return getApplicationLevelConfig().isCodyDebugEnabled();
+  }
+
+  public static boolean isCodyVerboseDebugEnabled() {
+    return getApplicationLevelConfig().isCodyVerboseDebugEnabled();
+  }
+
   public static boolean isCodyAutoCompleteEnabled() {
     return getApplicationLevelConfig().isCodyEnabled
         && getApplicationLevelConfig().isCodyAutoCompleteEnabled();
@@ -277,13 +287,16 @@ public class ConfigUtil {
     if (project.getBasePath() != null) {
       return project.getBasePath();
     }
-    // The base path should only be null for the default project. The agent server assumes that the
-    // workspace root is not null, so we have to provide some default value. Feel free to change to
+    // The base path should only be null for the default project. The agent server
+    // assumes that the
+    // workspace root is not null, so we have to provide some default value. Feel
+    // free to change to
     // something else than the home directory if this is causing problems.
     return System.getProperty("user.home");
   }
 
-  // Null means user denied access to token storage. Empty string means no token found.
+  // Null means user denied access to token storage. Empty string means no token
+  // found.
   @Nullable
   public static String getProjectAccessToken(@NotNull Project project) {
     SettingsComponent.InstanceType instanceType = ConfigUtil.getInstanceType(project);
@@ -296,7 +309,8 @@ public class ConfigUtil {
     }
   }
 
-  // Null means user denied access to token storage. Empty string means no token found.
+  // Null means user denied access to token storage. Empty string means no token
+  // found.
   @Nullable
   public static String getEnterpriseAccessToken(Project project) {
     // Project level overrides secure storage
@@ -315,7 +329,8 @@ public class ConfigUtil {
       return securelyStoredAccessToken.get();
     }
 
-    // No secure token found, so use app-level token and migrate it to secure storage.
+    // No secure token found, so use app-level token and migrate it to secure
+    // storage.
     String unsafeApplicationLevelAccessToken = getApplicationLevelConfig().enterpriseAccessToken;
     if (unsafeApplicationLevelAccessToken != null) {
       AccessTokenStorage.setApplicationEnterpriseAccessToken(unsafeApplicationLevelAccessToken);
@@ -324,7 +339,8 @@ public class ConfigUtil {
     return unsafeApplicationLevelAccessToken != null ? unsafeApplicationLevelAccessToken : "";
   }
 
-  // Null means user denied access to token storage. Empty string means no token found.
+  // Null means user denied access to token storage. Empty string means no token
+  // found.
   @Nullable
   public static String getDotComAccessToken(@NotNull Project project) {
     // Project level overrides secure storage
@@ -342,7 +358,8 @@ public class ConfigUtil {
       return securelyStoredAccessToken.get();
     }
 
-    // No secure token found, so use app-level token and migrate it to secure storage.
+    // No secure token found, so use app-level token and migrate it to secure
+    // storage.
     String unsafeApplicationLevelAccessToken = getApplicationLevelConfig().dotComAccessToken;
     if (unsafeApplicationLevelAccessToken != null) {
       AccessTokenStorage.setApplicationDotComAccessToken(unsafeApplicationLevelAccessToken);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -31,8 +31,8 @@ public class ConfigUtil {
         .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutoCompleteServerEndpoint())
         .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutoCompleteAccessToken())
         .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
-        .setCodyDebug(isCodyDebugEnabled())
-        .setCodyVerboseDebug(isCodyVerboseDebugEnabled());
+        .setDebug(isCodyDebugEnabled())
+        .setVerboseDebug(isCodyVerboseDebugEnabled());
   }
 
   @NotNull
@@ -287,16 +287,13 @@ public class ConfigUtil {
     if (project.getBasePath() != null) {
       return project.getBasePath();
     }
-    // The base path should only be null for the default project. The agent server
-    // assumes that the
-    // workspace root is not null, so we have to provide some default value. Feel
-    // free to change to
+    // The base path should only be null for the default project. The agent server assumes that the
+    // workspace root is not null, so we have to provide some default value. Feel free to change to
     // something else than the home directory if this is causing problems.
     return System.getProperty("user.home");
   }
 
-  // Null means user denied access to token storage. Empty string means no token
-  // found.
+  // Null means user denied access to token storage. Empty string means no token found.
   @Nullable
   public static String getProjectAccessToken(@NotNull Project project) {
     SettingsComponent.InstanceType instanceType = ConfigUtil.getInstanceType(project);
@@ -309,8 +306,7 @@ public class ConfigUtil {
     }
   }
 
-  // Null means user denied access to token storage. Empty string means no token
-  // found.
+  // Null means user denied access to token storage. Empty string means no token found.
   @Nullable
   public static String getEnterpriseAccessToken(Project project) {
     // Project level overrides secure storage
@@ -329,8 +325,7 @@ public class ConfigUtil {
       return securelyStoredAccessToken.get();
     }
 
-    // No secure token found, so use app-level token and migrate it to secure
-    // storage.
+    // No secure token found, so use app-level token and migrate it to secure storage.
     String unsafeApplicationLevelAccessToken = getApplicationLevelConfig().enterpriseAccessToken;
     if (unsafeApplicationLevelAccessToken != null) {
       AccessTokenStorage.setApplicationEnterpriseAccessToken(unsafeApplicationLevelAccessToken);
@@ -339,8 +334,7 @@ public class ConfigUtil {
     return unsafeApplicationLevelAccessToken != null ? unsafeApplicationLevelAccessToken : "";
   }
 
-  // Null means user denied access to token storage. Empty string means no token
-  // found.
+  // Null means user denied access to token storage. Empty string means no token found.
   @Nullable
   public static String getDotComAccessToken(@NotNull Project project) {
     // Project level overrides secure storage
@@ -358,8 +352,7 @@ public class ConfigUtil {
       return securelyStoredAccessToken.get();
     }
 
-    // No secure token found, so use app-level token and migrate it to secure
-    // storage.
+    // No secure token found, so use app-level token and migrate it to secure storage.
     String unsafeApplicationLevelAccessToken = getApplicationLevelConfig().dotComAccessToken;
     if (unsafeApplicationLevelAccessToken != null) {
       AccessTokenStorage.setApplicationDotComAccessToken(unsafeApplicationLevelAccessToken);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -7,6 +7,8 @@ public class PluginSettingChangeContext {
   @NotNull public final String oldUrl;
   public final boolean oldCodyEnabled;
   public final boolean oldCodyAutoCompleteEnabled;
+  public final boolean oldCodyDebugEnabled;
+  public final boolean oldCodyVerboseDebugEnabled;
 
   @NotNull public final String newUrl;
   public final boolean isDotComAccessTokenChanged;
@@ -15,25 +17,35 @@ public class PluginSettingChangeContext {
   @Nullable public final String newCustomRequestHeaders;
   public final boolean newCodyEnabled;
   public final boolean newCodyAutoCompleteEnabled;
+  public final boolean newCodyDebugEnabled;
+  public final boolean newCodyVerboseDebugEnabled;
 
   public PluginSettingChangeContext(
       boolean oldCodyEnabled,
       boolean oldCodyAutoCompleteEnabled,
       @NotNull String oldUrl,
+      boolean oldCodyDebugEnabled,
+      boolean oldCodyVerboseDebugEnabled,
       @NotNull String newUrl,
       boolean isDotComAccessTokenChanged,
       boolean isEnterpriseAccessTokenChanged,
       @Nullable String newCustomRequestHeaders,
       boolean newCodyEnabled,
-      boolean newCodyAutoCompleteEnabled) {
+      boolean newCodyAutoCompleteEnabled,
+      boolean newCodyDebugEnabled,
+      boolean newCodyVerboseDebugEnabled) {
     this.oldCodyEnabled = oldCodyEnabled;
     this.oldCodyAutoCompleteEnabled = oldCodyAutoCompleteEnabled;
     this.oldUrl = oldUrl;
+    this.oldCodyDebugEnabled = oldCodyDebugEnabled;
+    this.oldCodyVerboseDebugEnabled = oldCodyVerboseDebugEnabled;
     this.newUrl = newUrl;
     this.isDotComAccessTokenChanged = isDotComAccessTokenChanged;
     this.isEnterpriseAccessTokenChanged = isEnterpriseAccessTokenChanged;
     this.newCustomRequestHeaders = newCustomRequestHeaders;
     this.newCodyEnabled = newCodyEnabled;
     this.newCodyAutoCompleteEnabled = newCodyAutoCompleteEnabled;
+    this.newCodyDebugEnabled = newCodyDebugEnabled;
+    this.newCodyVerboseDebugEnabled = newCodyVerboseDebugEnabled;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -459,7 +459,7 @@ public class SettingsComponent implements Disposable {
     return isCodyDebugEnabledCheckBox.isSelected();
   }
 
-  public void setIsDebugEnabled(boolean value) {
+  public void setIsCodyDebugEnabled(boolean value) {
     isCodyDebugEnabledCheckBox.setSelected(value);
   }
 
@@ -467,7 +467,7 @@ public class SettingsComponent implements Disposable {
     return isCodyVerboseDebugEnabledCheckBox.isSelected();
   }
 
-  public void setIsVerboseDebugEnabled(boolean value) {
+  public void setIsCodyVerboseDebugEnabled(boolean value) {
     isCodyVerboseDebugEnabledCheckBox.setSelected(value);
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -61,6 +61,8 @@ public class SettingsComponent implements Disposable {
   private JLabel installLocalAppComment;
   private ActionLink runLocalAppLink;
   private JLabel runLocalAppComment;
+  private JBCheckBox isCodyDebugEnabledCheckBox;
+  private JBCheckBox isCodyVerboseDebugEnabledCheckBox;
 
   private final ScheduledExecutorService codyAppStateCheckerExecutorService =
       Executors.newSingleThreadScheduledExecutor();
@@ -126,7 +128,7 @@ public class SettingsComponent implements Disposable {
     // Create URL field for the enterprise section
     JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
     urlTextField = new JBTextField();
-    //noinspection DialogTitleCapitalization
+    // noinspection DialogTitleCapitalization
     urlTextField.getEmptyText().setText("https://sourcegraph.example.com");
     urlTextField.setToolTipText("The default is \"" + ConfigUtil.DOTCOM_URL + "\".");
     addValidation(
@@ -453,6 +455,22 @@ public class SettingsComponent implements Disposable {
     isCodyAutoCompleteEnabledCheckBox.setSelected(value);
   }
 
+  public boolean isCodyDebugEnabled() {
+    return isCodyDebugEnabledCheckBox.isSelected();
+  }
+
+  public void setIsDebugEnabled(boolean value) {
+    isCodyDebugEnabledCheckBox.setSelected(value);
+  }
+
+  public boolean isCodyVerboseDebugEnabled() {
+    return isCodyVerboseDebugEnabledCheckBox.isSelected();
+  }
+
+  public void setIsVerboseDebugEnabled(boolean value) {
+    isCodyVerboseDebugEnabledCheckBox.setSelected(value);
+  }
+
   private void setInstanceSettingsEnabled(@NotNull InstanceType instanceType) {
     // enterprise stuff
     boolean isEnterprise = instanceType == InstanceType.ENTERPRISE;
@@ -540,14 +558,14 @@ public class SettingsComponent implements Disposable {
   private JPanel createNavigationSettingsPanel() {
     JBLabel defaultBranchNameLabel = new JBLabel("Default branch name:");
     defaultBranchNameTextField = new JBTextField();
-    //noinspection DialogTitleCapitalization
+    // noinspection DialogTitleCapitalization
     defaultBranchNameTextField.getEmptyText().setText("main");
     defaultBranchNameTextField.setToolTipText(
         "Usually \"main\" or \"master\", but can be any name");
 
     JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
     remoteUrlReplacementsTextField = new JBTextField();
-    //noinspection DialogTitleCapitalization
+    // noinspection DialogTitleCapitalization
     remoteUrlReplacementsTextField
         .getEmptyText()
         .setText("search1, replacement1, search2, replacement2, ...");
@@ -582,20 +600,26 @@ public class SettingsComponent implements Disposable {
 
   @NotNull
   private JPanel createCodySettingsPanel() {
-    //noinspection DialogTitleCapitalization
+    // noinspection DialogTitleCapitalization
     isCodyEnabledCheckBox = new JBCheckBox("Enable Cody");
     isCodyAutoCompleteEnabledCheckBox = new JBCheckBox("Enable Cody autocomplete");
+    isCodyDebugEnabledCheckBox = new JBCheckBox("Enable debug");
+    isCodyVerboseDebugEnabledCheckBox = new JBCheckBox("Verbose debug");
     JPanel codySettingsPanel =
         FormBuilder.createFormBuilder()
             .addComponent(isCodyEnabledCheckBox, 10)
             .addTooltip(
                 "Disable this to turn off all AI-based functionality of the plugin, including the Cody chat sidebar and autocomplete")
             .addComponent(isCodyAutoCompleteEnabledCheckBox, 5)
+            .addComponent(isCodyDebugEnabledCheckBox)
+            .addTooltip("Enables debug output visible in the idea.log")
+            .addComponent(isCodyVerboseDebugEnabledCheckBox)
             .getPanel();
     codySettingsPanel.setBorder(
         IdeBorderFactory.createTitledBorder("Cody Settings", true, JBUI.insetsTop(8)));
 
-    // Disable isCodyAutoCompleteEnabledCheckBox if isCodyEnabledCheckBox is not selected
+    // Disable isCodyAutoCompleteEnabledCheckBox if isCodyEnabledCheckBox is not
+    // selected
     isCodyEnabledCheckBox.addActionListener(
         e -> {
           if (!isCodyEnabledCheckBox.isSelected()) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -128,7 +128,7 @@ public class SettingsComponent implements Disposable {
     // Create URL field for the enterprise section
     JBLabel urlLabel = new JBLabel("Sourcegraph URL:");
     urlTextField = new JBTextField();
-    // noinspection DialogTitleCapitalization
+    //noinspection DialogTitleCapitalization
     urlTextField.getEmptyText().setText("https://sourcegraph.example.com");
     urlTextField.setToolTipText("The default is \"" + ConfigUtil.DOTCOM_URL + "\".");
     addValidation(
@@ -558,14 +558,14 @@ public class SettingsComponent implements Disposable {
   private JPanel createNavigationSettingsPanel() {
     JBLabel defaultBranchNameLabel = new JBLabel("Default branch name:");
     defaultBranchNameTextField = new JBTextField();
-    // noinspection DialogTitleCapitalization
+    //noinspection DialogTitleCapitalization
     defaultBranchNameTextField.getEmptyText().setText("main");
     defaultBranchNameTextField.setToolTipText(
         "Usually \"main\" or \"master\", but can be any name");
 
     JBLabel remoteUrlReplacementsLabel = new JBLabel("Remote URL replacements:");
     remoteUrlReplacementsTextField = new JBTextField();
-    // noinspection DialogTitleCapitalization
+    //noinspection DialogTitleCapitalization
     remoteUrlReplacementsTextField
         .getEmptyText()
         .setText("search1, replacement1, search2, replacement2, ...");
@@ -600,7 +600,7 @@ public class SettingsComponent implements Disposable {
 
   @NotNull
   private JPanel createCodySettingsPanel() {
-    // noinspection DialogTitleCapitalization
+    //noinspection DialogTitleCapitalization
     isCodyEnabledCheckBox = new JBCheckBox("Enable Cody");
     isCodyAutoCompleteEnabledCheckBox = new JBCheckBox("Enable Cody autocomplete");
     isCodyDebugEnabledCheckBox = new JBCheckBox("Enable debug");
@@ -618,8 +618,7 @@ public class SettingsComponent implements Disposable {
     codySettingsPanel.setBorder(
         IdeBorderFactory.createTitledBorder("Cody Settings", true, JBUI.insetsTop(8)));
 
-    // Disable isCodyAutoCompleteEnabledCheckBox if isCodyEnabledCheckBox is not
-    // selected
+    // Disable isCodyAutoCompleteEnabledCheckBox if isCodyEnabledCheckBox is not selected
     isCodyEnabledCheckBox.addActionListener(
         e -> {
           if (!isCodyEnabledCheckBox.isSelected()) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -172,8 +172,8 @@ public class SettingsConfigurable implements Configurable {
     mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());
     mySettingsComponent.setCodyEnabled(ConfigUtil.isCodyEnabled());
     mySettingsComponent.setCodyAutoCompleteEnabled(ConfigUtil.isCodyAutoCompleteEnabled());
-    mySettingsComponent.setIsDebugEnabled(ConfigUtil.isCodyDebugEnabled());
-    mySettingsComponent.setIsVerboseDebugEnabled(ConfigUtil.isCodyVerboseDebugEnabled());
+    mySettingsComponent.setIsCodyDebugEnabled(ConfigUtil.isCodyDebugEnabled());
+    mySettingsComponent.setIsCodyVerboseDebugEnabled(ConfigUtil.isCodyVerboseDebugEnabled());
     mySettingsComponent.getPanel().requestFocusInWindow();
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -57,8 +57,10 @@ public class SettingsConfigurable implements Configurable {
         || mySettingsComponent.isUrlNotificationDismissed()
             != ConfigUtil.isUrlNotificationDismissed()
         || mySettingsComponent.isCodyEnabled() != ConfigUtil.isCodyEnabled()
-        || mySettingsComponent.isCodyAutoCompleteEnabled()
-            != ConfigUtil.isCodyAutoCompleteEnabled();
+        || mySettingsComponent.isCodyAutoCompleteEnabled() != ConfigUtil.isCodyAutoCompleteEnabled()
+        || mySettingsComponent.isCodyDebugEnabled() != ConfigUtil.isCodyDebugEnabled()
+        || mySettingsComponent.isCodyVerboseDebugEnabled()
+            != ConfigUtil.isCodyVerboseDebugEnabled();
   }
 
   @Override
@@ -72,6 +74,8 @@ public class SettingsConfigurable implements Configurable {
 
     boolean oldCodyEnabled = ConfigUtil.isCodyEnabled();
     boolean oldCodyAutoCompleteEnabled = ConfigUtil.isCodyAutoCompleteEnabled();
+    boolean oldCodyDebugEnabled = ConfigUtil.isCodyDebugEnabled();
+    boolean oldCodyVerboseDebugEnabled = ConfigUtil.isCodyVerboseDebugEnabled();
     String oldUrl = ConfigUtil.getSourcegraphUrl(project);
     String newDotComAccessToken = mySettingsComponent.getDotComAccessToken();
     String newEnterpriseAccessToken = mySettingsComponent.getEnterpriseAccessToken();
@@ -90,12 +94,16 @@ public class SettingsConfigurable implements Configurable {
             oldCodyEnabled,
             oldCodyAutoCompleteEnabled,
             oldUrl,
+            oldCodyDebugEnabled,
+            oldCodyVerboseDebugEnabled,
             newUrl,
             mySettingsComponent.isDotComAccessTokenChanged(),
             mySettingsComponent.isEnterpriseAccessTokenChanged(),
             mySettingsComponent.getCustomRequestHeaders(),
             mySettingsComponent.isCodyEnabled(),
-            mySettingsComponent.isCodyAutoCompleteEnabled());
+            mySettingsComponent.isCodyAutoCompleteEnabled(),
+            mySettingsComponent.isCodyDebugEnabled(),
+            mySettingsComponent.isCodyVerboseDebugEnabled());
 
     publisher.beforeAction(context);
 
@@ -144,6 +152,8 @@ public class SettingsConfigurable implements Configurable {
     aSettings.isUrlNotificationDismissed = mySettingsComponent.isUrlNotificationDismissed();
     aSettings.setCodyEnabled(mySettingsComponent.isCodyEnabled());
     aSettings.isCodyAutoCompleteEnabled = mySettingsComponent.isCodyAutoCompleteEnabled();
+    aSettings.isCodyDebugEnabled = mySettingsComponent.isCodyDebugEnabled();
+    aSettings.isCodyVerboseDebugEnabled = mySettingsComponent.isCodyVerboseDebugEnabled();
 
     publisher.afterAction(context);
   }
@@ -162,6 +172,8 @@ public class SettingsConfigurable implements Configurable {
     mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());
     mySettingsComponent.setCodyEnabled(ConfigUtil.isCodyEnabled());
     mySettingsComponent.setCodyAutoCompleteEnabled(ConfigUtil.isCodyAutoCompleteEnabled());
+    mySettingsComponent.setIsDebugEnabled(ConfigUtil.isCodyDebugEnabled());
+    mySettingsComponent.setIsVerboseDebugEnabled(ConfigUtil.isCodyVerboseDebugEnabled());
     mySettingsComponent.getPanel().requestFocusInWindow();
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -76,10 +76,9 @@ public class UserLevelConfig {
     return properties.getProperty("url", "");
   }
 
-  // readProps returns the first properties file it's able to parse from the
-  // following paths:
-  // $HOME/.sourcegraph-jetbrains.properties
-  // $HOME/sourcegraph-jetbrains.properties
+  // readProps returns the first properties file it's able to parse from the following paths:
+  //   $HOME/.sourcegraph-jetbrains.properties
+  //   $HOME/sourcegraph-jetbrains.properties
   @NotNull
   private static Properties readProperties() {
     Path[] candidatePaths = {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -76,9 +76,10 @@ public class UserLevelConfig {
     return properties.getProperty("url", "");
   }
 
-  // readProps returns the first properties file it's able to parse from the following paths:
-  //   $HOME/.sourcegraph-jetbrains.properties
-  //   $HOME/sourcegraph-jetbrains.properties
+  // readProps returns the first properties file it's able to parse from the
+  // following paths:
+  // $HOME/.sourcegraph-jetbrains.properties
+  // $HOME/sourcegraph-jetbrains.properties
   @NotNull
   private static Properties readProperties() {
     Path[] candidatePaths = {


### PR DESCRIPTION
Adds new settings to enable/disable cody agent debugging and adds a listener to capture debug messages and log them. Goes with Cody PR https://github.com/sourcegraph/cody/pull/668

## Test plan
Run extension with debug/verbose enabled ensure debug messages are added to logs
Run extension with debug/verbose disabled ensure no debugging message added to logs

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
