### PR TITLE
Move new license default expiration date to today

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -60,7 +60,7 @@ const getEmptyFormData = (account: string, latestLicense: License | undefined): 
     salesforceOpportunityID: latestLicense?.info?.salesforceOpportunityID ?? '',
     plan: 'enterprise-1',
     userCount: 1,
-    expiresAt: endOfDay(addDays(Date.now(), 366)),
+    expiresAt: endOfDay(Date.now()),
 })
 
 const DURATION_LINKS = [

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
                       max="2011-06-25"
                       min="2006-01-03"
                       type="date"
-                      value="2007-01-03"
+                      value="2006-01-02"
                     />
                   </div>
                   <small
@@ -256,8 +256,8 @@ exports[`SiteAdminGenerateProductLicenseForSubscriptionForm renders 1`] = `
                   >
                     <span>
                       Valid until 
-                      Jan 3, 2007, 11:59:59 PM
-                       (1 year remaining)
+                      Jan 2, 2006, 11:59:59 PM
+                       (2 hours remaining)
                     </span>
                     <p
                       class=""


### PR DESCRIPTION
Per discussion here: https://sourcegraph.slack.com/archives/C012NU3PXA9/p1692739028032289

>Another request: the date picker defaults to 1 year out. This is _really_ easy to miss and I know multiple people have sent out accidental 1 year licenses that were supposed to be 30 day licenses (which is very bad!). Is there a chance someone can change the default picker?

## Test plan

Honestly, I have not tested this, I edited it in the GitHub editor... This is for internal/admin usage only, and it's a low risk change. If it passes CI, I assume it's okay? Defer to eng.