### PR TITLE
Fix empty package names

### DIFF
--- a/client/shared/src/components/RepoLink.test.tsx
+++ b/client/shared/src/components/RepoLink.test.tsx
@@ -22,6 +22,7 @@ describe('displayRepoName', () => {
         { originalRepoName: 'sourcegraph', repoDisplayName: 'sourcegraph' },
         { originalRepoName: 'sourcegraph/sourcegraph', repoDisplayName: 'sourcegraph/sourcegraph' },
         { originalRepoName: 'sg.exe/sourcegraph', repoDisplayName: 'sourcegraph' },
+        { originalRepoName: 'org.scala-sbt:collections_2.12', repoDisplayName: 'org.scala-sbt:collections_2.12' },
     ]
 
     for (const { originalRepoName, repoDisplayName } of testCases) {

--- a/client/shared/src/components/RepoLink.tsx
+++ b/client/shared/src/components/RepoLink.tsx
@@ -7,7 +7,7 @@ import { LinkOrSpan } from '@sourcegraph/wildcard'
  */
 export function displayRepoName(repoName: string): string {
     let parts = repoName.split('/')
-    if (parts.length > 0 && parts[0].includes('.')) {
+    if (parts.length > 1 && parts[0].includes('.')) {
         parts = parts.slice(1) // remove hostname from repo name (reduce visual noise)
     }
     return parts.join('/')


### PR DESCRIPTION
In the packages list view, we use the repolink component with the package name, which can be something like `org.scala-sbt:collections_2.12`. The current logic returned an empty string, so to be safe, we're not only stripping hostnames when the remainder of the name is more than length 0.

<img width="933" alt="Screenshot 2023-08-17 at 18 27 49@2x" src="https://github.com/sourcegraph/sourcegraph/assets/19534377/1656b89e-a6e8-4a66-b2b3-c1f0355330d3">


## Test plan

Added a test case!