### PR TITLE
source: update profile link for github

### DIFF
--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, FC } from 'react'
+import React, { useState, useCallback, type FC } from 'react'
 
 import type { ErrorLike } from '@sourcegraph/common'
 import { Button, Link, H3 } from '@sourcegraph/wildcard'
@@ -121,6 +121,26 @@ export const ExternalAccountConnectionDetails: FC<ExternalAccountConnectionDetai
                     {account.external?.displayName ? (
                         <>
                             {account.external.displayName} (@{account.external?.login})
+                        </>
+                    ) : (
+                        'Not connected'
+                    )}
+                </>
+            )
+        case 'github':
+            return (
+                <>
+                    {account.external?.login ? (
+                        <>
+                            {account.external.displayName} (
+                            <Link
+                                to={`https://github.com/${account.external.login}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                @{account.external.login}
+                            </Link>
+                            )
                         </>
                     ) : (
                         'Not connected'

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -127,26 +127,6 @@ export const ExternalAccountConnectionDetails: FC<ExternalAccountConnectionDetai
                     )}
                 </>
             )
-        case 'github':
-            return (
-                <>
-                    {account.external?.login ? (
-                        <>
-                            {account.external.displayName} (
-                            <Link
-                                to={`https://github.com/${account.external.login}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                @{account.external.login}
-                            </Link>
-                            )
-                        </>
-                    ) : (
-                        'Not connected'
-                    )}
-                </>
-            )
         default:
             return (
                 <>

--- a/client/web/src/user/settings/auth/__snapshots__/ExternalAccount.test.tsx.snap
+++ b/client/web/src/user/settings/auth/__snapshots__/ExternalAccount.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExternalAccountConnectionDetails renders correctly when display name is
   test@sourcegraph.com (
   <a
     class=""
-    href="https://example.com"
+    href="https://github.com/test"
     rel="noopener noreferrer"
     target="_blank"
   >

--- a/client/web/src/user/settings/auth/__snapshots__/ExternalAccount.test.tsx.snap
+++ b/client/web/src/user/settings/auth/__snapshots__/ExternalAccount.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ExternalAccountConnectionDetails renders correctly when display name is
   test@sourcegraph.com (
   <a
     class=""
-    href="https://github.com/test"
+    href="https://example.com"
     rel="noopener noreferrer"
     target="_blank"
   >

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -2033,7 +2033,10 @@ func GetPublicExternalAccountData(ctx context.Context, data *extsvc.AccountData)
 	return &extsvc.PublicAccountData{
 		DisplayName: d.Name,
 		Login:       d.Login,
-		URL:         d.URL,
+
+		// Github returns the API url as URL, so to ensure the link to the user's profile
+		// is correct, we substitute this for the HTMLURL which is the correct profile url.
+		URL: d.HTMLURL,
 	}, nil
 }
 


### PR DESCRIPTION
[Slack Thread](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1693616116217119)

The profile link for GitHub external account links to the API view for a user's profile instead of the actual link. This is fixed as I updated the component to concatenate the user's login with `https://github.com/`.

I considered changing this from the backend so the URL points to the actual user page; however, that information comes from GitHub, and it makes sense that we don't change it in the database as it'll affect old accounts also.

![CleanShot 2023-09-04 at 09 33 31](https://github.com/sourcegraph/sourcegraph/assets/25608335/0fe210c0-9fe3-495d-b9c1-d340ba9f3468)

## Test plan

* Snapshot update
* Manually tested