### PR TITLE
fix: Alert component does not properly wrap long strings

### DIFF
--- a/client/wildcard/src/components/Alert/Alert.module.scss
+++ b/client/wildcard/src/components/Alert/Alert.module.scss
@@ -3,6 +3,8 @@
     margin-bottom: 1rem;
     border-radius: var(--border-radius);
     border: 1px solid transparent;
+    max-width: 100%;
+    word-wrap: break-word;
 }
 
 .alert a:not(.btn) {


### PR DESCRIPTION
### Description
I added `word-wrap: break-word;` and also added `max-width: 100%` since it was extending the screen

### Refs
[Sourcegraph Issue](https://github.com/sourcegraph/sourcegraph/issues/43056)

### Demo
<img width="1440" alt="Screen Shot 2023-07-20 at 15 19 46" src="https://github.com/GitStartHQ/client-sourcegraph-front-end/assets/51731962/46e2e747-6b48-455a-9043-7c69c1c0f998">

