### PR TITLE
feat(setup-checklist): add configure SSO notification alert

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts_test.go
+++ b/cmd/frontend/graphqlbackend/site_alerts_test.go
@@ -113,34 +113,27 @@ func TestDetermineOutOfDateAlert(t *testing.T) {
 
 func TestObservabilityActiveAlertsAlert(t *testing.T) {
 	f := false
-	type args struct {
-		args AlertFuncArgs
-	}
 	tests := []struct {
 		name string
-		args args
+		args AlertFuncArgs
 		want []*Alert
 	}{
 		{
 			name: "do not show anything for non-admin",
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: false,
-					ViewerFinalSettings: &schema.Settings{
-						AlertsHideObservabilitySiteAlerts: &f,
-					},
+			args: AlertFuncArgs{
+				IsSiteAdmin: false,
+				ViewerFinalSettings: &schema.Settings{
+					AlertsHideObservabilitySiteAlerts: &f,
 				},
 			},
 			want: nil,
 		},
 		{
 			name: "prometheus unreachable for admin",
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					ViewerFinalSettings: &schema.Settings{
-						AlertsHideObservabilitySiteAlerts: &f,
-					},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				ViewerFinalSettings: &schema.Settings{
+					AlertsHideObservabilitySiteAlerts: &f,
 				},
 			},
 			want: []*Alert{{
@@ -153,10 +146,8 @@ func TestObservabilityActiveAlertsAlert(t *testing.T) {
 			// blocked by https://github.com/sourcegraph/sourcegraph/issues/12190
 			// see observabilityActiveAlertsAlert docstrings
 			name: "alerts disabled by default for admin",
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
 			},
 			want: nil,
 		},
@@ -171,7 +162,7 @@ func TestObservabilityActiveAlertsAlert(t *testing.T) {
 				return
 			}
 			fn := observabilityActiveAlertsAlert(prom)
-			gotAlerts := fn(tt.args.args)
+			gotAlerts := fn(tt.args)
 			if len(gotAlerts) != len(tt.want) {
 				t.Errorf("expected %+v, got %+v", tt.want, gotAlerts)
 				return
@@ -188,9 +179,6 @@ func TestObservabilityActiveAlertsAlert(t *testing.T) {
 }
 
 func TestFreePlanAlert(t *testing.T) {
-	type args struct {
-		args AlertFuncArgs
-	}
 	plan := func(p licensing.Plan) string {
 		return "plan:" + string(p)
 	}
@@ -199,40 +187,34 @@ func TestFreePlanAlert(t *testing.T) {
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"setup-checklist": true}, nil, nil))
 	tests := []struct {
 		name    string
-		args    args
+		args    AlertFuncArgs
 		license *license.Info
 		want    []*Alert
 	}{
 		{
 			name:    "do not show anything for non-admin",
 			license: &license.Info{Tags: []string{plan(licensing.PlanFree0)}},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: false,
-					Ctx:         ctx,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: false,
+				Ctx:         ctx,
 			},
 			want: nil,
 		},
 		{
 			name:    "do not show alert if license is not on free plan",
 			license: &license.Info{Tags: []string{plan(licensing.PlanEnterprise0)}},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					Ctx:         ctx,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				Ctx:         ctx,
 			},
 			want: nil,
 		},
 		{
 			name:    "show alert if license is on free plan 0",
 			license: &license.Info{Tags: []string{plan(licensing.PlanFree0)}},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					Ctx:         ctx,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				Ctx:         ctx,
 			},
 			want: []*Alert{{
 				GroupValue:                AlertGroupLicense,
@@ -244,11 +226,9 @@ func TestFreePlanAlert(t *testing.T) {
 		{
 			name:    "show alert if license is on free plan 1",
 			license: &license.Info{Tags: []string{plan(licensing.PlanFree1)}},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					Ctx:         ctx,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				Ctx:         ctx,
 			},
 			want: []*Alert{{
 				GroupValue:                AlertGroupLicense,
@@ -264,7 +244,7 @@ func TestFreePlanAlert(t *testing.T) {
 				return test.license, "test-signature", nil
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
-			gotAlerts := freePlanAlert(test.args.args)
+			gotAlerts := freePlanAlert(test.args)
 			if len(gotAlerts) != len(test.want) {
 				t.Errorf("expected %+v, got %+v", test.want, gotAlerts)
 				return
@@ -280,10 +260,6 @@ func TestFreePlanAlert(t *testing.T) {
 }
 
 func TestUserCountExceededAlert(t *testing.T) {
-	type args struct {
-		args AlertFuncArgs
-	}
-
 	ctx := actor.WithActor(context.Background(), actor.FromMockUser(1))
 	ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"setup-checklist": true}, nil, nil))
 
@@ -294,43 +270,37 @@ func TestUserCountExceededAlert(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		args    args
+		args    AlertFuncArgs
 		license *license.Info
 		want    []*Alert
 	}{
 		{
 			name:    "do not show anything for non-admin",
 			license: &license.Info{Tags: []string{}},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: false,
-					Ctx:         ctx,
-					DB:          db,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: false,
+				Ctx:         ctx,
+				DB:          db,
 			},
 			want: nil,
 		},
 		{
 			name:    "do not show alert if true up license",
 			license: &license.Info{Tags: []string{licensing.TrueUpUserCountTag}, UserCount: 1},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					Ctx:         ctx,
-					DB:          db,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				Ctx:         ctx,
+				DB:          db,
 			},
 			want: nil,
 		},
 		{
 			name:    "show alert if exceeded user count",
 			license: &license.Info{Tags: []string{}, UserCount: 1},
-			args: args{
-				args: AlertFuncArgs{
-					IsSiteAdmin: true,
-					Ctx:         ctx,
-					DB:          db,
-				},
+			args: AlertFuncArgs{
+				IsSiteAdmin: true,
+				Ctx:         ctx,
+				DB:          db,
 			},
 			want: []*Alert{{
 				GroupValue:                AlertGroupLicense,
@@ -346,7 +316,7 @@ func TestUserCountExceededAlert(t *testing.T) {
 				return test.license, "test-signature", nil
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
-			gotAlerts := userCountExceededAlert(test.args.args)
+			gotAlerts := userCountExceededAlert(test.args)
 			if len(gotAlerts) != len(test.want) {
 				t.Errorf("expected %+v, got %+v", test.want, gotAlerts)
 				return

--- a/enterprise/cmd/frontend/internal/auth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -23,7 +24,23 @@ go_library(
         "//internal/auth",
         "//internal/conf",
         "//internal/database",
+        "//internal/featureflag",
         "//internal/licensing",
         "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "auth_test",
+    srcs = ["init_test.go"],
+    embed = [":auth"],
+    deps = [
+        "//cmd/frontend/graphqlbackend",
+        "//internal/actor",
+        "//internal/conf",
+        "//internal/featureflag",
+        "//internal/licensing",
+        "//schema",
+        "@com_github_google_go_cmp//cmp",
     ],
 )

--- a/enterprise/cmd/frontend/internal/auth/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/auth/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//enterprise/cmd/frontend/internal/auth/saml",
         "//enterprise/cmd/frontend/internal/auth/sourcegraphoperator",
         "//internal/auth",
+        "//internal/collections",
         "//internal/conf",
         "//internal/database",
         "//internal/featureflag",

--- a/enterprise/cmd/frontend/internal/auth/init.go
+++ b/enterprise/cmd/frontend/internal/auth/init.go
@@ -27,6 +27,7 @@ import (
 	internalauth "github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
 )
 
@@ -60,60 +61,68 @@ func Init(logger log.Logger, db database.DB) {
 	app.RegisterSSOSignOutHandler(ssoSignOutHandler)
 
 	// Warn about usage of auth providers that are not enabled by the license.
-	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
-		// Only site admins can act on this alert, so only show it to site admins.
-		if !args.IsSiteAdmin {
-			return nil
+	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, requireLicenseOrSuggestSSOAlerts)
+}
+
+func requireLicenseOrSuggestSSOAlerts(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
+	// Only site admins can act on this alert, so only show it to site admins.
+	if !args.IsSiteAdmin {
+		return nil
+	}
+
+	collected := make(map[string]struct{})
+	var names []string
+	for _, p := range conf.Get().AuthProviders {
+		// Only built-in authentication provider is allowed by default.
+		if p.Builtin != nil {
+			continue
 		}
 
-		if licensing.IsFeatureEnabledLenient(licensing.FeatureSSO) {
-			return nil
+		var name string
+		switch {
+		case p.Github != nil:
+			name = "GitHub OAuth"
+		case p.Gitlab != nil:
+			name = "GitLab OAuth"
+		case p.Bitbucketcloud != nil:
+			name = "Bitbucket Cloud OAuth"
+		case p.AzureDevOps != nil:
+			name = "Azure DevOps"
+		case p.HttpHeader != nil:
+			name = "HTTP header"
+		case p.Openidconnect != nil:
+			name = "OpenID Connect"
+		case p.Saml != nil:
+			name = "SAML"
+		default:
+			name = "Other"
 		}
 
-		collected := make(map[string]struct{})
-		var names []string
-		for _, p := range conf.Get().AuthProviders {
-			// Only built-in authentication provider is allowed by default.
-			if p.Builtin != nil {
-				continue
-			}
-
-			var name string
-			switch {
-			case p.Github != nil:
-				name = "GitHub OAuth"
-			case p.Gitlab != nil:
-				name = "GitLab OAuth"
-			case p.Bitbucketcloud != nil:
-				name = "Bitbucket Cloud OAuth"
-			case p.AzureDevOps != nil:
-				name = "Azure DevOps"
-			case p.HttpHeader != nil:
-				name = "HTTP header"
-			case p.Openidconnect != nil:
-				name = "OpenID Connect"
-			case p.Saml != nil:
-				name = "SAML"
-			default:
-				name = "Other"
-			}
-
-			if _, ok := collected[name]; !ok {
-				collected[name] = struct{}{}
-				names = append(names, name)
-			}
+		if _, ok := collected[name]; !ok {
+			collected[name] = struct{}{}
+			names = append(names, name)
 		}
-		if len(names) == 0 {
-			return nil
-		}
+	}
 
+	if len(names) > 0 && !licensing.IsFeatureEnabledLenient(licensing.FeatureSSO) {
 		sort.Strings(names)
 		return []*graphqlbackend.Alert{{
 			GroupValue:   graphqlbackend.AlertGroupLicense,
 			TypeValue:    graphqlbackend.AlertTypeError,
 			MessageValue: fmt.Sprintf("A Sourcegraph license is required to enable following authentication providers: %s. [**Get a license.**](/site-admin/license)", strings.Join(names, ", ")),
 		}}
-	})
+	}
+
+	if len(names) == 0 && licensing.IsFeatureEnabledLenient(licensing.FeatureSSO) && featureflag.FromContext(args.Ctx).GetBoolOr("setup-checklist", false) {
+		return []*graphqlbackend.Alert{{
+			GroupValue:                graphqlbackend.AlertGroupAuthentication,
+			TypeValue:                 graphqlbackend.AlertTypeWarning,
+			MessageValue:              "We recommend that enterprise instances use SSO or SAML to authenticate users. [Set up authentication now](/site-admin/configuration)",
+			IsDismissibleWithKeyValue: "configure-sso-providers",
+		}}
+	}
+
+	return nil
 }
 
 func ssoSignOutHandler(w http.ResponseWriter, r *http.Request) {

--- a/enterprise/cmd/frontend/internal/auth/init_test.go
+++ b/enterprise/cmd/frontend/internal/auth/init_test.go
@@ -1,0 +1,134 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/licensing"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestRequireLicenseOrSuggestSSOAlerts(t *testing.T) {
+	tests := []struct {
+		name               string
+		hasSSOFeature      bool
+		builtInEnabled     bool
+		githubSSOEnabled   bool
+		featureFlagEnabled bool
+		isSiteAdmin        bool
+		want               []*graphqlbackend.Alert
+	}{
+		{
+			name:               "do not show anything for non-admin",
+			hasSSOFeature:      true,
+			builtInEnabled:     true,
+			githubSSOEnabled:   true,
+			featureFlagEnabled: true,
+			isSiteAdmin:        false,
+
+			want: nil,
+		},
+		{
+			name:               "show alert if SSO providers are configured but license doesn't allow it",
+			hasSSOFeature:      false,
+			builtInEnabled:     false,
+			githubSSOEnabled:   true,
+			featureFlagEnabled: true,
+			isSiteAdmin:        true,
+			want: []*graphqlbackend.Alert{{
+				GroupValue:   graphqlbackend.AlertGroupLicense,
+				TypeValue:    graphqlbackend.AlertTypeError,
+				MessageValue: "A Sourcegraph license is required to enable following authentication providers: GitHub OAuth. [**Get a license.**](/site-admin/license)",
+			}},
+		},
+		{
+			name:               "show alert if no SSO providers configured but license allows it",
+			hasSSOFeature:      true,
+			builtInEnabled:     true,
+			githubSSOEnabled:   false,
+			featureFlagEnabled: true,
+			isSiteAdmin:        true,
+			want: []*graphqlbackend.Alert{{
+				GroupValue:                graphqlbackend.AlertGroupAuthentication,
+				TypeValue:                 graphqlbackend.AlertTypeWarning,
+				MessageValue:              "We recommend that enterprise instances use SSO or SAML to authenticate users. [Set up authentication now](/site-admin/configuration)",
+				IsDismissibleWithKeyValue: "configure-sso-providers",
+			}},
+		},
+		{
+			name:               "do not show alert if no SSO providers configured and license has SSO feature and and feature flag is disabled",
+			hasSSOFeature:      true,
+			builtInEnabled:     true,
+			githubSSOEnabled:   true,
+			featureFlagEnabled: false,
+			isSiteAdmin:        true,
+			want:               nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup
+			providers := make([]schema.AuthProviders, 0)
+			if test.githubSSOEnabled {
+				providers = append(providers, schema.AuthProviders{
+					Github: &schema.GitHubAuthProvider{
+						Url:          "https://github.com",
+						ClientSecret: "some-secret",
+						ClientID:     "some-id",
+						AllowOrgs:    []string{"myorg"},
+					},
+				})
+			}
+			if test.builtInEnabled {
+				providers = append(providers, schema.AuthProviders{
+					Builtin: &schema.BuiltinAuthProvider{
+						Type:        "builtin",
+						AllowSignup: true,
+					},
+				})
+			}
+			conf.Mock(&conf.Unified{
+				SiteConfiguration: schema.SiteConfiguration{
+					AuthProviders: providers,
+				},
+			})
+			oldMock := licensing.MockCheckFeature
+			licensing.MockCheckFeature = func(feature licensing.Feature) error {
+				if test.hasSSOFeature {
+					return nil
+				}
+				return licensing.NewFeatureNotActivatedError("test")
+			}
+			t.Cleanup(func() {
+				conf.Mock(nil)
+				licensing.MockCheckFeature = oldMock
+			})
+			ctx := actor.WithActor(context.Background(), actor.FromMockUser(1))
+			if test.featureFlagEnabled {
+				ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(map[string]bool{"setup-checklist": true}, nil, nil))
+			}
+			// run
+			gotAlerts := requireLicenseOrSuggestSSOAlerts(graphqlbackend.AlertFuncArgs{
+				IsSiteAdmin: test.isSiteAdmin,
+				Ctx:         ctx,
+			})
+			// checkks
+			if len(gotAlerts) != len(test.want) {
+				t.Errorf("expected %+v, got %+v", test.want, gotAlerts)
+				return
+			}
+			for i, got := range gotAlerts {
+				want := test.want[i]
+				if diff := cmp.Diff(*want, *got); diff != "" {
+					t.Fatalf("diff mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/enterprise/cmd/frontend/internal/auth/init_test.go
+++ b/enterprise/cmd/frontend/internal/auth/init_test.go
@@ -62,7 +62,7 @@ func TestRequireLicenseOrSuggestSSOAlerts(t *testing.T) {
 			}},
 		},
 		{
-			name:               "do not show alert if no SSO providers configured and license has SSO feature and and feature flag is disabled",
+			name:               "do not show alert if no SSO providers configured and license has SSO feature and feature flag is disabled",
 			hasSSOFeature:      true,
 			builtInEnabled:     true,
 			githubSSOEnabled:   true,

--- a/enterprise/cmd/frontend/internal/auth/init_test.go
+++ b/enterprise/cmd/frontend/internal/auth/init_test.go
@@ -118,7 +118,7 @@ func TestRequireLicenseOrSuggestSSOAlerts(t *testing.T) {
 				IsSiteAdmin: test.isSiteAdmin,
 				Ctx:         ctx,
 			})
-			// checkks
+			// checks
 			if len(gotAlerts) != len(test.want) {
 				t.Errorf("expected %+v, got %+v", test.want, gotAlerts)
 				return


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/55433.

This PR adds a warning notification/alert if an enterprise license and no SSO providers are configured.

## Test plan
- Added new tests

## Screenshots
<img width="408" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6717049/cf7e3b85-34c4-40e1-9c36-8e53b3a4f063">
