### PR TITLE
JetBrains: Cody: Removing autocomplete when esc pressed using IdeaVIM plugin

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.java
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.autocomplete;
 
+import static com.sourcegraph.common.EditorUtils.VIM_EXIT_INSERT_MODE_ACTION;
+
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.editor.Caret;
@@ -25,6 +27,7 @@ import com.sourcegraph.cody.vscode.InlineAutocompleteTriggerKind;
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind;
 import com.sourcegraph.config.ConfigUtil;
 import java.util.List;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,6 +65,10 @@ public class CodyEditorFactoryListener implements EditorFactoryListener {
     @Override
     public void caretPositionChanged(@NotNull CaretEvent e) {
       if (!ConfigUtil.isCodyEnabled()) {
+        return;
+      }
+      String commandName = CommandProcessor.getInstance().getCurrentCommandName();
+      if (Objects.equals(commandName, VIM_EXIT_INSERT_MODE_ACTION)) {
         return;
       }
       informAgentAboutEditorChange(e.getEditor());

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/EditorUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/EditorUtils.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class EditorUtils {
 
+  public static final String VIM_EXIT_INSERT_MODE_ACTION = "VimInsertExitModeAction";
+
   /**
    * Returns a new String, using the given indentation settings to determine the tab size.
    *

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/editor/CommandListener.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/editor/CommandListener.kt
@@ -1,0 +1,18 @@
+package com.sourcegraph.cody.editor
+
+import com.intellij.openapi.command.CommandEvent
+import com.intellij.openapi.command.CommandListener
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
+import com.sourcegraph.common.EditorUtils.VIM_EXIT_INSERT_MODE_ACTION
+
+class CodyCommandListener(val project: Project) : CommandListener {
+    override fun commandFinished(event: CommandEvent) {
+        if (event.commandName.isNullOrBlank() || event.commandName.equals(VIM_EXIT_INSERT_MODE_ACTION))  {
+            val fileEditorManager = FileEditorManager.getInstance(this.project)
+            fileEditorManager.selectedTextEditor?.let { CodyAutocompleteManager.getInstance().disposeInlays(it) }
+        }
+    }
+
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -203,4 +203,9 @@
             <reference ref="cody.disableCodyAutocomplete"/>
         </group>
     </actions>
+
+    <projectListeners>
+    <listener topic="com.intellij.openapi.command.CommandListener"
+              class="com.sourcegraph.cody.editor.CodyCommandListener"/>
+    </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
It fixes #56051 


## Test plan

* Make sure that IdeaVIM plugin is installed
* Enter insert mode
* Trigger autocompletion
* Press escape
* Normal mode is active and autocompletion removed


https://github.com/sourcegraph/sourcegraph/assets/9321940/3604e15d-9948-40a4-a196-3280c580df79


