### PR TITLE
search jobs: implement exhaustiveSearchRepoHandler

### DIFF
--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // newExhaustiveSearchRepoWorker creates a background routine that periodically runs the exhaustive search of a repo.
@@ -22,11 +22,13 @@ func newExhaustiveSearchRepoWorker(
 	observationCtx *observation.Context,
 	workerStore dbworkerstore.Store[*types.ExhaustiveSearchRepoJob],
 	exhaustiveSearchStore *store.Store,
+	newSearcher service.NewSearcher,
 	config config,
 ) goroutine.BackgroundRoutine {
 	handler := &exhaustiveSearchRepoHandler{
-		logger: log.Scoped("exhaustive-search-repo", "The background worker running exhaustive searches on a repository"),
-		store:  exhaustiveSearchStore,
+		logger:      log.Scoped("exhaustive-search-repo", "The background worker running exhaustive searches on a repository"),
+		store:       exhaustiveSearchStore,
+		newSearcher: newSearcher,
 	}
 
 	opts := workerutil.WorkerOptions{
@@ -42,13 +44,49 @@ func newExhaustiveSearchRepoWorker(
 }
 
 type exhaustiveSearchRepoHandler struct {
-	logger log.Logger
-	store  *store.Store
+	logger      log.Logger
+	store       *store.Store
+	newSearcher service.NewSearcher
 }
 
 var _ workerutil.Handler[*types.ExhaustiveSearchRepoJob] = &exhaustiveSearchRepoHandler{}
 
 func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Logger, record *types.ExhaustiveSearchRepoJob) error {
-	// TODO at the moment this does nothing. This will be implemented in a future PR.
-	return errors.New("not implemented")
+	repoRevSpec := service.RepositoryRevSpec{
+		Repository:        record.RepoID,
+		RevisionSpecifier: record.RefSpec,
+	}
+
+	parent, err := h.store.GetExhaustiveSearchJob(ctx, record.SearchJobID)
+	if err != nil {
+		return err
+	}
+
+	q, err := h.newSearcher.NewSearch(ctx, parent.Query)
+	if err != nil {
+		return err
+	}
+
+	repoRevisions, err := q.ResolveRepositoryRevSpec(ctx, repoRevSpec)
+	if err != nil {
+		return err
+	}
+
+	tx, err := h.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	for _, repoRev := range repoRevisions {
+		_, err := tx.CreateExhaustiveSearchRepoRevisionJob(ctx, types.ExhaustiveSearchRepoRevisionJob{
+			SearchRepoJobID: record.ID,
+			Revision:        repoRev.Revision,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/enterprise/cmd/worker/internal/search/job.go
+++ b/enterprise/cmd/worker/internal/search/job.go
@@ -88,7 +88,7 @@ func (j *searchJob) Routines(_ context.Context, observationCtx *observation.Cont
 
 		j.workers = []goroutine.BackgroundRoutine{
 			newExhaustiveSearchWorker(workCtx, observationCtx, searchWorkerStore, exhaustiveSearchStore, newSearcher, j.config),
-			newExhaustiveSearchRepoWorker(workCtx, observationCtx, repoWorkerStore, exhaustiveSearchStore, j.config),
+			newExhaustiveSearchRepoWorker(workCtx, observationCtx, repoWorkerStore, exhaustiveSearchStore, newSearcher, j.config),
 			newExhaustiveSearchRepoRevisionWorker(workCtx, observationCtx, revWorkerStore, exhaustiveSearchStore, j.config),
 		}
 	})


### PR DESCRIPTION
This implements the handler of the second worker of the seach jobs processing chain.

Test plan:
- Updated unit test
- I ran the following query locally

```
mutation {
  createSearchJob(query:"1@rev1 1@rev2 2@rev3") {
    id
  }
}
```

and verified the contents of `exhaustive_search_jobs`, `exhaustive_search_repo_jobs` and `exhaustive_search_repo_revision_jobs`.
