### PR TITLE
site: use `pattern` to replace `minLength` for secret field validation

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1409,7 +1409,7 @@
       "examples": ["4.1.0"]
     },
     "executors.accessToken": {
-      "description": "The shared secret between Sourcegraph and executors. The value must be at least 20 characters.",
+      "description": "The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.",
       "type": "string",
       "pattern": "^(.{20,}|REDACTED)$",
       "examples": ["my-super-secret-access-token"]

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1409,7 +1409,7 @@
       "examples": ["4.1.0"]
     },
     "executors.accessToken": {
-      "description": "The shared secret between Sourcegraph and executors.",
+      "description": "The shared secret between Sourcegraph and executors. The value must be at least 20 characters.",
       "type": "string",
       "pattern": "^(.{20,}|REDACTED)$",
       "examples": ["my-super-secret-access-token"]

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1411,7 +1411,7 @@
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors.",
       "type": "string",
-      "minLength": 20,
+      "pattern": "^(.{20,}|REDACTED)$",
       "examples": ["my-super-secret-access-token"]
     },
     "executors.multiqueue": {


### PR DESCRIPTION
A very naive approach to allow the magic word `REDACTED` to be excempted from field validation using `pattern`. However, the error message for `pattern` isn't as user-friendly as builtin validation rules.

Alternatively, 

1. We can just change the `minLength` to be `1` (that just ensures it's not empty)
2. Update the field description to include the requirement (i.e. "the value must be at least 20 characters").

## Test plan

<table>
<tr><td><img width="587" alt="CleanShot 2023-08-23 at 23 02 09@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/486890ce-c858-4daf-819f-8d9fd52952c8">
<tr><td><img width="515" alt="CleanShot 2023-08-23 at 23 02 04@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/25dcc746-e302-4012-9ffe-e435e81fef71">
</table>




