### PR TITLE
sg: avoid silently discarding files if lint go is ran locally

### DIFF
--- a/dev/sg/linters/gogenerate.go
+++ b/dev/sg/linters/gogenerate.go
@@ -2,6 +2,7 @@ package linters
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/sourcegraph/run"
@@ -33,7 +34,11 @@ var goGenerateLinter = &linter{
 			out.WriteWarningf("Uncommitted changes found after running go generate:")
 			out.Write(strings.TrimSpace(diffOutput))
 			// Reset repo state
-			root.Run(run.Bash(ctx, "git add . && git reset HEAD --hard")).Wait()
+			if os.Getenv("CI") == "true" {
+				root.Run(run.Bash(ctx, "git add . && git reset HEAD --hard")).Wait()
+			} else {
+				out.WriteWarningf("Generated changes are left in the tree, skipping reseting state because not in CI")
+			}
 		}
 
 		return err


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/59

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
