### PR TITLE
cody web: fix first interaction transcript

### DIFF
--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -311,8 +311,9 @@ export const useCodyChat = ({
     )
 
     const initializeNewChat = useCallback((): Transcript | null => {
-        const isNewChat = !transcript?.getLastInteraction()
-        if (isNewChat) {
+        // If we already have a transcript, but it hasn't been interacted with yet, don't
+        // create a new one.
+        if (transcript && !transcript.getLastInteraction()) {
             return null
         }
 


### PR DESCRIPTION
Fixes the bug [reported in Slack](https://sourcegraph.slack.com/archives/C054KJEF8DQ/p1692205566031499) where a first-time user of Cody is unable to interact with Chat at all.

The issue was that the enhancement from https://github.com/sourcegraph/sourcegraph/pull/55556 actually also prevented the very first transcript from being properly initialized. This is why the transcript history appears completely empty, rather than with one new chat. The bigger problem, though, is that with a `null` transcript, `CodyClient` interactions like `submitMessage` and `executeRecipe` would [return early](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/chat/useClient.ts?L258-260), leading to the affect that Cody is just non-responsive.

This PR updates `initializeNewChat` to only return early if a _transcript already exists_ and it has not been interacted with.

## Test plan

- Log in and clear all of Cody chat from local storage, or log in as a user who has never used Cody chat before
- Visit Cody chat page
- Verify transcript history shows one new conversation
- Verify Cody responds when you submit a message
