### PR TITLE
chore: fix extra space that confused Markdown render

### DIFF
--- a/doc/cody/explanations/index.md
+++ b/doc/cody/explanations/index.md
@@ -4,7 +4,7 @@
   - [Enabling Cody for Sourcegraph Enterprise](enabling_cody_enterprise.md)
   - [Installing the Cody App](../../app/index.md)
   - [Enabling Cody with Sourcegraph.com](enabling_cody.md)
--  Configuration
+- Configuration
   - [Configuring code graph context](code_graph_context.md)
   - [Generating Index to Enable Codebase-Aware Answers](indexing.md)
   - [Embeddings Policies](policies.md)


### PR DESCRIPTION
The current broken view:
<img width="515" alt="CleanShot 2023-08-14 at 14 03 27@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/6cd7882d-7ec9-41fa-8a6b-314627b8ec61">


## Test plan

n/a