### PR TITLE
searcher: always do hybrid search

### DIFF
--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -209,7 +209,6 @@ Hello world example in go
 				Commit:       "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
 				PatternInfo:  tc.Pattern,
 				FetchTimeout: fetchTimeoutForCI(t),
-				FeatHybrid:   true,
 			}
 
 			m, err := doSearch(ts.URL, &req)

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -227,7 +227,9 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 		return path, zf, err
 	}
 
-	hybrid := !p.IsStructuralPat && p.FeatHybrid
+	// Hybrid search only works with our normal searcher code path, not
+	// structural search.
+	hybrid := !p.IsStructuralPat
 	if hybrid {
 		logger := logWithTrace(ctx, s.Log).Scoped("hybrid", "hybrid indexed and unindexed search").With(
 			log.String("repo", string(p.Repo)),

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -295,6 +297,7 @@ file contains invalid utf8 � characters
 `},
 	}
 
+	zoektURL := newZoekt(t, &zoekt.Repository{}, nil)
 	s := newStore(t, files)
 	s.FilterTar = func(_ context.Context, _ gitserver.Client, _ api.RepoName, _ api.CommitID) (search.FilterFunc, error) {
 		return func(hdr *tar.Header) bool {
@@ -302,8 +305,9 @@ file contains invalid utf8 � characters
 		}, nil
 	}
 	ts := httptest.NewServer(&search.Service{
-		Store: s,
-		Log:   s.Log,
+		Store:   s,
+		Log:     s.Log,
+		Indexed: backend.ZoektDial(zoektURL),
 	})
 	defer ts.Close()
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -53,6 +53,8 @@ type Request struct {
 	// structural search because it will query Zoekt for indexed structural search.
 	Indexed bool
 
+	// NOTE: This field is no longer read. It is always assumed to be true.
+	//
 	// FeatHybrid is a feature flag which enables hybrid search. Hybrid search
 	// will only search what has changed since Zoekt has indexed as well as
 	// including Zoekt results.


### PR DESCRIPTION
This makes it so the server side of searcher will never read the FeatHybrid field in a request, and always treat it as true. This is the server side step of removing the hybrid search feature flag which has been rolled out successfully for many many months.

Test Plan: CI