### PR TITLE
release tool: bump migrator tag in `deploy-sourcegraph-k8s` during releases

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -778,6 +778,7 @@ cc @${release.captainGitHubUsername}
                         edits: [
                             `sg ops update-images -pin-tag ${release.version.version} base/`,
                             `sg ops update-images -pin-tag ${release.version.version} components/executors/`,
+                            `sg ops update-images -pin-tag ${release.version.version} components/utils/migrator`,
                         ],
                         ...prBodyAndDraftState([]),
                     },


### PR DESCRIPTION
This was not bumped. Now it is.

## Test plan
Locally tested

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
