### PR TITLE
productsubscription: add audit logs

### DIFF
--- a/enterprise/cmd/frontend/internal/dotcom/init.go
+++ b/enterprise/cmd/frontend/internal/dotcom/init.go
@@ -51,10 +51,12 @@ func Init(
 	if envvar.SourcegraphDotComMode() {
 		enterpriseServices.DotcomRootResolver = dotcomRootResolver{
 			ProductSubscriptionLicensingResolver: productsubscription.ProductSubscriptionLicensingResolver{
-				DB: db,
+				Logger: observationCtx.Logger.Scoped("productsubscriptions", "resolvers for dotcom product subscriptions"),
+				DB:     db,
 			},
 			CodyGatewayDotcomUserResolver: productsubscription.CodyGatewayDotcomUserResolver{
-				DB: db,
+				Logger: observationCtx.Logger.Scoped("codygatewayuser", "resolvers for dotcom cody gateway users"),
+				DB:     db,
 			},
 		}
 		enterpriseServices.NewDotcomLicenseCheckHandler = func() http.Handler {

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//internal/actor",
+        "//internal/audit",
         "//internal/auth",
         "//internal/authz",
         "//internal/codygateway",
@@ -85,6 +86,7 @@ go_test(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
+        "//internal/audit/audittest",
         "//internal/auth",
         "//internal/authz",
         "//internal/conf",
@@ -108,6 +110,7 @@ go_test(
         "@com_github_gomodule_redigo//redis",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_uuid//:uuid",
+        "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_hexops_valast//:valast",
         "@com_github_sourcegraph_log//logtest",

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/graphql.go
@@ -9,6 +9,6 @@ import (
 // ProductSubscriptionLicensingResolver implements the GraphQL Query and Mutation fields related to product
 // subscriptions and licensing.
 type ProductSubscriptionLicensingResolver struct {
-	logger log.Logger
+	Logger log.Logger
 	DB     database.DB
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -8,6 +8,8 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -20,45 +22,46 @@ import (
 
 // productLicense implements the GraphQL type ProductLicense.
 type productLicense struct {
-	db database.DB
-	v  *dbLicense
+	logger log.Logger
+	db     database.DB
+	v      *dbLicense
 }
 
 // ProductLicenseByID looks up and returns the ProductLicense with the given GraphQL ID. If no such
 // ProductLicense exists, it returns a non-nil error.
 func (p ProductSubscriptionLicensingResolver) ProductLicenseByID(ctx context.Context, id graphql.ID) (graphqlbackend.ProductLicense, error) {
-	return productLicenseByID(ctx, p.DB, id)
+	return productLicenseByID(ctx, p.Logger, p.DB, id, "license-access")
 }
 
 // productLicenseByID looks up and returns the ProductLicense with the given GraphQL ID. If no such
 // ProductLicense exists, it returns a non-nil error.
-func productLicenseByID(ctx context.Context, db database.DB, id graphql.ID) (*productLicense, error) {
+func productLicenseByID(ctx context.Context, logger log.Logger, db database.DB, id graphql.ID, access string) (*productLicense, error) {
 	lid, err := unmarshalProductLicenseID(id)
 	if err != nil {
 		return nil, err
 	}
-	return productLicenseByDBID(ctx, db, lid)
+	return productLicenseByDBID(ctx, logger, db, lid, access)
 }
 
 // productLicenseByDBID looks up and returns the ProductLicense with the given database ID. If no
 // such ProductLicense exists, it returns a non-nil error.
-func productLicenseByDBID(ctx context.Context, db database.DB, id string) (*productLicense, error) {
+func productLicenseByDBID(ctx context.Context, logger log.Logger, db database.DB, id, access string) (*productLicense, error) {
 	v, err := dbLicenses{db: db}.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
 	// 🚨 SECURITY: Only site admins and the license's subscription's account's user may view a
-	// product license.
-	sub, err := productSubscriptionByDBID(ctx, db, v.ProductSubscriptionID)
-	if err != nil {
-		return nil, err
-	}
-	if err := auth.CheckSiteAdminOrSameUser(ctx, db, sub.v.UserID); err != nil {
+	// product license. Retrieving the subscription performs the necessary permission checks.
+	if _, err := productSubscriptionByDBID(ctx, logger, db, v.ProductSubscriptionID, access); err != nil {
 		return nil, err
 	}
 
-	return &productLicense{db: db, v: v}, nil
+	return &productLicense{
+		logger: logger,
+		db:     db,
+		v:      v,
+	}, nil
 }
 
 func (r *productLicense) ID() graphql.ID {
@@ -77,7 +80,7 @@ func unmarshalProductLicenseID(id graphql.ID) (productLicenseID string, err erro
 }
 
 func (r *productLicense) Subscription(ctx context.Context) (graphqlbackend.ProductSubscription, error) {
-	return productSubscriptionByDBID(ctx, r.db, r.v.ProductSubscriptionID)
+	return productSubscriptionByDBID(ctx, r.logger, r.db, r.v.ProductSubscriptionID, "access")
 }
 
 func (r *productLicense) Info() (*graphqlbackend.ProductLicenseInfo, error) {
@@ -143,7 +146,7 @@ func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscript
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
 		return nil, err
 	}
-	sub, err := productSubscriptionByID(ctx, r.DB, args.ProductSubscriptionID)
+	sub, err := productSubscriptionByID(ctx, r.Logger, r.DB, args.ProductSubscriptionID, "generate-license")
 	if err != nil {
 		return nil, err
 	}
@@ -151,19 +154,19 @@ func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscript
 	if err != nil {
 		return nil, err
 	}
-	return productLicenseByDBID(ctx, r.DB, id)
+	return productLicenseByDBID(ctx, r.Logger, r.DB, id, "access-license")
 }
 
 func (r ProductSubscriptionLicensingResolver) ProductLicenses(ctx context.Context, args *graphqlbackend.ProductLicensesArgs) (graphqlbackend.ProductLicenseConnection, error) {
 	// 🚨 SECURITY: Only site admins may list product licenses.
-	if err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
+	if _, err := serviceAccountOrSiteAdmin(ctx, r.DB, true); err != nil {
 		return nil, err
 	}
 
 	var sub *productSubscription
 	if args.ProductSubscriptionID != nil {
 		var err error
-		sub, err = productSubscriptionByID(ctx, r.DB, *args.ProductSubscriptionID)
+		sub, err = productSubscriptionByID(ctx, r.Logger, r.DB, *args.ProductSubscriptionID, "list-licenses")
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +180,11 @@ func (r ProductSubscriptionLicensingResolver) ProductLicenses(ctx context.Contex
 		opt.LicenseKeySubstring = *args.LicenseKeySubstring
 	}
 	args.ConnectionArgs.Set(&opt.LimitOffset)
-	return &productLicenseConnection{db: r.DB, opt: opt}, nil
+	return &productLicenseConnection{
+		logger: r.Logger,
+		db:     r.DB,
+		opt:    opt,
+	}, nil
 }
 
 func (r ProductSubscriptionLicensingResolver) RevokeLicense(ctx context.Context, args *graphqlbackend.RevokeLicenseArgs) (*graphqlbackend.EmptyResponse, error) {
@@ -205,6 +212,8 @@ func (r ProductSubscriptionLicensingResolver) RevokeLicense(ctx context.Context,
 // 🚨 SECURITY: When instantiating a productLicenseConnection value, the caller MUST
 // check permissions.
 type productLicenseConnection struct {
+	logger log.Logger
+
 	opt dbLicensesListOptions
 	db  database.DB
 
@@ -236,7 +245,11 @@ func (r *productLicenseConnection) Nodes(ctx context.Context) ([]graphqlbackend.
 
 	var l []graphqlbackend.ProductLicense
 	for _, result := range results {
-		l = append(l, &productLicense{db: r.db, v: result})
+		l = append(l, &productLicense{
+			logger: r.logger,
+			db:     r.db,
+			v:      result,
+		})
 	}
 	return l, nil
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/service_account.go
@@ -26,12 +26,13 @@ func serviceAccountOrSiteAdmin(
 	// requiresWriterServiceAccount, if true, requires "product-subscriptions-service-account",
 	// otherwise just "product-subscriptions-reader-service-account" is sufficient.
 	requiresWriterServiceAccount bool,
-) error {
+) (string, error) {
 	return serviceAccountOrOwnerOrSiteAdmin(ctx, db, nil, requiresWriterServiceAccount)
 }
 
 // 🚨 SECURITY: Use this to check if access to a subscription query or mutation
-// is authorized for service accounts, the owning user, and site admins.
+// is authorized for service accounts, the owning user, and site admins. Callers
+// should record the returned grant reason in an audit log tracking the access.
 func serviceAccountOrOwnerOrSiteAdmin(
 	ctx context.Context,
 	db database.DB,
@@ -39,31 +40,34 @@ func serviceAccountOrOwnerOrSiteAdmin(
 	// requiresWriterServiceAccount, if true, requires "product-subscriptions-service-account",
 	// otherwise just "product-subscriptions-reader-service-account" is sufficient.
 	requiresWriterServiceAccount bool,
-) error {
+) (string, error) {
 	// Check if the user is has the prerequisite service account.
 	serviceAccountIsWriter := readFeatureFlagFromDB(ctx, db, featureFlagProductSubscriptionsServiceAccount, false)
 	if requiresWriterServiceAccount {
 		// 🚨 SECURITY: Require the more strict featureFlagProductSubscriptionsServiceAccount
 		// if requiresWriterServiceAccount=true
 		if serviceAccountIsWriter {
-			return nil
+			return "writer_service_account", nil
 		}
 		// Otherwise, fall through to check if actor is owner or site admin.
 	} else {
 		// If requiresWriterServiceAccount==false, then just
 		// featureFlagProductSubscriptionsReaderServiceAccount is sufficient.
-		if serviceAccountIsWriter || readFeatureFlagFromDB(ctx, db, featureFlagProductSubscriptionsReaderServiceAccount, false) {
-			return nil
+		if serviceAccountIsWriter {
+			return "writer_service_account", nil
+		}
+		if readFeatureFlagFromDB(ctx, db, featureFlagProductSubscriptionsReaderServiceAccount, false) {
+			return "reader_service_account", nil
 		}
 	}
 
 	// If ownerUserID is specified, the user must be the owner, or a site admin.
 	if ownerUserID != nil {
-		return auth.CheckSiteAdminOrSameUser(ctx, db, *ownerUserID)
+		return "same_user_or_site_admin", auth.CheckSiteAdminOrSameUser(ctx, db, *ownerUserID)
 	}
 
 	// Otherwise, the user must be a site admin.
-	return auth.CheckCurrentUserIsSiteAdmin(ctx, db)
+	return "site_admin", auth.CheckCurrentUserIsSiteAdmin(ctx, db)
 }
 
 // readFeatureFlagFromDB explicitly reads the feature flag values from the database,

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
@@ -4,10 +4,20 @@ import (
 	"context"
 	"testing"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/audit/audittest"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/license"
 )
 
 func TestProductSubscription_Account(t *testing.T) {
@@ -21,4 +31,89 @@ func TestProductSubscription_Account(t *testing.T) {
 		_, err := (&productSubscription{v: &dbSubscription{UserID: 1}, db: db}).Account(context.Background())
 		assert.Nil(t, err)
 	})
+}
+
+// Test cases are very simple for now to expedite assertions that we are
+// generating adequate access logs. In the future we can extend this to
+// better cover more scenarios.
+func TestProductSubscriptionActiveLicense(t *testing.T) {
+	ctx := context.Background()
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+	subscriptionsDB := dbSubscriptions{db: db}
+	licensesDB := dbLicenses{db: db}
+
+	// Set global feature flag so we can override it per-user
+	_, err := db.FeatureFlags().CreateBool(ctx, featureFlagProductSubscriptionsServiceAccount, false)
+	require.NoError(t, err)
+
+	// Site admin
+	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin"})
+	require.NoError(t, err)
+	err = db.Users().SetIsSiteAdmin(ctx, adminUser.ID, true)
+	require.NoError(t, err)
+
+	// User owning the subscription in question
+	ownerUser, err := db.Users().Create(ctx, database.NewUser{Username: "verified"})
+	require.NoError(t, err)
+	sub, err := subscriptionsDB.Create(ctx, ownerUser.ID, "subscription")
+	require.NoError(t, err)
+	_, err = licensesDB.Create(ctx, sub, "license-key", 1, license.Info{})
+	require.NoError(t, err)
+
+	// Service account user
+	serviceAccountUser, err := db.Users().Create(ctx, database.NewUser{Username: "serviceaccount"})
+	require.NoError(t, err)
+	_, err = db.FeatureFlags().CreateOverride(ctx, &featureflag.Override{
+		UserID:   &serviceAccountUser.ID,
+		FlagName: featureFlagProductSubscriptionsServiceAccount,
+	})
+	require.NoError(t, err)
+
+	// Test cases
+	for _, test := range []struct {
+		name           string
+		actor          *actor.Actor
+		subscriptionID graphql.ID
+	}{
+		{
+			name:           "site admin",
+			actor:          actor.FromActualUser(adminUser),
+			subscriptionID: marshalProductSubscriptionID(sub),
+		},
+		{
+			name:           "subscription owner",
+			actor:          actor.FromActualUser(adminUser),
+			subscriptionID: marshalProductSubscriptionID(sub),
+		},
+		{
+			name:           "service account",
+			actor:          actor.FromActualUser(adminUser),
+			subscriptionID: marshalProductSubscriptionID(sub),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			logger, exportLogs := logtest.Captured(t)
+
+			requestCtx := actor.WithActor(ctx, test.actor)
+
+			r := ProductSubscriptionLicensingResolver{Logger: logger, DB: db}
+
+			// Resolve the subscription and then the active license of the subscription
+			sub, err := r.ProductSubscriptionByID(requestCtx, test.subscriptionID)
+			require.NoError(t, err)
+			_, err = sub.ActiveLicense(requestCtx)
+			require.NoError(t, err)
+
+			// A subscription was resolved in this test case, we should have an
+			// audit log
+			assert.True(t, exportLogs().Contains(func(l logtest.CapturedLog) bool {
+				fields, ok := audittest.ExtractAuditFields(l)
+				if !ok {
+					return ok
+				}
+				return fields.Entity == auditEntityProductSubscriptions &&
+					fields.Action == "access"
+			}))
+		})
+	}
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql.go
@@ -28,7 +28,7 @@ func (e ErrProductSubscriptionNotFound) Extensions() map[string]any {
 // given access token.
 func (r ProductSubscriptionLicensingResolver) ProductSubscriptionByAccessToken(ctx context.Context, args *graphqlbackend.ProductSubscriptionByAccessTokenArgs) (graphqlbackend.ProductSubscription, error) {
 	// 🚨 SECURITY: Only specific entities may use this functionality.
-	if err := serviceAccountOrSiteAdmin(ctx, r.DB, false); err != nil {
+	if _, err := serviceAccountOrSiteAdmin(ctx, r.DB, false); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql_test.go
@@ -18,7 +18,7 @@ func TestProductSubscriptionByAccessToken(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	ctx := context.Background()
-	r := ProductSubscriptionLicensingResolver{logger: logger, DB: db}
+	r := ProductSubscriptionLicensingResolver{Logger: logger, DB: db}
 
 	alice, err := db.Users().Create(ctx, database.NewUser{Username: "alice"})
 	require.NoError(t, err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -43,6 +43,7 @@ func Log(ctx context.Context, logger log.Logger, record Record) {
 
 	fields = append(fields, log.Object("audit",
 		log.String("auditId", auditId),
+		log.String("action", record.Action),
 		log.String("entity", record.Entity),
 		log.Object("actor",
 			log.String("actorUID", actorId(act)),

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -34,6 +34,7 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"action": "test audit action",
 				"actor": map[string]interface{}{
 					"X-Forwarded-For": "192.168.0.1",
 					"actorUID":        "1",
@@ -54,6 +55,7 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"action": "test audit action",
 				"actor": map[string]interface{}{
 					"X-Forwarded-For": "192.168.0.1",
 					"actorUID":        "anonymous",
@@ -74,6 +76,7 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"action": "test audit action",
 				"actor": map[string]interface{}{
 					"X-Forwarded-For": "192.168.0.1",
 					"actorUID":        "unknown",
@@ -90,6 +93,7 @@ func TestLog(t *testing.T) {
 			client:            nil,
 			additionalContext: []log.Field{log.String("additional", "stuff")},
 			expectedEntry: autogold.Expect(map[string]interface{}{"additional": "stuff", "audit": map[string]interface{}{
+				"action": "test audit action",
 				"actor": map[string]interface{}{
 					"X-Forwarded-For": "unknown",
 					"actorUID":        "1",
@@ -110,9 +114,11 @@ func TestLog(t *testing.T) {
 			},
 			additionalContext: nil,
 			expectedEntry: autogold.Expect(map[string]interface{}{"audit": map[string]interface{}{
-				"actor": map[string]interface{}{
-					"X-Forwarded-For": "192.168.0.1", "actorUID": "1", "ip": "192.168.0.1",
-					"userAgent": "Foobar",
+				"action": "test audit action", "actor": map[string]interface{}{
+					"X-Forwarded-For": "192.168.0.1",
+					"actorUID":        "1",
+					"ip":              "192.168.0.1",
+					"userAgent":       "Foobar",
 				},
 				"auditId": "test-audit-id-1234",
 				"entity":  "test entity",

--- a/internal/audit/audittest/BUILD.bazel
+++ b/internal/audit/audittest/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "audittest",
+    srcs = ["audittest.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/audit/audittest",
+    visibility = ["//:__subpackages__"],
+    deps = ["@com_github_sourcegraph_log//logtest"],
+)
+
+go_test(
+    name = "audittest_test",
+    srcs = ["audittest_test.go"],
+    embed = [":audittest"],
+    deps = [
+        "//internal/actor",
+        "//internal/audit",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/internal/audit/audittest/audittest.go
+++ b/internal/audit/audittest/audittest.go
@@ -1,0 +1,25 @@
+package audittest
+
+import "github.com/sourcegraph/log/logtest"
+
+type AuditFields struct {
+	Action string
+	Entity string
+}
+
+// ExtractAuditFields retrieves some high-level audit log fields for assertions
+// on captured log entries (using logtest.Captured(...))
+func ExtractAuditFields(entry logtest.CapturedLog) (*AuditFields, bool) {
+	f := entry.Fields["audit"]
+	if f == nil {
+		return nil, false
+	}
+	m, ok := f.(map[string]any)
+	if m == nil || !ok {
+		return nil, false
+	}
+	return &AuditFields{
+		Entity: m["entity"].(string),
+		Action: m["action"].(string),
+	}, true
+}

--- a/internal/audit/audittest/audittest_test.go
+++ b/internal/audit/audittest/audittest_test.go
@@ -1,0 +1,34 @@
+package audittest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/audit"
+)
+
+func TestExtractAuditFields(t *testing.T) {
+	l, exportLogs := logtest.Captured(t)
+	record := audit.Record{
+		Entity: "foobar",
+		Action: "barbaz",
+	}
+	ctx := actor.WithActor(context.Background(), actor.FromAnonymousUser("asdf"))
+
+	audit.Log(ctx, l, record)
+
+	entries := exportLogs()
+	assert.True(t, entries.Contains(func(l logtest.CapturedLog) bool {
+		fields, ok := ExtractAuditFields(l)
+		if !ok {
+			return ok
+		}
+		assert.Equal(t, record.Action, fields.Action)
+		assert.Equal(t, record.Entity, fields.Entity)
+		return !t.Failed()
+	}))
+}


### PR DESCRIPTION
This change adds audit logging to successful access to product subscriptions, licenses, and Cody Gateway dotcom users, recording `grant_reason` and propagating `access` to indicate the use case the prompted the access.

Audit logs are recorded under 2 "entities":

- `dotcom-productsubscriptions`
- `dotcom-codygatewayuser`

## Test plan

Unit/integration test cases covering:

- return of `grant_reason` from our lowest-level `serviceAccountOrOwnerOrSiteAdmin` helper for checking access
- audit logging of access to Cody Gateway dotcom user
- audit logging of access to product subscription and active license