### PR TITLE
nix: fix direnv hanging when starting redis

### DIFF
--- a/dev/nix/start-redis.sh
+++ b/dev/nix/start-redis.sh
@@ -10,7 +10,7 @@ fi
 
 if ! redis-cli -e ping &>/dev/null; then
   echo "Starting redis..."
-  redis-server - >/dev/null <<-EOF
+  redis-server - 3>&- >/dev/null <<-EOF
 # use local data dir
 dir $data
 logfile $data/redis.log


### PR DESCRIPTION
Not sure when or why, but I just had the same issue as with postgres but with redis now :shrug: 

## Test plan

N/A nix stuff
