### PR TITLE
JetBrains: improve settings UI

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentProjectListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentProjectListener.java
@@ -12,19 +12,30 @@ public class CodyAgentProjectListener implements ProjectManagerListener {
     if (!ConfigUtil.isCodyEnabled()) {
       return;
     }
-    CodyAgent service = project.getService(CodyAgent.class);
-    if (service == null) {
-      return;
-    }
-    service.initialize();
+    this.startAgent(project);
   }
 
   @Override
   public void projectClosed(@NotNull Project project) {
+    this.stopAgent(project);
+  }
+
+  public void stopAgent(@NotNull Project project) {
     CodyAgent service = project.getService(CodyAgent.class);
     if (service == null) {
       return;
     }
     service.shutdown();
+  }
+
+  public void startAgent(@NotNull Project project) {
+    CodyAgent service = project.getService(CodyAgent.class);
+    if (service == null) {
+      return;
+    }
+    if (CodyAgent.isConnected(project)) {
+      return;
+    }
+    service.initialize();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -83,7 +83,8 @@ public class CodyAutoCompleteManager {
 
   @RequiresEdt
   public boolean isEnabledForEditor(Editor editor) {
-    return ConfigUtil.isCodyAutoCompleteEnabled()
+    return ConfigUtil.isCodyEnabled()
+        && ConfigUtil.isCodyAutoCompleteEnabled()
         && editor != null
         && isProjectAvailable(editor.getProject())
         && isEditorSupported(editor);
@@ -96,8 +97,7 @@ public class CodyAutoCompleteManager {
    * @param offset The character offset in the editor to trigger auto-complete at.
    */
   public void triggerAutoComplete(@NotNull Editor editor, int offset) {
-    // Check if auto-complete is enabled via the config
-    if (!ConfigUtil.isCodyEnabled() || !ConfigUtil.isCodyAutoCompleteEnabled()) {
+    if (!isEnabledForEditor(editor)) {
       return;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -97,7 +97,7 @@ public class CodyAutoCompleteManager {
    */
   public void triggerAutoComplete(@NotNull Editor editor, int offset) {
     // Check if auto-complete is enabled via the config
-    if (!ConfigUtil.isCodyAutoCompleteEnabled()) {
+    if (!ConfigUtil.isCodyEnabled() || !ConfigUtil.isCodyAutoCompleteEnabled()) {
       return;
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -234,8 +234,7 @@ public class ConfigUtil {
   }
 
   public static boolean isCodyAutoCompleteEnabled() {
-    return getApplicationLevelConfig().isCodyEnabled
-        && getApplicationLevelConfig().isCodyAutoCompleteEnabled();
+    return getApplicationLevelConfig().isCodyAutoCompleteEnabled();
   }
 
   public static boolean isAccessTokenNotificationDismissed() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -31,7 +31,6 @@ import java.awt.event.KeyEvent;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.KeyStroke;
-
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.keymap.KeymapUtil;
@@ -17,6 +18,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
+import com.sourcegraph.cody.CodyAgentProjectListener;
 import com.sourcegraph.cody.CodyToolWindowFactory;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentServer;
@@ -29,6 +31,7 @@ import java.awt.event.KeyEvent;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.KeyStroke;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -38,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 public class SettingsChangeListener implements Disposable {
   private final MessageBusConnection connection;
   private JavaToJSBridge javaToJSBridge;
+  private final Logger logger = Logger.getInstance(SettingsChangeListener.class);
 
   public SettingsChangeListener(@NotNull Project project) {
     MessageBus bus = project.getMessageBus();
@@ -61,9 +65,17 @@ public class SettingsChangeListener implements Disposable {
               javaToJSBridge.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project));
             }
 
+            if (context.oldCodyEnabled && !context.newCodyEnabled) {
+              logger.warn("Stopping Cody agent because of config changes");
+              new CodyAgentProjectListener().stopAgent(project);
+            } else if (!context.oldCodyEnabled && context.newCodyEnabled) {
+              logger.warn("Starting Cody agent because of config changes");
+              new CodyAgentProjectListener().startAgent(project);
+            }
+
             // Notify Cody Agent about config changes.
             CodyAgentServer agentServer = CodyAgent.getServer(project);
-            if (agentServer != null) {
+            if (context.newCodyEnabled && agentServer != null) {
               agentServer.configurationDidChange(ConfigUtil.getAgentConfiguration(project));
             }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -79,8 +79,8 @@ public class SettingsComponent implements Disposable {
     panel =
         FormBuilder.createFormBuilder()
             .addComponent(userAuthenticationPanel)
-            .addComponent(navigationSettingsPanel)
             .addComponent(codySettingsPanel)
+            .addComponent(navigationSettingsPanel)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
   }
@@ -333,7 +333,7 @@ public class SettingsComponent implements Disposable {
             .addTooltip("Whitespace around commas doesn't matter.")
             .getPanel();
     userAuthenticationPanel.setBorder(
-        IdeBorderFactory.createTitledBorder("User Authentication", true, JBUI.insetsTop(8)));
+        IdeBorderFactory.createTitledBorder("Authentication", true, JBUI.insetsTop(8)));
 
     updateVisibilityOfHelperLinks();
     codyAppStateCheckerExecutorService.scheduleWithFixedDelay(
@@ -442,6 +442,7 @@ public class SettingsComponent implements Disposable {
 
   public void setCodyEnabled(boolean value) {
     isCodyEnabledCheckBox.setSelected(value);
+    this.onDidCodyEnableSettingChange();
     if (!value) {
       setCodyAutoCompleteEnabled(false);
     }
@@ -594,7 +595,7 @@ public class SettingsComponent implements Disposable {
             .addComponent(isUrlNotificationDismissedCheckBox, 10)
             .getPanel();
     navigationSettingsPanel.setBorder(
-        IdeBorderFactory.createTitledBorder("Navigation Settings", true, JBUI.insetsTop(8)));
+        IdeBorderFactory.createTitledBorder("Code Search", true, JBUI.insetsTop(8)));
     return navigationSettingsPanel;
   }
 
@@ -616,18 +617,19 @@ public class SettingsComponent implements Disposable {
             .addComponent(isCodyVerboseDebugEnabledCheckBox)
             .getPanel();
     codySettingsPanel.setBorder(
-        IdeBorderFactory.createTitledBorder("Cody Settings", true, JBUI.insetsTop(8)));
+        IdeBorderFactory.createTitledBorder("Cody AI", true, JBUI.insetsTop(8)));
 
     // Disable isCodyAutoCompleteEnabledCheckBox if isCodyEnabledCheckBox is not selected
-    isCodyEnabledCheckBox.addActionListener(
-        e -> {
-          if (!isCodyEnabledCheckBox.isSelected()) {
-            isCodyAutoCompleteEnabledCheckBox.setSelected(false);
-          }
-          isCodyAutoCompleteEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
-        });
+    isCodyEnabledCheckBox.addActionListener(e -> this.onDidCodyEnableSettingChange());
+    this.onDidCodyEnableSettingChange();
 
     return codySettingsPanel;
+  }
+
+  private void onDidCodyEnableSettingChange() {
+    isCodyAutoCompleteEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
+    isCodyDebugEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
+    isCodyVerboseDebugEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
   }
 
   @Override


### PR DESCRIPTION
- Clearer titles for sections: Authentication, Cody AI, Code Search
- Reorder groups to put Cody AI above Code Search
- Disabling Cody checkbox disables all checkboxes in the group
- Disabling Cody checkbox no longer sets autocomplete value to false. When you disable/enable Cody, the Cody-related setting values are the unchanged. Previously, all Cody values would be set to false.
- Automatically start/stop Agent based on Cody enabled setting

## Test plan

With `./gradlew -PenableAgent=true :runIde`:

- Cody + autocomplete is enabled, confirm autocomplete works.
- Disable Cody, confirm autocomplete checkbox is disabled but checked.
- Confirm autocomplete does not work.
- Enable Cody, disable autocomplete. Confirm autocomplete is still not working.
- Enable Cody, enable autocomplete, confirm autocomplete still works.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
