### PR TITLE
Qdrant: fix field type

### DIFF
--- a/internal/embeddings/db/migrate.go
+++ b/internal/embeddings/db/migrate.go
@@ -79,7 +79,7 @@ func ensureRepoIDIndex(ctx context.Context, cc qdrant.PointsClient, name string)
 		CollectionName:   name,
 		Wait:             pointers.Ptr(true),
 		FieldName:        fieldRepoID,
-		FieldType:        pointers.Ptr(qdrant.FieldType_FieldTypeKeyword),
+		FieldType:        pointers.Ptr(qdrant.FieldType_FieldTypeInteger),
 		FieldIndexParams: nil,
 		Ordering:         nil,
 	})


### PR DESCRIPTION
This fixes the field type for the `repoID` index, which will make it an effective index (it's currently ignored by the planner). For some reason, I was thinking I was using a string for `repoID`. 

## Test plan

Manually tested that embedding a repo still works and that the index claims there are points in it.