### PR TITLE
source: properly display size in terabytes

### DIFF
--- a/client/web/src/util/size.test.ts
+++ b/client/web/src/util/size.test.ts
@@ -18,7 +18,7 @@ describe('humanizeSize', () => {
     })
 
     it('returns TB size for values above 1TB', () => {
-        expect(humanizeSize(1234567890123)).toBe('1234.57TB')
+        expect(humanizeSize(1234567890123)).toBe('1.23TB')
     })
 
     it('rounds decimal values to 2 places', () => {

--- a/client/web/src/util/size.ts
+++ b/client/web/src/util/size.ts
@@ -1,4 +1,4 @@
-const ONE_KILO_BYTE = 1000
+const ONE_KILO_BYTE = 1_000
 const ONE_MEGA_BYTE = 1_000_000
 const ONE_GIGA_BYTE = 1_000_000_000
 const ONE_TERA_BYTE = 1_000_000_000_000
@@ -11,7 +11,7 @@ const ONE_TERA_BYTE = 1_000_000_000_000
  */
 export function humanizeSize(size: number): string {
     if (size > ONE_TERA_BYTE) {
-        const estimatedSize = size / ONE_GIGA_BYTE
+        const estimatedSize = size / ONE_TERA_BYTE
         return `${estimatedSize.toFixed(2)}TB`
     }
 


### PR DESCRIPTION
This slipped through the crack. I added a utility function to display size in a human-readable format. However, the logic for deriving the display value for sizes of over 1TB was wrong. 

![CleanShot 2023-09-11 at 14 41 48@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/6f9b7df6-26f7-4584-a35d-b349bf966d32)

This PR fixes that and ensures the human-readable size is correct.

## Test plan

* Updated the tests
* Manual testing on my local instance