### PR TITLE
JetBrains: Cody: Bump Jetbrains platform compat to `221.5080.210`

### DIFF
--- a/client/jetbrains/CHANGELOG.md
+++ b/client/jetbrains/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Enabled manually triggering autocomplete even when implicit autocomplete is disabled (globally or for a language) [#56473](https://github.com/sourcegraph/sourcegraph/pull/56473)
 - Onboarding notifications merged into one simple notification to Open Cody [#56610](https://github.com/sourcegraph/sourcegraph/pull/56610)
 - Enabled implicit autocomplete by default [#56617](https://github.com/sourcegraph/sourcegraph/pull/56617)
+- Bumped JetBrains platform plugin compat to `221.5080.210` and higher [#56625](https://github.com/sourcegraph/sourcegraph/pull/56625)
 
 ### Deprecated
 

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -10,8 +10,10 @@
             -> https://plugins.jetbrains.com/docs/intellij/jcef.html
         - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
              -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
+        - Version 2022.1 is the version introducing the Kotlin UI DSL API we are using at the moment
+          - if the need arises, we may try to implement backwards compatibility to 2021.3
     -->
-    <idea-version since-build="212.0"/>
+    <idea-version since-build="221.5080.210"/>
 
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>


### PR DESCRIPTION
Partially addresses #56620
We still need to verify the compat on CI, so won't close the ticket after this is merged

## Test plan
- `since-build` JetBrains platform version declared in `plugin.xml` should match the backwards compat of API we use
  - for the purpose of this PR, mostly the Kotlin UI DSL stuff was checked
