### PR TITLE
github: fix erratic 404s by keeping URL stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Fixed a bug when syncing repository lists from GitHub that could lead to 404 errors showing up when running into GitHub rate limits [#56478](https://github.com/sourcegraph/sourcegraph/pull/56478)
+
 ### Removed
 
 ## Unreleased 5.1.9 (planned release date: September 20, 2023)
@@ -30,6 +32,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 ### Fixed
+
+- Fixed a bug when syncing repository lists from GitHub that could lead to 404 errors showing up when running into GitHub rate limits [#56478](https://github.com/sourcegraph/sourcegraph/pull/56478)
 
 ### Removed
 

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -238,14 +238,25 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		c.externalRateLimiter.WaitForRateLimit(ctx, 1) // We don't care whether we waited or not, this is a preventative measure.
 	}
 
+	// Store request Body and URL because we might call `doRequest` twice and
+	// can't guarantee that `doRequest` doesn't modify them. (In fact: it does
+	// modify them!)
+	// So when we retry, we can reset to the original state.
 	var reqBody []byte
+	var reqURL *url.URL
 	if req.Body != nil {
 		reqBody, err = io.ReadAll(req.Body)
 		if err != nil {
 			return nil, err
 		}
 	}
+	if req.URL != nil {
+		u := *req.URL
+		reqURL = &u
+	}
+
 	req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+
 	var resp *httpResponseState
 	resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 
@@ -271,7 +282,14 @@ func (c *V3Client) request(ctx context.Context, req *http.Request, result any) (
 		// that time, the rate limit information we will have will look like old information and
 		// we won't retry the request.
 		if c.externalRateLimiter.WaitForRateLimit(ctx, 1) {
+			// Reset Body/URL to ignore changes that the first `doRequest`
+			// might have made.
 			req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+			// Create a copy of the URL, because this loop might execute
+			// multiple times.
+			reqURLCopy := *reqURL
+			req.URL = &reqURLCopy
+
 			resp, err = doRequest(ctx, c.log, c.apiURL, c.auth, c.externalRateLimiter, c.httpClient, req, result)
 			numRetries++
 		} else {


### PR DESCRIPTION
See [this comment](https://github.com/sourcegraph/customer/issues/2329#issuecomment-1711735942) and the issue it's in for full context.

Short version:

1. GitHub v3 and v4 clients execute this bit of code multiple times when retrying a request after it ran into rate limits: https://github.com/sourcegraph/sourcegraph/blob/16458d7e5c07ac69d00d32841a1a7dcd55a50ddb/internal/extsvc/github/common.go#L1589-L1590
2. When executed multiple times with the same `url.URL`, `req.URL.Path` ends up with invalid paths like `/api/v3/api/v3`

That lead to 404 errors showing up _sometimes_: when the client runs into rate limit and retries. And _sometimes_ these 404s were even ignored and lead to a "successful" end of the syncing process.

This changes the behaviour of the clients to keep a copy of the original `req.URL` around so that modifications made by `doRequest` don't have unintended side-effects.



## Test plan

- Existing and new tests