### PR TITLE
JetBrains: add ability to edit account from context menu

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AddCodyAccountWithTokenAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AddCodyAccountWithTokenAction.kt
@@ -4,41 +4,40 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.NlsContexts
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import java.awt.Component
 import javax.swing.JComponent
 
 class AddCodyAccountWithTokenAction : BaseAddAccountWithTokenAction() {
-    override val defaultServer: String
-        get() = SourcegraphServerPath.DEFAULT_HOST
+  override val defaultServer: String
+    get() = SourcegraphServerPath.DEFAULT_HOST
 }
 
 class AddCodyEnterpriseAccountAction : BaseAddAccountWithTokenAction() {
-    override val defaultServer: String
-        get() = ""
+  override val defaultServer: String
+    get() = ""
 }
 
 abstract class BaseAddAccountWithTokenAction : DumbAwareAction() {
-    abstract val defaultServer: String
+  abstract val defaultServer: String
 
-    override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = e.getData(CodyAccountsHost.KEY) != null
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabledAndVisible = e.getData(CodyAccountsHost.KEY) != null
+  }
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val accountsHost = e.getData(CodyAccountsHost.KEY)!!
+    val dialog =
+        newAddAccountDialog(
+            e.project,
+            e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
+            accountsHost::isAccountUnique)
+
+    dialog.setServer(defaultServer, defaultServer != SourcegraphServerPath.DEFAULT_HOST)
+    if (dialog.showAndGet()) {
+      accountsHost.addAccount(dialog.server, dialog.login, dialog.token)
     }
