### PR TITLE
cody web: provide suggestions in context selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,4 +205,6 @@ result-*
 # Windows
 /enterprise/cmd/sourcegraph/__debug_bin.exe
 
+# For locally building and testing shared packages from the sourcegraph/cody repository on
+# the web client.
 /cody

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -237,6 +237,7 @@ ts_project(
         "src/cody/components/ScopeSelector/ScopeSelector.tsx",
         "src/cody/components/ScopeSelector/backend.ts",
         "src/cody/components/ScopeSelector/index.tsx",
+        "src/cody/components/ScopeSelector/useRepoSuggestions.ts",
         "src/cody/isCodyEnabled.tsx",
         "src/cody/search/CodySearchPage.tsx",
         "src/cody/search/api.ts",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -43,7 +43,7 @@
     "@sourcegraph/branded": "workspace:*",
     "@sourcegraph/client-api": "workspace:*",
     "@sourcegraph/codeintellify": "workspace:*",
-    "@sourcegraph/cody-shared": "^0.0.5",
+    "@sourcegraph/cody-shared": "^0.0.6",
     "@sourcegraph/cody-ui": "^0.0.7",
     "@sourcegraph/common": "workspace:*",
     "@sourcegraph/http-client": "workspace:*",

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -89,7 +89,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     const isSetupWizardPage = location.pathname.startsWith(PageRoutes.SetupWizard)
 
     const [isFuzzyFinderVisible, setFuzzyFinderVisible] = useState(false)
-    const userHistory = useUserHistory(isRepositoryRelatedPage)
+    const userHistory = useUserHistory(props.authenticatedUser?.id, isRepositoryRelatedPage)
 
     const communitySearchContextPaths = communitySearchContextsRoutes.map(route => route.path)
     const isCommunitySearchContextPage = communitySearchContextPaths.includes(location.pathname)

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -99,6 +99,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     const navigate = useNavigate()
 
     const codyChatStore = useCodyChat({
+        userID: authenticatedUser?.id,
         onTranscriptHistoryLoad,
         autoLoadTranscriptFromHistory: false,
         autoLoadScopeWithRepositories: isSourcegraphApp,

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -373,7 +373,12 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                     New chat
                                 </Button>
                             </div>
-                            <ChatUI codyChatStore={codyChatStore} isSourcegraphApp={true} isCodyChatPage={true} />
+                            <ChatUI
+                                codyChatStore={codyChatStore}
+                                isSourcegraphApp={true}
+                                isCodyChatPage={true}
+                                authenticatedUser={authenticatedUser}
+                            />
                         </div>
 
                         {showMobileHistory && (
@@ -453,7 +458,11 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                 deleteHistoryItem={deleteHistoryItem}
                             />
                         ) : (
-                            <ChatUI codyChatStore={codyChatStore} isCodyChatPage={true} />
+                            <ChatUI
+                                codyChatStore={codyChatStore}
+                                isCodyChatPage={true}
+                                authenticatedUser={authenticatedUser}
+                            />
                         )}
                     </div>
                 )}

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -97,6 +97,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({
             fetchRepositoryNames,
             isSourcegraphApp,
             logTranscriptEvent,
+            transcriptHistory,
             className: 'mt-2',
             authenticatedUser,
         }),
@@ -108,6 +109,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({
             fetchRepositoryNames,
             isSourcegraphApp,
             logTranscriptEvent,
+            transcriptHistory,
             authenticatedUser,
         ]
     )

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -22,6 +22,7 @@ import {
     type FeedbackButtonsProps,
 } from '@sourcegraph/cody-ui/dist/Chat'
 import type { FileLinkProps } from '@sourcegraph/cody-ui/dist/chat/ContextFiles'
+import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -44,9 +45,15 @@ interface IChatUIProps {
     codyChatStore: CodyChatStore
     isSourcegraphApp?: boolean
     isCodyChatPage?: boolean
+    authenticatedUser: AuthenticatedUser | null
 }
 
-export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp, isCodyChatPage }): JSX.Element => {
+export const ChatUI: React.FC<IChatUIProps> = ({
+    codyChatStore,
+    isSourcegraphApp,
+    isCodyChatPage,
+    authenticatedUser,
+}): JSX.Element => {
     const {
         submitMessage,
         editMessage,
@@ -91,6 +98,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
             isSourcegraphApp,
             logTranscriptEvent,
             className: 'mt-2',
+            authenticatedUser,
         }),
         [
             scope,
@@ -100,6 +108,7 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
             fetchRepositoryNames,
             isSourcegraphApp,
             logTranscriptEvent,
+            authenticatedUser,
         ]
     )
 

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -22,7 +22,7 @@ import {
     type FeedbackButtonsProps,
 } from '@sourcegraph/cody-ui/dist/Chat'
 import type { FileLinkProps } from '@sourcegraph/cody-ui/dist/chat/ContextFiles'
