### PR TITLE
JetBrains: move caching graphql query loader to our sources from IntelliJ

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/CachingGraphQLQueryLoader.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/CachingGraphQLQueryLoader.kt
@@ -1,0 +1,114 @@
+package com.sourcegraph.cody.api
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import java.io.IOException
+import java.io.InputStream
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import org.jetbrains.annotations.VisibleForTesting
+
+abstract class CachingGraphQLQueryLoader(
+    private val fragmentsDirectory: String = "graphql/fragment",
+    private val fragmentsFileExtension: String = "graphql"
+) {
+
+  private val fragmentDefinitionRegex = Regex("fragment (.*) on .*\\{")
+
+  private val fragmentsCache =
+      Caffeine.newBuilder()
+          .expireAfterAccess(Duration.of(2, ChronoUnit.MINUTES))
+          .build<String, Fragment>()
+
+  private val queriesCache =
+      Caffeine.newBuilder()
+          .expireAfterAccess(Duration.of(1, ChronoUnit.MINUTES))
+          .build<String, String>()
+
+  // Use path to allow going to the file quickly
+  @Throws(IOException::class)
+  fun loadQuery(queryPath: String): String {
+    return queriesCache.get(queryPath) { path ->
+      val (body, fragmentNames) = readCollectingFragmentNames(path)
+
+      val builder = StringBuilder()
+      val fragments = LinkedHashMap<String, Fragment>()
+      readFragmentsWithDependencies(fragmentNames, fragments)
+      for (fragment in fragments.values.reversed()) {
+        builder.append(fragment.body).append("\n")
+      }
+
+      builder.append(body)
+      builder.toString()
+    }
+  }
+
+  private fun readFragmentsWithDependencies(
+      names: Set<String>,
+      into: MutableMap<String, Fragment>
+  ) {
+    for (fragmentName in names) {
+      val fragment = fragmentsCache.get(fragmentName) { name -> Fragment(name) }
+      into[fragment.name] = fragment
+
+      val nonProcessedDependencies = fragment.dependencies.filter { !into.contains(it) }.toSet()
+      readFragmentsWithDependencies(nonProcessedDependencies, into)
+    }
+  }
+
+  private fun readCollectingFragmentNames(filePath: String): Pair<String, Set<String>> {
+    val bodyBuilder = StringBuilder()
+    val fragments = mutableSetOf<String>()
+    val innerFragments = mutableSetOf<String>()
+
+    val stream =
+        getFileStream(filePath)
+            ?: throw GraphQLFileNotFoundException("Couldn't find file $filePath")
+    stream.reader().forEachLine {
+      val line = it.trim()
+      bodyBuilder.append(line).append("\n")
+
+      if (line.startsWith("fragment")) {
+        val fragmentName = fragmentDefinitionRegex.matchEntire(line)?.groupValues?.get(1)?.trim()
+        if (fragmentName != null) innerFragments.add(fragmentName)
+      }
+
+      if (line.startsWith("...") && line.length > 3 && !line[3].isWhitespace()) {
+        val fragmentName = line.substring(3)
+        fragments.add(fragmentName)
+      }
+    }
+    fragments.removeAll(innerFragments)
+    return bodyBuilder.toString().removeSuffix("\n") to fragments
+  }
+
+  // visible to avoid storing test queries with the code
+  @VisibleForTesting
+  protected open fun getFileStream(relativePath: String): InputStream? =
+      this::class.java.classLoader.getResourceAsStream(relativePath)
+
+  private inner class Fragment(val name: String) {
+
+    val body: String
+    val dependencies: Set<String>
+
+    init {
+      val (body, dependencies) =
+          readCollectingFragmentNames("$fragmentsDirectory/${name}.$fragmentsFileExtension")
+      this.body = body
+      this.dependencies = dependencies
+    }
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other !is Fragment) return false
+
+      if (name != other.name) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      return name.hashCode()
+    }
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/GraphQLFileNotFoundException.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/GraphQLFileNotFoundException.kt
@@ -1,0 +1,5 @@
+package com.sourcegraph.cody.api
+
+import java.io.FileNotFoundException
+
+class GraphQLFileNotFoundException(message: String) : FileNotFoundException(message)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphGQLQueryLoader.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphGQLQueryLoader.kt
@@ -1,5 +1,3 @@
 package com.sourcegraph.cody.api
 
