### PR TITLE
Remove ellipses after docker command

### DIFF
--- a/dev/sg/internal/wolfi/base-image.go
+++ b/dev/sg/internal/wolfi/base-image.go
@@ -102,7 +102,7 @@ func (c PackageRepoConfig) LoadBaseImage(name string) error {
 	}
 
 	std.Out.Write("")
-	std.Out.WriteLine(output.Linef("🛠️ ", output.StyleBold, "Run base image locally using:\n\n\tdocker run -it --entrypoint /bin/sh %s...\n", dockerImageName(name)))
+	std.Out.WriteLine(output.Linef("🛠️ ", output.StyleBold, "Run base image locally using:\n\n\tdocker run -it --entrypoint /bin/sh %s\n", dockerImageName(name)))
 
 	return nil
 }


### PR DESCRIPTION
to make copy/pasting command easier



## Test plan

after `sg wolfi image server`, see that the suggested command to run the image does not end with ellipses.