### PR TITLE
JetBrains: start/stop agent on install/unistall events

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentProjectListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyAgentProjectListener.java
@@ -12,15 +12,15 @@ public class CodyAgentProjectListener implements ProjectManagerListener {
     if (!ConfigUtil.isCodyEnabled()) {
       return;
     }
-    this.startAgent(project);
+    startAgent(project);
   }
 
   @Override
   public void projectClosed(@NotNull Project project) {
-    this.stopAgent(project);
+    stopAgent(project);
   }
 
-  public void stopAgent(@NotNull Project project) {
+  public static void stopAgent(@NotNull Project project) {
     CodyAgent service = project.getService(CodyAgent.class);
     if (service == null) {
       return;
@@ -28,7 +28,7 @@ public class CodyAgentProjectListener implements ProjectManagerListener {
     service.shutdown();
   }
 
-  public void startAgent(@NotNull Project project) {
+  public static void startAgent(@NotNull Project project) {
     CodyAgent service = project.getService(CodyAgent.class);
     if (service == null) {
       return;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/PostStartupActivity.java
@@ -5,6 +5,7 @@ import com.intellij.ide.plugins.PluginInstaller;
 import com.intellij.ide.plugins.PluginStateListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import com.sourcegraph.cody.CodyAgentProjectListener;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.SettingsChangeListener;
 import java.util.UUID;
@@ -30,6 +31,7 @@ public class PostStartupActivity implements StartupActivity.DumbAware {
     PluginInstaller.addStateListener(
         new PluginStateListener() {
           public void install(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
+            CodyAgentProjectListener.startAgent(project);
             GraphQlLogger.logInstallEvent(project)
                 .thenAccept(
                     wasSuccessful -> {
@@ -41,6 +43,7 @@ public class PostStartupActivity implements StartupActivity.DumbAware {
 
           @Override
           public void uninstall(@NotNull IdeaPluginDescriptor ideaPluginDescriptor) {
+            CodyAgentProjectListener.stopAgent(project);
             if (ideaPluginDescriptor
                 .getPluginId()
                 .getIdString()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/56049

It's idempotent to start/stop the agent so it's safe run this more frequently.

## Test plan
n/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
