### PR TITLE
#55846 follow up - Transcript event logger refactor

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -40,7 +40,6 @@ import { MarketingBlock } from '../../components/MarketingBlock'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
 import type { SourcegraphContext } from '../../jscontext'
-import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 import { ChatUI } from '../components/ChatUI'
 import { CodyMarketingPage } from '../components/CodyMarketingPage'
@@ -120,7 +119,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
 
     useEffect(() => {
         logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED)
-    }, [])
+    }, [logTranscriptEvent])
 
     const transcriptId = transcript?.id
 

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -118,7 +118,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     const onCTADismiss = (): void => setIsCTADismissed(true)
 
     useEffect(() => {
-        eventLogger.log(EventName.CODY_CHAT_PAGE_VIEWED, { chatId: transcript?.id })
+        eventLogger.log(EventName.CODY_CHAT_PAGE_VIEWED, { transcriptId: transcript?.id })
     }, [transcript?.id])
 
     const transcriptId = transcript?.id
@@ -288,7 +288,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                         )}
                                         onClick={() =>
                                             eventLogger.log(EventName.CODY_CHAT_DOWNLOAD_VSCODE, {
-                                                chatId: transcript?.id,
+                                                transcriptId: transcript?.id,
                                             })
                                         }
                                     >
@@ -330,7 +330,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                         )}
                                         onClick={() =>
                                             eventLogger.log(EventName.CODY_CHAT_TRY_ON_PUBLIC_CODE, {
-                                                chatId: transcript?.id,
+                                                transcriptId: transcript?.id,
                                             })
                                         }
                                     >

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -112,14 +112,15 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
         transcriptHistory,
         loadTranscriptFromHistory,
         deleteHistoryItem,
+        logTranscriptEvent,
     } = codyChatStore
     const [showVSCodeCTA] = useState<boolean>(Math.random() < 0.5 || true)
     const [isCTADismissed = true, setIsCTADismissed] = useTemporarySetting('cody.chatPageCta.dismissed', false)
     const onCTADismiss = (): void => setIsCTADismissed(true)
 
     useEffect(() => {
-        eventLogger.log(EventName.CODY_CHAT_PAGE_VIEWED, { transcriptId: transcript?.id })
-    }, [transcript?.id])
+        logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED)
+    }, [])
 
     const transcriptId = transcript?.id
 
@@ -286,11 +287,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                             'd-inline-flex align-items-center text-merged',
                                             styles.ctaLink
                                         )}
-                                        onClick={() =>
-                                            eventLogger.log(EventName.CODY_CHAT_DOWNLOAD_VSCODE, {
-                                                transcriptId: transcript?.id,
-                                            })
-                                        }
+                                        onClick={() => logTranscriptEvent(EventName.CODY_CHAT_DOWNLOAD_VSCODE)}
                                     >
                                         Download the VS Code Extension
                                         <Icon svgPath={mdiChevronRight} aria-hidden={true} />
@@ -328,11 +325,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                             'd-inline-flex align-items-center text-merged',
                                             styles.ctaLink
                                         )}
-                                        onClick={() =>
-                                            eventLogger.log(EventName.CODY_CHAT_TRY_ON_PUBLIC_CODE, {
-                                                transcriptId: transcript?.id,
-                                            })
-                                        }
+                                        onClick={() => logTranscriptEvent(EventName.CODY_CHAT_TRY_ON_PUBLIC_CODE)}
                                     >
                                         Try on a file, or repository
                                         <Icon svgPath={mdiChevronRight} aria-hidden={true} />

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -105,7 +105,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
 
     const gettingStartedComponentProps = useMemo(
         () => ({ ...scopeSelectorProps, logTranscriptEvent, isCodyChatPage }),
-        [scopeSelectorProps, isCodyChatPage, logTranscriptEvent]
+        [scopeSelectorProps, logTranscriptEvent, isCodyChatPage]
     )
 
     if (!loaded) {

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -57,6 +57,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
         loaded,
         scope,
         setScope,
+        logTranscriptEvent,
         toggleIncludeInferredRepository,
         toggleIncludeInferredFile,
         abortMessageInProgress,
@@ -88,7 +89,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
             toggleIncludeInferredFile,
             fetchRepositoryNames,
             isSourcegraphApp,
-            transcript,
+            logTranscriptEvent,
             className: 'mt-2',
         }),
         [
@@ -98,13 +99,13 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
             toggleIncludeInferredFile,
             fetchRepositoryNames,
             isSourcegraphApp,
-            transcript,
+            logTranscriptEvent,
         ]
     )
 
     const gettingStartedComponentProps = useMemo(
-        () => ({ ...scopeSelectorProps, transcript, isCodyChatPage }),
-        [scopeSelectorProps, isCodyChatPage, transcript]
+        () => ({ ...scopeSelectorProps, logTranscriptEvent, isCodyChatPage }),
+        [scopeSelectorProps, isCodyChatPage, logTranscriptEvent]
     )
 
     if (!loaded) {

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -21,7 +21,7 @@ export const GettingStarted: React.FC<
     Pick<
         CodyChatStore,
         | 'scope'
-        | 'transcript'
+        | 'logTranscriptEvent'
         | 'setScope'
         | 'toggleIncludeInferredRepository'
         | 'toggleIncludeInferredFile'

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -91,7 +91,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     const addRepository = useCallback(
         (repoName: string) => {
             if (!scope.repositories.includes(repoName)) {
-                eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_ADDED, { chatId: transcript?.id })
+                eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_ADDED, { transcriptId: transcript?.id })
                 setScope({ ...scope, repositories: [...scope.repositories, repoName] })
             }
         },
