### PR TITLE
App: disable executors for Cody App

### DIFF
--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -251,6 +251,12 @@ func run(
 			ready := syncx.OnceFunc(allReadyWG.Done)
 			defer ready()
 
+			// Don't run executors for Cody App
+			if deploy.IsApp() && !deploy.IsAppFullSourcegraph() && service.Name() == "executor" {
+				logger.Warn("Skipping", log.String("service", service.Name()))
+				return
+			}
+
 			// TODO: It's not clear or enforced but all the service.Start calls block until the service is completed
 			// This should be made explicit or refactored to accept to done channel or function in addition to ready.
 			err := service.Start(ctx, obctx, ready, serviceConfig)

--- a/internal/service/svcmain/svcmain.go
+++ b/internal/service/svcmain/svcmain.go
@@ -253,7 +253,7 @@ func run(
 
 			// Don't run executors for Cody App
 			if deploy.IsApp() && !deploy.IsAppFullSourcegraph() && service.Name() == "executor" {
-				logger.Warn("Skipping", log.String("service", service.Name()))
+				logger.Info("Skipping", log.String("service", service.Name()))
 				return
 			}
 


### PR DESCRIPTION
Since executors currently do not assist the Cody App disable starting them to avoid docker issues.
## Test plan
Build release version `CODESIGNING=0 CI=false ./enterprise/dev/app/build.sh`
Verify app startup and no docker containers running 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
