### PR TITLE
hide access token by default after creation

### DIFF
--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -78,7 +78,7 @@ export class CopyableText extends React.PureComponent<Props, State> {
                         </Button>
                     </div>
                     {this.props.secret && (
-                        <div className="input-group-append flex-shrink-0">
+                        <div className="input-group-append flex-shrink-0 ml-1">
                             <Button
                                 onClick={this.onClickSecretButton}
                                 variant="secondary"

--- a/client/web/src/components/CopyableText.tsx
+++ b/client/web/src/components/CopyableText.tsx
@@ -12,6 +12,8 @@ interface Props {
     /** The text to present and to copy. */
     text: string
 
+    children?: (props: { isRedacted: boolean }) => React.ReactNode
+
     /** An optional class name. */
     className?: string
 
@@ -55,43 +57,47 @@ export class CopyableText extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className={classNames('form-inline', this.props.className)}>
-                <div className={classNames('input-group', { 'flex-1': this.props.flex })}>
-                    <Input
-                        type={this.resolveInputType()}
-                        inputClassName={styles.input}
-                        aria-label={this.props.label}
-                        value={this.props.text}
-                        size={this.props.size}
-                        readOnly={true}
-                        onClick={this.onClickInput}
-                    />
-                    <div className="input-group-append flex-shrink-0">
-                        <Button
-                            onClick={this.onClickButton}
-                            disabled={this.state.copied}
-                            variant="secondary"
-                            aria-label="Copy"
-                        >
-                            <Icon aria-hidden={true} svgPath={mdiContentCopy} />{' '}
-                            {this.props.secret ? '' : this.state.copied ? 'Copied' : 'Copy'}
-                        </Button>
-                    </div>
-                    {this.props.secret && (
-                        <div className="input-group-append flex-shrink-0 ml-1">
+            <>
+                <div className={classNames('form-inline', this.props.className)}>
+                    <div className={classNames('input-group', { 'flex-1': this.props.flex })}>
+                        <Input
+                            type={this.resolveInputType()}
+                            inputClassName={styles.input}
+                            aria-label={this.props.label}
+                            value={this.props.text}
+                            size={this.props.size}
+                            readOnly={true}
+                            onClick={this.onClickInput}
+                        />
+                        <div className="input-group-append flex-shrink-0">
                             <Button
-                                onClick={this.onClickSecretButton}
+                                onClick={this.onClickButton}
+                                disabled={this.state.copied}
                                 variant="secondary"
-                                aria-label={
-                                    this.state.secretShown ? 'Reveal secret value as text' : 'Hide secret value'
-                                }
+                                aria-label="Copy"
                             >
-                                <Icon aria-hidden={true} svgPath={mdiEye} />
+                                <Icon aria-hidden={true} svgPath={mdiContentCopy} />{' '}
+                                {this.props.secret ? '' : this.state.copied ? 'Copied' : 'Copy'}
                             </Button>
                         </div>
-                    )}
+                        {this.props.secret && (
+                            <div className="input-group-append flex-shrink-0 ml-1">
+                                <Button
+                                    onClick={this.onClickSecretButton}
+                                    variant="secondary"
+                                    aria-label={
+                                        this.state.secretShown ? 'Reveal secret value as text' : 'Hide secret value'
+                                    }
+                                >
+                                    <Icon aria-hidden={true} svgPath={mdiEye} />
+                                </Button>
+                            </div>
+                        )}
+                    </div>
                 </div>
-            </div>
+
+                {this.props.children?.({ isRedacted: Boolean(this.props.secret && !this.state.secretShown) })}
+            </>
         )
     }
 

--- a/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
+++ b/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
@@ -25,7 +25,7 @@ export const AccessTokenCreatedAlert: React.FunctionComponent<
     return (
         <Alert className={classNames('access-token-created-alert', className)} variant="success">
             <Text>Copy the new access token now. You won't be able to see it again.</Text>
-            <CopyableText className="test-access-token" text={tokenSecret} size={48} />
+            <CopyableText className="test-access-token" text={tokenSecret} size={48} secret={true} />
             <H5 className="mt-4 mb-2">
                 <strong>Example usage</strong>
             </H5>

--- a/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
+++ b/client/web/src/settings/tokens/AccessTokenCreatedAlert.tsx
@@ -25,11 +25,24 @@ export const AccessTokenCreatedAlert: React.FunctionComponent<
     return (
         <Alert className={classNames('access-token-created-alert', className)} variant="success">
             <Text>Copy the new access token now. You won't be able to see it again.</Text>
-            <CopyableText className="test-access-token" text={tokenSecret} size={48} secret={true} />
-            <H5 className="mt-4 mb-2">
-                <strong>Example usage</strong>
-            </H5>
-            <CodeSnippet code={curlExampleCommand(tokenSecret, isSudoToken)} className="mb-0" language="bash" />
+            <CopyableText className="test-access-token" text={tokenSecret} size={48} secret={true}>
+                {({ isRedacted }) => {
+                    const secretToDisplay = isRedacted ? tokenSecret.replace(/./g, '*') : tokenSecret
+                    return (
+                        <>
+                            <H5 className="mt-4 mb-2">
+                                <strong>Example usage</strong>
+                            </H5>
+                            <CodeSnippet
+                                code={curlExampleCommand(secretToDisplay, isSudoToken)}
+                                className="mb-0"
+                                language="bash"
+                                withCopyButton={true}
+                            />
+                        </>
+                    )
+                }}
+            </CopyableText>
         </Alert>
     )
 }


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1694188323196199)

When a user creates an access token on Sourcegraph, we currently display the token by default in plain text. Sometimes the user is in a public place and this token could be captured by an attacker and used for malicious purposes.

This PR hides the token by default and the user can then click to see it or simply just copy it for use.

![CleanShot 2023-09-12 at 13 32 06](https://github.com/sourcegraph/sourcegraph/assets/25608335/d5eee3bf-42c0-4d8b-a7c7-7b5855ef4ef1)

## Test plan

* I manually went through the flow of creating an access token by visiting my profile page [`/users/<USER>/settings/tokens`](https://sourcegraph.sourcegraph.com/users/bolaji.olajide-tkzij/settings/tokens)
* Then clicking on the `Generate new token` button
* This should display the newly created access token with the token hidden by default.
