### PR TITLE
grpc: conf: add more robust URL parsing for SRC_FRONTEND_INTERNAL

### DIFF
--- a/internal/api/internalapi/BUILD.bazel
+++ b/internal/api/internalapi/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -19,4 +20,11 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
     ],
+)
+
+go_test(
+    name = "internalapi_test",
+    srcs = ["client_test.go"],
+    embed = [":internalapi"],
+    deps = ["@com_github_google_go_cmp//cmp"],
 )

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -4,14 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	proto "github.com/sourcegraph/sourcegraph/internal/api/internalapi/v1"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -23,7 +28,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var frontendInternal = env.Get("SRC_FRONTEND_INTERNAL", defaultFrontendInternal(), "HTTP address for internal frontend HTTP API.")
+var frontendInternal = func() *url.URL {
+	rawURL := env.Get("SRC_FRONTEND_INTERNAL", defaultFrontendInternal(), "HTTP address for internal frontend HTTP API.")
+	return mustParseSourcegraphInternalURL(rawURL)
+}()
 
 // NOTE: this intentionally does not use the site configuration option because we need to make the decision
 // about whether or not to use gRPC to fetch the site configuration in the first place.
@@ -44,10 +52,10 @@ type internalClient struct {
 }
 
 var Client = &internalClient{
-	URL: "http://" + frontendInternal,
+	URL: frontendInternal.String(),
 	getConfClient: syncx.OnceValues(func() (proto.ConfigServiceClient, error) {
 		logger := log.Scoped("internalapi", "")
-		conn, err := defaults.Dial(frontendInternal, logger)
+		conn, err := defaults.Dial(frontendInternal.Host, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -165,4 +173,104 @@ func checkAPIResponse(resp *http.Response) error {
 		return errors.Errorf("internal API response error code %d (%s)", resp.StatusCode, resp.Request.URL)
 	}
 	return nil
+}
+
+// mustParseSourcegraphInternalURL parses a frontend internal URL string and panics if it is invalid.
+//
+// The URL will be parsed with a default scheme of "http" and a default port of "80" if no scheme or port is specified.
+func mustParseSourcegraphInternalURL(rawURL string) *url.URL {
+	u, err := parseAddress(rawURL)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse frontend internal URL %q: %s", rawURL, err))
+	}
+
+	u = addDefaultScheme(u, "http")
+	u = addDefaultPort(u)
+
+	return u
+}
+
+// parseAddress parses rawAddress into a URL object. It accommodates cases where the rawAddress is a
+// simple host:port pair without a URL scheme (e.g., "example.com:8080").
+//
+// This function aims to provide a flexible way to parse addresses that may or may not strictly adhere to the URL format.
+func parseAddress(rawAddress string) (*url.URL, error) {
+	addedScheme := false
+
+	// Temporarily prepend "http://" if no scheme is present
+	if !strings.Contains(rawAddress, "://") {
+		rawAddress = "http://" + rawAddress
+		addedScheme = true
+	}
+
+	parsedURL, err := url.Parse(rawAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// If we added the "http://" scheme, remove it from the final URL
+	if addedScheme {
+		parsedURL.Scheme = ""
+	}
+
+	return parsedURL, nil
+}
+
+// addDefaultScheme adds a default scheme to a URL if one is not specified.
+//
+// The original URL is not mutated. A copy is modified and returned.
+func addDefaultScheme(original *url.URL, scheme string) *url.URL {
+	if original == nil {
+		return nil // don't panic
+	}
+
+	if original.Scheme != "" {
+		return original
+	}
+
+	u := cloneURL(original)
+	u.Scheme = scheme
+
+	return u
+}
+
+// addDefaultPort adds a default port to a URL if one is not specified.
+//
+// If the URL scheme is "http" and no port is specified, "80" is used.
+// If the scheme is "https", "443" is used.
+//
+// The original URL is not mutated. A copy is modified and returned.
+func addDefaultPort(original *url.URL) *url.URL {
+	if original == nil {
+		return nil // don't panic
+	}
+
+	if original.Scheme == "http" && original.Port() == "" {
+		u := cloneURL(original)
+		u.Host = net.JoinHostPort(u.Host, "80")
+		return u
+	}
+
+	if original.Scheme == "https" && original.Port() == "" {
+		u := cloneURL(original)
+		u.Host = net.JoinHostPort(u.Host, "443")
+		return u
+	}
+
+	return original
+}
+
+// cloneURL returns a copy of the URL. It is safe to mutate the returned URL.
+// This is copied from net/http/clone.go
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	u2 := new(url.URL)
+	*u2 = *u
+	if u.User != nil {
+		u2.User = new(url.Userinfo)
+		*u2.User = *u.User
+	}
+	return u2
 }

--- a/internal/api/internalapi/client_test.go
+++ b/internal/api/internalapi/client_test.go
@@ -1,0 +1,294 @@
+package internalapi
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseAddress(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected *url.URL
+	}{
+		{
+			name: "valid URL",
+
+			input: "https://example.com",
+			expected: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+		},
+		{
+			name: "host:port pair",
+
+			input: "example.com:8080",
+			expected: &url.URL{
+				Host: "example.com:8080",
+			},
+		},
+		{
+			name:  "gitserver URL with port and scheme",
+			input: "http://gitserver-0:3181",
+			expected: &url.URL{
+				Scheme: "http",
+				Host:   "gitserver-0:3181",
+			},
+		},
+		{
+			name:  "IPv4 host:port",
+			input: "127.0.0.1:3181",
+			expected: &url.URL{
+				Host: "127.0.0.1:3181",
+			},
+		},
+		{
+			name:  "IPv4 URL with port",
+			input: "http://127.0.0.1:3181",
+			expected: &url.URL{
+				Scheme: "http",
+				Host:   "127.0.0.1:3181",
+			},
+		},
+		{
+			name:  "IPv6 host:port",
+			input: "[dead:beef::3]:80",
+			expected: &url.URL{
+				Host: "[dead:beef::3]:80",
+			},
+		},
+		{
+			name:  "IPv6 URL with port",
+			input: "http://[dead:beef::3]:80",
+			expected: &url.URL{
+				Scheme: "http",
+				Host:   "[dead:beef::3]:80",
+			},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: &url.URL{},
+		},
+		{
+			name:  "hostname without port",
+			input: "example.com",
+			expected: &url.URL{
+				Host: "example.com",
+			},
+		},
+		{
+			name:  "hostname with no port and no scheme",
+			input: "sourcegraph-frontend-internal",
+			expected: &url.URL{
+				Host: "sourcegraph-frontend-internal",
+			},
+		},
+		{
+			name:  "non-standard scheme",
+			input: "ftp://example.com",
+			expected: &url.URL{
+				Scheme: "ftp",
+				Host:   "example.com",
+			},
+		},
+		{
+			name:  "URL with path, query, and fragment",
+			input: "http://example.com/path?query#fragment",
+			expected: &url.URL{
+				Scheme:   "http",
+				Host:     "example.com",
+				Path:     "/path",
+				RawQuery: "query",
+				Fragment: "fragment",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := parseAddress(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected.String(), u.String()); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+}
+
+func TestAddDefaultPort(t *testing.T) {
+	tests := []struct {
+		name string
+
+		input string
+		want  string
+	}{
+		{
+			name:  "http no port",
+			input: "http://example.com",
+			want:  "http://example.com:80",
+		},
+		{
+			name:  "http custom port",
+			input: "http://example.com:90",
+			want:  "http://example.com:90",
+		},
+		{
+			name:  "https no port",
+			input: "https://example.com",
+			want:  "https://example.com:443",
+		},
+		{
+			name:  "https custom port",
+			input: "https://example.com:444",
+			want:  "https://example.com:444",
+		},
+		{
+			name:  "non-http scheme",
+			input: "ftp://example.com",
+			want:  "ftp://example.com",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "local file path",
+			input: "/etc/hosts",
+			want:  "/etc/hosts",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input, err := url.Parse(test.input)
+			if err != nil {
+				t.Fatalf("failed to parse test URL %q: %v", test.input, err)
+			}
+
+			got := addDefaultPort(input)
+			if diff := cmp.Diff(test.want, got.String()); diff != "" {
+				t.Errorf("addDefaultPort(%q) mismatch (-want +got):\n%s", test.input, diff)
+			}
+		})
+	}
+}
+
+func TestAddDefaultScheme(t *testing.T) {
+	tests := []struct {
+		name string
+
+		input  string
+		scheme string
+
+		want string
+	}{
+		{
+			name:   "empty URL",
+			input:  "",
+			scheme: "http",
+
+			want: "http:",
+		},
+		{
+			name:   "local file path",
+			input:  "file:///path/to/resource",
+			scheme: "http",
+
+			want: "file:///path/to/resource",
+		},
+		{
+			name:   "URL without scheme",
+			input:  "example.com",
+			scheme: "http",
+
+			want: "http://example.com",
+		},
+		{
+			name:   "URL with scheme",
+			input:  "https://example.com/",
+			scheme: "http",
+
+			want: "https://example.com/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := url.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("failed to parse test URL %q: %v", tt.input, err)
+			}
+
+			got := addDefaultScheme(input, tt.scheme)
+
+			if diff := cmp.Diff(tt.want, got.String()); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMustParseInternalURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+
+		want      *url.URL
+		wantPanic bool
+	}{
+		{
+			name:  "valid URL with scheme and port",
+			input: "http://example.com:8080",
+
+			want: &url.URL{Scheme: "http", Host: "example.com:8080"},
+		},
+		{
+			name:  "valid URL without scheme",
+			input: "example.com:8080",
+			want:  &url.URL{Scheme: "http", Host: "example.com:8080"},
+		},
+		{
+			name:  "valid URL without port",
+			input: "http://example.com",
+			want:  &url.URL{Scheme: "http", Host: "example.com:80"},
+		},
+		{
+			name:  "invalid URL",
+			input: "://example.com",
+
+			wantPanic: true,
+		},
+		{
+			name:  "raw sourcegraph-frontend-internal URL",
+			input: "sourcegraph-frontend-internal",
+			want:  &url.URL{Scheme: "http", Host: "sourcegraph-frontend-internal:80"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wantPanic {
+						t.Fatalf("mustParseInternalURL() panic = %v, wantPanic = %v", r, tt.wantPanic)
+					}
+				}
+			}()
+
+			got := mustParseSourcegraphInternalURL(tt.input)
+
+			if diff := cmp.Diff(tt.want.String(), got.String()); diff != "" {
+				t.Fatalf("unexpected diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/C039KBLH65V/p1692211398788339

-- 

This PR adds more robust URL parsing for the sourcegraph-frontend-internal URL that our configuration client uses. Notably, this logic:

- Will add a "http://" scheme if one isn't already specified in the URL
- Will add a default port of 80 to the URL if one isn't already defined 

So, under this new logic, a SOURCEGRAPH_FRONTEND-INTERNAL_URL value of `sourcegraph-frontend-internal` will now be transformed into `http://sourcegraph-frontend-internal:80`.


## Test plan

CI
