### PR TITLE
source: ensure transact method returns non-nil store for deferred operations

### DIFF
--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -155,7 +155,8 @@ func (s *store) transact(ctx context.Context) (stx *store, err error) {
 
 	txBase, err := s.Store.Transact(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "starting transaction")
+		// We return the `store` here because callers of the transact method may expect a non-nil return value.
+		return s, errors.Wrap(err, "starting transaction")
 	}
 	return &store{
 		Store:   txBase,


### PR DESCRIPTION
Earlier today, Source support received this [report](https://console.cloud.google.com/errors/detail/CMPopKr2iqDmXA;time=P30D?project=sourcegraph-dev&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error) about a nil panic in `repo-updater`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1b7bf4d]

goroutine 3560 [running]:
github.com/sourcegraph/sourcegraph/internal/repos.(*store).DeleteExternalServiceRepo.func1({0xc00a54d620?, 0x23d61ce?, 0x44777c0?})
	internal/repos/store.go:269 +0x6d
github.com/sourcegraph/sourcegraph/internal/repos.(*store).DeleteExternalServiceRepo(0x0, {0x2e2a070?, 0xc0029a2e10?}, 0xc001649e10, 0x34b184b)
	internal/repos/store.go:282 +0xa0f
github.com/sourcegraph/sourcegraph/internal/repos.(*store).DeleteExternalServiceReposNotIn(0xc00114fc20, {0x2e29fc8?, 0xc0024d7680?}, 0xc001649e10, 0xc002a29890)
	internal/repos/store.go:242 +0xa7a
github.com/sourcegraph/sourcegraph/internal/repos.(*Syncer).delete(0xc001ae30e0, {0x2e29fc8, 0xc0024d7680}, 0xc002992bc0?, 0x1a?)
	internal/repos/syncer.go:842 +0x34
github.com/sourcegraph/sourcegraph/internal/repos.(*Syncer).SyncExternalService(0xc001ae30e0, {0x2e2a070, 0xc0029a23f0}, 0xc002c27ac0?, 0xdf8475800, 0xc002689b78)
	internal/repos/syncer.go:698 +0x209a
github.com/sourcegraph/sourcegraph/internal/repos.(*syncHandler).Handle(0xc002979fa0, {0x2e2a070, 0xc0029a23f0}, {0x0?, 0x0?}, 0xc00212c340)
	internal/repos/syncer.go:136 +0xc5
```

I dug into this and figured the panic came from this code block. 

```go
s, err = s.transact(ctx)
if err != nil {
	return errors.Wrap(err, "DeleteExternalServiceRepo")
}
```

### Background
When an error is returned by the `s.transact` method, it has been observed that a nil value is returned for the Store object. There are places in the codebase where, after this call, a deferred function` s.Metrics...` is executed. When the value of Store is nil, this results in a panic due to a nil dereference.

The main goal of this PR is to address the above issue by ensuring that even when s.transact encounters an error, it returns a valid struct instead of nil. This will prevent the panic from occurring during the deferred call to s.Metrics('').

## Test plan

I manually mocked an error in the call for `s.Transact` and ensured there were no `nil` panics when `repo-updater` works.
