### PR TITLE
searchjobs: factor out newSearcher test logic

### DIFF
--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     srcs = ["search_test.go"],
     deps = [
         ":service",
+        "//internal/search/exhaustive/types",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//slices",
     ],

--- a/internal/search/exhaustive/service/search_test.go
+++ b/internal/search/exhaustive/service/search_test.go
@@ -12,48 +12,57 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 )
 
 func TestBackendFake(t *testing.T) {
+	testNewSearcher(t, service.NewSearcherFake(), newSearcherTestCase{
+		Query:        "1@rev1 1@rev2 2@rev3",
+		WantRefSpecs: "RepositoryRevSpec{1@spec} RepositoryRevSpec{2@spec}",
+		WantRepoRevs: "RepositoryRevision{1@rev1} RepositoryRevision{1@rev2} RepositoryRevision{2@rev3}",
+		WantCSV: `repo,revspec,revision
+1,spec,rev1
+1,spec,rev2
+2,spec,rev3
+`,
+	})
+}
+
+type newSearcherTestCase struct {
+	Query        string
+	WantRefSpecs string
+	WantRepoRevs string
+	WantCSV      string
+}
+
+func testNewSearcher(t *testing.T, newSearcher service.NewSearcher, tc newSearcherTestCase) {
 	assert := require.New(t)
 
 	ctx := context.Background()
-	searcher, err := service.NewSearcherFake().NewSearch(ctx, "1@rev1 1@rev2 2@rev3")
+	searcher, err := newSearcher.NewSearch(ctx, tc.Query)
 	assert.NoError(err)
 
 	// Test RepositoryRevSpecs
 	refSpecs, err := searcher.RepositoryRevSpecs(ctx)
 	assert.NoError(err)
-	assert.Equal("RepositoryRevSpec{1@spec} RepositoryRevSpec{2@spec}", joinStringer(refSpecs))
+	assert.Equal(tc.WantRefSpecs, joinStringer(refSpecs))
 
 	// Test ResolveRepositoryRevSpec
-	{
-		// RepositoryRevSpec{1@spec}
-		repoRevs, err := searcher.ResolveRepositoryRevSpec(ctx, refSpecs[0])
+	var repoRevs []types.RepositoryRevision
+	for _, refSpec := range refSpecs {
+		repoRevsPart, err := searcher.ResolveRepositoryRevSpec(ctx, refSpec)
 		assert.NoError(err)
-		assert.Equal("RepositoryRevision{1@rev1} RepositoryRevision{1@rev2}", joinStringer(repoRevs))
-
-		// RepositoryRevSpec{2@spec}
-		repoRevs, err = searcher.ResolveRepositoryRevSpec(ctx, refSpecs[1])
-		assert.NoError(err)
-		assert.Equal("RepositoryRevision{2@rev3}", joinStringer(repoRevs))
+		repoRevs = append(repoRevs, repoRevsPart...)
 	}
+	assert.Equal(tc.WantRepoRevs, joinStringer(repoRevs))
 
 	// Test Search
 	var csv csvBuffer
-	for _, refSpec := range refSpecs {
-		repoRevs, err := searcher.ResolveRepositoryRevSpec(ctx, refSpec)
+	for _, repoRev := range repoRevs {
+		err := searcher.Search(ctx, repoRev, &csv)
 		assert.NoError(err)
-		for _, repoRev := range repoRevs {
-			err := searcher.Search(ctx, repoRev, &csv)
-			assert.NoError(err)
-		}
 	}
-	assert.Equal(`repo,revspec,revision
-1,spec,rev1
-1,spec,rev2
-2,spec,rev3
-`, csv.buf.String())
+	assert.Equal(tc.WantCSV, csv.buf.String())
 }
 
 func joinStringer[T fmt.Stringer](xs []T) string {


### PR DESCRIPTION
I am busy implementing the NewSearcher for real and this test logic is useful to reuse. This commit just refactors the existing test case to make the assertion part re-useable. It also has the nice side-effect of putting all the bits we assert on next to each other which makes the test easier to understand.

Test Plan: go test