### PR TITLE
Rename release cache rate limiter urn

### DIFF
--- a/cmd/frontend/internal/httpapi/releasecache/config.go
+++ b/cmd/frontend/internal/httpapi/releasecache/config.go
@@ -21,6 +21,7 @@ type config struct {
 	api   *url.URL
 	owner string
 	name  string
+	uri   string
 	urn   string
 
 	token         string
@@ -35,6 +36,7 @@ func parseSiteConfig(conf *conf.Unified) (*config, error) {
 		interval: 1 * time.Hour,
 		owner:    "sourcegraph",
 		name:     "src-cli",
+		uri:      "https://github.com",
 		urn:      "releasecache:github.com",
 	}
 
@@ -68,12 +70,10 @@ func parseSiteConfig(conf *conf.Unified) (*config, error) {
 		}
 	}
 
-	// We need to turn the GitHub URI into the "urn" and "apiUrl" required to
-	// build a GitHub V4Client.
 	if c.Github.Uri != "" {
-		config.urn = c.Github.Uri
+		config.uri = c.Github.Uri
 	}
-	configUrl, err := url.Parse(config.urn)
+	configUrl, err := url.Parse(config.uri)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing GitHub URL from configuration")
 	}

--- a/cmd/frontend/internal/httpapi/releasecache/config.go
+++ b/cmd/frontend/internal/httpapi/releasecache/config.go
@@ -35,7 +35,7 @@ func parseSiteConfig(conf *conf.Unified) (*config, error) {
 		interval: 1 * time.Hour,
 		owner:    "sourcegraph",
 		name:     "src-cli",
-		urn:      "https://github.com",
+		urn:      "releasecache:github.com",
 	}
 
 	// There's a _lot_ of pointer indirection boilerplate required to build up


### PR DESCRIPTION
Simply renames the URN for the release cache so that it's more identifiable.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
