### PR TITLE
Autocomplete: Add option to stream code completion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Adds an option to stream code completion results. [#55967](https://github.com/sourcegraph/sourcegraph/pull/55967)
+
 ### Changed
 
 - OpenTelemetry Collector has been upgraded to v0.81, and OpenTelemetry packages have been upgraded to v1.16. [#54969](https://github.com/sourcegraph/sourcegraph/pull/54969), [#54999](https://github.com/sourcegraph/sourcegraph/pull/54999)

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -24,32 +25,74 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
 		// TODO(eseliger): Look into reviving this, but it was unused so far.
 		return c.CompletionModel
 	}, func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter) {
-		completion, err := cc.Complete(ctx, types.CompletionsFeatureCode, requestParams)
-		if err != nil {
-			logFields := []log.Field{log.Error(err)}
-
-			// Propagate the upstream headers to the client if available.
-			if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
-				errNotOK.WriteHeader(w)
-				if tc := errNotOK.SourceTraceContext; tc != nil {
-					logFields = append(logFields,
-						log.String("sourceTraceContext.traceID", tc.TraceID),
-						log.String("sourceTraceContext.spanID", tc.SpanID))
-				}
-			} else {
-				w.WriteHeader(http.StatusInternalServerError)
+		if requestParams.Stream {
+			eventWriter, err := streamhttp.NewWriter(w)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
 			}
-			_, _ = w.Write([]byte(err.Error()))
 
-			trace.Logger(ctx, logger).Error("error on completion", logFields...)
-			return
-		}
+			// Always send a final done event so clients know the stream is shutting down.
+			defer func() {
+				_ = eventWriter.Event("done", map[string]any{})
+			}()
 
-		completionBytes, err := json.Marshal(completion)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			err = cc.Stream(ctx, types.CompletionsFeatureCode, requestParams,
+				func(event types.CompletionResponse) error {
+					return eventWriter.Event("completion", event)
+				})
+			if err != nil {
+				l := trace.Logger(ctx, logger)
+
+				logFields := []log.Field{log.Error(err)}
+				if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
+					if tc := errNotOK.SourceTraceContext; tc != nil {
+						logFields = append(logFields,
+							log.String("sourceTraceContext.traceID", tc.TraceID),
+							log.String("sourceTraceContext.spanID", tc.SpanID))
+					}
+				}
+				l.Error("error while streaming completions", logFields...)
+
+				// Note that we do NOT attempt to forward the status code to the
+				// client here, since we are using streamhttp.Writer - see
+				// streamhttp.NewWriter for more details. Instead, we send an error
+				// event, which clients should check as appropriate.
+				if err := eventWriter.Event("error", map[string]string{"error": err.Error()}); err != nil {
+					l.Error("error reporting streaming completion error", log.Error(err))
+				}
+				return
+
+			}
+		} else {
+			completion, err := cc.Complete(ctx, types.CompletionsFeatureCode, requestParams)
+			if err != nil {
+				logFields := []log.Field{log.Error(err)}
+
+				// Propagate the upstream headers to the client if available.
+				if errNotOK, ok := types.IsErrStatusNotOK(err); ok {
+					errNotOK.WriteHeader(w)
+					if tc := errNotOK.SourceTraceContext; tc != nil {
+						logFields = append(logFields,
+							log.String("sourceTraceContext.traceID", tc.TraceID),
+							log.String("sourceTraceContext.spanID", tc.SpanID))
+					}
+				} else {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+				_, _ = w.Write([]byte(err.Error()))
+
+				trace.Logger(ctx, logger).Error("error on completion", logFields...)
+				return
+			}
+
+			completionBytes, err := json.Marshal(completion)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(completionBytes)
 		}
-		_, _ = w.Write(completionBytes)
 	})
+
 }

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const HUMAN_MESSAGE_SPEAKER = "human"
@@ -58,6 +59,7 @@ type CompletionRequestParameters struct {
 	TopK              int       `json:"topK,omitempty"`
 	TopP              float32   `json:"topP,omitempty"`
 	Model             string    `json:"model,omitempty"`
+	Stream            bool      `json:"stream,omitempty"`
 }
 
 func (p *CompletionRequestParameters) Attrs() []attribute.KeyValue {


### PR DESCRIPTION
This adds a new boolean `stream` to the code completion handler. When set, the resulting response will be an SSE stream instead of requiring us to buffer the response.

This goes hand-in-hand with these client changes: https://github.com/sourcegraph/cody/pull/723 however, both PRs can be implemented in parallel and are backward compatible. If a client sends the stream flag but a regular HTTP response (as detected by the response header) is encountered, it'll fall back to the old JSON warning. If a server gets a response with `stream: true` that does not have this change, it will response with the previous format.

Note: There's a lot of repetition here. If someone could help me with more idiomatic Go patters for this fork I'd highly appreciate it 😬 

## Test plan

Tested in combination with https://github.com/sourcegraph/cody/pull/723

 - Run [sourcegraph/sourcegraph#55967](https://github.com/sourcegraph/sourcegraph/pull/55967) as a local SG server
 - Set up Cody VS Code to connect to localhost
 - Check out https://github.com/sourcegraph/cody/pull/723
 - Start a dev instance and see that completions will work and might be faster
   - I've tested this with our completion testing tool but since we only have a handful of examples and don't do a bazillion test runs, there's a log of variance in the early results. 
   - We can roll this out as an A/B test very easily (cc @taras-yemets)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
