### PR TITLE
exhaustive search store: refactoring 2 - return of the scan helpers (and also: unit test & cleanup)

### DIFF
--- a/internal/search/exhaustive/store/BUILD.bazel
+++ b/internal/search/exhaustive/store/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//internal/search/exhaustive/types",
         "//internal/types",
         "//lib/errors",
+        "@com_github_google_go_cmp//cmp",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -30,10 +30,6 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 
 	bs := basestore.NewWithHandle(db.Handle())
 
-	t.Cleanup(func() {
-		cleanupUsers(bs)
-	})
-
 	userID, err := createUser(bs, "alice")
 	require.NoError(t, err)
 	malloryID, err := createUser(bs, "mallory")

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -108,10 +108,6 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				cleanupSearchJobs(bs)
-			})
-
 			act := test.actor
 			if act == nil {
 				act = &actor.Actor{UID: userID}

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,5 +136,68 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 				assert.NotZero(t, jobID)
 			}
 		})
+	}
+}
+
+func TestStore_GetAndListSearchJobs(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	bs := basestore.NewWithHandle(db.Handle())
+
+	userID, err := createUser(bs, "alice")
+	require.NoError(t, err)
+
+	ctx := actor.WithActor(context.Background(), actor.FromUser(userID))
+
+	s := store.New(db, &observation.TestContext)
+
+	jobs := []types.ExhaustiveSearchJob{
+		{InitiatorID: userID, Query: "repo:job1"},
+		{InitiatorID: userID, Query: "repo:job2"},
+		{InitiatorID: userID, Query: "repo:job3"},
+	}
+
+	// Create jobs
+	for i, job := range jobs {
+		jobID, err := s.CreateExhaustiveSearchJob(ctx, job)
+		require.NoError(t, err)
+		assert.NotZero(t, jobID)
+
+		jobs[i].ID = jobID
+	}
+
+	// Now get them one-by-one
+	for _, job := range jobs {
+		haveJob, err := s.GetExhaustiveSearchJob(ctx, job.ID)
+		require.NoError(t, err)
+
+		// Ensure we got the right job and that the fields are scanned correctly
+		assert.Equal(t, haveJob.ID, job.ID)
+		assert.Equal(t, haveJob.Query, job.Query)
+		assert.Equal(t, haveJob.State, types.JobStateQueued)
+		assert.NotZero(t, haveJob.CreatedAt)
+		assert.NotZero(t, haveJob.UpdatedAt)
+	}
+
+	// Now list them all
+	haveJobs, err := s.ListExhaustiveSearchJobs(ctx)
+	require.NoError(t, err)
+	require.Equal(t, len(haveJobs), len(jobs))
+
+	haveIDs := make([]int64, len(haveJobs))
+	for i, job := range haveJobs {
+		haveIDs[i] = job.ID
+	}
+	wantIDs := make([]int64, len(jobs))
+	for i, job := range jobs {
+		wantIDs[i] = job.ID
+	}
+
+	if diff := cmp.Diff(haveIDs, wantIDs); diff != "" {
+		t.Fatalf("List returned wrong jobs: %s", diff)
 	}
 }

--- a/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
@@ -86,10 +86,6 @@ func TestStore_CreateExhaustiveSearchRepoJob(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				cleanupRepoJobs(bs)
-			})
-
 			jobID, err := s.CreateExhaustiveSearchRepoJob(ctx, test.job)
 
 			if test.expectedErr != nil {

--- a/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
@@ -28,12 +28,6 @@ func TestStore_CreateExhaustiveSearchRepoJob(t *testing.T) {
 
 	bs := basestore.NewWithHandle(db.Handle())
 
-	t.Cleanup(func() {
-		cleanupUsers(bs)
-		cleanupRepos(bs)
-		cleanupSearchJobs(bs)
-	})
-
 	userID, err := createUser(bs, "alice")
 	require.NoError(t, err)
 	repoID, err := createRepo(db, "repo-test")

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
@@ -81,10 +81,6 @@ func TestStore_CreateExhaustiveSearchRepoRevisionJob(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				cleanupRevJobs(bs)
-			})
-
 			jobID, err := s.CreateExhaustiveSearchRepoRevisionJob(ctx, test.job)
 
 			if test.expectedErr != nil {

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
@@ -28,13 +28,6 @@ func TestStore_CreateExhaustiveSearchRepoRevisionJob(t *testing.T) {
 
 	bs := basestore.NewWithHandle(db.Handle())
 
-	t.Cleanup(func() {
-		cleanupUsers(bs)
-		cleanupRepos(bs)
-		cleanupSearchJobs(bs)
-		cleanupRepoJobs(bs)
-	})
-
 	userID, err := createUser(bs, "alice")
 	require.NoError(t, err)
 	repoID, err := createRepo(db, "repo-test")

--- a/internal/search/exhaustive/store/store_test.go
+++ b/internal/search/exhaustive/store/store_test.go
@@ -14,10 +14,7 @@ import (
 func createUser(store *basestore.Store, username string) (int32, error) {
 	admin := username == "admin"
 	q := sqlf.Sprintf(`INSERT INTO users(username, site_admin) VALUES(%s, %s) RETURNING id`, username, admin)
-	row := store.QueryRow(context.Background(), q)
-	var userID int32
-	err := row.Scan(&userID)
-	return userID, err
+	return basestore.ScanAny[int32](store.QueryRow(context.Background(), q))
 }
 
 func createRepo(db database.DB, name string) (api.RepoID, error) {

--- a/internal/search/exhaustive/store/store_test.go
+++ b/internal/search/exhaustive/store/store_test.go
@@ -20,34 +20,9 @@ func createUser(store *basestore.Store, username string) (int32, error) {
 	return userID, err
 }
 
-func cleanupUsers(store *basestore.Store) error {
-	q := sqlf.Sprintf(`TRUNCATE TABLE users RESTART IDENTITY CASCADE`)
-	return store.Exec(context.Background(), q)
-}
-
 func createRepo(db database.DB, name string) (api.RepoID, error) {
 	repoStore := db.Repos()
 	repo := types.Repo{Name: api.RepoName(name)}
 	err := repoStore.Create(context.Background(), &repo)
 	return repo.ID, err
-}
-
-func cleanupRepos(store *basestore.Store) error {
-	q := sqlf.Sprintf(`TRUNCATE TABLE repo`)
-	return store.Exec(context.Background(), q)
-}
-
-func cleanupSearchJobs(store *basestore.Store) error {
-	q := sqlf.Sprintf(`TRUNCATE TABLE exhaustive_search_jobs`)
-	return store.Exec(context.Background(), q)
-}
-
-func cleanupRepoJobs(store *basestore.Store) error {
-	q := sqlf.Sprintf(`TRUNCATE TABLE exhaustive_search_repo_jobs`)
-	return store.Exec(context.Background(), q)
-}
-
-func cleanupRevJobs(store *basestore.Store) error {
-	q := sqlf.Sprintf(`TRUNCATE TABLE exhaustive_search_repo_revision_jobs`)
-	return store.Exec(context.Background(), q)
 }


### PR DESCRIPTION
Three things in three commits:

- Added a unit test for `Get` and `List` - I think it's fine having them both in a single test right now. Just a sanity check really.
- Removed the `cleanup` stuff, since that's not necessary: `dbtest.New` creates a new database for every test, so state is not global and thus does not need to be cleaned up and THUS cleaning up is actually costing us time, you know
- Another `basestore.ScanAny` switch

## Test plan

- New and existing tests
