### PR TITLE
JetBrains: add options to accept non-trusted certificates

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -239,10 +239,11 @@ public class CodyAgent implements Disposable {
   private void startListeningToAgent() throws IOException, CodyAgentException {
     File binary = agentBinary();
     logger.info("starting Cody agent " + binary.getAbsolutePath());
-    this.process =
-        new ProcessBuilder(binary.getAbsolutePath())
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-            .start();
+    ProcessBuilder processBuilder = new ProcessBuilder(binary.getAbsolutePath());
+    if (Boolean.getBoolean("cody.accept-non-trusted-certificates-automatically")) {
+      processBuilder.environment().put("NODE_TLS_REJECT_UNAUTHORIZED", "0");
+    }
+    this.process = processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT).start();
     Launcher<CodyAgentServer> launcher =
         new Launcher.Builder<CodyAgentServer>()
             // emit `null` instead of leaving fields undefined because Cody in VSC has


### PR DESCRIPTION

Previously, there was no clean way to ensure that the agent process would accept non-trusted certificates. This PR addresses the issue by setting the environment variable `NODE_TLS_REJECT_UNAUTHORIZED=0` based on the presence of the system property `-Dcody.accept-non-trusted-certificates-automatically=true`.

Ideally, we would infer the correct value of this property based on the "Server Certificates" settings in IntelliJ. Using a system property is a quick solution that solves our immediate problem.

## Test plan

n/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
