### PR TITLE
Revert "Don't configure empty dummy authz providers in OSS apps (#56483)

### DIFF
--- a/cmd/sourcegraph/osscmd/BUILD.bazel
+++ b/cmd/sourcegraph/osscmd/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/sourcegraph/osscmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/authz",
         "//internal/service",
         "//internal/service/svcmain",
     ],

--- a/cmd/sourcegraph/osscmd/osscmd.go
+++ b/cmd/sourcegraph/osscmd/osscmd.go
@@ -3,11 +3,18 @@
 package osscmd
 
 import (
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/service/svcmain"
 )
 
-var config = svcmain.Config{}
+var config = svcmain.Config{
+	AfterConfigure: func() {
+		// Set dummy authz provider to unblock channel for checking permissions in GraphQL APIs.
+		// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
+		authz.SetProviders(true, []authz.Provider{})
+	},
+}
 
 // MainOSS is called from the `main` function of the `cmd/sourcegraph` command.
 func MainOSS(services []service.Service, args []string) {


### PR DESCRIPTION
This reverts commit dbf3ceedaf67324b456b71dec9d935b0497dbe86.

Seems to fails CI on main, but didn't on the PR build.

## Test plan

Just a simple revert.