### PR TITLE
[backport 5.1] gRPC: use byte slices for exec args (#55990)

### DIFF
--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -70,7 +70,7 @@ func (gs *GRPCServer) Exec(req *proto.ExecRequest, ss proto.GitserverService_Exe
 	internalReq := protocol.ExecRequest{
 		Repo:           api.RepoName(req.GetRepo()),
 		EnsureRevision: req.GetEnsureRevision(),
-		Args:           req.GetArgs(),
+		Args:           byteSlicesToStrings(req.GetArgs()),
 		Stdin:          req.GetStdin(),
 		NoTimeout:      req.GetNoTimeout(),
 	}
@@ -82,7 +82,7 @@ func (gs *GRPCServer) Exec(req *proto.ExecRequest, ss proto.GitserverService_Exe
 	})
 
 	// Log which actor is accessing the repo.
-	args := req.GetArgs()
+	args := byteSlicesToStrings(req.GetArgs())
 	cmd := ""
 	if len(args) > 0 {
 		cmd = args[0]
@@ -219,7 +219,7 @@ func (gs *GRPCServer) GetObject(ctx context.Context, req *proto.GetObjectRequest
 }
 
 func (gs *GRPCServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService_P4ExecServer) error {
-	arguments := req.GetArgs()
+	arguments := byteSlicesToStrings(req.GetArgs())
 
 	if len(arguments) < 1 {
 		return status.Error(codes.InvalidArgument, "args must be greater than or equal to 1")
@@ -417,4 +417,12 @@ func (gs *GRPCServer) IsRepoCloneable(ctx context.Context, req *proto.IsRepoClon
 		return nil, err
 	}
 	return resp.ToProto(), nil
+}
+
+func byteSlicesToStrings(in [][]byte) []string {
+	res := make([]string, len(in))
+	for i, b := range in {
+		res[i] = string(b)
+	}
+	return res
 }

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -335,7 +335,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 			t.Cleanup(closeFunc)
 
 			stream, err := client.P4Exec(context.Background(), &proto.P4ExecRequest{
-				Args: []string{"users"},
+				Args: [][]byte{[]byte("users")},
 			})
 			if err != nil {
 				t.Fatalf("failed to call P4Exec: %v", err)
@@ -383,7 +383,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 			t.Cleanup(closeFunc)
 
 			stream, err := client.P4Exec(context.Background(), &proto.P4ExecRequest{
-				Args: []string{"bad_command"},
+				Args: [][]byte{[]byte("bad_command")},
 			})
 			if err != nil {
 				t.Fatalf("failed to call P4Exec: %v", err)
@@ -409,7 +409,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 			t.Cleanup(closeFunc)
 
 			stream, err := client.P4Exec(ctx, &proto.P4ExecRequest{
-				Args: []string{"users"},
+				Args: [][]byte{[]byte("users")},
 			})
 			if err != nil {
 				t.Fatalf("failed to call P4Exec: %v", err)

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -616,7 +616,7 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, err e
 		req := &proto.ExecRequest{
 			Repo:           string(repoName),
 			EnsureRevision: c.EnsureRevision(),
-			Args:           c.args[1:],
+			Args:           stringsToByteSlices(c.args[1:]),
 			Stdin:          c.stdin,
 			NoTimeout:      c.noTimeout,
 		}
@@ -1808,4 +1808,12 @@ func readResponseBody(body io.Reader) string {
 type clientAndError struct {
 	client proto.GitserverServiceClient
 	err    error
+}
+
+func stringsToByteSlices(in []string) [][]byte {
+	res := make([][]byte, len(in))
+	for i, s := range in {
+		res[i] = []byte(s)
+	}
+	return res
 }

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1955,6 +1955,13 @@ func TestRepository_Commits_options_path(t *testing.T) {
 			},
 			wantCommits: wantGitCommits,
 		},
+		"git cmd non utf8": {
+			opt: CommitsOptions{
+				Range:  "master",
+				Author: "a\xc0rn",
+			},
+			wantCommits: nil,
+		},
 	}
 
 	runCommitsTest := func(checker authz.SubRepoPermissionChecker) {

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -384,7 +384,7 @@ func (r *P4ExecRequest) ToProto() *proto.P4ExecRequest {
 		P4Port:   r.P4Port,
 		P4User:   r.P4User,
 		P4Passwd: r.P4Passwd,
-		Args:     r.Args,
+		Args:     stringsToByteSlices(r.Args),
 	}
 }
 
@@ -393,7 +393,7 @@ func (r *P4ExecRequest) FromProto(p *proto.P4ExecRequest) {
 		P4Port:   p.GetP4Port(),
 		P4User:   p.GetP4User(),
 		P4Passwd: p.GetP4Passwd(),
-		Args:     p.GetArgs(),
+		Args:     byteSlicesToStrings(p.GetArgs()),
 	}
 }
 
@@ -933,4 +933,20 @@ func ParsePerforceChangelistState(state string) (PerforceChangelistState, error)
 	default:
 		return "", errors.Newf("invalid Perforce changelist state: %s", state)
 	}
+}
+
+func stringsToByteSlices(in []string) [][]byte {
+	res := make([][]byte, len(in))
+	for i, s := range in {
+		res[i] = []byte(s)
+	}
+	return res
+}
+
+func byteSlicesToStrings(in [][]byte) []string {
+	res := make([]string, len(in))
+	for i, s := range in {
+		res[i] = string(s)
+	}
+	return res
 }

--- a/internal/gitserver/v1/gitserver.pb.go
+++ b/internal/gitserver/v1/gitserver.pb.go
@@ -136,9 +136,11 @@ type BatchLogRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// repo_commits is the list of repositories and commits to run the git log command on.
+	// repo_commits is the list of repositories and commits to run the git log
+	// command on.
 	RepoCommits []*RepoCommit `protobuf:"bytes,1,rep,name=repo_commits,json=repoCommits,proto3" json:"repo_commits,omitempty"`
-	// format is the entire `--format=<format>` argument to git log. This value is expected to be non-empty.
+	// format is the entire `--format=<format>` argument to git log. This value is
+	// expected to be non-empty.
 	Format string `protobuf:"bytes,2,opt,name=format,proto3" json:"format,omitempty"`
 }
 
@@ -194,7 +196,8 @@ type BatchLogResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// results is the list of results for each repository and commit pair from the input of a BatchLog request.
+	// results is the list of results for each repository and commit pair from the
+	// input of a BatchLog request.
 	Results []*BatchLogResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 }
 
