### PR TITLE
cleanup: More idiomatic cmp.Diff API usage

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -533,6 +533,7 @@ go_test(
         "@com_github_gofrs_uuid//:uuid",
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_graph_gophers_graphql_go//errors",
         "@com_github_graph_gophers_graphql_go//relay",

--- a/cmd/frontend/graphqlbackend/site_test.go
+++ b/cmd/frontend/graphqlbackend/site_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -286,17 +287,8 @@ func TestSiteConfigurationHistory(t *testing.T) {
 				siteConfigChangeResolverIDs[i] = s.siteConfig.ID
 			}
 
-			if len(siteConfigChangeResolvers) != len(tc.expectedSiteConfigIDs) {
-				diff := cmp.Diff(tc.expectedSiteConfigIDs, siteConfigChangeResolverIDs)
-				t.Fatalf(`mismatched number of resolvers, expected %d, got %d\n
-diff in IDs: %s,\n
-`, len(tc.expectedSiteConfigIDs), len(siteConfigChangeResolvers), diff)
-			}
-
-			for i, resolver := range siteConfigChangeResolvers {
-				if resolver.siteConfig.ID != tc.expectedSiteConfigIDs[i] {
-					t.Errorf("position %d: expected siteConfig.ID %d, but got %d", i, tc.expectedSiteConfigIDs[i], resolver.siteConfig.ID)
-				}
+			if diff := cmp.Diff(tc.expectedSiteConfigIDs, siteConfigChangeResolverIDs, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("unexpected site config ids (-want +got):%s\n", diff)
 			}
 		})
 	}

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -2,10 +2,10 @@ package database
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 
@@ -544,10 +544,9 @@ func assertRepoStatistics(t *testing.T, ctx context.Context, s RepoStatisticsSto
 		t.Fatalf("GetRepoStatistics failed: %s", err)
 	}
 
-	sort.Slice(haveGitserverStats, func(i, j int) bool { return haveGitserverStats[i].ShardID < haveGitserverStats[j].ShardID })
-	sort.Slice(wantGitserverStats, func(i, j int) bool { return wantGitserverStats[i].ShardID < wantGitserverStats[j].ShardID })
-
-	if diff := cmp.Diff(haveGitserverStats, wantGitserverStats); diff != "" {
+	type Stat = GitserverReposStatistic
+	lessThan := func(s1 Stat, s2 Stat) bool { return s1.ShardID < s2.ShardID }
+	if diff := cmp.Diff(haveGitserverStats, wantGitserverStats, cmpopts.SortSlices(lessThan)); diff != "" {
 		t.Fatalf("gitserverReposStatistics differ: %s", diff)
 	}
 }


### PR DESCRIPTION
I was looking at existing usages of cmp.Diff and noticed these two
looked a bit unidiomatic, so I figured I'd simplify them.

## Test plan

n/a