### PR TITLE
App-less: Flip sections and change wording

### DIFF
--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -204,10 +204,15 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                         </div>
                     </div>
 
+                    <div className={classNames(styles.card, styles.startCodingWithMeImgWrapper, 'get-cody-step')}>
+                        <CodyStartCoding className={styles.startCodingWithMeImg} />
+                    </div>
+
                     {/* Install cody desktop app section */}
                     <div className={classNames(styles.card, 'get-cody-step')}>
                         <H2 className={classNames(styles.cardTitle, 'mb-4')}>
-                            Install the <span className={styles.installCodyTitle}>Cody desktop app</span>
+                            Optional: Install the <span className={styles.installCodyTitle}>Cody desktop app</span> for
+                            higher quality responses from Cody
                         </H2>
                         <Text className={styles.cardDescription}>
                             The Cody app, when combined with a Cody IDE extension, enables context fetching for all of
@@ -290,10 +295,6 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                                 </Link>
                             </Text>
                         </div>
-                    </div>
-
-                    <div className={classNames(styles.card, styles.startCodingWithMeImgWrapper, 'get-cody-step')}>
-                        <CodyStartCoding className={styles.startCodingWithMeImg} />
                     </div>
 
                     {/* cody for enterprise section */}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/cody/issues/978

- Flipped the two sections like we had in the [mock](https://docs.google.com/drawings/d/1O-tB3SUljrJxztvWn5Nmtzlxme5mypMjFIiyhqwAuAI/edit)
- Added "Optional: " prefix and a clarification in the same title.

## Test plan

This is how the page looks now:

![image](https://github.com/sourcegraph/sourcegraph/assets/2552265/53cbaa82-81dd-433b-842c-fc0cd9400e8e)
