### PR TITLE
search jobs: implement exhaustiveSearchRepoRevHandler

### DIFF
--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//internal/workerutil",
         "//internal/workerutil/dbworker",
         "//internal/workerutil/dbworker/store",
-        "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],
 )
@@ -44,6 +43,7 @@ go_test(
         "//internal/database/basestore",
         "//internal/database/dbtest",
         "//internal/observation",
+        "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
         "@com_github_keegancsmith_sqlf//:sqlf",

--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//internal/database/basestore",
         "//internal/database/dbtest",
         "//internal/observation",
-        "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
         "@com_github_keegancsmith_sqlf//:sqlf",

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -52,7 +52,7 @@ type exhaustiveSearchRepoHandler struct {
 var _ workerutil.Handler[*types.ExhaustiveSearchRepoJob] = &exhaustiveSearchRepoHandler{}
 
 func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Logger, record *types.ExhaustiveSearchRepoJob) error {
-	repoRevSpec := service.RepositoryRevSpec{
+	repoRevSpec := types.RepositoryRevSpec{
 		Repository:        record.RepoID,
 		RevisionSpecifier: record.RefSpec,
 	}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -48,7 +48,6 @@ type exhaustiveSearchRepoRevHandler struct {
 	logger      log.Logger
 	store       *store.Store
 	newSearcher service.NewSearcher
-	csvWriter   service.CSVWriter
 }
 
 var _ workerutil.Handler[*types.ExhaustiveSearchRepoRevisionJob] = &exhaustiveSearchRepoRevHandler{}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -55,7 +55,6 @@ type exhaustiveSearchRepoRevHandler struct {
 var _ workerutil.Handler[*types.ExhaustiveSearchRepoRevisionJob] = &exhaustiveSearchRepoRevHandler{}
 
 func (h *exhaustiveSearchRepoRevHandler) Handle(ctx context.Context, logger log.Logger, record *types.ExhaustiveSearchRepoRevisionJob) error {
-	// TODO (stefan): why do we need the full RepositoryRevision for q.Search? Can we get rid of revSpec?
 	query, repoRev, err := h.store.GetQueryRepoRev(ctx, record)
 	if err != nil {
 		return err

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 )
@@ -57,8 +56,8 @@ func TestExhaustiveSearch(t *testing.T) {
 		},
 	}
 
-	csvBuf := &bytes.Buffer{}
-	routines, err := searchJob.routines(ctx, observationCtx, service.NewSearcherFake(), service.NewCSVWriterFake(csvBuf))
+	csvBuf = &bytes.Buffer{}
+	routines, err := searchJob.Routines(ctx, observationCtx)
 	require.NoError(err)
 	for _, routine := range routines {
 		go routine.Start()
@@ -124,7 +123,7 @@ func TestExhaustiveSearch(t *testing.T) {
 			"repo,revspec,revision",
 			"2,spec,rev3",
 		},
-	}, parseCSV(csvBuf.String()))
+	}, parseCSV(csvBuf.(*bytes.Buffer).String()))
 }
 
 func parseCSV(csv string) (o [][]string) {

--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/actor",
-        "//internal/api",
         "//internal/metrics",
         "//internal/observation",
         "//internal/search/exhaustive/store",

--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+	"encoding/csv"
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -24,47 +26,6 @@ type NewSearcher interface {
 	// Sourcegraph what is returned could change. This means we are not exactly
 	// safe across repeated calls.
 	NewSearch(ctx context.Context, q string) (SearchQuery, error)
-}
-
-// RepositoryRevSpec represents zero or more revisions we need to search in a
-// repository for a revision specifier. This can be inferred relatively
-// cheaply from parsing a query and the repos table.
-//
-// This type needs to be serializable so that we can persist it to a database
-// or queue.
-//
-// Note: this is like a search/repos.RepoRevSpecs except we store 1 revision
-// specifier per repository. It may be worth updating this to instead store a
-// slice of RevisionSpecifiers.
-type RepositoryRevSpec struct {
-	// Repository is the repository to search.
-	Repository api.RepoID
-
-	// RevisionSpecifier is something that still needs to be resolved on gitserver. This
-	// is a serialiazed version of query.RevisionSpecifier.
-	RevisionSpecifier string
-}
-
-func (r RepositoryRevSpec) String() string {
-	return fmt.Sprintf("RepositoryRevSpec{%d@%s}", r.Repository, r.RevisionSpecifier)
-}
-
-// RepositoryRevision represents the smallest unit we can search over, a
-// specific repository and revision.
-//
-// This type needs to be serializable so that we can persist it to a database
-// or queue.
-type RepositoryRevision struct {
-	// RepositoryRevSpec is where this RepositoryRevision got resolved from.
-	RepositoryRevSpec
-
-	// Revision is a resolved revision specifier. eg HEAD, branch-name,
-	// commit-hash, etc.
-	Revision string
-}
-
-func (r RepositoryRevision) String() string {
-	return fmt.Sprintf("RepositoryRevision{%d@%s}", r.Repository, r.Revision)
 }
 
 // SearchQuery represents a search in a way we can break up the work. The flow is
@@ -100,11 +61,11 @@ func (r RepositoryRevision) String() string {
 // a SearchQuery, but this makes it harder to make changes to search going
 // forward for what should be rare errors.
 type SearchQuery interface {
-	RepositoryRevSpecs(context.Context) ([]RepositoryRevSpec, error)
+	RepositoryRevSpecs(context.Context) ([]types.RepositoryRevSpec, error)
 
-	ResolveRepositoryRevSpec(context.Context, RepositoryRevSpec) ([]RepositoryRevision, error)
+	ResolveRepositoryRevSpec(context.Context, types.RepositoryRevSpec) ([]types.RepositoryRevision, error)
 
-	Search(context.Context, RepositoryRevision, CSVWriter) error
+	Search(context.Context, types.RepositoryRevision, CSVWriter) error
 }
 
 // CSVWriter makes it so we can avoid caring about search types and leave it
@@ -120,6 +81,34 @@ type CSVWriter interface {
 	// WriteRow should have the same number of values as WriteHeader and can be
 	// called zero or more times.
 	WriteRow(...string) error
+}
+
+func NewCSVWriterFake(w io.Writer) CSVWriter {
+	return CSVWriterFake{
+		w: csv.NewWriter(w),
+	}
+}
+
+type CSVWriterFake struct {
+	w *csv.Writer
+}
+
+func (c CSVWriterFake) writeAndFlush(s []string) error {
+	err := c.w.Write(s)
+	if err != nil {
+		return err
+	}
+	c.w.Flush()
+	return c.w.Error()
+}
+
+func (c CSVWriterFake) WriteHeader(s ...string) error {
+	return c.writeAndFlush(s)
+}
+
+func (c CSVWriterFake) WriteRow(s ...string) error {
+	return c.writeAndFlush(s)
+
 }
 
 // NewSearcherFake is a convenient working implementation of SearchQuery which
@@ -140,9 +129,9 @@ func NewSearcherFake() NewSearcher {
 type backendFake struct{}
 
 func (backendFake) NewSearch(ctx context.Context, q string) (SearchQuery, error) {
-	var repoRevs []RepositoryRevision
+	var repoRevs []types.RepositoryRevision
 	for _, part := range strings.Fields(q) {
-		var r RepositoryRevision
+		var r types.RepositoryRevision
 		if n, err := fmt.Sscanf(part, "%d@%s", &r.Repository, &r.Revision); n != 2 || err != nil {
 			return nil, errors.Errorf("failed to parse repository revision %q", part)
 		}
@@ -154,12 +143,12 @@ func (backendFake) NewSearch(ctx context.Context, q string) (SearchQuery, error)
 }
 
 type searcherFake struct {
-	repoRevs []RepositoryRevision
+	repoRevs []types.RepositoryRevision
 }
 
-func (s searcherFake) RepositoryRevSpecs(context.Context) ([]RepositoryRevSpec, error) {
-	seen := map[RepositoryRevSpec]bool{}
-	var repoRevSpecs []RepositoryRevSpec
+func (s searcherFake) RepositoryRevSpecs(context.Context) ([]types.RepositoryRevSpec, error) {
+	seen := map[types.RepositoryRevSpec]bool{}
+	var repoRevSpecs []types.RepositoryRevSpec
 	for _, r := range s.repoRevs {
 		if seen[r.RepositoryRevSpec] {
 			continue
@@ -170,8 +159,8 @@ func (s searcherFake) RepositoryRevSpecs(context.Context) ([]RepositoryRevSpec, 
 	return repoRevSpecs, nil
 }
 
-func (s searcherFake) ResolveRepositoryRevSpec(_ context.Context, repoRevSpec RepositoryRevSpec) ([]RepositoryRevision, error) {
-	var repoRevs []RepositoryRevision
+func (s searcherFake) ResolveRepositoryRevSpec(_ context.Context, repoRevSpec types.RepositoryRevSpec) ([]types.RepositoryRevision, error) {
+	var repoRevs []types.RepositoryRevision
 	for _, r := range s.repoRevs {
 		if r.RepositoryRevSpec == repoRevSpec {
 			repoRevs = append(repoRevs, r)
@@ -180,7 +169,7 @@ func (s searcherFake) ResolveRepositoryRevSpec(_ context.Context, repoRevSpec Re
 	return repoRevs, nil
 }
 
-func (s searcherFake) Search(_ context.Context, r RepositoryRevision, w CSVWriter) error {
+func (s searcherFake) Search(_ context.Context, r types.RepositoryRevision, w CSVWriter) error {
 	if err := w.WriteHeader("repo", "revspec", "revision"); err != nil {
 		return err
 	}

--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -84,16 +84,16 @@ type CSVWriter interface {
 }
 
 func NewCSVWriterFake(w io.Writer) CSVWriter {
-	return CSVWriterFake{
+	return csvWriterFake{
 		w: csv.NewWriter(w),
 	}
 }
 
-type CSVWriterFake struct {
+type csvWriterFake struct {
 	w *csv.Writer
 }
 
-func (c CSVWriterFake) writeAndFlush(s []string) error {
+func (c csvWriterFake) writeAndFlush(s []string) error {
 	err := c.w.Write(s)
 	if err != nil {
 		return err
@@ -102,11 +102,11 @@ func (c CSVWriterFake) writeAndFlush(s []string) error {
 	return c.w.Error()
 }
 
-func (c CSVWriterFake) WriteHeader(s ...string) error {
+func (c csvWriterFake) WriteHeader(s ...string) error {
 	return c.writeAndFlush(s)
 }
 
-func (c CSVWriterFake) WriteRow(s ...string) error {
+func (c csvWriterFake) WriteRow(s ...string) error {
 	return c.writeAndFlush(s)
 
 }

--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -90,7 +90,8 @@ func NewCSVWriterFake(w io.Writer) CSVWriter {
 }
 
 type csvWriterFake struct {
-	w *csv.Writer
+	header []string
+	w      *csv.Writer
 }
 
 func (c csvWriterFake) writeAndFlush(s []string) error {
@@ -103,6 +104,21 @@ func (c csvWriterFake) writeAndFlush(s []string) error {
 }
 
 func (c csvWriterFake) WriteHeader(s ...string) error {
+	// assert the header hasn't changed since the first call
+	if c.header == nil {
+		// first call to WriteHeader
+		c.header = s
+	} else {
+		if len(c.header) != len(s) {
+			return errors.Errorf("header mismatch: %v != %v", c.header, s)
+		}
+		for i := range c.header {
+			if c.header[i] != s[i] {
+				return errors.Errorf("header mismatch: %v != %v", c.header, s)
+			}
+		}
+	}
+
 	return c.writeAndFlush(s)
 }
 

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -6,13 +6,14 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // New returns a Service.

--- a/internal/search/exhaustive/types/BUILD.bazel
+++ b/internal/search/exhaustive/types/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "types",
     srcs = [
+        "exhaustive_search.go",
         "exhaustive_search_job.go",
         "exhaustive_search_repo_job.go",
         "exhaustive_search_repo_revision_job.go",

--- a/internal/search/exhaustive/types/exhaustive_search.go
+++ b/internal/search/exhaustive/types/exhaustive_search.go
@@ -1,0 +1,48 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+// RepositoryRevSpec represents zero or more revisions we need to search in a
+// repository for a revision specifier. This can be inferred relatively
+// cheaply from parsing a query and the repos table.
+//
+// This type needs to be serializable so that we can persist it to a database
+// or queue.
+//
+// Note: this is like a search/repos.RepoRevSpecs except we store 1 revision
+// specifier per repository. It may be worth updating this to instead store a
+// slice of RevisionSpecifiers.
+type RepositoryRevSpec struct {
+	// Repository is the repository to search.
+	Repository api.RepoID
+
+	// RevisionSpecifier is something that still needs to be resolved on gitserver. This
+	// is a serialiazed version of query.RevisionSpecifier.
+	RevisionSpecifier string
+}
+
+func (r RepositoryRevSpec) String() string {
+	return fmt.Sprintf("RepositoryRevSpec{%d@%s}", r.Repository, r.RevisionSpecifier)
+}
+
+// RepositoryRevision represents the smallest unit we can search over, a
+// specific repository and revision.
+//
+// This type needs to be serializable so that we can persist it to a database
+// or queue.
+type RepositoryRevision struct {
+	// RepositoryRevSpec is where this RepositoryRevision got resolved from.
+	RepositoryRevSpec
+
+	// Revision is a resolved revision specifier. eg HEAD, branch-name,
+	// commit-hash, etc.
+	Revision string
+}
+
+func (r RepositoryRevision) String() string {
+	return fmt.Sprintf("RepositoryRevision{%d@%s}", r.Repository, r.Revision)
+}


### PR DESCRIPTION
This implements the worker that runs the user's query against 1 repo@rev.  For now we use a fake CSVWriter IE results are not yet persisted to a blobstore.

Test plan:
- updated unit test
