### PR TITLE
JetBrains: make sure caret is visible after accepting autocomplete

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
@@ -130,6 +130,7 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
       document.replaceString(
           range.getStartOffset(), range.getEndOffset(), completionItem.insertText);
       caret.moveToOffset(range.getStartOffset() + completionItem.insertText.length());
+      editor.getScrollingModel().scrollToCaret(ScrollType.MAKE_VISIBLE);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/55917

Previously, when accepting multiline autocomplete, the caret could move outside of the visible window. This commit fixes the issue by scrolling the window to make the caret visible. When the caret is already visible, the editor doesn't scroll.

## Test plan

Trigger a multiline completion, scroll so the inlay hint appears at the bottom of the window, accept, confirm the window scrolls.

Trigger multiline completion so that the entire hint appears in the window, accept, confirm the editor doesn't scroll.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
