### PR TITLE
JetBrains: fix path of agent binaries in plugin zip

### DIFF
--- a/client/jetbrains/gradle.properties
+++ b/client/jetbrains/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=3.0.9
+pluginVersion=3.0.10
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.0

--- a/client/jetbrains/scripts/release.sh
+++ b/client/jetbrains/scripts/release.sh
@@ -14,6 +14,7 @@ popd > /dev/null || exit
 # Build the JavaScript artifacts
 pnpm build
 
+./gradlew -PforceAgentBuild=true clean buildPluginAndAssertAgentBinariesExist
 # Build the release candidate and publish it onto the registry
 ./gradlew -PforceAgentBuild=true publishPlugin
 


### PR DESCRIPTION
The 3.0.9 was a failure because the agent binaries were located in the `agent/agent/` directory instead of `agent/`. This code path was working correctly at one point but it was only manually tested. This commit fixes the issue and adds new assertions to the release script to prevent a regression like this in the future.

## Test plan

- Ran `./gradlew buildPlugin` and manually installed the zip file. Manually confirmed that autocomplete via agent works as expected. 
<img width="675" alt="CleanShot 2023-08-15 at 14 34 55@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/5e95a853-b2b2-4907-a2e1-e1637efef551">

- Ran `./gradlew -PforceAgentBuild=true buildPluginAndAssertAgentBinariesExist` to confirm it runs successfully. Manually added a file that doesn't exist and confirmed the task fails.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
