### PR TITLE
zoekt: update to fcb279ae404c0aa102121b28257143ad16e77482

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6273,8 +6273,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:mi8zKWhOb8dX/wXXkvSwIyOXHWX6E2T3yf5yIGUcmF0=",
-        version = "v0.0.0-20230811181333-956d775e32b3",
+        sum = "h1:rTFtMFg9EQuHLchNF9wpw5gVJQKCD7aHAav51nwWy18=",
+        version = "v0.0.0-20230816191938-fcb279ae404c",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -543,7 +543,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3
+	github.com/sourcegraph/zoekt v0.0.0-20230816191938-fcb279ae404c
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2027,8 +2027,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3 h1:mi8zKWhOb8dX/wXXkvSwIyOXHWX6E2T3yf5yIGUcmF0=
-github.com/sourcegraph/zoekt v0.0.0-20230811181333-956d775e32b3/go.mod h1:QJc8dPAIRJ9KZbFBXteD4/YbXkSnMe7zK9wJkOoPg7c=
+github.com/sourcegraph/zoekt v0.0.0-20230816191938-fcb279ae404c h1:rTFtMFg9EQuHLchNF9wpw5gVJQKCD7aHAav51nwWy18=
+github.com/sourcegraph/zoekt v0.0.0-20230816191938-fcb279ae404c/go.mod h1:3rlMtZdLxkc7P1R14qWq20fWDDyRQwL6TmAqH81WQ4M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/grpc.go
+++ b/internal/search/backend/grpc.go
@@ -91,7 +91,10 @@ func (z *zoektGRPCClient) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 			return convertError(err)
 		}
 
-		sender.Send(zoekt.SearchResultFromProto(msg))
+		var repoURLS map[string]string      // We don't use repoURLs in Sourcegraph
+		var lineFragments map[string]string // We don't use lineFragments in Sourcegraph
+
+		sender.Send(zoekt.SearchResultFromProto(msg, repoURLS, lineFragments))
 	}
 }
 
@@ -110,7 +113,10 @@ func (z *zoektGRPCClient) Search(ctx context.Context, q query.Q, opts *zoekt.Sea
 		return nil, convertError(err)
 	}
 
-	return zoekt.SearchResultFromProto(resp), nil
+	var repoURLS map[string]string      // We don't use repoURLs in Sourcegraph
+	var lineFragments map[string]string // We don't use lineFragments in Sourcegraph
+
+	return zoekt.SearchResultFromProto(resp, repoURLS, lineFragments), nil
 }
 
 // List lists repositories. The query `q` can only contain


### PR DESCRIPTION
This PR updates our Zoekt dependency to https://github.com/sourcegraph/zoekt/commit/fcb279ae404c0aa102121b28257143ad16e77482.

This update includes changes to the Zoekt Search result protobuf definition. LineFragments and RepoURLs are no longer defined in the protobuf spec, and our go struct <-> protobuf struct conversion functions have been updated to reflect this. 

## Test plan

CI 

