### PR TITLE
clear evaluated FF cache on FF value change

### DIFF
--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -146,6 +146,7 @@ func (f *featureFlagStore) UpdateFeatureFlag(ctx context.Context, flag *ff.Featu
 		rollout,
 		flag.Name,
 	))
+	clearRedisCache(flag.Name)
 	return scanFeatureFlag(row)
 }
 


### PR DESCRIPTION
Clears Redis store with evaluated feature flag values when the feature flag value/rollout basis changes. 

Previously, the hash table storing the evaluated feature flag value for users has been deleted [only when the feature flag was deleted](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/feature_flags.go?L16:5-16:20#tab=references). Feature flag value change didn't clear the cache, resulting in incorrect rollout feature flags users split. 

For example (more details in [this thread](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1693220251878639?thread_ts=1692782949.435119&cid=C022SPMNR0W)):
- A feature flag is created with a rollout value of 1,000 basis points, leading to an expected split of 10/90.
- A certain number of users evaluate it, with values stored in the cache.
- The flag value is then changed to, let's say, 5,000 basis points, aiming for a 50/50 split.
- Users who have already evaluated this feature flag receive the value from the cache, which was calculated using the initial value of 1,000 basis points. Users evaluating the feature flag for the first time have it calculated based on the current rollout value (5,000 points).
 

## Test plan
Updated unit tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
