### PR TITLE
JetBrains: stop logging `completion:started` events

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -149,7 +149,6 @@ public class CodyAutocompleteManager {
       return;
     }
     currentAutocompleteTelemetry = AutocompleteTelemetry.createAndMarkTriggered();
-    GraphQlLogger.logCodyEvent(project, "completion", "started");
 
     TextDocument textDocument = new IntelliJTextDocument(editor, project);
     AutocompleteDocumentContext autoCompleteDocumentContext =


### PR DESCRIPTION
These events are not needed for our analytics and we're currently sending a very large volume of these events.

## Test plan

n/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
