### PR TITLE
extsvc: Also delete old canceled jobs

### DIFF
--- a/internal/repos/sync_worker.go
+++ b/internal/repos/sync_worker.go
@@ -123,7 +123,7 @@ DELETE FROM external_service_sync_jobs
 WHERE
 	finished_at < NOW() - INTERVAL '1 day'
   	AND
-  	state IN ('completed', 'failed')
+  	state IN ('completed', 'failed', 'canceled')
 `
 
 func newJobCleanerRoutine(ctx context.Context, handle basestore.TransactableHandle, interval time.Duration) goroutine.BackgroundRoutine {


### PR DESCRIPTION
We're currently keeping canceled jobs forever, this adds canceled jobs to the prune method.

## Test plan

Verified locally using sg start. This method needs refactoring to be programmatically testable, so saving that for another day.