### PR TITLE
Access tokens: add URL search parameter to control default description

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -92,6 +92,8 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
         )
     )
 
+    const defaultDescriptionValue = new URLSearchParams(location.search).get('description') || undefined
+
     return (
         <div className="user-settings-create-access-token-page">
             <PageTitle title="Create access token" />
@@ -106,6 +108,7 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
                         required={true}
                         autoFocus={true}
                         placeholder="What's this token for?"
+                        defaultValue={defaultDescriptionValue}
                         className="form-group"
                         label="Token description"
                     />


### PR DESCRIPTION
Previously, when using the JetBrains plugin with manual access token creation, the user had to type out the description of the access token. This PR adds the ability for the plugin to optionally include a default description value saving one manual step for the user. With this change, the user only needs to click "Generate token" instead of having to additionally type out a description value.

## Test plan

- Ran `SOURCEGRAPHDOTCOM_MODE=true SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone`
- Visited URL https://sourcegraph.test:3443/users/olafurpg-testing/settings/tokens/new?description=foobar
- Confirmed that the default value is set
<img width="1030" alt="CleanShot 2023-09-12 at 11 34 17@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/40009675-2cea-4f58-aa0c-743107002038">
- Visited URL https://sourcegraph.test:3443/users/olafurpg-testing/settings/tokens/new
- Confirmed that the default value is empty, as usual

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
