### PR TITLE
searchjobs: PoC of listing search jobs

### DIFF
--- a/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
@@ -43,7 +43,12 @@ func (r *Resolver) DeleteSearchJob(ctx context.Context, args *graphqlbackend.Del
 }
 
 func (r *Resolver) SearchJobs(ctx context.Context, args *graphqlbackend.SearchJobsArgs) (graphqlbackend.SearchJobsConnectionResolver, error) {
-	return nil, errors.New("not implemented")
+	// TODO respect args. For now we always return everything a user created
+	jobs, err := r.svc.ListSearchJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &searchJobsConnectionResolver{Jobs: jobs, db: r.db}, nil
 }
 
 func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {

--- a/enterprise/cmd/frontend/internal/search/resolvers/search_jobs_connection.go
+++ b/enterprise/cmd/frontend/internal/search/resolvers/search_jobs_connection.go
@@ -5,22 +5,29 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 )
 
 var _ graphqlbackend.SearchJobsConnectionResolver = &searchJobsConnectionResolver{}
 
 type searchJobsConnectionResolver struct {
+	Jobs []*types.ExhaustiveSearchJob
+	db   database.DB
 }
 
 func (e *searchJobsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	return 0, errors.New("not implemented")
+	return int32(len(e.Jobs)), nil
 }
 
 func (e *searchJobsConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return nil, errors.New("not implemented")
+	return graphqlutil.HasNextPage(false), nil
 }
 
 func (e *searchJobsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.SearchJobResolver, error) {
-	return nil, errors.New("not implemented")
+	resolvers := make([]graphqlbackend.SearchJobResolver, 0, len(e.Jobs))
+	for _, job := range e.Jobs {
+		resolvers = append(resolvers, searchJobResolver{Job: job, db: e.db})
+	}
+	return resolvers, nil
 }

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -40,6 +40,7 @@ func opAttrs(attrs ...attribute.KeyValue) observation.Args {
 type operations struct {
 	createSearchJob *observation.Operation
 	getSearchJob    *observation.Operation
+	listSearchJobs  *observation.Operation
 }
 
 var (
@@ -71,6 +72,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		singletonOperations = &operations{
 			createSearchJob: op("CreateSearchJob"),
 			getSearchJob:    op("GetSearchJob"),
+			listSearchJobs:  op("ListSearchJobs"),
 		}
 	})
 	return singletonOperations
@@ -114,4 +116,15 @@ func (s *Service) GetSearchJob(ctx context.Context, id int64) (_ *types.Exhausti
 	defer endObservation(1, observation.Args{})
 
 	return s.store.GetExhaustiveSearchJob(ctx, id)
+}
+
+func (s *Service) ListSearchJobs(ctx context.Context) (jobs []*types.ExhaustiveSearchJob, err error) {
+	ctx, _, endObservation := s.operations.listSearchJobs.With(ctx, &err, observation.Args{})
+	defer func() {
+		endObservation(1, opAttrs(
+			attribute.Int("len", len(jobs)),
+		))
+	}()
+
+	return s.store.ListExhaustiveSearchJobs(ctx)
 }

--- a/internal/search/exhaustive/store/BUILD.bazel
+++ b/internal/search/exhaustive/store/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/actor",
         "//internal/auth",
         "//internal/database",
         "//internal/database/basestore",

--- a/internal/search/exhaustive/store/store.go
+++ b/internal/search/exhaustive/store/store.go
@@ -61,6 +61,7 @@ func opAttrs(attrs ...attribute.KeyValue) observation.Args {
 type operations struct {
 	createExhaustiveSearchJob *observation.Operation
 	getExhaustiveSearchJob    *observation.Operation
+	listExhaustiveSearchJobs  *observation.Operation
 
 	createExhaustiveSearchRepoJob *observation.Operation
 
@@ -90,6 +91,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 	return &operations{
 		createExhaustiveSearchJob: op("CreateExhaustiveSearchJob"),
 		getExhaustiveSearchJob:    op("GetExhaustiveSearchJob"),
+		listExhaustiveSearchJobs:  op("ListExhaustiveSearchJobs"),
 
 		createExhaustiveSearchRepoJob: op("CreateExhaustiveSearchRepoJob"),
 


### PR DESCRIPTION
This ignores all arguments sent via graphql and always lists all search jobs created by a user. This should be something we can build on.

From reading the graphql schema we likely need a way to establish which users we are listing for, unless that is somehow part of the query field. In particular I am thinking of admins looking at search jobs.

Test Plan: manually ran the below graphql query locally

```graphql
query {
  searchJobs {
    nodes {
      id
      query
    }
  }
}
```