### PR TITLE
batches: Fix regression the error message

### DIFF
--- a/internal/batches/reconciler/executor.go
+++ b/internal/batches/reconciler/executor.go
@@ -213,6 +213,8 @@ func (e *executor) pushChangesetPatch(ctx context.Context, triggerUpdateWebhook 
 					return afterDone, errCannotPushToArchivedRepo
 				}
 			}
+			// do not wrap the error (pushCommitError), so it can be nicely displayed in the UI
+			return afterDone, err
 		}
 		return afterDone, errors.Wrap(err, "pushing commit")
 	}

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -295,7 +295,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			wantChangeset: bt.ChangesetAssertions{
 				PublicationState: btypes.ChangesetPublicationStateUnpublished,
 			},
-			wantErr: errors.New("pushing commit: creating commit from patch for repository \"\": \n```\n$ \narchived\n```"),
+			wantErr: errors.New("creating commit from patch for repository \"\": \n```\n$ \narchived\n```"),
 		},
 		"general push error": {
 			hasCurrentSpec: true,


### PR DESCRIPTION
If we wrap the `pushCommitError`, it will not be displayed nicely in the UI. This returns the error if it is a `pushCommitError` without being wrapped, else we keep the error wrapped.

## Test plan

Covered by existing tests. Fixed failing test.