### PR TITLE
globallimiter: Improve reliability

### DIFF
--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -145,7 +145,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 		Locker:                  locker,
 		RPSLimiter: ratelimit.NewInstrumentedLimiter(
 			ratelimit.GitRPSLimiterBucketName,
-			ratelimit.NewGlobalRateLimiter(ratelimit.GitRPSLimiterBucketName),
+			ratelimit.NewGlobalRateLimiter(logger, ratelimit.GitRPSLimiterBucketName),
 		),
 	}
 

--- a/internal/extsvc/azuredevops/client.go
+++ b/internal/extsvc/azuredevops/client.go
@@ -84,7 +84,7 @@ func NewClient(urn string, url string, auth auth.Authenticator, httpClient httpc
 	return &client{
 		httpClient:          httpClient,
 		URL:                 u,
-		internalRateLimiter: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		internalRateLimiter: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("AzureDevOpsClient", ""), urn)),
 		externalRateLimiter: ratelimit.DefaultMonitorRegistry.GetOrSet(url, auth.Hash(), "rest", &ratelimit.Monitor{HeaderPrefix: "X-"}),
 		auth:                auth,
 		urn:                 urn,

--- a/internal/extsvc/bitbucketcloud/BUILD.bazel
+++ b/internal/extsvc/bitbucketcloud/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//internal/trace",
         "//lib/errors",
         "//schema",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -109,7 +111,7 @@ func newClient(urn string, config *schema.BitbucketCloudConnection, httpClient h
 			Password: config.AppPassword,
 		},
 		// Default limits are defined in extsvc.GetLimitFromConfig
-		rateLimit: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		rateLimit: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("BitbucketCloudClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/extsvc/bitbucketserver/BUILD.bazel
+++ b/internal/extsvc/bitbucketserver/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@com_github_inconshreveable_log15//:log15",
         "@com_github_roaringbitmap_roaring//:roaring",
         "@com_github_segmentio_fasthash//fnv1",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_time//rate",
     ],
 )

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -20,6 +20,8 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/segmentio/fasthash/fnv1"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -104,7 +106,7 @@ func newClient(urn string, config *schema.BitbucketServerConnection, httpClient 
 		httpClient: httpClient,
 		URL:        u,
 		// Default limits are defined in extsvc.GetLimitFromConfig
-		rateLimit: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		rateLimit: ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("BitbucketServerClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/extsvc/crates/BUILD.bazel
+++ b/internal/extsvc/crates/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     deps = [
         "//internal/httpcli",
         "//internal/ratelimit",
+        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/internal/extsvc/crates/client.go
+++ b/internal/extsvc/crates/client.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 )
@@ -24,7 +26,7 @@ func NewClient(urn string, httpfactory *httpcli.Factory) (*Client, error) {
 	}
 	return &Client{
 		uncachedClient: uncached,
-		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("RustCratesClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/extsvc/gerrit/BUILD.bazel
+++ b/internal/extsvc/gerrit/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/httpcli",
         "//internal/ratelimit",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/internal/extsvc/gerrit/client.go
+++ b/internal/extsvc/gerrit/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -68,7 +70,7 @@ func NewClient(urn string, url *url.URL, creds *AccountCredentials, httpClient h
 	return &client{
 		httpClient: httpClient,
 		URL:        url,
-		rateLimit:  ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		rateLimit:  ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GerritClient", ""), urn)),
 		auther:     auther,
 	}, nil
 }

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -112,7 +112,7 @@ func newV3Client(logger log.Logger, urn string, apiURL *url.URL, a auth.Authenti
 		tokenHash = a.Hash()
 	}
 
-	rl := ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn))
+	rl := ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GitHubClient", ""), urn))
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, resource, &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V3Client{

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -94,7 +94,7 @@ func NewV4Client(urn string, apiURL *url.URL, a auth.Authenticator, cli httpcli.
 		tokenHash = a.Hash()
 	}
 
-	rl := ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn))
+	rl := ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GitHubClient", ""), urn))
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(apiURL.String(), tokenHash, "graphql", &ratelimit.Monitor{HeaderPrefix: "X-"})
 
 	return &V4Client{

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -180,7 +180,7 @@ func (p *ClientProvider) NewClient(a auth.Authenticator) *Client {
 	}
 	projCache := rcache.NewWithTTL(key, int(cacheTTL/time.Second))
 
-	rl := ratelimit.NewInstrumentedLimiter(p.urn, ratelimit.NewGlobalRateLimiter(p.urn))
+	rl := ratelimit.NewInstrumentedLimiter(p.urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GitLabClient", ""), p.urn))
 	rlm := ratelimit.DefaultMonitorRegistry.GetOrSet(p.baseURL.String(), tokenHash, "rest", &ratelimit.Monitor{})
 
 	return &Client{
@@ -300,7 +300,7 @@ func (c *Client) WithAuthenticator(a auth.Authenticator) *Client {
 	tokenHash := a.Hash()
 
 	cc := *c
-	cc.internalRateLimiter = ratelimit.NewInstrumentedLimiter(c.urn, ratelimit.NewGlobalRateLimiter(c.urn))
+	cc.internalRateLimiter = ratelimit.NewInstrumentedLimiter(c.urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GitLabClient", ""), c.urn))
 	cc.externalRateLimiter = ratelimit.DefaultMonitorRegistry.GetOrSet(cc.baseURL.String(), tokenHash, "rest", &ratelimit.Monitor{})
 	cc.Auth = a
 

--- a/internal/extsvc/gomodproxy/BUILD.bazel
+++ b/internal/extsvc/gomodproxy/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/httpcli",
         "//internal/ratelimit",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_mod//module",
     ],
 )

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -11,6 +11,8 @@ import (
 
 	"golang.org/x/mod/module"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -36,7 +38,7 @@ func NewClient(urn string, urls []string, httpfactory *httpcli.Factory) *Client 
 		urls:           urls,
 		cachedClient:   cached,
 		uncachedClient: uncached,
-		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("GoModClient", ""), urn)),
 	}
 }
 

