### PR TITLE
dbtest: mention bazel tag needed when we don't connect to DB

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -230,6 +230,12 @@ func dbConn(logger log.Logger, t testing.TB, cfg *url.URL, schemas ...*schemas.S
 	t.Helper()
 	db, err := connections.NewTestDB(t, logger, cfg.String(), schemas...)
 	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			t.Fatalf(`failed to connect to database %q: %s
+PROTIP: Ensure the below is part of the go_test rule in BUILD.bazel
+  tags = ["requires-network"]
+See https://docs.sourcegraph.com/dev/background-information/bazel/faq#tests-fail-with-connection-refuse`, cfg, err)
+		}
 		t.Fatalf("failed to connect to database %q: %s", cfg, err)
 	}
 	return db

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -230,7 +230,7 @@ func dbConn(logger log.Logger, t testing.TB, cfg *url.URL, schemas ...*schemas.S
 	t.Helper()
 	db, err := connections.NewTestDB(t, logger, cfg.String(), schemas...)
 	if err != nil {
-		if strings.Contains(err.Error(), "connection refused") {
+		if strings.Contains(err.Error(), "connection refused") && os.Getenv("BAZEL_TEST") == "1" {
 			t.Fatalf(`failed to connect to database %q: %s
 PROTIP: Ensure the below is part of the go_test rule in BUILD.bazel
   tags = ["requires-network"]


### PR DESCRIPTION
We ran into this this week and I just saw Noah run into it. This likely would of saved time and should help in the future.

Test Plan: yolo