### PR TITLE
JetBrains: Cody: Add a status bar toggle to enable/disable autocomplete

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added ability to hide completion suggestions with ESC key [#55955](https://github.com/sourcegraph/sourcegraph/pull/55955)
 - New alt-backslash shortcut to exlicitly trigger autocomplete [#55926](https://github.com/sourcegraph/sourcegraph/pull/55926)
 - Add visual hints about Cody status to status bar [#56046](https://github.com/sourcegraph/sourcegraph/pull/56046)
+- Added a status bar toggle for enabling/disabling Cody autocomplete [#56310](https://github.com/sourcegraph/sourcegraph/pull/56310)
 
 ### Changed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -99,7 +99,7 @@ public class CodyAutocompleteManager {
    * pending ones.
    */
   @RequiresEdt
-  public void clearAutocompleteSuggestions() {
+  public void clearAutocompleteSuggestionsForAllProjects() {
     Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
     Arrays.stream(openProjects)
         .flatMap(project -> Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()))

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -8,7 +8,10 @@ import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.editor.impl.ImaginaryEditor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
@@ -31,6 +34,7 @@ import com.sourcegraph.telemetry.GraphQlLogger;
 import difflib.Delta;
 import difflib.DiffUtils;
 import difflib.Patch;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,6 +62,12 @@ public class CodyAutocompleteManager {
     return ApplicationManager.getApplication().getService(CodyAutocompleteManager.class);
   }
 
+  /**
+   * Clears any already rendered autocomplete suggestions for the given editor and cancels any
+   * pending ones.
+   *
+   * @param editor the editor to clear autocomplete suggestions for
+   */
   @RequiresEdt
   public void clearAutocompleteSuggestions(@NotNull Editor editor) {
     // Log "suggested" event and clear current autocompletion
@@ -82,6 +92,20 @@ public class CodyAutocompleteManager {
 
     // Clear any existing inline elements
     disposeInlays(editor);
+  }
+
+  /**
+   * Clears any already rendered autocomplete suggestions for all open editors and cancels any
+   * pending ones.
+   */
+  @RequiresEdt
+  public void clearAutocompleteSuggestions() {
+    Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+    Arrays.stream(openProjects)
+        .flatMap(project -> Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()))
+        .filter(fileEditor -> fileEditor instanceof TextEditor)
+        .map(fileEditor -> ((TextEditor) fileEditor).getEditor())
+        .forEach(this::clearAutocompleteSuggestions);
   }
 
   @RequiresEdt

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -237,6 +237,10 @@ public class ConfigUtil {
     return getApplicationLevelConfig().isCodyAutocompleteEnabled();
   }
 
+  public static boolean setCodyAutocompleteEnabled(boolean toggle) {
+    return getApplicationLevelConfig().isCodyAutocompleteEnabled = toggle;
+  }
+
   public static boolean isAccessTokenNotificationDismissed() {
     return getApplicationLevelConfig().isAccessTokenNotificationDismissed();
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -8,12 +8,9 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.messages.MessageBus;
@@ -29,7 +26,6 @@ import com.sourcegraph.find.browser.JavaToJSBridge;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
-import java.util.Arrays;
 import java.util.Objects;
 import javax.swing.KeyStroke;
 import org.jetbrains.annotations.NotNull;
@@ -113,16 +109,7 @@ public class SettingsChangeListener implements Disposable {
 
             // clear autocomplete suggestions if freshly disabled
             if (context.oldCodyAutocompleteEnabled && !context.newCodyAutocompleteEnabled) {
-              Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
-              CodyAutocompleteManager codyAutocompleteManager =
-                  CodyAutocompleteManager.getInstance();
-              Arrays.stream(openProjects)
-                  .flatMap(
-                      project ->
-                          Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()))
-                  .filter(fileEditor -> fileEditor instanceof TextEditor)
-                  .map(fileEditor -> ((TextEditor) fileEditor).getEditor())
-                  .forEach(codyAutocompleteManager::clearAutocompleteSuggestions);
+              CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions();
             }
 
             // Disable/enable the Cody tool window depending on the setting

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsChangeListener.java
@@ -109,7 +109,7 @@ public class SettingsChangeListener implements Disposable {
 
             // clear autocomplete suggestions if freshly disabled
             if (context.oldCodyAutocompleteEnabled && !context.newCodyAutocompleteEnabled) {
-              CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions();
+              CodyAutocompleteManager.getInstance().clearAutocompleteSuggestionsForAllProjects();
             }
 
             // Disable/enable the Cody tool window depending on the setting

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -1,0 +1,16 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.config.ConfigUtil
+
+class CodyDisableAutocompleteAction : DumbAwareAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        ConfigUtil.setCodyAutocompleteEnabled(false)
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled()
+    }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -1,12 +1,25 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.config.ConfigUtil
+import java.util.Arrays
 
 class CodyDisableAutocompleteAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         ConfigUtil.setCodyAutocompleteEnabled(false)
+        Arrays.stream(ProjectManager.getInstance().openProjects)
+            .flatMap { project: Project? -> Arrays.stream(FileEditorManager.getInstance(project!!).allEditors) }
+            .filter { fileEditor: FileEditor? -> fileEditor is TextEditor }
+            .map { fileEditor: FileEditor -> (fileEditor as TextEditor).editor }
+            .forEach { editor: Editor? -> CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions(editor!!) }
     }
 
     override fun update(e: AnActionEvent) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -8,7 +8,7 @@ import com.sourcegraph.config.ConfigUtil
 class CodyDisableAutocompleteAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         ConfigUtil.setCodyAutocompleteEnabled(false)
-        CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions()
+        CodyAutocompleteManager.getInstance().clearAutocompleteSuggestionsForAllProjects()
     }
 
     override fun update(e: AnActionEvent) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -1,25 +1,14 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.fileEditor.FileEditor
-import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.DumbAwareAction
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.config.ConfigUtil
-import java.util.Arrays
 
 class CodyDisableAutocompleteAction : DumbAwareAction() {
     override fun actionPerformed(e: AnActionEvent) {
         ConfigUtil.setCodyAutocompleteEnabled(false)
-        Arrays.stream(ProjectManager.getInstance().openProjects)
-            .flatMap { project: Project? -> Arrays.stream(FileEditorManager.getInstance(project!!).allEditors) }
-            .filter { fileEditor: FileEditor? -> fileEditor is TextEditor }
-            .map { fileEditor: FileEditor -> (fileEditor as TextEditor).editor }
-            .forEach { editor: Editor? -> CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions(editor!!) }
+        CodyAutocompleteManager.getInstance().clearAutocompleteSuggestions()
     }
 
     override fun update(e: AnActionEvent) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
@@ -1,0 +1,16 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.config.ConfigUtil
+
+class CodyEnableAutocompleteAction : DumbAwareAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        ConfigUtil.setCodyAutocompleteEnabled(true)
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isEnabledAndVisible = ConfigUtil.isCodyEnabled() && !ConfigUtil.isCodyAutocompleteEnabled()
+    }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,0 +1,12 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.sourcegraph.config.ConfigUtil
+
+class CodyStatusBarActionGroup : DefaultActionGroup() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        e.presentation.isVisible = ConfigUtil.isCodyEnabled()
+    }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarWidget.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarWidget.kt
@@ -1,7 +1,11 @@
 package com.sourcegraph.cody.statusbar
 
+import com.intellij.ide.DataManager
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.ListPopup
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.StatusBarWidget
@@ -21,9 +25,17 @@ class CodyStatusBarWidget(project: Project) : EditorBasedStatusBarPopup(project,
     return state
   }
 
-  override fun createPopup(context: DataContext?): ListPopup? {
-    return null
-  }
+    override fun createPopup(context: DataContext?): ListPopup {
+        val actionGroup = ActionManager.getInstance().getAction("CodyStatusBarActions") as? ActionGroup
+            ?: CodyStatusBarActionGroup()
+        return JBPopupFactory.getInstance()
+            .createActionGroupPopup(
+                "Cody",
+                actionGroup,
+                DataManager.getInstance().getDataContext(this.component),
+                JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+                true)
+    }
 
   override fun createInstance(project: Project): StatusBarWidget {
     return CodyStatusBarWidget(project)

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -168,14 +168,12 @@
         <action
             id="cody.enableCodyAutocomplete"
             class="com.sourcegraph.cody.statusbar.CodyEnableAutocompleteAction"
-            text="Enable Cody Autocomplete"
-            icon="/icons/codyLogoSm.svg"/>
+            text="Enable Cody Autocomplete"/>
 
         <action
             id="cody.disableCodyAutocomplete"
             class="com.sourcegraph.cody.statusbar.CodyDisableAutocompleteAction"
-            text="Disable Cody Autocomplete"
-            icon="/icons/codyLogoSm.svg"/>
+            text="Disable Cody Autocomplete"/>
 
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
         - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
              -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
     -->
-    <idea-version since-build="212.0" />
+    <idea-version since-build="212.0"/>
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
@@ -60,8 +60,10 @@
     </extensions>
 
     <applicationListeners>
-        <listener class="com.sourcegraph.cody.CodyAgentProjectListener" topic="com.intellij.openapi.project.ProjectManagerListener"/>
-        <listener class="com.sourcegraph.cody.CodyFileEditorListener" topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
+        <listener class="com.sourcegraph.cody.CodyAgentProjectListener"
+                  topic="com.intellij.openapi.project.ProjectManagerListener"/>
+        <listener class="com.sourcegraph.cody.CodyFileEditorListener"
+                  topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
         <!-- CodyAgentFocusListener is commented out since it doesn't seem possible to register a listener via plugin.xml.
              We programmatically register a listener from CodyAgent instead. -->
         <!-- <listener class="com.sourcegraph.cody.CodyAgentFocusListener" topic="com.intellij.openapi.editor.ex.FocusChangeListener"/> -->
@@ -124,7 +126,8 @@
         </action>
 
         <!-- autocomplete -->
-        <action id="cody.acceptAutocompleteAction" class="com.sourcegraph.cody.autocomplete.AcceptCodyAutocompleteAction">
+        <action id="cody.acceptAutocompleteAction"
+                class="com.sourcegraph.cody.autocomplete.AcceptCodyAutocompleteAction">
             <keyboard-shortcut first-keystroke="TAB" keymap="$default"/>
             <override-text place="MainMenu" text="Accept Autocomplete Suggestion"/>
         </action>
@@ -154,13 +157,25 @@
             id="cody.downloadAndInstallCodyAction"
             class="com.sourcegraph.cody.recipes.DownloadCodyAppAction"
             text="Download Cody App"
-            icon="/icons/codyLogoSm.svg" />
+            icon="/icons/codyLogoSm.svg"/>
 
         <action
             id="cody.runCodyAppAction"
             class="com.sourcegraph.cody.recipes.RunCodyAppAction"
             text="Run Cody App"
-            icon="/icons/codyLogoSm.svg" />
+            icon="/icons/codyLogoSm.svg"/>
+
+        <action
+            id="cody.enableCodyAutocomplete"
+            class="com.sourcegraph.cody.statusbar.CodyEnableAutocompleteAction"
+            text="Enable Cody Autocomplete"
+            icon="/icons/codyLogoSm.svg"/>
+
+        <action
+            id="cody.disableCodyAutocomplete"
+            class="com.sourcegraph.cody.statusbar.CodyDisableAutocompleteAction"
+            text="Disable Cody Autocomplete"
+            icon="/icons/codyLogoSm.svg"/>
 
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>
@@ -182,6 +197,12 @@
             <reference ref="sourcegraph.openFile"/>
             <reference ref="sourcegraph.copy"/>
             <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+        </group>
+
+        <group id="CodyStatusBarActions" popup="true" text="Cody" searchable="false"
+               class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup">
+            <reference ref="cody.enableCodyAutocomplete"/>
+            <reference ref="cody.disableCodyAutocomplete"/>
         </group>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
Fixes #56281 

https://github.com/sourcegraph/sourcegraph/assets/18601388/6d4d5628-a0d2-4c4a-9638-01aca872ce9c

Note: the toggle only enables/disables autocomplete on the application level for now. We should probably have a separate toggle to enable/disable on the project level as well.

## Test plan
- green CI
- the `enable` toggle only appears when autocomplete is disabled globally
- likewise, the `disable` toggle only appears when autocomplete is enabled globally