@@ -237,18 +240,21 @@ func (x *BatchLogResponse) GetResults() []*BatchLogResult {
 	return nil
 }
 
-// BatchLogResult is the result that associates a repository and commit pair from the input of a BatchLog
-// request with the result of the associated git log command.
+// BatchLogResult is the result that associates a repository and commit pair
+// from the input of a BatchLog request with the result of the associated git
+// log command.
 type BatchLogResult struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// repo_commit is the repository and commit pair from the input of a BatchLog request.
+	// repo_commit is the repository and commit pair from the input of a BatchLog
+	// request.
 	RepoCommit *RepoCommit `protobuf:"bytes,1,opt,name=repo_commit,json=repoCommit,proto3" json:"repo_commit,omitempty"`
 	// command_output is the output of the git log command.
 	CommandOutput string `protobuf:"bytes,2,opt,name=command_output,json=commandOutput,proto3" json:"command_output,omitempty"`
-	// command_error is an optional error message if the git log command encountered an error.
+	// command_error is an optional error message if the git log command
+	// encountered an error.
 	CommandError *string `protobuf:"bytes,3,opt,name=command_error,json=commandError,proto3,oneof" json:"command_error,omitempty"`
 }
 
@@ -525,8 +531,8 @@ func (x *PushConfig) GetPassphrase() string {
 	return ""
 }
 
