### PR TITLE
source: implement logic for saving command output and success state of recorded commands

### DIFF
--- a/internal/wrexec/cmd.go
+++ b/internal/wrexec/cmd.go
@@ -121,8 +121,10 @@ func (c *Cmd) CombinedOutput() (_ []byte, err error) {
 	return c.output, err
 }
 
-func (c *Cmd) GetOutput() []byte {
-	return c.output
+// This is a workaround created to retrieve the output of an executed command without
+// calling `.Output()` or `.CombinedOutput()` again.
+func (c *Cmd) GetOutput() string {
+	return string(c.output)
 }
 
 // Environ returns the underlying command environ. It never call the hooks.

--- a/internal/wrexec/cmd.go
+++ b/internal/wrexec/cmd.go
@@ -15,6 +15,7 @@ type Cmd struct {
 	logger      log.Logger
 	beforeHooks []BeforeHook
 	afterHooks  []AfterHook
+	output      []byte
 }
 
 // BeforeHook are called before the execution of a command. Returning an error within a before
@@ -111,12 +112,17 @@ func (c *Cmd) runAfterHooks() {
 
 // CombinedOutput calls os/exec.Cmd.CombinedOutput after running the before hooks,
 // and run the after hooks once it returns.
-func (c *Cmd) CombinedOutput() ([]byte, error) {
+func (c *Cmd) CombinedOutput() (_ []byte, err error) {
 	if err := c.runBeforeHooks(); err != nil {
 		return nil, err
 	}
 	defer c.runAfterHooks()
-	return c.Cmd.CombinedOutput()
+	c.output, err = c.Cmd.CombinedOutput()
+	return c.output, err
+}
+
+func (c *Cmd) GetOutput() []byte {
+	return c.output
 }
 
 // Environ returns the underlying command environ. It never call the hooks.
@@ -126,12 +132,13 @@ func (c *Cmd) Environ() []string {
 
 // Output calls os/exec.Cmd.Output after running the before hooks,
 // and run the after hooks once it returns.
-func (c *Cmd) Output() ([]byte, error) {
+func (c *Cmd) Output() (_ []byte, err error) {
 	if err := c.runBeforeHooks(); err != nil {
 		return nil, err
 	}
 	defer c.runAfterHooks()
-	return c.Cmd.Output()
+	c.output, err = c.Cmd.Output()
+	return c.output, err
 }
 
 // Run calls os/exec.Cmd.Run after running the before hooks,

--- a/internal/wrexec/cmd_test.go
+++ b/internal/wrexec/cmd_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -78,6 +79,12 @@ func TestCombinedOutput(t *testing.T) {
 		}
 	})
 
+	t.Run("output is correctly saved", func(t *testing.T) {
+		if diff := cmp.Diff(string(want), tc.cmd.GetOutput()); diff != "" {
+			t.Error(diff)
+		}
+	})
+
 	t.Run("before hooks are called", func(t *testing.T) {
 		if diff := cmp.Diff(1, tc.beforeCounter); diff != "" {
 			t.Error(diff)
@@ -128,6 +135,12 @@ func TestOutput(t *testing.T) {
 			t.Error(diff)
 		}
 		if diff := cmp.Diff(wantErr, gotErr); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("output is correctly saved", func(t *testing.T) {
+		if diff := cmp.Diff(string(want), tc.cmd.GetOutput()); diff != "" {
 			t.Error(diff)
 		}
 	})

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -108,18 +108,16 @@ func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cm
 		return
 	}
 
-	isSuccess := cmd.ProcessState.Success()
-	output := rc.Cmd.GetOutput()
-
 	// record this command in redis
 	val := RecordedCommand{
-		Start:     rc.start,
-		Duration:  time.Since(rc.start).Seconds(),
-		Args:      cmd.Args,
-		Dir:       cmd.Dir,
-		Path:      cmd.Path,
-		IsSuccess: isSuccess,
-		Output:    string(output),
+		Start:    rc.start,
+		Duration: time.Since(rc.start).Seconds(),
+		Args:     cmd.Args,
+		Dir:      cmd.Dir,
+		Path:     cmd.Path,
+
+		IsSuccess: cmd.ProcessState.Success(),
+		Output:    rc.Cmd.GetOutput(),
 	}
 
 	data, err := json.Marshal(&val)

--- a/internal/wrexec/recording_cmd_test.go
+++ b/internal/wrexec/recording_cmd_test.go
@@ -292,5 +292,4 @@ func TestRecordingCmd(t *testing.T) {
 			t.Error("expected recording 1 and recording 2 to be different, but they're equal")
 		}
 	})
-
 }


### PR DESCRIPTION
Closes 
Closes

This PR allows Sourcegraph to store a recorded command's success state and output to Redis. This will allow site admins to debug failed commands and understand why they failed adequately.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

* Set up git recording for any repository on your Sourcegraph instance.
* Access the recorded commands via the redis-cli or any GUI used to access Redis
* There should be new fields `success` and `output` in the data saved for repositories.

![CleanShot 2023-08-22 at 11 33 47@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/41b1f52c-7ce3-44bf-9d87-5e18663d2afb)
