### PR TITLE
blob: Scroll selected line into view even with invalid character offset

### DIFF
--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -412,12 +412,16 @@ function normalizeLineRange(range: SelectedLineRange): SelectedLineRange {
  * outside of the editor viewport).
  */
 export function shouldScrollIntoView(view: EditorView, range: SelectedLineRange): boolean {
-    if (!range || !isValidLineRange(range, view.state.doc)) {
+    // Only consider start and end line when determining whether to scroll a line into view.
+    // Whether or not the character offset is valid doesn't matter in this case.
+    const normalizedRange: SelectedLineRange = range ? { line: range.line, endLine: range.endLine } : range
+
+    if (!normalizedRange || !isValidLineRange(normalizedRange, view.state.doc)) {
         return false
     }
 
-    const from = view.lineBlockAt(view.state.doc.line(range.line).from)
-    const to = range.endLine ? view.lineBlockAt(view.state.doc.line(range.endLine).to) : from
+    const from = view.lineBlockAt(view.state.doc.line(normalizedRange.line).from)
+    const to = normalizedRange.endLine ? view.lineBlockAt(view.state.doc.line(normalizedRange.endLine).to) : from
 
     return (
         from.top + from.height >= view.scrollDOM.scrollTop + view.scrollDOM.clientHeight ||


### PR DESCRIPTION
[Reported via Slack](https://sourcegraph.slack.com/archives/C03CSAER9LK/p1692186686023639)

When determining whether to scroll a line into the view we are first validating whether the selected position (which includes line number and (optionally) character offset) is valid.

It's possible to get a position that refers to a valid line but an invalid character offset. Currently the selected line is not scrolled into view in that case.

This change ignores the character offset when validating the position. The character offset should have no impact on determining whether or not to scroll the line into view.



## Test plan

Opened a file link with an invalid character offset ([example](https://sourcegraph.test:3443/github.com/JetBrains/intellij-scala@ce4785e85496fe9d9d0c315b247ca75f0062188b/-/blob/scala/scala-impl/src/org/jetbrains/plugins/scala/settings/ScalaProjectSettingsPanel.form?L640:69)). Line is scrolled into view.
