### PR TITLE
JetBrains: Rename plugin

### DIFF
--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -1,6 +1,6 @@
 <!-- Plugin description -->
 
-# Cody AI by Sourcegraph
+# Sourcegraph Cody + Code Search
 
 Cody for JetBrains IDEs is an AI code assistant that can write code and answers questions across your entire codebase. It combines the power of large language models with Sourcegraph’s Code Graph API, generating deep knowledge of all of your code (and not just your open files). Large monorepos, multiple languages, and complex codebases are no problem for Cody.
 

--- a/client/jetbrains/README.md
+++ b/client/jetbrains/README.md
@@ -2,23 +2,28 @@
 
 # Sourcegraph Cody + Code Search
 
-Cody for JetBrains IDEs is an AI code assistant that can write code and answers questions across your entire codebase. It combines the power of large language models with Sourcegraph’s Code Graph API, generating deep knowledge of all of your code (and not just your open files). Large monorepos, multiple languages, and complex codebases are no problem for Cody.
+Use Sourcegraph Code Search and Sourcegraph’s AI assistant Cody directly from your JetBrains IDE.
 
-For example, you can ask Cody:
+- With Code Search, you can search code across all your repositories and code hosts—even the code you don’t have locally.
+- Cody can write code and answer questions across your entire codebase.
+
+**Cody AI for JetBrains IDEs is experimental right now. We’d love your [feedback](https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&labels=cody,cody/jetbrains)**!
+
+## Features
+
+### 🤖 Ask Cody about anything in your codebase
+
+Cody combines the power of large language models (LLMs) with Sourcegraph’s Code Graph API, generating deep knowledge of all of your code—even the code you don’t have locally. Large monorepos, multiple languages, and complex codebases are no problem for Cody.
+
+Cody understands your entire codebase—not just your open files. Ask questions, insert code, and use the built-in recipes such as "Summarize recent code changes" and "Improve variable names".
+
+Example questions you can ask Cody:
 
 - Where is the CI config for the web integration tests?
 - Write a new GraphQL resolver for the AuditLog
 - Why is the UserConnectionResolver giving an error "unknown user", and how do I fix it?
 - Add helpful debug log statements
 - Make this work _(seriously, it often works—try it!)_
