### PR TITLE
sg: add ListArtifactsByJob to buildkite client

### DIFF
--- a/dev/sg/internal/bk/bk.go
+++ b/dev/sg/internal/bk/bk.go
@@ -161,6 +161,22 @@ func (c *Client) ListArtifactsByBuildNumber(ctx context.Context, pipeline string
 	return artifacts, nil
 }
 
+// ListArtifactsByJob queries the Buildkite API and retrieves all the artifacts for a particular job
+func (c *Client) ListArtifactsByJob(ctx context.Context, pipeline string, buildNumber string, jobID string) ([]buildkite.Artifact, error) {
+	artifacts, _, err := c.bk.Artifacts.ListByJob(BuildkiteOrg, pipeline, buildNumber, jobID, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err != nil {
+		if strings.Contains(err.Error(), "404 Not Found") {
+			return nil, errors.New("no artifacts because no build or job found")
+		}
+		return nil, err
+	}
+
+	return artifacts, nil
+}
+
 // DownloadArtifact downloads the Buildkite artifact into the provider io.Writer
 func (c *Client) DownloadArtifact(artifact buildkite.Artifact, w io.Writer) error {
 	url := artifact.DownloadURL


### PR DESCRIPTION
Add api to fetch artifacts for a particular job
## Test plan
Modified status to utilize the status call to rather use the add api and look fetch all artifacts on `:bazel: Tests` job for build `238522`
```
go run ./dev/sg ci status -n 238522
Artifacts [238522] Job[:bazel: Tests]: 2
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
