### PR TITLE
search jobs: add boilerplate to download results

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -40,6 +40,9 @@ type Services struct {
 	// Handler for exporting code insights data.
 	CodeInsightsDataExportHandler http.Handler
 
+	// Handler for exporting search jobs data.
+	SearchJobsDataExportHandler http.Handler
+
 	// Handler for completions stream.
 	NewChatCompletionsStreamHandler NewChatCompletionsStreamHandler
 
@@ -116,6 +119,7 @@ func DefaultServices() Services {
 		NewDotcomLicenseCheckHandler:    func() http.Handler { return makeNotFoundHandler("dotcom license check handler") },
 		NewChatCompletionsStreamHandler: func() http.Handler { return makeNotFoundHandler("chat completions streaming endpoint") },
 		NewCodeCompletionsHandler:       func() http.Handler { return makeNotFoundHandler("code completions streaming endpoint") },
+		SearchJobsDataExportHandler:     makeNotFoundHandler("search jobs data export handler"),
 	}
 }
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -291,6 +291,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 			NewCodeIntelUploadHandler:       enterprise.NewCodeIntelUploadHandler,
 			NewComputeStreamHandler:         enterprise.NewComputeStreamHandler,
 			CodeInsightsDataExportHandler:   enterprise.CodeInsightsDataExportHandler,
+			SearchJobsDataExportHandler:     enterprise.SearchJobsDataExportHandler,
 			NewDotcomLicenseCheckHandler:    enterprise.NewDotcomLicenseCheckHandler,
 			NewChatCompletionsStreamHandler: enterprise.NewChatCompletionsStreamHandler,
 			NewCodeCompletionsHandler:       enterprise.NewCodeCompletionsHandler,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -74,6 +74,9 @@ type Handlers struct {
 	// Code Insights
 	CodeInsightsDataExportHandler http.Handler
 
+	// Search jobs
+	SearchJobsDataExportHandler http.Handler
+
 	// Dotcom license check
 	NewDotcomLicenseCheckHandler enterprise.NewDotcomLicenseCheckHandler
 
@@ -178,6 +181,7 @@ func NewHandler(
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(logger, schema, rateLimiter, false))))
 
 	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(db)))
+	m.Get(apirouter.SearchJob).Handler(trace.Route(handlers.SearchJobsDataExportHandler))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCli).Handler(trace.Route(newSrcCliVersionHandler(logger)))

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -15,6 +15,7 @@ const (
 	SCIPUploadExists = "scip.upload.exists"
 
 	SearchStream          = "search.stream"
+	SearchJob             = "search.job"
 	ComputeStream         = "compute.stream"
 	GitBlameStream        = "git.blame.stream"
 	ChatCompletionsStream = "completions.stream"
@@ -77,6 +78,7 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/scip/upload").Methods("POST").Name(SCIPUpload)
 	base.Path("/scip/upload").Methods("HEAD").Name(SCIPUploadExists)
 	base.Path("/search/stream").Methods("GET").Name(SearchStream)
+	base.Path("/search/export/{id}").Methods("GET").Name(SearchJob)
 	base.Path("/compute/stream").Methods("GET", "POST").Name(ComputeStream)
 	base.Path("/blame/" + routevar.Repo + routevar.RepoRevSuffix + "/stream/{Path:.*}").Methods("GET").Name(GitBlameStream)
 	base.Path("/src-cli/versions/{rest:.*}").Methods("GET", "POST").Name(SrcCliVersionCache)

--- a/enterprise/cmd/frontend/internal/search/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/search/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/enterprise",
+        "//enterprise/cmd/frontend/internal/search/httpapi",
         "//enterprise/cmd/frontend/internal/search/resolvers",
         "//internal/codeintel",
         "//internal/conf/conftypes",

--- a/enterprise/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -6,11 +6,9 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/search/httpapi",
     visibility = ["//enterprise/cmd/frontend:__subpackages__"],
     deps = [
-        "//enterprise/cmd/frontend/internal/search/resolvers",
         "//internal/auth",
-        "//internal/search/exhaustive/store",
+        "//internal/search/exhaustive/service",
         "//lib/errors",
         "@com_github_gorilla_mux//:mux",
-        "@com_github_graph_gophers_graphql_go//:graphql-go",
     ],
 )

