### PR TITLE
Add GraphQL mutation for configuring code host rate limits

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -388,6 +388,7 @@ go_test(
         "access_requests_test.go",
         "access_tokens_test.go",
         "client_configuration_test.go",
+        "code_host_test.go",
         "code_hosts_test.go",
         "event_log_test.go",
         "event_logs_test.go",

--- a/cmd/frontend/graphqlbackend/code_host_test.go
+++ b/cmd/frontend/graphqlbackend/code_host_test.go
@@ -1,0 +1,242 @@
+package graphqlbackend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaResolver_SetCodeHostRateLimits_NotASiteAdmin(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+
+	usersStore := dbmocks.NewMockUserStore()
+	usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: false}, nil)
+	db.UsersFunc.SetDefaultReturn(usersStore)
+
+	_, err := r.SetCodeHostRateLimits(context.Background(), SetCodeHostRateLimitsArgs{
+		Input: SetCodeHostRateLimitsInput{},
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, "must be site admin", err.Error())
+}
+
+func TestSchemaResolver_SetCodeHostRateLimits_InvalidConfigs(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+	wantErr := errors.New("rate limit settings must be positive integers")
+
+	tests := []struct {
+		name    string
+		args    SetCodeHostRateLimitsArgs
+		wantErr error
+	}{
+		{
+			name: "Negative APIQuota",
+			args: SetCodeHostRateLimitsArgs{
+				Input: SetCodeHostRateLimitsInput{
+					CodeHostID:                      "Q29kZUhvc3Q6MQ==",
+					APIQuota:                        -1,
+					APIReplenishmentIntervalSeconds: 1,
+					GitQuota:                        1,
+					GitReplenishmentIntervalSeconds: 1,
+				},
+			},
+			wantErr: wantErr,
+		},
+		{
+			name: "Negative APIReplenishmentIntervalSeconds",
+			args: SetCodeHostRateLimitsArgs{
+				Input: SetCodeHostRateLimitsInput{
+					CodeHostID:                      "Q29kZUhvc3Q6MQ==",
+					APIQuota:                        1,
+					APIReplenishmentIntervalSeconds: -1,
+					GitQuota:                        1,
+					GitReplenishmentIntervalSeconds: 1,
+				},
+			},
+			wantErr: wantErr,
+		},
+		{
+			name: "Negative GitQuota",
+			args: SetCodeHostRateLimitsArgs{
+				Input: SetCodeHostRateLimitsInput{
+					CodeHostID:                      "Q29kZUhvc3Q6MQ==",
+					APIQuota:                        1,
+					APIReplenishmentIntervalSeconds: 1,
+					GitQuota:                        -1,
+					GitReplenishmentIntervalSeconds: 1,
+				},
+			},
+			wantErr: wantErr,
+		},
+		{
+			name: "Negative GitReplenishmentIntervalSeconds",
+			args: SetCodeHostRateLimitsArgs{
+				Input: SetCodeHostRateLimitsInput{
+					CodeHostID:                      "Q29kZUhvc3Q6MQ==",
+					APIQuota:                        1,
+					APIReplenishmentIntervalSeconds: 1,
+					GitQuota:                        1,
+					GitReplenishmentIntervalSeconds: -1,
+				},
+			},
+			wantErr: wantErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			usersStore := dbmocks.NewMockUserStore()
+			usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+			db.UsersFunc.SetDefaultReturn(usersStore)
+
+			_, err := r.SetCodeHostRateLimits(ctx, test.args)
+			assert.NotNil(t, err)
+			assert.Equal(t, "rate limit settings must be positive integers", err.Error())
+		})
+	}
+}
+
+func TestSchemaResolver_SetCodeHostRateLimits_InvalidCodeHostID(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+	wantErr := errors.New("test error")
+
+	usersStore := dbmocks.NewMockUserStore()
+	usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	db.UsersFunc.SetDefaultReturn(usersStore)
+
+	codeHostStore := dbmocks.NewMockCodeHostStore()
+	codeHostStore.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.CodeHost, error) {
+		return nil, wantErr
+	})
+	db.CodeHostsFunc.SetDefaultReturn(codeHostStore)
+
+	_, err := r.SetCodeHostRateLimits(context.Background(), SetCodeHostRateLimitsArgs{
+		Input: SetCodeHostRateLimitsInput{CodeHostID: ""},
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid code host id: invalid graphql.ID", err.Error())
+}
+
+func TestSchemaResolver_SetCodeHostRateLimits_GetCodeHostByIDError(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+	wantErr := errors.New("test error")
+
+	usersStore := dbmocks.NewMockUserStore()
+	usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	db.UsersFunc.SetDefaultReturn(usersStore)
+
+	codeHostStore := dbmocks.NewMockCodeHostStore()
+	codeHostStore.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.CodeHost, error) {
+		return nil, wantErr
+	})
+	db.CodeHostsFunc.SetDefaultReturn(codeHostStore)
+
+	_, err := r.SetCodeHostRateLimits(context.Background(), SetCodeHostRateLimitsArgs{
+		Input: SetCodeHostRateLimitsInput{CodeHostID: "Q29kZUhvc3Q6MQ=="},
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, wantErr.Error(), err.Error())
+}
+
+func TestSchemaResolver_SetCodeHostRateLimits_UpdateCodeHostError(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+	wantErr := errors.New("test error")
+
+	usersStore := dbmocks.NewMockUserStore()
+	usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	db.UsersFunc.SetDefaultReturn(usersStore)
+
+	codeHostStore := dbmocks.NewMockCodeHostStore()
+	codeHostStore.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.CodeHost, error) {
+		assert.Equal(t, int32(1), id)
+		return &types.CodeHost{ID: 1}, nil
+	})
+	codeHostStore.UpdateFunc.SetDefaultHook(func(ctx context.Context, host *types.CodeHost) error {
+		return wantErr
+	})
+	db.CodeHostsFunc.SetDefaultReturn(codeHostStore)
+
+	_, err := r.SetCodeHostRateLimits(context.Background(), SetCodeHostRateLimitsArgs{
+		Input: SetCodeHostRateLimitsInput{CodeHostID: "Q29kZUhvc3Q6MQ=="},
+	})
+	assert.NotNil(t, err)
+	assert.Equal(t, wantErr.Error(), err.Error())
+}
+
+func TestSchemaResolver_SetCodeHostRateLimits_Success(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDB()
+	r := &schemaResolver{logger: logger, db: db}
+	ctx := context.Background()
+	setCodeHostRateLimitsInput := SetCodeHostRateLimitsInput{
+		CodeHostID:                      "Q29kZUhvc3Q6MQ==",
+		APIQuota:                        1,
+		APIReplenishmentIntervalSeconds: 2,
+		GitQuota:                        3,
+		GitReplenishmentIntervalSeconds: 4,
+	}
+
+	usersStore := dbmocks.NewMockUserStore()
+	usersStore.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
+	db.UsersFunc.SetDefaultReturn(usersStore)
+
+	codeHostStore := dbmocks.NewMockCodeHostStore()
+	codeHostStore.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.CodeHost, error) {
+		assert.Equal(t, int32(1), id)
+		return &types.CodeHost{ID: 1}, nil
+	})
+	codeHostStore.UpdateFunc.SetDefaultHook(func(ctx context.Context, host *types.CodeHost) error {
+		assert.Equal(t, setCodeHostRateLimitsInput.APIQuota, *(host.APIRateLimitQuota))
+		assert.Equal(t, setCodeHostRateLimitsInput.APIReplenishmentIntervalSeconds, *(host.APIRateLimitIntervalSeconds))
+		assert.Equal(t, setCodeHostRateLimitsInput.GitQuota, *(host.GitRateLimitQuota))
+		assert.Equal(t, setCodeHostRateLimitsInput.GitReplenishmentIntervalSeconds, *(host.GitRateLimitIntervalSeconds))
+		return nil
+	})
+	db.CodeHostsFunc.SetDefaultReturn(codeHostStore)
+
+	variables := map[string]any{
+		"input": map[string]any{
+			"codeHostID":                      "Q29kZUhvc3Q6MQ==",
+			"apiQuota":                        setCodeHostRateLimitsInput.APIQuota,
+			"apiReplenishmentIntervalSeconds": setCodeHostRateLimitsInput.APIReplenishmentIntervalSeconds,
+			"gitQuota":                        setCodeHostRateLimitsInput.GitQuota,
+			"gitReplenishmentIntervalSeconds": setCodeHostRateLimitsInput.GitReplenishmentIntervalSeconds,
+		},
+	}
+	RunTest(t, &Test{
+		Context:   ctx,
+		Schema:    mustParseGraphQLSchema(t, db),
+		Variables: variables,
+
+		Query: `mutation setCodeHostRateLimits($input:SetCodeHostRateLimitsInput!) {
+		  setCodeHostRateLimits(input:$input) {
+			alwaysNil
+		  }
+		}`,
+		ExpectedResult: `{
+			"setCodeHostRateLimits": {
+			  "alwaysNil": null
+			}
+		}`,
+	})
+	_, err := r.SetCodeHostRateLimits(ctx, SetCodeHostRateLimitsArgs{
+		Input: setCodeHostRateLimitsInput,
+	})
+	assert.Nil(t, err)
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10604,6 +10604,43 @@ type PerforceChangelist {
     commit: GitCommit!
 }
 
