### PR TITLE
Add Cody Commands docs in VS Code

### DIFF
--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -1,0 +1,23 @@
+{
+  "title": "[Experimental] Custom Workspace Commands",
+  "description": "This file showcases how to build custom commandss for Cody by Sourcegraph in VS Code.",
+  "doc": "For more information, see https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MzA1NQ==",
+  "commands": {
+    "(example) Generate README.md for Current Directory": {
+      "prompt": "Write a detailed README.md file to document the code in the same directory as my current selection. Summarize what the code in this directory is meant to accomplish. Explain the key files, functions, classes, and features. Use Markdown formatting for headings, code blocks, lists, etc. to make it organized and readable. Aim for a beginner-friendly explanation that gives a developer unfamiliar with the code a good starting point to understand it. Ensure to include: - Overview of directory purpose - Functionality explanations - Relevant diagrams or visuals if helpful. Write the README content clearly and concisely using complete sentences and paragraphs based on the shared context. Use proper spelling, grammar, and punctuation throughout. Surround your full README text with triple backticks so it renders properly as a code block. Do not make assumptions or fabricate additional details.",
+      "context": {
+        "currentDir": true,
+        "selection": true
+      }
+    },
+    "(example) Commit Message Suggestion": {
+      "slashCommand": "commit",
+      "prompt": "Suggest a informative commit message by summarizing code changes from the shared command output. The commit message should follow the conventional commit format and provide meaningful context for future readers.",
+      "context": {
+        "selection": false,
+        "command": "git diff"
+      },
+      "note": "You must have git installed and authenticated to use this command. Runs this command before staging."
+    }
+  }
+}

--- a/.vscode/cody.json
+++ b/.vscode/cody.json
@@ -10,7 +10,7 @@
         "selection": true
       }
     },
