### PR TITLE
JetBrains: Cody: Disabling autocomplete in readonly files

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -99,6 +99,7 @@ public class CodyAutocompleteManager {
     return ConfigUtil.isCodyEnabled()
         && ConfigUtil.isCodyAutocompleteEnabled()
         && editor != null
+        && editor.getDocument().isWritable()
         && isProjectAvailable(editor.getProject())
         && isEditorSupported(editor);
   }


### PR DESCRIPTION
It fixes #55956 
## Test plan
* Enable agent tracing with a VM option -Dcody-agent.trace-path=/Users/{your-username}/.sourcegraph/jetbrains-trace.json (change to your local file system)
* Confirm the trace is not sending requests for readonly files
