### PR TITLE
App: disable ratelimiter job 

### DIFF
--- a/cmd/worker/internal/ratelimit/job.go
+++ b/cmd/worker/internal/ratelimit/job.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -28,6 +29,10 @@ func (s *rateLimitConfigJob) Config() []env.Config {
 }
 
 func (s *rateLimitConfigJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	//TODO: Allow this job to run once an in memory version is available
+	if deploy.IsApp() {
+		return nil, nil
+	}
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When app is running there is no access to redis which causes the ratelimiter job to fail, disable this job when running app
## Test plan
`sg start app` runs successfully

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
