### PR TITLE
JetBrains: add up/down shortcut in Cody chat input to iterate through previous messages

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -134,14 +134,23 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            chatMessageHistory.popUpperMessage(promptInput);
+            if (promptInput.getCaretPosition() == 0) {
+              chatMessageHistory.popUpperMessage(promptInput);
+            } else {
+              promptInput.setCaretPosition(0);
+            }
           }
         };
     AnAction lowerMessageAction =
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            chatMessageHistory.popLowerMessage(promptInput);
+            int promptLastPosition = promptInput.getText().length();
+            if (promptInput.getCaretPosition() == promptLastPosition) {
+              chatMessageHistory.popLowerMessage(promptInput);
+            } else {
+              promptInput.setCaretPosition(promptLastPosition);
+            }
           }
         };
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody;
 
 import static com.intellij.ui.SimpleTextAttributes.STYLE_PLAIN;
-import static java.awt.event.KeyEvent.VK_ENTER;
+import static java.awt.event.KeyEvent.*;
 import static javax.swing.KeyStroke.getKeyStroke;
 
 import com.intellij.icons.AllIcons;
@@ -42,6 +42,9 @@ import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
 import com.sourcegraph.cody.chat.Transcript;
+import com.sourcegraph.cody.chat.*;
+import com.sourcegraph.cody.config.AccountType;
+import com.sourcegraph.cody.config.AccountsHostProjectHolder;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
@@ -75,6 +78,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   public static final String SING_IN_WITH_SOURCEGRAPH_PANEL = "singInWithSourcegraphPanel";
   private static final int CHAT_TAB_INDEX = 0;
   private static final int RECIPES_TAB_INDEX = 1;
+  private static final int CHAT_MESSAGE_HISTORY_CAPACITY = 100;
   private final @NotNull CardLayout allContentLayout = new CardLayout();
   private final @NotNull JPanel allContentPanel = new JPanel(allContentLayout);
   private final @NotNull JBTabbedPane tabbedPane = new JBTabbedPane();
@@ -90,6 +94,8 @@ public class CodyToolWindowContent implements UpdatableChat {
   private @NotNull Transcript transcript = new Transcript();
   private boolean isChatVisible = false;
   private CodyOnboardingGuidancePanel codyOnboardingGuidancePanel;
+  private final @NotNull CodyChatMessageHistory chatMessageHistory =
+      new CodyChatMessageHistory(CHAT_MESSAGE_HISTORY_CAPACITY);
 
   public CodyToolWindowContent(@NotNull Project project) {
     this.project = project;
@@ -117,7 +123,28 @@ public class CodyToolWindowContent implements UpdatableChat {
     promptInput = autoGrowingTextArea.getTextArea();
     /* Submit on enter */
     KeyboardShortcut JUST_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, 0), null);
+    KeyboardShortcut UP = new KeyboardShortcut(getKeyStroke(VK_UP, 0), null);
+    KeyboardShortcut DOWN = new KeyboardShortcut(getKeyStroke(VK_DOWN, 0), null);
+
     ShortcutSet DEFAULT_SUBMIT_ACTION_SHORTCUT = new CustomShortcutSet(JUST_ENTER);
+    ShortcutSet POP_UPPER_MESSAGE_ACTION_SHORTCUT = new CustomShortcutSet(UP);
+    ShortcutSet POP_LOWER_MESSAGE_ACTION_SHORTCUT = new CustomShortcutSet(DOWN);
+
+    AnAction upperMessageAction =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            chatMessageHistory.popUpperMessage(promptInput);
+          }
+        };
+    AnAction lowerMessageAction =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            chatMessageHistory.popLowerMessage(promptInput);
+          }
+        };
+
     AnAction sendMessageAction =
         new DumbAwareAction() {
           @Override
@@ -126,7 +153,8 @@ public class CodyToolWindowContent implements UpdatableChat {
           }
         };
     sendMessageAction.registerCustomShortcutSet(DEFAULT_SUBMIT_ACTION_SHORTCUT, promptInput);
-
+    upperMessageAction.registerCustomShortcutSet(POP_UPPER_MESSAGE_ACTION_SHORTCUT, promptInput);
+    lowerMessageAction.registerCustomShortcutSet(POP_LOWER_MESSAGE_ACTION_SHORTCUT, promptInput);
     // Enable/disable the send button based on whether promptInput is empty
     promptInput
         .getDocument()
@@ -469,6 +497,7 @@ public class CodyToolWindowContent implements UpdatableChat {
               addWelcomeMessage();
               messagesPanel.revalidate();
               messagesPanel.repaint();
+              chatMessageHistory.clearHistory();
               CodyAgent.getInitializedServer(project).thenAccept(CodyAgentServer::transcriptReset);
             });
   }
