### PR TITLE
Restore github-proxy temporarily

### DIFF
--- a/cmd/github-proxy/BUILD.bazel
+++ b/cmd/github-proxy/BUILD.bazel
@@ -1,0 +1,71 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@container_structure_test//:defs.bzl", "container_structure_test")
+load("//dev:oci_defs.bzl", "image_repository")
+
+go_library(
+    name = "github-proxy_lib",
+    srcs = ["github-proxy.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/github-proxy",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd/github-proxy/shared",
+        "//cmd/sourcegraph/osscmd",
+        "//internal/sanitycheck",
+    ],
+)
+
+go_binary(
+    name = "github-proxy",
+    embed = [":github-proxy_lib"],
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",
+        "github.com/sourcegraph/sourcegraph/internal/version.timestamp": "{VERSION_TIMESTAMP}",
+    },
+)
+
+pkg_tar(
+    name = "tar_github-proxy",
+    srcs = [":github-proxy"],
+)
+
+oci_image(
+    name = "image",
+    base = "@wolfi_base",
+    entrypoint = [
+        "/sbin/tini",
+        "--",
+        "/github-proxy",
+    ],
+    env = {
+        "LOG_REQUEST": "true",
+    },
+    tars = [":tar_github-proxy"],
+    user = "sourcegraph",
+)
+
+oci_tarball(
+    name = "image_tarball",
+    image = ":image",
+    repo_tags = ["github-proxy:candidate"],
+)
+
+container_structure_test(
+    name = "image_test",
+    timeout = "short",
+    configs = ["image_test.yaml"],
+    driver = "docker",
+    image = ":image",
+    tags = [
+        "exclusive",
+        "requires-network",
+    ],
+)
+
+oci_push(
+    name = "candidate_push",
+    image = ":image",
+    repository = image_repository("github-proxy"),
+)

--- a/cmd/github-proxy/README.md
+++ b/cmd/github-proxy/README.md
@@ -1,0 +1,5 @@
+# github-proxy
+
+Proxies all requests to github.com to keep track of rate limits and prevent triggering abuse mechanisms.
+
+There is only one replica running in production.

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared"
+	"github.com/sourcegraph/sourcegraph/cmd/sourcegraph/osscmd"
+	"github.com/sourcegraph/sourcegraph/internal/sanitycheck"
+)
+
+func main() {
+	sanitycheck.Pass()
+	osscmd.SingleServiceMainOSS(shared.Service)
+}

--- a/cmd/github-proxy/image_test.yaml
+++ b/cmd/github-proxy/image_test.yaml
@@ -1,0 +1,20 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "binary is runnable"
+    command: "/github-proxy"
+    envVars:
+      - key: "SANITY_CHECK"
+        value: "true"
+
+  - name: "not running as root"
+    command: "/usr/bin/id"
+    args:
+      - -u
+    excludedOutput: ["^0"]
+    exitCode: 0
+
+metadataTest:
+  envVars:
+    - key: LOG_REQUEST
+      value: true

--- a/cmd/github-proxy/shared/BUILD.bazel
+++ b/cmd/github-proxy/shared/BUILD.bazel
@@ -1,0 +1,38 @@
+load("//dev:go_defs.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "shared",
+    srcs = [
+        "service.go",
+        "shared.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/cmd/github-proxy/shared",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//internal/conf",
+        "//internal/debugserver",
+        "//internal/env",
+        "//internal/goroutine",
+        "//internal/instrumentation",
+        "//internal/observation",
+        "//internal/service",
+        "//internal/trace",
+        "@com_github_gorilla_handlers//:handlers",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@com_github_prometheus_client_golang//prometheus/promhttp",
+        "@com_github_sourcegraph_log//:log",
+    ],
+)
+
+go_test(
+    name = "shared_test",
+    timeout = "short",
+    srcs = ["shared_test.go"],
+    embed = [":shared"],
+    deps = [
+        "//lib/errors",
+        "@com_github_prometheus_client_golang//prometheus",
+    ],
+)

--- a/cmd/github-proxy/shared/service.go
+++ b/cmd/github-proxy/shared/service.go
@@ -1,0 +1,22 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/debugserver"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/service"
+)
+
+type svc struct{}
+
+func (svc) Name() string { return "github-proxy" }
+
+func (svc) Configure() (env.Config, []debugserver.Endpoint) { return nil, nil }
+
+func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, _ env.Config) error {
+	return Main(ctx, observationCtx, ready)
+}
+
+var Service service.Service = svc{}

