### PR TITLE
source: improvement to user management date selector

### DIFF
--- a/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
+++ b/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
@@ -91,7 +91,26 @@ export const DateRangeSelect: React.FunctionComponent<DateRangeSelectProps> = ({
     const handleClear = useCallback(() => {
         setRange(() => undefined)
         setIsNegated(false)
-    }, [])
+
+        // When the user clicks on clear, we set the value of `range` to undefined
+        // and close the popover.
+        onChange?.(undefined, false)
+        setIsOpen(false)
+    }, [onChange])
+
+    const isApplyButtonDisabled = useMemo(() => {
+        // `isNegated` is true when we want to display users that don't meet a condition within
+        // the specified date range.
+        // Negation doesn't require the `Apply` button to be disabled because when no date range
+        // is selected we assume a date range from the beginning of time till the current time.
+        if (isNegated) {
+            return false
+        }
+
+        // If `isNegated` is false, we only need to disable the button if it is required and there
+        // is no date range selected.
+        return isRequired && !range
+    }, [isRequired, range, isNegated])
 
     const { tooltip, label } = useMemo(() => {
         let tooltipText = ''
@@ -174,12 +193,7 @@ export const DateRangeSelect: React.FunctionComponent<DateRangeSelectProps> = ({
                             <Button size="sm" className="mr-2" variant="secondary" onClick={handleCancel}>
                                 Cancel
                             </Button>
-                            <Button
-                                size="sm"
-                                variant="primary"
-                                onClick={handleApply}
-                                disabled={isRequired && !range && isNegated}
-                            >
+                            <Button size="sm" variant="primary" onClick={handleApply} disabled={isApplyButtonDisabled}>
                                 Apply
                             </Button>
                         </div>

--- a/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
+++ b/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
@@ -97,20 +97,13 @@ export const DateRangeSelect: React.FunctionComponent<DateRangeSelectProps> = ({
         onChange?.(undefined, false)
         setIsOpen(false)
     }, [onChange])
-
-    const isApplyButtonDisabled = useMemo(() => {
-        // `isNegated` is true when we want to display users that don't meet a condition within
-        // the specified date range.
-        // Negation doesn't require the `Apply` button to be disabled because when no date range
-        // is selected we assume a date range from the beginning of time till the current time.
-        if (isNegated) {
-            return false
-        }
-
-        // If `isNegated` is false, we only need to disable the button if it is required and there
-        // is no date range selected.
-        return isRequired && !range
-    }, [isRequired, range, isNegated])
+    // `isNegated` is true when we want to display users that don't meet a condition within
+    // the specified date range.
+    // Negation doesn't require the `Apply` button to be disabled because when no date range
+    // is selected we assume a date range from the beginning of time till the current time.
+    // If `isNegated` is false, we only need to disable the button if it is required and there
+    // is no date range selected.
+    const isApplyButtonDisabled = isNegated ? false : isRequired && !range
 
     const { tooltip, label } = useMemo(() => {
         let tooltipText = ''

--- a/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
+++ b/client/web/src/site-admin/UserManagement/components/DateRangeSelect.tsx
@@ -97,6 +97,7 @@ export const DateRangeSelect: React.FunctionComponent<DateRangeSelectProps> = ({
         onChange?.(undefined, false)
         setIsOpen(false)
     }, [onChange])
+
     // `isNegated` is true when we want to display users that don't meet a condition within
     // the specified date range.
     // Negation doesn't require the `Apply` button to be disabled because when no date range


### PR DESCRIPTION
Closes [#56380](https://github.com/sourcegraph/sourcegraph/issues/56380)

This PR adds improvements to the date selector component used in user management (`site-admin/users`) page.

![image](https://github.com/sourcegraph/sourcegraph/assets/25608335/4ad91136-5f0b-4c59-a63f-7c681d2aad87)

1. When a user clicks the `Clear` button, they do not need to click the `Apply` button. The Clear action automatically resets the date range to `undefined` and the `isNegated` value to `false`.
2. The `Apply` button will be disabled when the date is required, `isNegated` is false and there's no date range selected.
3. The `Apply` button will be enabled when `isNegated` is true regardless of whether a date range is selected or not.
4. The `Apply` button will be enabled when `isNegated` is false, date is required and a date range is selected.
5. The `Apply` button will be disabled when a single date is selected.

## Test plan

* Confirm from the component storybook that component works as described above.
* Local testing

[Context](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1693616679797639)
[Walkthrough 1](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1693997017740229?thread_ts=1693616679.797639&cid=C05EMJM2SLR)
[Walkthrough 2](https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1694005906677019?thread_ts=1693616679.797639&cid=C05EMJM2SLR)