### PR TITLE
JetBrains: add alt-backslash shortcut to trigger autocomplete

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
@@ -22,6 +22,7 @@ import com.sourcegraph.cody.agent.protocol.Position;
 import com.sourcegraph.cody.agent.protocol.Range;
 import com.sourcegraph.cody.agent.protocol.TextDocument;
 import com.sourcegraph.cody.vscode.InlineAutoCompleteTriggerKind;
+import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind;
 import com.sourcegraph.config.ConfigUtil;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -68,7 +69,10 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
       if (suggestions.isEnabledForEditor(e.getEditor())
           && CodyEditorFactoryListener.isSelectedEditor(e.getEditor())) {
         suggestions.clearAutoCompleteSuggestions(e.getEditor());
-        suggestions.triggerAutoComplete(e.getEditor(), e.getEditor().getCaretModel().getOffset());
+        suggestions.triggerAutoComplete(
+            e.getEditor(),
+            e.getEditor().getCaretModel().getOffset(),
+            InlineCompletionTriggerKind.AUTOMATIC);
       }
     }
   }
@@ -110,7 +114,8 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
               event.getOldLength() != event.getNewLength()
                   ? InlineAutoCompleteTriggerKind.Invoke
                   : InlineAutoCompleteTriggerKind.Automatic;
-          completions.triggerAutoComplete(this.editor, changeOffset);
+          completions.triggerAutoComplete(
+              this.editor, changeOffset, InlineCompletionTriggerKind.AUTOMATIC);
         }
       }
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/TriggerAutocompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/TriggerAutocompleteAction.java
@@ -1,0 +1,37 @@
+package com.sourcegraph.cody.autocomplete;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.actionSystem.EditorAction;
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
+import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class TriggerAutocompleteAction extends EditorAction {
+  public TriggerAutocompleteAction() {
+    super(new TriggerAutocompleteActionHandler());
+  }
+
+  private static class TriggerAutocompleteActionHandler extends EditorActionHandler {
+    Logger logger = Logger.getInstance(TriggerAutocompleteActionHandler.class);
+
+    @Override
+    protected boolean isEnabledForCaret(
+        @NotNull Editor editor, @NotNull Caret caret, DataContext dataContext) {
+      return CodyAutoCompleteManager.isEditorInstanceSupported(editor);
+    }
+
+    @Override
+    protected void doExecute(
+        @NotNull Editor editor, @Nullable Caret caret, DataContext dataContext) {
+
+      int offset =
+          caret == null ? editor.getCaretModel().getCurrentCaret().getOffset() : caret.getOffset();
+      CodyAutoCompleteManager.getInstance()
+          .triggerAutoComplete(editor, offset, InlineCompletionTriggerKind.INVOKE);
+    }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineCompletionTriggerKind.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineCompletionTriggerKind.java
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.vscode;
+
+public enum InlineCompletionTriggerKind {
+  INVOKE,
+  AUTOMATIC
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -132,6 +132,12 @@
             <override-text place="MainMenu" text="Hide Completions"/>
         </action>
 
+        <action id="cody.triggerAutocomplete"
+                class="com.sourcegraph.cody.autocomplete.TriggerAutocompleteAction">
+            <keyboard-shortcut first-keystroke="alt BACK_SLASH" keymap="$default"/>
+            <override-text place="MainMenu" text="Autocomplete"/>
+        </action>
+
         <action id="cody.resetCurrentConversation" icon="AllIcons.Actions.Refresh"
                 text="Reset the Current Conversation with Cody"
                 class="com.sourcegraph.cody.chat.ResetCurrentConversationAction">


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/55910

Previously, it was not possible to explicitly request Cody autocomplete. This commit fixes the problem by registering an action that can be triggered through the alt-backslash shortcut.

## Test plan

Write code, get autocomplete suggestion, press `Escape` to hide completion, press alt-tab to trigger completion.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
