### PR TITLE
JetBrains: ensure nonnull line separator method can't return a null 

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -343,7 +343,8 @@ public class CodyAutocompleteManager {
     VirtualFile virtualFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
 
     if (virtualFile != null) {
-      return Optional.ofNullable(virtualFile.getDetectedLineSeparator()).orElse(System.lineSeparator());
+      return Optional.ofNullable(virtualFile.getDetectedLineSeparator())
+          .orElse(System.lineSeparator());
     } else {
       return System.lineSeparator();
     }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -343,7 +343,7 @@ public class CodyAutocompleteManager {
     VirtualFile virtualFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
 
     if (virtualFile != null) {
-      return virtualFile.getDetectedLineSeparator();
+      return Optional.ofNullable(virtualFile.getDetectedLineSeparator()).orElse(System.lineSeparator());
     } else {
       return System.lineSeparator();
     }


### PR DESCRIPTION
Resolve the warning that the method may return null. In response to the following reported stack trace.

```
java.lang.IllegalStateException: @NotNull method com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.inferLineSeparator must not return null
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.$$$reportNull$$$0(CodyAutocompleteManager.java)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.inferLineSeparator(CodyAutocompleteManager.java:321)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.displayAgentAutocomplete(CodyAutocompleteManager.java:276)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.lambda$processAutocompleteResult$8(CodyAutocompleteManager.java:256)
...
```
## Test plan
Unable to recreate crash but updated code resolves warning that method could return null

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
