### PR TITLE
chore: add cody to the data privacy disclaimer

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -172,6 +172,12 @@ const ExternalServicesPrivacyAlert: FC<ExternalServicesPrivacyAlertProps> = ({ d
             This Sourcegraph installation will never send your code, repository names, file names, or any other specific
             code data to Sourcegraph.com or any other destination. Your code is kept private on this installation.
         </Text>
+        <Text>
+            When <Link to="/help/cody/overview">Cody AI</Link> is enabled, some of your data, including code, repository
+            names, file names, and other specific code details, might be shared temporarily with our trusted LLM
+            partner. We have established a strict retention policy agreement with the LLM company, to ensure the highest
+            levels of data protection and confidentiality.
+        </Text>
         <H3>This Sourcegraph installation will access your code host by:</H3>
         <ul>
             <li>

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -175,7 +175,7 @@ const ExternalServicesPrivacyAlert: FC<ExternalServicesPrivacyAlertProps> = ({ d
         <Text>
             When <Link to="/help/cody/overview">Cody AI</Link> is enabled, some of your data, including code, repository
             names, file names, and other specific code details, might be shared temporarily with our trusted LLM
-            partner. We have established a strict retention policy agreement with the LLM company, to ensure the highest
+            partner. We have established a zero retention policy agreement with the LLM company, to ensure the highest
             levels of data protection and confidentiality.
         </Text>
         <H3>This Sourcegraph installation will access your code host by:</H3>


### PR DESCRIPTION
## Screenshot

<img width="880" alt="Screenshot 2023-08-17 at 09 45 51" src="https://github.com/sourcegraph/sourcegraph/assets/9974711/466b18ce-a0c2-4ed1-bf9a-f3620311c431">

Notice the second paragraph, that's the only change suggested.

closes #55720 
- #55720

## Test plan

Tested locally, it's just a copy change in a React component.
