### PR TITLE
onboarding: Initial version of experimental onboarding tour configuration page

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1499,6 +1499,7 @@ ts_project(
         "src/site-admin/SiteAdminFeatureFlagsPage.tsx",
         "src/site-admin/SiteAdminGitHubAppsArea.tsx",
         "src/site-admin/SiteAdminMigrationsPage.tsx",
+        "src/site-admin/SiteAdminOnboardingTourPage.tsx",
         "src/site-admin/SiteAdminOrgsPage.tsx",
         "src/site-admin/SiteAdminOutboundRequestsPage.tsx",
         "src/site-admin/SiteAdminPackagesPage.tsx",

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -30,6 +30,7 @@ export type FeatureFlagName =
     | 'own-analytics'
     | 'enable-simple-search'
     | 'setup-checklist'
+    | 'end-user-onboarding'
 
 interface OrgFlagOverride {
     orgID: string

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -58,6 +58,8 @@ export interface SiteAdminAreaRouteContext
     overviewComponents: readonly React.ComponentType<React.PropsWithChildren<{}>>[]
 
     codeInsightsEnabled: boolean
+
+    endUserOnboardingEnabled: boolean
 }
 
 export interface SiteAdminAreaRoute extends RouteV6Descriptor<SiteAdminAreaRouteContext> {}
@@ -86,6 +88,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
     const { data: externalAccounts, loading: isExternalAccountsLoading } = useUserExternalAccounts(
         props.authenticatedUser.username
     )
+    const [endUserOnboardingEnabled] = useFeatureFlag('end-user-onboarding')
     const [isSourcegraphOperatorSiteAdminHideMaintenance] = useFeatureFlag(
         'sourcegraph-operator-site-admin-hide-maintenance'
     )
@@ -134,6 +137,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         overviewComponents: props.overviewComponents,
         telemetryService: props.telemetryService,
         codeInsightsEnabled: props.codeInsightsEnabled,
+        endUserOnboardingEnabled,
     }
 
     return (
@@ -155,6 +159,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
                     batchChangesExecutionEnabled={props.batchChangesExecutionEnabled}
                     batchChangesWebhookLogsEnabled={props.batchChangesWebhookLogsEnabled}
                     codeInsightsEnabled={props.codeInsightsEnabled}
+                    endUserOnboardingEnabled={endUserOnboardingEnabled}
                 />
                 <div className="flex-bounded">
                     <React.Suspense fallback={<LoadingSpinner className="m-2" />}>

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -1,0 +1,107 @@
+import { type FC, type PropsWithChildren, useState, useEffect } from 'react'
+
+import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
+import { PageHeader, Text, Container, BeforeUnloadPrompt, LoadingSpinner } from '@sourcegraph/wildcard'
+
+import onboardingSchemaJSON from '../../../../schema/onboardingtour.schema.json'
+import { PageTitle } from '../components/PageTitle'
+import { SaveToolbar } from '../components/SaveToolbar'
+import { MonacoSettingsEditor } from '../settings/MonacoSettingsEditor'
+
+interface Props extends TelemetryProps {}
+
+function useLoadOnboardingConfig(): { data: string; loading: boolean; error?: Error } {
+    const data = JSON.stringify(
+        {
+            tasks: [
+                {
+                    title: 'Code search use cases',
+                    steps: [
+                        {
+                            id: 'SymbolsSearch',
+                            label: 'Search multiple repos',
+                            action: {
+                                type: 'link',
+                                value: {
+                                    C: '/search?q=context:global+repo:torvalds/.*+lang:c+-file:.*/testing+magic&patternType=literal',
+                                },
+                            },
+                            info: 'some info',
+                        },
+                        {
+                            id: 'InstallOrSignUp',
+                            label: 'Get free trial',
+                            action: {
+                                type: 'new-tab-link',
+                                value: 'https://about.sourcegraph.com',
+                            },
+                            // This is done to mimic user creating an account, and signed in there is a different tour
+                            completeAfterEvents: ['non-existing-event'],
+                        },
+                    ],
+                },
+            ],
+        },
+        undefined,
+        4
+    )
+
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        const timer = window.setTimeout(() => {
+            setLoading(false)
+        }, 2000)
+        return () => window.clearTimeout(timer)
+    }, [])
+
+    return { data, loading }
+}
+
+export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
+    const isLightTheme = useIsLightTheme()
+    const [value, setValue] = useState<string | null>(null)
+    const { data, loading, error } = useLoadOnboardingConfig()
+    const dirty = !loading && value !== null && data !== value
+    const config = loading ? '' : value === null ? data : value
+
+    const discard = (): void => {
+        // TODO: Prompt user whether they really want to discard
+        setValue(null)
+    }
+
+    // Placeholder values
+    const saving = false
+    const save = (): void => {}
+    // End placeholder values
+
+    return (
+        <>
+            <PageTitle title="Onboarding tour" />
+            <PageHeader className="mb-3">
+                <PageHeader.Heading as="h3" styleAs="h2">
+                    <PageHeader.Breadcrumb>Onboarding tour</PageHeader.Breadcrumb>
+                </PageHeader.Heading>
+            </PageHeader>
+            <Text>Configure the onboarding tour steps</Text>
+            <Container>
+                {loading && <LoadingSpinner title="Loading onboarding configuration" />}
+                {!loading && error && 'Error'}
+                {!loading && (
+                    <>
+                        <BeforeUnloadPrompt when={saving || dirty} message="Discard settings changes?" />
+                        <MonacoSettingsEditor
+                            isLightTheme={isLightTheme}
+                            language="json"
+                            jsonSchema={onboardingSchemaJSON}
+                            value={config}
+                            onChange={setValue}
+                        />
+                        <SaveToolbar dirty={dirty} error={error} saving={saving} onSave={save} onDiscard={discard} />
+                    </>
+                )}
+            </Container>
+        </>
+    )
+}

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -1,6 +1,6 @@
-import { type FC, type PropsWithChildren, useState, useEffect } from 'react'
+import { type FC, type PropsWithChildren, useState } from 'react'
 
