### PR TITLE
dotcom: adjust sign-in CTAs when signup is disabled

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -89,6 +89,25 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
 
     const providers = showMoreProviders ? moreProviders : primaryProviders
 
+    const dotcomCTAs = (
+        <>
+            <Link
+                to="https://about.sourcegraph.com/app"
+                onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
+            >
+                download Cody app
+            </Link>{' '}
+            or{' '}
+            <Link
+                to="https://sourcegraph.com/get-started?t=enterprise"
+                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
+            >
+                get Sourcegraph Enterprise
+            </Link>
+            .
+        </>
+    )
+
     const body = !hasProviders ? (
         <Alert className="mt-3" variant="info">
             No authentication providers are available. Contact a site administrator for help.
@@ -159,32 +178,17 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
             {context.allowSignup ? (
                 <Text>
                     New to Sourcegraph? <Link to="/sign-up">Sign up.</Link>{' '}
-                    {context.sourcegraphDotComMode && (
-                        <>
-                            To use Sourcegraph on private repositories,{' '}
-                            <Link
-                                to="https://about.sourcegraph.com/app"
-                                onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
-                            >
-                                download Cody app
-                            </Link>{' '}
-                            or{' '}
-                            <Link
-                                to="https://sourcegraph.com/get-started?t=enterprise"
-                                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
-                            >
-                                get Sourcegraph Enterprise
-                            </Link>
-                            .
-                        </>
-                    )}
+                    {context.sourcegraphDotComMode && <>To use Sourcegraph on private repositories, {dotcomCTAs}</>}
                 </Text>
             ) : isRequestAccessAllowed ? (
                 <Text className="text-muted">
                     Need an account? <Link to="/request-access">Request access</Link> or contact your site admin.
                 </Text>
             ) : (
-                <Text className="text-muted">Need an account? Contact your site admin.</Text>
+                <Text className="text-muted">
+                    {context.sourcegraphDotComMode}?<>Account creation is disabled - to try Sourcegraph, {dotcomCTAs}</>
+                    : <>Need an account? Contact your site admin.</>
+                </Text>
             )}
         </div>
     )

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -182,7 +182,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                     {context.sourcegraphDotComMode ? (
                         <>
                             Currently, we are unable to create accounts using email. Please use the providers listed
-                            above to continue. For private code, {dotcomCTAs}
+                            above to continue. <br /> For private code, {dotcomCTAs}
                         </>
                     ) : (
                         <>Need an account? Contact your site admin.</>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -186,8 +186,11 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 </Text>
             ) : (
                 <Text className="text-muted">
-                    {context.sourcegraphDotComMode}?<>Account creation is disabled - to try Sourcegraph, {dotcomCTAs}</>
-                    : <>Need an account? Contact your site admin.</>
+                    {context.sourcegraphDotComMode ? (
+                        <>Account creation is disabled - to try Sourcegraph, {dotcomCTAs}</>
+                    ) : (
+                        <>Need an account? Contact your site admin.</>
+                    )}
                 </Text>
             )}
         </div>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -92,17 +92,10 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     const dotcomCTAs = (
         <>
             <Link
-                to="https://about.sourcegraph.com/app"
-                onClick={() => eventLogger.log('ClickedOnAppCTA', { location: 'SignInPage' })}
-            >
-                download Cody app
-            </Link>{' '}
-            or{' '}
-            <Link
                 to="https://sourcegraph.com/get-started?t=enterprise"
                 onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
             >
-                get Sourcegraph Enterprise
+                consider Sourcegraph Enterprise
             </Link>
             .
         </>
@@ -187,7 +180,10 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
             ) : (
                 <Text className="text-muted">
                     {context.sourcegraphDotComMode ? (
-                        <>Account creation is disabled - to try Sourcegraph, {dotcomCTAs}</>
+                        <>
+                            Currently, we are unable to create accounts using email. Please use the providers listed
+                            above to continue. For private code, {dotcomCTAs}
+                        </>
                     ) : (
                         <>Need an account? Contact your site admin.</>
                     )}

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -96,14 +96,14 @@ exports[`SignInPage renders "Other login methods" if primary provider count is l
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -230,14 +230,14 @@ exports[`SignInPage renders different prefix on provider buttons 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -341,14 +341,14 @@ exports[`SignInPage renders non-primary auth provider if primary provider count 
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -483,26 +483,19 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           To use Sourcegraph on private repositories, 
-          <a
-            class="anchorLink"
-            href="https://about.sourcegraph.com/app"
-          >
-            download Cody app
-          </a>
-           or 
+           To use Sourcegraph on private repositories,
           <a
             class="anchorLink"
             href="https://sourcegraph.com/get-started?t=enterprise"
           >
-            get Sourcegraph Enterprise
+            consider Sourcegraph Enterprise
           </a>
           .
         </p>
@@ -631,14 +624,14 @@ exports[`SignInPage renders sign in page (server) 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -794,14 +787,14 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -934,14 +927,14 @@ exports[`SignInPage renders sign in page (server) with only builtin authProvider
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -1068,7 +1061,7 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
         <p
           class="text-muted"
         >
-          Need an account? 
+          Need an account?
           <a
             class="anchorLink"
             href="/request-access"
@@ -1202,14 +1195,14 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -1336,14 +1329,14 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>
@@ -1480,14 +1473,14 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
         <p
           class=""
         >
-          New to Sourcegraph? 
+          New to Sourcegraph?
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           
+
         </p>
       </div>
     </div>

--- a/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignInPage.test.tsx.snap
@@ -96,14 +96,14 @@ exports[`SignInPage renders "Other login methods" if primary provider count is l
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -230,14 +230,14 @@ exports[`SignInPage renders different prefix on provider buttons 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -341,14 +341,14 @@ exports[`SignInPage renders non-primary auth provider if primary provider count 
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -483,14 +483,14 @@ exports[`SignInPage renders sign in page (dotcom) 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-           To use Sourcegraph on private repositories,
+           To use Sourcegraph on private repositories, 
           <a
             class="anchorLink"
             href="https://sourcegraph.com/get-started?t=enterprise"
@@ -624,14 +624,14 @@ exports[`SignInPage renders sign in page (server) 1`] = `
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -787,14 +787,14 @@ exports[`SignInPage renders sign in page (server) with email form expanded 1`] =
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -927,14 +927,14 @@ exports[`SignInPage renders sign in page (server) with only builtin authProvider
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -1061,7 +1061,7 @@ exports[`SignInPage renders sign in page (server) with request access link 1`] =
         <p
           class="text-muted"
         >
-          Need an account?
+          Need an account? 
           <a
             class="anchorLink"
             href="/request-access"
@@ -1195,14 +1195,14 @@ exports[`SignInPage with Gerrit auth provider does not render the Gerrit provide
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -1329,14 +1329,14 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 2 
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>
@@ -1473,14 +1473,14 @@ exports[`SignInPage with Sourcegraph operator auth provider renders page with 3 
         <p
           class=""
         >
-          New to Sourcegraph?
+          New to Sourcegraph? 
           <a
             class="anchorLink"
             href="/sign-up"
           >
             Sign up.
           </a>
-
+           
         </p>
       </div>
     </div>


### PR DESCRIPTION
The dotcom sign-in page now asks you to contact your site admin, which needs to make more sense in the dotcom context. This is because we disabled sign-ups for INC-239. Instead, we tell users to try App or Enterprise, which is what we did before

<img width="771" alt="CleanShot 2023-09-28 at 19 42 39@2x" src="https://github.com/sourcegraph/sourcegraph/assets/25608335/193d9354-bb9a-47a6-bad9-b0babf2f1231">

## Test plan

Start up your SG instance in dotcom mode. Ensure `allowSignups` is set to `false` in your Site Configuration.