### PR TITLE
gitserver: remove `repoUpdateLocks` and make any repo clone and fetch (update) request go through the DB worker.

### DIFF
--- a/cmd/gitserver/server/clone.go
+++ b/cmd/gitserver/server/clone.go
@@ -43,8 +43,21 @@ func (s *Server) maybeStartClone(ctx context.Context, logger log.Logger, repoNam
 	}, false
 }
 
+// ScheduleRepoClone is used to schedule a high-priority repo clone job which
+// will be processed by the RepoUpdateWorker.
 func ScheduleRepoClone(ctx context.Context, db database.DB, repoName api.RepoName, cloneOpts CloneOptions) error {
 	opts := database.CreateRepoUpdateJobOpts{RepoName: repoName, Clone: true, Priority: cloneOpts.Priority, OverwriteClone: cloneOpts.Overwrite}
+	_, _, err := db.RepoUpdateJobs().Create(ctx, opts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ScheduleRepoUpdate is used to schedule a high-priority repo update/fetch job
+// which will be processed by the RepoUpdateWorker.
+func ScheduleRepoUpdate(ctx context.Context, db database.DB, repoName api.RepoName, revision string) error {
+	opts := database.CreateRepoUpdateJobOpts{RepoName: repoName, Clone: false, Priority: types.HighPriorityRepoUpdate, FetchRevision: revision}
 	_, _, err := db.RepoUpdateJobs().Create(ctx, opts)
 	if err != nil {
 		return err

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -1149,10 +1149,10 @@ func TestHandleRepoUpdate(t *testing.T) {
 	}
 
 	// Now we'll call again and with an update that fails
-	doBackgroundRepoUpdateMock = func(name api.RepoName) error {
+	doScheduledRepoUpdateMock = func(name api.RepoName) error {
 		return errors.New("fail")
 	}
-	t.Cleanup(func() { doBackgroundRepoUpdateMock = nil })
+	t.Cleanup(func() { doScheduledRepoUpdateMock = nil })
 
 	// This will trigger an update since the repo is already cloned
 	_, _ = s.HandleRepoUpdateRequest(ctx, updatePayload, logger)
@@ -1175,7 +1175,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 	}
 
 	// Now we'll call again and with an update that succeeds
-	doBackgroundRepoUpdateMock = nil
+	doScheduledRepoUpdateMock = nil
 
 	// This will trigger an update since the repo is already cloned
 	_, _ = s.HandleRepoUpdateRequest(ctx, updatePayload, logger)

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -86,7 +86,7 @@ var repoLastFetched = func(dir common.GitDir) (time.Time, error) {
 //
 // This breaks on file systems that do not record mtime. This is a Sourcegraph
 // extension to track last time a repo changed. The file is updated by
-// setLastChanged via doBackgroundRepoUpdate.
+// setLastChanged via doScheduledRepoUpdate.
 //
 // As a special case, tries both the directory given, and the .git subdirectory,
 // because we're a bit inconsistent about which name to use.

--- a/internal/database/repo_update_jobs.go
+++ b/internal/database/repo_update_jobs.go
@@ -54,11 +54,12 @@ type CreateRepoUpdateJobOpts struct {
 	ProcessAfter   time.Time
 	Clone          bool
 	OverwriteClone bool
+	FetchRevision  string
 }
 
 const createRepoUpdateJobQueryFmtstr = `
-INSERT INTO repo_update_jobs(repo_id, priority, process_after, clone, overwrite_clone)
-SELECT r.id, %s, %s, %s, %s
+INSERT INTO repo_update_jobs(repo_id, priority, process_after, clone, overwrite_clone, fetch_revision)
+SELECT r.id, %s, %s, %s, %s, %s
 FROM repo r
 WHERE r.name = %s
 ON CONFLICT DO NOTHING
@@ -76,6 +77,7 @@ func createRepoUpdateJobQuery(opts CreateRepoUpdateJobOpts) *sqlf.Query {
 		dbutil.NullTimeColumn(opts.ProcessAfter),
 		opts.Clone,
 		opts.OverwriteClone,
+		opts.FetchRevision,
 		opts.RepoName,
 		sqlf.Join(RepoUpdateJobColumns, ", "))
 }
@@ -186,6 +188,7 @@ var RepoUpdateJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("repo_update_jobs.priority"),
 	sqlf.Sprintf("repo_update_jobs.clone"),
 	sqlf.Sprintf("repo_update_jobs.overwrite_clone"),
+	sqlf.Sprintf("repo_update_jobs.fetch_revision"),
 	sqlf.Sprintf("repo_update_jobs.last_fetched"),
 	sqlf.Sprintf("repo_update_jobs.last_changed"),
 	sqlf.Sprintf("repo_update_jobs.update_interval_seconds"),
@@ -220,6 +223,7 @@ func ScanRepoUpdateJob(s dbutil.Scanner) (job types.RepoUpdateJob, _ error) {
 		&job.Priority,
 		&job.Clone,
 		&job.OverwriteClone,
+		&job.FetchRevision,
 		&dbutil.NullTime{Time: &job.LastFetched},
 		&dbutil.NullTime{Time: &job.LastChanged},
 		&dbutil.NullInt{N: &job.UpdateIntervalSeconds},
@@ -250,6 +254,7 @@ func ScanFullRepoUpdateJob(s dbutil.Scanner) (job types.RepoUpdateJob, _ error) 
 		&job.Priority,
 		&job.Clone,
 		&job.OverwriteClone,
+		&job.FetchRevision,
 		&dbutil.NullTime{Time: &job.LastFetched},
 		&dbutil.NullTime{Time: &job.LastChanged},
 		&dbutil.NullInt{N: &job.UpdateIntervalSeconds},

--- a/internal/database/repo_update_jobs_test.go
+++ b/internal/database/repo_update_jobs_test.go
@@ -38,13 +38,13 @@ func TestRepoUpdateJobs_Create(t *testing.T) {
 	require.NoError(t, err)
 
 	// Queued job should be successfully created.
-	createdJob, ok, err := store.Create(ctx, CreateRepoUpdateJobOpts{RepoName: "repo1", Priority: types.HighPriorityRepoUpdate, OverwriteClone: true})
+	createdJob, ok, err := store.Create(ctx, CreateRepoUpdateJobOpts{RepoName: "repo1", Priority: types.HighPriorityRepoUpdate, FetchRevision: "HEAD"})
 	require.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, 1, createdJob.ID)
 	assert.Equal(t, types.HighPriorityRepoUpdate, createdJob.Priority)
 	assert.Equal(t, "queued", createdJob.State)
-	assert.True(t, createdJob.OverwriteClone)
+	assert.Equal(t, "HEAD", createdJob.FetchRevision)
 
 	listAndAssert := func(wantJob types.RepoUpdateJob, listOpts ListRepoUpdateJobOpts) {
 		repoUpdateJobs, err = store.List(ctx, listOpts)

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -24272,6 +24272,19 @@
           "Comment": ""
         },
         {
+          "Name": "fetch_revision",
+          "Index": 18,
+          "TypeName": "text",
+          "IsNullable": true,
+          "Default": "''::text",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "finished_at",
           "Index": 6,
           "TypeName": "timestamp with time zone",
@@ -24299,7 +24312,7 @@
         },
         {
           "Name": "last_changed",
-          "Index": 19,
+          "Index": 20,
           "TypeName": "timestamp with time zone",
           "IsNullable": true,
           "Default": "",
@@ -24312,7 +24325,7 @@
         },
         {
           "Name": "last_fetched",
-          "Index": 18,
+          "Index": 19,
           "TypeName": "timestamp with time zone",
           "IsNullable": true,
           "Default": "",
@@ -24455,7 +24468,7 @@
         },
         {
           "Name": "update_interval_seconds",
-          "Index": 20,
+          "Index": 21,
           "TypeName": "integer",
           "IsNullable": true,
           "Default": "",
@@ -28923,7 +28936,7 @@
     },
     {
       "Name": "repo_update_jobs_with_repo_name",
-      "Definition": " SELECT j.id,\n    j.state,\n    j.failure_message,\n    j.queued_at,\n    j.started_at,\n    j.finished_at,\n    j.process_after,\n    j.num_resets,\n    j.num_failures,\n    j.last_heartbeat_at,\n    j.execution_logs,\n    j.worker_hostname,\n    j.cancel,\n    j.repo_id,\n    j.priority,\n    j.clone,\n    j.overwrite_clone,\n    j.last_fetched,\n    j.last_changed,\n    j.update_interval_seconds,\n    r.name AS repository_name,\n    g.pool_repo_id\n   FROM ((repo_update_jobs j\n     JOIN gitserver_repos g ON ((g.repo_id = j.repo_id)))\n     JOIN repo r ON ((r.id = COALESCE(g.pool_repo_id, j.repo_id))))\n  WHERE (r.deleted_at IS NULL);"
+      "Definition": " SELECT j.id,\n    j.state,\n    j.failure_message,\n    j.queued_at,\n    j.started_at,\n    j.finished_at,\n    j.process_after,\n    j.num_resets,\n    j.num_failures,\n    j.last_heartbeat_at,\n    j.execution_logs,\n    j.worker_hostname,\n    j.cancel,\n    j.repo_id,\n    j.priority,\n    j.clone,\n    j.overwrite_clone,\n    j.fetch_revision,\n    j.last_fetched,\n    j.last_changed,\n    j.update_interval_seconds,\n    r.name AS repository_name,\n    g.pool_repo_id\n   FROM ((repo_update_jobs j\n     JOIN gitserver_repos g ON ((g.repo_id = j.repo_id)))\n     JOIN repo r ON ((r.id = COALESCE(g.pool_repo_id, j.repo_id))))\n  WHERE (r.deleted_at IS NULL);"
     },
     {
       "Name": "site_config",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3708,6 +3708,7 @@ Indexes:
  priority                | integer                  |           | not null | 0
  clone                   | boolean                  |           | not null | false
  overwrite_clone         | boolean                  |           | not null | false
+ fetch_revision          | text                     |           |          | ''::text
  last_fetched            | timestamp with time zone |           |          | 
  last_changed            | timestamp with time zone |           |          | 
  update_interval_seconds | integer                  |           |          | 
@@ -4905,6 +4906,7 @@ Foreign-key constraints:
     j.priority,
     j.clone,
     j.overwrite_clone,
+    j.fetch_revision,
     j.last_fetched,
     j.last_changed,
     j.update_interval_seconds,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2153,6 +2153,7 @@ type RepoUpdateJob struct {
 	Priority              RepoUpdateJobPriority
 	Clone                 bool
 	OverwriteClone        bool
+	FetchRevision         string
 }
 
 func (r RepoUpdateJob) RecordID() int {

--- a/migrations/frontend/1691420270_add_table_for_repo_clone_worker/up.sql
+++ b/migrations/frontend/1691420270_add_table_for_repo_clone_worker/up.sql
@@ -17,9 +17,11 @@ CREATE TABLE IF NOT EXISTS repo_update_jobs
     repo_id                 INTEGER NOT NULL REFERENCES repo (id) ON DELETE CASCADE,
     priority                INTEGER NOT NULL         DEFAULT 0,
     -- True if this is a clone job and we know it in advance. (Use case: reclone of an already cloned repo).
-    clone BOOLEAN NOT NULL DEFAULT FALSE,
+    clone                   BOOLEAN NOT NULL         DEFAULT FALSE,
     -- True if an existing clone should be overwritten.
     overwrite_clone         BOOLEAN NOT NULL         DEFAULT FALSE,
+    -- If provided, then the fetch (repo update) will be performed for a given revision.
+    fetch_revision          TEXT                     DEFAULT '',
     -- Populated after the job is processed.
     last_fetched            TIMESTAMP WITH TIME ZONE,
     -- Populated after the job is processed.
@@ -56,6 +58,7 @@ SELECT j.id,
        j.priority,
        j.clone,
        j.overwrite_clone,
+       j.fetch_revision,
        j.last_fetched,
        j.last_changed,
        j.update_interval_seconds,

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4466,6 +4466,7 @@ CREATE TABLE repo_update_jobs (
     priority integer DEFAULT 0 NOT NULL,
     clone boolean DEFAULT false NOT NULL,
     overwrite_clone boolean DEFAULT false NOT NULL,
+    fetch_revision text DEFAULT ''::text,
     last_fetched timestamp with time zone,
     last_changed timestamp with time zone,
     update_interval_seconds integer
@@ -4499,6 +4500,7 @@ CREATE VIEW repo_update_jobs_with_repo_name AS
     j.priority,
     j.clone,
     j.overwrite_clone,
+    j.fetch_revision,
     j.last_fetched,
     j.last_changed,
     j.update_interval_seconds,


### PR DESCRIPTION
Draft until https://github.com/sourcegraph/sourcegraph/pull/56005 is merged.

This commit moves the last synchronous repo fetches to the DB worker queue making them asynchronous. However, such "on-demand" fetches are scheduled with a high priority which means that they will be processed as soon as possible. Priority acts as a first ordering argument for repo update jobs dequeueing.

Test plan:
Not much from unit tests updating. They should work. Local sg run and tests that repos are getting cloned and updated.

Depends on https://github.com/sourcegraph/sourcegraph/pull/55936.