### PR TITLE
JetBrains: disable autocomplete with IdeaVIM visual mode

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.autocomplete;
 
 import com.intellij.codeInsight.lookup.LookupManager;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -123,13 +124,16 @@ public class CodyAutocompleteManager {
   public void triggerAutocomplete(
       @NotNull Editor editor, int offset, InlineCompletionTriggerKind triggerKind) {
     boolean isTriggeredManually = triggerKind.equals(InlineCompletionTriggerKind.INVOKE);
+    String currentCommand = CommandProcessor.getInstance().getCurrentCommandName();
     if (!ConfigUtil.isCodyEnabled()) return;
     else if (!CodyEditorUtil.isEditorValidForAutocomplete(editor)) {
       if (isTriggeredManually) logger.warn("triggered autocomplete with invalid editor " + editor);
       return;
     } else if (!isTriggeredManually
         && !CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor)) return;
-
+    else if (CodyEditorUtil.isCommandExcluded(currentCommand)) {
+      return;
+    }
     final Project project = editor.getProject();
     if (project == null) {
       logger.warn("triggered autocomplete with null project");

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -28,6 +28,8 @@ public class ConfigUtil {
   public static final String DOTCOM_URL = "https://sourcegraph.com/";
   public static final String SERVICE_DISPLAY_NAME = "Sourcegraph Cody + Code Search";
 
+  private static final String VIM_MOTION_COMMAND = "Motion";
+
   @NotNull
   public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
     ServerAuth serverAuth = ServerAuthLoader.loadServerAuth(project);
@@ -145,5 +147,9 @@ public class ConfigUtil {
 
   public static List<String> getBlacklistedAutocompleteLanguageIds() {
     return CodyApplicationSettings.getInstance().getBlacklistedLanguageIds();
+  }
+
+  public static boolean isCommandInVimVisualMode(String command){
+    return command.contains(VIM_MOTION_COMMAND);
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -28,8 +28,6 @@ public class ConfigUtil {
   public static final String DOTCOM_URL = "https://sourcegraph.com/";
   public static final String SERVICE_DISPLAY_NAME = "Sourcegraph Cody + Code Search";
 
-  private static final String VIM_MOTION_COMMAND = "Motion";
-
   @NotNull
   public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
     ServerAuth serverAuth = ServerAuthLoader.loadServerAuth(project);
@@ -147,9 +145,5 @@ public class ConfigUtil {
 
   public static List<String> getBlacklistedAutocompleteLanguageIds() {
     return CodyApplicationSettings.getInstance().getBlacklistedLanguageIds();
-  }
-
-  public static boolean isCommandInVimVisualMode(String command){
-    return command.contains(VIM_MOTION_COMMAND);
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -27,6 +27,8 @@ import kotlin.math.min
 object CodyEditorUtil {
     const val VIM_EXIT_INSERT_MODE_ACTION = "VimInsertExitModeAction"
 
+    private const val VIM_MOTION_COMMAND = "Motion"
+
     @JvmStatic
     private val KEY_EDITOR_SUPPORTED = Key.create<Boolean>("cody.editorSupported")
 
@@ -40,7 +42,8 @@ object CodyEditorUtil {
      */
     @JvmStatic
     fun tabsToSpaces(
-        inputText: String, indentOptions: IndentOptions): String {
+        inputText: String, indentOptions: IndentOptions
+    ): String {
         val tabReplacement = " ".repeat(indentOptions.TAB_SIZE)
         return inputText.replace("\t".toRegex(), tabReplacement)
     }
@@ -51,7 +54,8 @@ object CodyEditorUtil {
      */
     @JvmStatic
     fun indentOptions(
-        editor: Editor): IndentOptions {
+        editor: Editor
+    ): IndentOptions {
         return Optional.ofNullable(codeStyleSettings(editor).indentOptions)
             .orElse(IndentOptions.DEFAULT_INDENT_OPTIONS)
     }
@@ -73,10 +77,12 @@ object CodyEditorUtil {
     fun getTextRange(document: Document, range: Range): TextRange {
         val start = min(
             document.getLineEndOffset(range.start.line),
-            document.getLineStartOffset(range.start.line) + range.start.character)
+            document.getLineStartOffset(range.start.line) + range.start.character
+        )
         val end = min(
             document.getLineEndOffset(range.end.line),
-            document.getLineStartOffset(range.end.line) + range.end.character)
+            document.getLineStartOffset(range.end.line) + range.end.character
+        )
         return TextRange.create(start, end)
     }
 
@@ -92,10 +98,10 @@ object CodyEditorUtil {
     @JvmStatic
     fun isEditorInstanceSupported(editor: Editor): Boolean {
         return editor.project != null && !editor.isViewer
-            && !editor.isOneLineMode
-            && editor !is EditorWindow
-            && editor !is ImaginaryEditor
-            && (editor !is EditorEx || !editor.isEmbeddedIntoDialogWrapper)
+                && !editor.isOneLineMode
+                && editor !is EditorWindow
+                && editor !is ImaginaryEditor
+                && (editor !is EditorEx || !editor.isEmbeddedIntoDialogWrapper)
     }
 
     @JvmStatic
@@ -116,16 +122,16 @@ object CodyEditorUtil {
     @RequiresEdt
     fun isEditorValidForAutocomplete(editor: Editor?): Boolean {
         return editor != null
-            && editor.document.isWritable
-            && CodyProjectUtil.isProjectAvailable(editor.project)
-            && isEditorSupported(editor)
+                && editor.document.isWritable
+                && CodyProjectUtil.isProjectAvailable(editor.project)
+                && isEditorSupported(editor)
     }
 
     @JvmStatic
     fun isImplicitAutocompleteEnabledForEditor(editor: Editor): Boolean {
         return ConfigUtil.isCodyEnabled()
-            && ConfigUtil.isCodyAutocompleteEnabled()
-            && !isLanguageBlacklisted(editor)
+                && ConfigUtil.isCodyAutocompleteEnabled()
+                && !isLanguageBlacklisted(editor)
     }
 
     @JvmStatic
@@ -138,5 +144,11 @@ object CodyEditorUtil {
     fun isLanguageBlacklisted(editor: Editor): Boolean {
         val language = getLanguage(editor) ?: return false
         return ConfigUtil.getBlacklistedAutocompleteLanguageIds().contains(language.id)
+    }
+
+    @JvmStatic
+    fun isCommandExcluded(command: String?): Boolean {
+        return (command.isNullOrEmpty()
+                || command.contains(VIM_MOTION_COMMAND))
     }
 }


### PR DESCRIPTION
It fixes #56122 
## Test plan

* Install IdeaVIM plugin 
* Enter visual mode
* Navigate to closest whitespace to trigger autocomplete
* Autocomplete should not be triggered
