### PR TITLE
JetBrains: Detect other completion plugins

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/PluginUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/PluginUtil.java
@@ -7,21 +7,20 @@ import org.jetbrains.annotations.NotNull;
 public class PluginUtil {
 
   /**
-   * List of known plugin IDs you want to check.
-   * You can obtain the plugin IDs from each plugin's plugin.xml file, usually under the <id> tag.
-   * Add as many as you need.
+   * List of known plugin IDs you want to check. You can obtain the plugin IDs from each plugin's
+   * plugin.xml file, usually under the <id> tag. Add as many as you need.
    */
   private static final String[] KNOWN_PLUGINS = {
-      "com.github.copilot",
-      "com.tabnine.TabNine",
-      "com.tabnine.TabNine-Enterprise",
-      "aws.toolkit", // Includes CodeWhisperer
-      "com.codeium.intellij",
-      "com.codeium.enterpriseUpdater",
-      "com.nnthink.aixcoder",
-      "com.codota.csp.intellij",
-      "com.github.simiacryptus.intellijopenaicodeassist",
-      "com.tabbyml.intellij-tabby",
+    "com.github.copilot",
+    "com.tabnine.TabNine",
+    "com.tabnine.TabNine-Enterprise",
+    "aws.toolkit", // Includes CodeWhisperer
+    "com.codeium.intellij",
+    "com.codeium.enterpriseUpdater",
+    "com.nnthink.aixcoder",
+    "com.codota.csp.intellij",
+    "com.github.simiacryptus.intellijopenaicodeassist",
+    "com.tabbyml.intellij-tabby",
   };
 
   public static boolean isAnyKnownPluginEnabled() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/PluginUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/PluginUtil.java
@@ -1,0 +1,39 @@
+package com.sourcegraph.cody;
+
+import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.extensions.PluginId;
+import org.jetbrains.annotations.NotNull;
+
+public class PluginUtil {
+
+  /**
+   * List of known plugin IDs you want to check.
+   * You can obtain the plugin IDs from each plugin's plugin.xml file, usually under the <id> tag.
+   * Add as many as you need.
+   */
+  private static final String[] KNOWN_PLUGINS = {
+      "com.github.copilot",
+      "com.tabnine.TabNine",
+      "com.tabnine.TabNine-Enterprise",
+      "aws.toolkit", // Includes CodeWhisperer
+      "com.codeium.intellij",
+      "com.codeium.enterpriseUpdater",
+      "com.nnthink.aixcoder",
+      "com.codota.csp.intellij",
+      "com.github.simiacryptus.intellijopenaicodeassist",
+      "com.tabbyml.intellij-tabby",
+  };
+
+  public static boolean isAnyKnownPluginEnabled() {
+    for (String pluginId : KNOWN_PLUGINS) {
+      if (isPluginInstalledAndEnabled(PluginId.getId(pluginId))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isPluginInstalledAndEnabled(@NotNull PluginId pluginId) {
+    return PluginManagerCore.isPluginInstalled(pluginId) && !PluginManagerCore.isDisabled(pluginId);
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.api.GraphQlClient;
+import com.sourcegraph.cody.PluginUtil;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsComponent;
 import java.io.IOException;
@@ -37,6 +38,7 @@ public class GraphQlLogger {
     JsonObject eventParameters = new JsonObject();
     eventParameters.addProperty("latency", latencyMs);
     eventParameters.addProperty("displayDuration", displayDurationMs);
+    eventParameters.addProperty("isAnyKnownPluginEnabled", PluginUtil.isAnyKnownPluginEnabled());
     logEvent(project, createEvent(project, eventName, eventParameters), null);
   }
 


### PR DESCRIPTION
**Context:**
In VS Code, the `CodyVSCodeExtension:completion:suggested` events the extension emits, we have `"otherCompletionProviderEnabled": boolean`, which is set based on checking for [a hard-coded list](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/completions/logger.ts?L210) of known extensions being installed or not.
(This is not perfect because, for example, the GitHub Copilot extension could be installed, but the completions can be disabled, but it's still helpful to guess these cases.)
Before this PR, we didn't include this field in the events emitted in the JetBrains plugin.

**PR description:**
In this PR, I've added the same.
I went through the JetBrains Marketplace and searched for code completion plugins and added the IDs of the most popular ones, then sending this data in the events.

**Caveats:**
-  Like in VS Code, we won’t know if autocompletions are disabled in the settings of the plugins.

## Test plan

- Tested with no other plugins installed → it logs `false`
- Tested with Copilot installed → it logs `true`
