### PR TITLE
Bump jaeger epoch

### DIFF
--- a/wolfi-packages/jaeger.yaml
+++ b/wolfi-packages/jaeger.yaml
@@ -4,7 +4,7 @@
 package:
   name: jaeger
   version: 1.45.0 # Keep in sync with version in sg.config.yaml
-  epoch: 2
+  epoch: 3
   description: "Distributed Tracing Platform"
   target-architecture:
     - x86_64


### PR DESCRIPTION
Merging https://github.com/sourcegraph/sourcegraph/pull/55726 means that base images are expecting the package repo to be signed with our new keys.

This PR has two effects:
* Remove the old keys we were using for this purpose
* Bump a package, causing the repo's APKINDEX to be rebuild using the new key

## Test plan

- Manually checked that package repo has been rebuild using new key

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