-// CreateCommitFromPatchBinaryRequest is the request information needed for creating
-// the simulated staging area git object for a repo.
+// CreateCommitFromPatchBinaryRequest is the request information needed for
+// creating the simulated staging area git object for a repo.
 type CreateCommitFromPatchBinaryRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -540,7 +546,8 @@ type CreateCommitFromPatchBinaryRequest struct {
 	Patch []byte `protobuf:"bytes,3,opt,name=patch,proto3" json:"patch,omitempty"`
 	// target_ref is the ref that will be created for this patch
 	TargetRef string `protobuf:"bytes,4,opt,name=target_ref,json=targetRef,proto3" json:"target_ref,omitempty"`
-	// unique_ref is a boolean that indicates whether a unique number will be appended to the end (ie TargetRef-{#}). The generated ref will be returned.
+	// unique_ref is a boolean that indicates whether a unique number will be
+	// appended to the end (ie TargetRef-{#}). The generated ref will be returned.
 	UniqueRef bool `protobuf:"varint,5,opt,name=unique_ref,json=uniqueRef,proto3" json:"unique_ref,omitempty"`
 	// commit_info is the information to be used for the commit
 	CommitInfo *PatchCommitInfo `protobuf:"bytes,6,opt,name=commit_info,json=commitInfo,proto3" json:"commit_info,omitempty"`
@@ -722,8 +729,8 @@ func (x *CreateCommitFromPatchError) GetCombinedOutput() string {
 	return ""
 }
 
-// CreateCommitFromPatchBinaryResponse is the response type returned after creating
-// a commit from a patch
+// CreateCommitFromPatchBinaryResponse is the response type returned after
+// creating a commit from a patch
 type CreateCommitFromPatchBinaryResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -797,7 +804,7 @@ type ExecRequest struct {
 
 	Repo           string   `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
 	EnsureRevision string   `protobuf:"bytes,2,opt,name=ensure_revision,json=ensureRevision,proto3" json:"ensure_revision,omitempty"`
-	Args           []string `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`
+	Args           [][]byte `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty"`
 	Stdin          []byte   `protobuf:"bytes,4,opt,name=stdin,proto3" json:"stdin,omitempty"`
 	NoTimeout      bool     `protobuf:"varint,5,opt,name=no_timeout,json=noTimeout,proto3" json:"no_timeout,omitempty"`
 }
@@ -848,7 +855,7 @@ func (x *ExecRequest) GetEnsureRevision() string {
 	return ""
 }
 
-func (x *ExecRequest) GetArgs() []string {
+func (x *ExecRequest) GetArgs() [][]byte {
 	if x != nil {
 		return x.Args
 	}
@@ -1048,8 +1055,8 @@ type SearchRequest struct {
 	// limit is a limit on the number of search results returned. Additional
 	// results will be ignored.
 	Limit int64 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
-	// include_diff specifies whether the full diff should be included on the result messages.
-	// This can be expensive, so is disabled by default.
+	// include_diff specifies whether the full diff should be included on the
+	// result messages. This can be expensive, so is disabled by default.
 	IncludeDiff bool `protobuf:"varint,4,opt,name=include_diff,json=includeDiff,proto3" json:"include_diff,omitempty"`
 	// include_modified specifies whether to include the list of modified files
 	// in the search results. This can be expensive, so is disabled by default.
@@ -1201,8 +1208,8 @@ func (x *RevisionSpecifier) GetExcludeRefGlob() string {
 	return ""
 }
 
-// AuthorMatchesNode is a predicate that matches if the author's name or email address
-// matches the regex pattern.
+// AuthorMatchesNode is a predicate that matches if the author's name or email
+// address matches the regex pattern.
 type AuthorMatchesNode struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1258,8 +1265,8 @@ func (x *AuthorMatchesNode) GetIgnoreCase() bool {
 	return false
 }
 
-// CommitterMatchesNode is a predicate that matches if the author's name or email address
-// matches the regex pattern.
+// CommitterMatchesNode is a predicate that matches if the author's name or
+// email address matches the regex pattern.
 type CommitterMatchesNode struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1315,7 +1322,8 @@ func (x *CommitterMatchesNode) GetIgnoreCase() bool {
 	return false
 }
 
-// CommitBeforeNode is a predicate that matches if the commit is before the given date
+// CommitBeforeNode is a predicate that matches if the commit is before the
+// given date
 type CommitBeforeNode struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1363,7 +1371,8 @@ func (x *CommitBeforeNode) GetTimestamp() *timestamppb.Timestamp {
 	return nil
 }
 
-// CommitAfterNode is a predicate that matches if the commit is after the given date
+// CommitAfterNode is a predicate that matches if the commit is after the given
+// date
 type CommitAfterNode struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1525,8 +1534,8 @@ func (x *DiffMatchesNode) GetIgnoreCase() bool {
 	return false
 }
 
-// DiffModifiesFileNode is a predicate that matches if the commit modifies any files
-// that match the given regex pattern.
+// DiffModifiesFileNode is a predicate that matches if the commit modifies any
+// files that match the given regex pattern.
 type DiffModifiesFileNode struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2077,7 +2086,8 @@ type ArchiveRequest struct {
 	Treeish string `protobuf:"bytes,2,opt,name=treeish,proto3" json:"treeish,omitempty"`
 	// format is the format of the resulting archive (usually "tar" or "zip")
 	Format string `protobuf:"bytes,3,opt,name=format,proto3" json:"format,omitempty"`
-	// pathspecs is the list of pathspecs to include in the archive. If empty, all pathspecs are included.
+	// pathspecs is the list of pathspecs to include in the archive. If empty, all
+	// pathspecs are included.
 	Pathspecs []string `protobuf:"bytes,4,rep,name=pathspecs,proto3" json:"pathspecs,omitempty"`
 }
 
@@ -2141,7 +2151,8 @@ func (x *ArchiveRequest) GetPathspecs() []string {
 	return nil
 }
 
-// ArchiveResponse is the response from the Archive RPC that returns a chunk of the archive.
+// ArchiveResponse is the response from the Archive RPC that returns a chunk of
+// the archive.
 type ArchiveResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2402,8 +2413,8 @@ func (x *RepoCloneResponse) GetError() string {
 	return ""
 }
 
-// RepoCloneProgressRequest is a request for information about the clone progress of multiple
-// repositories on gitserver.
+// RepoCloneProgressRequest is a request for information about the clone
+// progress of multiple repositories on gitserver.
 type RepoCloneProgressRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2518,8 +2529,8 @@ func (x *RepoCloneProgress) GetCloned() bool {
 	return false
 }
 
-// RepoCloneProgressResponse is the response to a repository clone progress request
-// for multiple repositories at the same time.
+// RepoCloneProgressResponse is the response to a repository clone progress
+// request for multiple repositories at the same time.
 type RepoCloneProgressResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2664,7 +2675,8 @@ type RepoUpdateRequest struct {
 
 	// repo is the name of the repo to update.
 	Repo string `protobuf:"bytes,1,opt,name=repo,proto3" json:"repo,omitempty"`
-	// since is the debounce interval for queries, used only with request-repo-update
+	// since is the debounce interval for queries, used only with
+	// request-repo-update
 	Since *durationpb.Duration `protobuf:"bytes,2,opt,name=since,proto3" json:"since,omitempty"`
 	// clone_from_shard is the hostname of the gitserver instance that is the current owner of the
 	// repository. If this is set, then the RepoUpdateRequest is to migrate the repo from
@@ -2899,7 +2911,7 @@ type P4ExecRequest struct {
 	P4Port   string   `protobuf:"bytes,1,opt,name=p4port,proto3" json:"p4port,omitempty"`
 	P4User   string   `protobuf:"bytes,2,opt,name=p4user,proto3" json:"p4user,omitempty"`
 	P4Passwd string   `protobuf:"bytes,3,opt,name=p4passwd,proto3" json:"p4passwd,omitempty"`
-	Args     []string `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty"`
+	Args     [][]byte `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty"`
 }
 
 func (x *P4ExecRequest) Reset() {
@@ -2955,7 +2967,7 @@ func (x *P4ExecRequest) GetP4Passwd() string {
 	return ""
 }
 
-func (x *P4ExecRequest) GetArgs() []string {
+func (x *P4ExecRequest) GetArgs() [][]byte {
 	if x != nil {
 		return x.Args
 	}
@@ -3673,7 +3685,7 @@ var file_gitserver_proto_rawDesc = []byte{
 	0x09, 0x52, 0x04, 0x72, 0x65, 0x70, 0x6f, 0x12, 0x27, 0x0a, 0x0f, 0x65, 0x6e, 0x73, 0x75, 0x72,
 	0x65, 0x5f, 0x72, 0x65, 0x76, 0x69, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
 	0x52, 0x0e, 0x65, 0x6e, 0x73, 0x75, 0x72, 0x65, 0x52, 0x65, 0x76, 0x69, 0x73, 0x69, 0x6f, 0x6e,
-	0x12, 0x12, 0x0a, 0x04, 0x61, 0x72, 0x67, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x09, 0x52, 0x04,
+	0x12, 0x12, 0x0a, 0x04, 0x61, 0x72, 0x67, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0c, 0x52, 0x04,
 	0x61, 0x72, 0x67, 0x73, 0x12, 0x14, 0x0a, 0x05, 0x73, 0x74, 0x64, 0x69, 0x6e, 0x18, 0x04, 0x20,
 	0x01, 0x28, 0x0c, 0x52, 0x05, 0x73, 0x74, 0x64, 0x69, 0x6e, 0x12, 0x1d, 0x0a, 0x0a, 0x6e, 0x6f,
 	0x5f, 0x74, 0x69, 0x6d, 0x65, 0x6f, 0x75, 0x74, 0x18, 0x05, 0x20, 0x01, 0x28, 0x08, 0x52, 0x09,
@@ -3944,7 +3956,7 @@ var file_gitserver_proto_rawDesc = []byte{
 	0x06, 0x70, 0x34, 0x75, 0x73, 0x65, 0x72, 0x12, 0x1a, 0x0a, 0x08, 0x70, 0x34, 0x70, 0x61, 0x73,
 	0x73, 0x77, 0x64, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x70, 0x34, 0x70, 0x61, 0x73,
 	0x73, 0x77, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x61, 0x72, 0x67, 0x73, 0x18, 0x04, 0x20, 0x03, 0x28,
-	0x09, 0x52, 0x04, 0x61, 0x72, 0x67, 0x73, 0x22, 0x24, 0x0a, 0x0e, 0x50, 0x34, 0x45, 0x78, 0x65,
+	0x0c, 0x52, 0x04, 0x61, 0x72, 0x67, 0x73, 0x22, 0x24, 0x0a, 0x0e, 0x50, 0x34, 0x45, 0x78, 0x65,
 	0x63, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x12, 0x0a, 0x04, 0x64, 0x61, 0x74,
 	0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x04, 0x64, 0x61, 0x74, 0x61, 0x22, 0x3a, 0x0a,
 	0x13, 0x4c, 0x69, 0x73, 0x74, 0x47, 0x69, 0x74, 0x6f, 0x6c, 0x69, 0x74, 0x65, 0x52, 0x65, 0x71,

--- a/internal/gitserver/v1/gitserver.proto
+++ b/internal/gitserver/v1/gitserver.proto
@@ -27,26 +27,32 @@ service GitserverService {
 // BatchLogRequest is a request to execute a `git log` command inside a set of
 // git repositories present on the target shard.
 message BatchLogRequest {
-  // repo_commits is the list of repositories and commits to run the git log command on.
+  // repo_commits is the list of repositories and commits to run the git log
+  // command on.
   repeated RepoCommit repo_commits = 1;
-  // format is the entire `--format=<format>` argument to git log. This value is expected to be non-empty.
+  // format is the entire `--format=<format>` argument to git log. This value is
+  // expected to be non-empty.
   string format = 2;
 }
 
 // BatchLogResponse contains the results of the BatchLog request.
 message BatchLogResponse {
-  // results is the list of results for each repository and commit pair from the input of a BatchLog request.
+  // results is the list of results for each repository and commit pair from the
+  // input of a BatchLog request.
   repeated BatchLogResult results = 1;
 }
 
-// BatchLogResult is the result that associates a repository and commit pair from the input of a BatchLog
-// request with the result of the associated git log command.
+// BatchLogResult is the result that associates a repository and commit pair
+// from the input of a BatchLog request with the result of the associated git
+// log command.
 message BatchLogResult {
-  // repo_commit is the repository and commit pair from the input of a BatchLog request.
+  // repo_commit is the repository and commit pair from the input of a BatchLog
+  // request.
   RepoCommit repo_commit = 1;
   // command_output is the output of the git log command.
   string command_output = 2;
-  // command_error is an optional error message if the git log command encountered an error.
+  // command_error is an optional error message if the git log command
+  // encountered an error.
   optional string command_error = 3;
 }
 
@@ -85,8 +91,8 @@ message PushConfig {
   string passphrase = 3;
 }
 
-// CreateCommitFromPatchBinaryRequest is the request information needed for creating
-// the simulated staging area git object for a repo.
+// CreateCommitFromPatchBinaryRequest is the request information needed for
+// creating the simulated staging area git object for a repo.
 message CreateCommitFromPatchBinaryRequest {
   // repo is the name of the repo to be updated
   string repo = 1;
@@ -96,7 +102,8 @@ message CreateCommitFromPatchBinaryRequest {
   bytes patch = 3;
   // target_ref is the ref that will be created for this patch
   string target_ref = 4;
-  // unique_ref is a boolean that indicates whether a unique number will be appended to the end (ie TargetRef-{#}). The generated ref will be returned.
+  // unique_ref is a boolean that indicates whether a unique number will be
+  // appended to the end (ie TargetRef-{#}). The generated ref will be returned.
   bool unique_ref = 5;
   // commit_info is the information to be used for the commit
   PatchCommitInfo commit_info = 6;
@@ -119,8 +126,8 @@ message CreateCommitFromPatchError {
   string combined_output = 4;
 }
 
-// CreateCommitFromPatchBinaryResponse is the response type returned after creating
-// a commit from a patch
+// CreateCommitFromPatchBinaryResponse is the response type returned after
+// creating a commit from a patch
 message CreateCommitFromPatchBinaryResponse {
   // rev is the tag that the staging object can be found at
   string rev = 1;
@@ -132,7 +139,7 @@ message CreateCommitFromPatchBinaryResponse {
 message ExecRequest {
   string repo = 1;
   string ensure_revision = 2;
-  repeated string args = 3;
+  repeated bytes args = 3;
   bytes stdin = 4;
   bool no_timeout = 5;
 }
@@ -162,8 +169,8 @@ message SearchRequest {
   // limit is a limit on the number of search results returned. Additional
   // results will be ignored.
   int64 limit = 3;
-  // include_diff specifies whether the full diff should be included on the result messages.
-  // This can be expensive, so is disabled by default.
+  // include_diff specifies whether the full diff should be included on the
+  // result messages. This can be expensive, so is disabled by default.
   bool include_diff = 4;
   // include_modified specifies whether to include the list of modified files
   // in the search results. This can be expensive, so is disabled by default.
@@ -184,26 +191,28 @@ message RevisionSpecifier {
   string exclude_ref_glob = 3;
 }
 
-// AuthorMatchesNode is a predicate that matches if the author's name or email address
-// matches the regex pattern.
+// AuthorMatchesNode is a predicate that matches if the author's name or email
+// address matches the regex pattern.
 message AuthorMatchesNode {
   string expr = 1;
   bool ignore_case = 2;
 }
 
-// CommitterMatchesNode is a predicate that matches if the author's name or email address
-// matches the regex pattern.
+// CommitterMatchesNode is a predicate that matches if the author's name or
+// email address matches the regex pattern.
 message CommitterMatchesNode {
   string expr = 1;
   bool ignore_case = 2;
 }
 
-// CommitBeforeNode is a predicate that matches if the commit is before the given date
+// CommitBeforeNode is a predicate that matches if the commit is before the
+// given date
 message CommitBeforeNode {
   google.protobuf.Timestamp timestamp = 1;
 }
 
-// CommitAfterNode is a predicate that matches if the commit is after the given date
+// CommitAfterNode is a predicate that matches if the commit is after the given
+// date
 message CommitAfterNode {
   google.protobuf.Timestamp timestamp = 1;
 }
@@ -222,8 +231,8 @@ message DiffMatchesNode {
   bool ignore_case = 2;
 }
 
-// DiffModifiesFileNode is a predicate that matches if the commit modifies any files
-// that match the given regex pattern.
+// DiffModifiesFileNode is a predicate that matches if the commit modifies any
+// files that match the given regex pattern.
 message DiffModifiesFileNode {
   string expr = 1;
   bool ignore_case = 2;
@@ -319,11 +328,13 @@ message ArchiveRequest {
   string treeish = 2;
   // format is the format of the resulting archive (usually "tar" or "zip")
   string format = 3;
-  // pathspecs is the list of pathspecs to include in the archive. If empty, all pathspecs are included.
+  // pathspecs is the list of pathspecs to include in the archive. If empty, all
+  // pathspecs are included.
   repeated string pathspecs = 4;
 }
 
-// ArchiveResponse is the response from the Archive RPC that returns a chunk of the archive.
+// ArchiveResponse is the response from the Archive RPC that returns a chunk of
+// the archive.
 message ArchiveResponse {
   bytes data = 1;
 }
@@ -355,8 +366,8 @@ message RepoCloneResponse {
   string error = 1;
 }
 
-// RepoCloneProgressRequest is a request for information about the clone progress of multiple
-// repositories on gitserver.
+// RepoCloneProgressRequest is a request for information about the clone
+// progress of multiple repositories on gitserver.
 message RepoCloneProgressRequest {
   repeated string repos = 1;
 }
@@ -371,8 +382,8 @@ message RepoCloneProgress {
   bool cloned = 3;
 }
 
-// RepoCloneProgressResponse is the response to a repository clone progress request
-// for multiple repositories at the same time.
+// RepoCloneProgressResponse is the response to a repository clone progress
+// request for multiple repositories at the same time.
 message RepoCloneProgressResponse {
   // results is a map from repository name to clone progress information
   map<string, RepoCloneProgress> results = 1;
@@ -391,7 +402,8 @@ message RepoDeleteResponse {}
 message RepoUpdateRequest {
   // repo is the name of the repo to update.
   string repo = 1;
-  // since is the debounce interval for queries, used only with request-repo-update
+  // since is the debounce interval for queries, used only with
+  // request-repo-update
   google.protobuf.Duration since = 2;
   // clone_from_shard is the hostname of the gitserver instance that is the current owner of the
   // repository. If this is set, then the RepoUpdateRequest is to migrate the repo from
@@ -426,7 +438,7 @@ message P4ExecRequest {
   string p4port = 1;
   string p4user = 2;
   string p4passwd = 3;
-  repeated string args = 4;
+  repeated bytes args = 4;
 }
 
 message P4ExecResponse {


### PR DESCRIPTION
Manual backport of https://github.com/sourcegraph/sourcegraph/pull/55990, which was accidentally not cherry-picked into the 5.1 branch.

 Conflicts:
	internal/gitserver/client.go
	internal/gitserver/v1/gitserver.pb.go



## Test plan

CI