### PR TITLE
JetBrains: document `auth` package 

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/package.md
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/package.md
@@ -1,0 +1,6 @@
+# Package com.sourcegraph.cody.auth
+
+This package contains API to manage user accounts. 
+Most of the code was copied here from package `com.intellij.collaboration.auth`, because it looks like it is a public API,
+but it was changing without any sign of deprecation, and it broke our code. That's why we decided to copy it to our sources.
+The code can be updated to the same state as in the original package in the new versions of IntelliJ IDEA

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/package.md
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/package.md
@@ -1,6 +1,6 @@
 # Package com.sourcegraph.cody.auth
 
-This package contains API to manage user accounts. 
+This package contains API to manage user accounts.
 Most of the code was copied here from package `com.intellij.collaboration.auth`, because it looks like it is a public API,
 but it was changing without any sign of deprecation, and it broke our code. That's why we decided to copy it to our sources.
 The code can be updated to the same state as in the original package in the new versions of IntelliJ IDEA


### PR DESCRIPTION
Added documentation to copied `auth` package with markdown as it is the default way of doing it in kotlin

## Test plan
- Green CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
