### PR TITLE
nix: add ln to ctags without version

### DIFF
--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -64,7 +64,7 @@ unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
 
   # we create two symbolic links
   # 1. ctags-$version: Used bazel in dev/tool_deps.bzl. With the version it allows us to pin the ctags version bazel uses
-  # 2. ctags: gets referenced by shell.nix and there is no version to ensure we always point to the lattest.
+  # 2. ctags: gets referenced by shell.nix and there is no version to ensure we always point to the latest.
   postFixup = ''
     ln -s $out/bin/ctags $out/bin/universal-ctags-$version
     ln -s $out/bin/ctags $out/bin/universal-ctags

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -62,8 +62,9 @@ unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
     patchShebangs misc/*
   '';
 
-  # extra ln to ctags without the version since it is referenced in shell.nix, and
-  # allows us to always point to the latest
+  # we create two symbolic links
+  # 1. ctags-$version: Used bazel in dev/tool_deps.bzl. With the version it allows us to pin the ctags version bazel uses
+  # 2. ctags: gets referenced by shell.nix and there is no version to ensure we always point to the lattest.
   postFixup = ''
     ln -s $out/bin/ctags $out/bin/universal-ctags-$version
     ln -s $out/bin/ctags $out/bin/universal-ctags

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -62,8 +62,11 @@ unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
     patchShebangs misc/*
   '';
 
+  # extra ln to ctags without the version since it is referenced in shell.nix, and
+  # allows us to always point to the latest
   postFixup = ''
     ln -s $out/bin/ctags $out/bin/universal-ctags-$version
+    ln -s $out/bin/ctags $out/bin/universal-ctags
   '';
 
   doCheck = true;


### PR DESCRIPTION
add missing `ln` for `ctags` without version since it is referenced in shell.nix
## Test plan
tested locally
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
