### PR TITLE
dbconn: wrap did not start error

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -72,7 +72,7 @@ func openDBWithStartupWait(cfg *pgx.ConnConfig) (db *sql.DB, err error) {
 	startupDeadline := time.Now().Add(startupTimeout)
 	for {
 		if time.Now().After(startupDeadline) {
-			return nil, errors.Errorf("database did not start up within %s (%v)", startupTimeout, err)
+			return nil, errors.Wrapf(err, "database did not start up within %s", startupTimeout)
 		}
 		db, err = open(cfg)
 		if err == nil {


### PR DESCRIPTION
The errors.Errorf string dates back to sourcegraph being open sourced and likely was missed in a migration to using error wrapping.

I took a quick look to see if we have any references to the string mentioned here in docs/etc and found nothing. Also took a quick look at uses of errors.Is/etc and didn't see anything that would change behaviour. Nearly all code around here relies on strings.Contains because that is all we had back in the day when this code was written.

Test Plan: CI