### PR TITLE
Wildcard Adjust exhaustive search creation alert banner styles

### DIFF
--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.module.scss
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.module.scss
@@ -89,7 +89,7 @@
     }
 
     &-warning-list {
-        padding: 0 0.75rem;
         margin: 0;
+        padding: 0 1rem;
     }
 }

--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
@@ -164,7 +164,7 @@ export const StreamingProgressSkippedPopover: FC<StreamingProgressSkippedPopover
 
             {exhaustiveSearch && (
                 <>
-                    <hr className="mx-3" />
+                    <hr className="mx-3 mt-3" />
                     <ExhaustiveSearchMessage query={query} />
                 </>
             )}
@@ -196,6 +196,10 @@ const SkippedReasons: FC<SkippedReasonsProps> = props => {
 
 const SlimSkippedReasons: FC<SkippedReasonsProps> = props => {
     const { items } = props
+
+    if (items.length === 0) {
+        return null
+    }
 
     return (
         <div className={styles.streamingSkippedItem}>
@@ -256,7 +260,7 @@ const SkippedItemsSearch: FC<SkippedItemsSearchProps> = props => {
     const { slim, items, disabled, onSearchSettingsChange, onSubmit } = props
 
     return (
-        <Form className="pb-3 px-3" onSubmit={onSubmit} data-testid="popover-form">
+        <Form className={classNames('px-3', { 'pb-3': !slim })} onSubmit={onSubmit} data-testid="popover-form">
             <div className="mb-2 mt-3">Search again:</div>
             <div className="form-check">
                 {items.map(
@@ -312,7 +316,7 @@ export const ExhaustiveSearchMessage: FC<ExhaustiveSearchMessageProps> = props =
             </header>
 
             {validationErrors.length > 0 && (
-                <Alert variant="warning">
+                <Alert variant="secondary" withIcon={false}>
                     <ul className={styles.exhaustiveSearchWarningList}>
                         {validationErrors.map(validationError => (
                             <li key={validationError.reason}>{validationError.reason}</li>

--- a/client/branded/src/search-ui/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/branded/src/search-ui/results/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -322,7 +322,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     />
   </div>
   <form
-    class="pb-3 px-3"
+    class="px-3 pb-3"
     data-testid="popover-form"
   >
     <div

--- a/client/wildcard/src/components/Alert/Alert.module.scss
+++ b/client/wildcard/src/components/Alert/Alert.module.scss
@@ -13,7 +13,8 @@
 
     /* Apply `background-color` and `padding` only to .alert-variants because we also use `.alert` elements without variants. */
     background-color: var(--alert-background-color);
-    padding: var(--alert-content-padding) var(--alert-content-padding) var(--alert-content-padding) calc(var(--alert-icon-block-width) + var(--alert-content-padding));
+    padding: var(--alert-content-padding) var(--alert-content-padding) var(--alert-content-padding)
+        calc(var(--alert-icon-block-width) + var(--alert-content-padding));
 
     &--with-no-icon {
         padding: var(--alert-content-padding);

--- a/client/wildcard/src/components/Alert/Alert.module.scss
+++ b/client/wildcard/src/components/Alert/Alert.module.scss
@@ -1,8 +1,28 @@
 .alert {
+    --alert-icon-display: block;
+    --alert-icon-block-width: 2.5rem;
+    --alert-content-padding: 0.5rem;
+    --alert-background-color: var(--color-bg-1);
+
+    overflow: hidden;
     position: relative;
     margin-bottom: 1rem;
+    color: var(--body-color);
     border-radius: var(--border-radius);
-    border: 1px solid transparent;
+    border: 1px solid var(--alert-border-color);
+
+    /* Apply `background-color` and `padding` only to .alert-variants because we also use `.alert` elements without variants. */
+    background-color: var(--alert-background-color);
+    padding: var(--alert-content-padding) var(--alert-content-padding) var(--alert-content-padding) calc(var(--alert-icon-block-width) + var(--alert-content-padding));
+
+    &--with-no-icon {
+        padding: var(--alert-content-padding);
+
+        &::before,
+        &::after {
+            --alert-icon-display: none;
+        }
+    }
 }
 
 .alert a:not(.btn) {
@@ -26,22 +46,9 @@
 .alert-merged,
 .alert-note,
 .alert-waiting {
-    --alert-icon-block-width: 2.5rem;
-    --alert-content-padding: 0.5rem;
-    --alert-background-color: var(--color-bg-1);
-
-    color: var(--body-color);
-    overflow: hidden;
-    border-color: var(--alert-border-color);
-
-    /* Apply `background-color` and `padding` only to .alert-variants because we also use `.alert` elements without variants. */
-    background-color: var(--alert-background-color);
-    padding: var(--alert-content-padding) var(--alert-content-padding) var(--alert-content-padding)
-        calc(var(--alert-icon-block-width) + var(--alert-content-padding));
-
     &::before,
     &::after {
-        display: block;
+        display: var(--alert-icon-display);
         content: '';
         position: absolute;
         top: 0;

--- a/client/wildcard/src/components/Alert/Alert.story.tsx
+++ b/client/wildcard/src/components/Alert/Alert.story.tsx
@@ -68,6 +68,16 @@ export const Alerts: Story = () => (
                     Dismiss
                 </AlertLink>
             </Alert>
+
+            <Alert variant="secondary" withIcon={false} className="d-flex align-items-center">
+                <div className="flex-grow-1">
+                    <H4>Too many matching repositories</H4>
+                    Use a 'repo:' filter to narrow your search.
+                </div>
+                <AlertLink className="mr-2" to="/" onClick={flow(preventDefault, action(classNames('link clicked')))}>
+                    Dismiss
+                </AlertLink>
+            </Alert>
         </div>
     </>
 )

--- a/client/wildcard/src/components/Alert/Alert.tsx
+++ b/client/wildcard/src/components/Alert/Alert.tsx
@@ -14,6 +14,12 @@ type AlertVariant = typeof ALERT_VARIANTS[number]
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
     variant?: AlertVariant
+
+    /**
+     * Setting to control alert icon appearance, has true value
+     * be default.
+     */
+    withIcon?: boolean
 }
 
 const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
@@ -27,7 +33,7 @@ const userShouldBeImmediatelyNotified = (variant?: AlertVariant): boolean =>
  * Further details: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role
  */
 export const Alert = React.forwardRef(function Alert(
-    { children, as: Component = 'div', variant, className, role = 'alert', ...attributes },
+    { children, withIcon = true, as: Component = 'div', variant, className, role = 'alert', ...attributes },
     reference
 ) {
     const { isBranded } = useWildcardTheme()
@@ -43,7 +49,7 @@ export const Alert = React.forwardRef(function Alert(
     return (
         <Component
             ref={reference}
-            className={classNames(brandedClassName, className)}
+            className={classNames(brandedClassName, className, { [styles.alertWithNoIcon]: !withIcon })}
             role={role}
             aria-live={alertAssertiveness}
             {...attributes}


### PR DESCRIPTION
This PR adds yet another alert variation — "an alert block without alert icon within", This variation is needed for the newly added search job (exhaustive search creation banner UI on the search page); see screenshots below

| Light | Dark |
| ------ | ------ |
| <img width="381" alt="Screenshot 2023-09-06 at 19 39 41" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/970f1ec5-b0ea-41f7-8632-94d0601bde8a"> | <img width="375" alt="Screenshot 2023-09-06 at 19 39 53" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/dba69d26-c82a-4d0d-a8a9-1db9b6da0f92"> |

It also fixes a few corner cases in the layout when we have 0 results
 
## Test plan
- Check storybook alert UI story where a new alert block without icon is presented 
- Check the search jobs UI (you have to enable it first, by setting "searchJobs" true in the experimental settings) 
