### PR TITLE
gitserver: Move urlredactor to separate package

### DIFF
--- a/cmd/gitserver/server/BUILD.bazel
+++ b/cmd/gitserver/server/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//cmd/gitserver/server/internal/cacert",
         "//cmd/gitserver/server/perforce",
         "//cmd/gitserver/server/sshagent",
+        "//cmd/gitserver/server/urlredactor",
         "//internal/actor",
         "//internal/api",
         "//internal/codeintel/dependencies",

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2103,7 +2103,7 @@ func (s *Server) doClone(
 
 	redactor := urlredactor.New(remoteURL)
 
-	go readCloneProgress(s.DB, logger, redactor, lock, pr, s.ReposDir, repo)
+	go readCloneProgress(s.DB, logger, redactor, lock, pr, repo)
 
 	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, s.Logger, repo, cmd), true, pw)
 	redactedOutput := redactor.Redact(string(output))
@@ -2201,7 +2201,7 @@ func postRepoFetchActions(
 
 // readCloneProgress scans the reader and saves the most recent line of output
 // as the lock status.
-func readCloneProgress(db database.DB, logger log.Logger, redactor *urlredactor.URLRedactor, lock RepositoryLock, pr io.Reader, reposDir string, repo api.RepoName) {
+func readCloneProgress(db database.DB, logger log.Logger, redactor *urlredactor.URLRedactor, lock RepositoryLock, pr io.Reader, repo api.RepoName) {
 	// Use a background context to ensure we still update the DB even if we
 	// time out. IE we intentionally don't take an input ctx.
 	ctx := featureflag.WithFlags(context.Background(), db.FeatureFlags())

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/accesslog"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/perforce"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/urlredactor"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -1978,7 +1979,7 @@ func (s *Server) CloneRepo(ctx context.Context, repo api.RepoName, opts CloneOpt
 	}
 
 	if err := syncer.IsCloneable(ctx, repo, remoteURL); err != nil {
-		redactedErr := newURLRedactor(remoteURL).redact(err.Error())
+		redactedErr := urlredactor.New(remoteURL).Redact(err.Error())
 		return "", errors.Errorf("error cloning repo: repo %s not cloneable: %s", repo, redactedErr)
 	}
 
@@ -2100,10 +2101,12 @@ func (s *Server) doClone(
 	pr, pw := io.Pipe()
 	defer pw.Close()
 
-	go readCloneProgress(s.DB, logger, newURLRedactor(remoteURL), lock, pr, repo)
+	redactor := urlredactor.New(remoteURL)
+
+	go readCloneProgress(s.DB, logger, redactor, lock, pr, s.ReposDir, repo)
 
 	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, s.Logger, repo, cmd), true, pw)
-	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+	redactedOutput := redactor.Redact(string(output))
 	// best-effort update the output of the clone
 	if err := s.DB.GitserverRepos().SetLastOutput(context.Background(), repo, redactedOutput); err != nil {
 		s.Logger.Warn("Setting last output in DB", log.Error(err))
@@ -2198,7 +2201,7 @@ func postRepoFetchActions(
 
 // readCloneProgress scans the reader and saves the most recent line of output
 // as the lock status.
-func readCloneProgress(db database.DB, logger log.Logger, redactor *urlRedactor, lock RepositoryLock, pr io.Reader, repo api.RepoName) {
+func readCloneProgress(db database.DB, logger log.Logger, redactor *urlredactor.URLRedactor, lock RepositoryLock, pr io.Reader, reposDir string, repo api.RepoName) {
 	// Use a background context to ensure we still update the DB even if we
 	// time out. IE we intentionally don't take an input ctx.
 	ctx := featureflag.WithFlags(context.Background(), db.FeatureFlags())
@@ -2229,7 +2232,7 @@ func readCloneProgress(db database.DB, logger log.Logger, redactor *urlRedactor,
 		// $ git clone http://token@github.com/foo/bar
 		// Cloning into 'nick'...
 		// fatal: repository 'http://token@github.com/foo/bar/' not found
-		redactedProgress := redactor.redact(progress)
+		redactedProgress := redactor.Redact(progress)
 
 		lock.SetStatus(redactedProgress)
 
@@ -2252,44 +2255,6 @@ func readCloneProgress(db database.DB, logger log.Logger, redactor *urlRedactor,
 	if err := scan.Err(); err != nil {
 		logger.Error("error reporting progress", log.Error(err))
 	}
-}
-
-// urlRedactor redacts all sensitive strings from a message.
-type urlRedactor struct {
-	// sensitive are sensitive strings to be redacted.
-	// The strings should not be empty.
-	sensitive []string
-}
-
-// newURLRedactor returns a new urlRedactor that redacts
-// credentials found in rawurl, and the rawurl itself.
-func newURLRedactor(parsedURL *vcs.URL) *urlRedactor {
-	var sensitive []string
-	pw, _ := parsedURL.User.Password()
-	u := parsedURL.User.Username()
-	if pw != "" && u != "" {
-		// Only block password if we have both as we can
-		// assume that the username isn't sensitive in this case
-		sensitive = append(sensitive, pw)
-	} else {
-		if pw != "" {
-			sensitive = append(sensitive, pw)
-		}
-		if u != "" {
-			sensitive = append(sensitive, u)
-		}
-	}
-	sensitive = append(sensitive, parsedURL.String())
-	return &urlRedactor{sensitive: sensitive}
-}
-
-// redact returns a redacted version of message.
-// Sensitive strings are replaced with "<redacted>".
-func (r *urlRedactor) redact(message string) string {
-	for _, s := range r.sensitive {
-		message = strings.ReplaceAll(message, s, "<redacted>")
-	}
-	return message
 }
 
 // scanCRLF is similar to bufio.ScanLines except it splits on both '\r' and '\n'
@@ -2511,7 +2476,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 	defer cleanTmpFiles(s.Logger, dir)
 
 	output, err := syncer.Fetch(ctx, remoteURL, repo, dir, revspec)
-	redactedOutput := newURLRedactor(remoteURL).redact(string(output))
+	redactedOutput := urlredactor.New(remoteURL).Redact(string(output))
 	// best-effort update the output of the fetch
 	if err := s.DB.GitserverRepos().SetLastOutput(context.Background(), repo, redactedOutput); err != nil {
 		s.Logger.Warn("Setting last output in DB", log.Error(err))

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -627,46 +627,6 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) 
 	b.StopTimer()
 }
 
-func TestUrlRedactor(t *testing.T) {
-	testCases := []struct {
-		url      string
-		message  string
-		redacted string
-	}{
-		{
-			url:      "http://token@github.com/foo/bar/",
-			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
-			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
-		},
-		{
-			url:      "http://user:password@github.com/foo/bar/",
-			message:  "fatal: repository 'http://user:password@github.com/foo/bar/' not found",
-			redacted: "fatal: repository 'http://user:<redacted>@github.com/foo/bar/' not found",
-		},
-		{
-			url:      "http://git:password@github.com/foo/bar/",
-			message:  "fatal: repository 'http://git:password@github.com/foo/bar/' not found",
-			redacted: "fatal: repository 'http://git:<redacted>@github.com/foo/bar/' not found",
-		},
-		{
-			url:      "http://token@github.com///repo//nick/",
-			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
-			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run("", func(t *testing.T) {
-			remoteURL, err := vcs.ParseURL(testCase.url)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if actual := newURLRedactor(remoteURL).redact(testCase.message); actual != testCase.redacted {
-				t.Fatalf("newUrlRedactor(%q).redact(%q) got %q; want %q", testCase.url, testCase.message, actual, testCase.redacted)
-			}
-		})
-	}
-}
-
 func runCmd(t *testing.T, dir string, cmd string, arg ...string) string {
 	t.Helper()
 	c := exec.Command(cmd, arg...)

--- a/cmd/gitserver/server/urlredactor/BUILD.bazel
+++ b/cmd/gitserver/server/urlredactor/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "urlredactor",
+    srcs = ["urlredactor.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/gitserver/server/urlredactor",
+    visibility = ["//visibility:public"],
+    deps = ["//internal/vcs"],
+)
+
+go_test(
+    name = "urlredactor_test",
+    srcs = ["urlredactor_test.go"],
+    embed = [":urlredactor"],
+    deps = ["//internal/vcs"],
+)

--- a/cmd/gitserver/server/urlredactor/urlredactor.go
+++ b/cmd/gitserver/server/urlredactor/urlredactor.go
@@ -1,0 +1,45 @@
+package urlredactor
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+)
+
+// URLRedactor redacts all sensitive strings from a message.
+type URLRedactor struct {
+	// sensitive are sensitive strings to be redacted.
+	// The strings should not be empty.
+	sensitive []string
+}
+
+// New returns a new urlRedactor that redacts credentials found in rawurl, and
+// the rawurl itself.
+func New(parsedURL *vcs.URL) *URLRedactor {
+	var sensitive []string
+	pw, _ := parsedURL.User.Password()
+	u := parsedURL.User.Username()
+	if pw != "" && u != "" {
+		// Only block password if we have both as we can
+		// assume that the username isn't sensitive in this case
+		sensitive = append(sensitive, pw)
+	} else {
+		if pw != "" {
+			sensitive = append(sensitive, pw)
+		}
+		if u != "" {
+			sensitive = append(sensitive, u)
+		}
+	}
+	sensitive = append(sensitive, parsedURL.String())
+	return &URLRedactor{sensitive: sensitive}
+}
+
+// Redact returns a redacted version of message.
+// Sensitive strings are replaced with "<redacted>".
+func (r *URLRedactor) Redact(message string) string {
+	for _, s := range r.sensitive {
+		message = strings.ReplaceAll(message, s, "<redacted>")
+	}
+	return message
+}

--- a/cmd/gitserver/server/urlredactor/urlredactor_test.go
+++ b/cmd/gitserver/server/urlredactor/urlredactor_test.go
@@ -1,0 +1,47 @@
+package urlredactor
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
+)
+
+func TestUrlRedactor(t *testing.T) {
+	testCases := []struct {
+		url      string
+		message  string
+		redacted string
+	}{
+		{
+			url:      "http://token@github.com/foo/bar/",
+			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://user:password@github.com/foo/bar/",
+			message:  "fatal: repository 'http://user:password@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://user:<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://git:password@github.com/foo/bar/",
+			message:  "fatal: repository 'http://git:password@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://git:<redacted>@github.com/foo/bar/' not found",
+		},
+		{
+			url:      "http://token@github.com///repo//nick/",
+			message:  "fatal: repository 'http://token@github.com/foo/bar/' not found",
+			redacted: "fatal: repository 'http://<redacted>@github.com/foo/bar/' not found",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			remoteURL, err := vcs.ParseURL(testCase.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if actual := New(remoteURL).Redact(testCase.message); actual != testCase.redacted {
+				t.Fatalf("newUrlRedactor(%q).redact(%q) got %q; want %q", testCase.url, testCase.message, actual, testCase.redacted)
+			}
+		})
+	}
+}

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/urlredactor"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -82,7 +83,7 @@ func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, repoName 
 	dir.Set(cmd)
 	output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd), configRemoteOpts, nil)
 	if err != nil {
-		return nil, &common.GitCommandError{Err: err, Output: newURLRedactor(remoteURL).redact(string(output))}
+		return nil, &common.GitCommandError{Err: err, Output: urlredactor.New(remoteURL).Redact(string(output))}
 	}
 	return output, nil
 }

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -14,9 +14,11 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/common"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server/urlredactor"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -181,7 +183,7 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, _ a
 	// something for p4?
 	output, err := runCommandCombinedOutput(ctx, cmd)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to update with output %q", newURLRedactor(remoteURL).redact(string(output)))
+		return nil, errors.Wrapf(err, "failed to update with output %q", urlredactor.New(remoteURL).Redact(string(output)))
 	}
 
 	if !s.FusionConfig.Enabled {


### PR DESCRIPTION
Self-contained code piece, so it can live in it's own package, decluttering the massive gitserver package.

## Test plan

Moved code, relying on CI.