### PR TITLE
JetBrains: automatically generate access token description

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
@@ -69,8 +69,8 @@ internal class CodyTokenCredentialsUi(
         runCatching { SourcegraphServerPath.from(serverTextField.text, "") }.getOrNull()
             ?: return ""
     val productName = ApplicationNamesInfo.getInstance().fullProductName
-    val productNameDecoded = URLEncoder.encode(productName, "UTF-8")
-    return sourcegraphServerPath.url + "user/settings/tokens/new?description=" + productNameDecoded
+    val productNameEncoded= URLEncoder.encode(productName, "UTF-8")
+    return sourcegraphServerPath.url + "user/settings/tokens/new?description=" + productNameEncoded
   }
 
   override fun getValidator(): () -> ValidationInfo? = {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyTokenCredentialsUi.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.config
 
+import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.setEmptyState
@@ -17,6 +18,7 @@ import com.sourcegraph.cody.config.DialogValidationUtils.custom
 import com.sourcegraph.cody.config.DialogValidationUtils.notBlank
 import com.sourcegraph.common.AuthorizationUtil
 import com.sourcegraph.common.BrowserOpener
+import java.net.URLEncoder
 import java.net.UnknownHostException
 import javax.swing.JComponent
 import javax.swing.JTextField
@@ -66,7 +68,9 @@ internal class CodyTokenCredentialsUi(
     val sourcegraphServerPath =
         runCatching { SourcegraphServerPath.from(serverTextField.text, "") }.getOrNull()
             ?: return ""
-    return sourcegraphServerPath.url + "user/settings/tokens/new"
+    val productName = ApplicationNamesInfo.getInstance().fullProductName
+    val productNameDecoded = URLEncoder.encode(productName, "UTF-8")
+    return sourcegraphServerPath.url + "user/settings/tokens/new?description=" + productNameDecoded
   }
 
   override fun getValidator(): () -> ValidationInfo? = {


### PR DESCRIPTION
Previously, when creating an account, users had to manually type out the description for their access token. This PR fixes the problem by providing a default access token description, allowing the user to only click on "Generate token" without additional steps.


## Test plan

Manually test tested with sourcegraph.com token (where `?description` URL parameter is already respected).

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
