### PR TITLE
JetBrains: Send config changed event when codebase changes

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentFocusListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentFocusListener.java
@@ -5,7 +5,7 @@ import com.intellij.openapi.editor.ex.FocusChangeListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.agent.CodyAgent;
-import com.sourcegraph.cody.agent.CodyAgentServer;
+import com.sourcegraph.cody.agent.CodyAgentClient;
 import com.sourcegraph.cody.agent.protocol.TextDocument;
 import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
@@ -23,10 +23,15 @@ public class CodyAgentFocusListener implements FocusChangeListener {
     if (file == null) {
       return;
     }
-    CodyAgentServer server = CodyAgent.getServer(editor.getProject());
-    if (server == null) {
+    CodyAgentClient client = CodyAgent.getClient(editor.getProject());
+    if (client.server == null) {
       return;
     }
-    server.textDocumentDidFocus(new TextDocument().setFilePath(file.getPath()));
+    client.server.textDocumentDidFocus(new TextDocument().setFilePath(file.getPath()));
+
+    if (client.codebase == null) {
+      return;
+    }
+    client.codebase.handlePotentialCodebaseChange(editor.getProject(), file);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.agent.CodyAgent;
+import com.sourcegraph.cody.agent.CodyAgentClient;
 import com.sourcegraph.cody.agent.CodyAgentServer;
 import com.sourcegraph.cody.agent.protocol.TextDocument;
 import com.sourcegraph.config.ConfigUtil;
@@ -21,12 +22,17 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
     if (document == null) {
       return;
     }
-    CodyAgentServer server = CodyAgent.getServer(source.getProject());
-    if (server == null) {
+    CodyAgentClient client = CodyAgent.getClient(source.getProject());
+    if (client.server == null) {
       return;
     }
-    server.textDocumentDidOpen(
+    client.server.textDocumentDidOpen(
         new TextDocument().setFilePath(file.getPath()).setContent(document.getText()));
+
+    if (client.codebase == null) {
+      return;
+    }
+    client.codebase.handlePotentialCodebaseChange(source.getProject(), file);
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -80,6 +80,13 @@ public class CodyAgent implements Disposable {
     return getClient(project).server;
   }
 
+  public static CodyAgentCodebase getCodebase(@NotNull Project project) {
+    if (!isConnected(project)) {
+      return null;
+    }
+    return getClient(project).codebase;
+  }
+
   public void initialize() {
     if (!"true".equals(System.getProperty("cody-agent.enabled", "false"))) {
       logger.info("Cody agent is disabled due to system property '-Dcody-agent.enabled=false'");
@@ -98,7 +105,7 @@ public class CodyAgent implements Disposable {
                               .setName("JetBrains")
                               .setVersion(ConfigUtil.getPluginVersion())
                               .setWorkspaceRootPath(ConfigUtil.getWorkspaceRoot(project))
-                              .setConnectionConfiguration(
+                              .setExtensionConfiguration(
                                   ConfigUtil.getAgentConfiguration(this.project)))
                       .get();
               logger.info("connected to Cody agent " + info.name);
@@ -225,6 +232,7 @@ public class CodyAgent implements Disposable {
             .create();
     client.server = launcher.getRemoteProxy();
     client.documents = new CodyAgentDocuments(client.server);
+    client.codebase = new CodyAgentCodebase(client.server);
     this.listeningToJsonRpc = launcher.startListening();
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -18,6 +18,7 @@ public class CodyAgentClient {
   private static final Logger logger = Logger.getInstance(CodyAgentClient.class);
   @Nullable public CodyAgentServer server;
   @Nullable public CodyAgentDocuments documents;
+  @Nullable public CodyAgentCodebase codebase;
   // Callback that is invoked when the agent sends a "chat/updateMessageInProgress" notification.
   @Nullable public Consumer<ChatMessage> onChatUpdateMessageInProgress;
   @Nullable public Editor editor;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
@@ -1,0 +1,35 @@
+package com.sourcegraph.cody.agent;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.sourcegraph.config.ConfigUtil;
+import com.sourcegraph.vcs.RepoUtil;
+import java.util.Objects;
+
+public class CodyAgentCodebase {
+  private final CodyAgentServer underlying;
+  private String currentCodebase = null;
+
+  public CodyAgentCodebase(CodyAgentServer underlying) {
+    this.underlying = underlying;
+  }
+
+  public void handlePotentialCodebaseChange(Project project, VirtualFile file) {
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
+            () -> {
+              String repositoryName = RepoUtil.findRepositoryName(project, file);
+              ApplicationManager.getApplication()
+                  .invokeLater(
+                      () -> {
+                        if (!Objects.equals(this.currentCodebase, repositoryName)) {
+                          ExtensionConfiguration config =
+                              ConfigUtil.getAgentConfiguration(project).setCodebase(repositoryName);
+                          this.currentCodebase = repositoryName;
+                          underlying.configurationDidChange(config);
+                        }
+                      });
+            });
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -38,8 +38,8 @@ public interface CodyAgentServer {
   @JsonNotification("exit")
   void exit();
 
-  @JsonNotification("connectionConfiguration/didChange")
-  void configurationDidChange(ConnectionConfiguration document);
+  @JsonNotification("extensionConfiguration/didChange")
+  void configurationDidChange(ExtensionConfiguration document);
 
   @JsonNotification("textDocument/didFocus")
   void textDocumentDidFocus(TextDocument document);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ExtensionConfiguration.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ExtensionConfiguration.java
@@ -2,7 +2,7 @@ package com.sourcegraph.cody.agent;
 
 import java.util.Map;
 
-public class ConnectionConfiguration {
+public class ExtensionConfiguration {
 
   public String serverEndpoint;
   public String accessToken;
@@ -13,59 +13,65 @@ public class ConnectionConfiguration {
   public boolean autocompleteAdvancedEmbeddings;
   public boolean debug;
   public boolean verboseDebug;
+  public String codebase;
 
-  public ConnectionConfiguration setServerEndpoint(String serverEndpoint) {
+  public ExtensionConfiguration setServerEndpoint(String serverEndpoint) {
     this.serverEndpoint = serverEndpoint;
     return this;
   }
 
-  public ConnectionConfiguration setAccessToken(String accessToken) {
+  public ExtensionConfiguration setAccessToken(String accessToken) {
     this.accessToken = accessToken;
     return this;
   }
 
-  public ConnectionConfiguration setCustomHeaders(Map<String, String> customHeaders) {
+  public ExtensionConfiguration setCustomHeaders(Map<String, String> customHeaders) {
     this.customHeaders = customHeaders;
     return this;
   }
 
-  public ConnectionConfiguration setAutocompleteAdvancedProvider(
+  public ExtensionConfiguration setAutocompleteAdvancedProvider(
       String autocompleteAdvancedProvider) {
     this.autocompleteAdvancedProvider = autocompleteAdvancedProvider;
     return this;
   }
 
-  public ConnectionConfiguration setAutocompleteAdvancedServerEndpoint(
+  public ExtensionConfiguration setAutocompleteAdvancedServerEndpoint(
       String autocompleteAdvancedServerEndpoint) {
     this.autocompleteAdvancedServerEndpoint = autocompleteAdvancedServerEndpoint;
     return this;
   }
 
-  public ConnectionConfiguration setAutocompleteAdvancedAccessToken(
+  public ExtensionConfiguration setAutocompleteAdvancedAccessToken(
       String autocompleteAdvancedAccessToken) {
     this.autocompleteAdvancedAccessToken = autocompleteAdvancedAccessToken;
     return this;
   }
 
-  public ConnectionConfiguration setAutocompleteAdvancedEmbeddings(
+  public ExtensionConfiguration setAutocompleteAdvancedEmbeddings(
       boolean autocompleteAdvancedEmbeddings) {
     this.autocompleteAdvancedEmbeddings = autocompleteAdvancedEmbeddings;
     return this;
   }
 
-  public ConnectionConfiguration setDebug(boolean debug) {
+  public ExtensionConfiguration setDebug(boolean debug) {
     this.debug = debug;
     return this;
   }
 
-  public ConnectionConfiguration setVerboseDebug(boolean verboseDebug) {
+  public ExtensionConfiguration setVerboseDebug(boolean verboseDebug) {
     this.verboseDebug = verboseDebug;
+    return this;
+  }
+
+  public ExtensionConfiguration setCodebase(String codebase) {
+    this.codebase = codebase;
     return this;
   }
 
   @Override
   public String toString() {
-    return "ConnectionConfiguration{"
+    return "ExtensionConfiguration{"
         + "serverEndpoint='"
         + serverEndpoint
         + '\''
@@ -91,6 +97,8 @@ public class ConnectionConfiguration {
         + '\''
         + ", verboseDebug="
         + verboseDebug
+        + ", codebase="
+        + codebase
         + '}';
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/ClientInfo.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/ClientInfo.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.agent.protocol;
 
-import com.sourcegraph.cody.agent.ConnectionConfiguration;
+import com.sourcegraph.cody.agent.ExtensionConfiguration;
 import org.jetbrains.annotations.Nullable;
 
 public class ClientInfo {
@@ -8,7 +8,7 @@ public class ClientInfo {
   public String name;
   public String version;
   public String workspaceRootPath;
-  @Nullable public ConnectionConfiguration connectionConfiguration;
+  @Nullable public ExtensionConfiguration extensionConfiguration;
 
   public ClientInfo setName(String name) {
     this.name = name;
@@ -25,8 +25,8 @@ public class ClientInfo {
     return this;
   }
 
-  public ClientInfo setConnectionConfiguration(ConnectionConfiguration connectionConfiguration) {
-    this.connectionConfiguration = connectionConfiguration;
+  public ClientInfo setExtensionConfiguration(ExtensionConfiguration extensionConfiguration) {
+    this.extensionConfiguration = extensionConfiguration;
     return this;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
@@ -17,7 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.agent.CodyAgent;
-import com.sourcegraph.cody.agent.CodyAgentServer;
+import com.sourcegraph.cody.agent.CodyAgentClient;
 import com.sourcegraph.cody.agent.protocol.Position;
 import com.sourcegraph.cody.agent.protocol.Range;
 import com.sourcegraph.cody.agent.protocol.TextDocument;
@@ -177,8 +177,8 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
     if (editor.getProject() == null) {
       return;
     }
-    CodyAgentServer server = CodyAgent.getServer(editor.getProject());
-    if (server == null) {
+    CodyAgentClient client = CodyAgent.getClient(editor.getProject());
+    if (client.server == null) {
       return;
     }
     VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
@@ -190,6 +190,11 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
             .setFilePath(file.getPath())
             .setContent(editor.getDocument().getText())
             .setSelection(getSelection(editor));
-    server.textDocumentDidChange(document);
+    client.server.textDocumentDidChange(document);
+
+    if (client.codebase == null) {
+      return;
+    }
+    client.codebase.handlePotentialCodebaseChange(editor.getProject(), file);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -5,7 +5,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
-import com.sourcegraph.cody.agent.ConnectionConfiguration;
+import com.sourcegraph.cody.agent.ExtensionConfiguration;
 import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.find.Search;
 import java.util.HashMap;
@@ -21,8 +21,8 @@ public class ConfigUtil {
   public static final String DOTCOM_URL = "https://sourcegraph.com/";
 
   @NotNull
-  public static ConnectionConfiguration getAgentConfiguration(@NotNull Project project) {
-    return new ConnectionConfiguration()
+  public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
+    return new ExtensionConfiguration()
         .setServerEndpoint(getSourcegraphUrl(project))
         .setAccessToken(getProjectAccessToken(project))
         .setCustomHeaders(getCustomRequestHeadersAsMap(project))


### PR DESCRIPTION
This adds new logic to track the current codebase associated with the active editor/file and send the `extensionConfiguration/didChange`  notification to the agent with the codebase changes.

This also renames the ConnectionConfiguration to ExtensionConfiguration to match recent agent changes, since the configuration is inclusive of additional configuration beyond connection information.

I included the `textDocumentDidChange` event because I did not get `textDocumentDidOpen` or `textDocumentDidFocus`  events when the project opened to a specific file.


## Test plan

Opened editor to repo that has embeddings, verified that codebase was sent to agent and embeddings were fetched to use with autocomplete.

Opened editor to folder containing multiple repos observed that opening files updated the configuration when changing the file was part of a different repo.  Split window with 1 file from each repo on each side, moved focus to each side and ensured codebase updated.

```
[Trace - 10:51:14 PM] Sending notification 'textDocument/didFocus'
Params: {
  "filePath": "/Users/chriswarwick/projects/foldertest/codenotify/main.go"
}


[Trace - 10:51:14 PM] Sending notification 'extensionConfiguration/didChange'
Params: {
  "serverEndpoint": "https://sourcegraph.sourcegraph.com/",
  "accessToken": "REDACTED",
  "customHeaders": {},
  "autocompleteAdvancedProvider": "anthropic",
  "autocompleteAdvancedEmbeddings": true,
  "debug": true,
  "verboseDebug": true,
  "codebase": "github.com/sourcegraph/codenotify"
}


[Trace - 10:51:15 PM] Sending notification 'textDocument/didFocus'
Params: {
  "filePath": "/Users/chriswarwick/projects/foldertest/errwrap/errwrap.go"
}


[Trace - 10:51:15 PM] Sending notification 'extensionConfiguration/didChange'
Params: {
  "serverEndpoint": "https://sourcegraph.sourcegraph.com/",
  "accessToken": "REDACTED",
  "customHeaders": {},
  "autocompleteAdvancedProvider": "anthropic",
  "autocompleteAdvancedEmbeddings": true,
  "debug": true,
  "verboseDebug": true,
  "codebase": "github.com/hashicorp/errwrap"
}
```


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
