### PR TITLE
release: update token used for backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: sourcegraph/backport@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR changes the GitHub PAT used for backport operations from the default one provided by GitHub to a custom one. This is to enable the backport action to tag the release guild on backport PRs.

[Context](https://sourcegraph.slack.com/archives/C032Z79NZQC/p1692989033762689)

The token is associated with the release bot on GitHub.

## Test plan

The way to test this is with a backport PR after this is merged. I'll share a message on #discuss-release-guild channel about this though.

