### PR TITLE
populate monitors_enabled field

### DIFF
--- a/internal/usagestats/code_monitoring.go
+++ b/internal/usagestats/code_monitoring.go
@@ -45,6 +45,7 @@ func GetCodeMonitoringUsageStatistics(ctx context.Context, db database.DB) (*typ
 		&stats.TriggerRunsErrored,
 		&stats.P50TriggerRunTimeSeconds,
 		&stats.P90TriggerRunTimeSeconds,
+		&stats.MonitorsEnabled,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/code_monitoring_test.go
+++ b/internal/usagestats/code_monitoring_test.go
@@ -72,7 +72,7 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO users (id, username) 
+		INSERT INTO users (id, username)
 		VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
 	`)
 	require.NoError(t, err)
@@ -104,20 +104,20 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO cm_queries (monitor, query, created_by, changed_by)
-		SELECT 
-			s as monitor, 
-			'', 
-			cm_monitors.created_by, 
-			cm_monitors.changed_by 
+		SELECT
+			s as monitor,
+			'',
+			cm_monitors.created_by,
+			cm_monitors.changed_by
 		FROM generate_series(1,14) s
 		JOIN cm_monitors ON cm_monitors.id = s
 	`)
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO cm_emails 
+		INSERT INTO cm_emails
 			(monitor, enabled, priority, header, created_by, changed_by)
-		SELECT 
+		SELECT
 			cm_monitors.id,
 			CASE WHEN cm_monitors.id = 2 THEN false ELSE true END,
 			'NORMAL',
@@ -130,7 +130,7 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO cm_slack_webhooks 
+		INSERT INTO cm_slack_webhooks
 			(monitor, enabled, url, created_by, changed_by)
 		SELECT
 			cm_monitors.id,
@@ -144,7 +144,7 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO cm_webhooks 
+		INSERT INTO cm_webhooks
 			(monitor, enabled, url, created_by, changed_by)
 		SELECT
 			cm_monitors.id,
