### PR TITLE
JetBrains: add cancelation support

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -224,6 +224,7 @@ public class CodyAutocompleteManager {
               if (cancellationToken.isCancelled()) {
                 return;
               }
+              cancellationToken.dispose();
               this.clearAutocompleteSuggestions(editor);
 
               if (currentAutocompleteTelemetry != null) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -44,9 +44,8 @@ public class CodyAutocompleteManager {
   private static final Logger logger = Logger.getInstance(CodyAutocompleteManager.class);
   private static final Key<Boolean> KEY_EDITOR_SUPPORTED = Key.create("cody.editorSupported");
   private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-  // TODO: figure out how to avoid the ugly nested `Future<CompletableFuture<T>>` type.
-  private final AtomicReference<Optional<Future<CompletableFuture<Void>>>> currentJob =
-      new AtomicReference<>(Optional.empty());
+  private final AtomicReference<CancellationToken> currentJob =
+      new AtomicReference<>(new CancellationToken());
   private @Nullable AutocompleteTelemetry currentAutocompleteTelemetry = null;
 
   public static @NotNull CodyAutocompleteManager getInstance() {
@@ -127,12 +126,17 @@ public class CodyAutocompleteManager {
     // and asynchronously trigger the auto-complete
     if (triggerKind.equals(InlineCompletionTriggerKind.INVOKE)
         || autoCompleteDocumentContext.isCompletionTriggerValid()) { // TODO: skip this condition
+      CancellationToken cancellationToken = new CancellationToken();
       Callable<CompletableFuture<Void>> callable =
-          () -> triggerAutocompleteAsync(project, editor, offset, textDocument, triggerKind);
+          () ->
+              triggerAutocompleteAsync(
+                  project, editor, offset, textDocument, triggerKind, cancellationToken);
+      ScheduledFuture<CompletableFuture<Void>> scheduledAutocomplete =
+          this.scheduler.schedule(callable, 20, TimeUnit.MILLISECONDS);
+      cancellationToken.onCancellationRequested(() -> scheduledAutocomplete.cancel(true));
       // debouncing the autocomplete trigger
       cancelCurrentJob();
-      this.currentJob.set(
-          Optional.of(this.scheduler.schedule(callable, 20, TimeUnit.MILLISECONDS)));
+      this.currentJob.set(cancellationToken);
     }
   }
 
@@ -142,7 +146,8 @@ public class CodyAutocompleteManager {
       @NotNull Editor editor,
       int offset,
       @NotNull TextDocument textDocument,
-      InlineCompletionTriggerKind triggerKind) {
+      InlineCompletionTriggerKind triggerKind,
+      CancellationToken cancellationToken) {
     CodyAgentServer server = CodyAgent.getServer(project);
     boolean isAgentAutocomplete = server != null;
     if (!isAgentAutocomplete) {
@@ -163,13 +168,19 @@ public class CodyAutocompleteManager {
                     .setCharacter(position.character));
 
     CodyAutocompleteStatusService.notifyApplication(CodyAutocompleteStatus.AutocompleteInProgress);
-    return server
-        .autocompleteExecute(params)
+    CompletableFuture<InlineAutocompleteList> completions = server.autocompleteExecute(params);
+    cancellationToken.onCancellationRequested(() -> completions.cancel(true));
+    return completions
         .thenAccept(
-            result -> processAutocompleteResult(project, editor, offset, triggerKind, result))
+            result ->
+                processAutocompleteResult(
+                    project, editor, offset, triggerKind, result, cancellationToken))
         .exceptionally(
             error -> {
-              logger.warn("failed autocomplete request " + params, error);
+              if (!(error instanceof CancellationException
+                  || error instanceof CompletionException)) {
+                logger.warn("failed autocomplete request " + params, error);
+              }
               return null;
             })
         .thenAccept(
@@ -182,10 +193,11 @@ public class CodyAutocompleteManager {
       @NotNull Editor editor,
       int offset,
       InlineCompletionTriggerKind triggerKind,
-      InlineAutocompleteList result) {
-    if (Thread.interrupted()) {
+      InlineAutocompleteList result,
+      CancellationToken cancellationToken) {
+    if (Thread.interrupted() || cancellationToken.isCancelled()) {
       if (triggerKind.equals(InlineCompletionTriggerKind.INVOKE)) {
-        logger.warn("canceled autocomplete due to thread interruption");
+        logger.warn("autocomplete canceled");
       }
       return;
     }
@@ -204,6 +216,9 @@ public class CodyAutocompleteManager {
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
+              if (cancellationToken.isCancelled()) {
+                return;
+              }
               this.clearAutocompleteSuggestions(editor);
 
               if (currentAutocompleteTelemetry != null) {
@@ -339,26 +354,7 @@ public class CodyAutocompleteManager {
   }
 
   private void cancelCurrentJob() {
-    // TODO: change this implementation when we avoid nested `Future<CompletableFuture<T>>`
-    this.currentJob
-        .get()
-        .ifPresent(
-            job -> {
-              if (job.isDone()) {
-                try {
-                  job.get().cancel(true);
-                } catch (ExecutionException
-                    | InterruptedException
-                    | CancellationException ignored) {
-                }
-              } else {
-                // Cancelling the toplevel `Future<>` appears to cancel the nested
-                // `CompletableFuture<>`.
-                // Feel free to reimplement this entire method if it's causing problems because this
-                // logic is not bulletproof.
-                job.cancel(true);
-              }
-            });
+    this.currentJob.get().abort();
     CodyAutocompleteStatusService.notifyApplication(CodyAutocompleteStatus.Ready);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -169,7 +169,12 @@ public class CodyAutocompleteManager {
 
     CodyAutocompleteStatusService.notifyApplication(CodyAutocompleteStatus.AutocompleteInProgress);
     CompletableFuture<InlineAutocompleteList> completions = server.autocompleteExecute(params);
+
+    // Important: we have to `.cancel()` the original `CompletableFuture<T>` from lsp4j. As soon as
+    // we use `thenAccept()` we get a new instance of `CompletableFuture<Void>` which does not
+    // correctly propagate the cancelation to the agent.
     cancellationToken.onCancellationRequested(() -> completions.cancel(true));
+
     return completions
         .thenAccept(
             result ->

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
@@ -10,7 +10,11 @@ public class CancellationToken {
     this.cancelled.thenAccept(
         (cancelled) -> {
           if (cancelled) {
-            callback.run();
+            try {
+              callback.run();
+            } catch (Exception ignored) {
+              // Do nothing about exceptions in cancelation callbacks
+            }
           }
         });
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
@@ -4,7 +4,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 public class CancellationToken {
-  public final CompletableFuture<Boolean> cancelled = new CompletableFuture<>();
+  private final CompletableFuture<Boolean> cancelled = new CompletableFuture<>();
 
   public void onCancellationRequested(Runnable callback) {
     this.cancelled.thenAccept(
@@ -25,6 +25,10 @@ public class CancellationToken {
     } catch (ExecutionException | InterruptedException ignored) {
       return true;
     }
+  }
+
+  public void dispose() {
+    this.cancelled.complete(false);
   }
 
   public void abort() {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/56042

Previously, we didn't correctly propagate autocomplete cancelation to the agent. This was problematic because we could end up queueing a lot of autocomplete requests making the experience lag. This PR fixes the problem by sending a `$/cancelRequest` notification to the agent as implemented in https://github.com/sourcegraph/cody/pull/787

## Test plan

While using the plugin, confirm that we're sending a lot of `$/cancelRequest` notifications. Also confirm that autocomplete still works as expected.
```
❯ tail -f build/sourcegraph/cody-agent-trace.json  | grep cancelRe
```
My anecdotal experience is that autocomplete feels somewhat snappier with this change, which makes sense if we're cancelling old requests more aggressively.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
