### PR TITLE
JetBrains: add link to generate new token

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserErrorNotification.java
@@ -12,9 +12,10 @@ import com.sourcegraph.Icons;
 import java.awt.datatransfer.StringSelection;
 import java.net.URI;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BrowserErrorNotification {
-  public static void show(Project project, URI uri) {
+  public static void show(@Nullable Project project, URI uri) {
     Notification notification =
         new Notification(
             "Sourcegraph errors",

--- a/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserOpener.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/common/BrowserOpener.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BrowserOpener {
   public static void openRelativeUrlInBrowser(
@@ -16,7 +17,7 @@ public class BrowserOpener {
     openInBrowser(project, ConfigUtil.getServerPath(project).getUrl() + "/" + relativeUrl);
   }
 
-  public static void openInBrowser(@NotNull Project project, @NotNull String absoluteUrl) {
+  public static void openInBrowser(@Nullable Project project, @NotNull String absoluteUrl) {
     try {
       openInBrowser(project, new URI(absoluteUrl));
     } catch (URISyntaxException e) {
@@ -25,7 +26,7 @@ public class BrowserOpener {
     }
   }
 
-  private static void openInBrowser(@NotNull Project project, @NotNull URI uri) {
+  private static void openInBrowser(@Nullable Project project, @NotNull URI uri) {
     try {
       BrowserUtil.browse(uri);
     } catch (Exception e) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -79,5 +79,5 @@ class CodyAccountListModel(private val project: Project) :
   }
 
   override fun isAccountUnique(login: String, server: SourcegraphServerPath): Boolean =
-      accountsListModel.items.none { it.name == login && it.server == server }
+      accountsListModel.items.none { it.name == login && it.server.url == server.url }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -28,7 +28,7 @@ class CodyAuthenticationManager internal constructor() {
       accountManager.findCredentials(account)
 
   internal fun isAccountUnique(name: String, server: SourcegraphServerPath) =
-      accountManager.accounts.none { it.name == name && it.server == server }
+      accountManager.accounts.none { it.name == name && it.server.url == server.url }
 
   @RequiresEdt
   internal fun login(

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
@@ -13,7 +13,6 @@ import com.intellij.ui.components.fields.ExtendableTextField
 import com.intellij.ui.components.panels.Wrapper
 import com.intellij.ui.dsl.builder.Panel
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
-import com.sourcegraph.cody.config.DialogValidationUtils.notBlank
 import java.util.concurrent.CompletableFuture
 import javax.swing.JComponent
 import javax.swing.JTextField
@@ -61,21 +60,10 @@ internal class CodyLoginPanel(
 
   fun doValidateAll(): List<ValidationInfo> {
     val uiError =
-        notBlank(serverTextField, "Server url cannot be empty")
-            ?: validateServerPath(serverTextField)
-                ?: validateCustomRequestHeaders(customRequestHeadersField)
-                ?: currentUi.getValidator().invoke()
+        validateCustomRequestHeaders(customRequestHeadersField) ?: currentUi.getValidator().invoke()
 
     return listOfNotNull(uiError, tokenAcquisitionError)
   }
-
-  private fun validateServerPath(field: JTextField): ValidationInfo? =
-      try {
-        SourcegraphServerPath.from(field.text, "")
-        null
-      } catch (e: Exception) {
-        ValidationInfo("Invalid server url", field)
-      }
 
   private fun validateCustomRequestHeaders(field: JTextField): ValidationInfo? {
     if (field.getText().isEmpty()) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
@@ -8,14 +8,20 @@ import com.intellij.ui.components.fields.ExtendableTextField
 import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_NO_WRAP
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.ui.layout.CellBuilder
+import com.intellij.ui.layout.LayoutBuilder
+import com.intellij.ui.layout.applyToComponent
+import com.intellij.ui.layout.enteredTextSatisfies
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import com.sourcegraph.cody.api.SourcegraphAuthenticationException
 import com.sourcegraph.cody.api.SourcegraphSecurityUtil
 import com.sourcegraph.cody.config.DialogValidationUtils.custom
 import com.sourcegraph.cody.config.DialogValidationUtils.notBlank
 import com.sourcegraph.common.AuthorizationUtil
+import com.sourcegraph.common.BrowserOpener
 import java.net.UnknownHostException
 import javax.swing.JComponent
+import javax.swing.JTextField
 
 internal class CodyTokenCredentialsUi(
     private val serverTextField: ExtendableTextField,
@@ -34,6 +40,20 @@ internal class CodyTokenCredentialsUi(
   override fun Panel.centerPanel() {
     row("Server: ") { cell(serverTextField).horizontalAlign(HorizontalAlign.FILL) }
     row("Token: ") { cell(tokenTextField).horizontalAlign(HorizontalAlign.FILL) }
+  override fun LayoutBuilder.centerPanel() {
+    lateinit var serverField: CellBuilder<ExtendableTextField>
+    row("Server: ") { serverField = serverTextField(pushX, growX) }
+    row {
+      cell { label("Token: ") }
+      cell(isFullWidth = true, isVerticalFlow = true) {
+        tokenTextField()
+        link("Generate new token") { BrowserOpener.openInBrowser(null, buildNewTokenUrl()) }
+            .enableIf(
+                serverField.component.enteredTextSatisfies {
+                  it.isNotEmpty() && isServerPathValid(it)
+                })
+      }
+    }
     row("Custom request headers: ") {
       cell(customRequestHeadersField)
           .horizontalAlign(HorizontalAlign.FILL)
@@ -50,11 +70,34 @@ internal class CodyTokenCredentialsUi(
 
   override fun getPreferredFocusableComponent(): JComponent = tokenTextField
 
+  private fun buildNewTokenUrl(): String {
+    val sourcegraphServerPath =
+        runCatching { SourcegraphServerPath.from(serverTextField.text, "") }.getOrNull()
+            ?: return ""
+    return sourcegraphServerPath.url + "user/settings/tokens/new"
+  }
+
   override fun getValidator(): () -> ValidationInfo? = {
-    notBlank(tokenTextField, "Token cannot be empty")
-        ?: custom(tokenTextField, "Invalid access token") {
+    getServerPathValidationInfo()
+        ?: notBlank(tokenTextField, "Token cannot be empty")
+            ?: custom(tokenTextField, "Invalid access token") {
           AuthorizationUtil.isValidAccessToken(tokenTextField.text)
         }
+  }
+
+  private fun getServerPathValidationInfo(): ValidationInfo? {
+    return notBlank(serverTextField, "Server url cannot be empty")
+        ?: validateServerPath(serverTextField)
+  }
+
+  private fun validateServerPath(field: JTextField): ValidationInfo? =
+      if (!isServerPathValid(field.text)) {
+        ValidationInfo("Invalid server url", field)
+      } else {
+        null
+      }
+  private fun isServerPathValid(text: String): Boolean {
+    return runCatching { SourcegraphServerPath.from(text, "") }.getOrNull() != null
   }
 
   override fun createExecutor() = factory.create(tokenTextField.text)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
@@ -5,12 +5,10 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.setEmptyState
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.components.fields.ExtendableTextField
+import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_NO_WRAP
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.intellij.ui.layout.CellBuilder
-import com.intellij.ui.layout.LayoutBuilder
-import com.intellij.ui.layout.applyToComponent
 import com.intellij.ui.layout.enteredTextSatisfies
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import com.sourcegraph.cody.api.SourcegraphAuthenticationException
@@ -38,21 +36,15 @@ internal class CodyTokenCredentialsUi(
   }
 
   override fun Panel.centerPanel() {
-    row("Server: ") { cell(serverTextField).horizontalAlign(HorizontalAlign.FILL) }
+    lateinit var serverField: Cell<ExtendableTextField>
+    row("Server: ") { serverField = cell(serverTextField).horizontalAlign(HorizontalAlign.FILL) }
     row("Token: ") { cell(tokenTextField).horizontalAlign(HorizontalAlign.FILL) }
-  override fun LayoutBuilder.centerPanel() {
-    lateinit var serverField: CellBuilder<ExtendableTextField>
-    row("Server: ") { serverField = serverTextField(pushX, growX) }
-    row {
-      cell { label("Token: ") }
-      cell(isFullWidth = true, isVerticalFlow = true) {
-        tokenTextField()
-        link("Generate new token") { BrowserOpener.openInBrowser(null, buildNewTokenUrl()) }
-            .enableIf(
-                serverField.component.enteredTextSatisfies {
-                  it.isNotEmpty() && isServerPathValid(it)
-                })
-      }
+    row("") {
+      link("Generate new token") { BrowserOpener.openInBrowser(null, buildNewTokenUrl()) }
+          .enabledIf(
+              serverField.component.enteredTextSatisfies {
+                it.isNotEmpty() && isServerPathValid(it)
+              })
     }
     row("Custom request headers: ") {
       cell(customRequestHeadersField)


### PR DESCRIPTION
User can now click on the link that will redirect him to a page on which he can generate a new token
<img width="599" alt="Screenshot 2023-09-12 at 10 04 13" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/786888d7-244a-46db-b139-d7c7f6f97f8a">


## Test plan
- Try to create/edit an account, link to generate a new token should appear and should redirect user to page on which he can generate new access token
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
