### PR TITLE
Add temporary logging to dotcom sudo handler

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -54,7 +54,7 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 		if headerValue := r.Header.Get("Authorization"); headerValue != "" && token == "" {
 			// Handle Authorization header
 			var err error
-			token, sudoUser, err = authz.ParseAuthorizationHeader(headerValue)
+			token, sudoUser, err = authz.ParseAuthorizationHeader(logger, r, headerValue)
 			if err != nil {
 				if authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.

--- a/internal/authz/BUILD.bazel
+++ b/internal/authz/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//lib/errors",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )
@@ -48,6 +49,7 @@ go_test(
         "//lib/errors",
         "@com_github_gobwas_glob//:glob",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/authz/header.go
+++ b/internal/authz/header.go
@@ -2,7 +2,11 @@ package authz
 
 import (
 	"bytes"
+	"io"
+	"net/http"
 	"strings"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -35,7 +39,7 @@ func IsUnrecognizedScheme(err error) bool {
 //
 // The returned values are derived directly from user input and have not been validated or
 // authenticated.
-func ParseAuthorizationHeader(headerValue string) (token, sudoUser string, err error) {
+func ParseAuthorizationHeader(logger log.Logger, r *http.Request, headerValue string) (token, sudoUser string, err error) {
 	scheme, token68, params, err := parseHTTPCredentials(headerValue)
 	if err != nil {
 		return "", "", err
@@ -55,6 +59,9 @@ func ParseAuthorizationHeader(headerValue string) (token, sudoUser string, err e
 	}
 
 	if envvar.SourcegraphDotComMode() {
+		// Attempt to read the body. This might fail if it was read before.
+		body, readErr := io.ReadAll(r.Body)
+		logger.Warn("saw request with sudo mode", log.String("path", r.URL.Path), log.String("body", string(body)), log.Error(readErr))
 		return "", "", errors.New("use of access tokens with sudo scope is disabled")
 	}
 


### PR DESCRIPTION
This should help us identify traffic better.

## Test plan

Added a test to ensure the logs are actually how we expect them to look like.