### PR TITLE
Add dotComPublic config for Other gitrepo type

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -447,6 +447,10 @@ func validateOtherExternalServiceConnection(c *schema.OtherExternalServiceConnec
 		parseRepo = baseURL.Parse
 	}
 
+	if !envvar.SourcegraphDotComMode() && c.MakeReposPublicOnDotCom {
+		return errors.Errorf(`"makeReposPublicOnDotCom" can only be set when running on Sourcegraph.com`)
+	}
+
 	for i, repo := range c.Repos {
 		cloneURL, err := parseRepo(repo)
 		if err != nil {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -2585,3 +2585,20 @@ func TestExternalServiceStore_ListRepos(t *testing.T) {
 		t.Fatalf("Expected 0 external service repos, got %d", len(haveRepos))
 	}
 }
+
+func Test_validateOtherExternalServiceConnection(t *testing.T) {
+	conn := &schema.OtherExternalServiceConnection{
+		MakeReposPublicOnDotCom: true,
+	}
+	// When not on DotCom, validation of a connection with "makeReposPublicOnDotCom" set to true should fail
+	err := validateOtherExternalServiceConnection(conn)
+	require.Error(t, err)
+
+	// On DotCom, no error should be returned
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(orig)
+
+	err = validateOtherExternalServiceConnection(conn)
+	require.NoError(t, err)
+}

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -72,10 +72,8 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 		return nil, err
 	}
 
-	if envvar.SourcegraphDotComMode() {
-		if c.DotComPublic {
-			svc.Unrestricted = true
-		}
+	if envvar.SourcegraphDotComMode() && c.DotComPublic {
+		svc.Unrestricted = true
 	}
 
 	return &OtherSource{

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -69,6 +70,12 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 	exclude, err := eb.Build()
 	if err != nil {
 		return nil, err
+	}
+
+	if envvar.SourcegraphDotComMode() {
+		if c.DotComPublic {
+			svc.Unrestricted = true
+		}
 	}
 
 	return &OtherSource{

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -72,7 +72,7 @@ func NewOtherSource(ctx context.Context, svc *types.ExternalService, cf *httpcli
 		return nil, err
 	}
 
-	if envvar.SourcegraphDotComMode() && c.DotComPublic {
+	if envvar.SourcegraphDotComMode() && c.MakeReposPublicOnDotCom {
 		svc.Unrestricted = true
 	}
 

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -186,7 +186,7 @@ func TestOther_DotComConfig(t *testing.T) {
 		source, err := NewOtherSource(context.Background(), &types.ExternalService{
 			ID:     1,
 			Kind:   extsvc.KindOther,
-			Config: extsvc.NewUnencryptedConfig(fmt.Sprintf(`{"url": "somegit.com/repo", "repos": ["%s"], "dotComPublic": true}`, "src-expose")),
+			Config: extsvc.NewUnencryptedConfig(fmt.Sprintf(`{"url": "somegit.com/repo", "repos": ["%s"], "makeReposPublicOnDotCom": true}`, "src-expose")),
 		}, nil, nil)
 		require.NoError(t, err)
 		return source

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -201,7 +201,9 @@ func TestOther_DotComConfig(t *testing.T) {
 	require.True(t, repo.Private)
 
 	// Enable Dotcom mode. Then repo should be public.
+	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(orig)
 	source = makeSource(t)
 
 	repo, err = source.otherRepoFromCloneURL("other:source", cloneURL)

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -6,13 +6,16 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -176,6 +179,34 @@ func TestSrcExpose_SrcExposeServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOther_DotComConfig(t *testing.T) {
+	makeSource := func(t *testing.T) *OtherSource {
+		source, err := NewOtherSource(context.Background(), &types.ExternalService{
+			ID:     1,
+			Kind:   extsvc.KindOther,
+			Config: extsvc.NewUnencryptedConfig(fmt.Sprintf(`{"url": "somegit.com/repo", "repos": ["%s"], "dotComPublic": true}`, "src-expose")),
+		}, nil, nil)
+		require.NoError(t, err)
+		return source
+	}
+	source := makeSource(t)
+
+	cloneURL, _ := url.Parse("https://somegit.com/repo")
+
+	// Not on Dotcom, so repo should still be private regardless of config
+	repo, err := source.otherRepoFromCloneURL("other:source", cloneURL)
+	require.NoError(t, err)
+	require.True(t, repo.Private)
+
+	// Enable Dotcom mode. Then repo should be public.
+	envvar.MockSourcegraphDotComMode(true)
+	source = makeSource(t)
+
+	repo, err = source.otherRepoFromCloneURL("other:source", cloneURL)
+	require.NoError(t, err)
+	require.False(t, repo.Private)
 }
 
 func TestSrcExpose_SrcServeLocalServer(t *testing.T) {
@@ -545,13 +576,11 @@ func TestOther_SrcExposeRequest(t *testing.T) {
 				Kind:   extsvc.KindOther,
 				Config: extsvc.NewUnencryptedConfig(string(config)),
 			}, httpcli.NewFactory(httpcli.NewMiddleware()), logtest.Scoped(t))
-
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			req, validSrcExposeConfig, err := source.srcExposeRequest()
-
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -80,6 +80,11 @@
           }
         ]
       ]
+    },
+    "dotComPublic": {
+      "description": "Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/schema/other_external_service.schema.json
+++ b/schema/other_external_service.schema.json
@@ -81,7 +81,7 @@
         ]
       ]
     },
