### PR TITLE
Promo Cody IDE after every Cody Web interaction

### DIFF
--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -249,7 +249,7 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
                 className="d-inline-block w-100 ml-auto text-right font-italic"
                 onClick={() => eventLogger.log('ClickedOnCodyCTA', { location: 'Chat Response' })}
             >
-                Use commands, autocomplete and more in your IDE
+                Use commands, autocomplete and more in your IDE.
             </Link>
         </div>
     )

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -26,6 +26,7 @@ import { CODY_TERMS_MARKDOWN } from '@sourcegraph/cody-ui/dist/terms'
 import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
+import { EventName, EventLocation } from '../../../util/constants'
 import { CodyPageIcon } from '../../chat/CodyPageIcon'
 import { isCodyEnabled, isEmailVerificationNeededForCody, isSignInRequiredForCody } from '../../isCodyEnabled'
 import { useCodySidebar } from '../../sidebar/Provider'
@@ -247,7 +248,7 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
             <Link
                 to="/get-cody"
                 className="d-inline-block w-100 ml-auto text-right font-italic"
-                onClick={() => eventLogger.log('ClickedOnCodyCTA', { location: 'Chat Response' })}
+                onClick={() => eventLogger.log(EventName.CODY_CTA, { location: EventLocation.CHAT_RESPONSE })}
             >
                 Use commands, autocomplete and more in your IDE.
             </Link>

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -219,13 +219,13 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
     )
 
     return (
-        <div className={classNames('d-flex', styles.feedbackButtonsWrapper)}>
+        <div className={styles.feedbackButtonsWrapper}>
             {feedbackSubmitted ? (
                 <Button title="Feedback submitted." disabled={true} className="ml-1 p-1">
                     <Icon aria-label="Feedback submitted" svgPath={mdiCheck} />
                 </Button>
             ) : (
-                <>
+                <div className="d-flex">
                     <Button
                         title="Thumbs up"
                         className="ml-1 p-1"
@@ -242,8 +242,15 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
                     >
                         <Icon aria-label="Thumbs down" svgPath={mdiThumbDown} />
                     </Button>
-                </>
+                </div>
             )}
+            <Link
+                to="/get-cody"
+                className="d-inline-block w-100 ml-auto text-right font-italic"
+                onClick={() => eventLogger.log('ClickedOnCodyCTA', { location: 'Chat Response' })}
+            >
+                Use commands, autocomplete and more in your IDE
+            </Link>
         </div>
     )
 })

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -219,16 +219,16 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
     )
 
     return (
-        <div className={styles.feedbackButtonsWrapper}>
+        <div className={classNames('d-flex align-items-center', styles.feedbackButtonsWrapper)}>
             {feedbackSubmitted ? (
-                <Button title="Feedback submitted." disabled={true} className="ml-1 p-1">
+                <Button title="Feedback submitted." disabled={true} className="p-1">
                     <Icon aria-label="Feedback submitted" svgPath={mdiCheck} />
                 </Button>
             ) : (
                 <div className="d-flex">
                     <Button
                         title="Thumbs up"
-                        className="ml-1 p-1"
+                        className="p-1"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('positive')}
                     >
@@ -236,7 +236,7 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
                     </Button>
                     <Button
                         title="Thumbs down"
-                        className="ml-1 p-1"
+                        className="p-1"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('negative')}
                     >

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect } from 'react'
 
 import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiShuffleVariant } from '@mdi/js'
-import { useNavigate } from 'react-router-dom'
 
 import { TranslateToLanguage } from '@sourcegraph/cody-shared/dist/chat/recipes/translate'
 
@@ -32,8 +31,6 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
     if (!loaded) {
         return null
     }
-
-    // let navigate = useNavigate()
 
     return (
         <Recipes>
@@ -90,7 +87,7 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
                     onClick={() => void executeRecipe('find-code-smells', { scope: { editor } })}
                     disabled={isMessageInProgress}
                 />
-                <RecipeAction title="Use locally" onClick={() => {}} disabled={isMessageInProgress} />
+                <RecipeAction title="Get Cody for your IDE" to="/get-cody" disabled={isMessageInProgress} />
             </Recipe>
         </Recipes>
     )

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect } from 'react'
 
 import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiShuffleVariant } from '@mdi/js'