@@ -100,14 +100,14 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
 
     const removeRepository = useCallback(
         (repoName: string) => {
-            eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, { chatId: transcript?.id })
+            eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, { transcriptId: transcript?.id })
             setScope({ ...scope, repositories: scope.repositories.filter(repo => repo !== repoName) })
         },
         [scope, setScope, transcript?.id]
     )
 
     const resetScope = useCallback(async (): Promise<void> => {
-        eventLogger.log(EventName.CODY_CHAT_SCOPE_RESET, { chatId: transcript?.id })
+        eventLogger.log(EventName.CODY_CHAT_SCOPE_RESET, { transcriptId: transcript?.id })
         if (!isSourcegraphApp) {
             return setScope({ ...scope, repositories: [], includeInferredRepository: true, includeInferredFile: true })
         }

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -93,7 +93,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                 setScope({ ...scope, repositories: [...scope.repositories, repoName] })
             }
         },
-        [scope, setScope]
+        [scope, setScope, logTranscriptEvent]
     )
 
     const removeRepository = useCallback(
@@ -101,7 +101,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
             logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED)
             setScope({ ...scope, repositories: scope.repositories.filter(repo => repo !== repoName) })
         },
-        [scope, setScope]
+        [scope, setScope, logTranscriptEvent]
     )
 
     const resetScope = useCallback(async (): Promise<void> => {
@@ -112,7 +112,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
 
         const repositories = await fetchRepositoryNames(10)
         return setScope({ ...scope, repositories, includeInferredRepository: true, includeInferredFile: true })
-    }, [scope, setScope, fetchRepositoryNames, isSourcegraphApp])
+    }, [scope, setScope, fetchRepositoryNames, isSourcegraphApp, logTranscriptEvent])
 
     return (
         <>

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -7,7 +7,6 @@ import { useLazyQuery } from '@sourcegraph/http-client'
 import { Text } from '@sourcegraph/wildcard'
 
 import type { ReposStatusResult, ReposStatusVariables } from '../../../graphql-operations'
-import { eventLogger } from '../../../tracking/eventLogger'
 import { EventName } from '../../../util/constants'
 
 import { ReposStatusQuery } from './backend'

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useCallback } from 'react'
 
 import classNames from 'classnames'
 
-import type { Transcript } from '@sourcegraph/cody-shared/dist/chat/transcript'
 import type { CodyClientScope } from '@sourcegraph/cody-shared/dist/chat/useClient'
 import { useLazyQuery } from '@sourcegraph/http-client'
 import { Text } from '@sourcegraph/wildcard'
@@ -23,7 +22,7 @@ export interface ScopeSelectorProps {
     toggleIncludeInferredFile: () => void
     fetchRepositoryNames: (count: number) => Promise<string[]>
     isSourcegraphApp?: boolean
-    transcript: Transcript | null
+    logTranscriptEvent: (eventLabel: string, eventProperties?: { [key: string]: any }) => void
     className?: string
     renderHint?: (repos: IRepo[]) => React.ReactNode
 }
@@ -35,7 +34,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     toggleIncludeInferredFile,
     fetchRepositoryNames,
     isSourcegraphApp,
-    transcript,
+    logTranscriptEvent,
     className,
     renderHint,
 }) {
@@ -91,30 +90,30 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     const addRepository = useCallback(
         (repoName: string) => {
             if (!scope.repositories.includes(repoName)) {
-                eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_ADDED, { transcriptId: transcript?.id })
+                logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_ADDED)
                 setScope({ ...scope, repositories: [...scope.repositories, repoName] })
             }
         },
