### PR TITLE
repos, codemonitors: remove duplicate error logging

### DIFF
--- a/internal/codemonitors/background/workers.go
+++ b/internal/codemonitors/background/workers.go
@@ -214,19 +214,13 @@ type actionRunner struct {
 
 func (r *actionRunner) Handle(ctx context.Context, logger log.Logger, j *database.ActionJob) (err error) {
 	logger.Info("actionRunner.Handle starting")
-	defer func() {
-		if err != nil {
-			logger.Error("actionRunner.Handle", log.Error(err))
-		}
-	}()
-
 	switch {
 	case j.Email != nil:
-		return r.handleEmail(ctx, j)
+		return errors.Wrap(r.handleEmail(ctx, j), "Email")
 	case j.Webhook != nil:
-		return r.handleWebhook(ctx, j)
+		return errors.Wrap(r.handleWebhook(ctx, j), "Webhook")
 	case j.SlackWebhook != nil:
-		return r.handleSlackWebhook(ctx, j)
+		return errors.Wrap(r.handleSlackWebhook(ctx, j), "SlackWebhook")
 	default:
 		return errors.New("job must be one of type email, webhook, or slack webhook")
 	}

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -339,7 +339,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 			})
 			logger.Debug("syncGroup completed", log.String("updatedRepo", fmt.Sprintf("%v", updatedRepo.(*types.Repo))))
 			if err != nil {
-				logger.Error("SyncRepo", log.Error(err), log.Bool("shared", shared))
+				logger.Error("background.SyncRepo", log.Error(err), log.Bool("shared", shared))
 			}
 		}()
 		return repo, nil
@@ -350,8 +350,7 @@ func (s *Syncer) SyncRepo(ctx context.Context, name api.RepoName, background boo
 		return s.syncRepo(ctx, codehost, name, repo)
 	})
 	if err != nil {
-		logger.Error("SyncRepo", log.Error(err), log.Bool("shared", shared))
-		return nil, err
+		return nil, errors.Wrapf(err, "foreground.SyncRepo (shared=%v)", shared)
 	}
 	return updatedRepo.(*types.Repo), nil
 }


### PR DESCRIPTION
Improve error logging at some common sources of logspam: https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1694018298564529 - at error level, this is causing us to get rate-limited in Sentry.

See self-review comments for details

No idea who to tag for reviews these days 😆 

## Test plan
CI