### PR TITLE
Remove redundant url redactor

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -153,7 +153,6 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 		// runRemoteGitCommand since one of our commands could be git push
 		out, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.Wrap(ctx, s.Logger, cmd), true, nil)
-		redactor := newURLRedactor(remoteURL)
 		logger := logger.With(
 			log.String("prefix", prefix),
 			log.String("command", redactor.redact(argsToString(cmd.Args))),


### PR DESCRIPTION
There was already a url redactor declared higher up.

## Test plan
N/A