### PR TITLE
embeddings: validate unmarshalled EmbeddingIndex

### DIFF
--- a/internal/embeddings/index_storage.go
+++ b/internal/embeddings/index_storage.go
@@ -238,6 +238,10 @@ func (d *decoder) decode() (*RepoEmbeddingIndex, error) {
 			}
 			ei.Embeddings = append(ei.Embeddings, Quantize(embeddingsBuf, quantizeBuf)...)
 		}
+
+		if err := ei.Validate(); err != nil {
+			return nil, err
+		}
 	}
 
 	return rei, nil


### PR DESCRIPTION
We are seeing an out of bounds access on the Embeddings slice that implies corrupted data. This prevents us from trying to read the index after unmarshalling if it is corrupted in this way.

Test Plan: added unit test