### PR TITLE
docs: add gcp private code host support

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -101,46 +101,26 @@ If the output is empty, you don't have to do anything. If the output is not empt
 ### Multiple region availability
 
 Sourcegraph Cloud instances are deployed in one of Google Cloud Platform data center locations:
-- North America (USA)
-- Europe (UK or Germany)
-- Asia (Japan)
-- Australia
+
+- North America (USA) - `us-central1`
+- Europe (UK or Germany) - `europe-west2` or `europe-west3`
+- Asia (Japan) - `asia-northeast1`
+- Australia - `australia-southeast1`
+
+If you have specific requirements for the region, please reach out to your Sourcegraph account team.
 
 More details about the locations and data storage can be found in [our handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/multi-region/)
 
 ### Private Code Host support
 
-Private Code Hosts refer to code hosts that are not publicly accessible, such as a GitHub or GitLab instance protected by a VPN.
+Public code hosts are supported by Sourcegraph Cloud out-of-the-box. They are either publically accessible or protected by IP-based firewall rules, Sourcegraph Cloud can provide static IP addresses for customers to add to their firewall allowlist. Please let your account team know.
 
-Sourcegraph Cloud connects to customer code hosts from Google Cloud Platform using NAT Gateway with 2 customer dedicated public NAT IPs. Customers can add the dedicated IPs for their Sourcegraph Cloud instance to an IP allowlist on their private code host.
+Private code hosts refer to code hosts that are not publicly accessible, such as self-hosted GitHub Enterprise servers or self-hosted GitLab instances deployed in a private network that are only accessible through VPN. Learn more about private code hosts support below:
 
