### PR TITLE
uploadstore: list with prefix

### DIFF
--- a/cmd/blobstore/internal/blobstore/BUILD.bazel
+++ b/cmd/blobstore/internal/blobstore/BUILD.bazel
@@ -34,5 +34,6 @@ go_test(
         "//internal/uploadstore",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/blobstore/internal/blobstore/blobstore.go
+++ b/cmd/blobstore/internal/blobstore/blobstore.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -195,7 +196,7 @@ func (s *Service) deleteObject(ctx context.Context, bucketName, objectName strin
 	return nil
 }
 
-func (s *Service) listObjects(_ context.Context, bucketName string) ([]objectMetadata, error) {
+func (s *Service) listObjects(_ context.Context, bucketName string, prefix string) ([]objectMetadata, error) {
 
 	// Ensure the bucket cannot be created/deleted while we look at it.
 	bucketLock := s.bucketLock(bucketName)
@@ -213,6 +214,12 @@ func (s *Service) listObjects(_ context.Context, bucketName string) ([]objectMet
 	var objects []objectMetadata
 	for _, entry := range entries {
 		objectName := fnameToObjectName(entry.Name())
+
+		// Skip objects that don't match the prefix.
+		if !strings.HasPrefix(objectName, prefix) {
+			continue
+		}
+
 		info, err := entry.Info()
 		if err != nil {
 			s.Log.Warn("error listing objects in bucket (ignoring)", sglog.String("key", bucketName+"/"+objectName), sglog.Error(err))

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -129,7 +129,7 @@ func TestList(t *testing.T) {
 	autogold.Expect([]interface{}{9, "<nil>"}).Equal(t, []any{uploaded, fmt.Sprint(err)})
 
 	// List the keys
-	iter, err := store.List(ctx)
+	iter, err := store.List(ctx, "foobar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestListEmpty(t *testing.T) {
 	store, server, _ := initTestStore(ctx, t, t.TempDir())
 	defer server.Close()
 
-	iter, err := store.List(ctx)
+	iter, err := store.List(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/blobstore/internal/blobstore/blobstore_test.go
+++ b/cmd/blobstore/internal/blobstore/blobstore_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hexops/autogold/v2"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/blobstore/internal/blobstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -122,24 +123,46 @@ func TestList(t *testing.T) {
 	uploaded, err := store.Upload(ctx, "foobar1", strings.NewReader("Hello 1! "))
 	autogold.Expect([]interface{}{9, "<nil>"}).Equal(t, []any{uploaded, fmt.Sprint(err)})
 
-	uploaded, err = store.Upload(ctx, "foobar3", strings.NewReader("Hello 3!"))
+	uploaded, err = store.Upload(ctx, "foobar2", strings.NewReader("Hello 3!"))
 	autogold.Expect([]interface{}{8, "<nil>"}).Equal(t, []any{uploaded, fmt.Sprint(err)})
 
-	uploaded, err = store.Upload(ctx, "foobar2", strings.NewReader("Hello 2! "))
+	uploaded, err = store.Upload(ctx, "banana", strings.NewReader("Hello 2! "))
 	autogold.Expect([]interface{}{9, "<nil>"}).Equal(t, []any{uploaded, fmt.Sprint(err)})
 
-	// List the keys
-	iter, err := store.List(ctx, "foobar")
-	if err != nil {
-		t.Fatal(err)
+	tc := []struct {
+		prefix string
+		keys   []string
+	}{
+		{
+			prefix: "foobar",
+			keys:   []string{"foobar1", "foobar2"},
+		},
+		{
+			prefix: "banana",
+			keys:   []string{"banana"},
+		},
+		{
+			prefix: "",
+			keys:   []string{"banana", "foobar1", "foobar2"},
+		},
 	}
 
-	var keys []string
-	for iter.Next() {
-		keys = append(keys, iter.Current())
-	}
+	for _, c := range tc {
+		t.Run(c.prefix, func(t *testing.T) {
+			iter, err := store.List(ctx, c.prefix)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	autogold.Expect([]interface{}{[]string{"foobar1", "foobar2", "foobar3"}}).Equal(t, []any{keys})
+			var keys []string
+			for iter.Next() {
+				keys = append(keys, iter.Current())
+			}
+
+			require.Equal(t, c.keys, keys)
+		},
+		)
+	}
 }
 
 func TestListEmpty(t *testing.T) {

--- a/cmd/blobstore/internal/blobstore/s3_routes.go
+++ b/cmd/blobstore/internal/blobstore/s3_routes.go
@@ -67,8 +67,10 @@ func (s *Service) serveS3(w http.ResponseWriter, r *http.Request) error {
 // GET /<bucket>
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
 func (s *Service) serveListObjectsV2(w http.ResponseWriter, r *http.Request, bucketName string) error {
+	prefix := r.URL.Query().Get("prefix")
+
 	var contents []s3Object
-	objects, err := s.listObjects(r.Context(), bucketName)
+	objects, err := s.listObjects(r.Context(), bucketName, prefix)
 	if err != nil {
 		return writeS3Error(w, s3ErrorNoSuchBucket, bucketName, err, http.StatusConflict)
 	}

--- a/internal/embeddings/index_storage_test.go
+++ b/internal/embeddings/index_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func (s *noOpUploadStore) Get(ctx context.Context, key string) (io.ReadCloser, e
 	return nil, nil
 }
 
-func (s *noOpUploadStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
+func (s *noOpUploadStore) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
 	return nil, nil
 }
 
@@ -85,10 +86,12 @@ func (s *mockUploadStore) Get(ctx context.Context, key string) (io.ReadCloser, e
 	return io.NopCloser(bytes.NewReader(file)), nil
 }
 
-func (s *mockUploadStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
+func (s *mockUploadStore) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
 	var names []string
 	for k := range s.files {
-		names = append(names, k)
+		if strings.HasPrefix(k, prefix) {
+			names = append(names, k)
+		}
 	}
 
 	return iterator.From[string](names), nil

--- a/internal/uploadstore/gcs_client.go
+++ b/internal/uploadstore/gcs_client.go
@@ -98,6 +98,7 @@ func (s *gcsStore) List(ctx context.Context, prefix string) (_ *sgiterator.Itera
 		for len(keys) < maxKeys {
 			attr, err := iter.Next()
 			if err != nil && err != iterator.Done {
+				s.operations.List.Logger.Error("Failed to list objects in GCS bucket", sglog.Error(err))
 				return nil, err
 			}
 			if err == iterator.Done {

--- a/internal/uploadstore/gcs_client.go
+++ b/internal/uploadstore/gcs_client.go
@@ -80,8 +80,8 @@ func (s *gcsStore) Init(ctx context.Context) error {
 // Equals the default of S3's ListObjectsV2Input.MaxKeys
 const maxKeys = 1_000
 
-func (s *gcsStore) List(ctx context.Context) (*sgiterator.Iterator[string], error) {
-	query := storage.Query{}
+func (s *gcsStore) List(ctx context.Context, prefix string) (*sgiterator.Iterator[string], error) {
+	query := storage.Query{Prefix: prefix}
 
 	// Performance optimization
 	query.SetAttrSelection([]string{"Name"})

--- a/internal/uploadstore/gcs_client_test.go
+++ b/internal/uploadstore/gcs_client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,17 +175,28 @@ func TestGCSList(t *testing.T) {
 	gcsClient := NewMockGcsAPI()
 	bucketHandle := NewMockGcsBucketHandle()
 	objectHandle := NewMockGcsObjectHandle()
-	mockIterator := mockGCSObjectsIterator{objects: []storage.ObjectAttrs{{Name: "test-key1"}, {Name: "test-key2"}}}
 
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewWriterFunc.SetDefaultReturn(nopCloser{buf})
 
-	bucketHandle.ObjectsFunc.SetDefaultReturn(&mockIterator)
+	objects := []storage.ObjectAttrs{{Name: "test-key1"}, {Name: "test-key2"}}
+	bucketHandle.ObjectsFunc.SetDefaultHook(func(ctx context.Context, query *storage.Query) gcsObjectIterator {
+		j := 0
+		for i, obj := range objects {
+			if strings.HasPrefix(obj.Name, query.Prefix) {
+				objects[j] = objects[i]
+				j++
+			}
+		}
+		objects = objects[:j]
+
+		return &mockGCSObjectsIterator{objects}
+	})
 
 	client := testGCSClient(gcsClient, false)
 
-	iter, err := client.List(context.Background())
+	iter, err := client.List(context.Background(), "test-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/uploadstore/gcs_client_test.go
+++ b/internal/uploadstore/gcs_client_test.go
@@ -180,7 +180,7 @@ func TestGCSList(t *testing.T) {
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
 	objectHandle.NewWriterFunc.SetDefaultReturn(nopCloser{buf})
 
-	objects := []storage.ObjectAttrs{{Name: "test-key1"}, {Name: "test-key2"}}
+	objects := []storage.ObjectAttrs{{Name: "test-key1"}, {Name: "test-key2"}, {Name: "other-key"}}
 	bucketHandle.ObjectsFunc.SetDefaultHook(func(ctx context.Context, query *storage.Query) gcsObjectIterator {
 		j := 0
 		for i, obj := range objects {

--- a/internal/uploadstore/lazy_client.go
+++ b/internal/uploadstore/lazy_client.go
@@ -33,12 +33,12 @@ func (s *lazyStore) Get(ctx context.Context, key string) (io.ReadCloser, error) 
 	return s.store.Get(ctx, key)
 }
 
-func (s *lazyStore) List(ctx context.Context) (*iterator.Iterator[string], error) {
+func (s *lazyStore) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
 	if err := s.initOnce(ctx); err != nil {
 		return nil, err
 	}
 
-	return s.store.List(ctx)
+	return s.store.List(ctx, prefix)
 }
 
 func (s *lazyStore) Upload(ctx context.Context, key string, r io.Reader) (int64, error) {

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -86,14 +86,11 @@ const maxZeroReads = 3
 var errNoDownloadProgress = errors.New("no download progress")
 
 func (s *s3Store) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
-	input := s3.ListObjectsV2Input{Bucket: &s.bucket}
-
-	if prefix != "" {
-		input.Prefix = &prefix
-	}
-
 	// We wrap the client's paginator and just return the keys.
-	paginator := s.client.NewListObjectsV2Paginator(&input)
+	paginator := s.client.NewListObjectsV2Paginator(&s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
 
 	next := func() ([]string, error) {
 		if !paginator.HasMorePages() {

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -85,7 +85,12 @@ const maxZeroReads = 3
 // in a row.
 var errNoDownloadProgress = errors.New("no download progress")
 
-func (s *s3Store) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
+func (s *s3Store) List(ctx context.Context, prefix string) (_ *iterator.Iterator[string], err error) {
+	ctx, _, endObservation := s.operations.List.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+		attribute.String("prefix", prefix),
+	}})
+	defer endObservation(1, observation.Args{})
+
 	// We wrap the client's paginator and just return the keys.
 	paginator := s.client.NewListObjectsV2Paginator(&s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),

--- a/internal/uploadstore/s3_client.go
+++ b/internal/uploadstore/s3_client.go
@@ -85,9 +85,15 @@ const maxZeroReads = 3
 // in a row.
 var errNoDownloadProgress = errors.New("no download progress")
 
-func (s *s3Store) List(ctx context.Context) (*iterator.Iterator[string], error) {
+func (s *s3Store) List(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
+	input := s3.ListObjectsV2Input{Bucket: &s.bucket}
+
+	if prefix != "" {
+		input.Prefix = &prefix
+	}
+
 	// We wrap the client's paginator and just return the keys.
-	paginator := s.client.NewListObjectsV2Paginator(&s3.ListObjectsV2Input{Bucket: &s.bucket})
+	paginator := s.client.NewListObjectsV2Paginator(&input)
 
 	next := func() ([]string, error) {
 		if !paginator.HasMorePages() {

--- a/internal/uploadstore/store.go
+++ b/internal/uploadstore/store.go
@@ -33,8 +33,8 @@ type Store interface {
 	// the age of the object exceeds the given max age.
 	ExpireObjects(ctx context.Context, prefix string, maxAge time.Duration) error
 
-	// List returns an iterator over all keys.
-	List(ctx context.Context) (*iterator.Iterator[string], error)
+	// List returns an iterator over all keys with the given prefix.
+	List(ctx context.Context, prefix string) (*iterator.Iterator[string], error)
 }
 
 var storeConstructors = map[string]func(ctx context.Context, config Config, operations *Operations) (Store, error){


### PR DESCRIPTION
We extend `Store.List` and allow the caller to filter the objects by prefix. I need the prefix in a follow-up PR to iterate over all blobs associated with a search job.

`Store.List` isn't used anywhere, so it is fine to modify it instead of adding a dedicated new method.

Why isn't `Store.List` used anywhere?

I added this method a while ago to support the effort to create a single source of truth for embeddings. However, in the end I decided for a different approach. I left the method in place because I anticipated we might use it soon for other purposes.

## Test plan:
updated unit tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
