### PR TITLE
Add config to allow for ignoring Perforce protects rules that specify a Host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
+- User access to Perforce depots is sometimes denied unintentionally when using `"authorization"/"subRepoPermissions": true` in the code host config and the protects file contains exclusionary entries with the Host field filled out. Ignoring those rules (that use anything other than the wildcard (`*`) in the Host field) is now toggle-able by adding `"authorization"/"ignoreRulesWithHost"` to the code host config and setting the value to `true`. [#56450](https://github.com/sourcegraph/sourcegraph/pull/56450)
+
 ### Fixed
 
 - Fixed an issue where the "gitLabProjectVisibilityExperimental" feature flag would not be respected by the permissions syncer. This meant that users on Sourcegraph that have signed in with GitLab would not see GitLab internal repositories that should be accessible to everyone on the GitLab instance, even though the feature flag was enabled [#56492](https://github.com/sourcegraph/sourcegraph/pull/56492)

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -193,6 +193,19 @@ To enable file-level permissions:
 
 1. Save the configuration. Permissions will be synced in the background based on your [Perforce protects file](https://www.perforce.com/manuals/cmdref/Content/CmdRef/p4_protect.html).
 
+#### Handling Host rules in the protects file
+
+When file-level permissions are enabled, Sourcegraph will read the Perforce protects file to determine what users can access. Because Sourcegraph originates all depot access from one host, protects rules with a Host field cannot be followed exactly. By default, they are parsed as if they apply to all hosts, which can result in users losing access when they should have access. If you have protects rules with hosts that are causing lost access for users, you can set `ignoreRulesWithHost` to `true` in the code host configuration.
+
+```json
+    {
+      "authorization": {
+        "subRepoPermissions": true,
+        "ignoreRulesWithHost": true
+      }
+    }
+```
+
 ### Notes about permissions
 
 - Sourcegraph users are mapped to Perforce users based on their verified email addresses.

--- a/internal/authz/providers/perforce/authz.go
+++ b/internal/authz/providers/perforce/authz.go
@@ -68,7 +68,7 @@ func newAuthzProvider(
 		}
 	}
 
-	return NewProvider(logger, gitserver.NewClient(), urn, host, user, password, depotIDs), nil
+	return NewProvider(logger, gitserver.NewClient(), urn, host, user, password, depotIDs, a.IgnoreRulesWithHost), nil
 }
 
 // ValidateAuthz validates the authorization fields of the given Perforce

--- a/internal/authz/providers/perforce/cmd/scanprotects/main.go
+++ b/internal/authz/providers/perforce/cmd/scanprotects/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 var depot = flag.String("d", "", "depot name")
+var ignoreHostRulesFlag = flag.Bool("i", false, "ignore protects rules with a non-wildcard Host field")
 
 func main() {
 	flag.Parse()
@@ -36,12 +37,14 @@ func main() {
 	})
 	defer liblog.Sync()
 
+	ignoreHostRules := ignoreHostRulesFlag == nil || *ignoreHostRulesFlag
+
 	logger := log.Scoped("scanprotects", "")
-	run(logger, *depot, os.Stdin)
+	run(logger, *depot, os.Stdin, ignoreHostRules)
 }
 
