### PR TITLE
ci: use array for running containers in preexit

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -18,10 +18,8 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" == "bazel" ]]; then
   # Remove any hanging containers and/or volumes to ensure the next tests are able to run.
   if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
     echo "Removing docker containers..."
-    set -x
-    docker ps -a
-    docker rm -f "$(docker ps -aq)"
-    set +x
+    mapfile -t containers < <(docker ps -aq)
+    for c in "${containers[@]}"; do docker rm -f "$c"; done
   fi
   if [[ $(docker volume ls -q) -gt 0 ]]; then
     docker volume rm "$(docker volume ls -q)"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -17,7 +17,11 @@ if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" == "bazel" ]]; then
 
   # Remove any hanging containers and/or volumes to ensure the next tests are able to run.
   if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
+    echo "Removing docker containers..."
+    set -x
+    docker ps -a
     docker rm -f "$(docker ps -aq)"
+    set +x
   fi
   if [[ $(docker volume ls -q) -gt 0 ]]; then
     docker volume rm "$(docker volume ls -q)"


### PR DESCRIPTION
We've observed failures in e2e tests due to dangling containers. Despite the a `docker rm -f` being run in the pre-exit they aren't being removed. 

I suspect this is because for some reason, this is being read as one container name, and not as two separate containers. I've done some testing and you can observe in the output below

```
2023-08-21 09:17:47 CST | docker ps -a | 0s
-- | -- | --
  | 2023-08-21 09:17:47 CST | CONTAINER ID   IMAGE     COMMAND                  CREATED          STATUS          PORTS                  NAMES
  | 2023-08-21 09:17:47 CST | 54254a437fdc   nginx     "/docker-entrypoint.…"   35 seconds ago   Up 34 seconds   0.0.0.0:7081->80/tcp   pedantic_faraday
  | 2023-08-21 09:17:47 CST | 6acac2db587f   nginx     "/docker-entrypoint.…"   40 seconds ago   Up 38 seconds   0.0.0.0:7080->80/tcp   gallant_grothendieck
  | 2023-08-21 09:17:47 CST | ++++ docker ps -aq
  | 2023-08-21 09:17:47 CST | docker rm -f '54254a437fdc | 0s
  | 2023-08-21 09:17:47 CST | 6acac2db587f'
  | 2023-08-21 09:17:47 CST | Error: No such container: 54254a437fdc
  | 2023-08-21 09:17:47 CST | 6acac2db587f
```

When reading the two container ID's into an array and then looping through it...there's no further issue

```


2023-08-21 10:05:38 CST | $ .buildkite/hooks/pre-exit
-- | --
  | 2023-08-21 10:05:38 CST | Removing docker containers...
  | 2023-08-21 10:05:38 CST | 01774172c839
  | 2023-08-21 10:05:39 CST | 72ecba0b1412

```

## Test plan

See description and the checks on this PR