### PR TITLE
Qdrant: add wolfi image

### DIFF
--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -1,0 +1,18 @@
+include: ./sourcegraph-base.yaml
+
+contents:
+  packages:
+    # Included by existing SG base image
+    - tini
+    - mailcap # TODO: is this actually needed
+
+    - qdrant@sourcegraph
+
+paths:
+  - path: /data
+    type: directory
+    uid: 100
+    gid: 101
+    permissions: 0o755
+
+workdir: /

--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -4,7 +4,6 @@ contents:
   packages:
     # Included by existing SG base image
     - tini
-    - mailcap # TODO: is this actually needed
 
     - qdrant@sourcegraph
 

--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -14,4 +14,5 @@ paths:
     gid: 101
     permissions: 0o755
 
-workdir: /
+entrypoint:
+  command: /usr/local/bin/qdrant --config-path /etc/qdrant/config.yaml

--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -15,4 +15,4 @@ paths:
     permissions: 0o755
 
 entrypoint:
-  command: /usr/local/bin/qdrant --config-path /etc/qdrant/config.yaml
+  command: /sbin/tini -- /usr/local/bin/qdrant --config-path /etc/qdrant/config.yaml


### PR DESCRIPTION
This adds a wolfi image definition for qdrant. 

## Test plan

Ran `sg wolfi image qdrant` and it built a usable image.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
