### PR TITLE
ci: report dangling containers on Sentry

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -36,4 +36,13 @@ fi
 if [[ "$BUILDKITE_AGENT_META_DATA_QUEUE" == "bazel" ]]; then
     echo "~~~ Checking dangling docker containers"
     docker ps -a
+
+    if [[ $(docker ps -aq | wc -l) -gt 0 ]]; then
+      SENTRY_DSN="$CI_SENTRY_DSN" sentry-cli send-event \
+        -m "Dangling containers detected" \
+        -e "job_name:$BUILDKITE_LABEL" \
+        -e "job_url:$BUILDKITE_BUILD_URL" \
+        -e "build_number:$BUILDKITE_BUILD_NUMBER" \
+        -e "agent_name:$BUILDKITE_AGENT_NAME"
+    fi
 fi


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/55661

We've adding an echo command to see dangling containers, but because we don't monitor carefully all builds, we're surely missing them. 

This PR fixes that by opening a sentry ticket it it happens, so we won't miss those ever again. 

## Test plan

To be dropped commit, that triggers Sentry to ensure it's working as intended.
➡️ https://sourcegraph.sentry.io/issues/4410318138/?project=6110304&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
