### PR TITLE
search jobs: implement Resolver.CancelSearchJob

### DIFF
--- a/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
@@ -35,7 +35,12 @@ func (r *Resolver) CreateSearchJob(ctx context.Context, args *graphqlbackend.Cre
 }
 
 func (r *Resolver) CancelSearchJob(ctx context.Context, args *graphqlbackend.CancelSearchJobArgs) (*graphqlbackend.EmptyResponse, error) {
-	return nil, errors.New("not implemented")
+	jobID, err := unmarshalSearchJobID(args.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, r.svc.CancelSearchJob(ctx, jobID)
 }
 
 func (r *Resolver) DeleteSearchJob(ctx context.Context, args *graphqlbackend.DeleteSearchJobArgs) (*graphqlbackend.EmptyResponse, error) {

--- a/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
@@ -35,7 +35,7 @@ func (r *Resolver) CreateSearchJob(ctx context.Context, args *graphqlbackend.Cre
 }
 
 func (r *Resolver) CancelSearchJob(ctx context.Context, args *graphqlbackend.CancelSearchJobArgs) (*graphqlbackend.EmptyResponse, error) {
-	jobID, err := unmarshalSearchJobID(args.ID)
+	jobID, err := UnmarshalSearchJobID(args.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -116,6 +116,16 @@ func TestExhaustiveSearch(t *testing.T) {
 		job2.WorkerJob = job.WorkerJob
 		require.Equal(job, job2)
 	}
+
+	// Assert that cancellation affects the number of rows we expect. This is a bit
+	// counterintuitive at this point because we have already completed the job.
+	// However, cancellation affects the rows independently of the job state.
+	{
+		wantCount := 6
+		gotCount, err := store.CancelSearchJob(userCtx, job.ID)
+		require.NoError(err)
+		require.Equal(wantCount, gotCount)
+	}
 }
 
 func parseCSV(csv string) (o [][]string) {

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -110,6 +110,17 @@ func (s *Service) CreateSearchJob(ctx context.Context, query string) (_ *types.E
 	return tx.GetExhaustiveSearchJob(ctx, jobID)
 }
 
+func (s *Service) CancelSearchJob(ctx context.Context, id int64) error {
+	tx, err := s.store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	_, err = tx.CancelSearchJob(ctx, id)
+	return err
+}
+
 func (s *Service) GetSearchJob(ctx context.Context, id int64) (_ *types.ExhaustiveSearchJob, err error) {
 	ctx, _, endObservation := s.operations.getSearchJob.With(ctx, &err, opAttrs(
 		attribute.Int64("id", id),

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -118,11 +118,6 @@ func (s *Service) CancelSearchJob(ctx context.Context, id int64) (err error) {
 	))
 	defer endObservation(1, observation.Args{})
 
-	actor := actor.FromContext(ctx)
-	if !actor.IsAuthenticated() {
-		return errors.New("search jobs can only be canceled by an authenticated user")
-	}
-
 	tx, err := s.store.Transact(ctx)
 	if err != nil {
 		return err

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -100,13 +100,9 @@ func (s *Store) CancelSearchJob(ctx context.Context, jobID int64) (int, error) {
 	row := s.QueryRow(ctx, q)
 
 	var totalCanceled int
-	row.Scan(&totalCanceled)
-	if row.Err() != nil {
-		return -1, row.Err()
-	}
-
-	if totalCanceled == 0 {
-		return 0, errors.Newf("could not find cancellable search job: jobID=%d", jobID)
+	err := row.Scan(&totalCanceled)
+	if err != nil {
+		return -1, err
 	}
 
 	return totalCanceled, nil

--- a/internal/search/exhaustive/store/store.go
+++ b/internal/search/exhaustive/store/store.go
@@ -60,6 +60,7 @@ func opAttrs(attrs ...attribute.KeyValue) observation.Args {
 
 type operations struct {
 	createExhaustiveSearchJob *observation.Operation
+	cancelSearchJob           *observation.Operation
 	getExhaustiveSearchJob    *observation.Operation
 	listExhaustiveSearchJobs  *observation.Operation
 
@@ -90,6 +91,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		createExhaustiveSearchJob: op("CreateExhaustiveSearchJob"),
+		cancelSearchJob:           op("CancelSearchJob"),
 		getExhaustiveSearchJob:    op("GetExhaustiveSearchJob"),
 		listExhaustiveSearchJobs:  op("ListExhaustiveSearchJobs"),
 


### PR DESCRIPTION
We cancel the search job and all jobs that derive from it.

Test plan:
- updated unit test
- locally tested with

```graphql
mutation create {
  createSearchJob(query: "1@rev1 1@rev2 2@rev3") {
    id
  }
}

mutation cancel  {
  cancelSearchJob(id: "<id>") {
    alwaysNil
  }
}
```