### PR TITLE
Resolve sudo error for empty token header

### DIFF
--- a/internal/authz/header.go
+++ b/internal/authz/header.go
@@ -58,7 +58,7 @@ func ParseAuthorizationHeader(logger log.Logger, r *http.Request, headerValue st
 		}
 	}
 
-	if envvar.SourcegraphDotComMode() {
+	if envvar.SourcegraphDotComMode() && scheme == SchemeTokenSudo {
 		// Attempt to read the body. This might fail if it was read before.
 		body, readErr := io.ReadAll(r.Body)
 		logger.Warn("saw request with sudo mode", log.String("path", r.URL.Path), log.String("body", string(body)), log.Error(readErr))

--- a/internal/authz/header_test.go
+++ b/internal/authz/header_test.go
@@ -77,7 +77,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 		}, logs[0].Fields)
 	})
 
-	t.Run("empty does not raise sudo error on dotcom", func(t *testing.T) {
+	t.Run("empty token does not raise sudo error on dotcom", func(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
 

--- a/internal/authz/header_test.go
+++ b/internal/authz/header_test.go
@@ -85,8 +85,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 			URL:  &url.URL{Path: ".api/graphql"},
 			Body: io.NopCloser(strings.NewReader("the body")),
 		}
-		logger, _ := logtest.Captured(t)
-		_, _, err := ParseAuthorizationHeader(logger, r, `token`)
+		_, _, err := ParseAuthorizationHeader(logtest.Scoped(t), r, `token`)
 		got := fmt.Sprintf("%v", err)
 		want := "no token value in the HTTP Authorization request header"
 		if diff := cmp.Diff(want, got); diff != "" {


### PR DESCRIPTION
Previously if a header such as `Authorization: token` was passed, it would throw a sudo error on DotCom. We now make sure that we have the correct schema to ensure it's truly a sudo scheme.

## Test plan
Tested locally, added tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
