### PR TITLE
JetBrains: Rename Settings group titles

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -333,7 +333,7 @@ public class SettingsComponent implements Disposable {
             .addTooltip("Whitespace around commas doesn't matter.")
             .getPanel();
     userAuthenticationPanel.setBorder(
-        IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+        IdeBorderFactory.createTitledBorder("Authentication (Applies to Code Search and Cody)", true, JBUI.insetsTop(8)));
 
     updateVisibilityOfHelperLinks();
     codyAppStateCheckerExecutorService.scheduleWithFixedDelay(
@@ -594,7 +594,7 @@ public class SettingsComponent implements Disposable {
             .addComponent(isUrlNotificationDismissedCheckBox, 10)
             .getPanel();
     navigationSettingsPanel.setBorder(
-        IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
+        IdeBorderFactory.createTitledBorder("Code Search Settings", true, JBUI.insetsTop(8)));
     return navigationSettingsPanel;
   }
 


### PR DESCRIPTION
The current settings page for the plugin is becoming a bit overwhelming with different options and it's difficult to know which settings impact which functionality.

As a solution, I've renamed two of the three sections.

Before:

![image](https://github.com/sourcegraph/sourcegraph/assets/2552265/3be41de2-6994-4fe1-8482-ad8afb2eb252)

After:

![image](https://github.com/sourcegraph/sourcegraph/assets/2552265/6c284b22-7067-4a34-b09c-2b9909c79f57)

## Test plan

Only UI change. We'll have a peer and design review to make sure we want this.