### PR TITLE
Update p4 package to fetch over https

### DIFF
--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -3,7 +3,7 @@
 package:
   name: p4-fusion
   version: 1.12
-  epoch: 3
+  epoch: 4
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
     - x86_64

--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -56,6 +56,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://www.perforce.com/downloads/perforce/r22.1/bin.linux26x86_64/p4api-glibc2.3-openssl1.0.2.tgz
+      # Hash occasionally changes, available at https://filehost.perforce.com/perforce/r22.1/bin.linux26x86_64/SHA256SUMS (check version)
       expected-sha256: 7a7ca5b1b6c2401282a30c93065cd88f1bb47412246231c640ad3a6b7002c93b
       extract: false
   - runs: |

--- a/wolfi-packages/p4cli.yaml
+++ b/wolfi-packages/p4cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: p4cli
   version: 22.2
-  epoch: 1
+  epoch: 2
   description: "Command line interface for Perforce"
   target-architecture:
     - x86_64

--- a/wolfi-packages/p4cli.yaml
+++ b/wolfi-packages/p4cli.yaml
@@ -25,8 +25,9 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: http://cdist2.perforce.com/perforce/r${{package.version}}/bin.linux26x86_64/p4
-      expected-sha256: 8bc10fca1c5a26262b4072deec76150a668581a9749d0504cd443084773d4fd0
+      uri: https://cdist2.perforce.com/perforce/r${{package.version}}/bin.linux26x86_64/p4
+      # Hash occasionally changes, available at https://filehost.perforce.com/perforce/r22.2/bin.linux26x86_64/SHA256SUMS (check version)
+      expected-sha256: 3dfa10fb0cca6e305037e1ec69df7f32cb4a04844bc8e0d662ebc562b470cf8b
       extract: false
   - runs: |
       chmod +x p4


### PR DESCRIPTION
We previously verified the Perforce-published hash so fetching over http isn't an issue. However, using https is best practice.

This is a holdover from fetching over HTTP in the old Dockerfiles, and wasn't picked up in the migration to packaging.

Well spotted @evict !



## Test plan

- Green CI - hash is verified as part of CI pipeline
- Manually check package works before merging

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