+import { useNavigate } from 'react-router-dom'
 
 import { TranslateToLanguage } from '@sourcegraph/cody-shared/dist/chat/recipes/translate'
 
@@ -31,6 +32,8 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
     if (!loaded) {
         return null
     }
+
+    // let navigate = useNavigate()
 
     return (
         <Recipes>
@@ -87,6 +90,7 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
                     onClick={() => void executeRecipe('find-code-smells', { scope: { editor } })}
                     disabled={isMessageInProgress}
                 />
+                <RecipeAction title="Use locally" onClick={() => {}} disabled={isMessageInProgress} />
             </Recipe>
         </Recipes>
     )

--- a/client/web/src/cody/widgets/components/RecipeAction.tsx
+++ b/client/web/src/cody/widgets/components/RecipeAction.tsx
@@ -1,19 +1,27 @@
 import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { MenuItem, Icon } from '@sourcegraph/wildcard'
+import { AnchorLink, MenuItem, Icon, MenuLink } from '@sourcegraph/wildcard'
 
 import styles from './Recipes.module.scss'
 
 export interface RecipeActionProps {
     title: string
-    onClick: () => void
+    onClick?: () => void
+    to?: string
     disabled?: boolean
 }
 
-export const RecipeAction = ({ title, onClick, disabled }: RecipeActionProps): JSX.Element => (
-    <MenuItem className={classNames(styles.recipeMenuWrapper)} onSelect={onClick} disabled={disabled}>
-        {title}
-        {title === 'Use locally' && <Icon svgPath={mdiOpenInNew} className="ml-1" />}
-    </MenuItem>
+export const RecipeAction = ({ title, onClick, to, disabled }: RecipeActionProps): JSX.Element => (
+    <>
+        {!!onClick ? (
+            <MenuItem className={classNames(styles.recipeMenuWrapper)} onSelect={onClick} disabled={disabled}>
+                {title}
+            </MenuItem>
+        ) : !!to ? (
+            <MenuLink as={AnchorLink} to={to}>
+                {title} <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
+            </MenuLink>
+        ) : null}
+    </>
 )

--- a/client/web/src/cody/widgets/components/RecipeAction.tsx
+++ b/client/web/src/cody/widgets/components/RecipeAction.tsx
@@ -1,6 +1,7 @@
+import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { MenuItem } from '@sourcegraph/wildcard'
+import { MenuItem, Icon } from '@sourcegraph/wildcard'
 
 import styles from './Recipes.module.scss'
 
@@ -13,5 +14,6 @@ export interface RecipeActionProps {
 export const RecipeAction = ({ title, onClick, disabled }: RecipeActionProps): JSX.Element => (
     <MenuItem className={classNames(styles.recipeMenuWrapper)} onSelect={onClick} disabled={disabled}>
         {title}
+        {title === 'Use locally' && <Icon svgPath={mdiOpenInNew} className="ml-1" />}
     </MenuItem>
 )

--- a/client/web/src/cody/widgets/components/RecipeAction.tsx
+++ b/client/web/src/cody/widgets/components/RecipeAction.tsx
@@ -16,7 +16,7 @@ export const RecipeAction = ({ title, disabled, ...props }: RecipeActionProps): 
             {title}
         </MenuItem>
     ) : (
-        <MenuLink as={AnchorLink} to={props.to} disabled={disabled}>
+        <MenuLink as={AnchorLink} to={props.to} className={classNames(styles.recipeMenuWrapper)} disabled={disabled}>
             {title} <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
         </MenuLink>
     )

--- a/client/web/src/cody/widgets/components/RecipeAction.tsx
+++ b/client/web/src/cody/widgets/components/RecipeAction.tsx
@@ -19,7 +19,7 @@ export const RecipeAction = ({ title, onClick, to, disabled }: RecipeActionProps
                 {title}
             </MenuItem>
         ) : !!to ? (
-            <MenuLink as={AnchorLink} to={to}>
+            <MenuLink as={AnchorLink} to={to} disabled={disabled}>
                 {title} <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
             </MenuLink>
         ) : null}