--- a/enterprise/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "httpapi",
+    srcs = ["export.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/search/httpapi",
+    visibility = ["//enterprise/cmd/frontend:__subpackages__"],
+    deps = [
+        "//enterprise/cmd/frontend/internal/search/resolvers",
+        "//internal/auth",
+        "//internal/search/exhaustive/store",
+        "//lib/errors",
+        "@com_github_gorilla_mux//:mux",
+        "@com_github_graph_gophers_graphql_go//:graphql-go",
+    ],
+)

--- a/enterprise/cmd/frontend/internal/search/httpapi/export.go
+++ b/enterprise/cmd/frontend/internal/search/httpapi/export.go
@@ -1,0 +1,48 @@
+package httpapi
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/search/resolvers"
+	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func ServeSearchJobDownload(store *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		nodeID := mux.Vars(r)["id"]
+
+		jobID, err := resolvers.UnmarshalSearchJobID(graphql.ID(nodeID))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// 🚨 SECURITY: only the initiator, internal or site admins may view a job
+		_, err = store.GetExhaustiveSearchJob(r.Context(), jobID)
+		if err != nil {
+			if errors.Is(err, auth.ErrMustBeSiteAdminOrSameUser) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.csv\"", jobID))
+
+		// dummy data
+		csvWriter := csv.NewWriter(w)
+		_ = csvWriter.Write([]string{"repo", "revspec", "revision"})
+		_ = csvWriter.Write([]string{"1", "spec", "2"})
+		csvWriter.Flush()
+	}
+}

--- a/enterprise/cmd/frontend/internal/search/httpapi/export.go
+++ b/enterprise/cmd/frontend/internal/search/httpapi/export.go
@@ -37,7 +37,7 @@ func ServeSearchJobDownload(store *store.Store) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.csv\"", jobID))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%d.csv\"", jobID))
 
 		// dummy data
 		csvWriter := csv.NewWriter(w)

--- a/enterprise/cmd/frontend/internal/search/init.go
+++ b/enterprise/cmd/frontend/internal/search/init.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/search/httpapi"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/search/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -26,6 +27,7 @@ func Init(
 	svc := service.New(observationCtx, store)
 
 	enterpriseServices.SearchJobsResolver = resolvers.New(observationCtx.Logger, db, svc)
+	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(store)
 
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/search/init.go
+++ b/enterprise/cmd/frontend/internal/search/init.go
@@ -27,7 +27,7 @@ func Init(
 	svc := service.New(observationCtx, store)
 
 	enterpriseServices.SearchJobsResolver = resolvers.New(observationCtx.Logger, db, svc)
-	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(store)
+	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(svc)
 
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/search/resolvers/BUILD.bazel
+++ b/enterprise/cmd/frontend/internal/search/resolvers/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
+        "//internal/conf",
         "//internal/database",
         "//internal/gqlutil",
         "//internal/search/exhaustive/service",

--- a/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/search/resolvers/resolver.go
@@ -60,7 +60,7 @@ func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {
 }
 
 func (r *Resolver) searchJobByID(ctx context.Context, id graphql.ID) (graphqlbackend.SearchJobResolver, error) {
-	jobID, err := unmarshalSearchJobID(id)
+	jobID, err := UnmarshalSearchJobID(id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -6,13 +6,14 @@ import (
 	"sync"
 
 	"github.com/sourcegraph/log"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 // New returns a Service.


### PR DESCRIPTION
This registers the handler to download the results of a search job in csv format. For now we only return dummy data.

Test plan:

I manually tested the following workflow
- Create search job in API Console
```graphql
mutation {
  createSearchJob(query: "1@rev1 1@rev2 2@rev3 3@rev5") {
    id
  }
}
```
- Use the id to request the URL
```graphql
query {
  node(id:"U2VhcmNoSm9iOjMy") {
    ... on SearchJob {
      URL
    }
  }
}
```
- Download the file
```
curl -JO -H 'Authorization: token <TOKEN>' <URL>
```
  - check the downloaded csv