+extend type Mutation {
+    """
+    Updates a code host's rate limit configurations. All rate limit values must be positive integers.
+    """
+    setCodeHostRateLimits(input: SetCodeHostRateLimitsInput!): EmptyResponse
+}
+
+"""
+SetCodeHostRateLimitsInput represents the input for configuring rate limits for a code host.
+"""
+input SetCodeHostRateLimitsInput {
+    """
+    ID of the code host for which rate limits are being set.
+    """
+    codeHostID: ID!
+
+    """
+    The maximum number of API requests allowed per time window defined by apiReplenishmentIntervalSeconds.
+    """
+    apiQuota: Int!
+
+    """
+    The time interval at which the apiQuota's worth of API requests are replenished.
+    """
+    apiReplenishmentIntervalSeconds: Int!
+
+    """
+    The maximum number of Git requests allowed per time window defined by gitReplenishmentIntervalSeconds.
+    """
+    gitQuota: Int!
+
+    """
+    The time interval at which the gitQuota's worth of Git requests are replenished.
+    """
+    gitReplenishmentIntervalSeconds: Int!
+}
+
 extend type Query {
     """
     List of all configured code hosts on this instance.


### PR DESCRIPTION
Add GraphQL mutation for configuring code host rate limits.

## Test plan

Added a bunch of tests and also tested manually.
