### PR TITLE
JetBrains: hide autocomplete with ESC keyboard shortcut

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - New settings to enable debugging with the agent [#55821](https://github.com/sourcegraph/sourcegraph/pull/55821)
+- Added ability to hide completion suggestions with ESC key [#55955](https://github.com/sourcegraph/sourcegraph/pull/55955)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
@@ -4,12 +4,10 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.actionSystem.EditorAction;
-import com.intellij.openapi.editor.actionSystem.EditorActionHandler;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentServer;
-import com.sourcegraph.cody.autocomplete.render.CodyAutoCompleteElementRenderer;
 import com.sourcegraph.cody.vscode.InlineAutoCompleteItem;
 import com.sourcegraph.common.EditorUtils;
 import com.sourcegraph.telemetry.GraphQlLogger;
@@ -29,18 +27,7 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
     super(new AcceptCompletionActionHandler());
   }
 
-  private static class AcceptCompletionActionHandler extends EditorActionHandler {
-
-    @Override
-    protected boolean isEnabledForCaret(
-        @NotNull Editor editor, @NotNull Caret caret, DataContext dataContext) {
-      // Returns false to fall back to normal TAB character if there is no suggestion at the caret.
-      return editor.getProject() != null
-              && CodyAutoCompleteManager.isEditorInstanceSupported(editor)
-              && CodyAgent.isConnected(editor.getProject())
-          ? getAgentAutocompleteItem(caret).isPresent()
-          : AutoCompleteText.atCaret(caret).isPresent();
-    }
+  private static class AcceptCompletionActionHandler extends AutoCompleteActionHandler {
 
     /**
      * Applies the autocomplete to the document at a caret: 1. Replaces the string between the caret
@@ -81,35 +68,13 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
       if (caret == null) {
         return;
       }
-      InlineAutoCompleteItem completionItem = getAgentAutocompleteItem(caret).orElse(null);
+      InlineAutoCompleteItem completionItem = getAgentAutocompleteItem(caret);
       if (completionItem == null) {
         return;
       }
       WriteAction.run(() -> applyInsertText(editor, caret, completionItem));
     }
 
-    /**
-     * Returns the autocompletion item for the first inlay of type `CodyAutoCompleteElementRenderer`
-     * regardless if the inlay is positioned at the caret. The reason we don't require the inlay to
-     * be positioned at the caret is that completions can suggest changes in a nearby character like
-     * in this situation:
-     *
-     * <p><code>
-     *     System.out.println("a: CARET");     // original
-     *     System.out.println("a: " + a);CARET // autocomplete
-     * </code>
-     */
-    @NotNull
-    private static Optional<@NotNull InlineAutoCompleteItem> getAgentAutocompleteItem(Caret caret) {
-      return InlayModelUtils.getAllInlaysForEditor(caret.getEditor()).stream()
-          .filter(r -> r.getRenderer() instanceof CodyAutoCompleteElementRenderer)
-          .map(
-              r ->
-                  Optional.ofNullable(
-                      ((CodyAutoCompleteElementRenderer) r.getRenderer()).completionItem))
-          .flatMap(Optional::stream)
-          .findFirst();
-    }
 
     @NotNull
     private static Optional<Caret> getCaret(@NotNull Editor editor) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutoCompleteAction.java
@@ -75,7 +75,6 @@ public class AcceptCodyAutoCompleteAction extends EditorAction {
       WriteAction.run(() -> applyInsertText(editor, caret, completionItem));
     }
 
-
     @NotNull
     private static Optional<Caret> getCaret(@NotNull Editor editor) {
       List<Caret> allCarets = editor.getCaretModel().getAllCarets();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteActionHandler.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutoCompleteActionHandler.kt
@@ -1,0 +1,42 @@
+package com.sourcegraph.cody.autocomplete
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.Inlay
+import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.autocomplete.render.CodyAutoCompleteElementRenderer
+import com.sourcegraph.cody.vscode.InlineAutoCompleteItem
+
+open class AutoCompleteActionHandler : EditorActionHandler() {
+
+  override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
+    // Returns false to fall back to normal action if there is no suggestion at the caret.
+    val project = editor.project
+    return if (project != null &&
+        CodyAutoCompleteManager.isEditorInstanceSupported(editor) &&
+        CodyAgent.isConnected(project)) {
+      getAgentAutocompleteItem(caret) != null
+    } else {
+      AutoCompleteText.atCaret(caret).isPresent
+    }
+  }
+
+  /**
+   * Returns the autocompletion item for the first inlay of type `CodyAutoCompleteElementRenderer`
+   * regardless if the inlay is positioned at the caret. The reason we don't require the inlay to be
+   * positioned at the caret is that completions can suggest changes in a nearby character like in
+   * this situation:
+   *
+   * ` System.out.println("a: CARET"); // original System.out.println("a: " + a);CARET //
+   * autocomplete ` *
+   */
+  protected fun getAgentAutocompleteItem(caret: Caret): InlineAutoCompleteItem? {
+    return InlayModelUtils.getAllInlaysForEditor(caret.editor)
+        .filter { r: Inlay<*> -> r.renderer is CodyAutoCompleteElementRenderer }
+        .firstNotNullOfOrNull { r: Inlay<*> ->
+          (r.renderer as CodyAutoCompleteElementRenderer).completionItem
+        }
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutoCompleteManager.java
@@ -76,6 +76,14 @@ public class CodyAutoCompleteManager {
     cancelCurrentJob();
 
     // Clear any existing inline elements
+    disposeInlays(editor);
+  }
+
+  @RequiresEdt
+  public void disposeInlays(@NotNull Editor editor) {
+    if (editor.isDisposed()) {
+      return;
+    }
     InlayModelUtils.getAllInlaysForEditor(editor).stream()
         .filter(inlay -> inlay.getRenderer() instanceof CodyAutoCompleteElementRenderer)
         .forEach(Disposer::dispose);

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/DisposeInlaysAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/autocomplete/DisposeInlaysAction.kt
@@ -1,0 +1,19 @@
+package com.sourcegraph.cody.autocomplete
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.actionSystem.EditorAction
+import com.intellij.openapi.project.DumbAware
+
+class DisposeInlaysAction : EditorAction(DisposeInlaysActionHandler()), DumbAware {
+  init {
+    setInjectedContext(true)
+  }
+}
+
+class DisposeInlaysActionHandler : AutoCompleteActionHandler() {
+  override fun doExecute(editor: Editor, caret: Caret?, dataContext: DataContext?) {
+    CodyAutoCompleteManager.getInstance().disposeInlays(editor)
+  }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -127,6 +127,11 @@
             <override-text place="MainMenu" text="Accept Autocomplete Suggestion"/>
         </action>
 
+        <action id="cody.disposeInlays" class="com.sourcegraph.cody.autocomplete.DisposeInlaysAction">
+            <keyboard-shortcut first-keystroke="ESCAPE" keymap="$default"/>
+            <override-text place="MainMenu" text="Hide Completions"/>
+        </action>
+
         <action id="cody.resetCurrentConversation" icon="AllIcons.Actions.Refresh"
                 text="Reset the Current Conversation with Cody"
                 class="com.sourcegraph.cody.chat.ResetCurrentConversationAction">


### PR DESCRIPTION
Closes [#55918](https://github.com/sourcegraph/sourcegraph/issues/55918)

Previously, pressing `Escape` had no effect when Cody autocomplete suggestions were visible. This PR fixes the issue by adding a new `Escape` keyboard shortcut to reject the completion. 


Note that the completion will appear again if the user moves the cursor around and back into the original position. We can consider changing the behavior in the future to never display autocomplete again in that position unless explicitly requested again, but we should rely on user feedback before making such a decision.


## Test plan
- Display inlay autocomplete suggestion and press ESC to hide the inlay

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