-    "(example) Commit Message Suggestion": {
+    "Commit Message Suggestion": {
       "slashCommand": "commit",
       "prompt": "Suggest a informative commit message by summarizing code changes from the shared command output. The commit message should follow the conventional commit format and provide meaningful context for future readers.",
       "context": {

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -66,7 +66,7 @@ VS Code logs can be accessed via the **Outputs** view. To access autocomplete lo
 
 ## Commands
 
-Cody supports **Commands** with its [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). These allow you to create and run reusable prompts without submitting pull requests or opening the chat sidebar.
+Cody supports executing reusable prompts known as **Cody Commands** from within the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). They allow you to run predefined actions (like `Explain Selected Code` and `Generate Unit Tests` for example) with smart context-fetching anywhere in the editor.
 
 You can run a command in 3 ways:
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -71,7 +71,7 @@ Cody supports executing reusable prompts known as **Cody Commands** from within 
 There are three ways to run a Cody Command:
 
 1. Type `/` in the chat bar. Cody will then suggest a list of available commands
-2. Right click > Cody > Select a command
+2. Right click and select `"Cody"` > Choose a command from the list
 3. Press the command hotkey (`⌥` + `C` / `Alt` + `C`)
 
 ![Cody Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-commands.png)

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -70,7 +70,7 @@ Cody supports executing reusable prompts known as **Cody Commands** from within 
 
 You can run a command in 3 ways:
 
-1. Type `/` in the chat bar. Cody will then suggest a list of commands
+1. Type `/` in the chat bar. Cody will then suggest a list of available commands
 2. Right click > Cody > Select a command
 3. Press the command hotkey (`⌥` + `C` / `Alt` + `C`)
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -72,7 +72,7 @@ There are three ways to run a Cody Command:
 
 1. Type `/` in the chat bar. Cody will then suggest a list of available commands
 2. Right click and select `"Cody"` > Choose a command from the list
-3. Press the command hotkey (`⌥` + `C` / `Alt` + `C`)
+3. Use the predefined command hotkey: `⌥` + `C` / `Alt` + `C`
 
 ![Cody Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-commands.png)
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -78,7 +78,7 @@ There are three ways to run a Cody Command:
 
 ### Custom Commands <span class="badge badge-experimental">Experimental</span>
 
-The **Custom Commands** feature lets you customize Cody's abilities for your projects without writing code. This provides a flexible way to create reusable "commands" that give Cody targeted instructions and context from your project to enhance productivity.
+The **Custom Commands** feature allows you to customize Cody's abilities for your specific projects and workflow without writing code. They are defined in JSON format and let you call CLI tools, write custom prompts, and configure context sent to Cody. This provides a flexible way to create reusable "commands" tailored to your needs.
 
 You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in the chat box or using keyboard shortcuts `⌥` + `C` / `Alt` + `C` without opening the chat sidebar.
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -34,27 +34,6 @@ Examples of questions Cody can handle:
   <a class="demo text-center" target="_blank" href="https://twitter.com/beyang/status/1647744307045228544">View Demo</a>
 </div>
 
-## Fix code inline
-
-Cody can help you make interactive edits and refactor code by following natural-language instructions. To do so, select the relevant code snippet, and ask Cody a question or request inline fix with `/fix` or `/touch` commands.
-
-Cody will take it from there and figure out what edits to make.
-
-![Example of Cody inline code fix ](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody_inline_June23-sm.gif)
-
-Examples of fix-up instructions Cody can handle:
-
-- Factor out any common helper functions (when multiple functions are selected)
-- Use the imported CSS module's class `n`
-- Extract the list item to a separate React component
-- Handle errors better
-- Add helpful debug log statements
-- Make this work (and yes, it often does work—give it a try!)
-
-<div class="getting-started">
-  <a class="demo text-center" target="_blank" href="https://twitter.com/sqs/status/1647673013343780864">View Demo</a>
-</div>
-
 ## Code Autocomplete
 
 Cody provides real-time code auto-completion as you type, based on the context around your open files and file history. This predictive feature tells what you are trying to implement for a smoother coding experience.
@@ -84,3 +63,52 @@ VS Code logs can be accessed via the **Outputs** view. To access autocomplete lo
 - Select **Cody by Sourcegraph** from the dropdown list
 
 ![View Cody's autocomplete logs from the Output View in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/view-autocomplete-logs.png)
+
+## Commands
+
+Cody supports **Commands** with its [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). These allow you to create and run reusable prompts without needing to submit pull requests or open the chat sidebar.
+
+You can run a command in 3 ways:
+
+1. Type `/` in the chat bar. Cody will then suggest a list of commands
+2. Right click > Cody > Select a command
+3. Press the command hotkey (`⌥` + `c` / `alt` + `c`)
+
+![Cody Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-commands.png)
+
+### Custom Commands
+
+The **Custom Commands** feature lets you customize Cody's abilities for your projects without writing code. This provides a flexible way to create reusable "commands" that give Cody targeted instructions and context from your project to enhance productivity.
+
+You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in chat box, or using keyboard shortcuts `Shift+Cmd+V`, without opening the chat sidebar.
+
+Right-click on the selected code to open the Cody context menu and select the **Custom Commands (Experiemental)** option.
+
+![Cody Custom Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/create-custom-commands.png)
+
+### `cody.json` file
+
+You can define custom commands for Cody in the `cody.json` file. To make commands accessible only in a specific project, create the `cody.json` file in the `.vscode` directory of your project. Cody will execute these workspace-specific custom commands when working in that project.
+
+To make commands accessible across multiple projects, create a new `cody.json` file in the `.vscode` directory of your home directory. Cody will execute these global custom commands in any workspace.
+
+## Fix code inline
+
+Cody can help you make interactive edits and refactor code by following natural-language instructions. To do so, select the relevant code snippet, and ask Cody a question or request inline fix with `/fix` or `/touch` commands.
+
+Cody will take it from there and figure out what edits to make.
+
+![Example of Cody inline code fix ](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody_inline_June23-sm.gif)
+
+Examples of fix-up instructions Cody can handle:
+
+- Factor out any common helper functions (when multiple functions are selected)
+- Use the imported CSS module's class `n`
+- Extract the list item to a separate React component
+- Handle errors better
+- Add helpful debug log statements
+- Make this work (and yes, it often does work—give it a try!)
+
+<div class="getting-started">
+  <a class="demo text-center" target="_blank" href="https://twitter.com/sqs/status/1647673013343780864">View Demo</a>
+</div>

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -76,7 +76,7 @@ You can run a command in 3 ways:
 
 ![Cody Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-commands.png)
 
-### Custom Commands
+### Custom Commands <span class="badge badge-experimental">Experimental</span>
 
 The **Custom Commands** feature lets you customize Cody's abilities for your projects without writing code. This provides a flexible way to create reusable "commands" that give Cody targeted instructions and context from your project to enhance productivity.
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -80,7 +80,7 @@ You can run a command in 3 ways:
 
 The **Custom Commands** feature lets you customize Cody's abilities for your projects without writing code. This provides a flexible way to create reusable "commands" that give Cody targeted instructions and context from your project to enhance productivity.
 
-You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in the chat box or using keyboard shortcuts `Shift+Cmd+V` without opening the chat sidebar.
+You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in the chat box or using keyboard shortcuts `⌥` + `C` / `Alt` + `C` without opening the chat sidebar.
 
 Right-click on the selected code to open the Cody context menu and select the **Custom Commands (Experimental)** option.
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -90,7 +90,7 @@ Right-click on the selected code to open the Cody context menu and select the **
 
 You can define custom commands for Cody in a `cody.json` file. To make commands only available for a specific project, create the `cody.json` file in the `.vscode` directory of that project. These workspace-specific custom commands will be available to you when you work on that project.
 
-To make commands accessible across multiple projects, create a new `cody.json` file in the `.vscode` directory of your home directory. Cody will execute these global custom commands in any workspace.
+To make custom commands globally available across multiple projects, create a new `cody.json` file in the `.vscode` folder of your home directory. These global custom commands will be available for you in Cody in any workspace.
 
 ## Fix code inline
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -68,7 +68,7 @@ VS Code logs can be accessed via the **Outputs** view. To access autocomplete lo
 
 Cody supports executing reusable prompts known as **Cody Commands** from within the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). They allow you to run predefined actions (like `Explain Selected Code` and `Generate Unit Tests` for example) with smart context-fetching anywhere in the editor.
 
-You can run a command in 3 ways:
+There are three ways to run a Cody Command:
 
 1. Type `/` in the chat bar. Cody will then suggest a list of available commands
 2. Right click > Cody > Select a command

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -66,13 +66,13 @@ VS Code logs can be accessed via the **Outputs** view. To access autocomplete lo
 
 ## Commands
 
-Cody supports **Commands** with its [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). These allow you to create and run reusable prompts without needing to submit pull requests or open the chat sidebar.
+Cody supports **Commands** with its [VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai). These allow you to create and run reusable prompts without submitting pull requests or opening the chat sidebar.
 
 You can run a command in 3 ways:
 
 1. Type `/` in the chat bar. Cody will then suggest a list of commands
 2. Right click > Cody > Select a command
-3. Press the command hotkey (`⌥` + `c` / `alt` + `c`)
+3. Press the command hotkey (`⌥` + `C` / `Alt` + `C`)
 
 ![Cody Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/cody-commands.png)
 
@@ -80,9 +80,9 @@ You can run a command in 3 ways:
 
 The **Custom Commands** feature lets you customize Cody's abilities for your projects without writing code. This provides a flexible way to create reusable "commands" that give Cody targeted instructions and context from your project to enhance productivity.
 
-You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in chat box, or using keyboard shortcuts `Shift+Cmd+V`, without opening the chat sidebar.
+You can define customized prompts using `JSON` files that can be invoked simply by typing a `/` in the chat box or using keyboard shortcuts `Shift+Cmd+V` without opening the chat sidebar.
 
-Right-click on the selected code to open the Cody context menu and select the **Custom Commands (Experiemental)** option.
+Right-click on the selected code to open the Cody context menu and select the **Custom Commands (Experimental)** option.
 
 ![Cody Custom Commands in VS Code](https://storage.googleapis.com/sourcegraph-assets/Docs/create-custom-commands.png)
 

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -88,7 +88,7 @@ Right-click on the selected code to open the Cody context menu and select the **
 
 ### `cody.json` file
 
-You can define custom commands for Cody in the `cody.json` file. To make commands accessible only in a specific project, create the `cody.json` file in the `.vscode` directory of your project. Cody will execute these workspace-specific custom commands when working in that project.
+You can define custom commands for Cody in a `cody.json` file. To make commands only available for a specific project, create the `cody.json` file in the `.vscode` directory of that project. These workspace-specific custom commands will be available to you when you work on that project.
 
 To make commands accessible across multiple projects, create a new `cody.json` file in the `.vscode` directory of your home directory. Cody will execute these global custom commands in any workspace.
 


### PR DESCRIPTION
This PR adds a new section of **Cody Commands** in our [Capabilities](https://docs.sourcegraph.com/cody/capabilities) docs.

## Context

- [Slack thread](https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1692636946491599)

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Docs added


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cody-commands)