-func run(logger log.Logger, depot string, input io.Reader) {
-	perms, err := perforce.PerformDebugScan(logger, input, extsvc.RepoID(depot))
+func run(logger log.Logger, depot string, input io.Reader, ignoreHostRules bool) {
+	perms, err := perforce.PerformDebugScan(logger, input, extsvc.RepoID(depot), ignoreHostRules)
 	if err != nil {
 		fail(fmt.Sprintf("Error parsing permissions: %s", err))
 	}

--- a/internal/authz/providers/perforce/cmd/scanprotects/main.go
+++ b/internal/authz/providers/perforce/cmd/scanprotects/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var depot = flag.String("d", "", "depot name")
-var ignoreHostRulesFlag = flag.Bool("i", false, "ignore protects rules with a non-wildcard Host field")
+var ignoreRulesWithHostFlag = flag.Bool("i", false, "ignore protects rules with a non-wildcard Host field")
 
 func main() {
 	flag.Parse()
@@ -37,14 +37,14 @@ func main() {
 	})
 	defer liblog.Sync()
 
-	ignoreHostRules := ignoreHostRulesFlag == nil || *ignoreHostRulesFlag
+	ignoreRulesWithHost := ignoreRulesWithHostFlag == nil || *ignoreRulesWithHostFlag
 
 	logger := log.Scoped("scanprotects", "")
-	run(logger, *depot, os.Stdin, ignoreHostRules)
+	run(logger, *depot, os.Stdin, ignoreRulesWithHost)
 }
 
-func run(logger log.Logger, depot string, input io.Reader, ignoreHostRules bool) {
-	perms, err := perforce.PerformDebugScan(logger, input, extsvc.RepoID(depot), ignoreHostRules)
+func run(logger log.Logger, depot string, input io.Reader, ignoreRulesWithHost bool) {
+	perms, err := perforce.PerformDebugScan(logger, input, extsvc.RepoID(depot), ignoreRulesWithHost)
 	if err != nil {
 		fail(fmt.Sprintf("Error parsing permissions: %s", err))
 	}

--- a/internal/authz/providers/perforce/cmd/scanprotects/main_test.go
+++ b/internal/authz/providers/perforce/cmd/scanprotects/main_test.go
@@ -21,7 +21,7 @@ func TestPerformDebugScan(t *testing.T) {
 		}
 	})
 
-	run(logger, "//depot/main/", input)
+	run(logger, "//depot/main/", input, false)
 
 	logged := exporter()
 	// For now we'll just check that the count as well as first and last lines are

--- a/internal/authz/providers/perforce/cmd/scanprotects/main_test.go
+++ b/internal/authz/providers/perforce/cmd/scanprotects/main_test.go
@@ -26,7 +26,7 @@ func TestPerformDebugScan(t *testing.T) {
 	logged := exporter()
 	// For now we'll just check that the count as well as first and last lines are
 	// what we expect
-	assert.Len(t, logged, 448)
+	assert.Len(t, logged, 444)
 	assert.Equal(t, "Converted depot to glob", logged[0].Message) // fails without error
 	assert.Equal(t, "Include rule", logged[len(logged)-1].Message)
 }

--- a/internal/authz/providers/perforce/perforce.go
+++ b/internal/authz/providers/perforce/perforce.go
@@ -47,7 +47,7 @@ type Provider struct {
 	groupsCacheMutex      sync.RWMutex
 	cachedGroupMembers    map[string][]string // group -> members
 	groupsCacheLastUpdate time.Time
-	ignoreHostRules       bool
+	ignoreRulesWithHost   bool
 }
 
 func cacheIsUpToDate(lastUpdate time.Time) bool {
@@ -62,19 +62,19 @@ type p4Execer interface {
 // host, user and password to talk to a Perforce Server that is the source of
 // truth for permissions. It assumes emails of Sourcegraph accounts match 1-1
 // with emails of Perforce Server users.
-func NewProvider(logger log.Logger, p4Execer p4Execer, urn, host, user, password string, depots []extsvc.RepoID, ignoreHostRules bool) *Provider {
+func NewProvider(logger log.Logger, p4Execer p4Execer, urn, host, user, password string, depots []extsvc.RepoID, ignoreRulesWithHost bool) *Provider {
 	baseURL, _ := url.Parse(host)
 	return &Provider{
-		logger:             logger,
-		urn:                urn,
-		codeHost:           extsvc.NewCodeHost(baseURL, extsvc.TypePerforce),
-		depots:             depots,
-		host:               host,
-		user:               user,
-		password:           password,
-		p4Execer:           p4Execer,
-		cachedGroupMembers: make(map[string][]string),
-		ignoreHostRules:    ignoreHostRules,
+		logger:              logger,
+		urn:                 urn,
+		codeHost:            extsvc.NewCodeHost(baseURL, extsvc.TypePerforce),
+		depots:              depots,
+		host:                host,
+		user:                user,
+		password:            password,
+		p4Execer:            p4Execer,
+		cachedGroupMembers:  make(map[string][]string),
+		ignoreRulesWithHost: ignoreRulesWithHost,
 	}
 }
 
@@ -178,11 +178,11 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account, 
 	// Pull permissions from protects file.
 	perms := &authz.ExternalUserPermissions{}
 	if len(p.depots) == 0 {
-		err = errors.Wrap(scanProtects(p.logger, rc, repoIncludesExcludesScanner(perms), p.ignoreHostRules), "repoIncludesExcludesScanner")
+		err = errors.Wrap(scanProtects(p.logger, rc, repoIncludesExcludesScanner(perms), p.ignoreRulesWithHost), "repoIncludesExcludesScanner")
 	} else {
 		// SubRepoPermissions-enabled code path
 		perms.SubRepoPermissions = make(map[extsvc.RepoID]*authz.SubRepoPermissions, len(p.depots))
-		err = errors.Wrap(scanProtects(p.logger, rc, fullRepoPermsScanner(p.logger, perms, p.depots), p.ignoreHostRules), "fullRepoPermsScanner")
+		err = errors.Wrap(scanProtects(p.logger, rc, fullRepoPermsScanner(p.logger, perms, p.depots), p.ignoreRulesWithHost), "fullRepoPermsScanner")
 	}
 
 	// As per interface definition for this method, implementation should return
@@ -343,7 +343,7 @@ func (p *Provider) FetchRepoPerms(ctx context.Context, repo *extsvc.Repository, 
 	defer func() { _ = rc.Close() }()
 
 	users := make(map[string]struct{})
-	if err := scanProtects(p.logger, rc, allUsersScanner(ctx, p, users), p.ignoreHostRules); err != nil {
+	if err := scanProtects(p.logger, rc, allUsersScanner(ctx, p, users), p.ignoreRulesWithHost); err != nil {
 		return nil, errors.Wrap(err, "scanning protects")
 	}
 

--- a/internal/authz/providers/perforce/perforce_test.go
+++ b/internal/authz/providers/perforce/perforce_test.go
@@ -89,7 +89,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("nil account", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", nil)
+		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", nil, false)
 		_, err := p.FetchUserPerms(ctx, nil, authz.FetchPermsOptions{})
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
@@ -100,7 +100,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
+		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
 		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
@@ -119,7 +119,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("no user found in account data", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
+		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
 		_, err := p.FetchUserPerms(ctx,
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
@@ -343,7 +343,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("nil repository", func(t *testing.T) {
-		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
+		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
 		_, err := p.FetchRepoPerms(ctx, nil, authz.FetchPermsOptions{})
 		want := "no repository provided"
 		got := fmt.Sprintf("%v", err)
@@ -353,7 +353,7 @@ func TestProvider_FetchRepoPerms(t *testing.T) {
 	})
 
 	t.Run("not the code host of the repository", func(t *testing.T) {
-		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{})
+		p := NewProvider(logger, gitserver.NewClient(), "", "ssl:111.222.333.444:1666", "admin", "password", []extsvc.RepoID{}, false)
 		_, err := p.FetchRepoPerms(ctx,
 			&extsvc.Repository{
 				URI: "gitlab.com/user/repo",
@@ -439,7 +439,7 @@ Users:
 }
 
 func NewTestProvider(logger log.Logger, urn, host, user, password string, execer p4Execer) *Provider {
-	p := NewProvider(logger, gitserver.NewClient(), urn, host, user, password, []extsvc.RepoID{})
+	p := NewProvider(logger, gitserver.NewClient(), urn, host, user, password, []extsvc.RepoID{}, false)
 	p.p4Execer = execer
 	return p
 }

--- a/internal/authz/providers/perforce/protects.go
+++ b/internal/authz/providers/perforce/protects.go
@@ -185,12 +185,12 @@ func matchesAgainstDepot(match globMatch, depot string) bool {
 
 // PerformDebugScan will scan protections rules from r and log detailed
 // information about how each line was parsed.
-func PerformDebugScan(logger log.Logger, r io.Reader, depot extsvc.RepoID) (*authz.ExternalUserPermissions, error) {
+func PerformDebugScan(logger log.Logger, r io.Reader, depot extsvc.RepoID, ignoreHostRules bool) (*authz.ExternalUserPermissions, error) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
 	scanner := fullRepoPermsScanner(logger, perms, []extsvc.RepoID{depot})
-	err := scanProtects(logger, r, scanner)
+	err := scanProtects(logger, r, scanner, ignoreHostRules)
 	return perms, err
 }
 
@@ -205,7 +205,7 @@ type protectsScanner struct {
 // scanProtects is a utility function for processing values from `p4 protects`.
 // It handles skipping comments, cleaning whitespace, parsing relevant fields, and
 // skipping entries that do not affect read access.
-func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner) error {
+func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHostRules bool) error {
 	logger = logger.Scoped("scanProtects", "")
 	scanner := bufio.NewScanner(rc)
 	for scanner.Scan() {
@@ -244,7 +244,7 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner) error {
 		// GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/53374
 		// Subsequent approaches will need to add more sophisticated handling of hosts
 		// perhaps even capturing the browser IP address and comparing it to the host field.
-		if fields[3] != "*" {
+		if ignoreHostRules && fields[3] != "*" {
 			logger.Debug("Skipping host-specific rule", log.String("line", line))
 			continue
 		}

--- a/internal/authz/providers/perforce/protects.go
+++ b/internal/authz/providers/perforce/protects.go
@@ -211,6 +211,9 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHos
 	for scanner.Scan() {
 		line := scanner.Text()
 
+		// Trim whitespace
+		line = strings.TrimSpace(line)
+
 		// Skip comments
 		if strings.HasPrefix(line, "##") {
 			continue
@@ -220,9 +223,6 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHos
 		if i := strings.Index(line, "##"); i > -1 {
 			line = line[:i]
 		}
-
-		// Trim whitespace
-		line = strings.TrimSpace(line)
 
 		// Skip blank lines
 		if line == "" {

--- a/internal/authz/providers/perforce/protects.go
+++ b/internal/authz/providers/perforce/protects.go
@@ -185,12 +185,12 @@ func matchesAgainstDepot(match globMatch, depot string) bool {
 
 // PerformDebugScan will scan protections rules from r and log detailed
 // information about how each line was parsed.
-func PerformDebugScan(logger log.Logger, r io.Reader, depot extsvc.RepoID, ignoreHostRules bool) (*authz.ExternalUserPermissions, error) {
+func PerformDebugScan(logger log.Logger, r io.Reader, depot extsvc.RepoID, ignoreRulesWithHost bool) (*authz.ExternalUserPermissions, error) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
 	scanner := fullRepoPermsScanner(logger, perms, []extsvc.RepoID{depot})
-	err := scanProtects(logger, r, scanner, ignoreHostRules)
+	err := scanProtects(logger, r, scanner, ignoreRulesWithHost)
 	return perms, err
 }
 
@@ -205,7 +205,7 @@ type protectsScanner struct {
 // scanProtects is a utility function for processing values from `p4 protects`.
 // It handles skipping comments, cleaning whitespace, parsing relevant fields, and
 // skipping entries that do not affect read access.
-func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHostRules bool) error {
+func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreRulesWithHost bool) error {
 	logger = logger.Scoped("scanProtects", "")
 	scanner := bufio.NewScanner(rc)
 	for scanner.Scan() {
@@ -239,7 +239,7 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHos
 		// GitHub issue: https://github.com/sourcegraph/sourcegraph/issues/53374
 		// Subsequent approaches will need to add more sophisticated handling of hosts
 		// perhaps even capturing the browser IP address and comparing it to the host field.
-		if ignoreHostRules && fields[3] != "*" {
+		if ignoreRulesWithHost && fields[3] != "*" {
 			logger.Debug("Skipping host-specific rule", log.String("line", line))
 			continue
 		}

--- a/internal/authz/providers/perforce/protects.go
+++ b/internal/authz/providers/perforce/protects.go
@@ -214,19 +214,14 @@ func scanProtects(logger log.Logger, rc io.Reader, s *protectsScanner, ignoreHos
 		// Trim whitespace
 		line = strings.TrimSpace(line)
 
-		// Skip comments
-		if strings.HasPrefix(line, "##") {
+		// Skip comments and blank lines
+		if strings.HasPrefix(line, "##") || line == "" {
 			continue
 		}
 
 		// Trim trailing comments
 		if i := strings.Index(line, "##"); i > -1 {
 			line = line[:i]
-		}
-
-		// Skip blank lines
-		if line == "" {
-			continue
 		}
 
 		logger.Debug("Scanning protects line", log.String("line", line))

--- a/internal/authz/providers/perforce/protects_test.go
+++ b/internal/authz/providers/perforce/protects_test.go
@@ -379,6 +379,17 @@ write       group       Dev1    *    //depot/elm_proj/...
 			canReadAll: []string{"dev/productA/readme.txt"},
 		},
 		{
+			name:  "Rules that include a host are ignored",
+			depot: "//depot/",
+			protects: `
+write       group       Dev2    *    //depot/dev/...
+read        group       Dev1    *    //depot/dev/productA/...
+write       group       Dev1    *    //depot/elm_proj/...
+read		group		Dev1    192.168.10.1/24    -//depot/dev/productA/...
+`,
+			canReadAll: []string{"dev/productA/readme.txt"},
+		},
+		{
 			name:  "Exclusion overrides prior inclusion",
 			depot: "//depot/",
 			protects: `

--- a/internal/authz/providers/perforce/protects_test.go
+++ b/internal/authz/providers/perforce/protects_test.go
@@ -244,7 +244,7 @@ func TestScanFullRepoPermissions(t *testing.T) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -325,7 +325,7 @@ func TestScanFullRepoPermissionsWithWildcardMatchingDepot(t *testing.T) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -624,7 +624,7 @@ read    group   Dev1    *   //depot/main/.../*.go
 			perms := &authz.ExternalUserPermissions{
 				SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 			}
-			if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
+			if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots), true); err != nil {
 				t.Fatal(err)
 			}
 			rules, ok := perms.SubRepoPermissions[extsvc.RepoID(tc.depot)]
@@ -691,7 +691,7 @@ func TestFullScanWildcardDepotMatching(t *testing.T) {
 	perms := &authz.ExternalUserPermissions{
 		SubRepoPermissions: make(map[extsvc.RepoID]*authz.SubRepoPermissions),
 	}
-	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots)); err != nil {
+	if err := scanProtects(logger, rc, fullRepoPermsScanner(logger, perms, p.depots), false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -844,7 +844,7 @@ func TestScanAllUsers(t *testing.T) {
 	}
 
 	users := make(map[string]struct{})
-	if err := scanProtects(logger, rc, allUsersScanner(ctx, p, users)); err != nil {
+	if err := scanProtects(logger, rc, allUsersScanner(ctx, p, users), false); err != nil {
 		t.Fatal(err)
 	}
 	want := map[string]struct{}{

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -73,6 +73,11 @@
           "description": "Experimental: infer sub-repository permissions from protection rules.",
           "type": "boolean",
           "default": false
+        },
+        "ignoreRulesWithHost": {
+          "description": "Ignore host-based protection rules (any rule with something other than a wildcard in the Host field).",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1825,6 +1825,8 @@ type PasswordPolicy struct {
 
 // PerforceAuthorization description: If non-null, enforces Perforce depot permissions.
 type PerforceAuthorization struct {
+	// IgnoreRulesWithHost description: Ignore host-based protection rules (any rule with something other than a wildcard in the Host field).
+	IgnoreRulesWithHost bool `json:"ignoreRulesWithHost,omitempty"`
 	// SubRepoPermissions description: Experimental: infer sub-repository permissions from protection rules.
 	SubRepoPermissions bool `json:"subRepoPermissions,omitempty"`
 }


### PR DESCRIPTION
User access to Perforce depots is sometimes denied unintentionally when using `"authorization"/"subRepoPermissions": true` in the code host config and the protects file contains exclusionary entries with the Host field filled out. Ignoring those rules (that use anything other than the wildcard (`*`) in the Host field) is now toggle-able by adding `"authorization"/"ignoreRulesWithHost"` to the code host config and setting the value to `true`. 

This will cause the protects parser to simply ignore all rules that specify a Host.

closes #53374

## Test plan

Added unit tests to verify correct behavior of the protects file parser.