### PR TITLE
zoekt: update to 40a9a23bb04b

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6273,8 +6273,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:MPsjq7oKNyaJfQnhYkOpEne6b9CpoQU/eiIuzDPeMbU=",
-        version = "v0.0.0-20230822212419-f75df3d8a3f8",
+        sum = "h1:kqYHOCtMTKwkM2F6AbpelFE+Olt2qqJyxBCNps1oIjQ=",
+        version = "v0.0.0-20230825171831-40a9a23bb04b",
     )
 
     go_repository(

--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -34,6 +34,9 @@ go get "${repo}@${version}"
 go mod download ${repo}
 go mod tidy
 
+echo "Ensure that we update Bazel dependency files."
+bazel run '//:gazelle-update-repos'
+
 echo "Ensure we update go.sum by actually compiling some code which depends on zoekt."
 echo "We do this by running 'go test' without actually running any tests."
 go test -run '^$' github.com/sourcegraph/sourcegraph/internal/search/zoekt

--- a/go.mod
+++ b/go.mod
@@ -543,7 +543,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230822212419-f75df3d8a3f8
+	github.com/sourcegraph/zoekt v0.0.0-20230825171831-40a9a23bb04b
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2027,8 +2027,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230822212419-f75df3d8a3f8 h1:MPsjq7oKNyaJfQnhYkOpEne6b9CpoQU/eiIuzDPeMbU=
-github.com/sourcegraph/zoekt v0.0.0-20230822212419-f75df3d8a3f8/go.mod h1:3rlMtZdLxkc7P1R14qWq20fWDDyRQwL6TmAqH81WQ4M=
+github.com/sourcegraph/zoekt v0.0.0-20230825171831-40a9a23bb04b h1:kqYHOCtMTKwkM2F6AbpelFE+Olt2qqJyxBCNps1oIjQ=
+github.com/sourcegraph/zoekt v0.0.0-20230825171831-40a9a23bb04b/go.mod h1:3rlMtZdLxkc7P1R14qWq20fWDDyRQwL6TmAqH81WQ4M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This includes the changes from https://github.com/sourcegraph/zoekt/pull/641

## Test plan

CI 

