### PR TITLE
httpapi/auth: use audit logs for user errors

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -81,7 +81,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 				// Report errors on malformed Authorization headers for schemes we do handle, to
 				// make it clear to the client that their request is not proceeding with their
 				// supplied credentials.
-				logger.Error("invalid Authorization header", log.Error(err))
+				logger.Warn("invalid Authorization header", log.Error(err))
 				http.Error(w, "Invalid Authorization header.", http.StatusUnauthorized)
 				return
 			}
@@ -204,7 +204,7 @@ func AccessTokenAuthMiddleware(db database.DB, logger log.Logger, next http.Hand
 				// the necessary scope in the Lookup call above.
 				user, err := db.Users().GetByUsername(r.Context(), sudoUser)
 				if err != nil {
-					logger.Error(
+					logger.Warn(
 						"invalid username used with sudo access token",
 						log.String("sudoUser", sudoUser),
 						log.Error(err),


### PR DESCRIPTION
Reduces logs related to bad user input to `warn`. We have started to generate a huge amount of these events in Sentry recently: https://sourcegraph.slack.com/archives/C05497E9MDW/p1694017736611569?thread_ts=1694017010.274539&cid=C05497E9MDW

## Test plan

n/a