### PR TITLE
JetBrains: Fix agent binary name for Windows

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -182,7 +182,7 @@ public class CodyAgent implements Disposable {
   }
 
   private static String agentBinaryName() {
-    String os = SystemInfoRt.isMac ? "macos" : SystemInfoRt.isWindows ? "windows" : "linux";
+    String os = SystemInfoRt.isMac ? "macos" : SystemInfoRt.isWindows ? "win" : "linux";
     String arch = CpuArch.isArm64() ? "arm64" : "x64";
     return "agent-" + os + "-" + arch + binarySuffix();
   }


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/55916

We referenced the agent binary by `agent-windows-x64.exe`, but it should really be `agent-win-x64.exe`. This PR fixes this.

## Test plan

Got rid of the error message after this change.