--- a/client/web/src/cody/widgets/components/RecipeAction.tsx
+++ b/client/web/src/cody/widgets/components/RecipeAction.tsx
@@ -5,23 +5,18 @@ import { AnchorLink, MenuItem, Icon, MenuLink } from '@sourcegraph/wildcard'
 
 import styles from './Recipes.module.scss'
 
-export interface RecipeActionProps {
+export type RecipeActionProps = {
     title: string
-    onClick?: () => void
-    to?: string
     disabled?: boolean
-}
+} & ({ onClick: () => void } | { to: string })
 
-export const RecipeAction = ({ title, onClick, to, disabled }: RecipeActionProps): JSX.Element => (
-    <>
-        {!!onClick ? (
-            <MenuItem className={classNames(styles.recipeMenuWrapper)} onSelect={onClick} disabled={disabled}>
-                {title}
-            </MenuItem>
-        ) : !!to ? (
-            <MenuLink as={AnchorLink} to={to} disabled={disabled}>
-                {title} <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
-            </MenuLink>
-        ) : null}
-    </>
-)
+export const RecipeAction = ({ title, disabled, ...props }: RecipeActionProps): JSX.Element =>
+    'onClick' in props ? (
+        <MenuItem className={classNames(styles.recipeMenuWrapper)} onSelect={props.onClick} disabled={disabled}>
+            {title}
+        </MenuItem>
+    ) : (
+        <MenuLink as={AnchorLink} to={props.to} disabled={disabled}>
+            {title} <Icon aria-hidden={true} className="ml-1" svgPath={mdiOpenInNew} />
+        </MenuLink>
+    )

--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -137,6 +137,73 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                         </div>
                     )}
 
+                    {/* Install cody extension section */}
+                    <div className={classNames(styles.card, 'get-cody-step')}>
+                        <H2 className={classNames(styles.cardTitle, 'mb-4')}>
+                            Install the Cody extension for your IDE(s)
+                        </H2>
+                        <Text className={styles.cardDescription}>
+                            If you’ve downloaded the app, it will prompt you to sign in to your Sourcegraph.com account,
+                            connect your repositories, and connect your IDE extensions.
+                        </Text>
+                        <div className={classNames(styles.downloadBtnWrapper)}>
+                            <div className={classNames(styles.downloadBtn)}>
+                                <Link
+                                    to="vscode:extension/sourcegraph.cody-ai"
+                                    className={classNames('text-decoration-none', styles.downloadForVscode)}
+                                    onClick={() => logEvent(EventName.DOWNLOAD_IDE, 'VS Code')}
+                                >
+                                    <Icon
+                                        className={styles.vscodeIcon}
+                                        svgPath={mdiMicrosoftVisualStudioCode}
+                                        inline={false}
+                                        aria-hidden={true}
+                                    />{' '}
+                                    <span className={styles.downloadForVscodeText}>Install Cody for VS Code</span>
+                                </Link>
+                                <Link
+                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai#:~:text=Cody%20for%20VS%20Code%20is,no%20problem%20for%20Cody."
+                                    className={classNames('text-decoration-none', styles.vscodeMarketplace)}
+                                >
+                                    Or download on the VS Code Marketplace
+                                    <Icon
+                                        className="ml-2"
+                                        svgPath={mdiChevronRight}
+                                        inline={false}
+                                        aria-hidden={true}
+                                    />
+                                </Link>
+                            </div>
+                            <div className={classNames(styles.downloadBtn)}>
+                                <Link
+                                    to="https://plugins.jetbrains.com/plugin/9682-sourcegraph"
+                                    className={classNames('text-decoration-none', styles.downloadForVscode)}
+                                    onClick={() => logEvent(EventName.DOWNLOAD_IDE, 'IntelliJ')}
+                                >
+                                    <span className={styles.vscodeIcon}>
+                                        <IntellijIcon className={styles.joinWaitlistButtonIcon} />
+                                    </span>
+                                    <span className={styles.downloadForVscodeText}>Install Cody for Intellij</span>
+                                </Link>
+                            </div>
+                        </div>
+                        <div className={styles.comingSoonWrapper}>
+                            <Text className={styles.comingSoonWrapperText}>Coming soon:</Text>
+                            <div className={styles.joinWaitlistButtonWrapper}>
+                                <WaitListButton
+                                    to="https://info.sourcegraph.com/waitlist"
+                                    icon={<NeovimIcon className={styles.joinWaitlistButtonIcon} />}
+                                    title="Neovim"
+                                />
+                                <WaitListButton
+                                    to="https://info.sourcegraph.com/waitlist"
+                                    icon={<EmacsIcon className={styles.joinWaitlistButtonIcon} />}
+                                    title="Emacs"
+                                />
+                            </div>
+                        </div>
+                    </div>
+
                     {/* Install cody desktop app section */}
                     <div className={classNames(styles.card, 'get-cody-step')}>
                         <H2 className={classNames(styles.cardTitle, 'mb-4')}>
