### PR TITLE
Add GA details to root doc

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -41,6 +41,14 @@
                 })(window,document,'script','dataLayer','GTM-TB4NLS7');
             </script>
             <!-- End Google Tag Manager -->
+            <!-- Google tag (gtag.js) -->
+            <script async src="https://www.googletagmanager.com/gtag/js?id=G-K7F82VH69T"></script>
+            <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-K7F82VH69T');
+            </script>
 		</head>
 
         <!-- Default to light theme if no JavaScript -->


### PR DESCRIPTION
Adding GA tag on docs website to the root element of docs website.

## Test plan

Docs changes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@add-ga)