### PR TITLE
JetBrains: add ability to override automatic "codebase" detection

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
@@ -25,7 +25,7 @@ public class CodyAgentCodebase {
                       () -> {
                         if (!Objects.equals(this.currentCodebase, repositoryName)) {
                           ExtensionConfiguration config =
-                              ConfigUtil.getAgentConfiguration(project).setCodebase(repositoryName);
+                              ConfigUtil.updateAgentConfigurationWithDetectedCodebase(project, repositoryName);
                           this.currentCodebase = repositoryName;
                           underlying.configurationDidChange(config);
                         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -33,6 +33,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   public boolean isEnterpriseAccessTokenSet;
   @Nullable public String customRequestHeaders;
   @Nullable public String defaultBranch;
+  @Nullable public String codyCodebase;
   @Nullable public String remoteUrlReplacements;
   @Nullable public String anonymousUserId;
   public boolean isInstallEventLogged;
@@ -84,6 +85,11 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable
   public String getDefaultBranchName() {
     return defaultBranch;
+  }
+
+  @Nullable
+  public String getCodyCodebase() {
+    return codyCodebase;
   }
 
   @Nullable
@@ -167,6 +173,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
         loadedIsEnterpriseAccessTokenSet || StringUtils.isNotEmpty(settings.enterpriseAccessToken);
     this.customRequestHeaders = settings.customRequestHeaders;
     this.defaultBranch = settings.defaultBranch;
+    this.codyCodebase = settings.codyCodebase;
     this.remoteUrlReplacements = settings.remoteUrlReplacements;
     this.anonymousUserId = settings.anonymousUserId;
     this.isUrlNotificationDismissed = settings.isUrlNotificationDismissed;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyProjectService.java
@@ -24,6 +24,7 @@ public class CodyProjectService implements PersistentStateComponent<CodyProjectS
   @Nullable public String enterpriseAccessToken;
   @Nullable public String customRequestHeaders;
   @Nullable public String defaultBranch;
+  @Nullable public String codyCodebase;
   @Nullable public String remoteUrlReplacements;
   @Nullable public String lastSearchQuery;
   public boolean lastSearchCaseSensitive;
@@ -53,6 +54,11 @@ public class CodyProjectService implements PersistentStateComponent<CodyProjectS
   @Nullable
   public String getDefaultBranchName() {
     return defaultBranch;
+  }
+
+  @Nullable
+  public String getCodyCodebase() {
+    return codyCodebase;
   }
 
   @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -32,7 +32,21 @@ public class ConfigUtil {
         .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutocompleteAccessToken())
         .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
         .setDebug(isCodyDebugEnabled())
+        .setCodebase(getCodyCodebase(project))
         .setVerboseDebug(isCodyVerboseDebugEnabled());
+  }
+
+  @NotNull
+  public static ExtensionConfiguration updateAgentConfigurationWithDetectedCodebase(
+    @NotNull Project project,
+    String detectedCodebase) {
+        ExtensionConfiguration config = getAgentConfiguration(project);
+        if (!getCodyCodebase(project).isEmpty()) {
+            // Codebase override is configured
+            return config;
+        }
+        config.setCodebase(detectedCodebase);
+        return config;
   }
 
   @NotNull
@@ -151,6 +165,25 @@ public class ConfigUtil {
     // User level or default
     String userLevelDefaultBranchName = UserLevelConfig.getDefaultBranchName();
     return userLevelDefaultBranchName != null ? userLevelDefaultBranchName : "main";
+  }
+
+  @NotNull
+  public static String getCodyCodebase(@NotNull Project project) {
+    // Project level
+    String projectLevelCodyCodebase = getProjectLevelConfig(project).getCodyCodebase();
+    if (projectLevelCodyCodebase != null && !projectLevelCodyCodebase.isEmpty()) {
+      return projectLevelCodyCodebase;
+    }
+
+    // Application level
+    String applicationLevelCodyCodebase = getApplicationLevelConfig().getCodyCodebase();
+    if (applicationLevelCodyCodebase != null && !applicationLevelCodyCodebase.isEmpty()) {
+      return applicationLevelCodyCodebase;
+    }
+
+    // User level or default
+    String userLevelCodyCodebase = UserLevelConfig.getCodyCodebase();
+    return userLevelCodyCodebase != null ? userLevelCodyCodebase : "";
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -52,6 +52,7 @@ public class SettingsComponent implements Disposable {
   private JBLabel enterpriseAccessTokenLinkComment;
   private JBTextField customRequestHeadersTextField;
   private JBTextField defaultBranchNameTextField;
+  private JBTextField codyCodebaseTextField;
   private JBTextField remoteUrlReplacementsTextField;
   private JBCheckBox isUrlNotificationDismissedCheckBox;
   private JBCheckBox isCodyEnabledCheckBox;
@@ -420,6 +421,15 @@ public class SettingsComponent implements Disposable {
   }
 
   @NotNull
+  public String getCodyCodebase() {
+    return codyCodebaseTextField.getText();
+  }
+
+  public void setCodyCodebase(@NotNull String value) {
+    codyCodebaseTextField.setText(value);
+  }
+
+  @NotNull
   public String getRemoteUrlReplacements() {
     return remoteUrlReplacementsTextField.getText();
   }
@@ -606,6 +616,13 @@ public class SettingsComponent implements Disposable {
     isCodyAutocompleteEnabledCheckBox = new JBCheckBox("Enable Cody autocomplete");
     isCodyDebugEnabledCheckBox = new JBCheckBox("Enable debug");
     isCodyVerboseDebugEnabledCheckBox = new JBCheckBox("Verbose debug");
+
+    JBLabel codyCodebaseLabel = new JBLabel("Codebase:");
+    codyCodebaseTextField = new JBTextField();
+    codyCodebaseTextField.getEmptyText().setText("");
+    codyCodebaseTextField.setToolTipText(
+        "Sourcegraph repository that maps to this codebase");
+
     JPanel codySettingsPanel =
         FormBuilder.createFormBuilder()
             .addComponent(isCodyEnabledCheckBox, 10)
@@ -615,6 +632,8 @@ public class SettingsComponent implements Disposable {
             .addComponent(isCodyDebugEnabledCheckBox)
             .addTooltip("Enables debug output visible in the idea.log")
             .addComponent(isCodyVerboseDebugEnabledCheckBox)
+            .addLabeledComponent(codyCodebaseLabel, codyCodebaseTextField)
+            .addTooltip("If set, overrides the Sourcegraph repository that the project maps to")
             .getPanel();
     codySettingsPanel.setBorder(
         IdeBorderFactory.createTitledBorder("Cody AI", true, JBUI.insetsTop(8)));

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -52,6 +52,9 @@ public class SettingsConfigurable implements Configurable {
             .getDefaultBranchName()
             .equals(ConfigUtil.getDefaultBranchName(project))
         || !mySettingsComponent
+            .getCodyCodebase()
+            .equals(ConfigUtil.getCodyCodebase(project))
+        || !mySettingsComponent
             .getRemoteUrlReplacements()
             .equals(ConfigUtil.getRemoteUrlReplacements(project))
         || mySettingsComponent.isUrlNotificationDismissed()
@@ -144,6 +147,11 @@ public class SettingsConfigurable implements Configurable {
     } else {
       aSettings.defaultBranch = mySettingsComponent.getDefaultBranchName();
     }
+    if (pSettings.codyCodebase != null) {
+      pSettings.codyCodebase = mySettingsComponent.getCodyCodebase();
+    } else {
+      aSettings.codyCodebase = mySettingsComponent.getCodyCodebase();
+    }
     if (pSettings.remoteUrlReplacements != null) {
       pSettings.remoteUrlReplacements = mySettingsComponent.getRemoteUrlReplacements();
     } else {
@@ -167,6 +175,8 @@ public class SettingsConfigurable implements Configurable {
     mySettingsComponent.setCustomRequestHeaders(ConfigUtil.getCustomRequestHeaders(project));
     String defaultBranchName = ConfigUtil.getDefaultBranchName(project);
     mySettingsComponent.setDefaultBranchName(defaultBranchName);
+    String codyCodebase = ConfigUtil.getCodyCodebase(project);
+    mySettingsComponent.setCodyCodebase(codyCodebase);
     String remoteUrlReplacements = ConfigUtil.getRemoteUrlReplacements(project);
     mySettingsComponent.setRemoteUrlReplacements(remoteUrlReplacements);
     mySettingsComponent.setUrlNotificationDismissedEnabled(ConfigUtil.isUrlNotificationDismissed());

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -65,6 +65,12 @@ public class UserLevelConfig {
   }
 
   @Nullable
+  public static String getCodyCodebase() {
+    Properties properties = readProperties();
+    return properties.getProperty("codyCodebase", null);
+  }
+
+  @Nullable
   public static String getRemoteUrlReplacements() {
     Properties properties = readProperties();
     return properties.getProperty("remoteUrlReplacements", null);


### PR DESCRIPTION
Adds a setting to configure `cody.codebase` in the same way as e.g. VS Code:

<img width="719" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/3173176/dd05d912-55fc-4476-8304-2b290236677e">

Fixes https://github.com/sourcegraph/sourcegraph/issues/55795

## Test plan

Manually tested, I ran:

```
./gradlew -PenableAgent=true -PforceAgentBuild=true :runIde
```

Then modified the `Codebase` field and confirmed the agent was using that value to find embeddings.