### PR TITLE
gitserver: truncate output when ls-tree fails

### DIFF
--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -3296,3 +3296,27 @@ func Test_CommitLog(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorMessageTruncateOutput(t *testing.T) {
+	cmd := []string{"git", "ls-files"}
+
+	t.Run("short output", func(t *testing.T) {
+		shortOutput := "aaaaaaaaaab"
+		message := errorMessageTruncatedOutput(cmd, []byte(shortOutput))
+		want := fmt.Sprintf("git command [git ls-files] failed (output: %q)", shortOutput)
+
+		if diff := cmp.Diff(want, message); diff != "" {
+			t.Fatalf("wrong message. diff: %s", diff)
+		}
+	})
+
+	t.Run("truncating output", func(t *testing.T) {
+		longOutput := strings.Repeat("a", 5000) + "b"
+		message := errorMessageTruncatedOutput(cmd, []byte(longOutput))
+		want := fmt.Sprintf("git command [git ls-files] failed (truncated output: %q, 1 more)", longOutput[:5000])
+
+		if diff := cmp.Diff(want, message); diff != "" {
+			t.Fatalf("wrong message. diff: %s", diff)
+		}
+	})
+}


### PR DESCRIPTION
This fixes #56080 by truncating the output of the failing git command in case it failed.

When it _didn't_ fail, we don't want to truncate anything, but when it fails, 5000 bytes is probably enough output.

## Test plan

- I tested the helper function manually because I'm prone to off-by-one errors
- I do not know how to properly test this without pulling in a mock-lib from src-cli or overwriting `$PATH` in the test to put a different `git` in that'll fail. Suggestions welcome.
