### PR TITLE
Tracing: add logging for trace exporting

### DIFF
--- a/cmd/frontend/internal/cli/BUILD.bazel
+++ b/cmd/frontend/internal/cli/BUILD.bazel
@@ -84,6 +84,7 @@ go_library(
         "//lib/output",
         "//schema",
         "@com_github_fsnotify_fsnotify//:fsnotify",
+        "@com_github_go_logr_stdr//:stdr",
         "@com_github_gorilla_context//:context",
         "@com_github_gorilla_mux//:mux",
         "@com_github_graph_gophers_graphql_go//:graphql-go",

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/stdr"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/keegancsmith/tmpfriend"
 	sglog "github.com/sourcegraph/log"
@@ -99,6 +100,9 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		return err
 	}
 	db := database.NewDB(logger, sqlDB)
+
+	// Used by opentelemetry logging
+	stdr.SetVerbosity(10)
 
 	if os.Getenv("SRC_DISABLE_OOBMIGRATION_VALIDATION") != "" {
 		if !deploy.IsApp() {

--- a/go.mod
+++ b/go.mod
@@ -435,7 +435,7 @@ require (
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
-	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/stdr v1.2.2
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect


### PR DESCRIPTION
I'm still struggling to figure out why we are missing spans on sourcegraph.com, so this enables debug logging for the otel logging package. 

This can be removed in a couple of days or if we find what the cause of the missing spans is.

## Test plan

Tested locally that the logs work as expected. Note the `total_dropped`, which is of particular interest to me because we apparently also do batching in the service that is exporting to `otel-agent`, which is then exporting to `otel-collector`, which then exports to Jaeger and GCP 🤯 

```
[       frontend] 2023/08/15 21:44:57 internal_logging.go:63: "level"=8 "msg"="exporting spans" "count"=130 "total_dropped"=0
```