-import { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -113,8 +113,8 @@ export const ChatUI: React.FC<IChatUIProps> = ({
     )
 
     const gettingStartedComponentProps = useMemo(
-        () => ({ ...scopeSelectorProps, logTranscriptEvent, isCodyChatPage }),
-        [scopeSelectorProps, logTranscriptEvent, isCodyChatPage]
+        () => ({ ...scopeSelectorProps, logTranscriptEvent, isCodyChatPage, authenticatedUser }),
+        [scopeSelectorProps, isCodyChatPage, logTranscriptEvent, authenticatedUser]
     )
 
     if (!loaded) {

--- a/client/web/src/cody/components/CodeMirrorEditor.ts
+++ b/client/web/src/cody/components/CodeMirrorEditor.ts
@@ -99,6 +99,10 @@ export class CodeMirrorEditor implements Editor {
         return null
     }
 
+    public getActiveTextEditorSelectionOrVisibleContent(): ActiveTextEditorSelection | null {
+        return this.getActiveTextEditorSelectionOrEntireFile()
+    }
+
     public getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null {
         const editor = this.editor
         if (editor) {
@@ -152,5 +156,15 @@ export class CodeMirrorEditor implements Editor {
     public didReceiveFixupText(id: string, text: string, state: 'streaming' | 'complete'): Promise<void> {
         // Not implemented.
         return Promise.resolve(undefined)
+    }
+
+    public getActiveInlineChatTextEditor(): ActiveTextEditor | null {
+        // Not implemented.
+        return null
+    }
+
+    public getActiveInlineChatSelection(): ActiveTextEditorSelection | null {
+        // Not implemented.
+        return null
     }
 }

--- a/client/web/src/cody/components/FileContentEditor.ts
+++ b/client/web/src/cody/components/FileContentEditor.ts
@@ -42,6 +42,10 @@ export class FileContentEditor implements Editor {
         }
     }
 
+    public getActiveTextEditorSelectionOrVisibleContent(): ActiveTextEditorSelection | null {
+        return this.getActiveTextEditorSelectionOrEntireFile()
+    }
+
     public getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null {
         return {
             ...this.editor,
@@ -84,5 +88,15 @@ export class FileContentEditor implements Editor {
     public didReceiveFixupText(id: string, text: string, state: 'streaming' | 'complete'): Promise<void> {
         // Not implemented.
         return Promise.resolve(undefined)
+    }
+
+    public getActiveInlineChatTextEditor(): ActiveTextEditor | null {
+        // Not implemented.
+        return null
+    }
+
+    public getActiveInlineChatSelection(): ActiveTextEditorSelection | null {
+        // Not implemented.
+        return null
     }
 }

--- a/client/web/src/cody/components/GettingStarted.module.scss
+++ b/client/web/src/cody/components/GettingStarted.module.scss
@@ -62,9 +62,18 @@
         padding-left: var(--form-check-input-gutter);
     }
 
-    &-warning {
+    &-warning,
+    &-warning-link {
         margin-top: 0.75rem;
         color: var(--warning-3);
+    }
+
+    &-warning-link {
+        text-decoration: underline;
+    }
+
+    &-warning-link:hover {
+        color: var(--warning);
     }
 }
 

--- a/client/web/src/cody/components/GettingStarted.module.scss
+++ b/client/web/src/cody/components/GettingStarted.module.scss
@@ -64,7 +64,8 @@
 
     &-warning,
     &-warning-link {
-        margin-top: 0.75rem;
+        margin-top: 0.5rem;
+        margin-bottom: 0;
         color: var(--warning-3);
     }
 

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -124,11 +124,22 @@ export const GettingStarted: React.FC<
                 return null
             }
 
+            const unindexedCount = repos.filter(repo => !isRepoIndexed(repo)).length
+            const warningText =
+                repos.length === 1
+                    ? 'The selected repository is not indexed for Cody and is missing embeddings.'
+                    : `${unindexedCount} of ${repos.length} selected repositories are not indexed for Cody and are missing embeddings.`
+
             return (
                 <Text size="small" className={styles.scopeSelectorWarning}>
-                    {repos.length === 1 ? 'This repo is' : 'Some repos are'} not indexed for Cody. This may affect the
-                    quality of the answers. Learn more about this{' '}
-                    <Link to="/help/cody/explanations/code_graph_context#embeddings">in the docs</Link>.
+                    {warningText} This may affect the quality of the answers. To enable indexing, see the{' '}
+                    <Link
+                        className={styles.scopeSelectorWarningLink}
+                        to="/help/cody/explanations/code_graph_context#embeddings"
+                    >
+                        embeddings documentation
+                    </Link>
+                    .
                 </Text>
             )
         },

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -23,6 +23,7 @@ export const GettingStarted: React.FC<
         CodyChatStore,
         | 'scope'
         | 'logTranscriptEvent'
+        | 'transcriptHistory'
         | 'setScope'
         | 'toggleIncludeInferredRepository'
         | 'toggleIncludeInferredFile'

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -210,22 +210,26 @@ export const GettingStarted: React.FC<
                                         authenticatedUser={authenticatedUser}
                                     />
                                 </div>
-                                <hr className={styles.divider} />
 
-                                <Text size="small" className={classNames('text-muted', styles.hintTitle)}>
-                                    Why is context important?
-                                </Text>
-                                <Text size="small" className={classNames('text-muted', styles.hintText)}>
-                                    Without providing relevant repo(s) for context, Cody won't be able to answer
-                                    questions specific to your project.
-                                </Text>
+                                {scopeSelectorProps.scope.repositories.length === 0 && (
+                                    <>
+                                        <hr className={styles.divider} />
+                                        <Text size="small" className={classNames('text-muted', styles.hintTitle)}>
+                                            Why is context important?
+                                        </Text>
+                                        <Text size="small" className={classNames('text-muted', styles.hintText)}>
+                                            Without providing relevant repo(s) for context, Cody won't be able to answer
+                                            questions specific to your project.
+                                        </Text>
 
-                                <Text size="small" className="mb-0 text-muted">
-                                    <Text as="span" weight="bold">
-                                        Tip:
-                                    </Text>{' '}
-                                    The context selector is always available at the bottom of the screen
-                                </Text>
+                                        <Text size="small" className="mb-0 text-muted">
+                                            <Text as="span" weight="bold">
+                                                Tip:
+                                            </Text>{' '}
+                                            The context selector is always available at the bottom of the screen
+                                        </Text>
+                                    </>
+                                )}
                             </div>
                         </fieldset>
                     </div>

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -172,7 +172,7 @@ export const GettingStarted: React.FC<
                                         </Text>
                                     }
                                     value="general"
-                                    wrapperClassName="d-flex align-items-baseline"
+                                    wrapperClassName="d-flex align-items-center"
                                     checked={conversationScope === 'general'}
                                     onChange={event => setConversationScope(event.target.value as ConversationScope)}
                                 />
@@ -187,7 +187,7 @@ export const GettingStarted: React.FC<
                                         </Text>
                                     }
                                     value="repo"
-                                    wrapperClassName="d-flex align-items-baseline mb-1"
+                                    wrapperClassName="d-flex align-items-center mb-1"
                                     checked={conversationScope === 'repo'}
                                     onChange={event => setConversationScope(event.target.value as ConversationScope)}
                                 />

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -80,7 +80,7 @@ export const GettingStarted: React.FC<
     const content: { title: string; examples: { label?: string; text: string }[] } = useMemo(() => {
         if (conversationScope === 'repo') {
             return {
-                title: `Great examples to start with${
+                title: `Examples to start with${
                     scopeSelectorProps.scope.repositories.length === 1
                         ? ` for ${scopeSelectorProps.scope.repositories[0].split('/').slice(-2).join('/')}`
                         : ''

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { H4, H5, RadioButton, Text, Button, Grid, Icon, Link } from '@sourcegraph/wildcard'
 
 import { CodyColorIcon, CodySpeechBubbleIcon } from '../chat/CodyPageIcon'
@@ -30,8 +31,9 @@ export const GettingStarted: React.FC<
         isSourcegraphApp?: boolean
         isCodyChatPage?: boolean
         submitInput: (input: string, submitType: 'user' | 'suggestion' | 'example') => void
+        authenticatedUser: AuthenticatedUser | null
     }
-> = ({ isCodyChatPage, submitInput, ...scopeSelectorProps }) => {
+> = ({ isCodyChatPage, submitInput, authenticatedUser, ...scopeSelectorProps }) => {
     const [conversationScope, setConversationScope] = useState<ConversationScope>(
         !isCodyChatPage || scopeSelectorProps.scope.repositories.length > 0 ? 'repo' : 'general'
     )
@@ -193,6 +195,7 @@ export const GettingStarted: React.FC<
                                         {...scopeSelectorProps}
                                         renderHint={renderRepoIndexingWarning}
                                         encourageOverlap={true}
+                                        authenticatedUser={authenticatedUser}
                                     />
                                 </div>
                                 <hr className={styles.divider} />

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -104,10 +104,10 @@ export const GettingStarted: React.FC<
             examples: [
                 {
                     label: 'Algorithms',
-                    text: 'How the QuickSort algorithm works with an implementation in Python?',
+                    text: 'Can you explain how the QuickSort algorithm works in Python?',
                 },
                 {
-                    label: 'Good Practice',
+                    label: 'Best practices',
                     text: "I'm working on a large-scale web application using React. What are some best practices or design patterns I should be aware of to maintain code readability and performance?",
                 },
                 {
@@ -168,7 +168,7 @@ export const GettingStarted: React.FC<
                                     name="general"
                                     label={
                                         <Text as="span" size="small">
-                                            General Coding Knowledge
+                                            General knowledge
                                         </Text>
                                     }
                                     value="general"
@@ -183,7 +183,7 @@ export const GettingStarted: React.FC<
                                     name="repo"
                                     label={
                                         <Text as="span" size="small">
-                                            My Repos:
+                                            Specific repositories:
                                         </Text>
                                     }
                                     value="repo"
@@ -202,11 +202,11 @@ export const GettingStarted: React.FC<
                                 <hr className={styles.divider} />
 
                                 <Text size="small" className={classNames('text-muted', styles.hintTitle)}>
-                                    Why context is important?
+                                    Why is context important?
                                 </Text>
                                 <Text size="small" className={classNames('text-muted', styles.hintText)}>
-                                    Without providing a specific repo as context, Cody won’t be able to answer with
-                                    relevant knowledge about your project.
+                                    Without providing specific repo(s) for context, Cody won't be able to answer
+                                    questions specific to your project.
                                 </Text>
 
                                 <Text size="small" className="mb-0 text-muted">

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -82,7 +82,7 @@ export const GettingStarted: React.FC<
             return {
                 title: `Great examples to start with${
                     scopeSelectorProps.scope.repositories.length === 1
-                        ? ` for ${scopeSelectorProps.scope.repositories[0]}`
+                        ? ` for ${scopeSelectorProps.scope.repositories[0].split('/').slice(-2).join('/')}`
                         : ''
                 }`,
                 examples: [
@@ -205,7 +205,7 @@ export const GettingStarted: React.FC<
                                     Why is context important?
                                 </Text>
                                 <Text size="small" className={classNames('text-muted', styles.hintText)}>
-                                    Without providing specific repo(s) for context, Cody won't be able to answer
+                                    Without providing relevant repo(s) for context, Cody won't be able to answer
                                     questions specific to your project.
                                 </Text>
 

--- a/client/web/src/cody/components/RepoContainerEditor.ts
+++ b/client/web/src/cody/components/RepoContainerEditor.ts
@@ -29,6 +29,10 @@ export class RepoContainerEditor implements Editor {
         return null
     }
 
+    public getActiveTextEditorSelectionOrVisibleContent(): ActiveTextEditorSelection | null {
+        return null
+    }
+
     public getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null {
         return null
     }
@@ -68,5 +72,15 @@ export class RepoContainerEditor implements Editor {
     public didReceiveFixupText(id: string, text: string, state: 'streaming' | 'complete'): Promise<void> {
         // Not implemented.
         return Promise.resolve(undefined)
+    }
+
+    public getActiveInlineChatTextEditor(): ActiveTextEditor | null {
+        // Not implemented.
+        return null
+    }
+
+    public getActiveInlineChatSelection(): ActiveTextEditorSelection | null {
+        // Not implemented.
+        return null
     }
 }

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -334,33 +334,36 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         authenticatedUser={authenticatedUser}
                                                     />
                                                 ))}
-                                                <Text
-                                                    className={classNames(
-                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
-                                                        styles.subHeader
-                                                    )}
-                                                >
-                                                    <span className="small">Suggestions</span>
-                                                </Text>
-                                                <div
-                                                    className={classNames(
-                                                        'd-flex flex-column',
-                                                        styles.contextItemsContainer
-                                                    )}
-                                                >
-                                                    {suggestions.length &&
-                                                        suggestions.map(repository => (
-                                                            <SearchResultsListItem
-                                                                additionalRepositories={[]}
-                                                                key={repository.id}
-                                                                repository={repository}
-                                                                searchText=""
-                                                                addRepository={addRepository}
-                                                                removeRepository={removeRepository}
-                                                                authenticatedUser={authenticatedUser}
-                                                            />
-                                                        ))}
-                                                </div>
+                                                {suggestions.length > 0 && (
+                                                    <>
+                                                        <Text
+                                                            className={classNames(
+                                                                'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
+                                                                styles.subHeader
+                                                            )}
+                                                        >
+                                                            <span className="small">Suggestions</span>
+                                                        </Text>
+                                                        <div
+                                                            className={classNames(
+                                                                'd-flex flex-column',
+                                                                styles.contextItemsContainer
+                                                            )}
+                                                        >
+                                                            {suggestions.map(repository => (
+                                                                <SearchResultsListItem
+                                                                    additionalRepositories={[]}
+                                                                    key={repository.id}
+                                                                    repository={repository}
+                                                                    searchText=""
+                                                                    addRepository={addRepository}
+                                                                    removeRepository={removeRepository}
+                                                                    authenticatedUser={authenticatedUser}
+                                                                />
+                                                            ))}
+                                                        </div>
+                                                    </>
+                                                )}
                                             </div>
                                         )}
 

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -344,42 +344,76 @@ export const RepositoriesSelectorPopover: React.FC<{
                             styles.repositorySelectorContent
                         )}
                     >
-                        {!searchText && (
-                            <>
-                                <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                    <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
-                                    {resetScope && scopeChanged && (
-                                        <Button
-                                            onClick={resetScope}
-                                            variant="icon"
-                                            aria-label="Reset scope"
-                                            title="Reset scope"
-                                            className={styles.header}
-                                        >
-                                            Reset
-                                        </Button>
-                                    )}
-                                </div>
-                                <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
-                                    {inferredRepository && (
-                                        <div className="d-flex flex-column">
-                                            {inferredFilePath && (
+                        <>
+                            {!searchText && (
+                                <>
+                                    <div className="d-flex justify-content-between p-2 border-bottom mb-1">
+                                        <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
+                                        {resetScope && scopeChanged && (
+                                            <Button
+                                                onClick={resetScope}
+                                                variant="icon"
+                                                aria-label="Reset scope"
+                                                title="Reset scope"
+                                                className={styles.header}
+                                            >
+                                                Reset
+                                            </Button>
+                                        )}
+                                    </div>
+                                    <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
+                                        {inferredRepository && (
+                                            <div className="d-flex flex-column">
+                                                {inferredFilePath && (
+                                                    <button
+                                                        type="button"
+                                                        className={classNames(
+                                                            'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1 mt-1',
+                                                            styles.repositoryListItem,
+                                                            {
+                                                                [styles.notIncludedInContext]: !includeInferredFile,
+                                                            }
+                                                        )}
+                                                        onClick={toggleIncludeInferredFile}
+                                                    >
+                                                        <div className="d-flex align-items-center text-truncate">
+                                                            <Icon
+                                                                aria-hidden={true}
+                                                                className={classNames('mr-1 text-muted', {
+                                                                    [styles.visibilityHidden]: !includeInferredFile,
+                                                                })}
+                                                                svgPath={mdiCheck}
+                                                            />
+                                                            <ExternalRepositoryIcon
+                                                                externalRepo={inferredRepository.externalRepository}
+                                                                className={styles.repoIcon}
+                                                            />
+                                                            <span className="text-truncate">
+                                                                {getFileName(inferredFilePath)}
+                                                            </span>
+                                                        </div>
+                                                        <EmbeddingExistsIcon
+                                                            repo={inferredRepository}
+                                                            authenticatedUser={authenticatedUser}
+                                                        />
+                                                    </button>
+                                                )}
                                                 <button
                                                     type="button"
                                                     className={classNames(
-                                                        'd-flex justify-content-between flex-row text-truncate px-2 py-1 mt-1',
+                                                        'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1',
                                                         styles.repositoryListItem,
                                                         {
-                                                            [styles.notIncludedInContext]: !includeInferredFile,
+                                                            [styles.notIncludedInContext]: !includeInferredRepository,
                                                         }
                                                     )}
-                                                    onClick={toggleIncludeInferredFile}
+                                                    onClick={toggleIncludeInferredRepository}
                                                 >
                                                     <div className="d-flex align-items-center text-truncate">
                                                         <Icon
                                                             aria-hidden={true}
                                                             className={classNames('mr-1 text-muted', {
-                                                                [styles.visibilityHidden]: !includeInferredFile,
+                                                                [styles.visibilityHidden]: !includeInferredRepository,
                                                             })}
                                                             svgPath={mdiCheck}
                                                         />
@@ -388,7 +422,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                             className={styles.repoIcon}
                                                         />
                                                         <span className="text-truncate">
-                                                            {getFileName(inferredFilePath)}
+                                                            {getRepoName(inferredRepository.name)}
                                                         </span>
                                                     </div>
                                                     <EmbeddingExistsIcon
@@ -396,110 +430,139 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         authenticatedUser={authenticatedUser}
                                                     />
                                                 </button>
-                                            )}
-                                            <button
-                                                type="button"
-                                                className={classNames(
-                                                    'd-flex justify-content-between flex-row text-truncate px-2 py-1',
-                                                    styles.repositoryListItem,
-                                                    {
-                                                        [styles.notIncludedInContext]: !includeInferredRepository,
-                                                    }
-                                                )}
-                                                onClick={toggleIncludeInferredRepository}
-                                            >
-                                                <div className="d-flex align-items-center text-truncate">
-                                                    <Icon
-                                                        aria-hidden={true}
-                                                        className={classNames('mr-1 text-muted', {
-                                                            [styles.visibilityHidden]: !includeInferredRepository,
-                                                        })}
-                                                        svgPath={mdiCheck}
-                                                    />
-                                                    <ExternalRepositoryIcon
-                                                        externalRepo={inferredRepository.externalRepository}
-                                                        className={styles.repoIcon}
-                                                    />
-                                                    <span className="text-truncate">
-                                                        {getRepoName(inferredRepository.name)}
+                                            </div>
+                                        )}
+                                        {!!additionalRepositories.length && (
+                                            <div className="d-flex flex-column">
+                                                <Text
+                                                    className={classNames(
+                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
+                                                        styles.subHeader,
+                                                        {
+                                                            'mt-1': inferredRepository || inferredFilePath,
+                                                        }
+                                                    )}
+                                                >
+                                                    <span className="small">
+                                                        {inferredRepository
+                                                            ? 'Additional repositories'
+                                                            : 'Repositories'}
                                                     </span>
+                                                    <span className="small">
+                                                        {additionalRepositories.length}/{MAX_ADDITIONAL_REPOSITORIES}
+                                                    </span>
+                                                </Text>
+                                                {additionalRepositories.map(repository => (
+                                                    <AdditionalRepositoriesListItem
+                                                        key={repository.id}
+                                                        repository={repository}
+                                                        removeRepository={removeRepository}
+                                                        authenticatedUser={authenticatedUser}
+                                                    />
+                                                ))}
+                                                <Text
+                                                    className={classNames(
+                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
+                                                        styles.subHeader
+                                                    )}
+                                                >
+                                                    <span className="small">Suggestions</span>
+                                                </Text>
+                                                <div
+                                                    className={classNames(
+                                                        'd-flex flex-column',
+                                                        styles.contextItemsContainer
+                                                    )}
+                                                >
+                                                    {displaySuggestedRepos.length &&
+                                                        displaySuggestedRepos.map(repository => (
+                                                            <SearchResultsListItem
+                                                                additionalRepositories={[]}
+                                                                key={repository.id}
+                                                                repository={repository}
+                                                                searchText=""
+                                                                addRepository={addRepository}
+                                                                removeRepository={removeRepository}
+                                                                authenticatedUser={authenticatedUser}
+                                                            />
+                                                        ))}
                                                 </div>
-                                                <EmbeddingExistsIcon
-                                                    repo={inferredRepository}
-                                                    authenticatedUser={authenticatedUser}
-                                                />
-                                            </button>
-                                        </div>
-                                    )}
-                                    {!!additionalRepositories.length && (
-                                        <div className="d-flex flex-column">
-                                            <Text
-                                                className={classNames(
-                                                    'mb-0 px-2 py-1 text-muted d-flex justify-content-between',
-                                                    styles.subHeader,
-                                                    {
-                                                        'mt-1': inferredRepository || inferredFilePath,
-                                                    }
-                                                )}
-                                            >
-                                                <span className="small">
-                                                    {inferredRepository ? 'Additional repositories' : 'Repositories'}
-                                                </span>
-                                                <span className="small">{additionalRepositories.length}/10</span>
-                                            </Text>
-                                            {additionalRepositories.map(repository => (
-                                                <AdditionalRepositoriesListItem
+                                            </div>
+                                        )}
+
+                                        {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
+                                            <>
+                                                <div className="d-flex border-bottom">
+                                                    <Text size="small" className="m-0 text-center text-muted">
+                                                        Add up to {MAX_ADDITIONAL_REPOSITORIES} repositories for Cody to
+                                                        reference when providing answers.
+                                                    </Text>
+                                                </div>
+                                                <Text
+                                                    className={classNames(
+                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
+                                                        styles.subHeader
+                                                    )}
+                                                >
+                                                    <span className="small">Suggestions</span>
+                                                </Text>
+                                                <div
+                                                    className={classNames(
+                                                        'd-flex flex-column',
+                                                        styles.contextItemsContainer
+                                                    )}
+                                                >
+                                                    {displaySuggestedRepos.length &&
+                                                        displaySuggestedRepos.map(repository => (
+                                                            <SearchResultsListItem
+                                                                additionalRepositories={[]}
+                                                                key={repository.id}
+                                                                repository={repository}
+                                                                searchText=""
+                                                                addRepository={addRepository}
+                                                                removeRepository={removeRepository}
+                                                                authenticatedUser={authenticatedUser}
+                                                            />
+                                                        ))}
+                                                </div>
+                                            </>
+                                        )}
+                                    </div>
+                                </>
+                            )}
+                            {searchText && (
+                                <>
+                                    <div className="d-flex justify-content-between p-2 border-bottom mb-1">
+                                        <Text className={classNames('m-0', styles.header)}>
+                                            {additionalRepositoriesLeft
+                                                ? `Add up to ${additionalRepositoriesLeft} additional repositories`
+                                                : 'Maximum additional repositories added'}
+                                        </Text>
+                                    </div>
+                                    <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
+                                        {searchResults.length ? (
+                                            searchResults.map(repository => (
+                                                <SearchResultsListItem
+                                                    additionalRepositories={additionalRepositories}
                                                     key={repository.id}
                                                     repository={repository}
+                                                    searchText={searchText}
+                                                    addRepository={addRepository}
                                                     removeRepository={removeRepository}
                                                     authenticatedUser={authenticatedUser}
                                                 />
-                                            ))}
-                                        </div>
-                                    )}
-
-                                    {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
-                                        <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
-                                            <Text size="small" className="m-0 text-center text-muted">
-                                                Add up to 10 repositories for Cody to reference when providing answers.
-                                            </Text>
-                                        </div>
-                                    )}
-                                </div>
-                            </>
-                        )}
-                        {searchText && (
-                            <>
-                                <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                    <Text className={classNames('m-0', styles.header)}>
-                                        {additionalRepositoriesLeft
-                                            ? `Add up to ${additionalRepositoriesLeft} additional repositories`
-                                            : 'Maximum additional repositories added'}
-                                    </Text>
-                                </div>
-                                <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
-                                    {searchResults.length ? (
-                                        searchResults.map(repository => (
-                                            <SearchResultsListItem
-                                                additionalRepositories={additionalRepositories}
-                                                key={repository.id}
-                                                repository={repository}
-                                                searchText={searchText}
-                                                addRepository={addRepository}
-                                                removeRepository={removeRepository}
-                                                authenticatedUser={authenticatedUser}
-                                            />
-                                        ))
-                                    ) : !loadingSearchResults ? (
-                                        <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
-                                            <Text size="small" className="m-0 d-flex text-center">
-                                                No matching repositories found
-                                            </Text>
-                                        </div>
-                                    ) : null}
-                                </div>
-                            </>
-                        )}
+                                            ))
+                                        ) : !loadingSearchResults ? (
+                                            <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
+                                                <Text size="small" className="m-0 d-flex text-center">
+                                                    No matching repositories found
+                                                </Text>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                </>
+                            )}
+                        </>
                         <div className={classNames('relative p-2 border-top mt-auto', styles.inputContainer)}>
                             <Input
                                 role="combobox"
@@ -553,7 +616,7 @@ const AdditionalRepositoriesListItem: React.FC<{
         <button
             type="button"
             className={classNames(
-                'd-flex justify-content-between flex-row text-truncate px-2 py-1 mb-1',
+                'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1 mb-1',
                 styles.repositoryListItem
             )}
             onClick={onClick}
@@ -606,7 +669,7 @@ const SearchResultsListItem: React.FC<{
         <button
             type="button"
             className={classNames(
-                'd-flex justify-content-between flex-row text-truncate px-2 py-1 mb-1',
+                'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1 mb-1',
                 styles.repositoryListItem,
                 { [styles.disabledSearchResult]: disabled }
             )}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -221,7 +221,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                         <>
                             {!searchText && (
                                 <>
-                                    <div className="d-flex justify-content-between p-2 border-bottom mb-1">
+                                    <div className="d-flex justify-content-between p-2 border-bottom">
                                         <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
                                         {resetScope && scopeChanged && (
                                             <Button
@@ -237,12 +237,12 @@ export const RepositoriesSelectorPopover: React.FC<{
                                     </div>
                                     <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
                                         {inferredRepository && (
-                                            <div className="d-flex flex-column">
+                                            <div className="d-flex flex-column py-1">
                                                 {inferredFilePath && (
                                                     <button
                                                         type="button"
                                                         className={classNames(
-                                                            'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1 mt-1',
+                                                            'd-flex justify-content-between flex-row text-truncate pl-2 pr-3 py-1',
                                                             styles.repositoryListItem,
                                                             {
                                                                 [styles.notIncludedInContext]: !includeInferredFile,
@@ -307,14 +307,11 @@ export const RepositoriesSelectorPopover: React.FC<{
                                             </div>
                                         )}
                                         {!!additionalRepositories.length && (
-                                            <div className="d-flex flex-column">
+                                            <div className="d-flex flex-column mb-1">
                                                 <Text
                                                     className={classNames(
-                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
-                                                        styles.subHeader,
-                                                        {
-                                                            'mt-1': inferredRepository || inferredFilePath,
-                                                        }
+                                                        'm-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
+                                                        styles.subHeader
                                                     )}
                                                 >
                                                     <span className="small">
@@ -334,53 +331,21 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         authenticatedUser={authenticatedUser}
                                                     />
                                                 ))}
-                                                {suggestions.length > 0 && (
-                                                    <>
-                                                        <Text
-                                                            className={classNames(
-                                                                'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
-                                                                styles.subHeader
-                                                            )}
-                                                        >
-                                                            <span className="small">Suggestions</span>
-                                                        </Text>
-                                                        <div
-                                                            className={classNames(
-                                                                'd-flex flex-column',
-                                                                styles.contextItemsContainer
-                                                            )}
-                                                        >
-                                                            {suggestions.map(repository => (
-                                                                <SearchResultsListItem
-                                                                    additionalRepositories={[]}
-                                                                    key={repository.id}
-                                                                    repository={repository}
-                                                                    searchText=""
-                                                                    addRepository={addRepository}
-                                                                    removeRepository={removeRepository}
-                                                                    authenticatedUser={authenticatedUser}
-                                                                />
-                                                            ))}
-                                                        </div>
-                                                    </>
-                                                )}
                                             </div>
                                         )}
 
                                         {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
-                                            <>
-                                                <div className="d-flex border-bottom">
-                                                    <Text
-                                                        size="small"
-                                                        className="m-0 px-4 py-2 mb-1 text-center text-muted"
-                                                    >
-                                                        Add up to {MAX_ADDITIONAL_REPOSITORIES} repositories for Cody to
-                                                        reference when providing answers.
-                                                    </Text>
-                                                </div>
+                                            <Text size="small" className="m-0 px-4 py-2 my-1 text-center text-muted">
+                                                Add up to {MAX_ADDITIONAL_REPOSITORIES} repositories for Cody to
+                                                reference when providing answers.
+                                            </Text>
+                                        )}
+
+                                        {!!suggestions.length && (
+                                            <div className="d-flex flex-column">
                                                 <Text
                                                     className={classNames(
-                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
+                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
                                                         styles.subHeader
                                                     )}
                                                 >
@@ -392,20 +357,19 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         styles.contextItemsContainer
                                                     )}
                                                 >
-                                                    {suggestions.length &&
-                                                        suggestions.map(repository => (
-                                                            <SearchResultsListItem
-                                                                additionalRepositories={[]}
-                                                                key={repository.id}
-                                                                repository={repository}
-                                                                searchText=""
-                                                                addRepository={addRepository}
-                                                                removeRepository={removeRepository}
-                                                                authenticatedUser={authenticatedUser}
-                                                            />
-                                                        ))}
+                                                    {suggestions.map(repository => (
+                                                        <SearchResultsListItem
+                                                            additionalRepositories={[]}
+                                                            key={repository.id}
+                                                            repository={repository}
+                                                            searchText=""
+                                                            addRepository={addRepository}
+                                                            removeRepository={removeRepository}
+                                                            authenticatedUser={authenticatedUser}
+                                                        />
+                                                    ))}
                                                 </div>
-                                            </>
+                                            </div>
                                         )}
                                     </div>
                                 </>

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -370,7 +370,10 @@ export const RepositoriesSelectorPopover: React.FC<{
                                         {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
                                             <>
                                                 <div className="d-flex border-bottom">
-                                                    <Text size="small" className="m-0 text-center text-muted">
+                                                    <Text
+                                                        size="small"
+                                                        className="m-0 px-4 py-2 mb-1 text-center text-muted"
+                                                    >
                                                         Add up to {MAX_ADDITIONAL_REPOSITORIES} repositories for Cody to
                                                         reference when providing answers.
                                                     </Text>

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -15,7 +15,7 @@ import {
 import classNames from 'classnames'
 
 import type { TranscriptJSON } from '@sourcegraph/cody-shared/dist/chat/transcript'
-import { useLazyQuery, useQuery } from '@sourcegraph/http-client'
+import { useLazyQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import {
@@ -35,18 +35,12 @@ import {
     Overlapping,
 } from '@sourcegraph/wildcard'
 
-import { useUserHistory } from '../../../components/useUserHistory'
-import type {
-    ContextSelectorRepoFields,
-    SuggestedReposResult,
-    SuggestedReposVariables,
-    ReposSelectorSearchResult,
-    ReposSelectorSearchVariables,
-} from '../../../graphql-operations'
+import type { ReposSelectorSearchResult, ReposSelectorSearchVariables } from '../../../graphql-operations'
 import { ExternalRepositoryIcon } from '../../../site-admin/components/ExternalRepositoryIcon'
 
-import { SuggestedReposQuery, ReposSelectorSearchQuery } from './backend'
+import { ReposSelectorSearchQuery } from './backend'
 import { Callout } from './Callout'
+import { useRepoSuggestions } from './useRepoSuggestions'
 
 import styles from './ScopeSelector.module.scss'
 
@@ -67,33 +61,6 @@ export interface IRepo {
 }
 
 export const MAX_ADDITIONAL_REPOSITORIES = 10
-const MAX_SUGGESTED_REPOSITORIES = 10
-
-// NOTE: The actual 10 most popular OSS repositories on GitHub are typically just
-// plaintext resource collections like awesome lists or how-to-program tutorials, which
-// are not likely to be as interesting to Cody users. Instead, we hardcode a list of
-// repositories that are among the top 100 that contain actual source code.
-const TOP_TEN_DOTCOM_REPOS = [
-    'github.com/sourcegraph/sourcegraph',
-    'github.com/freeCodeCamp/freeCodeCamp',
-    'github.com/facebook/react',
-    'github.com/tensorflow/tensorflow',
-    'github.com/torvalds/linux',
-    'github.com/microsoft/vscode',
-    'github.com/flutter/flutter',
-    'github.com/golang/go',
-    'github.com/d3/d3',
-    'github.com/kubernetes/kubernetes',
-]
-
-/**
- * removeDupes is an `Array.filter` predicate function which removes duplicate entries
- * from an array of objects based on the `name` property. It filters out any entries which
- * are not the first occurrence with a given `name`, which means it will preserve the
- * earliest occurrence of each.
- */
-const removeDupes = (first: { name: string }, index: number, self: { name: string }[]): boolean =>
-    index === self.findIndex(entry => entry.name === first.name)
 
 export const RepositoriesSelectorPopover: React.FC<{
     includeInferredRepository: boolean
@@ -135,102 +102,9 @@ export const RepositoriesSelectorPopover: React.FC<{
         ReposSelectorSearchVariables
     >(ReposSelectorSearchQuery, {})
 
-    // TODO: Refactor out into custom hook
-    const userHistory = useUserHistory(authenticatedUser?.id, false)
-    const suggestedRepoNames: string[] = useMemo(() => {
-        const flattenedTranscriptHistoryEntries = transcriptHistory
-            .map(item => {
-                const { scope, lastInteractionTimestamp } = item
-                return (
-                    // Return a new item for each repository in the scope.
-                    scope?.repositories.map(name => ({
-                        // Parse a date from the last interaction timestamp.
-                        lastAccessed: new Date(lastInteractionTimestamp),
-                        name,
-                    })) || []
-                )
-            })
-            .flat()
-            // Remove duplicates.
-            .filter(removeDupes)
-            // We only need up to the first MAX_SUGGESTED_REPOSITORIES.
-            .slice(0, MAX_SUGGESTED_REPOSITORIES)
-
-        const userHistoryEntries =
-            userHistory
-                .loadEntries()
-                .map(item => ({
-                    name: item.repoName,
-                    // Parse a date from the last acessed timestamp.
-                    lastAccessed: new Date(item.lastAccessed),
-                }))
-                // We only need up to the first MAX_SUGGESTED_REPOSITORIES.
-                .slice(0, MAX_SUGGESTED_REPOSITORIES) || []
-
-        // We also take a list of 10 of the most popular OSS repositories on GitHub to
-        // fill in if we have fewer than MAX_SUGGESTED_REPOSITORIES. This is mostly
-        // relevant for dotcom but could fill in for any instance which indexes GitHub OSS
-        // repositories. If the repositories are not indexed on the instance, they will
-        // not return any results from the search API and thus will not be included in the
-        // final list of suggestions.
-        const topTenDotcomRepos = TOP_TEN_DOTCOM_REPOS.map(name => ({
-            name,
-            // We order by most recently accessed; these should always be ranked last.
-            lastAccessed: new Date(0),
-        }))
-
-        // Merge the lists.
-        const merged = [...flattenedTranscriptHistoryEntries, ...userHistoryEntries, ...topTenDotcomRepos]
-            // Sort by most recently accessed.
-            .sort((a, b) => b.lastAccessed.getTime() - a.lastAccessed.getTime())
-            // Remove duplicates.
-            .filter(removeDupes)
-            // Take the most recent MAX_SUGGESTED_REPOSITORIES.
-            .slice(0, MAX_SUGGESTED_REPOSITORIES)
-
-        // Return just the names.
-        return merged.map(({ name }) => name)
-    }, [transcriptHistory, userHistory])
-
-    // Query for the suggested repositories.
-    const { data: suggestedReposData } = useQuery<SuggestedReposResult, SuggestedReposVariables>(SuggestedReposQuery, {
-        variables: {
-            names: suggestedRepoNames,
-            includeJobs: !!authenticatedUser?.siteAdmin,
-        },
-        fetchPolicy: 'cache-first',
+    const suggestions = useRepoSuggestions(transcriptHistory, authenticatedUser, {
+        omitSuggestions: additionalRepositories,
     })
-    // Filter out and reorder the suggested repository results.
-    const displaySuggestedRepos: ContextSelectorRepoFields[] = useMemo(() => {
-        if (!suggestedReposData) {
-            return []
-        }
-
-        const nodes = [...suggestedReposData.byName.nodes]
-        // The order of the by-name repos returned by the search API will not match the
-        // order of suggestions we intend to display (the ordering of suggestedRepoNames),
-        // since the default ordering of the search API is alphabetical. Thus, we reorder
-        // them to match the initial ordering of suggestedRepoNames.
-        const sortedByNameNodes = nodes.sort(
-            (a, b) => suggestedRepoNames.indexOf(a.name) - suggestedRepoNames.indexOf(b.name)
-        )
-        // Make sure we have a full MAX_SUGGESTED_REPOSITORIES to display in the
-        // suggestions. We'll prioritize the repositories we looked up by name, and then
-        // fill in the rest from the first 10 embedded repositories returned by the search
-        // API.
-        return (
-            [...sortedByNameNodes, ...suggestedReposData.firstTen.nodes]
-                // Remove any duplicates.
-                .filter(removeDupes)
-                // Take the first MAX_SUGGESTED_REPOSITORIES.
-                .slice(0, MAX_SUGGESTED_REPOSITORIES)
-                // Finally, filter out repositories that are already selected in the chat
-                // context.
-                .filter(
-                    suggestion => !additionalRepositories.find(alreadyAdded => alreadyAdded.name === suggestion.name)
-                )
-        )
-    }, [suggestedReposData, suggestedRepoNames, additionalRepositories])
 
     const searchResults = useMemo(() => searchResultsData?.repositories.nodes || [], [searchResultsData])
 
@@ -474,8 +348,8 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         styles.contextItemsContainer
                                                     )}
                                                 >
-                                                    {displaySuggestedRepos.length &&
-                                                        displaySuggestedRepos.map(repository => (
+                                                    {suggestions.length &&
+                                                        suggestions.map(repository => (
                                                             <SearchResultsListItem
                                                                 additionalRepositories={[]}
                                                                 key={repository.id}
@@ -512,8 +386,8 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         styles.contextItemsContainer
                                                     )}
                                                 >
-                                                    {displaySuggestedRepos.length &&
-                                                        displaySuggestedRepos.map(repository => (
+                                                    {suggestions.length &&
+                                                        suggestions.map(repository => (
                                                             <SearchResultsListItem
                                                                 additionalRepositories={[]}
                                                                 key={repository.id}

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -310,7 +310,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                             <div className="d-flex flex-column mb-1">
                                                 <Text
                                                     className={classNames(
-                                                        'm-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between',
+                                                        'm-0 pl-2 pr-3 pb-1 pt-2 text-muted d-flex justify-content-between',
                                                         styles.subHeader
                                                     )}
                                                 >
@@ -345,7 +345,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                             <div className="d-flex flex-column">
                                                 <Text
                                                     className={classNames(
-                                                        'mb-0 pl-2 pr-3 py-1 text-muted d-flex justify-content-between border-top',
+                                                        'mb-0 pl-2 pr-3 pb-1 pt-2 text-muted d-flex justify-content-between border-top',
                                                         styles.subHeader
                                                     )}
                                                 >

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -15,6 +15,7 @@ import {
 import classNames from 'classnames'
 
 import { useLazyQuery } from '@sourcegraph/http-client'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import {
     Icon,
@@ -73,6 +74,7 @@ export const RepositoriesSelectorPopover: React.FC<{
     // Whether to encourage the popover to overlap its trigger if necessary, rather than
     // collapsing or flipping position.
     encourageOverlap?: boolean
+    authenticatedUser: AuthenticatedUser | null
 }> = React.memo(function RepositoriesSelectorPopoverContent({
     inferredRepository,
     inferredFilePath,
@@ -85,6 +87,7 @@ export const RepositoriesSelectorPopover: React.FC<{
     toggleIncludeInferredRepository,
     toggleIncludeInferredFile,
     encourageOverlap = false,
+    authenticatedUser,
 }) {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false)
     const [searchText, setSearchText] = useState('')
@@ -113,12 +116,12 @@ export const RepositoriesSelectorPopover: React.FC<{
         if (searchTextDebounced) {
             /* eslint-disable no-console */
             searchRepositories({
-                variables: { query: searchTextDebounced, includeJobs: !!window.context.currentUser?.siteAdmin },
+                variables: { query: searchTextDebounced, includeJobs: !!authenticatedUser?.siteAdmin },
                 pollInterval: 5000,
             }).catch(console.error)
             /* eslint-enable no-console */
         }
-    }, [searchTextDebounced, searchRepositories])
+    }, [searchTextDebounced, searchRepositories, authenticatedUser?.siteAdmin])
 
     const [isCalloutDismissed = true, setIsCalloutDismissed] = useTemporarySetting(
         'cody.contextCallout.dismissed',
@@ -254,7 +257,10 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                             {getFileName(inferredFilePath)}
                                                         </span>
                                                     </div>
-                                                    <EmbeddingExistsIcon repo={inferredRepository} />
+                                                    <EmbeddingExistsIcon
+                                                        repo={inferredRepository}
+                                                        authenticatedUser={authenticatedUser}
+                                                    />
                                                 </button>
                                             )}
                                             <button
@@ -284,7 +290,10 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                         {getRepoName(inferredRepository.name)}
                                                     </span>
                                                 </div>
-                                                <EmbeddingExistsIcon repo={inferredRepository} />
+                                                <EmbeddingExistsIcon
+                                                    repo={inferredRepository}
+                                                    authenticatedUser={authenticatedUser}
+                                                />
                                             </button>
                                         </div>
                                     )}
@@ -309,6 +318,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                     key={repository.id}
                                                     repository={repository}
                                                     removeRepository={removeRepository}
+                                                    authenticatedUser={authenticatedUser}
                                                 />
                                             ))}
                                         </div>
@@ -343,6 +353,7 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                 searchText={searchText}
                                                 addRepository={addRepository}
                                                 removeRepository={removeRepository}
+                                                authenticatedUser={authenticatedUser}
                                             />
                                         ))
                                     ) : !loadingSearchResults ? (
@@ -398,7 +409,8 @@ export const RepositoriesSelectorPopover: React.FC<{
 const AdditionalRepositoriesListItem: React.FC<{
     repository: IRepo
     removeRepository: (repoName: string) => void
-}> = React.memo(function RepositoryListItemContent({ repository, removeRepository }) {
+    authenticatedUser: AuthenticatedUser | null
+}> = React.memo(function RepositoryListItemContent({ repository, removeRepository, authenticatedUser }) {
     const onClick = useCallback(() => {
         removeRepository(repository.name)
     }, [repository, removeRepository])
@@ -421,7 +433,7 @@ const AdditionalRepositoriesListItem: React.FC<{
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 <span className="text-truncate">{getRepoName(repository.name)}</span>
             </div>
-            <EmbeddingExistsIcon repo={repository} />
+            <EmbeddingExistsIcon repo={repository} authenticatedUser={authenticatedUser} />
         </button>
     )
 })
@@ -432,12 +444,14 @@ const SearchResultsListItem: React.FC<{
     searchText: string
     addRepository: (repoName: string) => void
     removeRepository: (repoName: string) => void
+    authenticatedUser: AuthenticatedUser | null
 }> = React.memo(function RepositoryListItemContent({
     additionalRepositories,
     repository,
     searchText,
     addRepository,
     removeRepository,
+    authenticatedUser,
 }) {
     const selected = useMemo(
         () => !!additionalRepositories.find(({ name }) => name === repository.name),
@@ -474,7 +488,7 @@ const SearchResultsListItem: React.FC<{
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 {getTintedText(getRepoName(repository.name), searchText)}
             </div>
-            <EmbeddingExistsIcon repo={repository} />
+            <EmbeddingExistsIcon repo={repository} authenticatedUser={authenticatedUser} />
         </button>
     )
 })
@@ -594,12 +608,13 @@ export const isRepoIndexed = (repo: IRepo): boolean => getEmbeddingStatus(repo).
 
 const EmbeddingExistsIcon: React.FC<{
     repo: IRepo
-}> = React.memo(function EmbeddingExistsIconContent({ repo }) {
+    authenticatedUser: AuthenticatedUser | null
+}> = React.memo(function EmbeddingExistsIconContent({ repo, authenticatedUser }) {
     const { tooltip, icon, className } = getEmbeddingStatus(repo)
 
     return (
         <Tooltip content={tooltip}>
-            {window.context.currentUser?.siteAdmin ? (
+            {authenticatedUser?.siteAdmin ? (
                 <Link to="/site-admin/embeddings" className="text-body" onClick={event => event.stopPropagation()}>
                     <Icon aria-hidden={true} className={classNames(styles.icon, className)} svgPath={icon} />
                 </Link>

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import type { CodyClientScope } from '@sourcegraph/cody-shared/dist/chat/useClient'
 import { useLazyQuery } from '@sourcegraph/http-client'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { Text } from '@sourcegraph/wildcard'
 
 import type { ReposStatusResult, ReposStatusVariables } from '../../../graphql-operations'
@@ -27,6 +28,7 @@ export interface ScopeSelectorProps {
     // Whether to encourage the selector popover to overlap its trigger if necessary,
     // rather than collapsing or flipping position.
     encourageOverlap?: boolean
+    authenticatedUser: AuthenticatedUser | null
 }
 
 export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function ScopeSelectorComponent({
@@ -40,6 +42,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     className,
     renderHint,
     encourageOverlap,
+    authenticatedUser,
 }) {
     const [loadReposStatus, { data: newReposStatusData, previousData: previousReposStatusData }] = useLazyQuery<
         ReposStatusResult,
@@ -62,10 +65,10 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
         }
 
         loadReposStatus({
-            variables: { repoNames, first: repoNames.length, includeJobs: !!window.context.currentUser?.siteAdmin },
+            variables: { repoNames, first: repoNames.length, includeJobs: !!authenticatedUser?.siteAdmin },
             pollInterval: 2000,
         }).catch(() => null)
-    }, [activeEditor, scope.repositories, loadReposStatus])
+    }, [activeEditor, scope.repositories, loadReposStatus, authenticatedUser?.siteAdmin])
 
     const allRepositories = useMemo(() => reposStatusData?.repositories.nodes || [], [reposStatusData])
 
@@ -134,6 +137,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                         toggleIncludeInferredRepository={toggleIncludeInferredRepository}
                         toggleIncludeInferredFile={toggleIncludeInferredFile}
                         encourageOverlap={encourageOverlap}
+                        authenticatedUser={authenticatedUser}
                     />
                     {scope.includeInferredFile && activeEditor?.filePath && (
                         <Text size="small" className="ml-2 mb-0 align-self-center">

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useCallback } from 'react'
 
 import classNames from 'classnames'
 
+import type { TranscriptJSON } from '@sourcegraph/cody-shared/dist/chat/transcript'
 import type { CodyClientScope } from '@sourcegraph/cody-shared/dist/chat/useClient'
 import { useLazyQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
@@ -23,6 +24,7 @@ export interface ScopeSelectorProps {
     fetchRepositoryNames: (count: number) => Promise<string[]>
     isSourcegraphApp?: boolean
     logTranscriptEvent: (eventLabel: string, eventProperties?: { [key: string]: any }) => void
+    transcriptHistory: TranscriptJSON[]
     className?: string
     renderHint?: (repos: IRepo[]) => React.ReactNode
     // Whether to encourage the selector popover to overlap its trigger if necessary,
@@ -39,6 +41,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     fetchRepositoryNames,
     isSourcegraphApp,
     logTranscriptEvent,
+    transcriptHistory,
     className,
     renderHint,
     encourageOverlap,
@@ -137,6 +140,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                         toggleIncludeInferredRepository={toggleIncludeInferredRepository}
                         toggleIncludeInferredFile={toggleIncludeInferredFile}
                         encourageOverlap={encourageOverlap}
+                        transcriptHistory={transcriptHistory}
                         authenticatedUser={authenticatedUser}
                     />
                     {scope.includeInferredFile && activeEditor?.filePath && (

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -37,6 +37,105 @@ export const ReposSelectorSearchQuery = gql`
     ${REPO_FIELDS}
     ${EMBEDDING_JOB_FIELDS}
 `
+
+export const RecentReposSelectorQuery = gql`
+    query RecentReposSelector(
+        $name0: String!
+        $name1: String!
+        $name2: String!
+        $name3: String!
+        $name4: String!
+        $name5: String!
+        $name6: String!
+        $name7: String!
+        $name8: String!
+        $name9: String!
+        $includeJobs: Boolean!
+    ) {
+        repo0: repository(name: $name0) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo1: repository(name: $name1) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo2: repository(name: $name2) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo3: repository(name: $name3) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo4: repository(name: $name4) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo5: repository(name: $name5) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo6: repository(name: $name6) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo7: repository(name: $name7) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo8: repository(name: $name8) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+        repo9: repository(name: $name9) {
+            ...ContextSelectorRepoFields
+            embeddingJobs(first: 1) @include(if: $includeJobs) {
+                nodes {
+                    ...ContextSelectorEmbeddingJobFields
+                }
+            }
+        }
+    }
+
+    ${REPO_FIELDS}
+    ${EMBEDDING_JOB_FIELDS}
 `
 
 export const ReposStatusQuery = gql`

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -39,8 +39,8 @@ export const ReposSelectorSearchQuery = gql`
 `
 
 export const SuggestedReposQuery = gql`
-    query SuggestedRepos($names: [String!]!, $includeJobs: Boolean!) {
-        byName: repositories(names: $names, first: 10) {
+    query SuggestedRepos($names: [String!]!, $numResults: Int!, $includeJobs: Boolean!) {
+        byName: repositories(names: $names, first: $numResults) {
             nodes {
                 ...ContextSelectorRepoFields
                 embeddingJobs(first: 1) @include(if: $includeJobs) {
@@ -50,9 +50,9 @@ export const SuggestedReposQuery = gql`
                 }
             }
         }
-        # We also grab the first 10 embedded repos available on the site to
-        # show in suggestions as a backup.
-        firstTen: repositories(first: 10, embedded: true) {
+        # We also grab the first $numResults embedded repos available on the site
+        # to show in suggestions as a backup.
+        firstN: repositories(first: $numResults, embedded: true) {
             nodes {
                 ...ContextSelectorRepoFields
                 embeddingJobs(first: 1) @include(if: $includeJobs) {

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -1,47 +1,58 @@
 import { gql } from '@sourcegraph/http-client'
 
+const REPO_FIELDS = gql`
+    fragment ContextSelectorRepoFields on Repository {
+        id
+        name
+        embeddingExists
+        externalRepository {
+            id
+            serviceType
+        }
+    }
+`
+
+const EMBEDDING_JOB_FIELDS = gql`
+    fragment ContextSelectorEmbeddingJobFields on RepoEmbeddingJob {
+        id
+        state
+        failureMessage
+    }
+`
+
 export const ReposSelectorSearchQuery = gql`
     query ReposSelectorSearch($query: String!, $includeJobs: Boolean!) {
         repositories(query: $query, first: 10) {
             nodes {
-                id
-                name
-                embeddingExists
-                externalRepository {
-                    id
-                    serviceType
-                }
+                ...ContextSelectorRepoFields
                 embeddingJobs(first: 1) @include(if: $includeJobs) {
                     nodes {
-                        id
-                        state
-                        failureMessage
+                        ...ContextSelectorEmbeddingJobFields
                     }
                 }
             }
         }
     }
+
+    ${REPO_FIELDS}
+    ${EMBEDDING_JOB_FIELDS}
+`
 `
 
 export const ReposStatusQuery = gql`
     query ReposStatus($repoNames: [String!]!, $first: Int!, $includeJobs: Boolean!) {
         repositories(names: $repoNames, first: $first) {
             nodes {
-                id
-                name
-                embeddingExists
-                externalRepository {
-                    id
-                    serviceType
-                }
+                ...ContextSelectorRepoFields
                 embeddingJobs(first: 1) @include(if: $includeJobs) {
                     nodes {
-                        id
-                        state
-                        failureMessage
+                        ...ContextSelectorEmbeddingJobFields
                     }
                 }
             }
         }
     }
+
+    ${REPO_FIELDS}
+    ${EMBEDDING_JOB_FIELDS}
 `

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -38,97 +38,27 @@ export const ReposSelectorSearchQuery = gql`
     ${EMBEDDING_JOB_FIELDS}
 `
 
-export const RecentReposSelectorQuery = gql`
-    query RecentReposSelector(
-        $name0: String!
-        $name1: String!
-        $name2: String!
-        $name3: String!
-        $name4: String!
-        $name5: String!
-        $name6: String!
-        $name7: String!
-        $name8: String!
-        $name9: String!
-        $includeJobs: Boolean!
-    ) {
-        repo0: repository(name: $name0) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
+export const SuggestedReposQuery = gql`
+    query SuggestedRepos($names: [String!]!, $includeJobs: Boolean!) {
+        byName: repositories(names: $names, first: 10) {
+            nodes {
+                ...ContextSelectorRepoFields
+                embeddingJobs(first: 1) @include(if: $includeJobs) {
+                    nodes {
+                        ...ContextSelectorEmbeddingJobFields
+                    }
                 }
             }
         }
-        repo1: repository(name: $name1) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo2: repository(name: $name2) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo3: repository(name: $name3) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo4: repository(name: $name4) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo5: repository(name: $name5) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo6: repository(name: $name6) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo7: repository(name: $name7) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo8: repository(name: $name8) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
-                }
-            }
-        }
-        repo9: repository(name: $name9) {
-            ...ContextSelectorRepoFields
-            embeddingJobs(first: 1) @include(if: $includeJobs) {
-                nodes {
-                    ...ContextSelectorEmbeddingJobFields
+        # We also grab the first 10 embedded repos available on the site to
+        # show in suggestions as a backup.
+        firstTen: repositories(first: 10, embedded: true) {
+            nodes {
+                ...ContextSelectorRepoFields
+                embeddingJobs(first: 1) @include(if: $includeJobs) {
+                    nodes {
+                        ...ContextSelectorEmbeddingJobFields
+                    }
                 }
             }
         }

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -22,7 +22,7 @@ const EMBEDDING_JOB_FIELDS = gql`
 
 export const ReposSelectorSearchQuery = gql`
     query ReposSelectorSearch($query: String!, $includeJobs: Boolean!) {
-        repositories(query: $query, first: 10) {
+        repositories(query: $query, first: 15) {
             nodes {
                 ...ContextSelectorRepoFields
                 embeddingJobs(first: 1) @include(if: $includeJobs) {

--- a/client/web/src/cody/components/ScopeSelector/useRepoSuggestions.ts
+++ b/client/web/src/cody/components/ScopeSelector/useRepoSuggestions.ts
@@ -1,0 +1,179 @@
+import { useMemo } from 'react'
+
+import type { TranscriptJSON } from '@sourcegraph/cody-shared/dist/chat/transcript'
+import { useQuery } from '@sourcegraph/http-client'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+
+import { useUserHistory } from '../../../components/useUserHistory'
+import type {
+    ContextSelectorRepoFields,
+    SuggestedReposResult,
+    SuggestedReposVariables,
+} from '../../../graphql-operations'
+
+import { SuggestedReposQuery } from './backend'
+
+interface UseRepoSuggestionsOpts {
+    numSuggestions: number
+    fallbackSuggestions: string[]
+    omitSuggestions: { name: string }[]
+}
+
+const DEFAULT_OPTS: UseRepoSuggestionsOpts = {
+    numSuggestions: 10,
+    fallbackSuggestions: [
+        // This is mostly relevant for dotcom but could fill in for any instance which
+        // indexes GitHub OSS repositories. If the repositories are not indexed on the
+        // instance, they will not return any results from the search API and thus will
+        // not be included in the final list of suggestions.
+        //
+        // NOTE: The actual 10 most popular OSS repositories on GitHub are typically just
+        // plaintext resource collections like awesome lists or how-to-program tutorials, which
+        // are not likely to be as interesting to Cody users. Instead, we hardcode a list of
+        // repositories that are among the top 100 that contain actual source code.
+        'github.com/sourcegraph/sourcegraph',
+        'github.com/freeCodeCamp/freeCodeCamp',
+        'github.com/facebook/react',
+        'github.com/tensorflow/tensorflow',
+        'github.com/torvalds/linux',
+        'github.com/microsoft/vscode',
+        'github.com/flutter/flutter',
+        'github.com/golang/go',
+        'github.com/d3/d3',
+        'github.com/kubernetes/kubernetes',
+    ],
+    omitSuggestions: [],
+}
+
+/**
+ * useRepoSuggestions is a custom hook that generates repository suggestions for the
+ * context scope selector.
+ *
+ * The suggestions are based on the current user's chat transcript history, search
+ * browsing history, embedded repositories available on their instance, and any fallbacks
+ * configured in the options.
+ *
+ * The number of suggestions can be configured with `opts.numSuggestions`. The default is 10.
+ *
+ * Fallback suggestions can be configured with `opts.fallbackSuggestions`. The default is
+ * a list of 10 of the most popular OSS repositories on GitHub.
+ *
+ * Repositories can be omitted from the suggestions (for example, repositories that are
+ * already added to the context scope) by passing them as `opts.omitSuggestions.`
+ *
+ * @param transcriptHistory the current user's chat transcript history from the store
+ * @param authenticatedUser the current authenticated user
+ * @param opts any options for further configuring the suggestions
+ * @returns a list of repository suggestions as `ContextSelectorRepoFields` objects
+ */
+export const useRepoSuggestions = (
+    transcriptHistory: TranscriptJSON[],
+    authenticatedUser: AuthenticatedUser | null = null,
+    opts?: Partial<UseRepoSuggestionsOpts>
+): ContextSelectorRepoFields[] => {
+    const { numSuggestions, fallbackSuggestions, omitSuggestions } = { ...DEFAULT_OPTS, ...opts }
+
+    const userHistory = useUserHistory(authenticatedUser?.id, false)
+    const suggestedRepoNames: string[] = useMemo(() => {
+        const flattenedTranscriptHistoryEntries = transcriptHistory
+            .map(item => {
+                const { scope, lastInteractionTimestamp } = item
+                return (
+                    // Return a new item for each repository in the scope.
+                    scope?.repositories.map(name => ({
+                        // Parse a date from the last interaction timestamp.
+                        lastAccessed: new Date(lastInteractionTimestamp),
+                        name,
+                    })) || []
+                )
+            })
+            .flat()
+            // Remove duplicates.
+            .filter(removeDupes)
+            // We only need up to the first numSuggestions.
+            .slice(0, numSuggestions)
+
+        const userHistoryEntries =
+            userHistory
+                .loadEntries()
+                .map(item => ({
+                    name: item.repoName,
+                    // Parse a date from the last acessed timestamp.
+                    lastAccessed: new Date(item.lastAccessed),
+                }))
+                // We only need up to the first numSuggestions.
+                .slice(0, numSuggestions) || []
+
+        // We also can take a list of up to numSuggestions fallback repos to
+        // fill in if we have fewer than numSuggestions to actually suggest.
+        const fallbackRepos = fallbackSuggestions
+            .map(name => ({
+                name,
+                // We order by most recently accessed; these should always be ranked last.
+                lastAccessed: new Date(0),
+            }))
+            .slice(0, numSuggestions)
+
+        // Merge the lists.
+        const merged = [...flattenedTranscriptHistoryEntries, ...userHistoryEntries, ...fallbackRepos]
+            // Sort by most recently accessed.
+            .sort((a, b) => b.lastAccessed.getTime() - a.lastAccessed.getTime())
+            // Remove duplicates.
+            .filter(removeDupes)
+            // Take the most recent numSuggestions.
+            .slice(0, numSuggestions)
+
+        // Return just the names.
+        return merged.map(({ name }) => name)
+    }, [transcriptHistory, userHistory, numSuggestions, fallbackSuggestions])
+
+    // Query for the suggested repositories.
+    const { data: suggestedReposData } = useQuery<SuggestedReposResult, SuggestedReposVariables>(SuggestedReposQuery, {
+        variables: {
+            names: suggestedRepoNames,
+            numResults: numSuggestions,
+            includeJobs: !!authenticatedUser?.siteAdmin,
+        },
+        fetchPolicy: 'cache-first',
+    })
+
+    // Filter out and reorder the suggested repository results.
+    const suggestions: ContextSelectorRepoFields[] = useMemo(() => {
+        if (!suggestedReposData) {
+            return []
+        }
+
+        const nodes = [...suggestedReposData.byName.nodes]
+        // The order of the by-name repos returned by the search API will not match the
+        // order of suggestions we intend to display (the ordering of suggestedRepoNames),
+        // since the default ordering of the search API is alphabetical. Thus, we reorder
+        // them to match the initial ordering of suggestedRepoNames.
+        const sortedByNameNodes = nodes.sort(
+            (a, b) => suggestedRepoNames.indexOf(a.name) - suggestedRepoNames.indexOf(b.name)
+        )
+        // Make sure we have a full numSuggestions to display in the
+        // suggestions. We'll prioritize the repositories we looked up by name, and then
+        // fill in the rest from the first 10 embedded repositories returned by the search
+        // API.
+        return (
+            [...sortedByNameNodes, ...suggestedReposData.firstN.nodes]
+                // Remove any duplicates.
+                .filter(removeDupes)
+                // Take the first numSuggestions.
+                .slice(0, numSuggestions)
+                // Finally, filter out repositories that are should be omitted.
+                .filter(suggestion => !omitSuggestions.find(toOmit => toOmit.name === suggestion.name))
+        )
+    }, [suggestedReposData, suggestedRepoNames, omitSuggestions, numSuggestions])
+
+    return suggestions
+}
+
+/**
+ * removeDupes is an `Array.filter` predicate function which removes duplicate entries
+ * from an array of objects based on the `name` property. It filters out any entries which
+ * are not the first occurrence with a given `name`, which means it will preserve the
+ * earliest occurrence of each.
+ */
+const removeDupes = (first: { name: string }, index: number, self: { name: string }[]): boolean =>
+    index === self.findIndex(entry => entry.name === first.name)

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { mdiClose, mdiFormatListBulleted, mdiPlus, mdiDelete } from '@mdi/js'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { Button, Icon, Tooltip, Badge } from '@sourcegraph/wildcard'
 
 import { ChatUI, ScrollDownButton } from '../components/ChatUI'
@@ -16,9 +17,10 @@ export const SCROLL_THRESHOLD = 100
 
 interface CodySidebarProps {
     onClose?: () => void
+    authenticatedUser: AuthenticatedUser | null
 }
 
-export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
+export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose, authenticatedUser }) => {
     const codySidebarStore = useCodySidebar()
     const {
         initializeNewChat,
@@ -141,7 +143,7 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose }) => {
                         deleteHistoryItem={deleteHistoryItem}
                     />
                 ) : (
-                    <ChatUI codyChatStore={codySidebarStore} />
+                    <ChatUI codyChatStore={codySidebarStore} authenticatedUser={authenticatedUser} />
                 )}
             </div>
             {showScrollDownButton && <ScrollDownButton onClick={() => scrollToBottom('smooth')} />}

--- a/client/web/src/cody/sidebar/Provider.tsx
+++ b/client/web/src/cody/sidebar/Provider.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useState, useCallback, useMemo } from 'react'
 
+import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 
 import { useCodyChat, type CodyChatStore, codyChatStoreMock } from '../useCodyChat'
@@ -25,9 +26,10 @@ const CodySidebarContext = React.createContext<CodySidebarStore | null>({
 
 interface ICodySidebarStoreProviderProps {
     children?: React.ReactNode
+    authenticatedUser: AuthenticatedUser | null
 }
 
-export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> = ({ children }) => {
+export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> = ({ authenticatedUser, children }) => {
     const [isSidebarOpen, setIsSidebarOpenState] = useTemporarySetting('cody.showSidebar', false)
     const [inputNeedsFocus, setInputNeedsFocus] = useState(false)
     const { setSidebarSize } = useSidebarSize()
@@ -46,7 +48,7 @@ export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> 
 
     const onEvent = useCallback(() => setIsSidebarOpen(true), [setIsSidebarOpen])
 
-    const codyChatStore = useCodyChat({ onEvent })
+    const codyChatStore = useCodyChat({ userID: authenticatedUser?.id, onEvent })
 
     const state = useMemo<CodySidebarStore>(
         () => ({

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -340,8 +340,7 @@ export const useCodyChat = ({
             return null
         }
 
-        // TODO: Confirm correct behavior for autoLoadScope, i.e. with App, and add note
-        const newTranscript = initializeNewChatInternal(autoLoadScopeWithRepositories ? undefined : scope)
+        const newTranscript = initializeNewChatInternal(scope)
 
         if (!newTranscript) {
             return null
@@ -349,7 +348,10 @@ export const useCodyChat = ({
 
         pushTranscriptToHistory(newTranscript).catch(noop)
 
-        if (autoLoadScopeWithRepositories) {
+        // If we couldn't populate the scope with repositories from the last chat
+        // conversation and `autoLoadScopeWithRepositories` is enabled, then we fetch 10
+        // to set in the scope.
+        if (scope.repositories.length === 0 && autoLoadScopeWithRepositories) {
             fetchRepositoryNames(10)
                 .then(repositories => {
                     const updatedScope = {

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -145,6 +145,7 @@ export const useCodyChat = ({
             customHeaders: window.context.xhrHeaders,
             debugEnable: false,
             needsEmailVerification: isEmailVerificationNeededForCody(),
+            experimentalLocalSymbols: false,
         },
         scope: initialScope,
         onEvent,

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -145,6 +145,7 @@ export class UserHistory {
  * anonymous
  * @param isRepositoryRelatedPage whether the component rendering this hook is on a page
  * that is related to a repository (e.g. a code view page) and should be tracked
+ * @returns a `UserHistory` instance
  */
 export function useUserHistory(userID: Scalars['ID'] | undefined, isRepositoryRelatedPage: boolean): UserHistory {
     const location = useLocation()

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -63,7 +63,7 @@ export class UserHistory {
             this.deleteEntry(entries[index])
         }
     }
-    private loadEntries(): UserHistoryEntry[] {
+    public loadEntries(): UserHistoryEntry[] {
         return JSON.parse(this.storage.getItem(this.storageKey(this.userID)) ?? '[]')
     }
     private deleteEntry(entry: UserHistoryEntry): void {

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -126,6 +126,26 @@ export class UserHistory {
     }
 }
 
+/**
+ * useUserHistory is a custom hook that collects browser history events for the current
+ * user and stores visited repos and files in local storage.
+ *
+ * It takes in the user ID of the current user and whether the current page is
+ * repository-related. On repository pages, it parses the location to extract the repo
+ * name and file path. It then updates the history entry for that repo/file with the
+ * current timestamp.
+ *
+ * The returned `UserHistory` instance provides methods to get the list of visited repos,
+ * and lookup the last accessed timestamp for a repo or file.
+ *
+ * The repo history is persisted to local storage and can be used to personalize and
+ * improve the search experience for the user.
+ *
+ * @param userID the ID of the currently-authenticated user, or undefined if the user is
+ * anonymous
+ * @param isRepositoryRelatedPage whether the component rendering this hook is on a page
+ * that is related to a repository (e.g. a code view page) and should be tracked
+ */
 export function useUserHistory(userID: Scalars['ID'] | undefined, isRepositoryRelatedPage: boolean): UserHistory {
     const location = useLocation()
     const userHistory = useMemo(() => new UserHistory(userID), [userID])

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react'
 import type * as H from 'history'
 import { useLocation } from 'react-router-dom'
 
-import { Scalars } from '../graphql-operations'
+import type { Scalars } from '../graphql-operations'
 import { parseBrowserRepoURL } from '../util/url'
 
 export interface UserHistoryEntry {

--- a/client/web/src/components/useUserHistory.ts
+++ b/client/web/src/components/useUserHistory.ts
@@ -17,11 +17,13 @@ const LOCAL_STORAGE_KEY = 'user-history'
 const MAX_LOCAL_STORAGE_COUNT = 100
 
 /**
- * Collects all browser history events and stores which repos/files are visited
- * in local storage.  In the future, we should consider storing this history
- * remotely in temporary settings (or similar). The history is used to
- * personalize ranking in the fuzzy finder, but could theorically power other
- * features like improve ranking in the search bar suggestions.
+ * Collects all browser history events and stores which repos/files are visited in local
+ * storage. The history is used to personalize ranking in the fuzzy finder and populate
+ * suggestions in the Cody context selector.
+ *
+ * In the future, we should consider storing this history remotely in temporary settings
+ * and use them to power other features like improving ranking in the search bar
+ * suggestions.
  */
 export class UserHistory {
     private repos: Map<string, Map<string, number>> = new Map()

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -510,7 +510,10 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         storageKey="size-cache-cody-sidebar"
                         onResize={setCodySidebarSize}
                     >
-                        <CodySidebar onClose={() => setIsCodySidebarOpen(false)} />
+                        <CodySidebar
+                            onClose={() => setIsCodySidebarOpen(false)}
+                            authenticatedUser={props.authenticatedUser}
+                        />
                     </Panel>
                 )}
             </div>

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -155,7 +155,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => (
-                    <CodySidebarStoreProvider>
+                    <CodySidebarStoreProvider authenticatedUser={props.authenticatedUser}>
                         <RepoContainer {...props} />
                     </CodySidebarStoreProvider>
                 )}

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -89,7 +89,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
     const isSetupWizardPage = location.pathname.startsWith(PageRoutes.SetupWizard)
 
     const [isFuzzyFinderVisible, setFuzzyFinderVisible] = useState(false)
-    const userHistory = useUserHistory(isRepositoryRelatedPage)
+    const userHistory = useUserHistory(props.authenticatedUser?.id, isRepositoryRelatedPage)
 
     const communitySearchContextPaths = communitySearchContextsRoutes.map(route => route.path)
     const isCommunitySearchContextPage = communitySearchContextPaths.includes(location.pathname)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1587,8 +1587,8 @@ importers:
         specifier: workspace:*
         version: link:../codeintellify
       '@sourcegraph/cody-shared':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       '@sourcegraph/cody-ui':
         specifier: ^0.0.7
         version: 0.0.7
@@ -9351,6 +9351,21 @@ packages:
 
   /@sourcegraph/cody-shared@0.0.5:
     resolution: {integrity: sha512-xwNHKsE9NPEUcQoEqJMYuU86D3NRqBn/V6Fjc09FlkgNQUcouJhGZuVntpOuBa3g8aEqOVT+bI/QcX0Oy1QGfQ==}
+    dependencies:
+      '@microsoft/fetch-event-source': 2.0.1
+      dompurify: 3.0.4
+      highlight.js: 10.7.3
+      isomorphic-fetch: 3.0.0
+      lodash: 4.17.21
+      marked: 4.0.16
+      vscode-uri: 3.0.7
+      x2js: 3.4.4
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@sourcegraph/cody-shared@0.0.6:
+    resolution: {integrity: sha512-Lnc/E8ooH3O2FuvvqLM2T+Vy3a0fPrFh1o4LsTYvMBdekcTz7g2ENyRcEEMwqcbn83TlnO5OqYIPqq/2DJFKLg==}
     dependencies:
       '@microsoft/fetch-event-source': 2.0.1
       dompurify: 3.0.4


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/55363.

This PR provides suggestions to the context selector, so that it's less empty when you initially open the popover and it hopefully takes less work to find the repos you want to use Cody with.

### Screenshots
| Scenario | | Note |
|-----:|:-----------:|----|
| Popover first opened | <img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/4dae8ec2-6794-4a39-ad42-c6f5d6a43058"> | The suggestions fill most of the popover window area and can be scrolled through. |
| When several suggestions have been added | <img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/9d789d75-74b5-4693-94ce-d3c8be2c895c"> | Any repos added from suggestions move to populate the "Repositories" section. |
| Searching | <img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/1400bc5f-8cb0-4cad-84f3-83edcaa2c366"> | The search UI remains unchanged. |
| With inferred repo/file | <img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/84206fe7-01fe-4552-964b-4c63234fec4a"> | The suggestions fill in at the very bottom, distinct from the other sections.
| When all the suggestions have been added | <img width="300" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/8942601/51a40971-f876-489e-9d98-14dcb68e2c03"> | The "Suggestions" section disappears, leaving only "Repositories". |

### Demo

The algorithm for suggesting these repos has a couple layers to it, so let me walk you through it via a demo!

_NB, the popover presented in the demos is taller than in the final version._

I'm starting as a brand new user who has never interacted with Sourcegraph or Cody before. This user can see 10 suggestions for repos when they open the context selector:

https://github.com/sourcegraph/sourcegraph/assets/8942601/cf9c46e4-2a07-4cb3-b838-66251dbd0ec8

The suggestions list takes on the same visual appearance as the currently selected repos list does. When the user selects a repo from suggestions, it moves from "Suggestions" to "Repositories".

Since this user has never interacted with Sourcegraph or Cody before, there's no history to make suggestions from. So instead, this initial list of suggestions is a combination of:
1. Any repositories from a hard-coded list of 10 of the most popular open source repositories on GitHub that are available on the instance.
2. The first 10 repositories with embeddings available on the instance, alphabetically.

In this demo, `sourcegraph/sourcegraph`, `facebook/react`, and `tensorflow/tensorflow` are the only 3 repos from the hard-coded list of most popular repos that I have indexed locally, which is why they appear first. The following 7 repos are the first 7 repos with embeddings available on my dev instance. On dotcom, a first-time user would see all 10 suggestions come from the hard-coded list of top open source repos. On a customer's instance that's only connected to their private code hosts, they'd see none of those.

In this demo, the user selects `sourcegraph-batch-changes/etcd` and `sourcegraph-batch-changes/src-cli` for their first conversation. Keep this in mind as we move forward!

Once the user goes to start a new chat with Cody, we see the new chat automatically preserves the last-used set of repos in context:

https://github.com/sourcegraph/sourcegraph/assets/8942601/a4f12226-eacb-4898-8334-1879f8da0cd6

The getting started banner reflects this. It's easy to reset or update the context. In this example, the user removes `sourcegraph-batch-changes/etcd` and adds `sourcegraph/sourcegraph`. When `etcd` is removed, we see it appear at the top of the suggestions list. This is because it's part of the user's transcript history, now, from the previous conversation thread. Repositories that the user has recently interacted with take precedence over the top 10 open source repos and the first 10 repos with embeddings.

Now the user goes to use code search, and we add repo search history into the mix:

https://github.com/sourcegraph/sourcegraph/assets/8942601/76f5d859-985c-40ba-bd87-1a42e7422b7a

We see here that the user first visits `github.com/sourcegraph/cody`, and then shortly after `github.com/sourcegraph/automation-testing`. Upon returning to the Chat UI and starting a new conversation, we can observe that:
- Before resetting the scope, these two repos are now at the top of the suggestions list, above `sourcegraph-batch-changes/etcd`, because they were interacted with more recently.
- After resetting the scope, the two repos that were removed are now at the top, then the two from search, then `etcd` from the earlier chat.

Suggestions from the user's recent activity are the ones that will be the most relevant to the user, so they always take priority over the others. Cody chat and code search are treated as equally important sources, so the repo suggestions that come from them are combined, de-duped, and sorted by last interaction time before being displayed.

At the end of this demo, we now have repos from 4 different sources integrated into the suggestions! Once the user has interacted with 10 different repos via Cody or search, they will be the only suggestions a user sees from then on out. For users who have already used code search and/or Cody, then, they'll see these suggestions immediately after we roll out these changes.

### Implementation Notes

We get the information on repos recently visited with search from the `useUserHistory` hook. I actually initially implemented my own take on this hook because I didn't find this one when I was searching for something like it. I only discovered it was there when I was probing local storage to test that my own version was working. 🤦‍♀️ Rookie mistake! While its name might suggest it captures more than just repos recently visited, I can confirm that's all it is actually tracking. For the most part, I was able to use this hook exactly as it is. I only changed the structure and contents stored by this hook in one meaningful way, which I will describe inline with the changes.

We're playing a bit fast-and-loose with the currently authenticated user in a couple places across the web app. This PR tries to clean that up in a couple small ways that were relevant to the context selector feature:
- Preferring to prop-drill `authenticatedUser` rather than read it from `window.context.currentUser`. This is because `window.context` is only loaded once, when the page initially loads, whereas `authenticatedUser` is updated by other app interactions. If the user is logged out, has their site admin status changed, or other things happen to them mid-session, for example, this wouldn't be reflected by `window.context.currentUser`.
- Re-indexing the user history in local storage by a user-differentiated storage key. Previously, all user history, regardless of who was currently logged in, was collected under the same key. Though the average user probably doesn't share their machine with other SG users, an admin may have several SG accounts for different purposes, so it's best to be able to distinguish this locally saved history by user ID. Plus it makes dev testing with different users a whole lot more sane.
- Re-indexing Cody chat transcript history in local storage by a user-differentiated storage key. This is the equivalent migration as is described for user history; previously, all transcripts were collected under the same key, regardless of who was logged in. They will now live under distinct storage keys.

## Test plan

- Walk through the steps of the demo as listed above, as a new user
- Tested interactions manually in standalone chat as well as sidebar chat
- Tested interactions manually in Web as well as App
- Check that CI is passing