--- a/cmd/github-proxy/shared/shared.go
+++ b/cmd/github-proxy/shared/shared.go
@@ -1,0 +1,251 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/handlers"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/instrumentation"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/service"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+var logRequests, _ = strconv.ParseBool(env.Get("LOG_REQUESTS", "", "log HTTP requests"))
+
+const port = "3180"
+
+var metricWaitingRequestsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "github_proxy_waiting_requests",
+	Help: "Number of proxy requests waiting on the mutex",
+})
+
+// list obtained from httputil of headers not to forward.
+var hopHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Proxy-Connection":    {}, // non-standard but still sent by libcurl and rejected by e.g. google
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"Te":                  {}, // canonicalized version of "TE"
+	"Trailer":             {}, // not Trailers per URL above; http://www.rfc-editor.org/errata_search.php?eid=4522
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+}
+
+func Main(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc) error {
+	logger := observationCtx.Logger
+
+	// Ready immediately
+	ready()
+
+	p := &githubProxy{
+		logger: logger,
+		// Use a custom client/transport because GitHub closes keep-alive
+		// connections after 60s. In order to avoid running into EOF errors, we use
+		// a IdleConnTimeout of 30s, so connections are only kept around for <30s
+		client: &http.Client{Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			IdleConnTimeout: 30 * time.Second,
+		}},
+	}
+
+	h := http.Handler(p)
+	if logRequests {
+		h = handlers.LoggingHandler(os.Stdout, h)
+	}
+	h = instrumentHandler(prometheus.DefaultRegisterer, h)
+	h = trace.HTTPMiddleware(logger, h, conf.DefaultClient())
+	h = instrumentation.HTTPMiddleware("", h)
+	http.Handle("/", h)
+
+	host := ""
+	if env.InsecureDev {
+		host = "127.0.0.1"
+	}
+	addr := net.JoinHostPort(host, port)
+	logger.Info("github-proxy: listening", log.String("addr", addr))
+	s := http.Server{
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 10 * time.Minute,
+		Addr:         addr,
+		Handler:      http.DefaultServeMux,
+	}
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
+		<-c
+
+		ctx, cancel := context.WithTimeout(context.Background(), goroutine.GracefulShutdownTimeout)
+		if err := s.Shutdown(ctx); err != nil {
+			logger.Error("graceful termination timeout", log.Error(err))
+		}
+		cancel()
+
+	}()
+
+	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Fatal(err.Error())
+	}
+
+	return nil
+}
+
+func instrumentHandler(r prometheus.Registerer, h http.Handler) http.Handler {
+	var (
+		inFlightGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "src_githubproxy_in_flight_requests",
+			Help: "A gauge of requests currently being served by github-proxy.",
+		})
+		counter = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "src_githubproxy_requests_total",
+				Help: "A counter for requests to github-proxy.",
+			},
+			[]string{"code", "method"},
+		)
+		duration = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "src_githubproxy_request_duration_seconds",
+				Help:    "A histogram of latencies for requests.",
+				Buckets: []float64{.25, .5, 1, 2.5, 5, 10},
+			},
+			[]string{"method"},
+		)
+		responseSize = prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "src_githubproxy_response_size_bytes",
+				Help:    "A histogram of response sizes for requests.",
+				Buckets: []float64{200, 500, 900, 1500},
+			},
+			[]string{},
+		)
+	)
+
+	r.MustRegister(inFlightGauge, counter, duration, responseSize)
+
+	return promhttp.InstrumentHandlerInFlight(inFlightGauge,
+		promhttp.InstrumentHandlerDuration(duration,
+			promhttp.InstrumentHandlerCounter(counter,
+				promhttp.InstrumentHandlerResponseSize(responseSize, h),
+			),
+		),
+	)
+}
+
+type githubProxy struct {
+	logger     log.Logger
+	tokenLocks lockMap
+	client     interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+}
+
+func (p *githubProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var token string
+	q2 := r.URL.Query()
+	h2 := make(http.Header)
+	for k, v := range r.Header {
+		if _, found := hopHeaders[k]; !found {
+			h2[k] = v
+		}
+
+		if k == "Authorization" && len(v) > 0 {
+			fields := strings.Fields(v[0])
+			token = fields[len(fields)-1]
+		}
+	}
+
+	req2 := &http.Request{
+		Method: r.Method,
+		Body:   r.Body,
+		URL: &url.URL{
+			Scheme:   "https",
+			Host:     "api.github.com",
+			Path:     r.URL.Path,
+			RawQuery: q2.Encode(),
+		},
+		Header: h2,
+	}
+
+	lock := p.tokenLocks.get(token)
+	metricWaitingRequestsGauge.Inc()
+	lock.Lock()
+	metricWaitingRequestsGauge.Dec()
+	resp, err := p.client.Do(req2)
+	lock.Unlock()
+
+	if err != nil {
+		p.logger.Warn("proxy error", log.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+	if resp.StatusCode < 400 || !logRequests {
+		_, _ = io.Copy(w, resp.Body)
+		return
+	}
+	b, err := io.ReadAll(resp.Body)
+	p.logger.Warn("proxy error",
+		log.Int("status", resp.StatusCode),
+		log.String("body", string(b)),
+		log.NamedError("bodyErr", err))
+	_, _ = io.Copy(w, bytes.NewReader(b))
+}
+
+// lockMap is a map of strings to mutexes. It's used to serialize github.com API
+// requests of each access token in order to prevent abuse rate limiting due
+// to concurrency.
+type lockMap struct {
+	init  sync.Once
+	mu    sync.RWMutex
+	locks map[string]*sync.Mutex
+}
+
+func (m *lockMap) get(k string) *sync.Mutex {
+	m.init.Do(func() { m.locks = make(map[string]*sync.Mutex) })
+
+	m.mu.RLock()
+	lock, ok := m.locks[k]
+	m.mu.RUnlock()
+
+	if ok {
+		return lock
+	}
+
+	m.mu.Lock()
+	lock, ok = m.locks[k]
+	if !ok {
+		lock = &sync.Mutex{}
+		m.locks[k] = lock
+	}
+	m.mu.Unlock()
+
+	return lock
+}

--- a/cmd/github-proxy/shared/shared_test.go
+++ b/cmd/github-proxy/shared/shared_test.go
@@ -1,0 +1,110 @@
+package shared
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestInstrumentHandler(_ *testing.T) {
+	h := http.Handler(nil)
+	instrumentHandler(prometheus.DefaultRegisterer, h)
+}
+
+func TestGitHubProxy(t *testing.T) {
+	ch := make(chan struct{})
+	blocking := make(chan struct{})
+	p := &githubProxy{client: doerFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.URL.Path {
+		case "/block":
+			select {
+			case <-ch:
+			default:
+				close(blocking)
+				<-ch
+			}
+		}
+
+		return &http.Response{
+			StatusCode: 200,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("body")),
+		}, nil
+	})}
+
+	srv := httptest.NewServer(p)
+	t.Cleanup(srv.Close)
+
+	go func() {
+		req, _ := http.NewRequest("GET", srv.URL+"/block", nil)
+		req.Header.Add("Authorization", "user1")
+		http.DefaultClient.Do(req) // blocks
+	}()
+
+	t.Run("locked", func(t *testing.T) {
+		<-blocking
+
+		req, _ := http.NewRequest("GET", srv.URL+"/ok", nil)
+		req.Header.Add("Authorization", "user1")
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		_, err := http.DefaultClient.Do(req.WithContext(ctx))
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("different user", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", srv.URL+"/ok", nil)
+
+		// Different user request can go through
+		req.Header.Set("Authorization", "Bearer user2")
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("want status code 200, got %v", resp.StatusCode)
+		}
+	})
+
+	t.Run("unlocked", func(t *testing.T) {
+		// Now the first user's request will finish, we can go through.
+		close(ch)
+
+		req, _ := http.NewRequest("GET", srv.URL+"/ok", nil)
+		req.Header.Set("Authorization", "Bearer user1")
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("want status code 200, got %v", resp.StatusCode)
+		}
+	})
+}
+
+type doerFunc func(*http.Request) (*http.Response, error)
+
+func (do doerFunc) Do(r *http.Request) (*http.Response, error) {
+	return do(r)
+}

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -89,6 +89,7 @@ var DeploySourcegraphDockerImages = []string{
 	"codeintel-db",
 	"embeddings",
 	"frontend",
+	"github-proxy",
 	"gitserver",
 	"grafana",
 	"indexed-searcher",

--- a/go.mod
+++ b/go.mod
@@ -269,6 +269,7 @@ require (
 	github.com/aws/jsii-runtime-go v1.84.0
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/go-redsync/redsync/v4 v4.8.1
+	github.com/gorilla/handlers v1.5.1
 	github.com/hashicorp/cronexpr v1.1.1
 	github.com/hashicorp/go-tfe v1.32.1
 	github.com/hashicorp/terraform-cdk-go/cdktf v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -1192,6 +1192,7 @@ github.com/gorilla/csrf v1.7.1/go.mod h1:+a/4tCmqhG6/w4oafeAZ9pEa3/NZOWYVbD9fV0F
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=


### PR DESCRIPTION
Just to be safe and make rollbacks easier, we keep building `github-proxy` for a while.

## Test plan

N/a

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
