### PR TITLE
release tool: bump chart versions of executor charts during release

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -834,8 +834,8 @@ cc @${release.captainGitHubUsername}
                         title: defaultPRMessage,
                         edits: [
                             `for i in charts/{sourcegraph,sourcegraph-executor/{dind,k8s},sourcegraph-migrator}; do sg ops update-images -kind helm -pin-tag ${release.version.version} $i/.; done`,
-                            `${sed} -i 's/appVersion:.*/appVersion: "${release.version.version}"/g' charts/*/Chart.yaml`,
-                            `${sed} -i 's/version:.*/version: "${release.version.version}"/g' charts/*/Chart.yaml`,
+                            `find charts -name Chart.yaml | xargs ${sed} -i 's/appVersion:.*/appVersion: "${release.version.version}"/g'`,
+                            `find charts -name Chart.yaml | xargs ${sed} -i 's/version:.*/version: "${release.version.version}"/g'`,
                             './scripts/helm-docs.sh',
                         ],
                         ...prBodyAndDraftState([]),


### PR DESCRIPTION
- Closes #55790 

The existing `sed` pattern didn't catch the executor directories. The updated command targets all `Chart.yaml` files.

## Test plan
Locally tested

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
