### PR TITLE
[fix] GHE and GitLab code host types not showing settings

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useState, useCallback, useMemo } from 'react'
+import React, { type FC, useEffect, useState, useCallback, useMemo, ReactElement } from 'react'
 
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -101,7 +101,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
         navigate(`/site-admin/external-services/${encodeURIComponent(externalService.id)}`, { replace: true })
     }
 
-    const renderService = (externalService: ExternalServiceFieldsWithConfig) => {
+    const renderService = (externalService: ExternalServiceFieldsWithConfig): ReactElement => {
         const externalServiceCategory = resolveExternalServiceCategory(externalService, ghApp)
         return (
             <Container className="mb-3">

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -94,13 +94,59 @@ export const ExternalServiceEditPage: FC<Props> = ({
 
     const path = useMemo(() => getBreadCrumbs(externalService, true), [externalService])
 
-    const externalServiceCategory = resolveExternalServiceCategory(externalService, ghApp)
-
     const combinedError = fetchError || updateExternalServiceError || fetchGHAppError
     const combinedLoading = fetchLoading || updateExternalServiceLoading || fetchGHAppLoading
 
     if (updated && !combinedLoading && externalService?.warning === null) {
         navigate(`/site-admin/external-services/${encodeURIComponent(externalService.id)}`, { replace: true })
+    }
+
+    const renderService = (externalService: ExternalServiceFieldsWithConfig) => {
+        const externalServiceCategory = resolveExternalServiceCategory(externalService, ghApp)
+        return (
+            <Container className="mb-3">
+                <PageHeader
+                    path={path}
+                    byline={
+                        <CreatedByAndUpdatedByInfoByline
+                            createdAt={externalService.createdAt}
+                            updatedAt={externalService.updatedAt}
+                            noAuthor={true}
+                        />
+                    }
+                    className="mb-3"
+                    headingElement="h2"
+                    actions={
+                        <ButtonLink
+                            to={`/site-admin/external-services/${encodeURIComponent(externalService.id)}`}
+                            variant="secondary"
+                        >
+                            Cancel
+                        </ButtonLink>
+                    }
+                />
+                {externalServiceCategory && (
+                    <ExternalServiceForm
+                        input={{ ...externalService }}
+                        externalServiceID={externalServiceID}
+                        editorActions={externalServiceCategory.editorActions}
+                        jsonSchema={externalServiceCategory.jsonSchema}
+                        error={updateExternalServiceError}
+                        warning={externalService.warning}
+                        mode="edit"
+                        loading={combinedLoading}
+                        onSubmit={onSubmit}
+                        onChange={onChange}
+                        telemetryService={telemetryService}
+                        autoFocus={autoFocusForm}
+                        externalServicesFromFile={externalServicesFromFile}
+                        allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
+                        additionalFormComponent={externalServiceCategory.additionalFormComponent}
+                    />
+                )}
+                <ExternalServiceWebhook externalService={externalService} className="mt-3" />
+            </Container>
+        )
     }
 
     return (
@@ -111,50 +157,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
                 <PageTitle title="Code host" />
             )}
             {combinedError !== undefined && !combinedLoading && <ErrorAlert className="mb-3" error={combinedError} />}
-            {externalService && (
-                <Container className="mb-3">
-                    <PageHeader
-                        path={path}
-                        byline={
-                            <CreatedByAndUpdatedByInfoByline
-                                createdAt={externalService.createdAt}
-                                updatedAt={externalService.updatedAt}
-                                noAuthor={true}
-                            />
-                        }
-                        className="mb-3"
-                        headingElement="h2"
-                        actions={
-                            <ButtonLink
-                                to={`/site-admin/external-services/${encodeURIComponent(externalService.id)}`}
-                                variant="secondary"
-                            >
-                                Cancel
-                            </ButtonLink>
-                        }
-                    />
-                    {externalServiceCategory && (
-                        <ExternalServiceForm
-                            input={{ ...externalService }}
-                            externalServiceID={externalServiceID}
-                            editorActions={externalServiceCategory.editorActions}
-                            jsonSchema={externalServiceCategory.jsonSchema}
-                            error={updateExternalServiceError}
-                            warning={externalService.warning}
-                            mode="edit"
-                            loading={combinedLoading}
-                            onSubmit={onSubmit}
-                            onChange={onChange}
-                            telemetryService={telemetryService}
-                            autoFocus={autoFocusForm}
-                            externalServicesFromFile={externalServicesFromFile}
-                            allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
-                            additionalFormComponent={externalServiceCategory.additionalFormComponent}
-                        />
-                    )}
-                    <ExternalServiceWebhook externalService={externalService} className="mt-3" />
-                </Container>
-            )}
+            {externalService && renderService(externalService)}
         </div>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useState, useCallback, useMemo, ReactElement } from 'react'
+import React, { type FC, useEffect, useState, useCallback, useMemo } from 'react'
 
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -101,7 +101,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
         navigate(`/site-admin/external-services/${encodeURIComponent(externalService.id)}`, { replace: true })
     }
 
-    const renderService = (externalService: ExternalServiceFieldsWithConfig): ReactElement => {
+    const renderService = (externalService: ExternalServiceFieldsWithConfig): JSX.Element => {
         const externalServiceCategory = resolveExternalServiceCategory(externalService, ghApp)
         return (
             <Container className="mb-3">

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo, type FC } from 'react'
+import React, { useEffect, useState, useCallback, useMemo, type FC, ReactElement } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import { mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
@@ -131,7 +131,7 @@ export const ExternalServicePage: FC<Props> = props => {
 
     const mergedError = fetchError || fetchGHAppError
 
-    const renderExternalService = (externalService: ExternalServiceFieldsWithConfig) => {
+    const renderExternalService = (externalService: ExternalServiceFieldsWithConfig): ReactElement => {
         let externalServiceAvailabilityStatus
         if (loading) {
             externalServiceAvailabilityStatus = (

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -97,8 +97,6 @@ export const ExternalServicePage: FC<Props> = props => {
         [externalService, syncExternalService, syncJobUpdates]
     )
 
-    const externalServiceCategory = resolveExternalServiceCategory(externalService)
-
     const editingDisabled = externalServicesFromFile && !allowEditExternalServicesWithFile
 
     const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
@@ -129,42 +127,170 @@ export const ExternalServicePage: FC<Props> = props => {
 
     const checkConnectionNode = data?.node?.__typename === 'ExternalService' ? data.node.checkConnection : null
 
-    let externalServiceAvailabilityStatus
-    if (loading) {
-        externalServiceAvailabilityStatus = (
-            <Alert className="mt-2" variant="waiting">
-                Checking code host connection status...
-            </Alert>
-        )
-    } else if (!error) {
-        if (checkConnectionNode?.__typename === 'ExternalServiceAvailable') {
-            externalServiceAvailabilityStatus = (
-                <Alert className="mt-2" variant="success">
-                    Code host is reachable.
-                </Alert>
-            )
-        } else if (checkConnectionNode?.__typename === 'ExternalServiceUnavailable') {
-            externalServiceAvailabilityStatus = (
-                <ErrorAlert
-                    className="mt-2"
-                    prefix="Error during code host connection check"
-                    error={checkConnectionNode.suspectedReason}
-                />
-            )
-        }
-    } else {
-        externalServiceAvailabilityStatus = (
-            <ErrorAlert
-                className="mt-2"
-                prefix="Unexpected error during code host connection check"
-                error={error.message}
-            />
-        )
-    }
-
     const path = useMemo(() => getBreadCrumbs(externalService), [externalService])
 
     const mergedError = fetchError || fetchGHAppError
+
+    const renderExternalService = (externalService: ExternalServiceFieldsWithConfig) => {
+        let externalServiceAvailabilityStatus
+        if (loading) {
+            externalServiceAvailabilityStatus = (
+                <Alert className="mt-2" variant="waiting">
+                    Checking code host connection status...
+                </Alert>
+            )
+        } else if (!error) {
+            if (checkConnectionNode?.__typename === 'ExternalServiceAvailable') {
+                externalServiceAvailabilityStatus = (
+                    <Alert className="mt-2" variant="success">
+                        Code host is reachable.
+                    </Alert>
+                )
+            } else if (checkConnectionNode?.__typename === 'ExternalServiceUnavailable') {
+                externalServiceAvailabilityStatus = (
+                    <ErrorAlert
+                        className="mt-2"
+                        prefix="Error during code host connection check"
+                        error={checkConnectionNode.suspectedReason}
+                    />
+                )
+            }
+        } else {
+            externalServiceAvailabilityStatus = (
+                <ErrorAlert
+                    className="mt-2"
+                    prefix="Unexpected error during code host connection check"
+                    error={error.message}
+                />
+            )
+        }
+        const externalServiceCategory = resolveExternalServiceCategory(externalService)
+        return (
+            <Container className="mb-3">
+                <PageHeader
+                    path={path}
+                    byline={
+                        <CreatedByAndUpdatedByInfoByline
+                            createdAt={externalService.createdAt}
+                            updatedAt={externalService.updatedAt}
+                            noAuthor={true}
+                        />
+                    }
+                    className="mb-3"
+                    headingElement="h2"
+                    actions={
+                        <div className="d-flex align-items-center justify-content-between">
+                            <div className="align-self-start">
+                                <Tooltip
+                                    content={
+                                        externalService.hasConnectionCheck
+                                            ? 'Test if code host is reachable from Sourcegraph'
+                                            : 'Connection check unavailable'
+                                    }
+                                >
+                                    <LoaderButton
+                                        className="test-connection-external-service-button"
+                                        variant="secondary"
+                                        onClick={() => doCheckConnection()}
+                                        disabled={!externalService.hasConnectionCheck || loading}
+                                        size="sm"
+                                        loading={loading}
+                                        alwaysShowLabel={true}
+                                        icon={<Icon aria-hidden={true} svgPath={mdiConnection} />}
+                                        label="Test connection"
+                                    />
+                                </Tooltip>
+                            </div>
+                            {!editingDisabled && (
+                                <div className="flex-grow-1 ml-1">
+                                    <Tooltip content="Edit code host connection settings">
+                                        <Button
+                                            className="test-edit-external-service-button"
+                                            to={`/site-admin/external-services/${encodeURIComponent(
+                                                externalService.id
+                                            )}/edit`}
+                                            variant="primary"
+                                            size="sm"
+                                            as={Link}
+                                        >
+                                            <Icon aria-hidden={true} svgPath={mdiCog} />
+                                            {' Edit'}
+                                        </Button>
+                                    </Tooltip>
+                                </div>
+                            )}
+                            <div className="flex-shrink-0 ml-1">
+                                <Tooltip
+                                    content={
+                                        editingDisabled
+                                            ? 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
+                                            : 'Delete code host connection'
+                                    }
+                                >
+                                    <Button
+                                        aria-label="Delete"
+                                        className="test-delete-external-service-button"
+                                        onClick={onDelete}
+                                        disabled={isDeleting === true || editingDisabled}
+                                        variant="danger"
+                                        size="sm"
+                                    >
+                                        <Icon aria-hidden={true} svgPath={mdiDelete} />
+                                        {' Delete'}
+                                    </Button>
+                                </Tooltip>
+                            </div>
+                        </div>
+                    }
+                />
+                {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
+                {externalServiceAvailabilityStatus}
+                <H2>Information</H2>
+                {externalServiceCategory && (
+                    <ExternalServiceInformation
+                        displayName={externalService.displayName}
+                        codeHostID={externalService.id}
+                        reposNumber={numberOfRepos === 0 ? externalService.repoCount : numberOfRepos}
+                        syncInProgress={syncInProgress}
+                        gitHubApp={ghApp}
+                        {...externalServiceCategory}
+                    />
+                )}
+                <H2>Configuration</H2>
+                {externalServiceCategory && (
+                    <DynamicallyImportedMonacoSettingsEditor
+                        value={externalService.config}
+                        jsonSchema={externalServiceCategory.jsonSchema}
+                        canEdit={false}
+                        loading={fetchLoading}
+                        height={350}
+                        readOnly={true}
+                        isLightTheme={isLightTheme}
+                        className="test-external-service-editor"
+                        telemetryService={telemetryService}
+                    />
+                )}
+                <ExternalServiceWebhook externalService={externalService} className="mt-3" />
+                <LoaderButton
+                    label="Trigger manual sync"
+                    className="mt-3 mb-2 float-right"
+                    alwaysShowLabel={true}
+                    variant="secondary"
+                    onClick={triggerSync}
+                    loading={syncExternalServiceLoading}
+                    disabled={syncExternalServiceLoading}
+                />
+                {syncExternalServiceError && <ErrorAlert error={syncExternalServiceError} />}
+                <ExternalServiceSyncJobsList
+                    queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
+                    updateSyncInProgress={updateSyncInProgress}
+                    updateNumberOfRepos={updateNumberOfRepos}
+                    externalServiceID={externalService.id}
+                    updates={syncJobUpdates}
+                />
+            </Container>
+        )
+    }
 
     return (
         <div className={styles.externalServicePage}>
@@ -175,131 +301,7 @@ export const ExternalServicePage: FC<Props> = props => {
             )}
             {mergedError && <ErrorAlert className="mb-3" error={fetchError} />}
             {!fetchLoading && !externalService && !fetchError && <NotFoundPage />}
-            {externalService && (
-                <Container className="mb-3">
-                    <PageHeader
-                        path={path}
-                        byline={
-                            <CreatedByAndUpdatedByInfoByline
-                                createdAt={externalService.createdAt}
-                                updatedAt={externalService.updatedAt}
-                                noAuthor={true}
-                            />
-                        }
-                        className="mb-3"
-                        headingElement="h2"
-                        actions={
-                            <div className="d-flex align-items-center justify-content-between">
-                                <div className="align-self-start">
-                                    <Tooltip
-                                        content={
-                                            externalService.hasConnectionCheck
-                                                ? 'Test if code host is reachable from Sourcegraph'
-                                                : 'Connection check unavailable'
-                                        }
-                                    >
-                                        <LoaderButton
-                                            className="test-connection-external-service-button"
-                                            variant="secondary"
-                                            onClick={() => doCheckConnection()}
-                                            disabled={!externalService.hasConnectionCheck || loading}
-                                            size="sm"
-                                            loading={loading}
-                                            alwaysShowLabel={true}
-                                            icon={<Icon aria-hidden={true} svgPath={mdiConnection} />}
-                                            label="Test connection"
-                                        />
-                                    </Tooltip>
-                                </div>
-                                {!editingDisabled && (
-                                    <div className="flex-grow-1 ml-1">
-                                        <Tooltip content="Edit code host connection settings">
-                                            <Button
-                                                className="test-edit-external-service-button"
-                                                to={`/site-admin/external-services/${encodeURIComponent(
-                                                    externalService.id
-                                                )}/edit`}
-                                                variant="primary"
-                                                size="sm"
-                                                as={Link}
-                                            >
-                                                <Icon aria-hidden={true} svgPath={mdiCog} />
-                                                {' Edit'}
-                                            </Button>
-                                        </Tooltip>
-                                    </div>
-                                )}
-                                <div className="flex-shrink-0 ml-1">
-                                    <Tooltip
-                                        content={
-                                            editingDisabled
-                                                ? 'Deleting code host connections through the UI is disabled when the EXTSVC_CONFIG_FILE environment variable is set.'
-                                                : 'Delete code host connection'
-                                        }
-                                    >
-                                        <Button
-                                            aria-label="Delete"
-                                            className="test-delete-external-service-button"
-                                            onClick={onDelete}
-                                            disabled={isDeleting === true || editingDisabled}
-                                            variant="danger"
-                                            size="sm"
-                                        >
-                                            <Icon aria-hidden={true} svgPath={mdiDelete} />
-                                            {' Delete'}
-                                        </Button>
-                                    </Tooltip>
-                                </div>
-                            </div>
-                        }
-                    />
-                    {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
-                    {externalServiceAvailabilityStatus}
-                    <H2>Information</H2>
-                    {externalServiceCategory && (
-                        <ExternalServiceInformation
-                            displayName={externalService.displayName}
-                            codeHostID={externalService.id}
-                            reposNumber={numberOfRepos === 0 ? externalService.repoCount : numberOfRepos}
-                            syncInProgress={syncInProgress}
-                            gitHubApp={ghApp}
-                            {...externalServiceCategory}
-                        />
-                    )}
-                    <H2>Configuration</H2>
-                    {externalServiceCategory && (
-                        <DynamicallyImportedMonacoSettingsEditor
-                            value={externalService.config}
-                            jsonSchema={externalServiceCategory.jsonSchema}
-                            canEdit={false}
-                            loading={fetchLoading}
-                            height={350}
-                            readOnly={true}
-                            isLightTheme={isLightTheme}
-                            className="test-external-service-editor"
-                            telemetryService={telemetryService}
-                        />
-                    )}
-                    <ExternalServiceWebhook externalService={externalService} className="mt-3" />
-                    <LoaderButton
-                        label="Trigger manual sync"
-                        className="mt-3 mb-2 float-right"
-                        alwaysShowLabel={true}
-                        variant="secondary"
-                        onClick={triggerSync}
-                        loading={syncExternalServiceLoading}
-                        disabled={syncExternalServiceLoading}
-                    />
-                    {syncExternalServiceError && <ErrorAlert error={syncExternalServiceError} />}
-                    <ExternalServiceSyncJobsList
-                        queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
-                        updateSyncInProgress={updateSyncInProgress}
-                        updateNumberOfRepos={updateNumberOfRepos}
-                        externalServiceID={externalService.id}
-                        updates={syncJobUpdates}
-                    />
-                </Container>
-            )}
+            {externalService && renderExternalService(externalService)}
         </div>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useMemo, type FC, ReactElement } from 'react'
+import React, { useEffect, useState, useCallback, useMemo, type FC } from 'react'
 
 import { useApolloClient } from '@apollo/client'
 import { mdiCog, mdiConnection, mdiDelete } from '@mdi/js'
@@ -131,7 +131,7 @@ export const ExternalServicePage: FC<Props> = props => {
 
     const mergedError = fetchError || fetchGHAppError
 
-    const renderExternalService = (externalService: ExternalServiceFieldsWithConfig): ReactElement => {
+    const renderExternalService = (externalService: ExternalServiceFieldsWithConfig): JSX.Element => {
         let externalServiceAvailabilityStatus
         if (loading) {
             externalServiceAvailabilityStatus = (

--- a/client/web/src/components/externalServices/externalServices.test.tsx
+++ b/client/web/src/components/externalServices/externalServices.test.tsx
@@ -19,10 +19,6 @@ describe('gitHubAppConfig', () => {
     })
 
     describe('resolveExternalServiceCategory', () => {
-        test('returns undefined with no external service', () => {
-            expect(resolveExternalServiceCategory()).toEqual(undefined)
-        })
-
         test('parses config from JSONC if parsed config is not given', () => {
             const externalService = {
                 config: '{"url": "https://github.com"}',

--- a/client/web/src/components/externalServices/externalServices.test.tsx
+++ b/client/web/src/components/externalServices/externalServices.test.tsx
@@ -43,7 +43,7 @@ describe('gitHubAppConfig', () => {
                 kind: ExternalServiceKind.GITHUB,
             } as ExternalServiceFieldsWithConfig
 
-            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.ghe)
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.github)
         })
 
         test('returns GitLab dotcom if GITLAB kind and gitlab.com URL', () => {
@@ -61,7 +61,7 @@ describe('gitHubAppConfig', () => {
                 parsedConfig: { url: 'https://gitlab.example.com' },
             } as ExternalServiceFieldsWithConfig
 
-            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.gitlab)
+            expect(resolveExternalServiceCategory(externalService)).toEqual(codeHostExternalServices.gitlabcom)
         })
 
         test('returns GitHub App category if config contains gitHubAppDetails', () => {

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -380,7 +380,7 @@ const githubEditorActions = (isEnterprise: boolean): EditorAction[] => [
     },
 ]
 
-const gitHubAppEditorActions = (isEnterprise: boolean): EditorAction[] => {
+const gitHubAppEditorActions = (): EditorAction[] => {
     const actions = githubEditorActions(true).filter(
         item =>
             !['setURL', 'setAccessToken', 'addAffiliatedRepos', 'enablePermissions', 'addWebhooks'].includes(item.id)
@@ -603,7 +603,7 @@ const GITHUB_APP: AddExternalServiceOptions = {
     title: 'GitHub App',
     shortDescription:
         'Connect repositories on GitHub.com or self-hosted GitHub Enterprise installations using a GitHub App installation',
-    editorActions: gitHubAppEditorActions(false),
+    editorActions: gitHubAppEditorActions(),
     Instructions: () => <GitHubAppInstructions />,
     additionalFormComponent: <GitHubAppSelector />,
 }
@@ -1660,10 +1660,10 @@ export const EXTERNAL_SERVICE_SYNC_RUNNING_STATUSES = new Set<ExternalServiceSyn
 ])
 
 export const resolveExternalServiceCategory = (
-    externalService?: ExternalServiceFieldsWithConfig,
+    externalService: ExternalServiceFieldsWithConfig,
     gitHubApp?: GitHubAppByAppIDResult['gitHubAppByAppID']
-): AddExternalServiceOptions | undefined => {
-    let externalServiceCategory = externalService && defaultExternalServices[externalService.kind]
+): AddExternalServiceOptions => {
+    let externalServiceCategory = defaultExternalServices[externalService.kind]
     if (externalService && [ExternalServiceKind.GITHUB, ExternalServiceKind.GITLAB].includes(externalService.kind)) {
         let { parsedConfig } = externalService
         if (!parsedConfig) {

--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -1672,17 +1672,6 @@ export const resolveExternalServiceCategory = (
         if (!parsedConfig) {
             return externalServiceCategory
         }
-        if (parsedConfig.url) {
-            const url = isValidURL(parsedConfig.url) ? new URL(parsedConfig.url) : undefined
-            // We have no way of finding out whether an external service is GITHUB or GitHub.com or GitHub enterprise, so we need to guess based on the URL.
-            if (externalService.kind === ExternalServiceKind.GITHUB && url?.hostname !== 'github.com') {
-                externalServiceCategory = codeHostExternalServices.ghe
-            }
-            // We have no way of finding out whether an external service is GITLAB or Gitlab.com or Gitlab self-hosted, so we need to guess based on the URL.
-            if (externalService.kind === ExternalServiceKind.GITLAB && url?.hostname !== 'gitlab.com') {
-                externalServiceCategory = codeHostExternalServices.gitlab
-            }
-        }
         // if config contains gitHubAppDetails, we should use GitHub App instead
         if (parsedConfig.gitHubAppDetails && gitHubApp) {
             externalServiceCategory = { ...codeHostExternalServices.ghapp }


### PR DESCRIPTION
Fixes a bug where GitHub and GitLab code hosts that aren't github.com or gitlab.com has their settings disappear.

This comes from a recent code change where we're no longer distinguishing between GitHub and GitHub enterprise connections (or GitLab and GitLab on-prem conns)

## Test plan

Confirmed locally. Function adjusted to no longer be able to return undefined, as it doesn't make sense. Tests that should have been failing updated as well.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
