### PR TITLE
JetBrains: fix `CodyAgent.isConnected` logic

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -48,7 +48,7 @@ public class CodyAgent implements Disposable {
   private String agentNotRunningExplanation = "";
   private @NotNull CompletableFuture<CodyAgentServer> initialized = new CompletableFuture<>();
   private AtomicBoolean firstConnection = new AtomicBoolean(true);
-  private Future<Void> listeningToJsonRpc;
+  @NotNull private Future<Void> listeningToJsonRpc = CompletableFuture.completedFuture(null);
   private Process process;
 
   public CodyAgent(@NotNull Project project) {
@@ -74,8 +74,6 @@ public class CodyAgent implements Disposable {
     return agent != null
         && agent.process != null
         && agent.process.isAlive()
-        && agent.agentNotRunningExplanation.isEmpty()
-        && agent.listeningToJsonRpc != null
         && !agent.listeningToJsonRpc.isDone()
         && !agent.listeningToJsonRpc.isCancelled()
         && agent.client.server != null;
@@ -113,6 +111,7 @@ public class CodyAgent implements Disposable {
         // the Cody agent server.
         this.initialized = new CompletableFuture<>();
       }
+      this.agentNotRunningExplanation = "";
       startListeningToAgent();
       executorService.submit(
           () -> {


### PR DESCRIPTION
Previously, we would report "agent is not connected" even when we had a successful agent connection. The root problem was that a string variable `agentNotRunningExplanation` could be non-empty even when we were connected. This PR fixes the problem by ignoring the value of `agentNotRunningExplanation` when we are testing for a connection.

## Test plan
n/a
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
