### PR TITLE
sveltekit: Fix error when rendering repo search results

### DIFF
--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -9,15 +9,14 @@
 
     import SearchResult from './SearchResult.svelte'
     import { Badge } from '$lib/wildcard'
-    import { getContext } from 'svelte'
-    import type { SearchResultsContext } from './SearchResults.svelte'
+    import { getSearchResultsContext } from './SearchResults.svelte'
     import { limitDescription, getMetadata, buildSearchURLQueryForMeta, simplifyLineRange } from '$lib/search/results'
     import { highlightRanges } from '$lib/dom'
 
     export let result: RepositoryMatch
 
     const enableRepositoryMetadata = featureFlag('repository-metadata')
-    const queryState = getContext<SearchResultsContext>('search-results').queryState
+    const queryState = getSearchResultsContext().queryState
 
     $: repoAtRevisionURL = getRepoMatchUrl(result)
     $: metadata = $enableRepositoryMetadata ? getMetadata(result) : []


### PR DESCRIPTION
PR #55542 added support for missing search results and refactored some code. Seems like I missed updating repo search results to use the new API.



## Test plan

- `pnpm dev`
- Open search page and search for `type:repo test`.
-> Search results are rendered without error