### PR TITLE
JetBrains: clear last autocomplete candidate after acceptance

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -61,4 +61,7 @@ public interface CodyAgentServer {
 
   @JsonNotification("debug/message")
   void debugMessage(DebugMessage message);
+
+  @JsonNotification("autocomplete/clearLastCandidate")
+  void autocompleteClearLastCandidate();
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutocompleteAction.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AcceptCodyAutocompleteAction.java
@@ -51,6 +51,7 @@ public class AcceptCodyAutocompleteAction extends EditorAction {
             CodyAutocompleteManager.getInstance().getCurrentAutocompleteTelemetry();
         GraphQlLogger.logAutocompleteAcceptedEvent(
             project, telemetry != null ? telemetry.params() : null);
+        server.autocompleteClearLastCandidate();
         acceptAgentAutocomplete(editor, maybeCaret);
       } else {
         Optional.ofNullable(maybeCaret)


### PR DESCRIPTION
Clears the last autocomplete candidate after acceptance so that new autocompletes will get a new ID 

closes https://github.com/sourcegraph/sourcegraph/issues/56469
## Test plan
Tested with https://github.com/sourcegraph/cody/pull/998
Accepted an autocomplete and then immediately removed it and triggered another
Got the same suggestion but verified the id was different.

```
[Trace - 09:00:18 AM] Sending request 'graphql/logEvent - (33)'
Params: {
  "event": "CodyJetBrainsPlugin:completion:accepted",
  "userCookieID": "4cbce745-e0bd-43d9-97ea-fc08be33ac0c",
  "url": "",
  "source": "IDEEXTENSION",
  "referrer": "JETBRAINS",
  "argument": {},
  "publicArgument": {
    "contextSummary": {
      "local": 2.0,
      "duration": 10.141000270843506
    },
    "id": "8rpyvgn2g",
    "languageId": "go",
    "source": "Network",
    "charCount": 32,
    "lineCount": 1,
    "providerIdentifier": "anthropic",
    "serverEndpoint": "https://sourcegraph.sourcegraph.com/",
    "extensionDetails": {
      "ide": "JetBrains",
      "ideExtensionType": "Cody",
      "version": "3.1.0-alpha.3"
    }
  },
  "deviceID": "4cbce745-e0bd-43d9-97ea-fc08be33ac0c"
}


[Trace - 09:00:18 AM] Sending notification 'autocomplete/clearLastCandidate'
Params: null
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
