### PR TITLE
JetBrains: Cody: Make implicit autocomplete trigger enabled by default

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -45,7 +45,7 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
   public Boolean areCodyCompletionsEnabled; // kept for backwards compatibility
 
   public boolean isCodyEnabled = true;
-  @Nullable public Boolean isCodyAutocompleteEnabled;
+  @Nullable public Boolean isCodyAutocompleteEnabled = true;
   public boolean isAccessTokenNotificationDismissed;
   @Nullable public Boolean authenticationFailedLastTime;
   @Nullable public Boolean isCodyDebugEnabled;

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -7,8 +7,8 @@ import com.intellij.openapi.components.service
 
 @State(name = "CodyApplicationSettings", storages = [Storage("cody_application_settings.xml")])
 data class CodyApplicationSettings(
-    var isCodyEnabled: Boolean = false,
-    var isCodyAutocompleteEnabled: Boolean = false,
+    var isCodyEnabled: Boolean = true,
+    var isCodyAutocompleteEnabled: Boolean = true,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
     var isGetStartedNotificationDismissed: Boolean = false,

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -5,8 +5,8 @@ import java.awt.Color
 data class SettingsModel(
     var defaultBranchName: String = "",
     var remoteUrlReplacements: String = "",
-    var isCodyEnabled: Boolean = false,
-    var isCodyAutocompleteEnabled: Boolean = false,
+    var isCodyEnabled: Boolean = true,
+    var isCodyAutocompleteEnabled: Boolean = true,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
     var isCustomAutocompleteColorEnabled: Boolean = false,


### PR DESCRIPTION
Fixes #56562

Note: even though `CodyApplicationService` is deprecated, we still automatically migrate values from there.
This in turn means that any defaults in the latest settings model aren't respected, really, as they'll just get overridden by the deprecated defaults, counterintuitively.
I adjusted the values everywhere to keep things consistent, but really, only the (deprecated) `CodyApplicationService` defaults are respected.

I don't think it's worth tidying up right now, as this problem will be gone once we can remove the old model migration after the deprecation period.

## Test plan
- implicit autocomplete should be enabled by default.
