### PR TITLE
JetBrains: Bump IntelliJ version to 2022.1

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -6,19 +6,15 @@ pluginName=Sourcegraph
 pluginVersion=3.0.9
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-#  - 2020.2 was the first version to have JCEF enabled by default
-#    -> https://plugins.jetbrains.com/docs/intellij/jcef.html
-#  - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
-#    -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
-pluginSinceBuild=212.0
+pluginSinceBuild=221.0
 pluginUntilBuild=*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2021.2
+platformVersion=2022.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin
-# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
+# Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
 javaVersion=11
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion=8.1.1


### PR DESCRIPTION
Updated `pluginSinceBuild` and `platformVersion` to mitigate an issue we're having with IDE versions below 221.5080.210 on macOS with Apple silicon CPUs.

More info:
- Before this PR, we supported 221.0 (release date: 2021-08-06) and newer
- **221.0 was released on 2022-01-27**
- 221.5080.210 was released on 2022-04-12
- 222.0 was released on 2022-05-19

We decided to require 221.0+ because it was released 1.5 years ago, so it's reasonable that all users have upgraded to this major version.
We didn't want to risk our users losing support with any of the newer versions, but we hope that whoever uses 221.0+ installs the patches, even if they don't upgrade to 222.0+

## Test plan

We've already tested our functionality with 221.0+ versions (and earlier) so this should bring no surprises.