### PR TITLE
Add singleton message to Ruby package host

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1586,6 +1586,8 @@ const RUBY_PACKAGES: AddExternalServiceOptions = {
                     for details on how to configure an internal Artifactory repository.
                 </li>
             </ol>
+            <Text>⚠️ Ruby package repositories are visible by all users of the Sourcegraph instance.</Text>
+            <Text>⚠️ It is only possible to register one Ruby packages code host per Sourcegraph instance.</Text>
         </div>
     ),
     editorActions: [],


### PR DESCRIPTION
All other package hosts have this disclaimer, ruby should have it too, to my understanding of the packages architecture.

## Test plan

Verified it renders correctly.