### PR TITLE
[docsite]: Add "Copy Code" Button to Code Snippets

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -1456,6 +1456,24 @@ body > #sidebar .current > a  {
     display: none;
 }
 
+pre.chroma.sgquery {
+    position: relative;
+    margin: 5px 0;
+    padding: 1.75rem 0 1.5rem 1rem;
+    border-radius: 5px;
+}
+
+pre.chroma.sgquery button {
+    position: absolute;
+    top: 5px;
+    right: 0px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: #a1a1a1;
+    outline: none;
+}
+
 @media (min-width: 1350px) {
     .markdown-body {
         max-width: 665px;

--- a/doc/_resources/assets/docsite.js
+++ b/doc/_resources/assets/docsite.js
@@ -165,3 +165,47 @@ Promise.all([domContentLoadedPromise, importEventLoggerPromise]).then(([_, { Eve
     }
   })
 })
+
+// Add a "Copy" button to code blocks
+document.addEventListener('DOMContentLoaded', () => {
+  let copyButtonLabel = new DOMParser().parseFromString(
+    '<svg xmlns="http://www.w3.org/2000/svg" height="18px" viewBox="0 0 24 24" width="18px" fill="currentColor"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>',
+    'application/xml'
+  );
+
+  // use a class selector if available
+  let blocks = document.querySelectorAll("pre.chroma.sgquery");
+
+  blocks.forEach((block) => {
+    // only add button if browser supports Clipboard API
+    if (navigator.clipboard) {
+      let button = document.createElement("button");
+
+      //button.innerHTML = copyButtonLabel;
+      button.appendChild(
+        button.ownerDocument.importNode(copyButtonLabel.documentElement, true)
+      );
+      block.appendChild(button);
+
+      button.addEventListener("click", async () => {
+        await copyCode(block, button);
+      });
+    }
+  });
+
+  async function copyCode(block, button) {
+    let text = block.innerText;
+
+    await navigator.clipboard.writeText(text);
+
+    // visual feedback that task is completed
+    button.innerText = "Copied!";
+
+    setTimeout(() => {
+      button.replaceChild(
+        button.ownerDocument.importNode(copyButtonLabel.documentElement, true),
+        button.childNodes[0]
+      );
+    }, 900);
+  }
+})


### PR DESCRIPTION
**Summary:**
This PR introduces a "Copy Code" button to all code snippets across the documentation site, enhancing user experience by allowing users to easily copy example code for their use.

Related Issue(s): [#15](https://github.com/sourcegraph/documentation/issues/15)

**Changes:**

- Added a new utility function, copyCode, to handle the clipboard action.
- Integrated the "Copy Code" button to our existing code snippet component.
- Updated styles and UX to ensure the button is unobtrusive but clear.




**Screenshots:**
Attached are screenshots highlighting the changes across various themes.

![CleanShot 2023-08-21 at 14 19 44](https://github.com/sourcegraph/sourcegraph/assets/6225160/3bc78c8c-2691-40a6-89d4-cdcd93bc8098)

![CleanShot 2023-08-21 at 14 19 33](https://github.com/sourcegraph/sourcegraph/assets/6225160/048323e5-dc78-4fd6-9e2c-7542ccc88b74)


**Note:**
Feedback on the button's style or positioning is welcome. We aim for maximum user convenience with minimum distraction.

Kindly check and let me know if any changes are required.

## Test plan
Manually tested across major browsers: Chrome, Firefox, Safari, and Arc.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cesar/add-copy-code-button)