### PR TITLE
Qdrant: add docker image

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -194,3 +194,9 @@ def oci_deps():
         digest = "sha256:42ff3ba38633022bfb2d7982e2ad671670b160fdaa04b453368f2098aaf9bf86",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
+
+    oci_pull(
+        name = "wolfi_qdrant_base",
+        digest = "sha256:7f81b52aa6accda3ccfd8d8ec79892de03b8935c7fb0e786a445de0bf1824a93",
+        image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
+    )

--- a/docker-images/qdrant/BUILD.bazel
+++ b/docker-images/qdrant/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("//dev:oci_defs.bzl", "image_repository")
+
+oci_image(
+    name = "qdrant_image",
+    base = "@wolfi_qdrant_base",
+    entrypoint = [
+        "/sbin/tini",
+        "--",
+        "/usr/local/bin/qdrant",
+        "--config-path=/etc/qdrant/config.yaml",
+    ],
+    env = {},
+    user = "sourcegraph",
+)
+
+container_structure_test(
+    name = "qdrant_image_test",
+    timeout = "short",
+    configs = ["qdrant_image_test.yaml"],
+    driver = "docker",
+    image = ":qdrant_image",
+    tags = [
+        "exclusive",
+        "requires-network",
+    ],
+)
+
+oci_tarball(
+    name = "qdrant_image_tarball",
+    image = ":qdrant_image",
+    repo_tags = ["qdrant:candidate"],
+)
+
+oci_push(
+    name = "qdrant_candidate_push",
+    image = ":qdrant_image",
+    repository = image_repository("qdrant"),
+)

--- a/docker-images/qdrant/qdrant_image_test.yaml
+++ b/docker-images/qdrant/qdrant_image_test.yaml
@@ -1,0 +1,20 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+  - name: "qdrant is runnable"
+    command: "/usr/local/bin/qdrant"
+    args:
+      - --version
+
+fileExistenceTests:
+- name: 'Test for qdrant'
+  path: '/usr/local/bin/qdrant'
+  shouldExist: true
+  uid: 0
+  gid: 0


### PR DESCRIPTION
This creates a docker image from the wolfi base image and adds it to `docker-images`. 

## Test plan

Building the image passes and basic image tests pass.