-import {
+import type {
     OnboardingTourConfigMutationResult,
     OnboardingTourConfigMutationVariables,
     OnboardingTourConfigResult,
@@ -56,13 +56,7 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
     const existingConfiguration = data?.onboardingTourContent.current?.value
     const initialLoad = loading && !previousData
     const dirty = !loading && value !== null && existingConfiguration !== value
-    const config = loading
-        ? value ?? ''
-        : value !== null
-        ? value
-        : existingConfiguration
-        ? existingConfiguration
-        : DEFAULT_VALUE
+    const config = loading ? value ?? '' : value !== null ? value : existingConfiguration || DEFAULT_VALUE
 
     const discard = (): void => {
         if (dirty && window.confirm('Discard onboarding tour edits?')) {
@@ -70,18 +64,18 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
         }
     }
 
-    // Placeholder values
     const [updateOnboardinTourConfig, { loading: saving, error: mutationError }] = useMutation<
         OnboardingTourConfigMutationResult,
         OnboardingTourConfigMutationVariables
     >(ONBOARDING_TOUR_MUTATION, { refetchQueries: ['OnboardingTourConfig'] })
 
-    async function save() {
+    function save(): void {
         if (value !== null) {
-            updateOnboardinTourConfig({ variables: { json: value } })
+            // Conflicts with @typescript-eslint/no-floating-promises
+            // eslint-disable-next-line no-void
+            void updateOnboardinTourConfig({ variables: { json: value } })
         }
     }
-    // End placeholder values
 
     return (
         <>

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -10,7 +10,7 @@ import type {
 import { gql, useMutation, useQuery } from '@sourcegraph/http-client'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { PageHeader, Text, Container, BeforeUnloadPrompt, LoadingSpinner, Alert } from '@sourcegraph/wildcard'
+import { PageHeader, Text, Container, BeforeUnloadPrompt, LoadingSpinner, Alert, H3 } from '@sourcegraph/wildcard'
 
 import onboardingSchemaJSON from '../../../../schema/onboardingtour.schema.json'
 import { PageTitle } from '../components/PageTitle'
@@ -59,7 +59,7 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
     const config = loading ? value ?? '' : value !== null ? value : existingConfiguration || DEFAULT_VALUE
 
     const discard = (): void => {
-        if (dirty && window.confirm('Discard onboarding tour edits?')) {
+        if (dirty && window.confirm('Discard onboarding tour changes?')) {
             setValue(null)
         }
     }
@@ -79,17 +79,15 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
 
     return (
         <>
-            <PageTitle title="Onboarding tour" />
+            <PageTitle title="End user onboarding" />
             <PageHeader className="mb-3">
                 <PageHeader.Heading as="h3" styleAs="h2">
-                    <PageHeader.Breadcrumb>Onboarding tour</PageHeader.Breadcrumb>
+                    <PageHeader.Breadcrumb>End user onboarding</PageHeader.Breadcrumb>
                 </PageHeader.Heading>
             </PageHeader>
-            <Text>Configure the onboarding tour steps</Text>
+            <Text>This settings controls the onboarding task list that is displayed to all users by default.</Text>
             <Container>
                 {initialLoad && <LoadingSpinner title="Loading onboarding configuration" />}
-                {error && <Alert>{error.message}</Alert>}
-                {mutationError && <Alert>{mutationError.message}</Alert>}
                 {!initialLoad && (
                     <>
                         <BeforeUnloadPrompt when={saving || dirty} message="Discard settings changes?" />
@@ -99,11 +97,26 @@ export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
                             jsonSchema={onboardingSchemaJSON}
                             value={config}
                             onChange={setValue}
+                            height={450}
                         />
-                        <SaveToolbar dirty={dirty} error={error} saving={saving} onSave={save} onDiscard={discard} />
+                        <SaveToolbar
+                            dirty={dirty}
+                            error={error || mutationError}
+                            saving={saving}
+                            onSave={save}
+                            onDiscard={discard}
+                        />
                     </>
                 )}
             </Container>
+            <H3 as="h4" className="mt-3">
+                Most common parameters reference
+            </H3>
+            <img
+                src="https://storage.googleapis.com/sourcegraph-assets/onboarding/onboarding-config-reference.svg"
+                alt="onboarding tour reference"
+                className="percy-hide w-100"
+            />
         </>
     )
 }

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -10,7 +10,7 @@ import type {
 import { gql, useMutation, useQuery } from '@sourcegraph/http-client'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { PageHeader, Text, Container, BeforeUnloadPrompt, LoadingSpinner, Alert, H3 } from '@sourcegraph/wildcard'
+import { PageHeader, Text, Container, BeforeUnloadPrompt, LoadingSpinner, H3 } from '@sourcegraph/wildcard'
 
 import onboardingSchemaJSON from '../../../../schema/onboardingtour.schema.json'
 import { PageTitle } from '../components/PageTitle'

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -15,6 +15,7 @@ export interface SiteAdminSideBarGroupContext extends BatchChangesProps {
     isSourcegraphDotCom: boolean
     isSourcegraphApp: boolean
     codeInsightsEnabled: boolean
+    endUserOnboardingEnabled: boolean
 }
 
 export interface SiteAdminSideBarGroup extends NavGroupDescriptor<SiteAdminSideBarGroupContext> {}

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -34,6 +34,10 @@ const SiteAdminConfigurationPage = lazyComponent(
     'SiteAdminConfigurationPage'
 )
 const SiteAdminSettingsPage = lazyComponent(() => import('./SiteAdminSettingsPage'), 'SiteAdminSettingsPage')
+const SiteAdminOnboardingTourPage = lazyComponent(
+    () => import('./SiteAdminOnboardingTourPage'),
+    'SiteAdminOnboardingTourPage'
+)
 const SiteAdminExternalServicesArea = lazyComponent(
     () => import('./SiteAdminExternalServicesArea'),
     'SiteAdminExternalServicesArea'
@@ -137,6 +141,10 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/global-settings',
         render: props => <SiteAdminSettingsPage {...props} />,
+    },
+    {
+        path: '/onboarding-tour',
+        render: props => <SiteAdminOnboardingTourPage {...props} />,
     },
     {
         path: '/github-apps/*',

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -143,7 +143,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
         render: props => <SiteAdminSettingsPage {...props} />,
     },
     {
-        path: '/onboarding-tour',
+        path: '/end-user-onboarding',
         render: props => <SiteAdminOnboardingTourPage {...props} />,
     },
     {

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -145,6 +145,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/end-user-onboarding',
         render: props => <SiteAdminOnboardingTourPage {...props} />,
+        condition: ({ endUserOnboardingEnabled }) => endUserOnboardingEnabled,
     },
     {
         path: '/github-apps/*',

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -80,6 +80,10 @@ export const configurationGroup: SiteAdminSideBarGroup = {
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
+            label: 'Onboarding tour',
+            to: '/site-admin/onboarding-tour',
+        },
+        {
             label: 'Feature flags',
             to: '/site-admin/feature-flags',
         },

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -82,6 +82,7 @@ export const configurationGroup: SiteAdminSideBarGroup = {
         {
             label: 'End user onboarding',
             to: '/site-admin/end-user-onboarding',
+            condition: ({ endUserOnboardingEnabled }) => endUserOnboardingEnabled,
         },
         {
             label: 'Feature flags',

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -80,8 +80,8 @@ export const configurationGroup: SiteAdminSideBarGroup = {
             condition: ({ isSourcegraphApp }) => !isSourcegraphApp,
         },
         {
-            label: 'Onboarding tour',
-            to: '/site-admin/onboarding-tour',
+            label: 'End user onboarding',
+            to: '/site-admin/end-user-onboarding',
         },
         {
             label: 'Feature flags',

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "onboardingtour.schema.json#",
+  "title": "Onboarding tour configuration",
+  "description": "Configuration for a onboarding tour.",
+  "allowComments": true,
+  "type": "object",
+  "properties": {
+    "tasks": {
+      "type": "array",
+      "items": {
+        "description": "An onboarding task",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "title": {
+            "description": "Title of this task",
+            "type": "string"
+          },
+          "dataAttributes": {
+            "description": "Additional attributes to add to the task HTML element as data-* attributes",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "steps": {
+            "description": "Steps that need to be completed by the user",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "description": "Unique step ID",
+                  "type": "string"
+                },
+                "label": {
+                  "description": "Label of the step shown to the user",
+                  "type": "string"
+                },
+                "tooltip": {
+                  "description": "More information about this step",
+                  "type": "string"
+                },
+                "action": {
+                  "oneOf": [
+                    {
+                      "description": "Video step",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "const": "video"
+                        },
+                        "value": {
+                          "$ref": "#/$defs/actionValue"
+                        }
+                      },
+                      "required": ["type", "value"]
+                    },
+                    {
+                      "description": "Link step",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "enum": ["link", "new-tab-link"]
+                        },
+                        "variant": {
+                          "const": "button-primary"
+                        },
+                        "value": {
+                          "$ref": "#/$defs/actionValue"
+                        }
+                      },
+                      "required": ["type", "value"]
+                    },
+                    {
+                      "description": "Restart step",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "const": "restart"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["type", "value"]
+                    }
+                  ]
+                },
+                "info": {
+                  "type": "string"
+                },
+                "completeAfterEvents": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": ["id", "label", "action"],
+              "additionalProperties": false
+            },
+            "minItems": 1
+          }
+        },
+        "required": ["steps"]
+      }
+    }
+  },
+  "required": ["tasks"],
+  "additionalProperties": false,
+  "$defs": {
+    "actionValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        { "$ref": "#/$defs/languageRecord" }
+      ]
+    },
+    "languageRecord": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -9,6 +9,7 @@
     "tasks": {
       "type": "array",
       "items": {
+        "title": "Onboarding task",
         "description": "An onboarding task",
         "type": "object",
         "additionalProperties": false,
@@ -26,6 +27,7 @@
             "description": "Steps that need to be completed by the user",
             "type": "array",
             "items": {
+              "title": "Onboarding step",
               "type": "object",
               "properties": {
                 "id": {
@@ -43,6 +45,7 @@
                 "action": {
                   "oneOf": [
                     {
+                      "title": "Video step",
                       "description": "Video step",
                       "type": "object",
                       "properties": {
@@ -56,6 +59,7 @@
                       "required": ["type", "value"]
                     },
                     {
+                      "title": "Link step",
                       "description": "Link step",
                       "type": "object",
                       "properties": {
@@ -72,6 +76,7 @@
                       "required": ["type", "value"]
                     },
                     {
+                      "title": "Restart step",
                       "description": "Restart step",
                       "type": "object",
                       "properties": {

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -50,7 +50,7 @@
                           "const": "video"
                         },
                         "value": {
-                          "$ref": "#/$defs/ActionValue"
+                          "$ref": "#/definitions/ActionValue"
                         }
                       },
                       "required": ["type", "value"]
@@ -66,7 +66,7 @@
                           "const": "button-primary"
                         },
                         "value": {
-                          "$ref": "#/$defs/ActionValue"
+                          "$ref": "#/definitions/ActionValue"
                         }
                       },
                       "required": ["type", "value"]
@@ -108,7 +108,7 @@
   },
   "required": ["tasks"],
   "additionalProperties": false,
-  "$defs": {
+  "definitions": {
     "ActionValue": {
       "oneOf": [
         {

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -50,7 +50,7 @@
                           "const": "video"
                         },
                         "value": {
-                          "$ref": "#/definitions/ActionValue"
+                          "$ref": "#/definitions/StepAction"
                         }
                       },
                       "required": ["type", "value"]
@@ -66,7 +66,7 @@
                           "const": "button-primary"
                         },
                         "value": {
-                          "$ref": "#/definitions/ActionValue"
+                          "$ref": "#/definitions/StepAction"
                         }
                       },
                       "required": ["type", "value"]
@@ -109,7 +109,7 @@
   "required": ["tasks"],
   "additionalProperties": false,
   "definitions": {
-    "ActionValue": {
+    "StepAction": {
       "oneOf": [
         {
           "type": "string"

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -50,7 +50,7 @@
                           "const": "video"
                         },
                         "value": {
-                          "$ref": "#/$defs/actionValue"
+                          "$ref": "#/$defs/ActionValue"
                         }
                       },
                       "required": ["type", "value"]
@@ -66,7 +66,7 @@
                           "const": "button-primary"
                         },
                         "value": {
-                          "$ref": "#/$defs/actionValue"
+                          "$ref": "#/$defs/ActionValue"
                         }
                       },
                       "required": ["type", "value"]
@@ -109,22 +109,21 @@
   "required": ["tasks"],
   "additionalProperties": false,
   "$defs": {
-    "actionValue": {
+    "ActionValue": {
       "oneOf": [
         {
           "type": "string"
         },
-        { "$ref": "#/$defs/languageRecord" }
-      ]
-    },
-    "languageRecord": {
-      "type": "object",
-      "patternProperties": {
-        "^.*$": {
-          "type": "string"
+        {
+          "type": "object",
+          "patternProperties": {
+            "^.*$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1436,6 +1436,13 @@ type JVMPackagesConnection struct {
 	Maven Maven `json:"maven"`
 }
 
+// LinkStep description: Link step
+type LinkStep struct {
+	Type    any `json:"type"`
+	Value   any `json:"value"`
+	Variant any `json:"variant,omitempty"`
+}
+
 // LocalGitExternalService description: Configuration for integration local Git repositories.
 type LocalGitExternalService struct {
 	Repos []*LocalGitRepoPattern `json:"repos,omitempty"`
@@ -1674,6 +1681,32 @@ type OnRepository struct {
 	Branches []string `json:"branches,omitempty"`
 	// Repository description: The name of the repository (as it is known to Sourcegraph).
 	Repository string `json:"repository"`
+}
+type OnboardingStep struct {
+	Action              any      `json:"action"`
+	CompleteAfterEvents []string `json:"completeAfterEvents,omitempty"`
+	// Id description: Unique step ID
+	Id   string `json:"id"`
+	Info string `json:"info,omitempty"`
+	// Label description: Label of the step shown to the user
+	Label string `json:"label"`
+	// Tooltip description: More information about this step
+	Tooltip string `json:"tooltip,omitempty"`
+}
+
+// OnboardingTask description: An onboarding task
+type OnboardingTask struct {
+	// DataAttributes description: Additional attributes to add to the task HTML element as data-* attributes
+	DataAttributes map[string]any `json:"dataAttributes,omitempty"`
+	// Steps description: Steps that need to be completed by the user
+	Steps []*OnboardingStep `json:"steps"`
+	// Title description: Title of this task
+	Title string `json:"title,omitempty"`
+}
+
+// OnboardingTourConfiguration description: Configuration for a onboarding tour.
+type OnboardingTourConfiguration struct {
+	Tasks []*OnboardingTask `json:"tasks"`
 }
 
 // OpenIDConnectAuthProvider description: Configures the OpenID Connect authentication provider for SSO.
@@ -1935,6 +1968,12 @@ type Responders struct {
 	Name     string `json:"name,omitempty"`
 	Type     string `json:"type,omitempty"`
 	Username string `json:"username,omitempty"`
+}
+
+// RestartStep description: Restart step
+type RestartStep struct {
+	Type  any    `json:"type"`
+	Value string `json:"value"`
 }
 
 // RubyPackagesConnection description: Configuration for a connection to Ruby packages
@@ -2938,6 +2977,12 @@ type UpdateIntervalRule struct {
 }
 type UsernameIdentity struct {
 	Type string `json:"type"`
+}
+
+// VideoStep description: Video step
+type VideoStep struct {
+	Type  any `json:"type"`
+	Value any `json:"value"`
 }
 
 // WebhookLogging description: Configuration for logging incoming webhooks.


### PR DESCRIPTION
I wanted to use CodeMirror but the plugin I found for schema validation doesn't seem to be complete yet. So I'm using the Monaco settings editor as it is used in other places.

I added a new schema for the onboarding tour based on the existing type definitions.

![2023-08-18_10-04](https://github.com/sourcegraph/sourcegraph/assets/179026/6da21c41-1365-4551-b5e9-788fcb72e0e7)




## Test plan

- Opened site-admin settings without feature flag set -> page not listed in menu and not accessible
- Overwrite flag with `?feature-flag-key=end-user-onboarding&feature-flag-value=true` -> menu entry is visible and page is accessible
- Change JSON -> save and and discard buttons are enbaled
- Click save button -> JSON is sent to the server