### PR TITLE
JetBrains: Add remaining autocomplete telemetry parameters 

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.agent.protocol;
 
-import jnr.ffi.annotations.In;
 import org.jetbrains.annotations.Nullable;
 
 public class CompletionEvent {
@@ -15,7 +14,7 @@ public class CompletionEvent {
     @Nullable public String source;
     public String id;
     @Nullable public Integer lineCount;
-    @Nullable public Integer  charCount;
+    @Nullable public Integer charCount;
 
     @Override
     public String toString() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/CompletionEvent.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.agent.protocol;
 
+import jnr.ffi.annotations.In;
 import org.jetbrains.annotations.Nullable;
 
 public class CompletionEvent {
@@ -11,10 +12,10 @@ public class CompletionEvent {
     public String providerIdentifier;
     public String languageId;
     @Nullable public ContextSummary contextSummary;
-    public String source;
+    @Nullable public String source;
     public String id;
-    public int lineCount;
-    public int charCount;
+    @Nullable public Integer lineCount;
+    @Nullable public Integer  charCount;
 
     @Override
     public String toString() {
@@ -50,8 +51,8 @@ public class CompletionEvent {
   }
 
   public static class ContextSummary {
-    public boolean embeddings;
-    public double local;
+    @Nullable public Double embeddings;
+    @Nullable public Double local;
     public double duration;
 
     @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutocompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutocompleteAction.java
@@ -50,7 +50,7 @@ public class AcceptCodyAutocompleteAction extends EditorAction {
         AutocompleteTelemetry telemetry =
             CodyAutocompleteManager.getInstance().getCurrentAutocompleteTelemetry();
         GraphQlLogger.logAutocompleteAcceptedEvent(
-            project, telemetry != null ? telemetry.contextSummary() : null);
+            project, telemetry != null ? telemetry.params() : null);
         acceptAgentAutocomplete(editor, maybeCaret);
       } else {
         Optional.ofNullable(maybeCaret)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -48,6 +48,13 @@ public class AutocompleteTelemetry {
         : null;
   }
 
+  @Nullable
+  public CompletionEvent.Params params() {
+    return (completionEvent != null )
+            ? completionEvent.params
+            : null;
+  }
+
   public @NotNull AutocompletionStatus getStatus() {
     if (completionDisplayedTimestampMs == 0) {
       return AutocompletionStatus.TRIGGERED_NOT_DISPLAYED;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteTelemetry.java
@@ -50,9 +50,7 @@ public class AutocompleteTelemetry {
 
   @Nullable
   public CompletionEvent.Params params() {
-    return (completionEvent != null )
-            ? completionEvent.params
-            : null;
+    return (completionEvent != null) ? completionEvent.params : null;
   }
 
   public @NotNull AutocompletionStatus getStatus() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -72,7 +72,7 @@ public class CodyAutocompleteManager {
                     p,
                     currentAutocompleteTelemetry.getLatencyMs(),
                     currentAutocompleteTelemetry.getDisplayDurationMs(),
-                    currentAutocompleteTelemetry.contextSummary());
+                    currentAutocompleteTelemetry.params());
                 currentAutocompleteTelemetry = null;
               }
             });

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -50,7 +50,8 @@ public class GraphQlLogger {
     logEvent(project, createEvent(project, eventName, eventParameters));
   }
 
-  private static JsonObject addCompletionEventParams(JsonObject eventParameters, CompletionEvent.@Nullable Params params) {
+  private static JsonObject addCompletionEventParams(
+      JsonObject eventParameters, CompletionEvent.@Nullable Params params) {
     var updatedEventParameters = eventParameters.deepCopy();
     if (params != null) {
       if (params.contextSummary != null) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class GraphQlLogger {
   private static final Gson gson = new GsonBuilder().serializeNulls().create();
+
   public static CompletableFuture<Boolean> logInstallEvent(@NotNull Project project) {
     if (ConfigUtil.getAnonymousUserId() != null && project.isDisposed()) {
       var event = createEvent(project, "CodyInstalled", new JsonObject());

--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.telemetry;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.PluginUtil;
@@ -13,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class GraphQlLogger {
-
+  private static final Gson gson = new GsonBuilder().serializeNulls().create();
   public static CompletableFuture<Boolean> logInstallEvent(@NotNull Project project) {
     if (ConfigUtil.getAnonymousUserId() != null && project.isDisposed()) {
       var event = createEvent(project, "CodyInstalled", new JsonObject());
@@ -55,7 +56,7 @@ public class GraphQlLogger {
     var updatedEventParameters = eventParameters.deepCopy();
     if (params != null) {
       if (params.contextSummary != null) {
-        updatedEventParameters.add("contextSummary", new Gson().toJsonTree(params.contextSummary));
+        updatedEventParameters.add("contextSummary", gson.toJsonTree(params.contextSummary));
       }
       updatedEventParameters.addProperty("id", params.id);
       updatedEventParameters.addProperty("languageId", params.languageId);


### PR DESCRIPTION
This adds the remaining autocomplete telemetry data that the vs code extension currently sends.  This includes language, provider, lineCount, charCount and additional source information.

The suggestion's id is also included so it is possible to connect the suggested event to the accepted event.

## Test plan
`./gradlew -PforceAgentBuild=true :runIde`

Capture event data 
```json
{
    "event": "CodyJetBrainsPlugin:completion:suggested",    
    "source": "IDEEXTENSION",
    "referrer": "JETBRAINS",    
    "publicArgument": "{\"latency\":927,\"displayDuration\":520,\"isAnyKnownPluginEnabled\":false,\"contextSummary\":{\"embeddings\":null,\"local\":2,\"duration\":3.05745792388916},\"id\":\"o2rg1k8p1\",\"languageId\":\"go\",\"source\":\"Network\",\"charCount\":2,\"lineCount\":1,\"multilineMode\":null,\"providerIdentifier\":\"anthropic\",\"serverEndpoint\":\"https://sourcegraph.sourcegraph.com/\"}",
    ...
}
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
