### PR TITLE
Add redirects for Cody QS

### DIFF
--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -349,3 +349,11 @@
 /app /cody/overview/app 308
 /cody/explanations/enabling_cody /cody/overview/cody-with-sourcegraph 308
 /cody/explanations/enabling_cody_enterprise /cody/overview/enable-cody-enterprise 308
+
+# Cody Quickstart redirects
+/cody/quickstart#quickstart-for-cody-in-vs-code /cody/quickstart#cody-quickstart 308
+/cody/quickstart#introduction /cody/quickstart#cody-quickstart 308
+/cody/quickstart#getting-started-with-the-cody-extension-and-recipes /cody/quickstart#getting-started-with-cody-extension-and-commands 308
+/cody/quickstart#generate-a-unit-test /cody/quickstart#1-generate-a-unit-test 308
+/cody/quickstart#ask-cody-to-pull-reference-documentation /cody/quickstart#3-ask-cody-to-pull-reference-documentation 308
+/cody/quickstart#ask-cody-to-write-context-aware-code /cody/quickstart#working-with-the-cody-extension 308


### PR DESCRIPTION
The PR adds redirects for our new Cody Quickstart tutorial.
## Test plan

Docs added

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@redirects-cody-quickstart)