### PR TITLE
ci/wolfi: upgrade packages and images build deps

### DIFF
--- a/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-base-image.sh
@@ -26,10 +26,10 @@ trap cleanup EXIT
   mkdir bin
 
   # Install apko from Sourcegraph cache
-  # Source: https://github.com/chainguard-dev/apko/releases/download/v0.6.0/apko_0.6.0_linux_amd64.tar.gz
-  wget https://storage.googleapis.com/package-repository/ci-binaries/apko_0.6.0_linux_amd64.tar.gz
-  tar zxf apko_0.6.0_linux_amd64.tar.gz
-  mv apko_0.6.0_linux_amd64/apko bin/apko
+  # Source: https://github.com/chainguard-dev/apko/releases/download/v0.10.0/apko_0.10.0_linux_amd64.tar.gz
+  wget https://storage.googleapis.com/package-repository/ci-binaries/apko_0.10.0_linux_amd64.tar.gz
+  tar zxf apko_0.10.0_linux_amd64.tar.gz
+  mv apko_0.10.0_linux_amd64/apko bin/apko
 
   # Install apk from Sourcegraph cache
   # Source: https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v2.12.11/x86_64/apk.static

--- a/enterprise/dev/ci/scripts/wolfi/build-package.sh
+++ b/enterprise/dev/ci/scripts/wolfi/build-package.sh
@@ -17,10 +17,10 @@ trap cleanup EXIT
   mkdir bin
 
   # Install melange from Sourcegraph cache
-  # Source: https://github.com/chainguard-dev/melange/releases/download/v0.2.0/melange_0.2.0_linux_amd64.tar.gz
-  wget https://storage.googleapis.com/package-repository/ci-binaries/melange_0.2.0_linux_amd64.tar.gz
-  tar zxf melange_0.2.0_linux_amd64.tar.gz
-  mv melange_0.2.0_linux_amd64/melange bin/melange
+  # Source: https://github.com/chainguard-dev/melange/releases/download/v0.4.0/melange_0.4.0_linux_amd64.tar.gz
+  wget https://storage.googleapis.com/package-repository/ci-binaries/melange_0.4.0_linux_amd64.tar.gz
+  tar zxf melange_0.4.0_linux_amd64.tar.gz
+  mv melange_0.4.0_linux_amd64/melange bin/melange
 
   # Install apk from Sourcegraph cache
   # Source: https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic//v2.12.11/x86_64/apk.static


### PR DESCRIPTION
older version of melange is breaking my build: https://buildkite.com/sourcegraph/sourcegraph/builds/241239 (it worked locally using the latest v0.4.0)

we might as well bump apko with it, the difference between local and CI is annoying https://sourcegraph.slack.com/archives/C04MYFW01NV/p1692288383092059?thread_ts=1692287435.835749&cid=C04MYFW01NV

## Test plan

CI