### PR TITLE
go: Upgrade to 1.20.8

### DIFF
--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.5
+          go-version: 1.20.8
 
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.20.5
+golang 1.20.8
 nodejs 16.18.1
 fd 8.6.0
 shfmt 3.5.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -290,7 +290,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.20.5",
+    version = "1.20.8",
 )
 
 linter_dependencies()

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -34,7 +34,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"pnpm":                  check.Combine(check.InPath("pnpm"), checkPnpmVersion(">= 8.3.0")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.20.5")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.20.8")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),


### PR DESCRIPTION
Upgrades go from 1.20.5 to 1.20.8 which includes

go1.20.6 (released 2023-07-11) includes a security fix to the net/http package, as well as bug fixes to the compiler, cgo, the cover tool, the go command, the runtime, and the crypto/ecdsa, go/build, go/printer, net/mail, and text/template packages. See the Go 1.20.6 milestone on our issue tracker for details.

go1.20.7 (released 2023-08-01) includes a security fix to the crypto/tls package, as well as bug fixes to the assembler and the compiler. See the Go 1.20.7 milestone on our issue tracker for details.

go1.20.8 (released 2023-09-06) includes two security fixes to the html/template package, as well as bug fixes to the compiler, the go command, the runtime, and the crypto/tls, go/types, net/http, and path/filepath packages. See the Go 1.20.8 milestone on our issue tracker for details.

## Test plan

CI should find any potential issues.