-    "dotComPublic": {
+    "makeReposPublicOnDotCom": {
       "description": "Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.",
       "type": "boolean",
       "default": false

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1756,11 +1756,11 @@ type OrganizationInvitations struct {
 
 // OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
 type OtherExternalServiceConnection struct {
-	// DotComPublic description: Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.
-	DotComPublic bool `json:"dotComPublic,omitempty"`
 	// Exclude description: A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
 	Exclude []*ExcludedOtherRepo `json:"exclude,omitempty"`
-	Repos   []string             `json:"repos"`
+	// MakeReposPublicOnDotCom description: Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.
+	MakeReposPublicOnDotCom bool     `json:"makeReposPublicOnDotCom,omitempty"`
+	Repos                   []string `json:"repos"`
 	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for the repositories. In the pattern, the variable "{base}" is replaced with the Git clone base URL host and path, and "{repo}" is replaced with the repository path taken from the `repos` field.
 	//
 	// For example, if your Git clone base URL is https://git.example.com/repos and `repos` contains the value "my/repo", then a repositoryPathPattern of "{base}/{repo}" would mean that a repository at https://git.example.com/repos/my/repo is available on Sourcegraph at https://sourcegraph.example.com/git.example.com/repos/my/repo.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1756,6 +1756,8 @@ type OrganizationInvitations struct {
 
 // OtherExternalServiceConnection description: Configuration for a Connection to Git repositories for which an external service integration isn't yet available.
 type OtherExternalServiceConnection struct {
+	// DotComPublic description: Whether or not these repositories should be marked as public on Sourcegraph.com. Defaults to false.
+	DotComPublic bool `json:"dotComPublic,omitempty"`
 	// Exclude description: A list of repositories to never mirror by name after applying repositoryPathPattern. Supports excluding by exact name ({"name": "myrepo"}) or regular expression ({"pattern": ".*secret.*"}).
 	Exclude []*ExcludedOtherRepo `json:"exclude,omitempty"`
 	Repos   []string             `json:"repos"`


### PR DESCRIPTION
Closes #56057 

Adds a config option for "Other" code host connections that only works on DotCom:

By adding

```json
"dotComPublic": true
```

to the code host config, repos added by that connection will be marked as public. This needs to be added explicitly, so it is on the configurator of that code host connection that all the repositories added by that connection is in fact public repositories.


https://github.com/sourcegraph/sourcegraph/assets/6427795/01cef46e-2814-43b2-b7be-3572622af2bd

When not on Sourcegraph.com, the config can't be saved at all:

![image](https://github.com/sourcegraph/sourcegraph/assets/6427795/ba558197-77d5-4d57-bb12-2c23c8711ee7)

## Test plan

Unit test as well as local test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