--- a/internal/extsvc/npm/npm.go
+++ b/internal/extsvc/npm/npm.go
@@ -11,6 +11,8 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -70,7 +72,7 @@ func NewHTTPClient(urn string, registryURL string, credentials string, httpfacto
 		registryURL:    registryURL,
 		uncachedClient: uncached,
 		cachedClient:   cached,
-		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("NPMClient", ""), urn)),
 		credentials:    credentials,
 	}, nil
 }

--- a/internal/extsvc/pagure/BUILD.bazel
+++ b/internal/extsvc/pagure/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//lib/iterator",
         "//schema",
         "@com_github_dnaeon_go_vcr//cassette",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_time//rate",
     ],
 )

--- a/internal/extsvc/pagure/client.go
+++ b/internal/extsvc/pagure/client.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -50,7 +52,7 @@ func NewClient(urn string, config *schema.PagureConnection, httpClient httpcli.D
 		Config:     config,
 		URL:        u,
 		httpClient: httpClient,
-		rateLimit:  ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		rateLimit:  ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("PagureClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/extsvc/pypi/BUILD.bazel
+++ b/internal/extsvc/pypi/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//internal/lazyregexp",
         "//internal/ratelimit",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_net//html",
     ],
 )

--- a/internal/extsvc/pypi/client.go
+++ b/internal/extsvc/pypi/client.go
@@ -35,6 +35,8 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -70,7 +72,7 @@ func NewClient(urn string, urls []string, httpfactory *httpcli.Factory) (*Client
 		urls:           urls,
 		uncachedClient: uncached,
 		cachedClient:   cached,
-		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("PyPiClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/extsvc/rubygems/BUILD.bazel
+++ b/internal/extsvc/rubygems/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//internal/httpcli",
         "//internal/ratelimit",
         "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/internal/extsvc/rubygems/client.go
+++ b/internal/extsvc/rubygems/client.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
@@ -30,7 +32,7 @@ func NewClient(urn string, registryURL string, httpfactory *httpcli.Factory) (*C
 	return &Client{
 		registryURL:    registryURL,
 		uncachedClient: uncached,
-		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(urn)),
+		limiter:        ratelimit.NewInstrumentedLimiter(urn, ratelimit.NewGlobalRateLimiter(log.Scoped("RubyGemsClient", ""), urn)),
 	}, nil
 }
 

--- a/internal/ratelimit/BUILD.bazel
+++ b/internal/ratelimit/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/conf",
+        "//internal/conf/deploy",
         "//internal/redispool",
         "//internal/timeutil",
         "//lib/errors",

--- a/internal/ratelimit/BUILD.bazel
+++ b/internal/ratelimit/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_gomodule_redigo//redis",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@com_github_sourcegraph_log//:log",
         "@org_golang_x_time//rate",
     ],
 )
