### PR TITLE
Don't configure empty dummy authz providers in OSS apps

### DIFF
--- a/cmd/sourcegraph/osscmd/BUILD.bazel
+++ b/cmd/sourcegraph/osscmd/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/sourcegraph/osscmd",
     visibility = ["//visibility:public"],
     deps = [
-        "//internal/authz",
         "//internal/service",
         "//internal/service/svcmain",
     ],

--- a/cmd/sourcegraph/osscmd/osscmd.go
+++ b/cmd/sourcegraph/osscmd/osscmd.go
@@ -3,18 +3,11 @@
 package osscmd
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/svcmain"
 )
 
-var config = svcmain.Config{
-	AfterConfigure: func() {
-		// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
-		// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
-		authz.SetProviders(true, []authz.Provider{})
-	},
-}
+var config = svcmain.Config{}
 
 // MainOSS is called from the `main` function of the `cmd/sourcegraph` command.
 func MainOSS(services []service.Service, args []string) {


### PR DESCRIPTION
Since OSS apps don't exist anymore, and we now use this entrypoint for the previous enterprise services, we should get rid of this, it might cause weird behavior with authz providers being empty briefly after startup. Instead, we should rely on the services to properly fetch the providers.

## Test plan

sg start stack still works. 