### PR TITLE
JetBrains: unify onboarding notifications

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Use agent for recipes [#56196](https://github.com/sourcegraph/sourcegraph/pull/56196)
 - Authentication settings changed to accounts from three types of instance types to which user can connect [#56362](https://github.com/sourcegraph/sourcegraph/pull/56362)
 - Enabled manually triggering autocomplete even when implicit autocomplete is disabled (globally or for a language) [#56473](https://github.com/sourcegraph/sourcegraph/pull/56473)
+- Onboarding notifications merged into one simple notification to Open Cody [#56610](https://github.com/sourcegraph/sourcegraph/pull/56610)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
@@ -8,53 +8,57 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.sourcegraph.Icons;
-import com.sourcegraph.cody.config.AccountType;
+import com.sourcegraph.cody.CodyToolWindowFactory;
+import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
-import javax.swing.*;
 import org.jetbrains.annotations.NotNull;
 
-public class NotificationActivity implements StartupActivity.DumbAware {
+public class CodyAuthNotificationActivity implements StartupActivity.DumbAware {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    AccountType defaultAccountType =
-        CodyAuthenticationManager.getInstance().getDefaultAccountType(project);
-    if (!ConfigUtil.isDefaultDotcomAccountNotificationDismissed()
-        && (defaultAccountType == AccountType.DOTCOM)) {
-      notifyAboutDefaultDotcomAccount();
+    CodyAccount activeAccount = CodyAuthenticationManager.getInstance().getActiveAccount(project);
+    if (!CodyApplicationSettings.getInstance().isGetStartedNotificationDismissed()
+        && activeAccount == null) {
+      showOpenCodySidebarNotification(project);
     }
   }
 
-  private void notifyAboutDefaultDotcomAccount() {
+  private void showOpenCodySidebarNotification(@NotNull Project project) {
     // Display notification
     Notification notification =
         new Notification(
-            "Sourcegraph: server access",
-            "Sourcegraph",
-            "An enterprise Sourcegraph account is not set for this project. You can only access public repos. Do you want to set an enterprise account as the default one?",
-            NotificationType.INFORMATION);
-    AnAction setEnterpriseAccountAction = new OpenPluginSettingsAction("Set Enterprise Account");
-    AnAction cancelAction =
-        new DumbAwareAction("Do Not Set") {
+            "cody.auth", "Open Cody sidebar to get started", "", NotificationType.WARNING);
+
+    AnAction openCodySidebar =
+        new DumbAwareAction("Open Cody") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             notification.expire();
+            ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
+            ToolWindow toolWindow =
+                toolWindowManager.getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID);
+            if (toolWindow != null) {
+              toolWindow.setAvailable(true, null);
+              toolWindow.activate(null);
+            }
           }
         };
+
     AnAction neverShowAgainAction =
         new DumbAwareAction("Never Show Again") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             notification.expire();
-            CodyApplicationSettings.getInstance()
-                .setDefaultDotcomAccountNotificationDismissed(true);
+            CodyApplicationSettings.getInstance().setGetStartedNotificationDismissed(true);
           }
         };
     notification.setIcon(Icons.CodyLogo);
-    notification.addAction(setEnterpriseAccountAction);
-    notification.addAction(cancelAction);
+    notification.addAction(openCodySidebar);
     notification.addAction(neverShowAgainAction);
     Notifications.Bus.notify(notification);
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -65,10 +65,10 @@ public class ConfigUtil {
 
   @NotNull
   public static SourcegraphServerPath getServerPath(@NotNull Project project) {
-    CodyAccount defaultAccount = CodyAuthenticationManager.getInstance().getDefaultAccount(project);
+    CodyAccount activeAccount = CodyAuthenticationManager.getInstance().getActiveAccount(project);
 
-    return defaultAccount != null
-        ? defaultAccount.getServer()
+    return activeAccount != null
+        ? activeAccount.getServer()
         : SourcegraphServerPath.from(DOTCOM_URL, "");
   }
 
@@ -89,10 +89,6 @@ public class ConfigUtil {
     IdeaPluginDescriptor plugin =
         PluginManagerCore.getPlugin(PluginId.getId("com.sourcegraph.jetbrains"));
     return plugin != null ? plugin.getVersion() : "unknown";
-  }
-
-  public static boolean isDefaultDotcomAccountNotificationDismissed() {
-    return CodyApplicationSettings.getInstance().isDefaultDotcomAccountNotificationDismissed();
   }
 
   public static boolean isCodyEnabled() {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/PersistentActiveAccountHolder.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/PersistentActiveAccountHolder.kt
@@ -5,13 +5,13 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.project.Project
 
 /**
- * Stores default account for project
+ * Stores active account for project
  * To register - [@State(name = SERVICE_NAME_HERE, storages = [Storage(StoragePathMacros.WORKSPACE_FILE)], reportStatistic = false)]
  *
  * @param A - account type
  */
-abstract class PersistentDefaultAccountHolder<A : Account>(protected val project: Project)
-  : PersistentStateComponent<PersistentDefaultAccountHolder.AccountState>, Disposable {
+abstract class PersistentActiveAccountHolder<A : Account>(protected val project: Project)
+  : PersistentStateComponent<PersistentActiveAccountHolder.AccountState>, Disposable {
 
   var account: A? = null
 
@@ -27,24 +27,24 @@ abstract class PersistentDefaultAccountHolder<A : Account>(protected val project
   }
 
   override fun getState(): AccountState {
-    return AccountState().apply { defaultAccountId = account?.id }
+    return AccountState().apply { activeAccountId = account?.id }
   }
 
   override fun loadState(state: AccountState) {
-    account = state.defaultAccountId?.let { id ->
+    account = state.activeAccountId?.let { id ->
       accountManager.accounts.find { it.id == id }.also {
-        if (it == null) notifyDefaultAccountMissing()
+        if (it == null) notifyActiveAccountMissing()
       }
     }
   }
 
   protected abstract fun accountManager(): AccountManager<A, *>
 
-  protected abstract fun notifyDefaultAccountMissing()
+  protected abstract fun notifyActiveAccountMissing()
 
   override fun dispose() {}
 
   class AccountState {
-    var defaultAccountId: String? = null
+    var activeAccountId: String? = null
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsListModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsListModel.kt
@@ -20,7 +20,7 @@ interface AccountsListModel<A: Account, Cred> {
 
   fun addCredentialsChangeListener(listener: (A) -> Unit)
 
-  interface WithDefault<A: Account, Cred>: AccountsListModel<A, Cred> {
-    var defaultAccount: A?
+  interface WithActive<A: Account, Cred>: AccountsListModel<A, Cred> {
+    var activeAccount: A?
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithSourcegraphAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithSourcegraphAction.kt
@@ -1,0 +1,39 @@
+package com.sourcegraph.cody.auth.ui
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.wm.ToolWindowManager
+import com.sourcegraph.cody.CodyToolWindowFactory
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.config.CodyPersistentAccountsHost
+import com.sourcegraph.cody.config.signInWithSourcegrapDialog
+import com.sourcegraph.config.ConfigUtil
+
+class SignInWithSourcegraphAction(private val defaultServer: String = ConfigUtil.DOTCOM_URL) :
+    DumbAwareAction("Sign in with Sourcegraph") {
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project
+    val accountsHost = CodyPersistentAccountsHost(project)
+    val dialog =
+        signInWithSourcegrapDialog(
+            project,
+            e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
+            accountsHost::isAccountUnique)
+
+    dialog.setServer(defaultServer)
+    if (dialog.showAndGet()) {
+      accountsHost.addAccount(dialog.server, dialog.login, dialog.token)
+      if (project != null && ConfigUtil.isCodyEnabled()) {
+        // Notify Cody Agent about config changes.
+        CodyAgent.getServer(project)
+            ?.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
+        // Open Cody sidebar
+        val toolWindowManager = ToolWindowManager.getInstance(project)
+        val toolWindow = toolWindowManager.getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)
+        toolWindow?.setAvailable(true, null)
+        toolWindow?.activate {}
+      }
+    }
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
@@ -131,7 +131,7 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
   }
 
   private fun isDefault(account: A): Boolean =
-      (listModel is AccountsListModel.WithDefault) && account == listModel.defaultAccount
+      (listModel is AccountsListModel.WithActive) && account == listModel.activeAccount
   private fun editAccount(parentComponent: JComponent, account: A) =
       listModel.editAccount(parentComponent, account)
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AddCodyAccountWithTokenAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AddCodyAccountWithTokenAction.kt
@@ -33,7 +33,7 @@ abstract class BaseAddAccountWithTokenAction : DumbAwareAction() {
             e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
             accountsHost::isAccountUnique)
 
-    dialog.setServer(defaultServer, defaultServer != SourcegraphServerPath.DEFAULT_HOST)
+    dialog.setServer(defaultServer)
     if (dialog.showAndGet()) {
       accountsHost.addAccount(dialog.server, dialog.login, dialog.token)
     }
@@ -48,6 +48,16 @@ private fun newAddAccountDialog(
     SourcegraphTokenLoginDialog(project, parent, isAccountUnique).apply {
       title = "Add Sourcegraph Account"
       setLoginButtonText("Add Account")
+    }
+
+fun signInWithSourcegrapDialog(
+    project: Project?,
+    parent: Component?,
+    isAccountUnique: UniqueLoginPredicate
+): BaseLoginDialog =
+    SourcegraphTokenLoginDialog(project, parent, isAccountUnique).apply {
+      title = "Sign in with Sourcegraph"
+      setLoginButtonText("Sign in")
     }
 
 internal class SourcegraphTokenLoginDialog(

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/BaseLoginDialog.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/BaseLoginDialog.kt
@@ -14,7 +14,7 @@ import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import java.awt.Component
 import javax.swing.JComponent
 
-internal abstract class BaseLoginDialog(
+abstract class BaseLoginDialog(
     project: Project?,
     parent: Component?,
     executorFactory: SourcegraphApiRequestExecutor.Factory,
@@ -36,7 +36,7 @@ internal abstract class BaseLoginDialog(
 
   fun setToken(token: String?) = loginPanel.setToken(token)
   fun setLogin(login: String?) = loginPanel.setLogin(login, false)
-  fun setServer(path: String, editable: Boolean) = loginPanel.setServer(path, editable)
+  fun setServer(path: String) = loginPanel.setServer(path)
   fun setCustomRequestHeaders(customRequestHeaders: String) =
       loginPanel.setCustomRequestHeaders(customRequestHeaders)
   fun setLoginButtonText(text: String) = setOKButtonText(text)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -13,12 +13,12 @@ import javax.swing.JComponent
 
 class CodyAccountListModel(private val project: Project) :
     AccountsListModelBase<CodyAccount, String>(),
-    AccountsListModel.WithDefault<CodyAccount, String>,
+    AccountsListModel.WithActive<CodyAccount, String>,
     CodyAccountsHost {
 
   private val actionManager = ActionManager.getInstance()
 
-  override var defaultAccount: CodyAccount? = null
+  override var activeAccount: CodyAccount? = null
 
   override fun addAccount(parentComponent: JComponent, point: RelativePoint?) {
     val group = actionManager.getAction("Cody.Accounts.AddAccount") as ActionGroup
@@ -44,7 +44,6 @@ class CodyAccountListModel(private val project: Project) :
                       customRequestHeaders = account.server.customRequestHeaders,
                       title = "Edit Sourcegraph Account",
                       loginButtonText = "Save account",
-                      isServerEditable = true,
                   ))
         } else {
           val localAppAccessToken = LocalAppManager.getLocalAppAccessToken().orNull()
@@ -69,10 +68,6 @@ class CodyAccountListModel(private val project: Project) :
 
   override fun addAccount(server: SourcegraphServerPath, login: String, token: String) {
     val account = CodyAccount.create(login, server)
-    addAccount(account, token)
-  }
-
-  override fun addAccount(account: CodyAccount, token: String) {
     accountsListModel.add(account)
     newCredentials[account] = token
     notifyCredentialsChanged(account)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountsHost.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountsHost.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.actionSystem.DataKey
 
 interface CodyAccountsHost {
   fun addAccount(server: SourcegraphServerPath, login: String, token: String)
-  fun addAccount(account: CodyAccount, token: String)
   fun isAccountUnique(login: String, server: SourcegraphServerPath): Boolean
 
   companion object {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -11,7 +11,7 @@ data class CodyApplicationSettings(
     var isCodyAutocompleteEnabled: Boolean = false,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
-    var isDefaultDotcomAccountNotificationDismissed: Boolean = false,
+    var isGetStartedNotificationDismissed: Boolean = false,
     var anonymousUserId: String? = null,
     var isInstallEventLogged: Boolean = false,
     var isCustomAutocompleteColorEnabled: Boolean = false,
@@ -25,8 +25,8 @@ data class CodyApplicationSettings(
     this.isCodyAutocompleteEnabled = state.isCodyAutocompleteEnabled
     this.isCodyDebugEnabled = state.isCodyDebugEnabled
     this.isCodyVerboseDebugEnabled = state.isCodyVerboseDebugEnabled
-    this.isDefaultDotcomAccountNotificationDismissed =
-        state.isDefaultDotcomAccountNotificationDismissed
+    this.isGetStartedNotificationDismissed =
+        state.isGetStartedNotificationDismissed
     this.anonymousUserId = state.anonymousUserId
     this.isInstallEventLogged = state.isInstallEventLogged
     this.isCustomAutocompleteColorEnabled = state.isCustomAutocompleteColorEnabled

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.AuthData
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.sourcegraph.cody.localapp.LocalAppManager
 import java.awt.Component
 import org.jetbrains.annotations.CalledInAny
 
@@ -41,15 +40,15 @@ class CodyAuthenticationManager internal constructor() {
   internal fun updateAccountToken(account: CodyAccount, newToken: String) =
       accountManager.updateAccount(account, newToken)
 
-  fun getDefaultAccount(project: Project): CodyAccount? =
-      project.service<CodyProjectDefaultAccountHolder>().account
+  fun getActiveAccount(project: Project): CodyAccount? =
+      project.service<CodyProjectActiveAccountHolder>().account
 
-  fun setDefaultAccount(project: Project, account: CodyAccount?) {
-    project.service<CodyProjectDefaultAccountHolder>().account = account
+  fun setActiveAccount(project: Project, account: CodyAccount?) {
+    project.service<CodyProjectActiveAccountHolder>().account = account
   }
 
   fun getDefaultAccountType(project: Project): AccountType {
-    return getDefaultAccount(project)?.getAccountType()
+    return getActiveAccount(project)?.getAccountType()
         ?: AccountType.DOTCOM
   }
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
@@ -19,7 +19,7 @@ import javax.swing.JTextField
 
 internal typealias UniqueLoginPredicate = (login: String, server: SourcegraphServerPath) -> Boolean
 
-internal class CodyLoginPanel(
+class CodyLoginPanel(
     executorFactory: SourcegraphApiRequestExecutor.Factory,
     isAccountUnique: UniqueLoginPredicate
 ) : Wrapper() {
@@ -112,9 +112,8 @@ internal class CodyLoginPanel(
   fun getServer(): SourcegraphServerPath =
       SourcegraphServerPath.from(serverTextField.text.trim(), customRequestHeadersField.text.trim())
 
-  fun setServer(path: String, editable: Boolean) {
+  fun setServer(path: String) {
     serverTextField.text = path
-    serverTextField.isEditable = editable
   }
 
   fun setCustomRequestHeaders(customRequestHeaders: String) {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginRequest.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginRequest.kt
@@ -7,7 +7,6 @@ import java.awt.Component
 internal class CodyLoginRequest(
     val title: String? = null,
     val server: SourcegraphServerPath? = null,
-    val isServerEditable: Boolean = server == null,
     val login: String? = null,
     val isCheckLoginUnique: Boolean = false,
     val token: String? = null,
@@ -31,7 +30,7 @@ private val CodyLoginRequest.isLoginUniqueChecker: UniqueLoginPredicate
   }
 
 private fun CodyLoginRequest.configure(dialog: BaseLoginDialog) {
-  server?.let { dialog.setServer(it.toString(), isServerEditable) }
+  server?.let { dialog.setServer(it.toString()) }
   login?.let { dialog.setLogin(it) }
   token?.let { dialog.setToken(it) }
   customRequestHeaders?.let { dialog.setCustomRequestHeaders(it) }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
@@ -1,0 +1,17 @@
+package com.sourcegraph.cody.config
+
+import com.intellij.openapi.project.Project
+
+class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHost {
+  override fun addAccount(server: SourcegraphServerPath, login: String, token: String) {
+    val codyAccount = CodyAccount.create(login, server)
+    CodyAuthenticationManager.getInstance().updateAccountToken(codyAccount, token)
+    if (project != null) {
+      CodyAuthenticationManager.getInstance().setActiveAccount(project, codyAccount)
+    }
+  }
+
+  override fun isAccountUnique(login: String, server: SourcegraphServerPath): Boolean {
+    return CodyAuthenticationManager.getInstance().isAccountUnique(login, server)
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectActiveAccountHolder.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectActiveAccountHolder.kt
@@ -5,16 +5,16 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.StoragePathMacros
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.sourcegraph.cody.auth.PersistentDefaultAccountHolder
+import com.sourcegraph.cody.auth.PersistentActiveAccountHolder
 
 @State(
-    name = "CodyDefaultAccount",
+    name = "CodyActiveAccount",
     storages = [Storage(StoragePathMacros.WORKSPACE_FILE)],
     reportStatistic = false)
-class CodyProjectDefaultAccountHolder(project: Project) :
-    PersistentDefaultAccountHolder<CodyAccount>(project) {
+class CodyProjectActiveAccountHolder(project: Project) :
+    PersistentActiveAccountHolder<CodyAccount>(project) {
 
   override fun accountManager() = service<CodyAccountManager>()
 
-  override fun notifyDefaultAccountMissing() {}
+  override fun notifyActiveAccountMissing() {}
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/NotifyAboutNoActiveAccount.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/NotifyAboutNoActiveAccount.kt
@@ -7,10 +7,10 @@ import com.sourcegraph.cody.chat.AssistantMessageWithSettingsButton
 import java.awt.BorderLayout
 import javax.swing.JPanel
 
-class NotifyAboutNoDefaultAccount : StartupActivity {
+class NotifyAboutNoActiveAccount : StartupActivity {
   override fun runActivity(project: Project) {
-    val defaultAccount = CodyAuthenticationManager.getInstance().getDefaultAccount(project)
-    if (defaultAccount == null) {
+    val activeAccount = CodyAuthenticationManager.getInstance().getActiveAccount(project)
+    if (activeAccount == null) {
       val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
       val noAccessTokenText =
           """

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ServerAuth.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ServerAuth.kt
@@ -14,7 +14,7 @@ object ServerAuthLoader {
   @JvmStatic
   fun loadServerAuth(project: Project): ServerAuth {
     val codyAuthenticationManager = CodyAuthenticationManager.getInstance()
-    val defaultAccount = codyAuthenticationManager.getDefaultAccount(project)
+    val defaultAccount = codyAuthenticationManager.getActiveAccount(project)
     if (defaultAccount != null) {
       val accessToken = codyAuthenticationManager.getTokenForAccount(defaultAccount) ?: ""
       return ServerAuth(

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -136,8 +136,8 @@ class SettingsMigration : StartupActivity, DumbAware {
     loadUserDetails(requestExecutorFactory, accessToken, progressIndicator, server) {
       val codyAccount = CodyAccount.create(it.name, server, id)
       addAccount(codyAccount, accessToken)
-      if (CodyAuthenticationManager.getInstance().getDefaultAccount(project) == null) {
-        CodyAuthenticationManager.getInstance().setDefaultAccount(project, codyAccount)
+      if (CodyAuthenticationManager.getInstance().getActiveAccount(project) == null) {
+        CodyAuthenticationManager.getInstance().setActiveAccount(project, codyAccount)
       }
     }
   }
@@ -317,8 +317,6 @@ class SettingsMigration : StartupActivity, DumbAware {
     codyApplicationSettings.isCodyDebugEnabled = codyApplicationService.isCodyDebugEnabled ?: false
     codyApplicationSettings.isCodyVerboseDebugEnabled =
         codyApplicationService.isCodyVerboseDebugEnabled ?: false
-    codyApplicationSettings.isDefaultDotcomAccountNotificationDismissed =
-        codyApplicationService.isUrlNotificationDismissed
     codyApplicationSettings.anonymousUserId = codyApplicationService.anonymousUserId
     codyApplicationSettings.isInstallEventLogged = codyApplicationService.isInstallEventLogged
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -9,7 +9,6 @@ data class SettingsModel(
     var isCodyAutocompleteEnabled: Boolean = false,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
-    var isUrlNotificationDismissed: Boolean = false,
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Color? = null,
     var blacklistedLanguageIds: List<String> = listOf(),

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -23,7 +23,7 @@ class AccountConfigurable(val project: Project) :
     BoundConfigurable(ConfigUtil.SOURCEGRAPH_DISPLAY_NAME) {
     private val accountManager = service<CodyAccountManager>()
     private val accountsModel = CodyAccountListModel(project)
-    private val defaultAccountHolder = project.service<CodyProjectDefaultAccountHolder>()
+    private val activeAccountHolder = project.service<CodyProjectActiveAccountHolder>()
     private lateinit var dialogPanel: DialogPanel
     override fun createPanel(): DialogPanel {
         dialogPanel = panel {
@@ -31,7 +31,7 @@ class AccountConfigurable(val project: Project) :
                 row {
                     customAccountsPanel(
                         accountManager,
-                        defaultAccountHolder,
+                        activeAccountHolder,
                         accountsModel,
                         CodyAccountDetailsProvider(
                             ProgressIndicatorsProvider().also { Disposer.register(disposable!!, it) },
@@ -75,28 +75,28 @@ class AccountConfigurable(val project: Project) :
         val bus = project.messageBus
         val publisher = bus.syncPublisher(AccountSettingChangeActionNotifier.TOPIC)
 
-        val oldDefaultAccount = defaultAccountHolder.account
+        val oldDefaultAccount = activeAccountHolder.account
         val oldUrl = oldDefaultAccount?.server?.url ?: ""
 
-        var defaultAccount = accountsModel.defaultAccount
-        val newAccessToken = defaultAccount?.let { accountsModel.newCredentials[it] }
-        val defaultAccountRemoved = !accountsModel.accounts.contains(defaultAccount)
-        if (defaultAccountRemoved) {
-            defaultAccount = accountsModel.accounts.getFirstAccountOrNull()
+        var activeAccount = accountsModel.activeAccount
+        val newAccessToken = activeAccount?.let { accountsModel.newCredentials[it] }
+        val activeAccountRemoved = !accountsModel.accounts.contains(activeAccount)
+        if (activeAccountRemoved) {
+            activeAccount = accountsModel.accounts.getFirstAccountOrNull()
         }
-        val defaultAccountChanged = oldDefaultAccount != defaultAccount
+        val activeAccountChanged = oldDefaultAccount != activeAccount
         val accessTokenChanged =
-            newAccessToken != null || defaultAccountRemoved || defaultAccountChanged
+            newAccessToken != null || activeAccountRemoved || activeAccountChanged
 
-        val newUrl = defaultAccount?.server?.url ?: ""
+        val newUrl = activeAccount?.server?.url ?: ""
 
         val serverUrlChanged = oldUrl != newUrl
 
         publisher.beforeAction(serverUrlChanged)
         super.apply()
         val context = AccountSettingChangeContext(serverUrlChanged, accessTokenChanged)
-        CodyAuthenticationManager.getInstance().setDefaultAccount(project, defaultAccount)
-        accountsModel.defaultAccount = defaultAccount
+        CodyAuthenticationManager.getInstance().setActiveAccount(project, activeAccount)
+        accountsModel.activeAccount = activeAccount
         publisher.afterAction(context)
     }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -13,7 +13,13 @@ import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.EmptyIcon
 import com.sourcegraph.cody.auth.ui.customAccountsPanel
-import com.sourcegraph.cody.config.*
+import com.sourcegraph.cody.config.CodyAccountDetailsProvider
+import com.sourcegraph.cody.config.CodyAccountListModel
+import com.sourcegraph.cody.config.CodyAccountManager
+import com.sourcegraph.cody.config.CodyAccountsHost
+import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.config.CodyProjectActiveAccountHolder
+import com.sourcegraph.cody.config.getFirstAccountOrNull
 import com.sourcegraph.cody.config.notification.AccountSettingChangeActionNotifier
 import com.sourcegraph.cody.config.notification.AccountSettingChangeContext
 import com.sourcegraph.config.ConfigUtil
@@ -60,7 +66,7 @@ class AccountConfigurable(val project: Project) :
                 row {
                     link("Open ${ConfigUtil.CODE_SEARCH_DISPLAY_NAME} settings...") {
                         ShowSettingsUtil.getInstance()
-                            .showSettingsDialog(project, CodyConfigurable::class.java)
+                            .showSettingsDialog(project, CodeSearchConfigurable::class.java)
                     }
                 }
             }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodeSearchConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodeSearchConfigurable.kt
@@ -6,73 +6,62 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.setEmptyState
 import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_NO_WRAP
-import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
-import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.config.CodyProjectSettings
 import com.sourcegraph.cody.config.SettingsModel
 import com.sourcegraph.config.ConfigUtil
 
 class CodeSearchConfigurable(val project: Project) :
     BoundConfigurable(ConfigUtil.CODE_SEARCH_DISPLAY_NAME) {
-    private lateinit var dialogPanel: DialogPanel
-    private val settingsModel = SettingsModel()
-    private val codyProjectSettings = project.service<CodyProjectSettings>()
-    private val codyApplicationSettings = service<CodyApplicationSettings>()
-    override fun createPanel(): DialogPanel {
-        dialogPanel = panel {
-            group("Code search") {
-                row {
-                    textField()
-                        .label("Default branch name:")
-                        .comment("The branch to use if the current branch is not yet pushed")
-                        .horizontalAlign(HorizontalAlign.FILL)
-                        .bindText(settingsModel::defaultBranchName)
-                        .applyToComponent {
-                            this.setEmptyState("main")
-                            toolTipText = "Usually \"main\" or \"master\", but can be any name"
-                        }
-                }
-                row {
-                    textField()
-                        .label("Remote URL replacements:")
-                        .comment(
-                            """You can replace specified strings in your repo's remote URL. <br>
+  private lateinit var dialogPanel: DialogPanel
+  private val settingsModel = SettingsModel()
+  private val codyProjectSettings = project.service<CodyProjectSettings>()
+  override fun createPanel(): DialogPanel {
+    dialogPanel = panel {
+      group("Code search") {
+        row {
+          textField()
+              .label("Default branch name:")
+              .comment("The branch to use if the current branch is not yet pushed")
+              .horizontalAlign(HorizontalAlign.FILL)
+              .bindText(settingsModel::defaultBranchName)
+              .applyToComponent {
+                this.setEmptyState("main")
+                toolTipText = "Usually \"main\" or \"master\", but can be any name"
+              }
+        }
+        row {
+          textField()
+              .label("Remote URL replacements:")
+              .comment(
+                  """You can replace specified strings in your repo's remote URL. <br>
                       |Use any number of pairs: "search1, replacement1, search2, replacement2, ...". <br>
                       |Pairs are replaced from left to right. Whitespace around commas doesn't matter.
                   """
-                                .trimMargin(),
-                            MAX_LINE_LENGTH_NO_WRAP)
-                        .horizontalAlign(HorizontalAlign.FILL)
-                        .bindText(settingsModel::remoteUrlReplacements)
-                        .applyToComponent {
-                            this.setEmptyState("search1, replacement1, search2, replacement2, ...")
-                        }
-                }
-                row {
-                    checkBox("Do not show the \"No Sourcegraph URL set\" notification for this project")
-                        .bindSelected(settingsModel::isUrlNotificationDismissed)
-                }
-            }
+                      .trimMargin(),
+                  MAX_LINE_LENGTH_NO_WRAP)
+              .horizontalAlign(HorizontalAlign.FILL)
+              .bindText(settingsModel::remoteUrlReplacements)
+              .applyToComponent {
+                this.setEmptyState("search1, replacement1, search2, replacement2, ...")
+              }
         }
-        return dialogPanel
+      }
     }
+    return dialogPanel
+  }
 
-    override fun reset() {
-        settingsModel.isUrlNotificationDismissed =
-            codyApplicationSettings.isDefaultDotcomAccountNotificationDismissed
-        settingsModel.defaultBranchName = codyProjectSettings.defaultBranchName
-        settingsModel.remoteUrlReplacements = codyProjectSettings.remoteUrlReplacements
-        dialogPanel.reset()
-    }
+  override fun reset() {
+    settingsModel.defaultBranchName = codyProjectSettings.defaultBranchName
+    settingsModel.remoteUrlReplacements = codyProjectSettings.remoteUrlReplacements
+    dialogPanel.reset()
+  }
 
-    override fun apply() {
-        super.apply()
-        codyProjectSettings.defaultBranchName = settingsModel.defaultBranchName
-        codyProjectSettings.remoteUrlReplacements = settingsModel.remoteUrlReplacements
-        codyApplicationSettings.isDefaultDotcomAccountNotificationDismissed =
-            settingsModel.isUrlNotificationDismissed
-    }
+  override fun apply() {
+    super.apply()
+    codyProjectSettings.defaultBranchName = settingsModel.defaultBranchName
+    codyProjectSettings.remoteUrlReplacements = settingsModel.remoteUrlReplacements
+  }
 }

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -51,16 +51,16 @@
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyPersisentAccounts"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.api.SourcegraphApiRequestExecutor$Factory"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CachingCodyUserAvatarLoader"/>
-        <projectService serviceImplementation="com.sourcegraph.cody.config.CodyProjectDefaultAccountHolder"/>
-        <notificationGroup id="Sourcegraph: server access" displayType="BALLOON"/>
+        <projectService serviceImplementation="com.sourcegraph.cody.config.CodyProjectActiveAccountHolder"/>
+        <notificationGroup id="cody.auth" displayType="BALLOON"/>
         <notificationGroup id="Sourcegraph errors" displayType="BALLOON"/>
         <notificationGroup id="Sourcegraph: URL sharing" displayType="BALLOON"/>
         <notificationGroup id="Sourcegraph Cody + Code Search plugin updates" displayType="STICKY_BALLOON"/>
         <projectService id="sourcegraph.findService" serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity implementation="com.sourcegraph.telemetry.PostStartupActivity"/>
-        <postStartupActivity implementation="com.sourcegraph.config.NotificationActivity"/>
+        <postStartupActivity implementation="com.sourcegraph.config.CodyAuthNotificationActivity"/>
         <postStartupActivity implementation="com.sourcegraph.cody.config.SettingsMigration"/>
-        <postStartupActivity implementation="com.sourcegraph.cody.config.NotifyAboutNoDefaultAccount"/>
+        <postStartupActivity implementation="com.sourcegraph.cody.config.NotifyAboutNoActiveAccount"/>
 
         <!-- Cody -->
         <toolWindow


### PR DESCRIPTION
Closes #56033 

Previously we displayed a notification that a user doesn't have an enterprise account and he can only access public repos. Now we removed all of the noisy notification and we have only one notification displayed per project if project doesn't have active account configured. There is a link in the notification to Open Cody which will open the Cody sidebar where user will be guided to create an account > https://github.com/sourcegraph/sourcegraph/issues/56024 
The notification can be dismissed for all of the projects with "Never Show Again" action

<img width="430" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/c3a390db-aa00-47a3-8bb1-28d4de8bae64">


## Test plan
- Open new project where you don't have an active account and notifcation should be displayed where you can click on the "Open Cody" action, then Cody sidebar should appear

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
