### PR TITLE
Allow banning of email domains for DotCom registration

### DIFF
--- a/internal/auth/userpasswd/BUILD.bazel
+++ b/internal/auth/userpasswd/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//cmd/frontend/backend",
-        "//cmd/frontend/envvar",
         "//cmd/frontend/globals",
         "//cmd/frontend/hubspot",
         "//cmd/frontend/hubspot/hubspotutil",

--- a/internal/auth/userpasswd/BUILD.bazel
+++ b/internal/auth/userpasswd/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//cmd/frontend/backend",
+        "//cmd/frontend/envvar",
         "//cmd/frontend/globals",
         "//cmd/frontend/hubspot",
         "//cmd/frontend/hubspot/hubspotutil",
@@ -41,6 +42,7 @@ go_library(
         "//internal/featureflag",
         "//internal/lazyregexp",
         "//internal/rcache",
+        "//internal/security",
         "//internal/session",
         "//internal/suspiciousnames",
         "//internal/txemail",

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -188,7 +188,7 @@ func unsafeSignUp(
 		logger.Error("failed to check if email is banned", log.Error(err))
 		return errors.New("could not determine if email domain is banned"), http.StatusInternalServerError, nil
 	} else if banned {
-		logger.Error("user tried to register with banned email address", log.String("email", creds.Email))
+		logger.Error("user tried to register with banned email domain", log.String("email", creds.Email))
 		return errors.New("this email address is not allowed to register"), http.StatusBadRequest, nil
 	}
 

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -14,8 +14,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/security"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hubspot/hubspotutil"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
@@ -181,6 +183,10 @@ func unsafeSignUp(
 			return errors.New(defaultErrorMessage), http.StatusInternalServerError, nil
 		}
 		newUserData.EmailVerificationCode = code
+	}
+
+	if envvar.SourcegraphDotComMode() && security.IsEmailBanned(creds.Email) {
+		return errors.New("this email address is not allowed to register"), http.StatusUnauthorized, nil
 	}
 
 	// Prevent abuse (users adding emails of other people whom they want to annoy) with the

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -185,7 +185,7 @@ func unsafeSignUp(
 	}
 
 	if banned, err := security.IsEmailBanned(creds.Email); err != nil {
-		logger.Error("failed to check if email is banned", log.Error(err))
+		logger.Error("failed to check if email domain is banned", log.Error(err))
 		return errors.New("could not determine if email domain is banned"), http.StatusInternalServerError, nil
 	} else if banned {
 		logger.Error("user tried to register with banned email domain", log.String("email", creds.Email))

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -186,7 +186,7 @@ func unsafeSignUp(
 
 	if banned, err := security.IsEmailBanned(creds.Email); err != nil {
 		logger.Error("failed to check if email is banned", log.Error(err))
-		return errors.New("could not determine if email address is banned"), http.StatusInternalServerError, nil
+		return errors.New("could not determine if email domain is banned"), http.StatusInternalServerError, nil
 	} else if banned {
 		logger.Error("user tried to register with banned email address", log.String("email", creds.Email))
 		return errors.New("this email address is not allowed to register"), http.StatusBadRequest, nil

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/security",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/conf",
+        "//internal/env",
         "//internal/errcode",
         "//internal/lazyregexp",
         "//lib/errors",

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//cmd/frontend/envvar",
+        "//internal/collections",
         "//internal/conf",
         "//internal/env",
         "//internal/errcode",
@@ -52,5 +53,6 @@ go_test(
         "//internal/conf",
         "//schema",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//cmd/frontend/envvar",
         "//internal/collections",
         "//internal/conf",
-        "//internal/env",
         "//internal/errcode",
         "//internal/lazyregexp",
         "//lib/errors",

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/collections"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -35,7 +34,7 @@ func ensureBannedEmailDomainsLoaded() error {
 			return
 		}
 
-		denyListPath := env.Get("SRC_EMAIL_DOMAIN_DENY_LIST", "", "A list of email domains to block")
+		denyListPath := os.Getenv("SRC_EMAIL_DOMAIN_DENY_LIST")
 		if denyListPath == "" {
 			return
 		}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -50,7 +50,7 @@ func IsEmailBanned(email string) bool {
 	}
 
 	domain := addr.Address[strings.Index(addr.Address, "@")+1:]
-	_, banned := bannedEmailDomains[domain]
+	_, banned := bannedEmailDomains[strings.ToLower(domain)]
 
 	return banned
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -205,7 +205,7 @@ func init() {
 
 	if envvar.SourcegraphDotComMode() {
 
-		denyList := env.Get("EMAIL_DOMAIN_DENY_LIST", "", "A list of disposable email domains to block")
+		denyList := env.Get("EMAIL_DOMAIN_DENY_LIST", "", "A list of email domains to block")
 
 		if denyList != "" {
 			err := loadBannedEmailDomains(denyList)

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -68,13 +68,13 @@ func IsEmailBanned(email string) (bool, error) {
 		return true, nil
 	}
 
-	parts := strings.SplitN(addr.Address, "@", 2)
+	parts := strings.Split(addr.Address, "@")
 
-	if len(parts) != 2 {
+	if len(parts) < 2 {
 		return true, nil
 	}
 
-	_, banned := bannedEmailDomains[strings.ToLower(parts[1])]
+	_, banned := bannedEmailDomains[strings.ToLower(parts[len(parts)-1])]
 
 	return banned, nil
 }

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -161,3 +161,24 @@ func TestAddrValidation(t *testing.T) {
 	}
 
 }
+
+func TestIsEmailBanned(t *testing.T) {
+
+	bannedEmailDomains["blocked.com"] = struct{}{}
+
+	if !IsEmailBanned("user@blocked.com") {
+		t.Error("Expected blocked domain to be detected")
+	}
+
+	if !IsEmailBanned("user@BlOCked.com") {
+		t.Error("Expected blocked domain with uppercase characters to be detected")
+	}
+
+	if IsEmailBanned("user@allowed.com") {
+		t.Error("Expected allowed domain to not be blocked")
+	}
+
+	if IsEmailBanned("invalid") {
+		t.Error("Expected invalid email to return false")
+	}
+}


### PR DESCRIPTION
This PR adds functionalities to block certain email domains during registration. This allows us to create and maintain a configmap of disallowed email domains.

## Test plan
Tested locally, added test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
