### PR TITLE
Delve for all packages

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -155,7 +155,7 @@ commands:
       .bin/frontend
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/frontend github.com/sourcegraph/sourcegraph/cmd/frontend
     checkBinary: .bin/frontend
@@ -176,7 +176,7 @@ commands:
     cmd: .bin/gitserver
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/gitserver github.com/sourcegraph/sourcegraph/cmd/gitserver
     checkBinary: .bin/gitserver
@@ -214,7 +214,7 @@ commands:
     cmd: .bin/github-proxy
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/github-proxy github.com/sourcegraph/sourcegraph/cmd/github-proxy
     checkBinary: .bin/github-proxy
@@ -229,7 +229,7 @@ commands:
       .bin/repo-updater
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/repo-updater github.com/sourcegraph/sourcegraph/cmd/repo-updater
     checkBinary: .bin/repo-updater
@@ -244,7 +244,7 @@ commands:
     cmd: .bin/symbols
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/symbols github.com/sourcegraph/sourcegraph/enterprise/cmd/symbols
@@ -267,7 +267,7 @@ commands:
       .bin/embeddings
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/embeddings github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings
@@ -293,7 +293,7 @@ commands:
       .bin/worker
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/worker github.com/sourcegraph/sourcegraph/enterprise/cmd/worker
     watch:
@@ -307,7 +307,7 @@ commands:
       .bin/cody-gateway
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/cody-gateway github.com/sourcegraph/sourcegraph/cmd/cody-gateway
@@ -332,7 +332,7 @@ commands:
       .bin/pings
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
 
       go build -gcflags="$GCFLAGS" -o .bin/pings github.com/sourcegraph/sourcegraph/cmd/pings
@@ -351,7 +351,7 @@ commands:
     cmd: .bin/searcher
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/searcher github.com/sourcegraph/sourcegraph/cmd/searcher
     checkBinary: .bin/searcher
@@ -492,7 +492,7 @@ commands:
       .bin/codeintel-worker
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/codeintel-worker github.com/sourcegraph/sourcegraph/cmd/precise-code-intel-worker
     checkBinary: .bin/codeintel-worker
@@ -508,7 +508,7 @@ commands:
       env TMPDIR="$HOME/.sourcegraph/executor-temp" .bin/executor
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/executor github.com/sourcegraph/sourcegraph/cmd/executor
     checkBinary: .bin/executor
@@ -641,7 +641,7 @@ commands:
       # Ensure the old blobstore Docker container is not running
       docker rm -f blobstore
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -o .bin/blobstore github.com/sourcegraph/sourcegraph/cmd/blobstore
     checkBinary: .bin/blobstore
@@ -921,7 +921,7 @@ commands:
       .bin/sourcegraph
     install: |
       if [ -n "$DELVE" ]; then
-        export GCFLAGS='-N -l'
+        export GCFLAGS='all=-N -l'
       fi
       go build -gcflags="$GCFLAGS" -ldflags="-X github.com/sourcegraph/sourcegraph/internal/conf/deploy.forceType=app" -o .bin/sourcegraph github.com/sourcegraph/sourcegraph/cmd/sourcegraph
     checkBinary: .bin/sourcegraph


### PR DESCRIPTION
When running in debug mode, we disable Go optimizations / inlining with `export GCFLAGS='-N -l'`, but this causes the debugger to fail to access variables when stepping through files (error: `(unreadable could not find loclist entry at 0x13b3835 for address 0x1063d4aa4)`), likely due to the fact that our GCFLAGS value only disables optimizations in main package?

Context:

- https://github.com/go-delve/delve/issues/1320#issuecomment-415939417
- https://youtrack.jetbrains.com/issue/GO-5311
## Test plan

- Tested locally (as it only affects local debugging)
- Reproduction steps:
-- Run `DELVE=1 sg start dotcom`
-- Put a breakpoint [here](https://sourcegraph.sourcegraph.com/-/editor?remote_url=git%40github.com%3Asourcegraph%2Fsourcegraph-inc239.git&branch=main&file=internal%2Fgitserver%2Fcommands.go&editor=VSCode&version=2.2.16&start_row=1270&start_col=7&end_row=1270&end_col=7) and start debugging frontend
-- Trigger a new embedding job [here](https://sourcegraph.test:3443/site-admin/embeddings)
-- Breakpoint is hit, but `short` variable can't be accessed (without PR), failing with error similar to `(unreadable could not find loclist entry at 0x13b3835 for address 0x1063d4aa4)`, with this PR we correctly return the bool value

