### PR TITLE
search: introduce backend interface for exhaustive search

### DIFF
--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "search",
+    srcs = ["search.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/search",
+    visibility = ["//enterprise/cmd/worker:__subpackages__"],
+    deps = ["//internal/api"],
+)

--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -5,5 +6,18 @@ go_library(
     srcs = ["search.go"],
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/worker/internal/search",
     visibility = ["//enterprise/cmd/worker:__subpackages__"],
-    deps = ["//internal/api"],
+    deps = [
+        "//internal/api",
+        "//lib/errors",
+    ],
+)
+
+go_test(
+    name = "search_test",
+    srcs = ["search_test.go"],
+    embed = [":search"],
+    deps = [
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
+    ],
 )

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -36,13 +36,13 @@ type RepositoryRefSpec struct {
 	RefSpec string
 }
 
-// Unit represents the smallest unit we can search over, a specific repository
-// and revision.
+// RepositoryRevision represents the smallest unit we can search over, a
+// specific repository and revision.
 //
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
-type Unit struct {
-	// RepositoryRefSpec is where this Unit got resolved from.
+type RepositoryRevision struct {
+	// RepositoryRefSpec is where this RepositoryRevision got resolved from.
 	RepositoryRefSpec
 
 	// Revision is the resolved revision.
@@ -69,9 +69,9 @@ type Unit struct {
 type Searcher interface {
 	UnresolvedUnits(context.Context) ([]RepositoryRefSpec, error)
 
-	ResolveUnit(context.Context, RepositoryRefSpec) ([]Unit, error)
+	ResolveUnit(context.Context, RepositoryRefSpec) ([]RepositoryRevision, error)
 
-	Search(context.Context, Unit, CSVWriter) error
+	Search(context.Context, RepositoryRevision, CSVWriter) error
 }
 
 // CSVWriter makes it so we can avoid caring about search types and leave it

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -66,6 +66,21 @@ type RepositoryRevision struct {
 // idempotent due to backend state changing. The main purpose of breaking it
 // out like this is so we can report progress, do retries, and spread out the
 // work over time.
+//
+// Commentary on exhaustive worker jobs added in
+// https://github.com/sourcegraph/sourcegraph/pull/55587:
+//
+//   - ExhaustiveSearchJob uses RepositoryRefSpecs to create ExhaustiveSearchRepoJob
+//   - ExhaustiveSearchRepoJob uses ResolveRepositoryRefSpec to create ExhaustiveSearchRepoRevisionJob
+//   - ExhaustiveSearchRepoRevisionJob uses Search
+//
+// In each case I imagine Backend.NewSearch(query) to get hold of the
+// Searcher. NewSearch is envisioned as being cheap to do. The only IO it does
+// is maybe reading featureflags/site configuration/etc. This does mean it is
+// possible for things to change over time, but this should be rare and will
+// result in a well defined error. The alternative is a way to serialize a
+// Searcher, but this makes it harder to make changes to search going forward
+// for what should be rare errors.
 type Searcher interface {
 	RepositoryRefSpecs(context.Context) ([]RepositoryRefSpec, error)
 

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -22,13 +22,13 @@ type Backend interface {
 	NewSearch(ctx context.Context, q string) (Searcher, error)
 }
 
-// UnresolvedUnit represents zero or more revisions we need to search in a
-// repository for a refspec. This can be inferred relativley cheaply from
+// RepositoryRefSpec represents zero or more revisions we need to search in a
+// repository for a refspec. This can be inferred relatively cheaply from
 // parsing a query and the repos table.
 //
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
-type UnresolvedUnit struct {
+type RepositoryRefSpec struct {
 	// Repository is the repository to search.
 	Repository api.RepoID
 
@@ -42,8 +42,8 @@ type UnresolvedUnit struct {
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
 type Unit struct {
-	// UnresolvedUnit is where this Unit got resolved from.
-	UnresolvedUnit
+	// RepositoryRefSpec is where this Unit got resolved from.
+	RepositoryRefSpec
 
 	// Revision is the resolved revision.
 	Revision api.CommitID
@@ -67,9 +67,9 @@ type Unit struct {
 // out like this is so we can report progress, do retries, and spread out the
 // work over time.
 type Searcher interface {
-	UnresolvedUnits(context.Context) ([]UnresolvedUnit, error)
+	UnresolvedUnits(context.Context) ([]RepositoryRefSpec, error)
 
-	ResolveUnit(context.Context, UnresolvedUnit) ([]Unit, error)
+	ResolveUnit(context.Context, RepositoryRefSpec) ([]Unit, error)
 
 	Search(context.Context, Unit, CSVWriter) error
 }

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type Backend interface {
+type NewSearcher interface {
 	// NewSearch parses and minimally resolves the search query q. The
 	// expectation is that this method is always fast and is deterministic, such
 	// that calling this again in the future should return the same Searcher. IE
@@ -23,25 +23,30 @@ type Backend interface {
 	// affect what is returned. Alternatively as we release new versions of
 	// Sourcegraph what is returned could change. This means we are not exactly
 	// safe across repeated calls.
-	NewSearch(ctx context.Context, q string) (Searcher, error)
+	NewSearch(ctx context.Context, q string) (SearchQuery, error)
 }
 
-// RepositoryRefSpec represents zero or more revisions we need to search in a
-// repository for a refspec. This can be inferred relatively cheaply from
-// parsing a query and the repos table.
+// RepositoryRevSpec represents zero or more revisions we need to search in a
+// repository for a revision specifier. This can be inferred relatively
+// cheaply from parsing a query and the repos table.
 //
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
-type RepositoryRefSpec struct {
+//
+// Note: this is like a search/repos.RepoRevSpecs except we store 1 revision
+// specifier per repository. It may be worth updating this to instead store a
+// slice of RevisionSpecifiers.
+type RepositoryRevSpec struct {
 	// Repository is the repository to search.
 	Repository api.RepoID
 
-	// RefSpec is something that still needs to be resolved on gitserver.
-	RefSpec string
+	// RevisionSpecifier is something that still needs to be resolved on gitserver. This
+	// is a serialiazed version of query.RevisionSpecifier.
+	RevisionSpecifier string
 }
 
-func (r RepositoryRefSpec) String() string {
-	return fmt.Sprintf("RepositoryRefSpec{%d@%s}", r.Repository, r.RefSpec)
+func (r RepositoryRevSpec) String() string {
+	return fmt.Sprintf("RepositoryRevSpec{%d@%s}", r.Repository, r.RevisionSpecifier)
 }
 
 // RepositoryRevision represents the smallest unit we can search over, a
@@ -50,22 +55,23 @@ func (r RepositoryRefSpec) String() string {
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
 type RepositoryRevision struct {
-	// RepositoryRefSpec is where this RepositoryRevision got resolved from.
-	RepositoryRefSpec
+	// RepositoryRevSpec is where this RepositoryRevision got resolved from.
+	RepositoryRevSpec
 
-	// Revision is the resolved revision.
-	Revision api.CommitID
+	// Revision is a resolved revision specifier. eg HEAD, branch-name,
+	// commit-hash, etc.
+	Revision string
 }
 
 func (r RepositoryRevision) String() string {
 	return fmt.Sprintf("RepositoryRevision{%d@%s}", r.Repository, r.Revision)
 }
 
-// Searcher represents a search in a way we can break up the work. The flow is
+// SearchQuery represents a search in a way we can break up the work. The flow is
 // something like:
 //
-//  1. RepositoryRefSpecs -> just speak to the DB to find the list of repos we need to search.
-//  2. ResolveRepositoryRefSpec -> speak to gitserver to find out which commits to search.
+//  1. RepositoryRevSpecs -> just speak to the DB to find the list of repos we need to search.
+//  2. ResolveRepositoryRevSpec -> speak to gitserver to find out which commits to search.
 //  3. Search -> actually do a search.
 //
 // This does mean that things like searching a commit in a monorepo are
@@ -82,21 +88,21 @@ func (r RepositoryRevision) String() string {
 // Commentary on exhaustive worker jobs added in
 // https://github.com/sourcegraph/sourcegraph/pull/55587:
 //
-//   - ExhaustiveSearchJob uses RepositoryRefSpecs to create ExhaustiveSearchRepoJob
-//   - ExhaustiveSearchRepoJob uses ResolveRepositoryRefSpec to create ExhaustiveSearchRepoRevisionJob
+//   - ExhaustiveSearchJob uses RepositoryRevSpecs to create ExhaustiveSearchRepoJob
+//   - ExhaustiveSearchRepoJob uses ResolveRepositoryRevSpec to create ExhaustiveSearchRepoRevisionJob
 //   - ExhaustiveSearchRepoRevisionJob uses Search
 //
-// In each case I imagine Backend.NewSearch(query) to get hold of the
-// Searcher. NewSearch is envisioned as being cheap to do. The only IO it does
-// is maybe reading featureflags/site configuration/etc. This does mean it is
-// possible for things to change over time, but this should be rare and will
-// result in a well defined error. The alternative is a way to serialize a
-// Searcher, but this makes it harder to make changes to search going forward
-// for what should be rare errors.
-type Searcher interface {
-	RepositoryRefSpecs(context.Context) ([]RepositoryRefSpec, error)
+// In each case I imagine NewSearcher.NewSearch(query) to get hold of the
+// SearchQuery. NewSearch is envisioned as being cheap to do. The only IO it
+// does is maybe reading featureflags/site configuration/etc. This does mean
+// it is possible for things to change over time, but this should be rare and
+// will result in a well defined error. The alternative is a way to serialize
+// a SearchQuery, but this makes it harder to make changes to search going
+// forward for what should be rare errors.
+type SearchQuery interface {
+	RepositoryRevSpecs(context.Context) ([]RepositoryRevSpec, error)
 
-	ResolveRepositoryRefSpec(context.Context, RepositoryRefSpec) ([]RepositoryRevision, error)
+	ResolveRepositoryRevSpec(context.Context, RepositoryRevSpec) ([]RepositoryRevision, error)
 
 	Search(context.Context, RepositoryRevision, CSVWriter) error
 }
@@ -116,32 +122,32 @@ type CSVWriter interface {
 	WriteRow(...string) error
 }
 
-// BackendFake is a convenient working implementation of Searcher which always
-// will write results generated from the repoRevs. It expects a query string
-// which looks like
+// NewSearcherFake is a convenient working implementation of SearchQuery which
+// always will write results generated from the repoRevs. It expects a query
+// string which looks like
 //
 //	 1@rev1 1@rev2 2@rev3
 //
 //	This is a space separated list of {repoid}@{revision}.
 //
-//	- RepositoryRefSpecs will return one RepositoryRefSpec per unique repository.
-//	- ResolveRepositoryRefSpec returns the repoRevs for that repository.
+//	- RepositoryRevSpecs will return one RepositoryRevSpec per unique repository.
+//	- ResolveRepositoryRevSpec returns the repoRevs for that repository.
 //	- Search will write one result which is just the repo and revision.
-func BackendFake() Backend {
+func NewSearcherFake() NewSearcher {
 	return backendFake{}
 }
 
 type backendFake struct{}
 
-func (backendFake) NewSearch(ctx context.Context, q string) (Searcher, error) {
+func (backendFake) NewSearch(ctx context.Context, q string) (SearchQuery, error) {
 	var repoRevs []RepositoryRevision
 	for _, part := range strings.Fields(q) {
 		var r RepositoryRevision
 		if n, err := fmt.Sscanf(part, "%d@%s", &r.Repository, &r.Revision); n != 2 || err != nil {
 			return nil, errors.Errorf("failed to parse repository revision %q", part)
 		}
-		r.RepositoryRefSpec.Repository = r.Repository
-		r.RepositoryRefSpec.RefSpec = "spec"
+		r.RepositoryRevSpec.Repository = r.Repository
+		r.RepositoryRevSpec.RevisionSpecifier = "spec"
 		repoRevs = append(repoRevs, r)
 	}
 	return searcherFake{repoRevs: repoRevs}, nil
@@ -151,23 +157,23 @@ type searcherFake struct {
 	repoRevs []RepositoryRevision
 }
 
-func (s searcherFake) RepositoryRefSpecs(context.Context) ([]RepositoryRefSpec, error) {
-	seen := map[RepositoryRefSpec]bool{}
-	var repoRefSpecs []RepositoryRefSpec
+func (s searcherFake) RepositoryRevSpecs(context.Context) ([]RepositoryRevSpec, error) {
+	seen := map[RepositoryRevSpec]bool{}
+	var repoRevSpecs []RepositoryRevSpec
 	for _, r := range s.repoRevs {
-		if seen[r.RepositoryRefSpec] {
+		if seen[r.RepositoryRevSpec] {
 			continue
 		}
-		seen[r.RepositoryRefSpec] = true
-		repoRefSpecs = append(repoRefSpecs, r.RepositoryRefSpec)
+		seen[r.RepositoryRevSpec] = true
+		repoRevSpecs = append(repoRevSpecs, r.RepositoryRevSpec)
 	}
-	return repoRefSpecs, nil
+	return repoRevSpecs, nil
 }
 
-func (s searcherFake) ResolveRepositoryRefSpec(_ context.Context, repoRefSpec RepositoryRefSpec) ([]RepositoryRevision, error) {
+func (s searcherFake) ResolveRepositoryRevSpec(_ context.Context, repoRevSpec RepositoryRevSpec) ([]RepositoryRevision, error) {
 	var repoRevs []RepositoryRevision
 	for _, r := range s.repoRevs {
-		if r.RepositoryRefSpec == repoRefSpec {
+		if r.RepositoryRevSpec == repoRevSpec {
 			repoRevs = append(repoRevs, r)
 		}
 	}
@@ -175,8 +181,8 @@ func (s searcherFake) ResolveRepositoryRefSpec(_ context.Context, repoRefSpec Re
 }
 
 func (s searcherFake) Search(_ context.Context, r RepositoryRevision, w CSVWriter) error {
-	if err := w.WriteHeader("repo", "refspec", "revision"); err != nil {
+	if err := w.WriteHeader("repo", "revspec", "revision"); err != nil {
 		return err
 	}
-	return w.WriteRow(strconv.Itoa(int(r.Repository)), r.RefSpec, string(r.Revision))
+	return w.WriteRow(strconv.Itoa(int(r.Repository)), r.RevisionSpecifier, string(r.Revision))
 }

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+type Backend interface {
+	// NewSearch parses and minimally resolves the search query q. The
+	// expectation is that this method is always fast and is deterministic, such
+	// that calling this again in the future should return the same Searcher. IE
+	// it can speak to the DB, but maybe not gitserver.
+	//
+	// I expect this to be roughly equivalent to creation of a search plan in
+	// our search codes job creator.
+	//
+	// Note: I expect things like feature flags for the user behind ctx could
+	// affect what is returned. Alternatively as we release new versions of
+	// Sourcegraph what is returned could change. This means we are not exactly
+	// safe across repeated calls.
+	NewSearch(ctx context.Context, q string) (Searcher, error)
+}
+
+// UnresolvedUnit represents zero or more revisions we need to search in a
+// repository for a refspec. This can be inferred relativley cheaply from
+// parsing a query and the repos table.
+//
+// This type needs to be serializable so that we can persist it to a database
+// or queue.
+type UnresolvedUnit struct {
+	// Repository is the repository to search.
+	Repository api.RepoID
+
+	// RefSpec is something that still needs to be resolved on gitserver.
+	RefSpec string
+}
+
+// Unit represents the smallest unit we can search over, a specific repository
+// and revision.
+//
+// This type needs to be serializable so that we can persist it to a database
+// or queue.
+type Unit struct {
+	// UnresolvedUnit is where this Unit got resolved from.
+	UnresolvedUnit
+
+	// Revision is the resolved revision.
+	Revision api.CommitID
+}
+
+// Searcher represents a search in a way we can break up the work. The flow is
+// something like:
+//
+//  1. UnresolvedUnits -> just speak to the DB to find the list of repos we need to search.
+//  2. ResolveUnit -> speak to gitserver to find out which commits to search.
+//  3. Search -> actually do a search.
+//
+// This does mean that things like searching a commit in a monorepo are
+// expected to run over a reasonable time frame (eg within a minute?).
+//
+// For example doing a diff search in an old repo may not be fast enough, but
+// I'm not sure if we should design that in?
+//
+// We expect each step can be retried, but with the expectation it isn't
+// idempotent due to backend state changing. The main purpose of breaking it
+// out like this is so we can report progress, do retries, and spread out the
+// work over time.
+type Searcher interface {
+	UnresolvedUnits(context.Context) ([]UnresolvedUnit, error)
+
+	ResolveUnit(context.Context, UnresolvedUnit) ([]Unit, error)
+
+	Search(context.Context, Unit, CSVWriter) error
+}
+
+// CSVWriter makes it so we can avoid caring about search types and leave it
+// up to the search job to decide the shape of data.
+//
+// Note: I expect the implementation of this to handle things like chunking up
+// the CSV/etc. EG once we hit 100MB of data it can write the data out then
+// start a new file. It takes care of remembering the header for the new file.
+type CSVWriter interface {
+	// WriteHeader should be called first and only once.
+	WriteHeader(...string) error
+
+	// WriteRow should have the same number of values as WriteHeader and can be
+	// called zero or more times.
+	WriteRow(...string) error
+}

--- a/enterprise/cmd/worker/internal/search/search.go
+++ b/enterprise/cmd/worker/internal/search/search.go
@@ -52,8 +52,8 @@ type RepositoryRevision struct {
 // Searcher represents a search in a way we can break up the work. The flow is
 // something like:
 //
-//  1. UnresolvedUnits -> just speak to the DB to find the list of repos we need to search.
-//  2. ResolveUnit -> speak to gitserver to find out which commits to search.
+//  1. RepositoryRefSpecs -> just speak to the DB to find the list of repos we need to search.
+//  2. ResolveRepositoryRefSpec -> speak to gitserver to find out which commits to search.
 //  3. Search -> actually do a search.
 //
 // This does mean that things like searching a commit in a monorepo are
@@ -67,9 +67,9 @@ type RepositoryRevision struct {
 // out like this is so we can report progress, do retries, and spread out the
 // work over time.
 type Searcher interface {
-	UnresolvedUnits(context.Context) ([]RepositoryRefSpec, error)
+	RepositoryRefSpecs(context.Context) ([]RepositoryRefSpec, error)
 
-	ResolveUnit(context.Context, RepositoryRefSpec) ([]RepositoryRevision, error)
+	ResolveRepositoryRefSpec(context.Context, RepositoryRefSpec) ([]RepositoryRevision, error)
 
 	Search(context.Context, RepositoryRevision, CSVWriter) error
 }

--- a/enterprise/cmd/worker/internal/search/search_test.go
+++ b/enterprise/cmd/worker/internal/search/search_test.go
@@ -1,0 +1,87 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestBackendFake(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := context.Background()
+	searcher, err := BackendFake().NewSearch(ctx, "1@rev1 1@rev2 2@rev3")
+	assert.NoError(err)
+
+	// Test RepositoryRefSpecs
+	refSpecs, err := searcher.RepositoryRefSpecs(ctx)
+	assert.NoError(err)
+	assert.Equal("RepositoryRefSpec{1@spec} RepositoryRefSpec{2@spec}", joinStringer(refSpecs))
+
+	// Test ResolveRepositoryRefSpec
+	{
+		// RepositoryRefSpec{1@spec}
+		repoRevs, err := searcher.ResolveRepositoryRefSpec(ctx, refSpecs[0])
+		assert.NoError(err)
+		assert.Equal("RepositoryRevision{1@rev1} RepositoryRevision{1@rev2}", joinStringer(repoRevs))
+
+		// RepositoryRefSpec{2@spec}
+		repoRevs, err = searcher.ResolveRepositoryRefSpec(ctx, refSpecs[1])
+		assert.NoError(err)
+		assert.Equal("RepositoryRevision{2@rev3}", joinStringer(repoRevs))
+	}
+
+	// Test Search
+	var csv csvBuffer
+	for _, refSpec := range refSpecs {
+		repoRevs, err := searcher.ResolveRepositoryRefSpec(ctx, refSpec)
+		assert.NoError(err)
+		for _, repoRev := range repoRevs {
+			err := searcher.Search(ctx, repoRev, &csv)
+			assert.NoError(err)
+		}
+	}
+	assert.Equal(`repo,refspec,revision
+1,spec,rev1
+1,spec,rev2
+2,spec,rev3
+`, csv.buf.String())
+}
+
+func joinStringer[T fmt.Stringer](xs []T) string {
+	var parts []string
+	for _, x := range xs {
+		parts = append(parts, x.String())
+	}
+	return strings.Join(parts, " ")
+}
+
+type csvBuffer struct {
+	buf    bytes.Buffer
+	header []string
+}
+
+func (c *csvBuffer) WriteHeader(header ...string) error {
+	if c.header == nil {
+		c.header = header
+		return c.WriteRow(header...)
+	}
+	if !slices.Equal(c.header, header) {
+		return errors.New("different header passed to WriteHeader")
+	}
+	return nil
+}
+
+func (c *csvBuffer) WriteRow(row ...string) error {
+	if len(row) != len(c.header) {
+		return errors.New("row size does not match header size in WriteRow")
+	}
+	_, err := c.buf.WriteString(strings.Join(row, ",") + "\n")
+	return err
+}

--- a/enterprise/cmd/worker/internal/search/search_test.go
+++ b/enterprise/cmd/worker/internal/search/search_test.go
@@ -16,23 +16,23 @@ func TestBackendFake(t *testing.T) {
 	assert := require.New(t)
 
 	ctx := context.Background()
-	searcher, err := BackendFake().NewSearch(ctx, "1@rev1 1@rev2 2@rev3")
+	searcher, err := NewSearcherFake().NewSearch(ctx, "1@rev1 1@rev2 2@rev3")
 	assert.NoError(err)
 
-	// Test RepositoryRefSpecs
-	refSpecs, err := searcher.RepositoryRefSpecs(ctx)
+	// Test RepositoryRevSpecs
+	refSpecs, err := searcher.RepositoryRevSpecs(ctx)
 	assert.NoError(err)
-	assert.Equal("RepositoryRefSpec{1@spec} RepositoryRefSpec{2@spec}", joinStringer(refSpecs))
+	assert.Equal("RepositoryRevSpec{1@spec} RepositoryRevSpec{2@spec}", joinStringer(refSpecs))
 
-	// Test ResolveRepositoryRefSpec
+	// Test ResolveRepositoryRevSpec
 	{
-		// RepositoryRefSpec{1@spec}
-		repoRevs, err := searcher.ResolveRepositoryRefSpec(ctx, refSpecs[0])
+		// RepositoryRevSpec{1@spec}
+		repoRevs, err := searcher.ResolveRepositoryRevSpec(ctx, refSpecs[0])
 		assert.NoError(err)
 		assert.Equal("RepositoryRevision{1@rev1} RepositoryRevision{1@rev2}", joinStringer(repoRevs))
 
-		// RepositoryRefSpec{2@spec}
-		repoRevs, err = searcher.ResolveRepositoryRefSpec(ctx, refSpecs[1])
+		// RepositoryRevSpec{2@spec}
+		repoRevs, err = searcher.ResolveRepositoryRevSpec(ctx, refSpecs[1])
 		assert.NoError(err)
 		assert.Equal("RepositoryRevision{2@rev3}", joinStringer(repoRevs))
 	}
@@ -40,14 +40,14 @@ func TestBackendFake(t *testing.T) {
 	// Test Search
 	var csv csvBuffer
 	for _, refSpec := range refSpecs {
-		repoRevs, err := searcher.ResolveRepositoryRefSpec(ctx, refSpec)
+		repoRevs, err := searcher.ResolveRepositoryRevSpec(ctx, refSpec)
 		assert.NoError(err)
 		for _, repoRev := range repoRevs {
 			err := searcher.Search(ctx, repoRev, &csv)
 			assert.NoError(err)
 		}
 	}
-	assert.Equal(`repo,refspec,revision
+	assert.Equal(`repo,revspec,revision
 1,spec,rev1
 1,spec,rev2
 2,spec,rev3


### PR DESCRIPTION
We introduce an interface for how we expect exhaustive search workers will interact with our search subsystem. Additionally we introduce a functional fake for this system which uses a fake search query language to make it easy to test how the parts interact.

I encourage reviewing this PR commit by commit since we start off with the current proposed interface from the issue and then improve it.

Note: The location of the code and names can all change. The purpose of this PR is so we have this code checked in so it can be incrementally improved / easier to track than comments on an issue. I also hope that the fake is useable today to unblock progress.

Fixes https://github.com/sourcegraph/sourcegraph/issues/55455

Test Plan: CI