-#### Code host on AWS without public access
-
-<aside class="experimental">
-<p>
-<span class="badge badge-experimental">Experimental</span> This feature is experimental
-</p>
-
-<p>Please contact Sourcegraph directly via <a href="https://about.sourcegraph.com/contact">prefered contact method</a> for more informations</p>
-</aside>
-
-As part of the [Enterprise tier](https://about.sourcegraph.com/pricing), Sourcegraph Cloud offers customers that have code hosts without public access deployed on AWS a [highly available site-to-site VPN solution](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws) with [AWS Private Link](https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html) inside AWS's network, so that access to a private code host never occurs over the public internet.
-
-Solution architecture:
-<img src="https://sourcegraphstatic.com/private-code-host-solution-vpn-aws-private-link.png" class="screenshot">
-
-Advantages of the site-to-site GCP to AWS VPN include:
-- encrypted connection between Sourcegraph Cloud and customer code host
-- multiple tunnels to provide high availability between Cloud
-instance and customer code host
-
-Advantages of AWS Private Link include:
-- connectivity to customer VPC is only available inside AWS network
--  ability to select AWS Principal (AWS Account or more granular) that can connect to customer code host
-- allows customer to control incoming connections
-- supports private DNS
-
-When a customer has private code hosts inside the AWS VPC and needs to expose it for Sourcegraph managed AWS VPC, customers can follow [AWS Documentation](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html)
+- [Code hosts on AWS without public access](./private_connectivity_aws.md)
+- [Code hosts on GCP without public access](./private_connectivity_gcp.md)
+- Code hosts on Azure is not supported yet, please reach out to your account manager if you are interested in this feature.
+- Code hosts on custom data center is not supported yet, please reach out to your account manager if you are interested in this feature.
 
 ### Health monitoring, support, and SLAs
 

--- a/doc/cloud/private_connectivity_aws.md
+++ b/doc/cloud/private_connectivity_aws.md
@@ -1,0 +1,27 @@
+# Code hosts on AWS without public access
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental
+</p>
+
+<p>Please contact Sourcegraph directly via <a href="https://about.sourcegraph.com/contact">prefered contact method</a> for more informations</p>
+</aside>
+
+As part of the [Enterprise tier](https://about.sourcegraph.com/pricing), Sourcegraph Cloud offers customers that have code hosts without public access deployed on AWS a [highly available site-to-site VPN solution](https://cloud.google.com/network-connectivity/docs/vpn/tutorials/create-ha-vpn-connections-google-cloud-aws) with [AWS Private Link](https://docs.aws.amazon.com/vpc/latest/privatelink/what-is-privatelink.html) inside AWS's network, so that access to a private code host never occurs over the public internet.
+
+Solution architecture:
+<img src="https://sourcegraphstatic.com/private-code-host-solution-vpn-aws-private-link.png" class="screenshot">
+
+Advantages of the site-to-site GCP to AWS VPN include:
+- encrypted connection between Sourcegraph Cloud and customer code host
+- multiple tunnels to provide high availability between Cloud
+instance and customer code host
+
+Advantages of AWS Private Link include:
+- connectivity to customer VPC is only available inside AWS network
+-  ability to select AWS Principal (AWS Account or more granular) that can connect to customer code host
+- allows customer to control incoming connections
+- supports private DNS
+
+When a customer has private code hosts inside the AWS VPC and needs to expose it for Sourcegraph managed AWS VPC, customers can follow [AWS Documentation](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html)

--- a/doc/cloud/private_connectivity_gcp.md
+++ b/doc/cloud/private_connectivity_gcp.md
@@ -1,0 +1,54 @@
+# Code hosts on GCP without public access
+
+<aside class="experimental">
+<p>
+<span class="badge badge-experimental">Experimental</span> This feature is experimental
+</p>
+
+<p>Please contact Sourcegraph directly via <a href="https://about.sourcegraph.com/contact">prefered contact method</a> for more informations</p>
+</aside>
+
+As part of the [Enterprise tier](https://about.sourcegraph.com/pricing), Sourcegraph Cloud supports connecting to customer code hosts on GCP using [GCP Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect). It creates a secure connection between customer GCP project and Sourcegraph Cloud instance, so that access to a private code host never occurs over the public internet.
+
+When a customer has private code hosts inside the GCP and needs to expose it for Sourcegraph Cloud instance, please reach out to your account manager to initiate the process.
+
+## How it works
+
+Sourcegraph supports connecting to private code hosts on GCP using GCP [Private Service Connect] (PSC). It is used to securely expose and connect services across the project boundary within GCP.
+
+The customer is the Service Producer (the "producer"), and the Sourcegraph Cloud instance is the Service Consumer (the "consumer"). PSC can expose an internal regional load balancer for the private code host to the consumer. The consumer can then connect to the private code host over PSC transparently on their Sourcegraph Cloud instance.
+
+<iframe src="https://link.excalidraw.com/readonly/Xiz9LWNPCa3DERBJUiZI" width="100%" height="100%" style="border: none;"></iframe>
+
+## Limitation
+
+Cross-region connectivity is not supported by Google Cloud for [Private Service Connect]. The Sourcegraph Cloud instance and the customer code host must be in the same region, learn more from our [supported regions](../index.md#multiple-region-availability).
+
+## Steps
+
+### Initiate the process
+
+Customer should reach out to their account manager to initiate the process. The account manager will work with the customer to collect the required information and initiate the process, including but not limited to:
+
+- The DNS name of the private code host, e.g., `gitlab.internal.company.net`.
+- The region of the private code host on GCP, e.g., `us-central1`.
+- The type of the TLS certificate used by the private code host, one of self-signed by internal private CA, or issued by a public CA.
+- The location of where the TLS connection is terminated, one of the load balancer, or the private code host node.
+
+Finally, Sourcegraph will provide the following:
+
+- A reference architecture in Terraform to demonstrate the setup on customer end.
+- The GCP Project ID of the Sourcegraph Cloud instance.
+
+### Create Private Serivce Connect connection
+
+Customer should publish their services using PSC by follow [GCP documentation](https://cloud.google.com/vpc/docs/configure-private-service-connect-producer). The customer needs to [permit connection](https://cloud.google.com/vpc/docs/manage-private-service-connect-services#access) from the provided GCP Project ID earlier. The customer needs to provide the [Service Attachment] uri to Sourcegraph. The Service Attachment uri is in the format of `projects/:id/regions/:region/serviceAttachments/:name`. 
+
+Upon receiving the Service Attachment uri, Sourcegraph will create a connection to the customer service using PSC and Sourcegraph will follow up with the customer to confirm the connection is established.
+
+### Create the code host connection
+
+Once the connection is established, the customer can create the [code host connection](../../admin/external_service/index.md) on their Sourcegraph Cloud instance.
+
+[private service connect]: https://cloud.google.com/vpc/docs/private-service-connect
+[service attachment]: https://cloud.google.com/vpc/docs/private-service-connect#service-attachments


### PR DESCRIPTION
also updated the comparision between private code hosts and public code hosts to get the terminology straight to avoid confusion

## Test plan

```sh
sg run docsite 
```

visit http://localhost:5080/cloud#private-code-host-support