### PR TITLE
JetBrains: customize autocomplete color new branch

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -4,7 +4,10 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.impl.FontInfo;
 import com.intellij.openapi.editor.markup.TextAttributes;
-import java.awt.*;
+import com.sourcegraph.cody.autocomplete.InlayModelUtils;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.FontMetrics;
 import org.jetbrains.annotations.NotNull;
 
 public class AutocompleteRenderUtils {
@@ -32,10 +35,41 @@ public class AutocompleteRenderUtils {
     }
   }
 
-  public static TextAttributes getCustomTextAttributes(Integer fontColor) {
+  public static TextAttributes getCustomTextAttributes(
+      @NotNull Editor editor, @NotNull Integer fontColor) {
     Color color = new Color(fontColor);
-    TextAttributes attrs = new TextAttributes();
+    TextAttributes attrs = getTextAttributesForEditor(editor);
     attrs.setForegroundColor(color);
     return attrs;
+  }
+
+  public static void rerenderAllAutocompleteInlays(Editor editor) {
+    InlayModelUtils.getAllInlaysForEditor(editor).stream()
+        .filter(inlay -> inlay.getRenderer() instanceof CodyAutocompleteElementRenderer)
+        .forEach(
+            inlayAutocomplete -> {
+              CodyAutocompleteElementRenderer renderer =
+                  (CodyAutocompleteElementRenderer) inlayAutocomplete.getRenderer();
+              if (renderer instanceof CodyAutocompleteSingleLineRenderer) {
+                editor
+                    .getInlayModel()
+                    .addInlineElement(
+                        inlayAutocomplete.getOffset(),
+                        new CodyAutocompleteSingleLineRenderer(
+                            renderer.getText(),
+                            renderer.completionItem,
+                            editor,
+                            renderer.getType()));
+                inlayAutocomplete.dispose();
+              } else if (renderer instanceof CodyAutocompleteBlockElementRenderer) {
+                editor
+                    .getInlayModel()
+                    .addInlineElement(
+                        inlayAutocomplete.getOffset(),
+                        new CodyAutocompleteBlockElementRenderer(
+                            renderer.getText(), renderer.completionItem, editor));
+                inlayAutocomplete.dispose();
+              }
+            });
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -38,7 +38,7 @@ public class AutocompleteRenderUtils {
   public static TextAttributes getCustomTextAttributes(
       @NotNull Editor editor, @NotNull Integer fontColor) {
     Color color = new Color(fontColor);
-    TextAttributes attrs = getTextAttributesForEditor(editor);
+    TextAttributes attrs = getTextAttributesForEditor(editor).clone();
     attrs.setForegroundColor(color);
     return attrs;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -32,9 +32,10 @@ public class AutocompleteRenderUtils {
     }
   }
 
-  public static TextAttributes getCustomTextAttributes(Color fontColor) {
+  public static TextAttributes getCustomTextAttributes(Integer fontColor) {
+    Color color = new Color(fontColor);
     TextAttributes attrs = new TextAttributes();
-    attrs.setForegroundColor(fontColor);
+    attrs.setForegroundColor(color);
     return attrs;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -31,4 +31,10 @@ public class AutocompleteRenderUtils {
           .getAttributes(DefaultLanguageHighlighterColors.INLINE_PARAMETER_HINT);
     }
   }
+
+  public static TextAttributes getCustomTextAttributes(Color fontColor) {
+    TextAttributes attrs = new TextAttributes();
+    attrs.setForegroundColor(fontColor);
+    return attrs;
+  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
@@ -1,5 +1,8 @@
 package com.sourcegraph.cody.autocomplete.render;
 
+import static com.sourcegraph.config.ConfigUtil.getCustomAutocompleteColor;
+import static com.sourcegraph.config.ConfigUtil.isCustomAutocompleteColorEnabled;
+
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorCustomElementRenderer;
 import com.intellij.openapi.editor.Inlay;
@@ -26,7 +29,10 @@ public abstract class CodyAutocompleteElementRenderer implements EditorCustomEle
       @Nullable AutocompleteRendererType type) {
     this.text = text;
     this.completionItem = completionItem;
-    this.themeAttributes = AutocompleteRenderUtils.getTextAttributesForEditor(editor);
+    this.themeAttributes =
+        isCustomAutocompleteColorEnabled()
+            ? AutocompleteRenderUtils.getCustomTextAttributes(getCustomAutocompleteColor())
+            : AutocompleteRenderUtils.getTextAttributesForEditor(editor);
     this.editor = editor;
     this.type = type;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
@@ -31,7 +31,7 @@ public abstract class CodyAutocompleteElementRenderer implements EditorCustomEle
     this.completionItem = completionItem;
     this.themeAttributes =
         isCustomAutocompleteColorEnabled()
-            ? AutocompleteRenderUtils.getCustomTextAttributes(getCustomAutocompleteColor())
+            ? AutocompleteRenderUtils.getCustomTextAttributes(editor, getCustomAutocompleteColor())
             : AutocompleteRenderUtils.getTextAttributesForEditor(editor);
     this.editor = editor;
     this.type = type;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.annotations.Transient;
 import com.sourcegraph.find.Search;
+import java.awt.*;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +50,8 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable public Boolean authenticationFailedLastTime;
   @Nullable public Boolean isCodyDebugEnabled;
   @Nullable public Boolean isCodyVerboseDebugEnabled;
+  @Nullable public Boolean isCustomAutocompleteColorEnabled;
+  @Nullable public Color customAutocompleteColor;
 
   @Nullable
   public String
@@ -138,6 +141,14 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     return isAccessTokenNotificationDismissed;
   }
 
+  public boolean isCustomAutocompleteColorEnabled() {
+    return Optional.ofNullable(isCustomAutocompleteColorEnabled).orElse(false);
+  }
+
+  public Color getCustomAutocompleteColor() {
+    return Optional.ofNullable(customAutocompleteColor).orElse(Color.WHITE);
+  }
+
   @Nullable
   public Boolean getAuthenticationFailedLastTime() {
     return authenticationFailedLastTime;
@@ -178,5 +189,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     this.lastUpdateNotificationPluginVersion = settings.lastUpdateNotificationPluginVersion;
     this.isCodyDebugEnabled = settings.isCodyDebugEnabled;
     this.isCodyVerboseDebugEnabled = settings.isCodyVerboseDebugEnabled;
+    this.isCustomAutocompleteColorEnabled = settings.isCustomAutocompleteColorEnabled;
+    this.customAutocompleteColor = settings.getCustomAutocompleteColor();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -51,7 +51,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   @Nullable public Boolean isCodyDebugEnabled;
   @Nullable public Boolean isCodyVerboseDebugEnabled;
   @Nullable public Boolean isCustomAutocompleteColorEnabled;
-  @Nullable public Color customAutocompleteColor;
+  @Nullable public Integer customAutocompleteColor;
 
   @Nullable
   public String
@@ -145,8 +145,8 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     return Optional.ofNullable(isCustomAutocompleteColorEnabled).orElse(false);
   }
 
-  public Color getCustomAutocompleteColor() {
-    return Optional.ofNullable(customAutocompleteColor).orElse(Color.WHITE);
+  public Integer getCustomAutocompleteColor() {
+    return Optional.ofNullable(customAutocompleteColor).orElse(0);
   }
 
   @Nullable
@@ -190,6 +190,6 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     this.isCodyDebugEnabled = settings.isCodyDebugEnabled;
     this.isCodyVerboseDebugEnabled = settings.isCodyVerboseDebugEnabled;
     this.isCustomAutocompleteColorEnabled = settings.isCustomAutocompleteColorEnabled;
-    this.customAutocompleteColor = settings.getCustomAutocompleteColor();
+    this.customAutocompleteColor = settings.customAutocompleteColor;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -145,8 +145,9 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     return Optional.ofNullable(isCustomAutocompleteColorEnabled).orElse(false);
   }
 
+  @Nullable
   public Integer getCustomAutocompleteColor() {
-    return Optional.ofNullable(customAutocompleteColor).orElse(0);
+    return customAutocompleteColor;
   }
 
   @Nullable

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.agent.ExtensionConfiguration;
 import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.find.Search;
+import java.awt.Color;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -235,6 +236,14 @@ public class ConfigUtil {
 
   public static boolean isCodyAutocompleteEnabled() {
     return getApplicationLevelConfig().isCodyAutocompleteEnabled();
+  }
+
+  public static boolean isCustomAutocompleteColorEnabled() {
+    return getApplicationLevelConfig().isCustomAutocompleteColorEnabled();
+  }
+
+  public static Color getCustomAutocompleteColor() {
+    return getApplicationLevelConfig().getCustomAutocompleteColor();
   }
 
   public static boolean setCodyAutocompleteEnabled(boolean toggle) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -242,7 +242,7 @@ public class ConfigUtil {
     return getApplicationLevelConfig().isCustomAutocompleteColorEnabled();
   }
 
-  public static Color getCustomAutocompleteColor() {
+  public static Integer getCustomAutocompleteColor() {
     return getApplicationLevelConfig().getCustomAutocompleteColor();
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -3,16 +3,21 @@ package com.sourcegraph.config;
 import com.google.gson.JsonObject;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.sourcegraph.cody.agent.ExtensionConfiguration;
 import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.find.Search;
-import java.awt.Color;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -371,5 +376,14 @@ public class ConfigUtil {
       getApplicationLevelConfig().dotComAccessToken = null;
     }
     return unsafeApplicationLevelAccessToken != null ? unsafeApplicationLevelAccessToken : "";
+  }
+
+  public static List<Editor> getAllEditors() {
+    Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+    return Arrays.stream(openProjects)
+        .flatMap(project -> Arrays.stream(FileEditorManager.getInstance(project).getAllEditors()))
+        .filter(fileEditor -> fileEditor instanceof com.intellij.openapi.fileEditor.TextEditor)
+        .map(fileEditor -> ((com.intellij.openapi.fileEditor.TextEditor) fileEditor).getEditor())
+        .collect(Collectors.toList());
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.config;
 
+import java.awt.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,6 +20,8 @@ public class PluginSettingChangeContext {
   public final boolean newCodyAutocompleteEnabled;
   public final boolean newCodyDebugEnabled;
   public final boolean newCodyVerboseDebugEnabled;
+  public final boolean isCustomAutocompleteColorEnabled;
+  public final Color customAutocompleteColor;
 
   public PluginSettingChangeContext(
       boolean oldCodyEnabled,
@@ -33,7 +36,9 @@ public class PluginSettingChangeContext {
       boolean newCodyEnabled,
       boolean newCodyAutocompleteEnabled,
       boolean newCodyDebugEnabled,
-      boolean newCodyVerboseDebugEnabled) {
+      boolean newCodyVerboseDebugEnabled,
+      boolean isCustomAutocompleteColorEnabled,
+      @Nullable Color customAutocompleteColor) {
     this.oldCodyEnabled = oldCodyEnabled;
     this.oldCodyAutocompleteEnabled = oldCodyAutocompleteEnabled;
     this.oldUrl = oldUrl;
@@ -47,5 +52,7 @@ public class PluginSettingChangeContext {
     this.newCodyAutocompleteEnabled = newCodyAutocompleteEnabled;
     this.newCodyDebugEnabled = newCodyDebugEnabled;
     this.newCodyVerboseDebugEnabled = newCodyVerboseDebugEnabled;
+    this.isCustomAutocompleteColorEnabled = isCustomAutocompleteColorEnabled;
+    this.customAutocompleteColor = customAutocompleteColor;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -1,6 +1,5 @@
 package com.sourcegraph.config;
 
-import java.awt.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,6 +11,7 @@ public class PluginSettingChangeContext {
   public final boolean oldCodyVerboseDebugEnabled;
 
   @NotNull public final String newUrl;
+  public final Integer oldCustomAutocompleteColor;
   public final boolean isDotComAccessTokenChanged;
   public final boolean isEnterpriseAccessTokenChanged;
 
@@ -20,6 +20,7 @@ public class PluginSettingChangeContext {
   public final boolean newCodyAutocompleteEnabled;
   public final boolean newCodyDebugEnabled;
   public final boolean newCodyVerboseDebugEnabled;
+  public final boolean oldIsCustomAutocompleteColorEnabled;
   public final boolean isCustomAutocompleteColorEnabled;
   @Nullable public final Integer customAutocompleteColor;
 
@@ -29,6 +30,8 @@ public class PluginSettingChangeContext {
       @NotNull String oldUrl,
       boolean oldCodyDebugEnabled,
       boolean oldCodyVerboseDebugEnabled,
+      Integer oldCustomAutocompleteColor,
+      boolean oldIsCustomAutocompleteColorEnabled,
       @NotNull String newUrl,
       boolean isDotComAccessTokenChanged,
       boolean isEnterpriseAccessTokenChanged,
@@ -45,6 +48,7 @@ public class PluginSettingChangeContext {
     this.oldCodyDebugEnabled = oldCodyDebugEnabled;
     this.oldCodyVerboseDebugEnabled = oldCodyVerboseDebugEnabled;
     this.newUrl = newUrl;
+    this.oldCustomAutocompleteColor = oldCustomAutocompleteColor;
     this.isDotComAccessTokenChanged = isDotComAccessTokenChanged;
     this.isEnterpriseAccessTokenChanged = isEnterpriseAccessTokenChanged;
     this.newCustomRequestHeaders = newCustomRequestHeaders;
@@ -53,6 +57,7 @@ public class PluginSettingChangeContext {
     this.newCodyDebugEnabled = newCodyDebugEnabled;
     this.newCodyVerboseDebugEnabled = newCodyVerboseDebugEnabled;
     this.isCustomAutocompleteColorEnabled = isCustomAutocompleteColorEnabled;
+    this.oldIsCustomAutocompleteColorEnabled = oldIsCustomAutocompleteColorEnabled;
     this.customAutocompleteColor = customAutocompleteColor;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -21,7 +21,7 @@ public class PluginSettingChangeContext {
   public final boolean newCodyDebugEnabled;
   public final boolean newCodyVerboseDebugEnabled;
   public final boolean isCustomAutocompleteColorEnabled;
-  public final Color customAutocompleteColor;
+  @Nullable public final Integer customAutocompleteColor;
 
   public PluginSettingChangeContext(
       boolean oldCodyEnabled,
@@ -38,7 +38,7 @@ public class PluginSettingChangeContext {
       boolean newCodyDebugEnabled,
       boolean newCodyVerboseDebugEnabled,
       boolean isCustomAutocompleteColorEnabled,
-      @Nullable Color customAutocompleteColor) {
+      @Nullable Integer customAutocompleteColor) {
     this.oldCodyEnabled = oldCodyEnabled;
     this.oldCodyAutocompleteEnabled = oldCodyAutocompleteEnabled;
     this.oldUrl = oldUrl;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/PluginSettingChangeContext.java
@@ -11,7 +11,7 @@ public class PluginSettingChangeContext {
   public final boolean oldCodyVerboseDebugEnabled;
 
   @NotNull public final String newUrl;
-  public final Integer oldCustomAutocompleteColor;
+  @Nullable public final Integer oldCustomAutocompleteColor;
   public final boolean isDotComAccessTokenChanged;
   public final boolean isEnterpriseAccessTokenChanged;
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -6,7 +6,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComponentValidator;
 import com.intellij.openapi.ui.ValidationInfo;
-import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.*;
 import com.intellij.ui.components.ActionLink;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
@@ -19,6 +19,7 @@ import com.jetbrains.jsonSchema.settings.mappings.JsonSchemaConfigurable;
 import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.cody.ui.PasswordFieldWithShowHideButton;
 import com.sourcegraph.common.AuthorizationUtil;
+import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.Enumeration;
@@ -28,12 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import javax.swing.AbstractButton;
-import javax.swing.ButtonGroup;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.Document;
@@ -63,9 +59,12 @@ public class SettingsComponent implements Disposable {
   private JLabel runLocalAppComment;
   private JBCheckBox isCodyDebugEnabledCheckBox;
   private JBCheckBox isCodyVerboseDebugEnabledCheckBox;
+  private JBCheckBox isCustomAutocompleteColorEnabledCheckBox;
+  private ColorPanel customAutocompleteColorPanel;
 
   private final ScheduledExecutorService codyAppStateCheckerExecutorService =
       Executors.newSingleThreadScheduledExecutor();
+  private final int colorPanelWidth = 62;
 
   public JComponent getPreferredFocusedComponent() {
     return defaultBranchNameTextField;
@@ -472,6 +471,22 @@ public class SettingsComponent implements Disposable {
     isCodyVerboseDebugEnabledCheckBox.setSelected(value);
   }
 
+  public boolean isCustomAutocompleteColorEnabled() {
+    return isCustomAutocompleteColorEnabledCheckBox.isSelected();
+  }
+
+  public void setIsCustomAutocompleteColorEnabled(boolean value) {
+    isCustomAutocompleteColorEnabledCheckBox.setSelected(value);
+  }
+
+  public Color getCustomAutocompleteColorPanel() {
+    return customAutocompleteColorPanel.getSelectedColor();
+  }
+
+  public void setCustomAutocompleteColorPanel(Color value) {
+    customAutocompleteColorPanel.setSelectedColor(value);
+  }
+
   private void setInstanceSettingsEnabled(@NotNull InstanceType instanceType) {
     // enterprise stuff
     boolean isEnterprise = instanceType == InstanceType.ENTERPRISE;
@@ -606,6 +621,22 @@ public class SettingsComponent implements Disposable {
     isCodyAutocompleteEnabledCheckBox = new JBCheckBox("Enable Cody autocomplete");
     isCodyDebugEnabledCheckBox = new JBCheckBox("Enable debug");
     isCodyVerboseDebugEnabledCheckBox = new JBCheckBox("Verbose debug");
+
+    isCustomAutocompleteColorEnabledCheckBox = new JBCheckBox("Enable custom autocomplete color");
+
+    customAutocompleteColorPanel = new ColorPanel();
+    customAutocompleteColorPanel.setVisible(false);
+    isCustomAutocompleteColorEnabledCheckBox.addChangeListener(
+        e -> {
+          customAutocompleteColorPanel.setVisible(
+              isCustomAutocompleteColorEnabledCheckBox.isSelected());
+        });
+
+    JPanel customAutocompleteColorPanelWrapper = new JPanel(new FlowLayout(FlowLayout.LEFT));
+    customAutocompleteColorPanelWrapper.setBounds(
+        0, 0, colorPanelWidth, customAutocompleteColorPanel.getHeight());
+    customAutocompleteColorPanelWrapper.add(customAutocompleteColorPanel);
+
     JPanel codySettingsPanel =
         FormBuilder.createFormBuilder()
             .addComponent(isCodyEnabledCheckBox, 10)
@@ -615,6 +646,8 @@ public class SettingsComponent implements Disposable {
             .addComponent(isCodyDebugEnabledCheckBox)
             .addTooltip("Enables debug output visible in the idea.log")
             .addComponent(isCodyVerboseDebugEnabledCheckBox)
+            .addLabeledComponent(
+                isCustomAutocompleteColorEnabledCheckBox, customAutocompleteColorPanelWrapper)
             .getPanel();
     codySettingsPanel.setBorder(
         IdeBorderFactory.createTitledBorder("Cody AI", true, JBUI.insetsTop(8)));
@@ -630,6 +663,8 @@ public class SettingsComponent implements Disposable {
     isCodyAutocompleteEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
     isCodyDebugEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
     isCodyVerboseDebugEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
+    isCustomAutocompleteColorEnabledCheckBox.setEnabled(isCodyEnabledCheckBox.isSelected());
+    customAutocompleteColorPanel.setEnabled(isCodyEnabledCheckBox.isSelected());
   }
 
   @Override

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -23,6 +23,7 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -479,12 +480,14 @@ public class SettingsComponent implements Disposable {
     isCustomAutocompleteColorEnabledCheckBox.setSelected(value);
   }
 
-  public Color getCustomAutocompleteColorPanel() {
-    return customAutocompleteColorPanel.getSelectedColor();
+  public Integer getCustomAutocompleteColorPanel() {
+    Color selectedColor = customAutocompleteColorPanel.getSelectedColor();
+    return Objects.requireNonNull(selectedColor).getRGB();
   }
 
-  public void setCustomAutocompleteColorPanel(Color value) {
-    customAutocompleteColorPanel.setSelectedColor(value);
+  public void setCustomAutocompleteColorPanel(Integer value) {
+    Color c = new Color(value);
+    customAutocompleteColorPanel.setSelectedColor(c);
   }
 
   private void setInstanceSettingsEnabled(@NotNull InstanceType instanceType) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsComponent.java
@@ -480,7 +480,7 @@ public class SettingsComponent implements Disposable {
     isCustomAutocompleteColorEnabledCheckBox.setSelected(value);
   }
 
-  public Integer getCustomAutocompleteColorPanel() {
+  public @NotNull Integer getCustomAutocompleteColorPanel() {
     Color selectedColor = customAutocompleteColorPanel.getSelectedColor();
     return Objects.requireNonNull(selectedColor).getRGB();
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -81,6 +81,8 @@ public class SettingsConfigurable implements Configurable {
     boolean oldCodyAutocompleteEnabled = ConfigUtil.isCodyAutocompleteEnabled();
     boolean oldCodyDebugEnabled = ConfigUtil.isCodyDebugEnabled();
     boolean oldCodyVerboseDebugEnabled = ConfigUtil.isCodyVerboseDebugEnabled();
+    boolean oldIsCustomAutocompleteColorEnabled = ConfigUtil.isCustomAutocompleteColorEnabled();
+    Integer oldCustomAutocompleteColor = ConfigUtil.getCustomAutocompleteColor();
     String oldUrl = ConfigUtil.getSourcegraphUrl(project);
     String newDotComAccessToken = mySettingsComponent.getDotComAccessToken();
     String newEnterpriseAccessToken = mySettingsComponent.getEnterpriseAccessToken();
@@ -101,6 +103,8 @@ public class SettingsConfigurable implements Configurable {
             oldUrl,
             oldCodyDebugEnabled,
             oldCodyVerboseDebugEnabled,
+            oldCustomAutocompleteColor,
+            oldIsCustomAutocompleteColorEnabled,
             newUrl,
             mySettingsComponent.isDotComAccessTokenChanged(),
             mySettingsComponent.isEnterpriseAccessTokenChanged(),

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -59,8 +59,12 @@ public class SettingsConfigurable implements Configurable {
         || mySettingsComponent.isCodyEnabled() != ConfigUtil.isCodyEnabled()
         || mySettingsComponent.isCodyAutocompleteEnabled() != ConfigUtil.isCodyAutocompleteEnabled()
         || mySettingsComponent.isCodyDebugEnabled() != ConfigUtil.isCodyDebugEnabled()
-        || mySettingsComponent.isCodyVerboseDebugEnabled()
-            != ConfigUtil.isCodyVerboseDebugEnabled();
+        || mySettingsComponent.isCodyVerboseDebugEnabled() != ConfigUtil.isCodyVerboseDebugEnabled()
+        || mySettingsComponent.isCustomAutocompleteColorEnabled()
+            != ConfigUtil.isCustomAutocompleteColorEnabled()
+        || !mySettingsComponent
+            .getCustomAutocompleteColorPanel()
+            .equals(ConfigUtil.getCustomAutocompleteColor());
   }
 
   @Override
@@ -103,7 +107,9 @@ public class SettingsConfigurable implements Configurable {
             mySettingsComponent.isCodyEnabled(),
             mySettingsComponent.isCodyAutocompleteEnabled(),
             mySettingsComponent.isCodyDebugEnabled(),
-            mySettingsComponent.isCodyVerboseDebugEnabled());
+            mySettingsComponent.isCodyVerboseDebugEnabled(),
+            mySettingsComponent.isCustomAutocompleteColorEnabled(),
+            mySettingsComponent.getCustomAutocompleteColorPanel());
 
     publisher.beforeAction(context);
 
@@ -154,6 +160,9 @@ public class SettingsConfigurable implements Configurable {
     aSettings.isCodyAutocompleteEnabled = mySettingsComponent.isCodyAutocompleteEnabled();
     aSettings.isCodyDebugEnabled = mySettingsComponent.isCodyDebugEnabled();
     aSettings.isCodyVerboseDebugEnabled = mySettingsComponent.isCodyVerboseDebugEnabled();
+    aSettings.isCustomAutocompleteColorEnabled =
+        mySettingsComponent.isCustomAutocompleteColorEnabled();
+    aSettings.customAutocompleteColor = mySettingsComponent.getCustomAutocompleteColorPanel();
 
     publisher.afterAction(context);
   }
@@ -174,6 +183,9 @@ public class SettingsConfigurable implements Configurable {
     mySettingsComponent.setCodyAutocompleteEnabled(ConfigUtil.isCodyAutocompleteEnabled());
     mySettingsComponent.setIsCodyDebugEnabled(ConfigUtil.isCodyDebugEnabled());
     mySettingsComponent.setIsCodyVerboseDebugEnabled(ConfigUtil.isCodyVerboseDebugEnabled());
+    mySettingsComponent.setIsCustomAutocompleteColorEnabled(
+        ConfigUtil.isCustomAutocompleteColorEnabled());
+    mySettingsComponent.setCustomAutocompleteColorPanel(ConfigUtil.getCustomAutocompleteColor());
     mySettingsComponent.getPanel().requestFocusInWindow();
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/SettingsConfigurable.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.messages.MessageBus;
 import com.sourcegraph.cody.localapp.LocalAppManager;
+import java.util.Objects;
 import javax.swing.*;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nls;
@@ -62,9 +63,9 @@ public class SettingsConfigurable implements Configurable {
         || mySettingsComponent.isCodyVerboseDebugEnabled() != ConfigUtil.isCodyVerboseDebugEnabled()
         || mySettingsComponent.isCustomAutocompleteColorEnabled()
             != ConfigUtil.isCustomAutocompleteColorEnabled()
-        || !mySettingsComponent
-            .getCustomAutocompleteColorPanel()
-            .equals(ConfigUtil.getCustomAutocompleteColor());
+        || !Objects.equals(
+            mySettingsComponent.getCustomAutocompleteColorPanel(),
+            ConfigUtil.getCustomAutocompleteColor());
   }
 
   @Override


### PR DESCRIPTION
It resolves https://github.com/sourcegraph/sourcegraph/issues/56097

## Test plan
* Go to cody settings page
* Check Enable Cody autocomplete checkbox
* Check Enable custom autocomplete color checkbox
* Pick the color that you want to use for cody autocomplete hint
* Press OK
* Trigger autocompletion

Reopened https://github.com/sourcegraph/sourcegraph/pull/56236 PR to pass github checks.