-
-  **Cody AI for JetBrains IDEs is experimental right now, and we’d love your [feedback](https://github.com/sourcegraph/sourcegraph/discussions/new?category=product-feedback&labels=cody,cody/jetbrains)**!
-
-## Features
-
-### 🤖 Ask Cody about anything in your codebase
-
-Cody understands your entire codebase — not just your open files. Ask questions, insert code, and use the built-in recipes such as "Summarize recent code changes" and "Improve variable names".
 
 ![Example of chatting with Cody](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/Chat_IntelliJ_SS.jpg)
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.java
@@ -203,7 +203,7 @@ public class CodyAgent implements Disposable {
   private static File agentBinary() throws CodyAgentException {
     Path pluginPath = agentDirectory();
     if (pluginPath == null) {
-      throw new CodyAgentException("Cody AI by Sourcegraph plugin path not found");
+      throw new CodyAgentException("Sourcegraph Cody + Code Search plugin path not found");
     }
     Path binarySource = pluginPath.resolve("agent").resolve(agentBinaryName());
     if (!Files.isRegularFile(binarySource)) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
@@ -17,8 +17,8 @@ public class BrowserErrorNotification {
   public static void show(Project project, URI uri) {
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph errors",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph errors",
+            "Sourcegraph",
             "Opening an external browser is not supported. You can still copy the URL to your clipboard and open it manually.",
             NotificationType.WARNING);
     AnAction copyUrlAction =

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
@@ -14,8 +14,8 @@ public class ErrorNotification {
   public static void show(Project project, String errorMessage) {
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph errors",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph errors",
+            "Sourcegraph",
             errorMessage,
             NotificationType.WARNING);
     AnAction dismissAction =

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/ErrorNotification.java
@@ -14,10 +14,7 @@ public class ErrorNotification {
   public static void show(Project project, String errorMessage) {
     Notification notification =
         new Notification(
-            "Sourcegraph errors",
-            "Sourcegraph",
-            errorMessage,
-            NotificationType.WARNING);
+            "Sourcegraph errors", "Sourcegraph", errorMessage, NotificationType.WARNING);
     AnAction dismissAction =
         new DumbAwareAction("Dismiss") {
           @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -122,10 +122,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             + " It is not possible to use Sourcegraph API and Cody without it.";
     Notification notification =
         new Notification(
-            "Sourcegraph: server access",
-            "Sourcegraph",
-            content,
-            NotificationType.INFORMATION);
+            "Sourcegraph: server access", "Sourcegraph", content, NotificationType.INFORMATION);
     notification.setIcon(Icons.CodyLogo);
     notification.addAction(new OpenPluginSettingsAction("Set Access Token"));
     notification.addAction(dumbAwareAction("Do Not Set", notification::expire));

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -49,8 +49,8 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     // Display notification
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph: server access",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph: server access",
+            "Sourcegraph",
             "A custom Sourcegraph URL is not set for this project. You can only access public repos. Do you want to set your custom URL?",
             NotificationType.INFORMATION);
     AnAction setUrlAction = new OpenPluginSettingsAction("Set URL");
@@ -83,8 +83,8 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph plugin updates",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph Cody + Code Search plugin updates",
+            "Sourcegraph Cody + Code Search",
             "Access the new plugin and try out code search with the shortcut "
                 + altSShortcutText
                 + "! Learn more about the plugin’s functionality in our blog post.",
@@ -122,7 +122,7 @@ public class NotificationActivity implements StartupActivity.DumbAware {
             + " It is not possible to use Sourcegraph API and Cody without it.";
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph: server access",
+            "Sourcegraph: server access",
             "Sourcegraph",
             content,
             NotificationType.INFORMATION);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeActionNotifier.java
@@ -7,7 +7,7 @@ public interface PluginSettingChangeActionNotifier {
 
   Topic<PluginSettingChangeActionNotifier> TOPIC =
       Topic.create(
-          "Cody AI by Sourcegraph plugin settings have changed",
+          "Sourcegraph Cody + Code Search plugin settings have changed",
           PluginSettingChangeActionNotifier.class);
 
   void beforeAction(@NotNull PluginSettingChangeContext context);

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -159,8 +159,8 @@ public class SettingsChangeListener implements Disposable {
     String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph: server access",
-            "Cody AI by Sourcegraph: auth success",
+            "Sourcegraph: server access",
+            "Sourcegraph: auth success",
             "Your Sourcegraph account has been connected to the Sourcegraph plugin. "
                 + "Open the Cody sidebar, or press "
                 + altSShortcutText

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -24,7 +24,7 @@ public class SettingsConfigurable implements Configurable {
   @Nls(capitalization = Nls.Capitalization.Title)
   @Override
   public String getDisplayName() {
-    return "Cody AI by Sourcegraph";
+    return "Sourcegraph Cody + Code Search";
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -105,8 +105,8 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
   private void showNoBrowserErrorNotification() {
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph errors",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph errors",
+            "Sourcegraph",
             "Your IDE doesn't support JCEF. You won't be able to use \"Find with Sourcegraph\". If you believe this is an error, please raise this at support@sourcegraph.com, specifying your OS and IDE version.",
             NotificationType.ERROR);
     AnAction copyEmailAddressAction =

--- a/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -68,7 +68,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
       emptyText.appendLine(
           "Make sure your Sourcegraph URL and access token are correct to use search.");
       emptyText.appendLine(
-          "Click here to configure your Cody AI by Sourcegraph settings.",
+          "Click here to configure your Sourcegraph Cody + Code Search settings.",
           new SimpleTextAttributes(STYLE_PLAIN, JBUI.CurrentTheme.Link.Foreground.ENABLED),
           __ ->
               ShowSettingsUtil.getInstance()

--- a/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/website/CopyAction.java
@@ -20,8 +20,8 @@ public class CopyAction extends FileActionBase {
     // Display notification
     Notification notification =
         new Notification(
-            "Cody AI by Sourcegraph: URL sharing",
-            "Cody AI by Sourcegraph",
+            "Sourcegraph: URL sharing",
+            "Sourcegraph",
             "File URL copied to clipboard: " + urlWithoutUtm,
             NotificationType.INFORMATION);
     Notifications.Bus.notify(notification);

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin require-restart="true">
     <id>com.sourcegraph.jetbrains</id>
-    <name>Cody AI by Sourcegraph</name>
+    <name>Sourcegraph Cody + Code Search</name>
     <vendor email="hi@sourcegraph.com" url="https://sourcegraph.com">Sourcegraph</vendor>
 
     <!--
@@ -25,13 +25,13 @@
             parentId="tools"
             instance="com.sourcegraph.config.SettingsConfigurable"
             id="com.sourcegraph.config.SettingsConfigurable"
-            displayName="Cody AI by Sourcegraph"
+            displayName="Sourcegraph Cody + Code Search"
             nonDefaultProject="false"
         />
-        <notificationGroup id="Cody AI by Sourcegraph: server access" displayType="BALLOON"/>
-        <notificationGroup id="Cody AI by Sourcegraph errors" displayType="BALLOON"/>
-        <notificationGroup id="Cody AI by Sourcegraph: URL sharing" displayType="BALLOON"/>
-        <notificationGroup id="Cody AI by Sourcegraph plugin updates" displayType="STICKY_BALLOON"/>
+        <notificationGroup id="Sourcegraph: server access" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph errors" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph: URL sharing" displayType="BALLOON"/>
+        <notificationGroup id="Sourcegraph Cody + Code Search plugin updates" displayType="STICKY_BALLOON"/>
         <projectService id="sourcegraph.findService" serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity implementation="com.sourcegraph.telemetry.PostStartupActivity"/>
         <postStartupActivity implementation="com.sourcegraph.config.NotificationActivity"/>


### PR DESCRIPTION
- Renamed the plugin to "Sourcegraph Cody + Code Search"
- Updated readme to emphasize the dual purpose of the plugin more.

## Test plan

Only string and docs changes, only the PR review is needed.