### PR TITLE
org members page: fix auth access when listing members as non-admin

### DIFF
--- a/client/web/src/org/backend.ts
+++ b/client/web/src/org/backend.ts
@@ -52,7 +52,6 @@ export const ORGANIZATION_MEMBERS_QUERY = gql`
         username
         displayName
         avatarURL
-        siteAdmin
     }
 `
 

--- a/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
@@ -105,8 +105,7 @@ const UserNode: React.FunctionComponent<UserNodeProps> = ({
                     </div>
                 </div>
                 <div className="flex-1 d-flex align-items-center justify-content-between">
-                    <span className="text-muted flex-1">{node.siteAdmin ? 'Admin' : 'Member'}</span>
-                    <div>
+                    <div className="flex-1">
                         {authenticatedUser && org.viewerCanAdminister && (
                             <Button
                                 className="site-admin-detail-list__action test-remove-org-member"
@@ -252,7 +251,6 @@ export const OrgSettingsMembersPage: React.FunctionComponent<Props> = ({
                                 } organization`}
                             </strong>
                             <div className="flex-1 d-flex align-items-center justify-content-between">
-                                <strong>Role</strong>
                                 <strong>Action</strong>
                             </div>
                         </li>


### PR DESCRIPTION
This fixes #56104 by removing the "role" column from the members page and not querying `siteAdmin` for a given `user`.

Only site-admins can query `user.siteAdmin`, so instead of loosening that restriction we remove the column.

## Before
<img width="994" alt="screenshot_2023-08-22_12 50 59@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/72c63e92-2565-4c8d-9752-9726325cad39">

## After
<img width="1197" alt="screenshot_2023-08-22_12 51 05@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/1c1c97ac-36cc-44c4-9080-fdc8a9f1ee42">


## Test plan

- Manual testing by opening an org page and listing the members on that page
