### PR TITLE
JetBrains: update autocomplete provider list and default to null

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteProviderType.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteProviderType.java
@@ -3,14 +3,12 @@ package com.sourcegraph.cody.autocomplete;
 import java.util.Arrays;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public enum AutocompleteProviderType {
   ANTHROPIC,
   UNSTABLE_CODEGEN,
   UNSTABLE_OPENAI,
   UNSTABLE_FIREWORKS;
-
 
   public static Optional<AutocompleteProviderType> optionalValueOf(@NotNull String name) {
     return Arrays.stream(AutocompleteProviderType.values())

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteProviderType.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteProviderType.java
@@ -3,15 +3,15 @@ package com.sourcegraph.cody.autocomplete;
 import java.util.Arrays;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public enum AutocompleteProviderType {
   ANTHROPIC,
   UNSTABLE_CODEGEN,
-  UNSTABLE_AZURE_OPENAI;
+  UNSTABLE_OPENAI,
+  UNSTABLE_FIREWORKS;
 
-  public static final AutocompleteProviderType DEFAULT_AUTOCOMPLETE_PROVIDER_TYPE = ANTHROPIC;
 
-  @NotNull
   public static Optional<AutocompleteProviderType> optionalValueOf(@NotNull String name) {
     return Arrays.stream(AutocompleteProviderType.values())
         .filter(providerType -> providerType.vscodeSettingString().equals(name))

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -15,10 +15,8 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager;
 import com.sourcegraph.cody.config.ServerAuth;
 import com.sourcegraph.cody.config.ServerAuthLoader;
 import com.sourcegraph.cody.config.SourcegraphServerPath;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,18 +29,21 @@ public class ConfigUtil {
   @NotNull
   public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
     ServerAuth serverAuth = ServerAuthLoader.loadServerAuth(project);
-    return new ExtensionConfiguration()
+    ExtensionConfiguration config = new ExtensionConfiguration()
         .setServerEndpoint(serverAuth.getInstanceUrl())
         .setAccessToken(serverAuth.getAccessToken())
         .setCustomHeaders(getCustomRequestHeadersAsMap(serverAuth.getCustomRequestHeaders()))
         .setProxy(UserLevelConfig.getProxy())
-        .setAutocompleteAdvancedProvider(
-            UserLevelConfig.getAutocompleteProviderType().vscodeSettingString())
         .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutocompleteServerEndpoint())
         .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutocompleteAccessToken())
         .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
         .setDebug(isCodyDebugEnabled())
         .setVerboseDebug(isCodyVerboseDebugEnabled());
+
+    if (UserLevelConfig.getAutocompleteProviderType() != null){
+        config.setAutocompleteAdvancedProvider(UserLevelConfig.getAutocompleteProviderType().vscodeSettingString());
+    }
+    return config;
   }
 
   @NotNull

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -15,7 +15,6 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager;
 import com.sourcegraph.cody.config.ServerAuth;
 import com.sourcegraph.cody.config.ServerAuthLoader;
 import com.sourcegraph.cody.config.SourcegraphServerPath;
-
 import java.util.*;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.Contract;
@@ -29,19 +28,21 @@ public class ConfigUtil {
   @NotNull
   public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
     ServerAuth serverAuth = ServerAuthLoader.loadServerAuth(project);
-    ExtensionConfiguration config = new ExtensionConfiguration()
-        .setServerEndpoint(serverAuth.getInstanceUrl())
-        .setAccessToken(serverAuth.getAccessToken())
-        .setCustomHeaders(getCustomRequestHeadersAsMap(serverAuth.getCustomRequestHeaders()))
-        .setProxy(UserLevelConfig.getProxy())
-        .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutocompleteServerEndpoint())
-        .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutocompleteAccessToken())
-        .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
-        .setDebug(isCodyDebugEnabled())
-        .setVerboseDebug(isCodyVerboseDebugEnabled());
+    ExtensionConfiguration config =
+        new ExtensionConfiguration()
+            .setServerEndpoint(serverAuth.getInstanceUrl())
+            .setAccessToken(serverAuth.getAccessToken())
+            .setCustomHeaders(getCustomRequestHeadersAsMap(serverAuth.getCustomRequestHeaders()))
+            .setProxy(UserLevelConfig.getProxy())
+            .setAutocompleteAdvancedServerEndpoint(UserLevelConfig.getAutocompleteServerEndpoint())
+            .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutocompleteAccessToken())
+            .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
+            .setDebug(isCodyDebugEnabled())
+            .setVerboseDebug(isCodyVerboseDebugEnabled());
 
-    if (UserLevelConfig.getAutocompleteProviderType() != null){
-        config.setAutocompleteAdvancedProvider(UserLevelConfig.getAutocompleteProviderType().vscodeSettingString());
+    if (UserLevelConfig.getAutocompleteProviderType() != null) {
+      config.setAutocompleteAdvancedProvider(
+          UserLevelConfig.getAutocompleteProviderType().vscodeSettingString());
     }
     return config;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -15,9 +15,9 @@ import org.jetbrains.annotations.Nullable;
 public class UserLevelConfig {
   /**
    * Overrides the provider used for generating autocomplete suggestions. Only supported values at
-   * the moment are 'anthropic' (default) or 'unstable-codegen'.
+   * the moment are 'anthropic' (default), 'unstable-codegen', 'unstable-openai', or 'unstable-fireworks'.
    */
-  @NotNull
+  @Nullable
   public static AutocompleteProviderType getAutocompleteProviderType() {
     Properties properties = readProperties();
     String currentKey = "cody.autocomplete.advanced.provider";
@@ -29,7 +29,7 @@ public class UserLevelConfig {
                 Optional.ofNullable(
                     properties.getProperty(oldKey, null))) // fallback to the old key
         .flatMap(AutocompleteProviderType::optionalValueOf)
-        .orElse(AutocompleteProviderType.DEFAULT_AUTOCOMPLETE_PROVIDER_TYPE); // or default
+        .orElse(null);
   }
 
   public static boolean getAutocompleteAdvancedEmbeddings() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -15,7 +15,8 @@ import org.jetbrains.annotations.Nullable;
 public class UserLevelConfig {
   /**
    * Overrides the provider used for generating autocomplete suggestions. Only supported values at
-   * the moment are 'anthropic' (default), 'unstable-codegen', 'unstable-openai', or 'unstable-fireworks'.
+   * the moment are 'anthropic' (default), 'unstable-codegen', 'unstable-openai', or
+   * 'unstable-fireworks'.
    */
   @Nullable
   public static AutocompleteProviderType getAutocompleteProviderType() {


### PR DESCRIPTION
Updates the list of available autocomplete providers to match what VS Code supports.  Also removes the default value, so that the default logic from the VS Code extension can be applied.  Currently a null value will result in a default to `anthropic` same as before however additional changes are being worked on so that the autocomplete provider will default based on the configuration of the sg instance the user is connected to. 

## Test plan
`./gradlew :runIde -PforceAgentBuild=true` - verify autocomplete works and defaults to anthropic

create `~/.sourcegraph-jetbrains.properties` and set `cody.autocomplete.advanced.provider=unstable-openai` 
restart plugin and verify it is using `unstable-openai` autocomplete provider.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
