### PR TITLE
bumped trufflehog version to v3.54.3

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Install TruffleHog
         run: |
-          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz -o trufflehog.tar.gz
+          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz -O trufflehog.tar.gz
           sudo tar xzf trufflehog.tar.gz --directory=/usr/local/bin/ trufflehog
 
       - name: Run TruffleHog

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install TruffleHog
         run: |
           wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz -o trufflehog.tar.gz
-          sudo tar xzf trufflehog_3.54.3_linux_amd64.tar.gz --directory=/usr/local/bin/ trufflehog
+          sudo tar xzf trufflehog.tar.gz --directory=/usr/local/bin/ trufflehog
 
       - name: Run TruffleHog
         id: scan

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,8 +11,8 @@ jobs:
 
       - name: Install TruffleHog
         run: |
-          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.1/trufflehog_3.54.1_linux_amd64.tar.gz
-          sudo tar xzf trufflehog_3.54.1_linux_amd64.tar.gz --directory=/usr/local/bin/ trufflehog
+          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz
+          sudo tar xzf trufflehog_3.54.3_linux_amd64.tar.gz --directory=/usr/local/bin/ trufflehog
 
       - name: Run TruffleHog
         id: scan

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Install TruffleHog
         run: |
-          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz
+          wget -q https://github.com/trufflesecurity/trufflehog/releases/download/v3.54.3/trufflehog_3.54.3_linux_amd64.tar.gz -o trufflehog.tar.gz
           sudo tar xzf trufflehog_3.54.3_linux_amd64.tar.gz --directory=/usr/local/bin/ trufflehog
 
       - name: Run TruffleHog


### PR DESCRIPTION
Bumping Trufflehog version o v3.54.3 to include my changes from https://github.com/trufflesecurity/trufflehog/pull/1742

## Test plan

CI 🟢  with trufflehog action 🟢 