-        [scope, setScope, transcript?.id]
+        [scope, setScope]
     )
 
     const removeRepository = useCallback(
         (repoName: string) => {
-            eventLogger.log(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, { transcriptId: transcript?.id })
+            logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED)
             setScope({ ...scope, repositories: scope.repositories.filter(repo => repo !== repoName) })
         },
-        [scope, setScope, transcript?.id]
+        [scope, setScope]
     )
 
     const resetScope = useCallback(async (): Promise<void> => {
-        eventLogger.log(EventName.CODY_CHAT_SCOPE_RESET, { transcriptId: transcript?.id })
+        logTranscriptEvent(EventName.CODY_CHAT_SCOPE_RESET)
         if (!isSourcegraphApp) {
             return setScope({ ...scope, repositories: [], includeInferredRepository: true, includeInferredFile: true })
         }
 
         const repositories = await fetchRepositoryNames(10)
         return setScope({ ...scope, repositories, includeInferredRepository: true, includeInferredFile: true })
-    }, [scope, setScope, fetchRepositoryNames, isSourcegraphApp, transcript?.id])
+    }, [scope, setScope, fetchRepositoryNames, isSourcegraphApp])
 
     return (
         <>

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -148,7 +148,7 @@ export const useCodyChat = ({
             }
             eventLogger.log(eventLabel, { transcriptId: transcript.id, ...eventProperties })
         },
-        [transcriptHistory, transcript?.id]
+        [transcript]
     )
 
     const loadTranscriptFromHistory = useCallback(
@@ -232,7 +232,6 @@ export const useCodyChat = ({
         scope,
         setScopeInternal,
         updateTranscriptInHistory,
-        transcriptHistory,
     ])
 
     const deleteHistoryItem = useCallback(
@@ -292,6 +291,7 @@ export const useCodyChat = ({
             autoLoadScopeWithRepositories,
             scope,
             updateTranscriptInHistory,
+            logTranscriptEvent,
         ]
     )
 
@@ -306,7 +306,7 @@ export const useCodyChat = ({
             logTranscriptEvent(EventName.CODY_CHAT_SUBMIT)
             return transcript
         },
-        [submitMessageInternal, updateTranscriptInHistory]
+        [submitMessageInternal, updateTranscriptInHistory, logTranscriptEvent]
     )
 
     const editMessage = useCallback<typeof editMessageInternal>(
@@ -320,7 +320,7 @@ export const useCodyChat = ({
             logTranscriptEvent(EventName.CODY_CHAT_EDIT)
             return transcript
         },
-        [editMessageInternal, updateTranscriptInHistory]
+        [editMessageInternal, updateTranscriptInHistory, logTranscriptEvent]
     )
 
     const initializeNewChat = useCallback((): Transcript | null => {
@@ -361,6 +361,7 @@ export const useCodyChat = ({
         autoLoadScopeWithRepositories,
         updateTranscriptInHistory,
         transcript,
+        logTranscriptEvent,
     ])
 
     const executeRecipe = useCallback<typeof executeRecipeInternal>(
@@ -447,7 +448,7 @@ export const useCodyChat = ({
                 includeInferredRepository: !scope.includeInferredRepository,
             }).catch(() => null)
         }
-    }, [transcript, updateTranscriptInHistory, scope, toggleIncludeInferredRepositoryInternal])
+    }, [transcript, updateTranscriptInHistory, scope, toggleIncludeInferredRepositoryInternal, logTranscriptEvent])
 
     const toggleIncludeInferredFile = useCallback<CodyClient['toggleIncludeInferredRepository']>(() => {
         logTranscriptEvent(
@@ -464,7 +465,7 @@ export const useCodyChat = ({
                 includeInferredFile: !scope.includeInferredFile,
             }).catch(() => null)
         }
-    }, [transcript, updateTranscriptInHistory, scope, toggleIncludeInferredFileInternal])
+    }, [transcript, updateTranscriptInHistory, scope, toggleIncludeInferredFileInternal, logTranscriptEvent])
 
     return {
         loaded,

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -87,7 +87,6 @@ interface CodyChatProps {
         transcriptHistory: TranscriptJSON[],
         initializeNewChat: CodyClient['initializeNewChat']
     ) => void
-    logTranscriptEvent?: (eventLabel: string, eventProperties?: { [key: string]: any }) => void
     autoLoadTranscriptFromHistory?: boolean
     autoLoadScopeWithRepositories?: boolean
 }
@@ -142,12 +141,15 @@ export const useCodyChat = ({
     })
 
     /** Event logger for transcript specific events to capture the transcriptId */
