### PR TITLE
Remove GitHub handles from notifications

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -8,5 +8,4 @@ team/iam:
   - '@ryphil'
   - '@mrnugget'
   - '@pjlast'
-  - '@kopancek'
   - '@thenamankumar'

--- a/.github/test.CODEOWNERS
+++ b/.github/test.CODEOWNERS
@@ -42,10 +42,6 @@
 /cmd/frontend/internal/search/**/* @camdencheek
 /cmd/frontend/internal/search/**/* @jtibshirani
 
-/cmd/gitserver/server/* @indradhanush @sashaostrikov
-
-/cmd/repo-updater/* @indradhanush @sashaostrikov
-
 /cmd/searcher/**/* @keegancsmith
 
 /cmd/server/internal/goreman/** @keegancsmith
@@ -100,8 +96,6 @@
 /enterprise/cmd/migrator/**/* @efritz
 
 /cmd/precise-code-intel-worker/**/* @efritz
-
-/cmd/repo-updater/**/* @indradhanush
 
 /cmd/repo-updater/internal/authz/**/* @unknwon
 
@@ -178,8 +172,6 @@
 
 /internal/extsvc/auth/**/* @unknwon
 
-/internal/gitserver/* @indradhanush @sashaostrikov
-
 /internal/goroutine/**/* @efritz
 
 /internal/gqltestutil/**/* @unknwon
@@ -201,8 +193,6 @@
 /internal/rcache/** @keegancsmith
 
 /internal/redispool/** @keegancsmith
-
-/internal/repos/* @indradhanush @sashaostrikov
 
 /internal/search/**/* @keegancsmith @camdencheek
 

--- a/cmd/gitserver/server/CODENOTIFY
+++ b/cmd/gitserver/server/CODENOTIFY
@@ -1,4 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-* @indradhanush
-* @sashaostrikov
+* @eseliger

--- a/cmd/repo-updater/CODENOTIFY
+++ b/cmd/repo-updater/CODENOTIFY
@@ -1,4 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-* @indradhanush
-* @sashaostrikov
+* @eseliger

--- a/internal/extsvc/CODENOTIFY
+++ b/internal/extsvc/CODENOTIFY
@@ -1,2 +1,1 @@
 **/* @eseliger
-**/* @sashaostrikov

--- a/internal/gitserver/CODENOTIFY
+++ b/internal/gitserver/CODENOTIFY
@@ -1,4 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-* @indradhanush
-* @sashaostrikov
+* @eseliger

--- a/internal/repos/CODENOTIFY
+++ b/internal/repos/CODENOTIFY
@@ -1,4 +1,3 @@
 # See https://github.com/sourcegraph/codenotify for documentation.
 
-* @indradhanush
-* @sashaostrikov
+* @eseliger


### PR DESCRIPTION
To not spam their accounts indefinitely, removing them from codenotify.

## Test plan

Just some config files. 