@@ -159,10 +159,10 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 
 	_, err = db.ExecContext(ctx, `
 		INSERT INTO cm_trigger_jobs (query, state, finished_at, started_at)
-		SELECT 
-			cm_queries.id, 
-			CASE WHEN s < 6 THEN 'completed' ELSE 'failed' END, 
-			now() - s * '1 day'::interval, 
+		SELECT
+			cm_queries.id,
+			CASE WHEN s < 6 THEN 'completed' ELSE 'failed' END,
+			now() - s * '1 day'::interval,
 			now() - s * '1 day'::interval - s * '1 second'::interval
 		FROM cm_queries
 		JOIN cm_monitors ON cm_queries.monitor = cm_monitors.id
@@ -172,14 +172,14 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO cm_action_jobs 
+		INSERT INTO cm_action_jobs
 			(email, webhook, slack_webhook, state, finished_at, started_at)
-		SELECT 
-			cm_emails.id, 
-			NULL::bigint, 
-			NULL::bigint, 
+		SELECT
+			cm_emails.id,
+			NULL::bigint,
+			NULL::bigint,
 			CASE WHEN s < 6 THEN 'completed' ELSE 'failed' END,
-			now() - s * '1 day'::interval, 
+			now() - s * '1 day'::interval,
 			now() - s * '1 day'::interval - s * '1 second'::interval
 		FROM cm_emails
 		CROSS JOIN generate_series(1, 10) s
@@ -187,12 +187,12 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 		WHERE cm_emails.enabled
 			AND cm_monitors.enabled
 		UNION ALL
-		SELECT 
-			NULL::bigint, 
-			cm_webhooks.id, 
-			NULL::bigint, 
+		SELECT
+			NULL::bigint,
+			cm_webhooks.id,
+			NULL::bigint,
 			CASE WHEN s < 6 THEN 'completed' ELSE 'failed' END,
-			now() - s * '1 day'::interval, 
+			now() - s * '1 day'::interval,
 			now() - s * '1 day'::interval - s * '1 second'::interval
 		FROM cm_webhooks
 		CROSS JOIN generate_series(1, 10) s
@@ -200,12 +200,12 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 		WHERE cm_webhooks.enabled
 			AND cm_monitors.enabled
 		UNION ALL
-		SELECT 
-			NULL::bigint, 
-			NULL::bigint, 
-			cm_slack_webhooks.id, 
+		SELECT
+			NULL::bigint,
+			NULL::bigint,
+			cm_slack_webhooks.id,
 			CASE WHEN s < 6 THEN 'completed' ELSE 'failed' END,
-			now() - s * '1 day'::interval, 
+			now() - s * '1 day'::interval,
 			now() - s * '1 day'::interval - s * '1 second'::interval
 		FROM cm_slack_webhooks
 		CROSS JOIN generate_series(1, 10) s
@@ -250,6 +250,7 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 		TriggerRunsErrored:                            ptr(int32(11)),
 		P50TriggerRunTimeSeconds:                      ptr(float32(3)),
 		P90TriggerRunTimeSeconds:                      ptr(float32(6)),
+		MonitorsEnabled:                               ptr(int32(8)),
 	}
 	require.Equal(t, want, have)
 }

--- a/internal/usagestats/code_monitoring_usage_stats.sql
+++ b/internal/usagestats/code_monitoring_usage_stats.sql
@@ -31,7 +31,7 @@ WITH event_log_stats AS (
 	SELECT
         NULLIF(COUNT(*), 0) :: INT AS email_actions_enabled,
         NULLIF(COUNT(DISTINCT users.id), 0) :: INT as email_actions_enabled_unique_users
-	FROM cm_emails 
+	FROM cm_emails
     LEFT JOIN cm_monitors ON cm_emails.monitor = cm_monitors.id
     LEFT JOIN users ON cm_monitors.namespace_user_id = users.id
     WHERE cm_emails.enabled AND cm_monitors.enabled
@@ -39,7 +39,7 @@ WITH event_log_stats AS (
 	SELECT
         NULLIF(COUNT(*), 0) :: INT AS slack_actions_enabled,
         NULLIF(COUNT(DISTINCT users.id), 0) :: INT as slack_actions_enabled_unique_users
-	FROM cm_slack_webhooks 
+	FROM cm_slack_webhooks
     LEFT JOIN cm_monitors ON cm_slack_webhooks.monitor = cm_monitors.id
     LEFT JOIN users ON cm_monitors.namespace_user_id = users.id
     WHERE cm_slack_webhooks.enabled AND cm_monitors.enabled
@@ -47,7 +47,7 @@ WITH event_log_stats AS (
 	SELECT
         NULLIF(COUNT(*), 0) :: INT AS webhook_actions_enabled,
         NULLIF(COUNT(DISTINCT users.id), 0) :: INT as webhook_actions_enabled_unique_users
-	FROM cm_webhooks 
+	FROM cm_webhooks
     LEFT JOIN cm_monitors ON cm_webhooks.monitor = cm_monitors.id
     LEFT JOIN users ON cm_monitors.namespace_user_id = users.id
     WHERE cm_webhooks.enabled AND cm_monitors.enabled
@@ -73,11 +73,11 @@ WITH event_log_stats AS (
     SELECT
         NULLIF(COUNT(*), 0) :: INT AS trigger_runs,
         NULLIF(COUNT(*) FILTER (WHERE state = 'failed'), 0) :: INT AS trigger_runs_errored,
-        PERCENTILE_CONT(0.5) 
+        PERCENTILE_CONT(0.5)
             WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)))
             FILTER (WHERE finished_at IS NOT NULL and started_at IS NOT NULL)
             AS p50_trigger_run_time,
-        PERCENTILE_CONT(0.9) 
+        PERCENTILE_CONT(0.9)
             WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (finished_at - started_at)))
             FILTER (WHERE finished_at IS NOT NULL and started_at IS NOT NULL)
             AS p90_trigger_run_time
@@ -122,8 +122,12 @@ SELECT
     trigger_jobs.trigger_runs,
     trigger_jobs.trigger_runs_errored,
     trigger_jobs.p50_trigger_run_time,
-    trigger_jobs.p90_trigger_run_time
-FROM 
+    trigger_jobs.p90_trigger_run_time,
+    -- monitors_enabled
+    COALESCE(slack_actions.slack_actions_enabled, 0) +
+    COALESCE(email_actions.email_actions_enabled, 0) +
+    COALESCE(webhook_actions.webhook_actions_enabled, 0) AS monitors_enabled
+FROM
     event_log_stats,
     email_actions,
     slack_actions,


### PR DESCRIPTION
- Before, `MonitorsEnabled` wouldn't populate, so it always returned 0.
- Now, `MonitorsEnabled` returns total monitors across webhooks, slack, and emails.

## Test plan
1. Adjusted unit test to account for new `monitors_enabled` field. 
2. Made sure test passes.
3. Manually tested: Ran dev environment, created code monitors, and made sure the next ping accounted for those code monitors, and that `MonitorsEnabled` no longer returned 0 when there are available code monitors.