### PR TITLE
JetBrains: log `contextSummary` property for autocomplete telemetry

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
@@ -1,0 +1,100 @@
+package com.sourcegraph.cody.agent.protocol;
+
+import org.jetbrains.annotations.Nullable;
+
+public class CompletionEvent {
+
+  public static class Params {
+    public String type;
+    public boolean multiline;
+    public String multilineMode;
+    public String providerIdentifier;
+    public String languageId;
+    @Nullable public ContextSummary contextSummary;
+    public String source;
+    public String id;
+    public int lineCount;
+    public int charCount;
+
+    @Override
+    public String toString() {
+      return "Params{"
+          + "type='"
+          + type
+          + '\''
+          + ", multiline="
+          + multiline
+          + ", multilineMode='"
+          + multilineMode
+          + '\''
+          + ", providerIdentifier='"
+          + providerIdentifier
+          + '\''
+          + ", languageId='"
+          + languageId
+          + '\''
+          + ", contextSummary="
+          + contextSummary
+          + ", source='"
+          + source
+          + '\''
+          + ", id='"
+          + id
+          + '\''
+          + ", lineCount="
+          + lineCount
+          + ", charCount="
+          + charCount
+          + '}';
+    }
+  }
+
+  public static class ContextSummary {
+    public boolean embeddings;
+    public double local;
+    public double duration;
+
+    @Override
+    public String toString() {
+      return "ContextSummary{"
+          + "embeddings="
+          + embeddings
+          + ", local="
+          + local
+          + ", duration="
+          + duration
+          + '}';
+    }
+  }
+
+  @Nullable public Params params;
+  public double startedAt;
+  public double networkRequestStartedAt;
+  public double startLoggedAt;
+  public double loadedAt;
+  public double suggestedAt;
+  public double suggestionLoggedAt;
+  public double acceptedAt;
+
+  @Override
+  public String toString() {
+    return "CompletionEvent{"
+        + "params="
+        + params
+        + ", startedAt="
+        + startedAt
+        + ", networkRequestStartedAt="
+        + networkRequestStartedAt
+        + ", startLoggedAt="
+        + startLoggedAt
+        + ", loadedAt="
+        + loadedAt
+        + ", suggestedAt="
+        + suggestedAt
+        + ", suggestionLoggedAt="
+        + suggestionLoggedAt
+        + ", acceptedAt="
+        + acceptedAt
+        + '}';
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -1,12 +1,15 @@
 package com.sourcegraph.cody.autocomplete;
 
+import com.sourcegraph.cody.agent.protocol.CompletionEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** A class that stores the state and timing information of an autocompletion. */
 public class AutocompleteTelemetry {
   private long completionTriggeredTimestampMs;
   private long completionDisplayedTimestampMs;
   private long completionHiddenTimestampMs;
+  @Nullable private CompletionEvent completionEvent;
 
   public static @NotNull AutocompleteTelemetry createAndMarkTriggered() {
     var autocompletion = new AutocompleteTelemetry();
@@ -26,12 +29,23 @@ public class AutocompleteTelemetry {
     return completionDisplayedTimestampMs - completionTriggeredTimestampMs;
   }
 
+  public void markCompletionEvent(@Nullable CompletionEvent event) {
+    this.completionEvent = event;
+  }
+
   public void markCompletionHidden() {
     this.completionHiddenTimestampMs = System.currentTimeMillis();
   }
 
   public long getDisplayDurationMs() {
     return completionHiddenTimestampMs - completionDisplayedTimestampMs;
+  }
+
+  @Nullable
+  public CompletionEvent.ContextSummary contextSummary() {
+    return (completionEvent != null && completionEvent.params != null)
+        ? completionEvent.params.contextSummary
+        : null;
   }
 
   public @NotNull AutocompletionStatus getStatus() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -66,7 +66,8 @@ public class CodyAutocompleteManager {
                 GraphQlLogger.logAutocompleteSuggestedEvent(
                     p,
                     currentAutocompleteTelemetry.getLatencyMs(),
-                    currentAutocompleteTelemetry.getDisplayDurationMs());
+                    currentAutocompleteTelemetry.getDisplayDurationMs(),
+                    currentAutocompleteTelemetry.contextSummary());
                 currentAutocompleteTelemetry = null;
               }
             });
@@ -201,6 +202,10 @@ public class CodyAutocompleteManager {
       InlineCompletionTriggerKind triggerKind,
       InlineAutocompleteList result,
       CancellationToken cancellationToken) {
+    if (currentAutocompleteTelemetry != null) {
+      currentAutocompleteTelemetry.markCompletionEvent(result.completionEvent);
+    }
+
     if (Thread.interrupted() || cancellationToken.isCancelled()) {
       if (triggerKind.equals(InlineCompletionTriggerKind.INVOKE)) {
         logger.warn("autocomplete canceled");

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineAutocompleteList.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/vscode/InlineAutocompleteList.java
@@ -1,9 +1,13 @@
 package com.sourcegraph.cody.vscode;
 
+import com.sourcegraph.cody.agent.protocol.CompletionEvent;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 
 public class InlineAutocompleteList {
   public final List<InlineAutocompleteItem> items;
+  @Nullable public CompletionEvent completionEvent;
 
   public InlineAutocompleteList(List<InlineAutocompleteItem> items) {
     this.items = items;

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -1,13 +1,16 @@
 package com.sourcegraph.telemetry;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.PluginUtil;
 import com.sourcegraph.cody.agent.CodyAgent;
+import com.sourcegraph.cody.agent.protocol.CompletionEvent;
 import com.sourcegraph.cody.agent.protocol.Event;
 import com.sourcegraph.config.ConfigUtil;
 import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class GraphQlLogger {
 
@@ -27,11 +30,17 @@ public class GraphQlLogger {
   }
 
   public static void logAutocompleteSuggestedEvent(
-      @NotNull Project project, long latencyMs, long displayDurationMs) {
+      @NotNull Project project,
+      long latencyMs,
+      long displayDurationMs,
+      CompletionEvent.@Nullable ContextSummary contextSummary) {
     String eventName = "CodyJetBrainsPlugin:completion:suggested";
     JsonObject eventParameters = new JsonObject();
     eventParameters.addProperty("latency", latencyMs);
     eventParameters.addProperty("displayDuration", displayDurationMs);
+    if (contextSummary != null) {
+      eventParameters.add("contextSummary", new Gson().toJsonTree(contextSummary));
+    }
     eventParameters.addProperty("isAnyKnownPluginEnabled", PluginUtil.isAnyKnownPluginEnabled());
     logEvent(project, createEvent(project, eventName, eventParameters));
   }


### PR DESCRIPTION
Previously, autocomplete didn't include whether the completion was
powered by embeddings. This PR fixes the problem by using the new
`completionEvent` property from the agent, added in the PR
https://github.com/sourcegraph/cody/pull/807


## Test plan

* Use build from https://github.com/sourcegraph/cody/pull/807
* Run local build
* Run `tail -f build/sourcegraph/cody-agent-trace.json`
* Trigger autocomplete
* Confirm trace has events like this
```
[Trace - 02:25:51 PM] Sending request 'graphql/logEvent - (27)'
Params: {
  "event": "CodyJetBrainsPlugin:completion:suggested",
  "userCookieID": "e72ccbcb-007c-4754-829b-f852ef7911e7",
  "url": "",
  "source": "IDEEXTENSION",
  "referrer": "JETBRAINS",
  "argument": {
    "latency": 29,
    "displayDuration": 155,
    "contextSummary": {
      "embeddings": false,
      "local": 1.0,
      "duration": 17.26658296585083
    },
    "isAnyKnownPluginEnabled": false,
    "serverEndpoint": "https://sourcegraph.sourcegraph.com/"
  },
...
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