@@ -487,6 +516,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   @RequiresEdt
   private void sendChatMessage(@NotNull Project project) {
     String text = promptInput.getText();
+    chatMessageHistory.messageSent(promptInput);
     sendMessage(project, text, "chat-question");
     promptInput.setText("");
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -134,9 +134,10 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             // When no text in prompt, pop from history.
-            if (!chatMessageHistory.getUpperStack().isEmpty()
-                && (promptInput.getText().isEmpty()
-                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))) {
+            if ((promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
+                && !chatMessageHistory.getUpperStack().isEmpty()
+                && promptInput.getCaretPosition() == 0) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();
@@ -167,8 +168,9 @@ public class CodyToolWindowContent implements UpdatableChat {
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
             // When no text in prompt, pop from history.
-            if (promptInput.getText().isEmpty()
-                || promptInput.getText().equals(chatMessageHistory.getCurrentValue())) {
+            if ((promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
+                && promptInput.getCaretPosition() == promptLastPosition) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -33,6 +33,8 @@ import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentManager;
 import com.sourcegraph.cody.agent.CodyAgentServer;
 import com.sourcegraph.cody.agent.protocol.RecipeInfo;
+import com.sourcegraph.cody.auth.ui.SignInWithSourcegraphAction;
+import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.chat.AssistantMessageWithSettingsButton;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatMessage;
@@ -42,7 +44,6 @@ import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
 import com.sourcegraph.cody.chat.Transcript;
-import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.config.AccountType;
 import com.sourcegraph.cody.config.AccountsHostProjectHolder;
 import com.sourcegraph.cody.config.CodyAccount;
@@ -134,7 +135,9 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            if (promptInput.getCaretPosition() == 0) {
+            if (!chatMessageHistory.getUpperStack().isEmpty()
+                && (promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
               promptInput.setCaretPosition(0);
@@ -146,7 +149,8 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
-            if (promptInput.getCaretPosition() == promptLastPosition) {
+            if (promptInput.getText().isEmpty()
+                || promptInput.getText().equals(chatMessageHistory.getCurrentValue())) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
               promptInput.setCaretPosition(promptLastPosition);

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -1,0 +1,55 @@
+package com.sourcegraph.cody.chat
+
+import com.intellij.ui.components.JBTextArea
+import java.util.*
+
+class CodyChatMessageHistory(
+    private val capacity: Int
+) {
+    private var upperStack: Stack<String> = Stack<String>()
+    private var lowerStack: Stack<String> = Stack<String>()
+    private var currentValue: String = ""
+
+    fun popUpperMessage(promptInput: JBTextArea) {
+        if (upperStack.isNotEmpty()) {
+            val pop = upperStack.pop()
+            lowerStack.push(currentValue)
+            promptInput.text = pop
+            currentValue = pop
+        }
+    }
+
+    fun popLowerMessage(promptInput: JBTextArea) {
+        if (lowerStack.isNotEmpty()) {
+            val pop = lowerStack.pop()
+            upperStack.push(currentValue)
+            promptInput.text = pop
+            currentValue = pop
+        }
+    }
+
+    /**
+     * When new message is sent it is pushing all messages
+     *  from lower stack to upper stack and at the end pushes new message
+     */
+    fun messageSent(promptInput: JBTextArea) {
+        if (currentValue.isNotEmpty()) {
+            upperStack.push(currentValue)
+        }
+        while (lowerStack.isNotEmpty()) {
+            val pop: String = lowerStack.pop()
+            if (pop.isNotEmpty()) upperStack.push(pop)
+        }
+        currentValue = ""
+        upperStack.push(promptInput.text)
+        if (upperStack.size > capacity) {
+            upperStack.removeFirst()
+        }
+    }
+
+    fun clearHistory() {
+        upperStack.clear()
+        lowerStack.clear()
+        currentValue = ""
+    }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -13,7 +13,7 @@ class CodyChatMessageHistory(
     fun popUpperMessage(promptInput: JBTextArea) {
         if (upperStack.isNotEmpty()) {
             val pop = upperStack.pop()
-            lowerStack.push(currentValue)
+            lowerStack.push(promptInput.text)
             promptInput.text = pop
             currentValue = pop
         }
@@ -22,7 +22,7 @@ class CodyChatMessageHistory(
     fun popLowerMessage(promptInput: JBTextArea) {
         if (lowerStack.isNotEmpty()) {
             val pop = lowerStack.pop()
-            upperStack.push(currentValue)
+            upperStack.push(promptInput.text)
             promptInput.text = pop
             currentValue = pop
         }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -3,53 +3,63 @@ package com.sourcegraph.cody.chat
 import com.intellij.ui.components.JBTextArea
 import java.util.*
 
-class CodyChatMessageHistory(
-    private val capacity: Int
-) {
-    private var upperStack: Stack<String> = Stack<String>()
-    private var lowerStack: Stack<String> = Stack<String>()
-    private var currentValue: String = ""
+class CodyChatMessageHistory(private val capacity: Int) {
+  var currentValue: String = ""
+  var upperStack: Stack<String> = Stack<String>()
+  private var lowerStack: Stack<String> = Stack<String>()
 
-    fun popUpperMessage(promptInput: JBTextArea) {
-        if (upperStack.isNotEmpty()) {
-            val pop = upperStack.pop()
-            lowerStack.push(promptInput.text)
-            promptInput.text = pop
-            currentValue = pop
-        }
+  fun popUpperMessage(promptInput: JBTextArea) {
+    resetHistoryIfPromptCleared(promptInput)
+    if (upperStack.isNotEmpty()) {
+      val pop = upperStack.pop()
+      lowerStack.push(promptInput.text)
+      promptInput.text = pop
+      currentValue = pop
     }
+  }
 
-    fun popLowerMessage(promptInput: JBTextArea) {
-        if (lowerStack.isNotEmpty()) {
-            val pop = lowerStack.pop()
-            upperStack.push(promptInput.text)
-            promptInput.text = pop
-            currentValue = pop
-        }
+  fun popLowerMessage(promptInput: JBTextArea) {
+    resetHistoryIfPromptCleared(promptInput)
+    if (lowerStack.isNotEmpty()) {
+      val pop = lowerStack.pop()
+      upperStack.push(promptInput.text)
+      promptInput.text = pop
+      currentValue = pop
     }
+  }
 
-    /**
-     * When new message is sent it is pushing all messages
-     *  from lower stack to upper stack and at the end pushes new message
-     */
-    fun messageSent(promptInput: JBTextArea) {
-        if (currentValue.isNotEmpty()) {
-            upperStack.push(currentValue)
-        }
-        while (lowerStack.isNotEmpty()) {
-            val pop: String = lowerStack.pop()
-            if (pop.isNotEmpty()) upperStack.push(pop)
-        }
-        currentValue = ""
-        upperStack.push(promptInput.text)
-        if (upperStack.size > capacity) {
-            upperStack.removeFirst()
-        }
+  /**
+   * When new message is sent it is pushing all messages from lower stack to upper stack and at the
+   * end pushes new message
+   */
+  fun messageSent(promptInput: JBTextArea) {
+    resetHistory()
+    upperStack.push(promptInput.text)
+    if (upperStack.size > capacity) {
+      upperStack.removeFirst()
     }
+  }
 
-    fun clearHistory() {
-        upperStack.clear()
-        lowerStack.clear()
-        currentValue = ""
+  fun clearHistory() {
+    upperStack.clear()
+    lowerStack.clear()
+    currentValue = ""
+  }
+
+  private fun resetHistory() {
+    if (currentValue.isNotEmpty()) {
+      upperStack.push(currentValue)
     }
+    while (lowerStack.isNotEmpty()) {
+      val pop: String = lowerStack.pop()
+      if (pop.isNotEmpty()) upperStack.push(pop)
+    }
+    currentValue = ""
+  }
+
+  private fun resetHistoryIfPromptCleared(promptInput: JBTextArea) {
+    if (promptInput.text.isEmpty() && currentValue.isNotEmpty()) {
+      resetHistory()
+    }
+  }
 }

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -1,0 +1,103 @@
+package com.sourcegraph.cody.chat
+
+import com.intellij.ui.components.JBTextArea
+import com.sourcegraph.config.ConfigUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CodyChatMessageHistoryTest {
+    private lateinit var history: CodyChatMessageHistory;
+
+    @BeforeEach
+    fun setup() {
+        history = CodyChatMessageHistory(10);
+    }
+    @Test
+    fun `messageSent adds message to latest position in history`() {
+        val textArea = JBTextArea()
+        textArea.text = "test"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test")
+    }
+
+    @Test
+    fun `popUpperMessage pops message from upper stack`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        textArea.text = "test 2"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 2")
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+    }
+
+    @Test
+    fun `popLowerMessages pop message from lower stack`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        textArea.text = "test 2"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 2")
+
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+    }
+
+    @Test
+    fun `popUpperMessage stops at last message`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+    }
+
+    @Test
+    fun `popLowerMessage stops at empty string`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        history.popUpperMessage(textArea)
+        history.popLowerMessage(textArea)
+
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+    }
+
+    @Test
+    fun `popUpperMessage overrides oldest message when capacity exceeded`() {
+        val textArea = JBTextArea()
+        val testString = "test"
+        for (i in 1..10){
+            textArea.text = testString.plus(i)
+            history.messageSent(textArea)
+        }
+        textArea.text = "last test"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("last test")
+
+        for (i in 1..11){
+            history.popUpperMessage(textArea)
+        }
+        assertThat(textArea.text).isEqualTo("test2")
+
+    }
+}

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -49,9 +49,11 @@ class CodyChatMessageHistoryTest {
 
         history.popUpperMessage(textArea)
         assertThat(textArea.text).isEqualTo("test 2")
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
 
         history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
+        assertThat(textArea.text).isEqualTo("test 2")
     }
 
     @Test
@@ -67,10 +69,11 @@ class CodyChatMessageHistoryTest {
     }
 
     @Test
-    fun `popLowerMessage stops at empty string`() {
+    fun `popLowerMessage stops at last message in stack`() {
         val textArea = JBTextArea()
         textArea.text = "test 1"
         history.messageSent(textArea)
+        textArea.text = ""
         history.popUpperMessage(textArea)
         history.popLowerMessage(textArea)
 

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -1,106 +1,123 @@
 package com.sourcegraph.cody.chat
 
 import com.intellij.ui.components.JBTextArea
-import com.sourcegraph.config.ConfigUtil
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CodyChatMessageHistoryTest {
-    private lateinit var history: CodyChatMessageHistory;
+  private lateinit var history: CodyChatMessageHistory
 
-    @BeforeEach
-    fun setup() {
-        history = CodyChatMessageHistory(10);
+  @BeforeEach
+  fun setup() {
+    history = CodyChatMessageHistory(10)
+  }
+
+  @Test
+  fun `messageSent adds message to latest position in history`() {
+    val textArea = JBTextArea()
+    textArea.text = "test"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test")
+  }
+
+  @Test
+  fun `popUpperMessage pops message from upper stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = "test 2"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+  }
+
+  @Test
+  fun `popLowerMessages pop message from lower stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = "test 2"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+  }
+
+  @Test
+  fun `popUpperMessage stops at last message`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+  }
+
+  @Test
+  fun `popLowerMessage stops at last message in stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = ""
+    history.popUpperMessage(textArea)
+    history.popLowerMessage(textArea)
+
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEmpty()
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEmpty()
+  }
+
+  @Test
+  fun `popUpperMessage overrides oldest message when capacity exceeded`() {
+    val textArea = JBTextArea()
+    val testString = "test"
+    for (i in 1..10) {
+      textArea.text = testString.plus(i)
+      history.messageSent(textArea)
     }
-    @Test
-    fun `messageSent adds message to latest position in history`() {
-        val textArea = JBTextArea()
-        textArea.text = "test"
-        history.messageSent(textArea)
+    textArea.text = "last test"
+    history.messageSent(textArea)
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("last test")
+
+    for (i in 1..11) {
+      history.popUpperMessage(textArea)
     }
+    assertThat(textArea.text).isEqualTo("test2")
+  }
 
-    @Test
-    fun `popUpperMessage pops message from upper stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = "test 2"
-        history.messageSent(textArea)
+  @Test
+  fun `popUpperMessage when history state reset`() {
+    val textArea = JBTextArea()
+    textArea.text = "test1"
+    history.messageSent(textArea)
+    textArea.text = "test2"
+    history.messageSent(textArea)
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test1")
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-    }
+    textArea.text = ""
 
-    @Test
-    fun `popLowerMessages pop message from lower stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = "test 2"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
-    }
-
-    @Test
-    fun `popUpperMessage stops at last message`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-    }
-
-    @Test
-    fun `popLowerMessage stops at last message in stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = ""
-        history.popUpperMessage(textArea)
-        history.popLowerMessage(textArea)
-
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
-    }
-
-    @Test
-    fun `popUpperMessage overrides oldest message when capacity exceeded`() {
-        val textArea = JBTextArea()
-        val testString = "test"
-        for (i in 1..10){
-            textArea.text = testString.plus(i)
-            history.messageSent(textArea)
-        }
-        textArea.text = "last test"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("last test")
-
-        for (i in 1..11){
-            history.popUpperMessage(textArea)
-        }
-        assertThat(textArea.text).isEqualTo("test2")
-
-    }
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test2")
+  }
 }


### PR DESCRIPTION
It helps #54933 
## Test plan
* Open new cody chat window
* Send message 1
* Send message 2
* Press ⬆️, message 2 should appear in the prompt
* Press ⬆️, message 1 should appear in the prompt
* Press ⬇️, message 2 should again appear in the prompt
* Modify message 2 and send
* Press ⬆️, modified message 2 should appear 


https://github.com/sourcegraph/sourcegraph/assets/9321940/5aefba04-f7eb-441c-ae23-9a4169ff3be8