-    const logTranscriptEvent = (eventLabel: string, eventProperties?: { [key: string]: any }) => {
-        if (!transcript) {
-            return
-        }
-        eventLogger.log(eventLabel, { transcriptId: transcript.id, ...eventProperties })
-    }
+    const logTranscriptEvent = useCallback(
+        (eventLabel: string, eventProperties?: { [key: string]: any }) => {
+            if (!transcript) {
+                return
+            }
+            eventLogger.log(eventLabel, { transcriptId: transcript.id, ...eventProperties })
+        },
+        [transcriptHistory, transcript?.id]
+    )
 
     const loadTranscriptFromHistory = useCallback(
         async (id: string) => {

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -188,8 +188,7 @@ export const useCodyChat = ({
             return
         }
 
-        const chatIds = transcriptHistory.map(chat => chat.id)
-        eventLogger.log(EventName.CODY_CHAT_HISTORY_CLEARED, { chatIds })
+        eventLogger.log(EventName.CODY_CHAT_HISTORY_CLEARED)
 
         const newTranscript = initializeNewChatInternal()
         if (newTranscript) {
@@ -229,7 +228,7 @@ export const useCodyChat = ({
                 return
             }
 
-            eventLogger.log(EventName.CODY_CHAT_HISTORY_ITEM_DELETED, { chatId: id })
+            eventLogger.log(EventName.CODY_CHAT_HISTORY_ITEM_DELETED, { transcriptId: id })
 
             setTranscriptHistoryState((history: TranscriptJSON[]) => {
                 const updatedHistory = [...history.filter(transcript => transcript.id !== id)]
@@ -291,7 +290,7 @@ export const useCodyChat = ({
                 await updateTranscriptInHistory(transcript)
             }
 
-            eventLogger.log(EventName.CODY_CHAT_SUBMIT, { chatId: transcript?.id })
+            eventLogger.log(EventName.CODY_CHAT_SUBMIT, { transcriptId: transcript?.id })
             return transcript
         },
         [submitMessageInternal, updateTranscriptInHistory]
@@ -304,7 +303,7 @@ export const useCodyChat = ({
                 await updateTranscriptInHistory(transcript)
             }
 
-            eventLogger.log(EventName.CODY_CHAT_EDIT, { chatId: transcript?.id })
+            eventLogger.log(EventName.CODY_CHAT_EDIT, { transcriptId: transcript?.id })
             return transcript
         },
         [editMessageInternal, updateTranscriptInHistory]
@@ -337,7 +336,7 @@ export const useCodyChat = ({
             }
         }
 
-        eventLogger.log(EventName.CODY_CHAT_INITIALIZED, { chatId: newTranscript?.id })
+        eventLogger.log(EventName.CODY_CHAT_INITIALIZED, { transcriptId: newTranscript?.id })
         return newTranscript
     }, [
         initializeNewChatInternal,
@@ -424,7 +423,7 @@ export const useCodyChat = ({
             scope.includeInferredRepository
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_REPO_DISABLED
                 : EventName.CODY_CHAT_SCOPE_INFERRED_REPO_ENABLED,
-            { chatId: transcript?.id }
+            { transcriptId: transcript?.id }
         )
 
         toggleIncludeInferredRepositoryInternal()
@@ -442,7 +441,7 @@ export const useCodyChat = ({
             scope.includeInferredRepository
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_FILE_DISABLED
                 : EventName.CODY_CHAT_SCOPE_INFERRED_FILE_ENABLED,
-            { chatId: transcript?.id }
+            { transcriptId: transcript?.id }
         )
 
         toggleIncludeInferredFileInternal()

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -399,7 +399,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                                         props.telemetryService.log(EventName.CODY_SIDEBAR_CHAT_OPENED, {
                                             repo,
                                             path: filePath,
-                                            chatId: transcript?.id,
+                                            transcriptId: transcript?.id,
                                         })
                                         setIsCodySidebarOpen(true)
                                     }}

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -156,7 +156,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
         setIsSidebarOpen: setIsCodySidebarOpen,
         scope,
         setEditorScope,
-        transcript,
+        logTranscriptEvent,
     } = useCodySidebar()
 
     const { sidebarSize, setSidebarSize: setCodySidebarSize } = useSidebarSize()
@@ -396,11 +396,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                             !isCodySidebarOpen ? (
                                 <AskCodyButton
                                     onClick={() => {
-                                        props.telemetryService.log(EventName.CODY_SIDEBAR_CHAT_OPENED, {
-                                            repo,
-                                            path: filePath,
-                                            transcriptId: transcript?.id,
-                                        })
+                                        logTranscriptEvent(EventName.CODY_SIDEBAR_CHAT_OPENED, { repo, path: filePath })
                                         setIsCodySidebarOpen(true)
                                     }}
                                 />


### PR DESCRIPTION
#55846 follow up - Adds a utility function to transcription events logged to consolidate accounting for a nullable `transcript` in one place in the store

## Test plan
- CI/CD
