### PR TITLE
fix: normalize github app base_url on read path

### DIFF
--- a/internal/github_apps/store/store.go
+++ b/internal/github_apps/store/store.go
@@ -391,6 +391,10 @@ func (s *gitHubAppsStore) list(ctx context.Context, where *sqlf.Query) ([]*ghtyp
 	return s.decrypt(ctx, apps...)
 }
 
+func baseURLWhere(baseURL string) *sqlf.Query {
+	return sqlf.Sprintf(`trim(trailing '/' from base_url) = %s`, strings.TrimRight(baseURL, "/"))
+}
+
 // GetByID retrieves a GitHub App from the database by ID.
 func (s *gitHubAppsStore) GetByID(ctx context.Context, id int) (*ghtypes.GitHubApp, error) {
 	return s.get(ctx, sqlf.Sprintf(`id = %s`, id))
@@ -398,17 +402,17 @@ func (s *gitHubAppsStore) GetByID(ctx context.Context, id int) (*ghtypes.GitHubA
 
 // GetByAppID retrieves a GitHub App from the database by appID and base url
 func (s *gitHubAppsStore) GetByAppID(ctx context.Context, appID int, baseURL string) (*ghtypes.GitHubApp, error) {
-	return s.get(ctx, sqlf.Sprintf(`app_id = %s AND base_url = %s`, appID, baseURL))
+	return s.get(ctx, sqlf.Sprintf(`app_id = %s AND %s`, appID, baseURLWhere(baseURL)))
 }
 
 // GetBySlug retrieves a GitHub App from the database by slug and base url
 func (s *gitHubAppsStore) GetBySlug(ctx context.Context, slug string, baseURL string) (*ghtypes.GitHubApp, error) {
-	return s.get(ctx, sqlf.Sprintf(`slug = %s AND base_url = %s`, slug, baseURL))
+	return s.get(ctx, sqlf.Sprintf(`slug = %s AND %s`, slug, baseURLWhere(baseURL)))
 }
 
 // GetByDomain retrieves a GitHub App from the database by domain and base url
 func (s *gitHubAppsStore) GetByDomain(ctx context.Context, domain itypes.GitHubAppDomain, baseURL string) (*ghtypes.GitHubApp, error) {
-	return s.get(ctx, sqlf.Sprintf(`domain = %s AND base_url = %s`, domain, baseURL))
+	return s.get(ctx, sqlf.Sprintf(`domain = %s AND %s`, domain, baseURLWhere(baseURL)))
 }
 
 // List lists all GitHub Apps in the store

--- a/internal/github_apps/store/store_test.go
+++ b/internal/github_apps/store/store_test.go
@@ -801,3 +801,39 @@ func TestSyncInstallations(t *testing.T) {
 		})
 	}
 }
+
+func TestTrailingSlashesInBaseURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	logger := logtest.Scoped(t)
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	ctx := context.Background()
+
+	app := &ghtypes.GitHubApp{
+		AppID:        1234,
+		Name:         "Test App 1",
+		Domain:       "repos",
+		Slug:         "test-app-1",
+		BaseURL:      "https://github.com",
+		ClientID:     "abc123",
+		ClientSecret: "secret",
+		PrivateKey:   "private-key",
+		Logo:         "logo.png",
+	}
+
+	_, err := store.Create(ctx, app)
+	require.NoError(t, err)
+
+	fetched, err := store.GetByAppID(ctx, 1234, "https://github.com")
+	require.NoError(t, err)
+	require.Equal(t, app.AppID, fetched.AppID)
+
+	fetched, err = store.GetByAppID(ctx, 1234, "https://github.com/")
+	require.NoError(t, err)
+	require.Equal(t, app.AppID, fetched.AppID)
+
+	fetched, err = store.GetByAppID(ctx, 1234, "https://github.com////")
+	require.NoError(t, err)
+	require.Equal(t, app.AppID, fetched.AppID)
+}


### PR DESCRIPTION
Previously, if github app baseURL did not contain a trailing slash but the code host did, it would not match correctly. This code fixes current and future problems by always trimming the / suffix.

fixes #55833 
- #55833 

## Test plan

tested locally + regression unit test
