### PR TITLE
Update /fix command to /edit in Cody docs

### DIFF
--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -93,6 +93,8 @@ Examples of `/edit` instructions Cody can handle:
 - Add helpful debug log statements
 - Make this work (and yes, it often does work—give it a try!)
 
+> NOTE: Inline chat functionality is currently only available in the VS Code extension. The `/edit` command was called `/fix` prior to version 0.10.0 of the VS Code extension.
+
 <div class="getting-started">
   <a class="demo text-center" target="_blank" href="https://twitter.com/sqs/status/1647673013343780864">View Demo</a>
 </div>

--- a/doc/cody/capabilities.md
+++ b/doc/cody/capabilities.md
@@ -76,15 +76,15 @@ More specifically, Cody can answer questions like:
   <a class="demo text-center" target="_blank" href="https://twitter.com/beyang/status/1647744307045228544">View Demo</a>
 </div>
 
-### Inline chat and code fixes
+### Inline chat and code edits
 
-You can also open Cody's chat inline in VS Code using the `+` icon. This opens a chat box that can be used for general chat questions, code fixes, and refactors. Select a code snippet to ask Cody for an inline code fix, then type `/fix` plus your desired code change. Cody will generate edits, which you can accept or reject with the `Apply` button.
+You can also open Cody's chat inline in VS Code using the `+` icon. This opens a chat box that can be used for general chat questions, code edits, and refactors. Select a code snippet to ask Cody for an inline code edit, then type `/edit` plus your desired code change. Cody will generate edits, which you can accept or reject with the `Apply` button.
 
 You can also use the or `/touch` command in the inline chat box if you'd like Cody to place its output in a new file.
 
 ![Example of Cody inline code fix ](https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody_inline_June23-sm.gif)
 
-Examples of `/fix` instructions Cody can handle:
+Examples of `/edit` instructions Cody can handle:
 
 - Factor out any common helper functions (when multiple functions are selected)
 - Use the imported CSS module's class `n`

--- a/doc/cody/use-cases.md
+++ b/doc/cody/use-cases.md
@@ -28,17 +28,17 @@ To refactor code inline:
 
 1. Highlight the snippet of code you'd like to refactor
 2. Click the `+` icon to the left of the first line of code
-3. In the Cody chat box, type `/fix` + your prompt for Cody. For example: `/fix refactor this code to be more easily readable`
+3. In the Cody chat box, type `/edit` + your prompt for Cody. For example: `/edit refactor this code to be more easily readable`
 4. Click `Ask Cody` (or alternatively use shortcut `Cmd + Enter`)
 
-After submitting the request, Cody will prepare a code fix. You can click `Apply` and Cody will change the code inline, or you can click `Show Diff` to see Cody's proposed change.
+After submitting the request, Cody will prepare a code edit. You can click `Apply` and Cody will change the code inline, or you can click `Show Diff` to see Cody's proposed change.
 
-Here are some examples of what you can do with inline /fix commands:
+Here are some examples of what you can do with inline /edit commands:
 
-- "/fix Add a link here to the admin settings page"
-- "/fix Make this code less verbose"
-- "/fix Factor out any common helper functions"
-- "/fix Convert this code to a react functional component"
+- "/edit Add a link here to the admin settings page"
+- "/edit Make this code less verbose"
+- "/edit Factor out any common helper functions"
+- "/edit Convert this code to a react functional component"
 
 Note: inline chat is currently only available in the VS Code extension.
 
@@ -60,9 +60,9 @@ Cody will respond with potential issues it sees in your code. You can then respo
 
 ### Fix bugs with inline chat
 
-The same inline chat `/fix` functionality that can be used to refactor code can also be used to debug, fix, and update code from directly within a file.
+The same inline chat `/edit` functionality that can be used to refactor code can also be used to debug, fix, and update code from directly within a file.
 
-For example, try: "/fix fix the bug in this function"
+For example, try: "/edit fix the bug in this function"
 
 ## Onboarding to a new codebase
 


### PR DESCRIPTION
Changes /fix to /edit (to reflect the product change) in the Cody docs.

## Test plan

Docs only, local testing.

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cody-docs-change-fix-to-edit)