### PR TITLE
[workflow]: automatically add preview link to pull request descriptio…

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,21 @@
+name: "Update Pull Request"
+on:
+  pull_request:
+    paths: ['doc/**']
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tzkhan/pr-update-action@v2
+        with:
+          base-branch-regex: '[a-z\d-_.\\/]+'
+          head-branch-regex: '[a-z\d-_.\\/]+'
+          body-template: |
+            Merging into '%basebranch%'
+            [Preview Link](https://docs.sourcegraph.com/@%headbranch%)
+          body-update-action: "suffix"
+          body-uppercase-base-match: false
+          body-uppercase-head-match: false
+          lowercase-branch: true
+          repo-token: "${{ secrets.GH_PROJECTS_ACTION_TOKEN }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,7 @@
 name: "Update Pull Request"
 on:
   pull_request:
+    types: [opened, reopened]
     paths: ['doc/**']
 
 jobs:


### PR DESCRIPTION
This PR adds a workflow to automatically add preview link to pull request description



## Test plan
I am testing it with this one
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
