### PR TITLE
Support detecting GCP SA keys

### DIFF
--- a/dev/check-tokens.sh
+++ b/dev/check-tokens.sh
@@ -44,6 +44,10 @@ function check() {
     echo "Found a Slack app token in git staged file: $file. Please remove it."
     exit 1
   fi
+  if grep -qE "service_account" "$file" && grep -qE "[0-9a-zA-Z-]*@[0-9a-zA-Z-]*\.iam\.gserviceaccount\.com" "$file"; then
+    echo "Found a Google service account key file in git staged file: $file. Please remove it."
+    exit 1
+  fi
 }
 
 export -f check


### PR DESCRIPTION
Detection isn't perfect, since the SA key file is json formatted, but matching on `service_account` and the GCP SA email structure should be sufficient.

## Test plan

- tested with a real GCP SA key file
- no false positives on current repo content