### PR TITLE
search-blitz: adjust megarepo queries

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -83,8 +83,9 @@ repo:^github\.com/sgtest/megarepo$ patterntype:regexp se[arc]{3}hZoekt rev:main
 # mono_structural_small
 repo:^github\.com/sgtest/megarepo$ patterntype:structural strings.ToUpper(...)
 
-# mono_rev_structural_small
-repo:^github\.com/sgtest/megarepo$ patterntype:structural strings.ToUpper(...) rev:main
+## we have disabled this test because it was just too slow.
+## mono_rev_structural_small
+## repo:^github\.com/sgtest/megarepo$ patterntype:structural strings.ToUpper(...) rev:main
 
 # mono_symbol_small
 repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion
@@ -92,11 +93,15 @@ repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion
 # mono_rev_symbol_small
 repo:^github\.com/sgtest/megarepo$ type:symbol IndexFormatVersion rev:main
 
+## for diff and commit search we limit the count. We are more interested in
+## time to first result. This depends on Camden remaining productive, so we
+## should be safe :P
+
 # mono_diff_small
-repo:^github\.com/sgtest/megarepo$ type:diff   author:camden before:"february 1 2021"
+repo:^github\.com/sgtest/megarepo$ type:diff   author:camden after:"february 1 2021" count:10
 
 # mono_commit_small
-repo:^github\.com/sgtest/megarepo$ type:commit author:camden before:"february 1 2021"
+repo:^github\.com/sgtest/megarepo$ type:commit author:camden after:"february 1 2021" count:10
 
 # mono_literal_small
 repo:^github\.com/sgtest/megarepo$ patterntype:literal --exclude-task=test


### PR DESCRIPTION
Our opsgenie alert keeps triggering and the root cause seems to be that these queries are just far too slow. Here are the decisions made:

- Disable structural queries on a commit. I don't know why this is slow but it honestly isn't worth an opsgenie alert.
- diff and commit look for recent commits. Over time this has gotten slower and slower thanks to feb 1 2021 getting further away.

Test Plan: go test then will deploy