### PR TITLE
conf: grpc: support silent retries if frontend isn't ready yet

### DIFF
--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -46,6 +46,8 @@ go_library(
         "@com_github_sourcegraph_jsonx//:jsonx",
         "@com_github_sourcegraph_log//:log",
         "@com_github_xeipuuv_gojsonschema//:gojsonschema",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 


### PR DESCRIPTION
Fixes https://sourcegraph.slack.com/archives/C04HCK4K3DL/p1691782868033789

Our configuration package has logic to automatically retry requests if any of them fail. However, on startup, it's likely the case that any given client will start before the frontend configuration server fully initializes. In the HTTP path, we had logic to "ignore" logging connection errors that occur during this initialization peroid. 

We regressed on this behavior when we introduced gRPC powered site configuration in #55648. This PR adds similar logic for gRPC to reduce the logspam on startup. 

## Test plan

Manual testing.

1) Before this change, run `sg start` from scratch with `SRC_GRPC_ENABLE_CONF: "true"` set in your `sg.config.yaml`. 

See errors like the following pop up in your terminal:

```
[    gitserver-1] ERROR conf.client conf/client.go:301 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""}
[       searcher] ERROR conf.client conf/client.go:301 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""}
[    gitserver-0] ERROR conf.client conf/client.go:301 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""}
[    zoekt-web-0] INFO server zoekt-webserver/main.go:261 adding reverse proxy {"socket": "/Users/ggilmore/.sourcegraph/zoekt/index-0/indexserver.sock"}
[       searcher] ERROR conf.client conf/client.go:301 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""}
[    gitserver-0] ERROR conf.client conf/client.go:301 received error during background config update {"triggered_by": "waitForSleep", "error": "unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""}
```

2) After this change, run `sg start` again with with `SRC_GRPC_ENABLE_CONF: "true"` set in your `sg.config.yaml`.

The above errors (`unable to fetch new configuration: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp [::1]:3090: connect: connection refused\""`) are no longer present. 
