### PR TITLE
[Backport] Redact command before logging  during create-commit-from-patch (#54811)

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -143,12 +143,14 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 		}
 
 		t := time.Now()
+
 		// runRemoteGitCommand since one of our commands could be git push
 		out, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, nil)
+		redactor := newURLRedactor(remoteURL)
 
 		logger := logger.With(
 			log.String("prefix", prefix),
-			log.String("command", argsToString(cmd.Args)),
+			log.String("command", redactor.redact(argsToString(cmd.Args))),
 			log.Duration("duration", time.Since(t)),
 			log.String("output", string(out)),
 		)


### PR DESCRIPTION
[Slack thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1689124650296469)

## Test plan
Backport, manual test
