### PR TITLE
dotcom: Don't allow feature flag overrides for service account

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
+        "//internal/actor",
         "//internal/auth",
         "//internal/authz",
         "//internal/codygateway",
@@ -36,7 +37,6 @@ go_library(
         "//internal/database/dbutil",
         "//internal/env",
         "//internal/errcode",
-        "//internal/featureflag",
         "//internal/gqlutil",
         "//internal/hashutil",
         "//internal/license",


### PR DESCRIPTION
Previously, headers and query strings could overwrite the feature flags, to prevent this, we're reading from the DB directly now.

cc #inc-234

## Test plan

Adjusted tests, got early feedback in slack. 