### PR TITLE
JetBrains: fix miscellaneous issues

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -164,6 +164,7 @@ tasks {
         systemProperty("cody-agent.trace-path", "$buildDir/sourcegraph/cody-agent-trace.json")
         systemProperty("cody-agent.directory", agentTargetDirectory.parent.toString())
         systemProperty("cody-agent.enabled", isAgentEnabled.toString())
+        systemProperty("sourcegraph.verbose-logging", "true")
     }
 
     // Configure UI tests plugin

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.agent;
 
+import com.google.gson.GsonBuilder;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.Disposable;
@@ -107,7 +108,7 @@ public class CodyAgent implements Disposable {
             } catch (Exception e) {
               initializationErrorMessage =
                   "failed to send 'initialize' JSON-RPC request Cody agent";
-              logger.warn(initializationErrorMessage, e);
+              logger.error(initializationErrorMessage, e);
             }
           });
     } catch (Exception e) {
@@ -212,6 +213,9 @@ public class CodyAgent implements Disposable {
             .start();
     Launcher<CodyAgentServer> launcher =
         new Launcher.Builder<CodyAgentServer>()
+            // emit `null` instead of leaving fields undefined because Cody in VSC has
+            // many `=== null` checks that return false for undefined fields.
+            .configureGson(GsonBuilder::serializeNulls)
             .setRemoteInterface(CodyAgentServer.class)
             .traceMessages(traceWriter())
             .setExecutorService(executorService)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -108,7 +108,7 @@ public class CodyAgent implements Disposable {
             } catch (Exception e) {
               initializationErrorMessage =
                   "failed to send 'initialize' JSON-RPC request Cody agent";
-              logger.error(initializationErrorMessage, e);
+              logger.warn(initializationErrorMessage, e);
             }
           });
     } catch (Exception e) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -107,4 +107,8 @@ public class UserLevelConfig {
 
     return properties;
   }
+
+  public static boolean isVerboseLoggingEnabled() {
+    return Boolean.getBoolean("sourcegraph.verbose-logging");
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -18,7 +18,7 @@ public class GraphQlLogger {
 
   public static void logInstallEvent(
       @NotNull Project project, @NotNull Consumer<Boolean> callback) {
-    if (ConfigUtil.getAnonymousUserId() != null) {
+    if (ConfigUtil.getAnonymousUserId() != null && project.isDisposed()) {
       var event = createEvent(project, "CodyInstalled", new JsonObject());
       logEvent(project, event, (responseStatusCode) -> callback.accept(responseStatusCode == 200));
     }


### PR DESCRIPTION
- Adds more helpful debug logging
- Stop displaying autocomplete when built-in completions are visible
- Emit `null` instead of undefined fields
- Fixes https://github.com/sourcegraph/sourcegraph/issues/55796


## Test plan

Manually tested with `./gradlew -PplatformVersion=221.5080.210 -PenableAgent=true -PforceAgentBuild=true :runIde`. Make sure we autocomplete works as expected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
