### PR TITLE
JetBrains: manually construct server url to fix any issues with it

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
@@ -18,7 +18,7 @@ enum class AccountType {
 data class CodyAccount(
     @NlsSafe @Attribute("name") override var name: String = "",
     @Property(style = Property.Style.ATTRIBUTE, surroundWithTag = false)
-    override val server: SourcegraphServerPath = SourcegraphServerPath(ConfigUtil.DOTCOM_URL),
+    override val server: SourcegraphServerPath = SourcegraphServerPath.from(ConfigUtil.DOTCOM_URL, ""),
     @Attribute("id") override val id: String = generateId(),
 ) : ServerAccount() {
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -59,7 +59,7 @@ class SettingsMigration : StartupActivity, DumbAware {
   ) {
     val dotcomAccessToken = extractDotcomAccessToken(project)
     if (!dotcomAccessToken.isNullOrEmpty()) {
-      val server = SourcegraphServerPath(ConfigUtil.DOTCOM_URL, customRequestHeaders)
+      val server = SourcegraphServerPath.from(ConfigUtil.DOTCOM_URL, customRequestHeaders)
       val extractedAccountType = extractAccountType(project)
       val shouldSetAccountAsDefault =
           extractedAccountType == AccountType.DOTCOM ||

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphServerPath.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphServerPath.kt
@@ -35,7 +35,26 @@ data class SourcegraphServerPath(
     fun from(uri: String, customRequestHeaders: String): SourcegraphServerPath {
       val matcher = URL_REGEX.matcher(uri)
       if (!matcher.matches()) throw SourcegraphParseException("Not a valid URL")
-      return SourcegraphServerPath(uri, customRequestHeaders)
+      val extractedSchema = matcher.group(1)
+      val schema = if (extractedSchema.isNullOrEmpty()) "https://" else extractedSchema
+      val host = matcher.group(2) ?: throw SourcegraphParseException("Empty host")
+      val port: Int?
+      val extractedPort = matcher.group(4)
+      port =
+          if (extractedPort == null) {
+            null
+          } else {
+            try {
+              extractedPort.toInt()
+            } catch (e: NumberFormatException) {
+              throw SourcegraphParseException("Invalid port format")
+            }
+          }
+
+      val extractedPath = matcher.group(5)
+      val path = if (!extractedPath.endsWith("/")) "$extractedPath/" else extractedPath
+      val fullUri = schema + host + (port?.let { ":$it" } ?: "") + path
+      return SourcegraphServerPath(fullUri, customRequestHeaders)
     }
   }
 }

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/SourcegraphServerPathTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/config/SourcegraphServerPathTest.kt
@@ -1,0 +1,68 @@
+package com.sourcegraph.cody.config
+
+import com.sourcegraph.config.ConfigUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SourcegraphServerPathTest {
+
+  @Test
+  fun `should create server path for dotcom`() {
+    // given
+    val url = ConfigUtil.DOTCOM_URL
+
+    // when
+    val serverPath = SourcegraphServerPath.from(url, "")
+
+    // then
+    assertThat(serverPath.url).isEqualTo(url)
+  }
+
+  @Test
+  fun `should create server path with additional slash at the end if missing`() {
+    // given
+    val url = "https://sourcegraph.com"
+
+    // then
+    val serverPath = SourcegraphServerPath.from(url, "")
+
+    // then
+    assertThat(serverPath.url).isEqualTo("https://sourcegraph.com/")
+  }
+
+  @Test
+  fun `should create server path with additional https schema if it's missing`() {
+    // given
+    val url = "sourcegraph.com"
+
+    // then
+    val serverPath = SourcegraphServerPath.from(url, "")
+
+    // then
+    assertThat(serverPath.url).isEqualTo("https://sourcegraph.com/")
+  }
+
+  @Test
+  fun `should create server path with port`() {
+    // given
+    val url = "sourcegraph.com:80"
+
+    // then
+    val serverPath = SourcegraphServerPath.from(url, "")
+
+    // then
+    assertThat(serverPath.url).isEqualTo("https://sourcegraph.com:80/")
+  }
+
+  @Test
+  fun `should create server path with url path`() {
+    // given
+    val url = "sourcegraph.com:80/some/path"
+
+    // then
+    val serverPath = SourcegraphServerPath.from(url, "")
+
+    // then
+    assertThat(serverPath.url).isEqualTo("https://sourcegraph.com:80/some/path/")
+  }
+}


### PR DESCRIPTION
Previously user had to insert full url as a complete and valid url, now we're able to adjust the inserted text so it's easier for user to configure a server url

For server url without the schema we're adding the `https://` schema automatically.
For server url without `/` at the end we're adding the `/` automatically

## Test plan
- Configure new account with server url in a simplified form, we should be able to adjust the url so it's possible to connect to our backend. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
