### PR TITLE
Remove gitlab.GetOAuthContext and add it to the AuthProvider itself

### DIFF
--- a/internal/authz/providers/gitlab/authz.go
+++ b/internal/authz/providers/gitlab/authz.go
@@ -62,6 +62,8 @@ func newAuthzProvider(db database.DB, urn string, a *schema.GitLabAuthorization,
 	case idp.Oauth != nil:
 		// Check that there is a GitLab authn provider corresponding to this GitLab instance
 		foundAuthProvider := false
+		var clientID string
+		var clientSecret string
 		for _, authnProvider := range ps {
 			if authnProvider.Gitlab == nil {
 				continue
@@ -77,6 +79,8 @@ func newAuthzProvider(db database.DB, urn string, a *schema.GitLabAuthorization,
 			}
 			if authProviderURL.Hostname() == glURL.Hostname() {
 				foundAuthProvider = true
+				clientID = authnProvider.Gitlab.ClientID
+				clientSecret = authnProvider.Gitlab.ClientSecret
 				break
 			}
 		}
@@ -85,11 +89,13 @@ func newAuthzProvider(db database.DB, urn string, a *schema.GitLabAuthorization,
 		}
 
 		return NewOAuthProvider(OAuthProviderOp{
-			URN:       urn,
-			BaseURL:   glURL,
-			Token:     token,
-			TokenType: tokenType,
-			DB:        db,
+			URN:          urn,
+			BaseURL:      glURL,
+			Token:        token,
+			TokenType:    tokenType,
+			DB:           db,
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
 		}), nil
 	case idp.Username != nil:
 		return NewSudoProvider(SudoProviderOp{

--- a/internal/authz/providers/gitlab/oauth_test.go
+++ b/internal/authz/providers/gitlab/oauth_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -19,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -107,19 +105,6 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 			},
 		)
 
-		gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
-			return &oauthutil.OAuthContext{
-				ClientID:     "client",
-				ClientSecret: "client_sec",
-				Endpoint: oauth2.Endpoint{
-					AuthURL:  "url/oauth/authorize",
-					TokenURL: "url/oauth/token",
-				},
-				Scopes: []string{"read_user"},
-			}
-		}
-		defer func() { gitlab.MockGetOAuthContext = nil }()
-
 		authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 		repoIDs, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
@@ -187,19 +172,6 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				},
 			},
 		)
-
-		gitlab.MockGetOAuthContext = func() *oauthutil.OAuthContext {
-			return &oauthutil.OAuthContext{
-				ClientID:     "client",
-				ClientSecret: "client_sec",
-				Endpoint: oauth2.Endpoint{
-					AuthURL:  "url/oauth/authorize",
-					TokenURL: "url/oauth/token",
-				},
-				Scopes: []string{"read_user"},
-			}
-		}
-		defer func() { gitlab.MockGetOAuthContext = nil }()
 
 		authData := json.RawMessage(`{"access_token": "my_access_token"}`)
 		repoIDs, err := p.FetchUserPerms(ctx,

--- a/internal/extsvc/gitlab/client_test.go
+++ b/internal/extsvc/gitlab/client_test.go
@@ -15,13 +15,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
-	"github.com/sourcegraph/sourcegraph/internal/oauthutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -97,7 +94,6 @@ func TestClient_doWithBaseURL(t *testing.T) {
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 			}, nil
-
 		},
 	}
 
@@ -209,79 +205,6 @@ func TestRateLimitRetry(t *testing.T) {
 
 			assert.Equal(t, tt.succeeded, succeeded)
 			assert.Equal(t, tt.wantNumRequests, numRequests)
-		})
-	}
-}
-
-func TestGetOAuthContext(t *testing.T) {
-	conf.Mock(
-		&conf.Unified{
-			SiteConfiguration: schema.SiteConfiguration{
-				AuthProviders: []schema.AuthProviders{
-					{
-						Github: &schema.GitHubAuthProvider{
-							Url: "https://gitlab.com/", // Matching URL but wrong provider
-						},
-					}, {
-						Gitlab: &schema.GitLabAuthProvider{
-							Url: "https://gitlab.myexample.com/", // URL doesn't match
-						},
-					}, {
-						Gitlab: &schema.GitLabAuthProvider{
-							ClientID:     "my-client-id",
-							ClientSecret: "my-client-secret",
-							Url:          "https://gitlab.com/", // Good
-						},
-					},
-				},
-			},
-		},
-	)
-	defer conf.Mock(nil)
-
-	tests := []struct {
-		name    string
-		baseURL string
-		want    *oauthutil.OAuthContext
-	}{
-		{
-			name:    "match with API URL",
-			baseURL: "https://gitlab.com/api/v4/",
-			want: &oauthutil.OAuthContext{
-				ClientID:     "my-client-id",
-				ClientSecret: "my-client-secret",
-				Endpoint: oauthutil.Endpoint{
-					AuthURL:   "https://gitlab.com/oauth/authorize",
-					TokenURL:  "https://gitlab.com/oauth/token",
-					AuthStyle: 0,
-				},
-				Scopes: []string{"read_user", "api"},
-			},
-		},
-		{
-			name:    "match with root URL",
-			baseURL: "https://gitlab.com/",
-			want: &oauthutil.OAuthContext{
-				ClientID:     "my-client-id",
-				ClientSecret: "my-client-secret",
-				Endpoint: oauthutil.Endpoint{
-					AuthURL:   "https://gitlab.com/oauth/authorize",
-					TokenURL:  "https://gitlab.com/oauth/token",
-					AuthStyle: 0,
-				},
-				Scopes: []string{"read_user", "api"},
-			},
-		},
-		{
-			name:    "no match",
-			baseURL: "https://gitlab.example.com/api/v4/",
-			want:    nil,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got := GetOAuthContext(test.baseURL)
-			assert.Equal(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
