### PR TITLE
Fix InternalClient comment

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -216,7 +216,7 @@ func NewInternalClientFactory(subsystem string, middleware ...Middleware) *Facto
 // convenience for existing uses of http.DefaultClient.
 var InternalDoer, _ = InternalClientFactory.Doer()
 
-// InternalClient returns a shared client for external communication. This is
+// InternalClient returns a shared client for internal communication. This is
 // a convenience for existing uses of http.DefaultClient.
 var InternalClient, _ = InternalClientFactory.Client()
 


### PR DESCRIPTION
Fix the `InternalClient` comment so Cody stops giving wrong answers in the test suite 😄 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

* No tests, comment change.