### PR TITLE
cody web: fixup context popover responsiveness

### DIFF
--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -127,7 +127,6 @@ export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isSourcegraphApp
                 submitButtonComponent={SubmitButton}
                 fileLinkComponent={isSourcegraphApp ? AppFileLink : FileLink}
                 className={styles.container}
-                afterMarkdown={transcriptHistory.length > 1 ? '' : CODY_TERMS_MARKDOWN}
                 transcriptItemClassName={styles.transcriptItem}
                 humanTranscriptItemClassName={styles.humanTranscriptItem}
                 transcriptItemParticipantClassName="text-muted"

--- a/client/web/src/cody/components/GettingStarted.module.scss
+++ b/client/web/src/cody/components/GettingStarted.module.scss
@@ -1,8 +1,6 @@
 .container {
     flex: 1;
-    display: flex;
     background: var(--color-bg-1);
-    flex-direction: column;
     overflow: auto;
 }
 

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -42,7 +42,7 @@ export const GettingStarted: React.FC<
     causes content top and bottom positions to change. This results in a "jumping" effect and not-optimal UX
     when interacting with conversation scope radio group.
     In order to avoid this, we calculate the vertical offset of the content and apply it as a margin. In this case
-    when content height chages, the top position remains the same and only the bottom position changes.
+    when content height changes, the top position remains the same and only the bottom position changes.
     */
     const [contentVerticalOffset, setContentVerticalOffset] = useState<string>(DEFAULT_VERTICAL_OFFSET)
     const containerRef = useRef<HTMLDivElement>(null)
@@ -136,19 +136,21 @@ export const GettingStarted: React.FC<
         <div ref={containerRef} className={styles.container}>
             {/* eslint-disable-next-line react/forbid-dom-props */}
             <div ref={contentRef} style={{ margin: `${contentVerticalOffset} 20%` }}>
