### PR TITLE
codygateway: Make fireworks key optional

### DIFF
--- a/cmd/cody-gateway/shared/config.go
+++ b/cmd/cody-gateway/shared/config.go
@@ -121,7 +121,7 @@ func (c *Config) Load() {
 		c.AddError(errors.New("must provide allowed models for OpenAI"))
 	}
 
-	c.Fireworks.AccessToken = c.Get("CODY_GATEWAY_FIREWORKS_ACCESS_TOKEN", "", "The Fireworks access token to be used.")
+	c.Fireworks.AccessToken = c.GetOptional("CODY_GATEWAY_FIREWORKS_ACCESS_TOKEN", "The Fireworks access token to be used.")
 	c.Fireworks.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_FIREWORKS_ALLOWED_MODELS",
 		strings.Join([]string{
 			"accounts/fireworks/models/starcoder-16b-w8a16",


### PR DESCRIPTION
Otherwise without this var set the service will not start properly.

## Test plan

Verified it starts up correctly again. 