### PR TITLE
internal/event_logger: Telemetry Gateway refactor

### DIFF
--- a/internal/eventlogger/BUILD.bazel
+++ b/internal/eventlogger/BUILD.bazel
@@ -2,7 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "eventlogger",
-    srcs = ["event_logger.go"],
+    srcs = [
+        "event_handler.go",
+        "event_logger.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/eventlogger",
     visibility = ["//:__subpackages__"],
+    deps = [
+        "//cmd/frontend/envvar",
+        "//internal/conf",
+        "//internal/conf/deploy",
+        "//internal/database",
+        "//internal/env",
+        "//internal/featureflag",
+        "//internal/pubsub",
+        "//internal/siteid",
+        "//internal/version",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_inconshreveable_log15//:log15",
+    ],
 )

--- a/internal/eventlogger/event_handler.go
+++ b/internal/eventlogger/event_handler.go
@@ -1,4 +1,4 @@
-package usagestats
+package eventlogger
 
 import (
 	"context"

--- a/internal/pubsub/topic.go
+++ b/internal/pubsub/topic.go
@@ -1,6 +1,8 @@
 // Package pubsub is a lightweight wrapper of the GCP Pub/Sub functionality.
 package pubsub
 
+// TODO: make a similar package to the GCP pubsub package but abstract away the GCP dependency
+
 import (
 	"context"
 


### PR DESCRIPTION
This PR is the refactor of the event_logger code focused on logging constructs internal to Sourcegraph (web, app, backend, extensions). It adds a bookmark for egressing event_log data, a worker to batch events to send to the Telemetry Gateway service, and logic to retry and verify transmission.

## Test plan

Run `sg start`
Verify that events log to `event_logs`
Verify that events log to BigQuery