### PR TITLE
Bazel: add precheck for `//:gazelle-update-repos`

### DIFF
--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -3,10 +3,10 @@
 set -eu
 EXIT_CODE=0
 
-bazelrc="--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc"
+bazelrc=(--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
 
 echo "--- :bazel: Running bazel configure"
-bazel $bazelrc configure
+bazel "${bazelrc[@]}" configure
 
 echo "--- Checking if BUILD.bazel files were updated"
 git diff --exit-code || EXIT_CODE=$? # do not fail on non-zero exit
@@ -30,7 +30,7 @@ END
 fi
 
 echo "--- :bazel: Running bazel run //:gazelle-update-repos"
-bazel $bazelrc run //:gazelle-update-repos
+bazel "${bazelrc[@]}" run //:gazelle-update-repos
 
 echo "--- Checking if deps.bzl was updated"
 git diff --exit-code || EXIT_CODE=$? # do not fail on non-zero exit
@@ -54,7 +54,7 @@ END
 fi
 
 echo "--- :bazel::go: Running gofmt"
-unformatted=$(bazel $bazelrc run @go_sdk//:bin/gofmt -- -l .)
+unformatted=$(bazel "${bazelrc[@]}" run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ ${unformatted} != "" ]]; then
   mkdir -p ./annotations

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 
 set -eu
+EXIT_CODE=0
 
 bazelrc="--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc"
 
 echo "--- :bazel: Running bazel configure"
-bazel "${bazelrc}" configure
-
-# We disable exit on error here, since we want to catch the exit code and interpret it
-set +e
+bazel $bazelrc configure
 
 echo "--- Checking if BUILD.bazel files were updated"
-git diff --exit-code
-
-EXIT_CODE=$?
+git diff --exit-code || EXIT_CODE=$? # do not fail on non-zero exit
 
 # if we get a non-zero exit code, bazel configure updated files
 if [[ $EXIT_CODE -ne 0 ]]; then
@@ -30,10 +26,35 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   #### For more information please see the [Bazel FAQ](https://docs.sourcegraph.com/dev/background-information/bazel#faq)
 
 END
+  exit "$EXIT_CODE"
+fi
+
+echo "--- :bazel: Running bazel run //:gazelle-update-repos"
+bazel $bazelrc run //:gazelle-update-repos
+
+echo "--- Checking if deps.bzl was updated"
+git diff --exit-code || EXIT_CODE=$? # do not fail on non-zero exit
+
+# if we get a non-zero exit code, bazel configure updated files
+if [[ $EXIT_CODE -ne 0 ]]; then
+  mkdir -p ./annotations
+  cat <<-'END' > ./annotations/bazel-prechecks.md
+  #### Missing deps.bzl updates
+
+  `deps.bzl` needs to be updated to match the repository state. You should run the following command and commit the result
+
+  ```
+  bazel run //:gazelle-update-repos
+  ```
+
+  #### For more information please see the [Bazel FAQ](https://docs.sourcegraph.com/dev/background-information/bazel#faq)
+
+END
+  exit "$EXIT_CODE"
 fi
 
 echo "--- :bazel::go: Running gofmt"
-unformatted=$(bazel "${bazelrc}" run @go_sdk//:bin/gofmt -- -l .)
+unformatted=$(bazel $bazelrc run @go_sdk//:bin/gofmt -- -l .)
 
 if [[ ${unformatted} != "" ]]; then
   mkdir -p ./annotations

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -4,7 +4,6 @@ set -eu
 
 bazelrc="--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc"
 
-# We run :gazelle since currently `bazel configure` tries to execute something with go and it doesn't exist on the bazel agent
 echo "--- :bazel: Running bazel configure"
 bazel "${bazelrc}" configure
 

--- a/enterprise/dev/ci/internal/ci/bazel_operations.go
+++ b/enterprise/dev/ci/internal/ci/bazel_operations.go
@@ -124,7 +124,6 @@ func bazelAnalysisPhase() func(*bk.Pipeline) {
 	}
 }
 func bazelPrechecks() func(*bk.Pipeline) {
-	// We run :gazelle since 'configure' causes issues on CI, where it doesn't have the go path available
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-prechecks"),
 		bk.SoftFail(100),


### PR DESCRIPTION
This adds a check that `bazel run //:gazelle-update-repos` has been run. It should help catch the easy-to-miss step when updating dependencies. Quite a few unrelated changes, but all with explanatory comments.

[Slack context](https://sourcegraph.slack.com/archives/C05FDP58LRF/p1692197008211619)

## Test plan

An example failure [here](https://buildkite.com/sourcegraph/sourcegraph/builds/238821). 
