### PR TITLE
searchjobs: use service API for integration test

### DIFF
--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//internal/database/basestore",
         "//internal/database/dbtest",
         "//internal/observation",
+        "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
         "@com_github_keegancsmith_sqlf//:sqlf",


### PR DESCRIPTION
Additionally we test the Get and List API explicitly in the integration test since it is convenient. I imagine this integration test living somewhere else in the future. But for now we can grow it.

Test Plan: go test
