### PR TITLE
JetBrains: make accounts panel smaller

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsConfigurable.kt
@@ -26,6 +26,7 @@ import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.config.PluginSettingChangeActionNotifier
 import com.sourcegraph.config.PluginSettingChangeContext
 import java.awt.Color
+import java.awt.Dimension
 
 class SettingsConfigurable(private val project: Project) :
     BoundConfigurable(ConfigUtil.SERVICE_DISPLAY_NAME) {
@@ -56,6 +57,9 @@ class SettingsConfigurable(private val project: Project) :
                   EmptyIcon.ICON_16)
               .horizontalAlign(HorizontalAlign.FILL)
               .verticalAlign(VerticalAlign.FILL)
+              .applyToComponent {
+                  this.preferredSize = Dimension(Int.MAX_VALUE, 200)
+              }
               .also {
                 DataManager.registerDataProvider(it.component) { key ->
                   if (CodyAccountsHost.KEY.`is`(key)) accountsModel else null


### PR DESCRIPTION
Accounts panel is now much smaller as we don't need to take as much space.
Previously
<img width="973" alt="Screenshot 2023-09-08 at 10 15 02" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/b91b9863-6c2f-4add-b5e3-0135bca1259e">

Now
<img width="973" alt="Screenshot 2023-09-08 at 10 51 46" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/3fd5c74e-9893-4cf3-92be-64afd9a33a80">

## Test plan
- Accounts panel should display 3 and a half of accounts instead of taking so much space which can be used by other settings

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
