### PR TITLE
Fix notepad widget disply after cody sidebar is closed

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -165,6 +165,14 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
     const codySidebarSize = useMemo(() => sidebarSize, [isCodySidebarOpen])
     /* eslint-enable react-hooks/exhaustive-deps */
 
+    // Set cody sidebar size to 0 when closed
+    // This ensures notepad widget displays on right side
+    useEffect(() => {
+        if (!isCodySidebarOpen) {
+            setCodySidebarSize(0)
+        }
+    }, [isCodySidebarOpen, setCodySidebarSize])
+
     useEffect(() => {
         const activeEditor = scope.editor.getActiveTextEditor()
 


### PR DESCRIPTION
### Description
When the `CodySidebar` is close I set the value of `sidebarSize` to 0

### Refs
[Issue](https://github.com/sourcegraph/cody/issues/617)

### Demo Video

https://github.com/GitStartHQ/client-sourcegraph-front-end/assets/51731962/eab3362f-ba80-4d09-a4fc-d3dfa751e2e5