@@ -41,6 +42,7 @@ go_test(
     deps = [
         "//internal/conf",
         "//internal/redispool",
+        "//lib/pointers",
         "//schema",
         "@com_github_derision_test_glock//:glock",
         "@com_github_gomodule_redigo//redis",

--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -220,18 +220,18 @@ func (r *globalRateLimiter) waitn(ctx context.Context, n int, requestTime time.T
 }
 
 const (
-	scriptInvokationMaxRetries      = 8
-	scriptInvokationMinRetryDelayMs = 50
-	scriptInvokationMaxRetryDelayMs = 250
+	scriptInvocationMaxRetries      = 8
+	scriptInvocationMinRetryDelayMs = 50
+	scriptInvocationMaxRetryDelayMs = 250
 )
 
 func invokeScriptWithRetries(ctx context.Context, script *redis.Script, c redis.Conn, keysAndArgs ...any) (result any, err error) {
-	for i := 0; i < scriptInvokationMaxRetries; i++ {
+	for i := 0; i < scriptInvocationMaxRetries; i++ {
 		if i != 0 {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(time.Duration(rand.Intn(scriptInvokationMaxRetryDelayMs-scriptInvokationMinRetryDelayMs)+scriptInvokationMinRetryDelayMs) * time.Millisecond):
+			case <-time.After(time.Duration(rand.Intn(scriptInvocationMaxRetryDelayMs-scriptInvocationMinRetryDelayMs)+scriptInvocationMinRetryDelayMs) * time.Millisecond):
 				// Continue.
 			}
 		}

--- a/internal/ratelimit/globallimiter_test.go
+++ b/internal/ratelimit/globallimiter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -257,7 +258,7 @@ func TestGlobalRateLimiter_UnconfiguredLimiter(t *testing.T) {
 	// We do NOT call SetTokenBucketConfig here. Instead, we set a sane default.
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
-			DefaultRateLimit: 10,
+			DefaultRateLimit: pointers.Ptr(10),
 		},
 	})
 	defer conf.Mock(nil)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2527,7 +2527,7 @@ type SiteConfiguration struct {
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
 	DebugSearchSymbolsParallelism int `json:"debug.search.symbolsParallelism,omitempty"`
 	// DefaultRateLimit description: The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.
-	DefaultRateLimit float64 `json:"defaultRateLimit,omitempty"`
+	DefaultRateLimit *int `json:"defaultRateLimit,omitempty"`
 	// DisableAutoCodeHostSyncs description: Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)
 	DisableAutoCodeHostSyncs bool `json:"disableAutoCodeHostSyncs,omitempty"`
 	// DisableAutoGitUpdates description: Disable periodically fetching git contents for existing repositories.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -38,7 +38,10 @@
     },
     "defaultRateLimit": {
       "description": "The rate limit (in requests per hour) for the default rate limiter in the rate limiters registry. By default this is disabled and the default rate limit is infinity.",
-      "type": "number",
+      "type": "integer",
+      "!go": {
+        "pointer": true
+      },
       "default": -1
     },
     "RedirectUnsupportedBrowser": {


### PR DESCRIPTION
When redis-store goes down (during rollouts, for example) all upstream operations that request a rate limit token will fail immediately. This is not great.

Instead, we are trying an approach now that adds retries. We attempt to get the rate limit up to 8 times, and wait between 50 and 250ms for a total of 400ms to 2000ms of additional wait time before failing now. This number is just guesswork, and will not fully cover a rollout, but keep delays low. We will test this on dotcom and see what a good number would be.

In addition, instead of failing we are now falling back to an in-memory limiter instead. The limiter uses either 1/s as it's internal rate, or siteconfig.defaultRateLimit, if configured.

## Test plan

Tests still pass and we're trying this out on dotcom to see if this fixes issues while redis-store rollouts are happening. 