### PR TITLE
Qdrant: add wolfi package

### DIFF
--- a/wolfi-packages/qdrant.yaml
+++ b/wolfi-packages/qdrant.yaml
@@ -1,0 +1,35 @@
+package:
+  name: qdrant
+  version: 1.4.1
+  epoch: 1
+  description: "Qdrant vector database"
+  target-architecture:
+    - x86_64
+  copyright:
+    - paths:
+      - "*"
+      license: 'Apache 2.0'
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/qdrant/qdrant/releases/download/v${{package.version}}/qdrant-x86_64-unknown-linux-gnu.tar.gz
+      expected-sha256: b299a8123fbc4ee5c7cd7fb161ee7e1ee0be96a3ce40fdbcdd1610a2be64e69e
+      strip-components: 0
+  - runs: |
+      chmod +x qdrant
+      mkdir -p ${{targets.destdir}}/usr/local/bin
+      mv qdrant ${{targets.destdir}}/usr/local/bin/qdrant


### PR DESCRIPTION
This adds a wolfi package for qdrant so we can build it into a wolfi image.

## Test plan

Tested that it builds into a container correctly (will be followup PRs showing this)