-import com.intellij.collaboration.api.graphql.CachingGraphQLQueryLoader
-
-object SourcegraphGQLQueryLoader: CachingGraphQLQueryLoader()
+object SourcegraphGQLQueryLoader : CachingGraphQLQueryLoader()

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/DeferredIconRepaintScheduler.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/DeferredIconRepaintScheduler.kt
@@ -1,0 +1,128 @@
+package com.sourcegraph.cody.auth.ui
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.ui.PaintingParent
+import com.intellij.ui.tabs.impl.TabLabel
+import com.intellij.util.Alarm
+import com.intellij.util.concurrency.annotations.RequiresEdt
+import java.awt.Component
+import java.awt.Rectangle
+import javax.swing.JComboBox
+import javax.swing.JList
+import javax.swing.JTable
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+
+class DeferredIconRepaintScheduler {
+  private val repaintScheduler = RepaintScheduler()
+
+  @RequiresEdt
+  fun createRepaintRequest(c: Component?, x: Int, y: Int): RepaintRequest {
+    val target = getTarget(c)
+    val paintingParent: Component? =
+        SwingUtilities.getAncestorOfClass(PaintingParent::class.java, c)
+    val paintingParentRec: Rectangle? =
+        if (paintingParent == null) null else (paintingParent as PaintingParent).getChildRec(c!!)
+
+    return RepaintRequest(c, x, y, target, paintingParent, paintingParentRec)
+  }
+
+  @RequiresEdt
+  fun scheduleRepaint(
+      request: RepaintRequest,
+      iconWidth: Int,
+      iconHeight: Int,
+      alwaysSchedule: Boolean
+  ) {
+    val actualTarget = request.getActualTarget()
+    if (actualTarget == null) {
+      return
+    }
+    val component = request.component
+    if (!alwaysSchedule && component == actualTarget) {
+      component.repaint(request.x, request.y, iconWidth, iconHeight)
+    } else {
+      repaintScheduler.pushDirtyComponent(actualTarget, request.paintingParentRec)
+    }
+  }
+
+  private fun getTarget(c: Component?): Component? {
+    val list = SwingUtilities.getAncestorOfClass(JList::class.java, c)
+    if (list != null) {
+      return list
+    }
+
+    // check table first to process com.intellij.ui.treeStructure.treetable.TreeTable correctly
+    val table = SwingUtilities.getAncestorOfClass(JTable::class.java, c)
+    if (table != null) {
+      return table
+    }
+
+    val tree = SwingUtilities.getAncestorOfClass(JTree::class.java, c)
+    if (tree != null) {
+      return tree
+    }
+
+    val box = SwingUtilities.getAncestorOfClass(JComboBox::class.java, c)
+    if (box != null) {
+      return box
+    }
+
+    val tabLabel = SwingUtilities.getAncestorOfClass(TabLabel::class.java, c)
+    if (tabLabel != null) {
+      return tabLabel
+    }
+
+    return c
+  }
+
+  class RepaintRequest(
+      val component: Component?,
+      val x: Int,
+      val y: Int,
+      val target: Component?,
+      val paintingParent: Component?,
+      val paintingParentRec: Rectangle?
+  ) {
+    fun getActualTarget(): Component? {
+      if (target == null) {
+        return null
+      }
+      if (SwingUtilities.getWindowAncestor(target) != null) {
+        return target
+      }
+
+      if (paintingParent != null && SwingUtilities.getWindowAncestor(paintingParent) != null) {
+        return paintingParent
+      }
+      return null
+    }
+  }
+
+  private class RepaintScheduler {
+    private val myAlarm = Alarm()
+    private val myQueue = LinkedHashSet<RepaintSchedulerRequest>()
+
+    fun pushDirtyComponent(c: Component, rec: Rectangle?) {
+      ApplicationManager.getApplication()
+          .assertIsDispatchThread() // assert myQueue accessed from EDT only
+      myAlarm.cancelAllRequests()
+      myAlarm.addRequest(
+          {
+            for (each in myQueue) {
+              val r = each.rectangle
+              if (r == null) {
+                each.component.repaint()
+              } else {
+                each.component.repaint(r.x, r.y, r.width, r.height)
+              }
+            }
+            myQueue.clear()
+          },
+          50)
+      myQueue.add(RepaintSchedulerRequest(c, rec))
+    }
+  }
+
+  private data class RepaintSchedulerRequest(val component: Component, val rectangle: Rectangle?)
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/ScaleContextCache.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/ScaleContextCache.kt
@@ -1,0 +1,30 @@
+package com.sourcegraph.cody.auth.ui
+
+import com.intellij.openapi.util.Pair
+import com.intellij.ui.scale.DerivedScaleType
+import com.intellij.ui.scale.UserScaleContext
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Function
+
+open class ScaleContextCache<D, S : UserScaleContext>(private val myDataProvider: Function<in S, out D>) {
+
+  private val myData = AtomicReference<Pair<Double, D>?>(null)
+
+  /**
+   * Returns the data object from the cache if it matches the `ctx`, otherwise provides the new data
+   * via the provider and caches it.
+   */
+  fun getOrProvide(ctx: S): D? {
+    var data = myData.get()
+    val scale = ctx.getScale(DerivedScaleType.PIX_SCALE)
+    if (data == null || scale.compareTo(data.first) != 0) {
+      myData.set(Pair.create(scale, myDataProvider.apply(ctx)).also { data = it })
+    }
+    return data!!.second
+  }
+
+  /** Clears the cache. */
+  fun clear() {
+    myData.set(null)
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/ScalingAsyncImageIcon.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/ScalingAsyncImageIcon.kt
@@ -1,0 +1,96 @@
+package com.sourcegraph.cody.auth.ui
+
+import com.intellij.ui.scale.ScaleContext
+import com.intellij.util.IconUtil
+import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.concurrency.EdtExecutorService
+import com.intellij.util.ui.ImageUtil
+import java.awt.Component
+import java.awt.Graphics
+import java.awt.Image
+import java.util.concurrent.CompletableFuture
+import javax.swing.Icon
+
+class ScalingAsyncImageIcon(
+    private val size: Int,
+    defaultIcon: Icon,
+    imageLoader: () -> CompletableFuture<Image?>
+) : Icon {
+  private val baseIcon = IconUtil.resizeSquared(defaultIcon, size)
+
+  // Icon can be located on different monitors (with different ScaleContext),
+  // so it is better to cache icon for each
+  private val scaledIconCache =
+      ScaleContextCache<DelegatingIcon, ScaleContext> { scaleCtx ->
+        val imageIcon =
+            imageLoader()
+                .thenApplyAsync(
+                    { image ->
+                      image?.let {
+                        val resizedImage = ImageUtil.resize(it, size, scaleCtx)
+                        IconUtil.createImageIcon(resizedImage)
+                      }
+                    },
+                    resizeExecutor)
+
+        DelegatingIcon(baseIcon, imageIcon)
+      }
+
+  override fun getIconHeight() = baseIcon.iconHeight
+  override fun getIconWidth() = baseIcon.iconWidth
+
+  override fun paintIcon(c: Component, g: Graphics, x: Int, y: Int) {
+    val orProvide: DelegatingIcon? = scaledIconCache.getOrProvide(ScaleContext.create(c))
+    orProvide?.paintIcon(c, g, x, y)
+  }
+
+  companion object {
+    private val resizeExecutor =
+        AppExecutorUtil.createBoundedApplicationPoolExecutor("ImageIcon resize executor", 1)
+  }
+}
+
+private class DelegatingIcon(
+    baseIcon: Icon,
+    private val delegateResult: CompletableFuture<out Icon?>
+) : Icon {
+  // We collect repaintRequests for the icon to understand which Components should be repainted when
+  // icon is loaded
+  // We can receive paintIcon few times for the same component but with different x, y
+  // Only the last request should be scheduled
+  private val repaintRequests =
+      mutableMapOf<Component, DeferredIconRepaintScheduler.RepaintRequest>()
+  private var delegate: Icon = baseIcon
+
+  init {
+    delegateResult.thenApplyAsync(
+        { icon ->
+          if (icon != null) {
+            delegate = icon
+            for ((_, repaintRequest) in repaintRequests) {
+              repaintScheduler.scheduleRepaint(
+                  repaintRequest, iconWidth, iconHeight, alwaysSchedule = false)
+            }
+          }
+          repaintRequests.clear()
+        },
+        EdtExecutorService.getInstance())
+  }
+
+  override fun getIconHeight() = delegate.iconHeight
+
+  override fun getIconWidth() = delegate.iconWidth
+
+  override fun paintIcon(c: Component?, g: Graphics?, x: Int, y: Int) {
+    delegate.paintIcon(c, g, x, y)
+    if (!delegateResult.isDone && c != null) {
+      repaintRequests[c] = repaintScheduler.createRepaintRequest(c, x, y)
+    }
+  }
+
+  companion object {
+    // Scheduler for all DelegatingIcon instances. It repaints components that contain these icons
+    // in a batch
+    private val repaintScheduler = DeferredIconRepaintScheduler()
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.auth.ui
 
 import com.intellij.collaboration.messages.CollaborationToolsBundle
-import com.intellij.ui.ScalingAsyncImageIcon
 import com.intellij.ui.components.labels.LinkLabel
 import com.intellij.ui.components.labels.LinkListener
 import com.intellij.util.IconUtil
@@ -29,9 +28,9 @@ import javax.swing.JPanel
 import javax.swing.ListCellRenderer
 
 class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
-  private val listModel: AccountsListModel<A, *>,
-  private val detailsProvider: AccountsDetailsProvider<A, D>,
-  private val defaultAvatarIcon: Icon
+    private val listModel: AccountsListModel<A, *>,
+    private val detailsProvider: AccountsDetailsProvider<A, D>,
+    private val defaultAvatarIcon: Icon
 ) : ListCellRenderer<A>, JPanel() {
 
   private val avatarIcons = mutableMapOf<A, Icon>()
@@ -50,31 +49,36 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
     layout = FlowLayout(FlowLayout.LEFT, 0, 0)
     border = JBUI.Borders.empty(5, 8)
 
-    val namesPanel = JPanel().apply {
-      layout = GridBagLayout()
-      border = JBUI.Borders.empty(0, 6, 4, 6)
+    val namesPanel =
+        JPanel().apply {
+          layout = GridBagLayout()
+          border = JBUI.Borders.empty(0, 6, 4, 6)
 
-      val bag = GridBag()
-        .setDefaultInsets(JBUI.insetsRight(UIUtil.DEFAULT_HGAP))
-        .setDefaultAnchor(GridBagConstraints.WEST)
-        .setDefaultFill(GridBagConstraints.VERTICAL)
-      add(fullName, bag.nextLine().next())
-      add(accountName, bag.next())
-      add(loadingError, bag.next())
-      add(reloginLink, bag.next())
-      add(serverName, bag.nextLine().coverLine())
-    }
+          val bag =
+              GridBag()
+                  .setDefaultInsets(JBUI.insetsRight(UIUtil.DEFAULT_HGAP))
+                  .setDefaultAnchor(GridBagConstraints.WEST)
+                  .setDefaultFill(GridBagConstraints.VERTICAL)
+          add(fullName, bag.nextLine().next())
+          add(accountName, bag.next())
+          add(loadingError, bag.next())
+          add(reloginLink, bag.next())
+          add(serverName, bag.nextLine().coverLine())
+        }
 
     add(profilePicture)
     add(namesPanel)
   }
 
-  override fun getListCellRendererComponent(list: JList<out A>,
-                                            account: A,
-                                            index: Int,
-                                            isSelected: Boolean,
-                                            cellHasFocus: Boolean): Component {
-    UIUtil.setBackgroundRecursively(this, ListUiUtil.WithTallRow.background(list, isSelected, list.hasFocus()))
+  override fun getListCellRendererComponent(
+      list: JList<out A>,
+      account: A,
+      index: Int,
+      isSelected: Boolean,
+      cellHasFocus: Boolean
+  ): Component {
+    UIUtil.setBackgroundRecursively(
+        this, ListUiUtil.WithTallRow.background(list, isSelected, list.hasFocus()))
     val primaryTextColor = ListUiUtil.WithTallRow.foreground(isSelected, list.hasFocus())
     val secondaryTextColor = ListUiUtil.WithTallRow.secondaryForeground(list, isSelected)
 
@@ -87,15 +91,12 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
       if (account is ServerAccount) {
         isVisible = true
         text = account.server.toString()
-      }
-      else {
+      } else {
         isVisible = false
       }
       foreground = secondaryTextColor
     }
-    profilePicture.apply {
-      icon = getAvatarIcon(account)
-    }
+    profilePicture.apply { icon = getAvatarIcon(account) }
     fullName.apply {
       text = getDetails(account)?.name
       setBold(isDefault(account))
@@ -108,9 +109,7 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
     }
     reloginLink.apply {
       isVisible = getError(account) != null && needReLogin(account)
-      setListener(LinkListener { _, _ ->
-        editAccount(list, account)
-      }, null)
+      setListener(LinkListener { _, _ -> editAccount(list, account) }, null)
     }
     return this
   }
@@ -121,30 +120,31 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
     if (image == null) return IconUtil.resizeSquared(defaultAvatarIcon, iconSize)
     return avatarIcons.getOrPut(account) {
       ScalingAsyncImageIcon(
-        iconSize,
-        defaultAvatarIcon,
-        imageLoader = {
-          CompletableFuture<Image?>().completeAsync({
-            getAvatarImage(account)
-          }, CachingCodyUserAvatarLoader.avatarLoadingExecutor)
-        }
-      )
+          iconSize,
+          defaultAvatarIcon,
+          imageLoader = {
+            CompletableFuture<Image?>()
+                .completeAsync(
+                    { getAvatarImage(account) }, CachingCodyUserAvatarLoader.avatarLoadingExecutor)
+          })
     }
   }
 
-  private fun isDefault(account: A): Boolean = (listModel is AccountsListModel.WithDefault) && account == listModel.defaultAccount
-  private fun editAccount(parentComponent: JComponent, account: A) = listModel.editAccount(parentComponent, account)
+  private fun isDefault(account: A): Boolean =
+      (listModel is AccountsListModel.WithDefault) && account == listModel.defaultAccount
+  private fun editAccount(parentComponent: JComponent, account: A) =
+      listModel.editAccount(parentComponent, account)
 
   private fun getDetails(account: A): D? = detailsProvider.getDetails(account)
   private fun getAvatarImage(account: A): Image? = detailsProvider.getAvatarImage(account)
 
-  @Nls
-  private fun getError(account: A): String? = detailsProvider.getErrorText(account)
+  @Nls private fun getError(account: A): String? = detailsProvider.getErrorText(account)
   private fun needReLogin(account: A): Boolean = detailsProvider.checkErrorRequiresReLogin(account)
 
   companion object {
     private fun JLabel.setBold(isBold: Boolean) {
-      font = font.deriveFont(if (isBold) font.style or Font.BOLD else font.style and Font.BOLD.inv())
+      font =
+          font.deriveFont(if (isBold) font.style or Font.BOLD else font.style and Font.BOLD.inv())
     }
   }
 }


### PR DESCRIPTION
More unstable API moved from IntelliJ to our sources because they broke the compatibility in new releases of Intellij IDEA

## Test plan
- Add account in new version of IntelliJ IDEA should work and should load the user avatar

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
