### PR TITLE
JetBrains: Cody: Fixing manual autocomplete trigger

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.java
@@ -130,7 +130,7 @@ public class CodyAutocompleteManager {
       return;
     } else if (!isTriggeredManually
         && !CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor)) return;
-    else if (CodyEditorUtil.isCommandExcluded(currentCommand)) {
+    else if (CodyEditorUtil.isCommandExcluded(currentCommand) && !isTriggeredManually) {
       return;
     }
     final Project project = editor.getProject();


### PR DESCRIPTION
Fixes bug introduced in https://github.com/sourcegraph/sourcegraph/pull/56506

## Test plan
* Trigger autocomplete manually (by pressing alt + backslash)