-                <Grid templateColumns="1fr 1fr" spacing={0} className={styles.iconSection}>
-                    <Grid templateColumns="1fr" spacing={0} className={styles.greetingContainer}>
-                        <div className={styles.greetingIcon}>
-                            <Icon as={CodySpeechBubbleIcon} className="h-auto w-auto" aria-hidden="true" />
+                {isCodyChatPage ? null : (
+                    <Grid templateColumns="1fr 1fr" spacing={0} className={styles.iconSection}>
+                        <Grid templateColumns="1fr" spacing={0} className={styles.greetingContainer}>
+                            <div className={styles.greetingIcon}>
+                                <Icon as={CodySpeechBubbleIcon} className="h-auto w-auto" aria-hidden="true" />
+                            </div>
+                            <Text as="span" className={styles.greetingText}>
+                                Hi! I'm Cody
+                            </Text>
+                        </Grid>
+                        <div className={styles.codyIconContainer}>
+                            <Icon as={CodyColorIcon} aria-hidden="true" className={styles.codyIcon} />
                         </div>
-                        <Text as="span" className={styles.greetingText}>
-                            Hi! I'm Cody
-                        </Text>
                     </Grid>
-                    <div className={styles.codyIconContainer}>
-                        <Icon as={CodyColorIcon} aria-hidden="true" className={styles.codyIcon} />
-                    </div>
-                </Grid>
+                )}
 
                 {isCodyChatPage ? (
                     <div className={classNames(styles.section, 'mb-3')}>

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -189,7 +189,11 @@ export const GettingStarted: React.FC<
                                     onChange={event => setConversationScope(event.target.value as ConversationScope)}
                                 />
                                 <div className={styles.scopeSelectorWrapper}>
-                                    <ScopeSelector {...scopeSelectorProps} renderHint={renderRepoIndexingWarning} />
+                                    <ScopeSelector
+                                        {...scopeSelectorProps}
+                                        renderHint={renderRepoIndexingWarning}
+                                        encourageOverlap={true}
+                                    />
                                 </div>
                                 <hr className={styles.divider} />
 

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -192,7 +192,11 @@ export const RepositoriesSelectorPopover: React.FC<{
                     overlap if necessary. Otherwise, on smaller viewports, the popover tends to
                     sit below the initially visible scroll area, or awkwardly scrunch up to the
                     left of the trigger. */}
-                <PopoverContent position={Position.bottom} flipping={Flipping.opposite} overlapping={Overlapping.all}>
+                <PopoverContent
+                    position={Position.bottomStart}
+                    flipping={Flipping.opposite}
+                    overlapping={Overlapping.all}
+                >
                     <Card
                         className={classNames(
                             'd-flex flex-column justify-content-between',

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -28,6 +28,9 @@ import {
     Tooltip,
     Link,
     useDebounce,
+    Position,
+    Flipping,
+    Overlapping,
 } from '@sourcegraph/wildcard'
 
 import type { ReposSelectorSearchResult, ReposSelectorSearchVariables } from '../../../graphql-operations'
@@ -184,7 +187,12 @@ export const RepositoriesSelectorPopover: React.FC<{
                     />
                 </PopoverTrigger>
 
-                <PopoverContent>
+                {/* We try to explicitly encourage the popover to only appear beneath its trigger
+                    by restricting it only permitting the Flipping.opposite strategy and allowing
+                    overlap if necessary. Otherwise, on smaller viewports, the popover tends to
+                    sit below the initially visible scroll area, or awkwardly scrunch up to the
+                    left of the trigger. */}
+                <PopoverContent position={Position.bottom} flipping={Flipping.opposite} overlapping={Overlapping.all}>
                     <Card
                         className={classNames(
                             'd-flex flex-column justify-content-between',

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -70,6 +70,9 @@ export const RepositoriesSelectorPopover: React.FC<{
     removeRepository: (repoName: string) => void
     toggleIncludeInferredRepository: () => void
     toggleIncludeInferredFile: () => void
+    // Whether to encourage the popover to overlap its trigger if necessary, rather than
+    // collapsing or flipping position.
+    encourageOverlap?: boolean
 }> = React.memo(function RepositoriesSelectorPopoverContent({
     inferredRepository,
     inferredFilePath,
@@ -81,6 +84,7 @@ export const RepositoriesSelectorPopover: React.FC<{
     includeInferredFile,
     toggleIncludeInferredRepository,
     toggleIncludeInferredFile,
+    encourageOverlap = false,
 }) {
     const [isPopoverOpen, setIsPopoverOpen] = useState(false)
     const [searchText, setSearchText] = useState('')
@@ -187,15 +191,15 @@ export const RepositoriesSelectorPopover: React.FC<{
                     />
                 </PopoverTrigger>
 
-                {/* We try to explicitly encourage the popover to only appear beneath its trigger
-                    by restricting it only permitting the Flipping.opposite strategy and allowing
-                    overlap if necessary. Otherwise, on smaller viewports, the popover tends to
-                    sit below the initially visible scroll area, or awkwardly scrunch up to the
-                    left of the trigger. */}
+                {/* We can try to explicitly encourage the popover to only appear beneath its
+                    trigger by restricting it only permitting the Flipping.opposite strategy
+                    and allowing overlap if necessary. Otherwise, on smaller viewports, the
+                    popover may wind up partially below the initially visible scroll area, or
+                    else awkwardly scrunched up to the left or right of the trigger. */}
                 <PopoverContent
                     position={Position.bottomStart}
-                    flipping={Flipping.opposite}
-                    overlapping={Overlapping.all}
+                    flipping={encourageOverlap ? Flipping.opposite : undefined}
+                    overlapping={encourageOverlap ? Overlapping.all : undefined}
                 >
                     <Card
                         className={classNames(

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -199,73 +199,42 @@ export const RepositoriesSelectorPopover: React.FC<{
                             styles.repositorySelectorContent
                         )}
                     >
-                        <div>
-                            {!searchText && (
-                                <>
-                                    <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                        <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
-                                        {resetScope && scopeChanged && (
-                                            <Button
-                                                onClick={resetScope}
-                                                variant="icon"
-                                                aria-label="Reset scope"
-                                                title="Reset scope"
-                                                className={styles.header}
-                                            >
-                                                Reset
-                                            </Button>
-                                        )}
-                                    </div>
-                                    <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
-                                        {inferredRepository && (
-                                            <div className="d-flex flex-column">
-                                                {inferredFilePath && (
-                                                    <button
-                                                        type="button"
-                                                        className={classNames(
-                                                            'd-flex justify-content-between flex-row text-truncate px-2 py-1 mt-1',
-                                                            styles.repositoryListItem,
-                                                            {
-                                                                [styles.notIncludedInContext]: !includeInferredFile,
-                                                            }
-                                                        )}
-                                                        onClick={toggleIncludeInferredFile}
-                                                    >
-                                                        <div className="d-flex align-items-center text-truncate">
-                                                            <Icon
-                                                                aria-hidden={true}
-                                                                className={classNames('mr-1 text-muted', {
-                                                                    [styles.visibilityHidden]: !includeInferredFile,
-                                                                })}
-                                                                svgPath={mdiCheck}
-                                                            />
-                                                            <ExternalRepositoryIcon
-                                                                externalRepo={inferredRepository.externalRepository}
-                                                                className={styles.repoIcon}
-                                                            />
-                                                            <span className="text-truncate">
-                                                                {getFileName(inferredFilePath)}
-                                                            </span>
-                                                        </div>
-                                                        <EmbeddingExistsIcon repo={inferredRepository} />
-                                                    </button>
-                                                )}
+                        {!searchText && (
+                            <>
+                                <div className="d-flex justify-content-between p-2 border-bottom mb-1">
+                                    <Text className={classNames('m-0', styles.header)}>Chat Context</Text>
+                                    {resetScope && scopeChanged && (
+                                        <Button
+                                            onClick={resetScope}
+                                            variant="icon"
+                                            aria-label="Reset scope"
+                                            title="Reset scope"
+                                            className={styles.header}
+                                        >
+                                            Reset
+                                        </Button>
+                                    )}
+                                </div>
+                                <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
+                                    {inferredRepository && (
+                                        <div className="d-flex flex-column">
+                                            {inferredFilePath && (
                                                 <button
                                                     type="button"
                                                     className={classNames(
-                                                        'd-flex justify-content-between flex-row text-truncate px-2 py-1',
+                                                        'd-flex justify-content-between flex-row text-truncate px-2 py-1 mt-1',
                                                         styles.repositoryListItem,
                                                         {
-                                                            [styles.notIncludedInContext]: !includeInferredRepository,
+                                                            [styles.notIncludedInContext]: !includeInferredFile,
                                                         }
                                                     )}
-                                                    onClick={toggleIncludeInferredRepository}
+                                                    onClick={toggleIncludeInferredFile}
                                                 >
                                                     <div className="d-flex align-items-center text-truncate">
                                                         <Icon
                                                             aria-hidden={true}
                                                             className={classNames('mr-1 text-muted', {
-                                                                [styles.visibilityHidden]: !includeInferredRepository,
+                                                                [styles.visibilityHidden]: !includeInferredFile,
                                                             })}
                                                             svgPath={mdiCheck}
                                                         />
@@ -274,84 +243,110 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                             className={styles.repoIcon}
                                                         />
                                                         <span className="text-truncate">
-                                                            {getRepoName(inferredRepository.name)}
+                                                            {getFileName(inferredFilePath)}
                                                         </span>
                                                     </div>
                                                     <EmbeddingExistsIcon repo={inferredRepository} />
                                                 </button>
-                                            </div>
-                                        )}
-                                        {!!additionalRepositories.length && (
-                                            <div className="d-flex flex-column">
-                                                <Text
-                                                    className={classNames(
-                                                        'mb-0 px-2 py-1 text-muted d-flex justify-content-between',
-                                                        styles.subHeader,
-                                                        {
-                                                            'mt-1': inferredRepository || inferredFilePath,
-                                                        }
-                                                    )}
-                                                >
-                                                    <span className="small">
-                                                        {inferredRepository
-                                                            ? 'Additional repositories'
-                                                            : 'Repositories'}
-                                                    </span>
-                                                    <span className="small">{additionalRepositories.length}/10</span>
-                                                </Text>
-                                                {additionalRepositories.map(repository => (
-                                                    <AdditionalRepositoriesListItem
-                                                        key={repository.id}
-                                                        repository={repository}
-                                                        removeRepository={removeRepository}
+                                            )}
+                                            <button
+                                                type="button"
+                                                className={classNames(
+                                                    'd-flex justify-content-between flex-row text-truncate px-2 py-1',
+                                                    styles.repositoryListItem,
+                                                    {
+                                                        [styles.notIncludedInContext]: !includeInferredRepository,
+                                                    }
+                                                )}
+                                                onClick={toggleIncludeInferredRepository}
+                                            >
+                                                <div className="d-flex align-items-center text-truncate">
+                                                    <Icon
+                                                        aria-hidden={true}
+                                                        className={classNames('mr-1 text-muted', {
+                                                            [styles.visibilityHidden]: !includeInferredRepository,
+                                                        })}
+                                                        svgPath={mdiCheck}
                                                     />
-                                                ))}
-                                            </div>
-                                        )}
-
-                                        {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
-                                            <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
-                                                <Text size="small" className="m-0 text-center text-muted">
-                                                    Add up to 10 repositories for Cody to reference when providing
-                                                    answers.
-                                                </Text>
-                                            </div>
-                                        )}
-                                    </div>
-                                </>
-                            )}
-                            {searchText && (
-                                <>
-                                    <div className="d-flex justify-content-between p-2 border-bottom mb-1">
-                                        <Text className={classNames('m-0', styles.header)}>
-                                            {additionalRepositoriesLeft
-                                                ? `Add up to ${additionalRepositoriesLeft} additional repositories`
-                                                : 'Maximum additional repositories added'}
-                                        </Text>
-                                    </div>
-                                    <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
-                                        {searchResults.length ? (
-                                            searchResults.map(repository => (
-                                                <SearchResultsListItem
-                                                    additionalRepositories={additionalRepositories}
+                                                    <ExternalRepositoryIcon
+                                                        externalRepo={inferredRepository.externalRepository}
+                                                        className={styles.repoIcon}
+                                                    />
+                                                    <span className="text-truncate">
+                                                        {getRepoName(inferredRepository.name)}
+                                                    </span>
+                                                </div>
+                                                <EmbeddingExistsIcon repo={inferredRepository} />
+                                            </button>
+                                        </div>
+                                    )}
+                                    {!!additionalRepositories.length && (
+                                        <div className="d-flex flex-column">
+                                            <Text
+                                                className={classNames(
+                                                    'mb-0 px-2 py-1 text-muted d-flex justify-content-between',
+                                                    styles.subHeader,
+                                                    {
+                                                        'mt-1': inferredRepository || inferredFilePath,
+                                                    }
+                                                )}
+                                            >
+                                                <span className="small">
+                                                    {inferredRepository ? 'Additional repositories' : 'Repositories'}
+                                                </span>
+                                                <span className="small">{additionalRepositories.length}/10</span>
+                                            </Text>
+                                            {additionalRepositories.map(repository => (
+                                                <AdditionalRepositoriesListItem
                                                     key={repository.id}
                                                     repository={repository}
-                                                    searchText={searchText}
-                                                    addRepository={addRepository}
                                                     removeRepository={removeRepository}
                                                 />
-                                            ))
-                                        ) : !loadingSearchResults ? (
-                                            <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
-                                                <Text size="small" className="m-0 d-flex text-center">
-                                                    No matching repositories found
-                                                </Text>
-                                            </div>
-                                        ) : null}
-                                    </div>
-                                </>
-                            )}
-                        </div>
+                                            ))}
+                                        </div>
+                                    )}
+
+                                    {!inferredRepository && !inferredFilePath && !additionalRepositories.length && (
+                                        <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
+                                            <Text size="small" className="m-0 text-center text-muted">
+                                                Add up to 10 repositories for Cody to reference when providing answers.
+                                            </Text>
+                                        </div>
+                                    )}
+                                </div>
+                            </>
+                        )}
+                        {searchText && (
+                            <>
+                                <div className="d-flex justify-content-between p-2 border-bottom mb-1">
+                                    <Text className={classNames('m-0', styles.header)}>
+                                        {additionalRepositoriesLeft
+                                            ? `Add up to ${additionalRepositoriesLeft} additional repositories`
+                                            : 'Maximum additional repositories added'}
+                                    </Text>
+                                </div>
+                                <div className={classNames('d-flex flex-column', styles.contextItemsContainer)}>
+                                    {searchResults.length ? (
+                                        searchResults.map(repository => (
+                                            <SearchResultsListItem
+                                                additionalRepositories={additionalRepositories}
+                                                key={repository.id}
+                                                repository={repository}
+                                                searchText={searchText}
+                                                addRepository={addRepository}
+                                                removeRepository={removeRepository}
+                                            />
+                                        ))
+                                    ) : !loadingSearchResults ? (
+                                        <div className="d-flex align-items-center justify-content-center flex-column p-4 mt-4">
+                                            <Text size="small" className="m-0 d-flex text-center">
+                                                No matching repositories found
+                                            </Text>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </>
+                        )}
                         <div className={classNames('relative p-2 border-top mt-auto', styles.inputContainer)}>
                             <Input
                                 role="combobox"

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.module.scss
@@ -55,15 +55,12 @@
 
 .repository-selector-content {
     width: 20rem;
-    height: 100%;
     max-width: 20rem;
-    min-height: 24rem;
-    max-height: 29rem;
-    overflow: hidden;
+    height: 20rem;
 }
 
 .context-items-container {
-    max-height: 23rem;
+    flex: 1;
     overflow-y: auto;
     overflow-x: hidden;
 }
@@ -82,6 +79,7 @@
 .repository-list-item {
     all: unset;
     font-size: 0.8rem;
+    flex-shrink: 0;
     line-height: 1rem;
     display: block;
 

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -26,6 +26,9 @@ export interface ScopeSelectorProps {
     transcript: Transcript | null
     className?: string
     renderHint?: (repos: IRepo[]) => React.ReactNode
+    // Whether to encourage the selector popover to overlap its trigger if necessary,
+    // rather than collapsing or flipping position.
+    encourageOverlap?: boolean
 }
 
 export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function ScopeSelectorComponent({
@@ -38,6 +41,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     transcript,
     className,
     renderHint,
+    encourageOverlap,
 }) {
     const [loadReposStatus, { data: newReposStatusData, previousData: previousReposStatusData }] = useLazyQuery<
         ReposStatusResult,
@@ -131,6 +135,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
                         removeRepository={removeRepository}
                         toggleIncludeInferredRepository={toggleIncludeInferredRepository}
                         toggleIncludeInferredFile={toggleIncludeInferredFile}
+                        encourageOverlap={encourageOverlap}
                     />
                     {scope.includeInferredFile && activeEditor?.filePath && (
                         <Text size="small" className="ml-2 mb-0 align-self-center">

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -77,6 +77,7 @@ export {
     usePopoverContext,
     Flipping,
     Strategy,
+    Overlapping,
 } from './Popover'
 export { Collapse, CollapseHeader, CollapsePanel } from './Collapse'
 export {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/56073.

Fixes responsiveness issues with the repo context selector popover on Web and in App when the viewport gets too small to display the full popover contents.

Before | After - Web | After - App
:-:|:-:
<video src="https://github.com/sourcegraph/sourcegraph/assets/8942601/3de6691f-ab5a-4ece-bbf2-50d2daec2fe7"> | <video src="https://github.com/sourcegraph/sourcegraph/assets/8942601/cc84d3c1-6f8e-479b-8656-5e8efd87c1d3"> | <video src="https://github.com/sourcegraph/sourcegraph/assets/8942601/e8a9e4ee-ff28-4457-8025-ed0342b82807">

This PR does a couple things to achieve this:
- Removes the "Hi! I'm Cody!" graphic above the Getting Started section on the Chat page to reduce the overall vertical space required for the Getting Started section. The graphic will still appear in other places where Chat appears but the context selector advice does not, such as in Chat on a file.
- Un-nests the children in the popover content so that the header and search input box remain in place and just the list component (either the list of repos added in context or the list of search results) scrolls
- Sets a static height on the popover to better facilitate the last bullet. This has the added benefit that the popover doesn't change size and induce layout shift when the user is interacting with it.
- Strongly encourages the popover to only appear beneath its trigger, and allows it to overlap the trigger in order to do so. This prevents it from over-compressing, or awkwardly trying to render to the left or right when there's more space there.

## Test plan

Manually tested on small viewports on both Web and App.