### PR TITLE
[backport 5.1] search: update zoekt with removal of RepositoryRankRequest (#54394)

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -231,7 +231,6 @@ func RegisterInternalServices(
 	}
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(indexer.serveConfiguration)))
 	m.Get(apirouter.ReposIndex).Handler(trace.Route(handler(indexer.serveList)))
-	m.Get(apirouter.RepoRank).Handler(trace.Route(handler(indexer.serveRepoRank)))
 	m.Get(apirouter.DocumentRanks).Handler(trace.Route(handler(indexer.serveDocumentRanks)))
 	m.Get(apirouter.UpdateIndexStatus).Handler(trace.Route(handler(indexer.handleIndexStatusUpdate)))
 

--- a/cmd/frontend/internal/httpapi/search.go
+++ b/cmd/frontend/internal/httpapi/search.go
@@ -117,21 +117,6 @@ func (s *searchIndexerGRPCServer) List(ctx context.Context, r *proto.ListRequest
 	return &response, nil
 }
 
-func (s *searchIndexerGRPCServer) RepositoryRank(ctx context.Context, request *proto.RepositoryRankRequest) (*proto.RepositoryRankResponse, error) {
-	ranks, err := s.server.Ranking.GetRepoRank(ctx, api.RepoName(request.Repository))
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-
-		return nil, err
-	}
-
-	return &proto.RepositoryRankResponse{
-		Rank: ranks,
-	}, nil
-}
-
 func (s *searchIndexerGRPCServer) DocumentRanks(ctx context.Context, request *proto.DocumentRanksRequest) (*proto.DocumentRanksResponse, error) {
 	ranks, err := s.server.Ranking.GetDocumentRanks(ctx, api.RepoName(request.Repository))
 	if err != nil {
@@ -474,10 +459,6 @@ var metricGetVersion = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "src_search_get_version_total",
 	Help: "The total number of times we poll gitserver for the version of a indexable branch.",
 })
-
-func (h *searchIndexerServer) serveRepoRank(w http.ResponseWriter, r *http.Request) error {
-	return serveRank(h.Ranking.GetRepoRank, w, r)
-}
 
 func (h *searchIndexerServer) serveDocumentRanks(w http.ResponseWriter, r *http.Request) error {
 	return serveRank(h.Ranking.GetDocumentRanks, w, r)

--- a/deps.bzl
+++ b/deps.bzl
@@ -6311,8 +6311,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:CTKmuHsEmO0T+CH3d3wYimeENVprNKip51L/sUfZVCA=",
-        version = "v0.0.0-20230619155016-edf0c8b4e978",
+        sum = "h1:R47B3db8T7o6/STiPywibnrD+kZvlAXp5W5N0S+dSvg=",
+        version = "v0.0.0-20230629101834-7643f3b313a2",
     )
 
     go_repository(

--- a/dev/backcompat/defs.bzl
+++ b/dev/backcompat/defs.bzl
@@ -47,13 +47,16 @@ PATCH_GO_TEST_CMDS = [
 # Join all individual go test patches into a single shell snippet.
 PATCH_ALL_GO_TESTS_CMD = "\n".join(PATCH_GO_TEST_CMDS)
 
-# Replaces all occurences of @com_github_sourcegraph_(scip|conc) by @back_compat_com_github_sourcegraph_(scip|conc).
+# Replaces all occurences of @com_github_sourcegraph_(scip|conc) and zoekt by @back_compat_com_github_sourcegraph_(scip|conc).
+# We need to do this, because the backcompat share the same deps as the current HEAD, so we need to handle deviations manually here.
+# It's annoying, but that's how we get cached back compat tests.
 PATCH_BUILD_FIXES_CMD = """_sed_binary="sed"
 if [ "$(uname)" == "Darwin" ]; then
     _sed_binary="gsed"
 fi
 find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_conc|@back_compat_com_github_sourcegraph_conc|g' {} +
 find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_scip|@back_compat_com_github_sourcegraph_scip|g' {} +
+find . -type f -name "*.bazel" -exec $_sed_binary -i 's|@com_github_sourcegraph_zoekt|@back_compat_com_github_sourcegraph_zoekt|g' {} +
 """
 
 # https://github.com/sourcegraph/sourcegraph/pull/54000 changes dependencies to reflect otel package changes,
@@ -115,6 +118,15 @@ def back_compat_defs():
         sum = "h1:96VpOCAtXDCQ8Oycz0ftHqdPyMi8w12ltN4L2noYg7s=",  # Need to be manually updated when bumping the back compat release target.
         version = "v0.2.0",  # Need to be manually updated when bumping the back compat release target.
     )
+
+    go_repository(
+        name = "back_compat_com_github_sourcegraph_zoekt",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/sourcegraph/zoekt",
+        sum = "h1:zFLcZUQ74dCV/oIiQT3+db8kFPstAnvFDm7pd+tjZ+8=",
+        version = "v0.0.0-20230620185637-63241cb1b17a",
+    )
+
 
     # Now that we have declared a replacement for the two problematic go packages that
     # @sourcegraph_back_compat depends on, we can define the repository itself. Because it

--- a/go.mod
+++ b/go.mod
@@ -512,7 +512,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230619155016-edf0c8b4e978
+	github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2068,8 +2068,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230619155016-edf0c8b4e978 h1:CTKmuHsEmO0T+CH3d3wYimeENVprNKip51L/sUfZVCA=
-github.com/sourcegraph/zoekt v0.0.0-20230619155016-edf0c8b4e978/go.mod h1:E6oxotmuKTfdjmlkhyqc4eR3YvDLAHDHyPYISBP5+0g=
+github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2 h1:R47B3db8T7o6/STiPywibnrD+kZvlAXp5W5N0S+dSvg=
+github.com/sourcegraph/zoekt v0.0.0-20230629101834-7643f3b313a2/go.mod h1:tulqNTjuUDxIO3W80Ipbe6drMJJdcJdQPyKwAwo9cmw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -180,6 +180,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		attribute.Int("stats.files_loaded", statsAgg.FilesLoaded),
 		attribute.Int("stats.files_skipped", statsAgg.FilesSkipped),
 		attribute.Int("stats.match_count", statsAgg.MatchCount),
+		attribute.Int("stats.ngram_lookups", statsAgg.NgramLookups),
 		attribute.Int("stats.ngram_matches", statsAgg.NgramMatches),
 		attribute.Int("stats.shard_files_considered", statsAgg.ShardFilesConsidered),
 		attribute.Int("stats.shards_scanned", statsAgg.ShardsScanned),


### PR DESCRIPTION
Manual cherry pick of #54394 since there were many merge conflicts

---

This endpoint was unused which was why it was removed in Zoekt. The changes from Zoekt included in this dep bump:

- 1686b50d50 indexserver: remove unused GetRepoRank
- 7078a585a9 shards: populate RepoList.Stats.Repos
- b9e6d9433e zoekt-indexserver: Check stderr for git fetch
- 93f7b0c983 matchtree: capture Stats before pruning
- 7643f3b313 matchiter: capture metric NgramLookups

Test Plan: CI

(cherry picked from commit 49aff3d61c8479a296ba3379e7cabab97635be07)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
