### PR TITLE
gitservice: use an error hook instead of a logger

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -74,10 +74,12 @@ func (s *Server) gitServiceHandler() *gitservice.Handler {
 	logger := s.Logger.Scoped("gitServiceHandler", "smart Git HTTP transfer protocol")
 
 	return &gitservice.Handler{
-		Logger: logger,
-
 		Dir: func(d string) string {
 			return string(repoDirFromName(s.ReposDir, api.RepoName(d)))
+		},
+
+		ErrorHook: func(err error, stderr string) {
+			logger.Error("git-service error", log.Error(err), log.String("stderr", stderr))
 		},
 
 		// Limit rate of stdout from git.

--- a/internal/service/servegit/serve.go
+++ b/internal/service/servegit/serve.go
@@ -167,6 +167,9 @@ func (s *Serve) handler() http.Handler {
 			// calling FromSlash.
 			return filepath.FromSlash("/" + name)
 		},
+		ErrorHook: func(err error, stderr string) {
+			s.Logger.Error("git-service error", log.Error(err), log.String("stderr", stderr))
+		},
 		Trace: func(ctx context.Context, svc, repo, protocol string) func(error) {
 			start := time.Now()
 			return func(err error) {

--- a/lib/gitservice/BUILD.bazel
+++ b/lib/gitservice/BUILD.bazel
@@ -6,18 +6,12 @@ go_library(
     srcs = ["gitservice.go"],
     importpath = "github.com/sourcegraph/sourcegraph/lib/gitservice",
     visibility = ["//visibility:public"],
-    deps = [
-        "//lib/errors",
-        "@com_github_sourcegraph_log//:log",
-    ],
+    deps = ["//lib/errors"],
 )
 
 go_test(
     name = "gitservice_test",
     timeout = "short",
     srcs = ["gitservice_test.go"],
-    deps = [
-        ":gitservice",
-        "@com_github_sourcegraph_log//logtest",
-    ],
+    deps = [":gitservice"],
 )

--- a/lib/gitservice/gitservice_test.go
+++ b/lib/gitservice/gitservice_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/sourcegraph/lib/gitservice"
 )
 
@@ -34,7 +33,6 @@ func TestHandler(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(&gitservice.Handler{
-		Logger: logtest.Scoped(t),
 		Dir: func(s string) string {
 			return filepath.Join(root, s, ".git")
 		},


### PR DESCRIPTION
src-cli doesn't use logger, so this changes the pattern to instead make how we log injectable by the client. Currently the logger is just not set in src-cli leading to a nil pointer panic. After this is merged a follow up PR will go out for that.

Additionally this PR fixes a use for sourcegraph app which didn't set the logger as well.

Test Plan: CI