### PR TITLE
JetBrains: don't warn about missing context with empty context files

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -560,30 +560,16 @@ public class CodyToolWindowContent implements UpdatableChat {
 
   @Override
   public void displayUsedContext(@NotNull List<ContextMessage> contextMessages) {
-    // Use context
     if (contextMessages.isEmpty()) {
-      AccountType accountType =
-          CodyAuthenticationManager.getInstance().getDefaultAccountType(project);
-
-      String report = "I found no context for your request.";
-      String ask =
-          accountType == AccountType.ENTERPRISE
-              ? "Please ensure this repository is added to your Sourcegraph Enterprise instance and that your access token and custom request headers are set up correctly."
-              : (accountType == AccountType.LOCAL_APP
-                  ? "Please ensure this repository is configured in Cody App."
-                  : (accountType == AccountType.DOTCOM
-                      ? "As your current server setting is Sourcegraph.com, please ensure this repository is public and indexed on Sourcegraph.com and that your access token is valid."
-                      : ""));
-      String resolution = "I will try to answer without context.";
-      this.addMessageToChat(
-          ChatMessage.createAssistantMessage(report + " " + ask + " " + resolution));
-    } else {
-
-      ContextFilesMessage contextFilesMessage = new ContextFilesMessage(contextMessages);
-      var messageContentPanel = new JPanel(new BorderLayout());
-      messageContentPanel.add(contextFilesMessage);
-      this.addComponentToChat(messageContentPanel);
+      // Do nothing when there are no context files. It's normal that some answers have no context
+      // files.
+      return;
     }
+
+    ContextFilesMessage contextFilesMessage = new ContextFilesMessage(contextMessages);
+    var messageContentPanel = new JPanel(new BorderLayout());
+    messageContentPanel.add(contextFilesMessage);
+    this.addComponentToChat(messageContentPanel);
   }
 
   public @NotNull JComponent getContentPanel() {


### PR DESCRIPTION
Previously, Cody chat reported a warning that there was no context when a chat message had no context files. This warning was not necessary since it's normal for some messages to have no context.

## Test plan
n/a
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