@@ -222,73 +289,6 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                                     Cody extension for VS Code
                                 </Link>
                             </Text>
-                        </div>
-                    </div>
-
-                    {/* Install cody extension section */}
-                    <div className={classNames(styles.card, 'get-cody-step')}>
-                        <H2 className={classNames(styles.cardTitle, 'mb-4')}>
-                            Install the Cody extension for your IDE(s)
-                        </H2>
-                        <Text className={styles.cardDescription}>
-                            If you’ve downloaded the app, it will prompt you to sign in to your Sourcegraph.com account,
-                            connect your repositories, and connect your IDE extensions.
-                        </Text>
-                        <div className={classNames(styles.downloadBtnWrapper)}>
-                            <div className={classNames(styles.downloadBtn)}>
-                                <Link
-                                    to="vscode:extension/sourcegraph.cody-ai"
-                                    className={classNames('text-decoration-none', styles.downloadForVscode)}
-                                    onClick={() => logEvent(EventName.DOWNLOAD_IDE, 'VS Code')}
-                                >
-                                    <Icon
-                                        className={styles.vscodeIcon}
-                                        svgPath={mdiMicrosoftVisualStudioCode}
-                                        inline={false}
-                                        aria-hidden={true}
-                                    />{' '}
-                                    <span className={styles.downloadForVscodeText}>Install Cody for VS Code</span>
-                                </Link>
-                                <Link
-                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai#:~:text=Cody%20for%20VS%20Code%20is,no%20problem%20for%20Cody."
-                                    className={classNames('text-decoration-none', styles.vscodeMarketplace)}
-                                >
-                                    Or download on the VS Code Marketplace
-                                    <Icon
-                                        className="ml-2"
-                                        svgPath={mdiChevronRight}
-                                        inline={false}
-                                        aria-hidden={true}
-                                    />
-                                </Link>
-                            </div>
-                            <div className={classNames(styles.downloadBtn)}>
-                                <Link
-                                    to="https://plugins.jetbrains.com/plugin/9682-sourcegraph"
-                                    className={classNames('text-decoration-none', styles.downloadForVscode)}
-                                    onClick={() => logEvent(EventName.DOWNLOAD_IDE, 'IntelliJ')}
-                                >
-                                    <span className={styles.vscodeIcon}>
-                                        <IntellijIcon className={styles.joinWaitlistButtonIcon} />
-                                    </span>
-                                    <span className={styles.downloadForVscodeText}>Install Cody for Intellij</span>
-                                </Link>
-                            </div>
-                        </div>
-                        <div className={styles.comingSoonWrapper}>
-                            <Text className={styles.comingSoonWrapperText}>Coming soon:</Text>
-                            <div className={styles.joinWaitlistButtonWrapper}>
-                                <WaitListButton
-                                    to="https://info.sourcegraph.com/waitlist"
-                                    icon={<NeovimIcon className={styles.joinWaitlistButtonIcon} />}
-                                    title="Neovim"
-                                />
-                                <WaitListButton
-                                    to="https://info.sourcegraph.com/waitlist"
-                                    icon={<EmacsIcon className={styles.joinWaitlistButtonIcon} />}
-                                    title="Emacs"
-                                />
-                            </div>
                         </div>
                     </div>
 

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -18,7 +18,6 @@ import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetry
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, ButtonLink, Link, ProductStatusBadge, useWindowSize } from '@sourcegraph/wildcard'
 
