### PR TITLE
grpc: remove zoekt-webserver specific feature flag

### DIFF
--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//internal/api",
         "//internal/conf",
         "//internal/ctags_config",
-        "//internal/featureflag",
         "//internal/grpc/defaults",
         "//internal/honey",
         "//internal/httpcli",

--- a/internal/search/backend/grpc.go
+++ b/internal/search/backend/grpc.go
@@ -11,12 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
-
-func IsZoektGRPCEnabled(ctx context.Context) bool {
-	return conf.IsGRPCEnabled(ctx) && featureflag.FromContext(ctx).GetBoolOr("grpc-zoekt", false)
-}
 
 // switchableZoektGRPCClient is a zoekt.Streamer that can switch between
 // gRPC and HTTP backends.
@@ -26,7 +21,7 @@ type switchableZoektGRPCClient struct {
 }
 
 func (c *switchableZoektGRPCClient) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) error {
-	if IsZoektGRPCEnabled(ctx) {
+	if conf.IsGRPCEnabled(ctx) {
 		return c.grpcClient.StreamSearch(ctx, q, opts, sender)
 	} else {
 		return c.httpClient.StreamSearch(ctx, q, opts, sender)
@@ -34,7 +29,7 @@ func (c *switchableZoektGRPCClient) StreamSearch(ctx context.Context, q query.Q,
 }
 
 func (c *switchableZoektGRPCClient) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	if IsZoektGRPCEnabled(ctx) {
+	if conf.IsGRPCEnabled(ctx) {
 		return c.grpcClient.Search(ctx, q, opts)
 	} else {
 		return c.httpClient.Search(ctx, q, opts)
@@ -42,7 +37,7 @@ func (c *switchableZoektGRPCClient) Search(ctx context.Context, q query.Q, opts 
 }
 
 func (c *switchableZoektGRPCClient) List(ctx context.Context, q query.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
-	if IsZoektGRPCEnabled(ctx) {
+	if conf.IsGRPCEnabled(ctx) {
 		return c.grpcClient.List(ctx, q, opts)
 	} else {
 		return c.httpClient.List(ctx, q, opts)

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -139,7 +139,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	// GobCache exists so we only pay the cost of marshalling a query once
 	// when we aggregate it out over all the replicas. Zoekt's RPC layers
 	// unwrap this before passing it on to the Zoekt evaluation layers.
-	if !IsZoektGRPCEnabled(ctx) {
+	if !conf.IsGRPCEnabled(ctx) {
 		q = &query.GobCache{Q: q}
 	}
 
@@ -223,7 +223,7 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	// GobCache exists, so we only pay the cost of marshalling a query once
 	// when we aggregate it out over all the replicas. Zoekt's RPC layers
 	// unwrap this before passing it on to the Zoekt evaluation layers.
-	if !IsZoektGRPCEnabled(ctx) {
+	if !conf.IsGRPCEnabled(ctx) {
 		q = &query.GobCache{Q: q}
 	}
 


### PR DESCRIPTION
grpc-zoekt webserver support has been running successfully on sourcegraph.com for a while now, so there is no need for two layers of feature flags here.

sourcegraph.com will speak zoekt-webserver via gRPC when the main conf.IsGRPCEnabled setting is set to true (like every other service).



## Test plan

CI
