### PR TITLE
JetBrains: Cody: Disable autocomplete when navigating with arrow keys

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -28,6 +28,10 @@ object CodyEditorUtil {
     const val VIM_EXIT_INSERT_MODE_ACTION = "VimInsertExitModeAction"
 
     private const val VIM_MOTION_COMMAND = "Motion"
+    private const val UP_COMMAND = "Up"
+    private const val DOWN_COMMAND = "Down"
+    private const val LEFT_COMMAND = "Left"
+    private const val RIGHT_COMMAND = "Right"
 
     @JvmStatic
     private val KEY_EDITOR_SUPPORTED = Key.create<Boolean>("cody.editorSupported")
@@ -149,6 +153,10 @@ object CodyEditorUtil {
     @JvmStatic
     fun isCommandExcluded(command: String?): Boolean {
         return (command.isNullOrEmpty()
-                || command.contains(VIM_MOTION_COMMAND))
+                || command.contains(VIM_MOTION_COMMAND)
+                || command == UP_COMMAND
+                || command == DOWN_COMMAND
+                || command == LEFT_COMMAND
+                || command == RIGHT_COMMAND)
     }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -32,6 +32,7 @@ object CodyEditorUtil {
     private const val DOWN_COMMAND = "Down"
     private const val LEFT_COMMAND = "Left"
     private const val RIGHT_COMMAND = "Right"
+    private const val MOVE_CARET_COMMAND = "Move Caret"
 
     @JvmStatic
     private val KEY_EDITOR_SUPPORTED = Key.create<Boolean>("cody.editorSupported")
@@ -157,6 +158,7 @@ object CodyEditorUtil {
                 || command == UP_COMMAND
                 || command == DOWN_COMMAND
                 || command == LEFT_COMMAND
-                || command == RIGHT_COMMAND)
+                || command == RIGHT_COMMAND
+                || command.contains(MOVE_CARET_COMMAND))
     }
 }


### PR DESCRIPTION
It fixes #56511 
## Test plan
* Enable Cody autocomplete
* Navigate with arrows, autocomplete should not be triggered
* Autocomplete should be triggered after pressing spacebar


https://github.com/sourcegraph/sourcegraph/assets/9321940/2da1af24-140e-4b31-baa7-57b75596b5f4

