### PR TITLE
Hide email signup from dotcom signup page

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -45,23 +45,6 @@ export const Default: Story = () => (
                 source="Monitor"
                 onSignUp={sinon.stub()}
                 context={context}
-                showEmailForm={false}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                isSourcegraphDotCom={true}
-            />
-        )}
-    </WebStory>
-)
-
-export const EmailForm: Story = () => (
-    <WebStory>
-        {({ isLightTheme }) => (
-            <CloudSignUpPage
-                isLightTheme={isLightTheme}
-                source="SearchCTA"
-                onSignUp={sinon.stub()}
-                context={context}
-                showEmailForm={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 isSourcegraphDotCom={true}
             />
@@ -77,7 +60,6 @@ export const InvalidSource: Story = () => (
                 source="test"
                 onSignUp={sinon.stub()}
                 context={context}
-                showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 isSourcegraphDotCom={true}
             />
@@ -93,7 +75,6 @@ export const OptimizationSignup: Story = () => (
                 source="test"
                 onSignUp={sinon.stub()}
                 context={context}
-                showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
                 isSourcegraphDotCom={true}
             />

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -107,7 +107,6 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 source={query.get('src')}
                 onSignUp={handleSignUp}
                 isLightTheme={isLightTheme}
-                showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
                 telemetryService={telemetryService}
                 isSourcegraphDotCom={context.sourcegraphDotComMode}


### PR DESCRIPTION
Temporary while we are finding better ways to allow email sign up. We can revert this later.

## Test plan

verified manually the email form doesn't show. Marc is going to disable allowSignup: true on the site config level, so the backend will be secured as well.