### PR TITLE
source: return full repository when fetching public github repos

### DIFF
--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -720,9 +720,6 @@ func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResul
 			results <- &githubResult{err: errors.Wrapf(err, "failed to list public repositories: sinceRepoID=%d", sinceRepoID)}
 			return
 		}
-		if !hasNextPage {
-			return
-		}
 		s.logger.Debug("github sync public", log.Int("repos", len(repos)), log.Error(err))
 		for _, r := range repos {
 			_, isArchived := archivedRepos[r.ID]
@@ -736,6 +733,9 @@ func (s *GitHubSource) listPublic(ctx context.Context, results chan *githubResul
 			if sinceRepoID < r.DatabaseID {
 				sinceRepoID = r.DatabaseID
 			}
+		}
+		if !hasNextPage {
+			return
 		}
 	}
 }


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C03K05FCRFH/p1694164347656019)

It seems when fetching GitHub repos, we return early before processing the last batch of repositories. This fixes that so we process every repository always.

## Test plan

* unit tests are passing
* testing fetching repos with ghe instance and nothing is broken