### PR TITLE
bazel: run tests even if prechecks fail

### DIFF
--- a/dev/ci/bazel-prechecks-apply.sh
+++ b/dev/ci/bazel-prechecks-apply.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -u
+
+response=$(buildkite-agent artifact download bazel-configure.diff . --step bazel-prechecks 2>&1)
+status=$?
+if [[ $status -ne 0 && "$response" == *"No artifacts found for downloading"* ]]; then
+  echo "--- No bazel-configure.diff artifact found, skipping diff check"
+  exit 0
+fi
+
+git apply bazel-configure.diff


### PR DESCRIPTION
Persists & applies `bazel configure` and `bazel run //:gazelle-update-repos` changes in the precheck step which subsequent steps can apply in order to run even if the user forgot to run those commands. We apply these to the bazel test, async and build image candidates steps 

## Test plan

Many many `sg ci build main-dry-run`s