-import { EventName, EventLocation } from '../../util/constants'
 import type { AuthenticatedUser } from '../auth'
 import type { BatchChangesProps } from '../batches'
 import { BatchChangesNavItem } from '../batches/BatchChangesNavItem'
@@ -40,6 +39,7 @@ import { AccessRequestsGlobalNavItem } from '../site-admin/AccessRequestsPage/Ac
 import { NotificationsNavbarItem } from '../site-admin/notifications/NotificationsNavbarItem'
 import { useNavbarQueryState } from '../stores'
 import { eventLogger } from '../tracking/eventLogger'
+import { EventName, EventLocation } from '../util/constants'
 
 import { NavAction, NavActions, NavBar, NavGroup, NavItem, NavLink } from '.'
 import { NavDropdown, type NavDropdownItem } from './NavBar/NavDropdown'

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -18,6 +18,7 @@ import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetry
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, ButtonLink, Link, ProductStatusBadge, useWindowSize } from '@sourcegraph/wildcard'
 
+import { EventName, EventLocation } from '../../util/constants'
 import type { AuthenticatedUser } from '../auth'
 import type { BatchChangesProps } from '../batches'
 import { BatchChangesNavItem } from '../batches/BatchChangesNavItem'
@@ -312,7 +313,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                             <Link
                                 to="/get-cody"
                                 className={classNames(styles.link, 'small')}
-                                onClick={() => eventLogger.log('ClickedOnCodyCTA', { location: 'NavBar' })}
+                                onClick={() => eventLogger.log(EventName.CODY_CTA, { location: EventLocation.NAV_BAR })}
                             >
                                 Install Cody locally
                             </Link>

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -21,6 +21,7 @@ export const enum EventName {
     CODY_SIGNUP = 'CodySignup',
     CODY_CHAT_DOWNLOAD_VSCODE = 'web:codyChat:downloadVSCodeCTA',
     CODY_CHAT_TRY_ON_PUBLIC_CODE = 'web:codyChat:tryOnPublicCodeCTA',
+    CODY_CTA = 'ClickedOnCodyCTA',
     VIEW_EDITOR_EXTENSIONS = 'CodyClickViewEditorExtensions',
     TRY_CODY_VSCODE = 'VSCodeInstall',
     TRY_CODY_MARKETPLACE = 'VSCodeMarketplace',
@@ -33,4 +34,9 @@ export const enum EventName {
     JOIN_IDE_WAITLIST = 'JoinIDEWaitlist',
     DOWNLOAD_IDE = 'DownloadIDE',
     DOWNLOAD_APP = 'DownloadApp',
+}
+
+export const enum EventLocation {
+    NAV_BAR = 'NavBar',
+    CHAT_RESPONSE = 'ChatResponse',
 }


### PR DESCRIPTION
Closes #[55848](https://github.com/sourcegraph/sourcegraph/issues/55848), adds a promo for Cody IDE extensions in the Cody tooltip & Cody chat response feedback footer:

<img width="750" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/37d243d4-83be-4565-8453-e9d5963c0186">

<img width="476" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/59381432/32dea3d4-3864-403e-8545-b51de6d1ac78">

## Test plan
- CI/CD
