### PR TITLE
docs: update kubectl command for blobstore debugging

### DIFF
--- a/doc/admin/how-to/blobstore_debugging.md
+++ b/doc/admin/how-to/blobstore_debugging.md
@@ -23,7 +23,7 @@ docker exec -u 0 -it blobstore sh
 or in a Kubernetes deployment:
 
 ```
-kubectl exec -it -u 0 blobstore sh
+kubectl exec -it deployment/blobstore -- sh
 ```
 
 Then, try manually creating a bucket by running a curl request like this:


### PR DESCRIPTION
The command for entering a shell in k8s for blobstore don't work and likely never did; `-u` isnt a flag for kubectl and only `blobstore` doesnt work as the pod is suffixed with a random ID, requiring to either do `blobstore-<hash>-<id>` or `deployment/blobstore`

## Test plan

Tested by youngboi @jac 
