### PR TITLE
grpc: put grpcwebui behind environment variable

### DIFF
--- a/internal/debugserver/grpcui.go
+++ b/internal/debugserver/grpcui.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/fullstorydev/grpcui/standalone"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"google.golang.org/grpc"
 
 	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+var envEnableGRPCWebUI = env.MustGetBool("GRPC_WEB_UI_ENABLED", false, "Enable the gRPC Web UI to debug and explore gRPC services")
 
 const gRPCWebUIPath = "/debug/grpcui"
 
@@ -50,6 +53,11 @@ type grpcHandler struct {
 }
 
 func (g *grpcHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !envEnableGRPCWebUI {
+		http.Error(w, "gRPC Web UI is disabled", http.StatusNotFound)
+		return
+	}
+
 	ctx := r.Context()
 
 	cc, err := grpc.DialContext(ctx, g.target, g.dialOpts...)

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -119,6 +119,9 @@ env:
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://127.0.0.1:4318
   # OTEL_EXPORTER_OTLP_PROTOCOL: http/json
 
+  # Enable gRPC Web UI for debugging
+  GRPC_WEB_UI_ENABLED: "true"
+
   # Enable full protobuf message logging when an internal error occurred
   SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_ENABLED: "true"
   SRC_GRPC_INTERNAL_ERROR_LOGGING_LOG_PROTOBUF_MESSAGES_JSON_TRUNCATION_SIZE_BYTES: "1KB"


### PR DESCRIPTION
The [gRPCWebUI](https://github.com/fullstorydev/grpcui) debug page for each of or services will only be enabled if GRPC_WEB_UI_ENABLED is set to true (false by default). 

## Test plan

1. Run `env GRPC_WEB_UI_ENABLED=false sg start`, open https://sourcegraph.test:3443/-/debug/proxies/frontend-127.0.0.1/debug/grpcui/ and see the following:

<img width="868" alt="Screenshot 2023-08-31 at 8 47 15 AM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/74d7fc28-bcb6-4b7d-b767-a3ec5d9894b0">

1. Run `env GRPC_WEB_UI_ENABLED=true sg start`, open https://sourcegraph.test:3443/-/debug/proxies/frontend-127.0.0.1/debug/grpcui/ and see the following:

<img width="846" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/72667e6f-8179-489a-9060-277de721194e">

