### PR TITLE
Deprecate unused perforce setting

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -199,7 +199,8 @@
           "description": "Allow adding Perforce code host connections",
           "type": "string",
           "enum": ["enabled", "disabled"],
-          "default": "enabled"
+          "default": "enabled",
+          "deprecationMessage": "Deprecated, Perforce is always enabled, setting is no longer used."
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",


### PR DESCRIPTION
Removed setting because its unused, Perforce is always enabled.

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/20795805/ff538a4c-eae1-4286-ba93-6f7b5398f7ec)

