### PR TITLE
JetBrains: fix repo embedding status in chat sidebar

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -86,6 +86,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   private final JButton stopGeneratingButton =
       new JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend));
   private final @NotNull JBPanelWithEmptyText recipesPanel;
+  public final EmbeddingStatusView embeddingStatusView;
   private @NotNull volatile CancellationToken cancellationToken = new CancellationToken();
   private @NotNull Transcript transcript = new Transcript();
   private boolean isChatVisible = false;
@@ -162,7 +163,7 @@ public class CodyToolWindowContent implements UpdatableChat {
     lowerPanel.add(stopGeneratingButtonPanel);
     lowerPanel.add(controlsPanel);
 
-    EmbeddingStatusView embeddingStatusView = new EmbeddingStatusView(project);
+    embeddingStatusView = new EmbeddingStatusView(project);
     embeddingStatusView.setBorder(topBorder);
     lowerPanel.add(embeddingStatusView);
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
@@ -6,9 +6,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.CodyToolWindowContent;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.vcs.RepoUtil;
-
 import java.util.Objects;
-
 import org.jetbrains.annotations.Nullable;
 
 public class CodyAgentCodebase {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
@@ -3,13 +3,17 @@ package com.sourcegraph.cody.agent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.sourcegraph.cody.CodyToolWindowContent;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.vcs.RepoUtil;
+
 import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
 
 public class CodyAgentCodebase {
   private final CodyAgentServer underlying;
-  private String currentCodebase = null;
+  @Nullable public String currentCodebase = null;
 
   public CodyAgentCodebase(CodyAgentServer underlying) {
     this.underlying = underlying;
@@ -26,6 +30,9 @@ public class CodyAgentCodebase {
                         if (!Objects.equals(this.currentCodebase, repositoryName)) {
                           ExtensionConfiguration config =
                               ConfigUtil.getAgentConfiguration(project).setCodebase(repositoryName);
+                          CodyToolWindowContent.getInstance(project)
+                              .embeddingStatusView
+                              .updateEmbeddingStatus();
                           this.currentCodebase = repositoryName;
                           underlying.configurationDidChange(config);
                         }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.java
@@ -28,13 +28,12 @@ public class CodyAgentCodebase {
                   .invokeLater(
                       () -> {
                         if (!Objects.equals(this.currentCodebase, repositoryName)) {
-                          ExtensionConfiguration config =
-                              ConfigUtil.getAgentConfiguration(project).setCodebase(repositoryName);
+                          this.currentCodebase = repositoryName;
                           CodyToolWindowContent.getInstance(project)
                               .embeddingStatusView
                               .updateEmbeddingStatus();
-                          this.currentCodebase = repositoryName;
-                          underlying.configurationDidChange(config);
+                          underlying.configurationDidChange(
+                              ConfigUtil.getAgentConfiguration(project));
                         }
                       });
             });

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -37,6 +37,9 @@ public interface CodyAgentServer {
   @JsonRequest("graphql/currentUserId")
   CompletableFuture<String> currentUserId();
 
+  @JsonRequest("graphql/getRepoIdIfEmbeddingExists")
+  CompletableFuture<String> getRepoIdIfEmbeddingExists(EmbeddingExistsParams repoName);
+
   // Notifications
   @JsonNotification("initialized")
   void initialized();

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ExtensionConfiguration.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/ExtensionConfiguration.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.agent;
 
 import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 
 public class ExtensionConfiguration {
 
@@ -14,7 +15,7 @@ public class ExtensionConfiguration {
   public boolean autocompleteAdvancedEmbeddings;
   public boolean debug;
   public boolean verboseDebug;
-  public String codebase;
+  @Nullable public String codebase;
 
   public ExtensionConfiguration setServerEndpoint(String serverEndpoint) {
     this.serverEndpoint = serverEndpoint;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/EmbeddingExistsParams.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/EmbeddingExistsParams.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.agent.protocol;
+
+public class EmbeddingExistsParams {
+  public final String repoName;
+
+  public EmbeddingExistsParams(String repoName) {
+    this.repoName = repoName;
+  }
+}

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -8,6 +8,10 @@ import com.intellij.ui.SimpleColoredComponent;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
+import com.sourcegraph.cody.agent.CodyAgent;
+import com.sourcegraph.cody.agent.CodyAgentClient;
+import com.sourcegraph.cody.agent.protocol.EmbeddingExistsParams;
+import com.sourcegraph.config.ConfigUtil;
 import java.awt.FlowLayout;
 import javax.swing.Box;
 import javax.swing.Icon;
@@ -39,13 +43,33 @@ public class EmbeddingStatusView extends JPanel {
     innerPanel.setBorder(new EmptyBorder(JBUI.insets(TEXT_MARGIN, TEXT_MARGIN, 0, TEXT_MARGIN)));
     this.add(innerPanel);
 
-    this.setEmbeddingStatus(new NoGitRepositoryEmbeddingStatus());
+    this.updateEmbeddingStatus();
+
     project
         .getMessageBus()
         .connect()
         .subscribe(
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             new CurrentlyOpenFileListener(project, this));
+  }
+
+  public void updateEmbeddingStatus() {
+    CodyAgentClient client = CodyAgent.getClient(project);
+    String repoName = client.codebase != null ? client.codebase.currentCodebase : null;
+    if (repoName == null) {
+      this.setEmbeddingStatus(new NoGitRepositoryEmbeddingStatus());
+    } else {
+      this.setEmbeddingStatus(new RepositoryMissingEmbeddingStatus(repoName));
+      CodyAgent.getInitializedServer(project)
+          .thenCompose(
+              server -> server.getRepoIdIfEmbeddingExists(new EmbeddingExistsParams(repoName)))
+          .thenAccept(
+              id -> {
+                if (id != null) {
+                  this.setEmbeddingStatus(new RepositoryIndexedEmbeddingStatus(repoName));
+                }
+              });
+    }
   }
 
   private void updateViewBasedOnStatus() {

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.java
@@ -11,7 +11,6 @@ import com.intellij.util.ui.JBUI;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentClient;
 import com.sourcegraph.cody.agent.protocol.EmbeddingExistsParams;
-import com.sourcegraph.config.ConfigUtil;
 import java.awt.FlowLayout;
 import javax.swing.Box;
 import javax.swing.Icon;

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -8,6 +8,8 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
+import com.sourcegraph.cody.agent.CodyAgent;
+import com.sourcegraph.cody.agent.CodyAgentCodebase;
 import com.sourcegraph.cody.agent.ExtensionConfiguration;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
@@ -28,6 +30,8 @@ public class ConfigUtil {
   @NotNull
   public static ExtensionConfiguration getAgentConfiguration(@NotNull Project project) {
     ServerAuth serverAuth = ServerAuthLoader.loadServerAuth(project);
+    CodyAgentCodebase codebase = CodyAgent.getClient(project).codebase;
+
     ExtensionConfiguration config =
         new ExtensionConfiguration()
             .setServerEndpoint(serverAuth.getInstanceUrl())
@@ -38,7 +42,8 @@ public class ConfigUtil {
             .setAutocompleteAdvancedAccessToken(UserLevelConfig.getAutocompleteAccessToken())
             .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
             .setDebug(isCodyDebugEnabled())
-            .setVerboseDebug(isCodyVerboseDebugEnabled());
+            .setVerboseDebug(isCodyVerboseDebugEnabled())
+            .setCodebase(codebase != null ? codebase.currentCodebase : null);
 
     if (UserLevelConfig.getAutocompleteProviderType() != null) {
       config.setAutocompleteAdvancedProvider(

--- a/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -95,11 +95,15 @@ public class RepoUtil {
   @Nullable
   private static String getSimpleRepositoryName(
       @NotNull Project project, @NotNull VirtualFile file) {
-    Repository repository = VcsRepositoryManager.getInstance(project).getRepositoryForFile(file);
-    if (repository == null) {
+    try {
+      Repository repository = VcsRepositoryManager.getInstance(project).getRepositoryForFile(file);
+      if (repository == null) {
+        return null;
+      }
+      return repository.getRoot().getName();
+    } catch (Exception e) {
       return null;
     }
-    return repository.getRoot().getName();
   }
 
   private static String doReplacements(


### PR DESCRIPTION
Previously, the Cody sidebar always said that the git repo did not exist. This PR fixes the problem by correctly showing what repository got inferred, and it additionally shows whether the repository has embeddings enabled or not.

## Test plan

Tested with https://github.com/sourcegraph/cody/pull/1045 

* Open the sourcegraph/about repository
* Open any file in the repository
* Notice that the embedding status gets updated when the file is opened

![CleanShot 2023-09-13 at 15 55 12](https://github.com/sourcegraph/sourcegraph/assets/1408093/ff3e0edc-29b9-405d-978f-ee4319ea7d9c)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
