### PR TITLE
grpc: p4exec: adjust client implementation to error immediately if a permission related error occurs

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -275,12 +275,26 @@ func (gs *GRPCServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 
 func (gs *GRPCServer) doP4Exec(ctx context.Context, logger log.Logger, req *protocol.P4ExecRequest, userAgent string, w io.Writer) error {
 	execStatus := gs.Server.p4Exec(ctx, logger, req, userAgent, w)
-	if execStatus.Err != nil {
+
+	if execStatus.ExitStatus != 0 || execStatus.Err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return status.FromContextError(ctxErr).Err()
 		}
 
-		return execStatus.Err
+		gRPCStatus := codes.Unknown
+		if strings.Contains(execStatus.Err.Error(), "signal: killed") {
+			gRPCStatus = codes.Aborted
+		}
+
+		s, err := status.New(gRPCStatus, execStatus.Err.Error()).WithDetails(&proto.ExecStatusPayload{
+			StatusCode: int32(execStatus.ExitStatus),
+			Stderr:     execStatus.Stderr,
+		})
+		if err != nil {
+			gs.Server.Logger.Error("failed to marshal status", log.Error(err))
+			return err
+		}
+		return s.Err()
 	}
 
 	return nil


### PR DESCRIPTION
## background

Our REST P4Exec implementation first checks to see if the provided credentials are valid before running streaming the p4 output. If it's invalid, the server returns a http.BadRequest response to the client:

https://github.com/sourcegraph/sourcegraph/blob/3e50ff1a904b8fb0e6d2eb010e33cab56503c91d/cmd/gitserver/server/server.go#L1731-L1739

Our client implementation is written in such a way where these errors are _immediately_ returned to the caller, without the need to consume the response body:

https://github.com/sourcegraph/sourcegraph/blob/457dc4813fc7614d84f91d0fb40404068ff1e362/internal/gitserver/client.go#L944-L956



## old gRPC behavior

The gRPC version of this function does the same credentials check, but it didn't maintain the invariant of _immediately_
returning credential errors to the caller. Instead, the caller is required to start consuming the streamed response in order to see the error:


https://github.com/sourcegraph/sourcegraph/blob/3e50ff1a904b8fb0e6d2eb010e33cab56503c91d/internal/gitserver/client.go#L890-L912

This broke a call-site that only checked the _immediate_ error returned by the client, and didn't actually consume the reader:

https://github.com/sourcegraph/sourcegraph/blob/dc0dfd1178326797e8c72f66af0c258960c3178c/internal/batches/sources/perforce.go#L82-L95



## new gRPC behavior

This PR adjust the gRPC client to cache the first message it receives from the stream. If the first message is a permissions / credentials related error - it returns immediately before returning the stream. Otherwise, it returns the stream and yields all the same messages as it did before. 

## Test plan

Unit tests 

