### PR TITLE
sg: use sourcegraph image for qdrant

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -276,9 +276,13 @@ commands:
   qdrant:
     cmd: |
       docker run -p 6333:6333 -p 6334:6334 \
-        -v $HOME/.sourcegraph-dev/data/qdrant_data:/qdrant/storage \
+        -v $HOME/.sourcegraph-dev/data/qdrant_data:/data \
         -e QDRANT__SERVICE__GRPC_PORT="6334" \
-        qdrant/qdrant
+        -e QDRANT__LOG_LEVEL=INFO \
+        -e QDRANT__STORAGE__STORAGE_PATH=/data \
+        -e QDRANT__STORAGE__SNAPSHOTS_PATH=/data \
+        --entrypoint /usr/local/bin/qdrant \
+        sourcegraph/qdrant:insiders
   worker:
     cmd: |
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)


### PR DESCRIPTION
This updates the `sg start qdrant` config to use the qdrant image published by sourcegraph rather than the qdrant-published image. This just makes the local env a bit closer to what gets deployed.

## Test plan

Ran an embedding job locally and ran a search via qdrant.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
