### PR TITLE
pings: add HubSpot ping to healthcheck

### DIFF
--- a/cmd/frontend/hubspot/BUILD.bazel
+++ b/cmd/frontend/hubspot/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
         "//internal/httpcli",
         "//lib/errors",
         "@com_github_google_go_querystring//query",
+        "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/cmd/pings/shared/BUILD.bazel
+++ b/cmd/pings/shared/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/pings/shared",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/frontend/hubspot/hubspotutil",
         "//internal/debugserver",
         "//internal/env",
         "//internal/goroutine",

--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -2,12 +2,14 @@ package shared
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot/hubspotutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -55,18 +57,36 @@ func newServerHandler(logger log.Logger, config *Config) (http.Handler, error) {
 		return nil, errors.Errorf("create Pub/Sub client: %v", err)
 	}
 	r.Path("/-/healthz").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		var errs error
-		if err = pubsubClient.Ping(context.Background()); err != nil {
-			errs = errors.Append(errs, errors.Errorf("Pub/Sub client: %v", err))
-		}
-		if errs != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte(errs.Error()))
-			return
+		failed := false
+		status := make(map[string]string)
+		if err := pubsubClient.Ping(context.Background()); err != nil {
+			failed = true
+			status["Pub/Sub client"] = err.Error()
+		} else {
+			status["Pub/Sub client"] = "OK"
 		}
 
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(http.StatusText(http.StatusOK)))
+		if hubspotutil.HasAPIKey() {
+			if err := hubspotutil.Client().Ping(30 * time.Second); err != nil {
+				failed = true
+				status["HubSpot client"] = err.Error()
+			} else {
+				status["HubSpot client"] = "OK"
+			}
+		} else {
+			status["HubSpot client"] = "Not configured"
+		}
+
+		if failed {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		err := json.NewEncoder(w).Encode(status)
+		if err != nil {
+			logger.Error("failed to encode health check status", log.Error(err))
+		}
+		return
 	})
 	r.Path("/updates").
 		Methods(http.MethodGet, http.MethodPost).

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -331,6 +331,9 @@ commands:
     checkBinary: .bin/pings
     env:
       SRC_LOG_LEVEL: info
+      PINGS_PUBSUB_PROJECT_ID: ''
+      PINGS_PUBSUB_TOPIC_ID: ''
+      HUBSPOT_ACCESS_TOKEN: ''
     watch:
       - lib
       - internal


### PR DESCRIPTION

## Test plan

1. Set up local development as described in https://docs.google.com/document/d/1knDauzIh0cW52RUOFTRQ3SHttTepcGUo69zmr4ZhSEw/edit#heading=h.rk82yvydt7cj
2. `sg run pings`
3. With HubSpot token configured:
	```
	$ curl http://localhost:10086/-/healthz
	{"HubSpot client":"OK","Pub/Sub client":"OK"}
	```
3. Without HubSpot token configured:
	```
	$ curl http://localhost:10086/-/healthz
	{"HubSpot client":"Not configured","Pub/Sub client":"OK"}
	```
