### PR TITLE
gh: give a proper name to Jetbrains test job

### DIFF
--- a/.github/workflows/jetbrains-tests.yml
+++ b/.github/workflows/jetbrains-tests.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    name: Test
+    name: JetBrains tests
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
GitHub settings to enable a status check identifies it by the job name, not the workflow name (see https://stackoverflow.com/questions/68554735/github-action-status-check-missing-from-the-list-of-checks-in-protected-branch-s) 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
