### PR TITLE
cleanup: Inline/Simplify function used only in one place

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/recognizers.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/recognizers.go
@@ -21,7 +21,9 @@ func (api recognizerAPI) LuaAPI() map[string]lua.LGFunction {
 		}),
 
 		"fallback_recognizer": util.WrapLuaFunction(func(state *lua.LState) error {
-			recognizers, err := luatypes.RecognizersFromUserData(state.CheckTable(1))
+			recognizers, err := util.MapSlice(state.CheckTable(1), func(value lua.LValue) (*luatypes.Recognizer, error) {
+				return util.TypecheckUserData[*luatypes.Recognizer](value, "*Recognizer")
+			})
 			state.Push(luar.New(state, luatypes.NewFallback(recognizers)))
 			return err
 		}),

--- a/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
+++ b/internal/codeintel/autoindexing/internal/inference/luatypes/recognizers.go
@@ -155,14 +155,6 @@ func NamedRecognizersFromUserDataMap(value lua.LValue, allowFalseAsNil bool) (re
 	return
 }
 
-// RecognizersFromUserData decodes a single recognize or slice of recognizers from the
-// given Lua value.
-func RecognizersFromUserData(value lua.LValue) (recognizers []*Recognizer, err error) {
-	return util.MapSliceOrSingleton(value, func(value lua.LValue) (*Recognizer, error) {
-		return util.TypecheckUserData[*Recognizer](value, "*Recognizer")
-	})
-}
-
 // RecognizerFromTable decodes a single Lua table value into a recognizer instance.
 func RecognizerFromTable(table *lua.LTable) (*Recognizer, error) {
 	recognizer := &Recognizer{}


### PR DESCRIPTION
The argument is first validated using `CheckTable`, which guarantees that
we'll have a table. So `new_fallback_recognizer` doesn't accept a `Recognizer` object,
which means that the singleton case in `MapSliceOrSingleton` is not triggered.
So directly use `MapSlice`.

## Test plan

Covered by existing tests