### PR TITLE
JetBrains: removes code search onboarding

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -26,6 +26,7 @@
 - All network traffic from the plugin process [56001](https://github.com/sourcegraph/sourcegraph/pull/56001)
 - Non-agent autocomplete and chat [55997](https://github.com/sourcegraph/sourcegraph/pull/55997)
 - Support for 2022.0, 2022.1 is now required [#55831](https://github.com/sourcegraph/sourcegraph/pull/55831)
+- Removed code search onboarding notification [#56564](https://github.com/sourcegraph/sourcegraph/pull/56564)
 
 ### Fixed
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -116,15 +116,6 @@ public class ConfigUtil {
     return CodyApplicationSettings.getInstance().getCustomAutocompleteColor();
   }
 
-  public static String getLastUpdateNotificationPluginVersion() {
-    return CodyApplicationSettings.getInstance().getLastUpdateNotificationPluginVersion();
-  }
-
-  public static void setLastUpdateNotificationPluginVersionToCurrent() {
-    CodyApplicationSettings.getInstance()
-        .setLastUpdateNotificationPluginVersion(getPluginVersion());
-  }
-
   @Nullable
   public static String getWorkspaceRoot(@NotNull Project project) {
     if (project.getBasePath() != null) {

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -25,18 +25,11 @@ public class NotificationActivity implements StartupActivity.DumbAware {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    String latestReleaseMilestoneVersion = "2.0.0";
-    String lastNotifiedPluginVersion = ConfigUtil.getLastUpdateNotificationPluginVersion();
-    if (lastNotifiedPluginVersion == null
-        || lastNotifiedPluginVersion.compareTo(latestReleaseMilestoneVersion) < 0) {
-      notifyAboutUpdate(project);
-    } else {
-      AccountType defaultAccountType =
-          CodyAuthenticationManager.getInstance().getDefaultAccountType(project);
-      if (!ConfigUtil.isDefaultDotcomAccountNotificationDismissed()
-          && (defaultAccountType == AccountType.DOTCOM)) {
-        notifyAboutDefaultDotcomAccount();
-      }
+    AccountType defaultAccountType =
+        CodyAuthenticationManager.getInstance().getDefaultAccountType(project);
+    if (!ConfigUtil.isDefaultDotcomAccountNotificationDismissed()
+        && (defaultAccountType == AccountType.DOTCOM)) {
+      notifyAboutDefaultDotcomAccount();
     }
   }
 
@@ -106,7 +99,5 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     notification.addAction(openAction);
     notification.addAction(learnMoreAction);
     Notifications.Bus.notify(notification);
-
-    ConfigUtil.setLastUpdateNotificationPluginVersionToCurrent();
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/NotificationActivity.java
@@ -5,8 +5,6 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.KeyboardShortcut;
-import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
@@ -14,10 +12,6 @@ import com.sourcegraph.Icons;
 import com.sourcegraph.cody.config.AccountType;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
-import com.sourcegraph.common.BrowserOpener;
-import com.sourcegraph.find.FindService;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 
@@ -62,42 +56,6 @@ public class NotificationActivity implements StartupActivity.DumbAware {
     notification.addAction(setEnterpriseAccountAction);
     notification.addAction(cancelAction);
     notification.addAction(neverShowAgainAction);
-    Notifications.Bus.notify(notification);
-  }
-
-  private void notifyAboutUpdate(@NotNull Project project) {
-    // Display notification
-    KeyboardShortcut altSShortcut =
-        new KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.ALT_DOWN_MASK), null);
-    String altSShortcutText = KeymapUtil.getShortcutText(altSShortcut);
-    Notification notification =
-        new Notification(
-            "Sourcegraph Cody + Code Search plugin updates",
-            "Sourcegraph Cody + Code Search",
-            "Access the new plugin and try out code search with the shortcut "
-                + altSShortcutText
-                + "! Learn more about the plugin’s functionality in our blog post.",
-            NotificationType.INFORMATION);
-    AnAction openAction =
-        new DumbAwareAction("Open Sourcegraph (" + altSShortcutText + ")") {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-            project.getService(FindService.class).showPopup();
-            notification.expire();
-          }
-        };
-    AnAction learnMoreAction =
-        new DumbAwareAction("Learn More", "Opens browser to describe the latest changes", null) {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-            String whatsNewUrl = "https://about.sourcegraph.com/blog/jetbrains-plugin";
-
-            BrowserOpener.openInBrowser(project, whatsNewUrl);
-          }
-        };
-    notification.setIcon(Icons.CodyLogo);
-    notification.addAction(openAction);
-    notification.addAction(learnMoreAction);
     Notifications.Bus.notify(notification);
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -14,7 +14,6 @@ data class CodyApplicationSettings(
     var isDefaultDotcomAccountNotificationDismissed: Boolean = false,
     var anonymousUserId: String? = null,
     var isInstallEventLogged: Boolean = false,
-    var lastUpdateNotificationPluginVersion: String? = null,
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Int? = null,
     var blacklistedLanguageIds: List<String> = listOf(),
@@ -30,7 +29,6 @@ data class CodyApplicationSettings(
         state.isDefaultDotcomAccountNotificationDismissed
     this.anonymousUserId = state.anonymousUserId
     this.isInstallEventLogged = state.isInstallEventLogged
-    this.lastUpdateNotificationPluginVersion = state.lastUpdateNotificationPluginVersion
     this.isCustomAutocompleteColorEnabled = state.isCustomAutocompleteColorEnabled
     this.customAutocompleteColor = state.customAutocompleteColor
     this.blacklistedLanguageIds = state.blacklistedLanguageIds

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -321,8 +321,6 @@ class SettingsMigration : StartupActivity, DumbAware {
         codyApplicationService.isUrlNotificationDismissed
     codyApplicationSettings.anonymousUserId = codyApplicationService.anonymousUserId
     codyApplicationSettings.isInstallEventLogged = codyApplicationService.isInstallEventLogged
-    codyApplicationSettings.lastUpdateNotificationPluginVersion =
-        codyApplicationService.lastUpdateNotificationPluginVersion
   }
 
   companion object {


### PR DESCRIPTION
Closes #56096

## Test plan
- After installing the plugin the notification with code search onboarding appeared and now it is removed so when you install the plugin the notification on how to use code search is not going to be displayed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