-
-    override fun actionPerformed(e: AnActionEvent) {
-        val accountsHost = e.getData(CodyAccountsHost.KEY)!!
-        val dialog =
-            newAddAccountDialog(
-                e.project,
-                e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
-                accountsHost::isAccountUnique)
-
-        dialog.setServer(defaultServer, defaultServer != SourcegraphServerPath.DEFAULT_HOST)
-        if (dialog.showAndGet()) {
-            accountsHost.addAccount(dialog.server, dialog.login, dialog.token)
-        }
-    }
+  }
 }
 
 private fun newAddAccountDialog(
@@ -47,8 +46,8 @@ private fun newAddAccountDialog(
     isAccountUnique: UniqueLoginPredicate
 ): BaseLoginDialog =
     SourcegraphTokenLoginDialog(project, parent, isAccountUnique).apply {
-        title = "Add Sourcegraph Account"
-        setLoginButtonText("Add Account")
+      title = "Add Sourcegraph Account"
+      setLoginButtonText("Add Account")
     }
 
 internal class SourcegraphTokenLoginDialog(
@@ -59,15 +58,12 @@ internal class SourcegraphTokenLoginDialog(
     BaseLoginDialog(
         project, parent, SourcegraphApiRequestExecutor.Factory.getInstance(), isAccountUnique) {
 
-    init {
-        title = "Login to Sourcegraph"
-        setLoginButtonText("Login")
-        loginPanel.setTokenUi()
-        init()
-    }
+  init {
+    title = "Login to Sourcegraph"
+    setLoginButtonText("Login")
+    loginPanel.setTokenUi()
+    init()
+  }
 
-    internal fun setLoginButtonText(@NlsContexts.Button text: String) = setOKButtonText(text)
-
-    override fun createCenterPanel(): JComponent = loginPanel
+  override fun createCenterPanel(): JComponent = loginPanel
 }
-

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/BaseLoginDialog.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/BaseLoginDialog.kt
@@ -39,6 +39,7 @@ internal abstract class BaseLoginDialog(
   fun setServer(path: String, editable: Boolean) = loginPanel.setServer(path, editable)
   fun setCustomRequestHeaders(customRequestHeaders: String) =
       loginPanel.setCustomRequestHeaders(customRequestHeaders)
+  fun setLoginButtonText(text: String) = setOKButtonText(text)
 
   fun setError(exception: Throwable) {
     loginPanel.setError(exception)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
@@ -18,19 +18,20 @@ enum class AccountType {
 data class CodyAccount(
     @NlsSafe @Attribute("name") override var name: String = "",
     @Property(style = Property.Style.ATTRIBUTE, surroundWithTag = false)
-    override val server: SourcegraphServerPath = SourcegraphServerPath.from(ConfigUtil.DOTCOM_URL, ""),
+    override val server: SourcegraphServerPath =
+        SourcegraphServerPath.from(ConfigUtil.DOTCOM_URL, ""),
     @Attribute("id") override val id: String = generateId(),
 ) : ServerAccount() {
 
   fun isCodyApp(): Boolean {
-    return id == LocalAppManager.LOCAL_APP_ID
+    return Companion.isCodyApp(server)
   }
 
   fun getAccountType(): AccountType {
     if (isDotcomAccount()) {
       return AccountType.DOTCOM
     }
-    if (id == LocalAppManager.LOCAL_APP_ID) {
+    if (isCodyApp()) {
       return AccountType.LOCAL_APP
     }
     return AccountType.ENTERPRISE
@@ -47,12 +48,16 @@ data class CodyAccount(
         id: String = generateId(),
     ): CodyAccount {
       val username =
-          if (id == LocalAppManager.LOCAL_APP_ID) {
+          if (isCodyApp(server)) {
             LocalAppManager.LOCAL_APP_ID
           } else {
             name
           }
       return CodyAccount(username, server, id)
+    }
+
+    fun isCodyApp(server: SourcegraphServerPath): Boolean {
+      return server.url.startsWith(LocalAppManager.DEFAULT_LOCAL_APP_URL)
     }
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginRequest.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginRequest.kt
@@ -1,19 +1,18 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.NlsContexts
 import git4idea.DialogManager
 import java.awt.Component
-import java.util.UUID
 
 internal class CodyLoginRequest(
-    @NlsContexts.DialogMessage val text: String? = null,
+    val title: String? = null,
     val server: SourcegraphServerPath? = null,
     val isServerEditable: Boolean = server == null,
     val login: String? = null,
     val isCheckLoginUnique: Boolean = false,
     val token: String? = null,
-    val customRequestHeaders: String? = null
+    val customRequestHeaders: String? = null,
+    val loginButtonText: String? = null
 )
 
 internal fun CodyLoginRequest.loginWithToken(
@@ -28,8 +27,7 @@ internal fun CodyLoginRequest.loginWithToken(
 
 private val CodyLoginRequest.isLoginUniqueChecker: UniqueLoginPredicate
   get() = { login, server ->
-    !isCheckLoginUnique ||
-        CodyAuthenticationManager.getInstance().isAccountUnique(login, server)
+    !isCheckLoginUnique || CodyAuthenticationManager.getInstance().isAccountUnique(login, server)
   }
 
 private fun CodyLoginRequest.configure(dialog: BaseLoginDialog) {
@@ -37,12 +35,11 @@ private fun CodyLoginRequest.configure(dialog: BaseLoginDialog) {
   login?.let { dialog.setLogin(it) }
   token?.let { dialog.setToken(it) }
   customRequestHeaders?.let { dialog.setCustomRequestHeaders(it) }
+  title?.let { dialog.title = it }
+  loginButtonText?.let { dialog.setLoginButtonText(it) }
 }
 
 private fun BaseLoginDialog.getAuthData(): CodyAuthData? {
   DialogManager.show(this)
-  return if (isOK)
-      CodyAuthData(
-          CodyAccount.create(login, server), login, token)
-  else null
+  return if (isOK) CodyAuthData(CodyAccount.create(login, server), login, token) else null
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsConfigurable.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.config
 
-import com.intellij.collaboration.auth.ui.AccountsPanelFactory.accountsPanel
 import com.intellij.collaboration.util.ProgressIndicatorsProvider
 import com.intellij.ide.DataManager
 import com.intellij.openapi.components.service
@@ -22,6 +21,7 @@ import com.intellij.ui.dsl.builder.toMutableProperty
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.EmptyIcon
+import com.sourcegraph.cody.config.ui.customAccountsPanel
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.config.PluginSettingChangeActionNotifier
 import com.sourcegraph.config.PluginSettingChangeContext
@@ -47,19 +47,19 @@ class SettingsConfigurable(private val project: Project) :
     dialogPanel = panel {
       group("Authentication") {
         row {
-          accountsPanel(
+          customAccountsPanel(
                   accountManager,
                   defaultAccountHolder,
                   accountsModel,
                   detailsProvider,
                   disposable!!,
                   true,
-                  EmptyIcon.ICON_16)
+                  EmptyIcon.ICON_16) {
+                    it.copy(server = it.server.copy())
+                  }
               .horizontalAlign(HorizontalAlign.FILL)
               .verticalAlign(VerticalAlign.FILL)
-              .applyToComponent {
-                  this.preferredSize = Dimension(Int.MAX_VALUE, 200)
-              }
+              .applyToComponent { this.preferredSize = Dimension(Int.MAX_VALUE, 200) }
               .also {
                 DataManager.registerDataProvider(it.component) { key ->
                   if (CodyAccountsHost.KEY.`is`(key)) accountsModel else null

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountsPanelFactoryExtensions.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountsPanelFactoryExtensions.kt
@@ -1,0 +1,198 @@
+package com.sourcegraph.cody.config.ui
+
+import com.intellij.collaboration.auth.Account
+import com.intellij.collaboration.auth.AccountManager
+import com.intellij.collaboration.auth.AccountsListener
+import com.intellij.collaboration.auth.PersistentDefaultAccountHolder
+import com.intellij.collaboration.auth.ui.AccountsDetailsProvider
+import com.intellij.collaboration.auth.ui.AccountsListModel
+import com.intellij.collaboration.auth.ui.SimpleAccountsListCellRenderer
+import com.intellij.collaboration.messages.CollaborationToolsBundle
+import com.intellij.collaboration.ui.util.JListHoveredRowMaterialiser
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonShortcuts
+import com.intellij.openapi.keymap.KeymapUtil
+import com.intellij.ui.LayeredIcon
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.components.JBList
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.Row
+import com.intellij.util.ui.EmptyIcon
+import com.intellij.util.ui.StatusText
+import com.intellij.util.ui.UIUtil
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.awt.event.MouseListener
+import javax.swing.Icon
+import javax.swing.JComponent
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
+import javax.swing.ListCellRenderer
+import javax.swing.ListSelectionModel
+import javax.swing.SwingUtilities
+
+/**
+ * Custom factory method to create and account panel with possibility to add mouse listener for list
+ * elements. This is a custom version of a
+ * [com.intellij.collaboration.auth.ui.AccountsPanelFactory.create]
+ */
+private fun <A : Account, Cred, R> create(
+    model: AccountsListModel<A, Cred>,
+    needAddBtnWithDropdown: Boolean,
+    listElementMouseListener: (JBList<A>, AccountsListModel<A, Cred>) -> MouseListener,
+    listCellRendererFactory: () -> R
+): JComponent where R : ListCellRenderer<A>, R : JComponent {
+
+  val accountsListModel = model.accountsListModel
+  val accountsList =
+      JBList(accountsListModel).apply {
+        val decoratorRenderer = listCellRendererFactory()
+        cellRenderer = decoratorRenderer
+        JListHoveredRowMaterialiser.install(this, listCellRendererFactory())
+        UIUtil.putClientProperty(
+            this, UIUtil.NOT_IN_HIERARCHY_COMPONENTS, listOf(decoratorRenderer))
+
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+        addMouseListener(listElementMouseListener(this, model))
+      }
+  model.busyStateModel.addListener { accountsList.setPaintBusy(it) }
+  accountsList.addListSelectionListener { model.selectedAccount = accountsList.selectedValue }
+
+  accountsList.emptyText.apply {
+    appendText(CollaborationToolsBundle.message("accounts.none.added"))
+    appendSecondaryText(
+        CollaborationToolsBundle.message("accounts.add.link"),
+        SimpleTextAttributes.LINK_PLAIN_ATTRIBUTES) {
+          val event = it.source
+          val relativePoint = if (event is MouseEvent) RelativePoint(event) else null
+          model.addAccount(accountsList, relativePoint)
+        }
+    appendSecondaryText(
+        " (${KeymapUtil.getFirstKeyboardShortcutText(CommonShortcuts.getNew())})",
+        StatusText.DEFAULT_ATTRIBUTES,
+        null)
+  }
+
+  model.busyStateModel.addListener { accountsList.setPaintBusy(it) }
+
+  val addIcon: Icon =
+      if (needAddBtnWithDropdown) LayeredIcon.ADD_WITH_DROPDOWN else AllIcons.General.Add
+
+  val toolbar =
+      ToolbarDecorator.createDecorator(accountsList)
+          .disableUpDownActions()
+          .setAddAction { model.addAccount(accountsList, it.preferredPopupPoint) }
+          .setAddIcon(addIcon)
+
+  if (model is AccountsListModel.WithDefault) {
+    toolbar.addExtraAction(
+        object :
+            ToolbarDecorator.ElementActionButton(
+                CollaborationToolsBundle.message("accounts.set.default"),
+                AllIcons.Actions.Checked) {
+          override fun actionPerformed(e: AnActionEvent) {
+            val selected = accountsList.selectedValue
+            if (selected == model.defaultAccount) return
+            if (selected != null) model.defaultAccount = selected
+          }
+
+          override fun updateButton(e: AnActionEvent) {
+            isEnabled = isEnabled && model.defaultAccount != accountsList.selectedValue
+          }
+        })
+  }
+
+  return toolbar.createPanel()
+}
+
+/**
+ * Accounts panel with context menu actions displayed when right-clicked on menu elements This is a
+ * custom version of a [com.intellij.collaboration.auth.ui.AccountsPanelFactory.accountsPanel]
+ */
+fun <A : Account, Cred> Row.customAccountsPanel(
+    accountManager: AccountManager<A, Cred>,
+    defaultAccountHolder: PersistentDefaultAccountHolder<A>,
+    accountsModel: AccountsListModel.WithDefault<A, Cred>,
+    detailsProvider: AccountsDetailsProvider<A, *>,
+    disposable: Disposable,
+    needAddBtnWithDropdown: Boolean,
+    defaultAvatarIcon: Icon = EmptyIcon.ICON_16,
+    copyAccount: (A) -> A = { it },
+): Cell<JComponent> {
+
+  accountsModel.addCredentialsChangeListener(detailsProvider::reset)
+  detailsProvider.loadingStateModel.addListener { accountsModel.busyStateModel.value = it }
+
+  fun isModified() =
+      accountsModel.newCredentials.isNotEmpty() ||
+          accountsModel.accounts != accountManager.accounts ||
+          accountsModel.defaultAccount != defaultAccountHolder.account
+
+  fun reset() {
+    val defaultAccount = defaultAccountHolder.account
+    val accountsWithoutDefault =
+        if (defaultAccount != null) accountManager.accounts - defaultAccount
+        else accountManager.accounts
+    if (defaultAccount != null) {
+      val defaultAccountCopy = copyAccount(defaultAccount)
+      accountsModel.accounts =
+          (accountsWithoutDefault.map(copyAccount) + defaultAccountCopy).toSet()
+      accountsModel.defaultAccount = defaultAccountCopy
+    } else {
+      accountsModel.accounts = accountsWithoutDefault.map(copyAccount).toSet()
+      accountsModel.defaultAccount = null
+    }
+
+    accountsModel.clearNewCredentials()
+    detailsProvider.resetAll()
+  }
+
+  fun apply() {
+    for ((account, token) in accountsModel.newCredentials) {
+      if (token != null) {
+        accountManager.updateAccount(account, token)
+      }
+    }
+    val newTokensMap = accountsModel.accounts.associateWith { null }
+    accountManager.updateAccounts(newTokensMap)
+    val defaultAccount = accountsModel.defaultAccount
+    defaultAccountHolder.account = defaultAccount
+    accountsModel.clearNewCredentials()
+  }
+
+  accountManager.addListener(
+      disposable,
+      object : AccountsListener<A> {
+        override fun onAccountCredentialsChanged(account: A) {
+          if (!isModified()) reset()
+        }
+      })
+
+  val component =
+      create(
+          accountsModel,
+          needAddBtnWithDropdown,
+          { list, model ->
+            object : MouseAdapter() {
+              override fun mouseReleased(e: MouseEvent) {
+                if (SwingUtilities.isRightMouseButton(e)) {
+                  list.selectedIndex = list.locationToIndex(e.point)
+                  list.setSelectedValue(list.model.getElementAt(list.selectedIndex), true)
+
+                  val menu = JPopupMenu()
+                  val editAccount = JMenuItem("Edit Account")
+                  editAccount.addActionListener { model.editAccount(list, list.selectedValue) }
+                  menu.add(editAccount)
+                  menu.show(list, e.getPoint().x, e.getPoint().y)
+                }
+              }
+            }
+          }) {
+            SimpleAccountsListCellRenderer(accountsModel, detailsProvider, defaultAvatarIcon)
+          }
+  return cell(component).onIsModified(::isModified).onReset(::reset).onApply(::apply)
+}


### PR DESCRIPTION
It's possible now to edit account from context menu (right click on account) 
![Screenshot 2023-09-11 at 10 14 35](https://github.com/sourcegraph/sourcegraph/assets/7345368/722cd166-a0ae-4124-b43c-89794df6e936)

## Test plan
- Right click on existing account and edit some fields, account should be updated after clicking "Apply" on dialog, reset and closing the dialog without applying the settings should not change account
- Add and remove should still work

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
