### PR TITLE
search jobs: fix pagination

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.module.scss
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.module.scss
@@ -165,6 +165,9 @@
     margin: 1rem 0;
     width: 100%;
     display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
     justify-content: center;
 }
 

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
@@ -36,6 +36,7 @@ const SEARCH_JOBS_MOCK: MockedResponse<SearchJobsResult, SearchJobsVariables> = 
             first: 20,
             after: null,
             query: '',
+            userIDs: [],
             states: [],
             orderBy: SearchJobsOrderBy.CREATED_AT,
         },

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
@@ -37,7 +37,7 @@ const SEARCH_JOBS_MOCK: MockedResponse<SearchJobsResult, SearchJobsVariables> = 
             after: null,
             query: '',
             states: [],
-            orderBy: SearchJobsOrderBy.CREATED_DATE,
+            orderBy: SearchJobsOrderBy.CREATED_AT,
         },
     },
     result: {

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -83,10 +83,11 @@ export const SEARCH_JOBS_QUERY = gql`
         $first: Int!
         $after: String
         $query: String!
+        $userIDs: [ID!]
         $states: [SearchJobState!]
         $orderBy: SearchJobsOrderBy
     ) {
-        searchJobs(first: $first, after: $after, query: $query, states: $states, orderBy: $orderBy) {
+        searchJobs(first: $first, after: $after, query: $query, userIDs: $userIDs, states: $states, orderBy: $orderBy) {
             nodes {
                 ...SearchJobNode
             }
@@ -128,6 +129,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
             first: 20,
             after: null,
             query: debouncedSearchTerm,
+            userIDs: selectedUsers.map(user => user.id),
             states: selectedStates,
             orderBy: sortBy,
         },

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -110,7 +110,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
     const [searchStateTerm, setSearchStateTerm] = useState('')
     const [selectedUsers, setUsers] = useState<User[]>([])
     const [selectedStates, setStates] = useState<SearchJobState[]>([])
-    const [sortBy, setSortBy] = useState<SearchJobsOrderBy>(SearchJobsOrderBy.CREATED_DATE)
+    const [sortBy, setSortBy] = useState<SearchJobsOrderBy>(SearchJobsOrderBy.CREATED_AT)
 
     const [jobToDelete, setJobToDelete] = useState<SearchJobNode | null>(null)
     const [jobToCancel, setJobToCancel] = useState<SearchJobNode | null>(null)
@@ -212,7 +212,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                         className={styles.sort}
                         selectClassName={styles.sortSelect}
                     >
-                        <option value={SearchJobsOrderBy.CREATED_DATE}>Sort by Created date</option>
+                        <option value={SearchJobsOrderBy.CREATED_AT}>Sort by Created date</option>
                         <option value={SearchJobsOrderBy.QUERY}>Sort by Query</option>
                         <option value={SearchJobsOrderBy.STATE}>Sort by Status</option>
                     </Select>

--- a/cmd/frontend/graphqlbackend/search_jobs.go
+++ b/cmd/frontend/graphqlbackend/search_jobs.go
@@ -38,7 +38,7 @@ type CreateSearchJobArgs struct {
 type SearchJobResolver interface {
 	ID() graphql.ID
 	Query() string
-	State(ctx context.Context) string
+	State() string
 	Creator(ctx context.Context) (*UserResolver, error)
 	CreatedAt() gqlutil.DateTime
 	StartedAt(ctx context.Context) *gqlutil.DateTime

--- a/cmd/frontend/graphqlbackend/search_jobs.go
+++ b/cmd/frontend/graphqlbackend/search_jobs.go
@@ -86,6 +86,7 @@ type SearchJobsArgs struct {
 	States     *[]string
 	OrderBy    string
 	Descending bool
+	UserIDs    *[]graphql.ID
 }
 
 type SearchJobsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/search_jobs.go
+++ b/cmd/frontend/graphqlbackend/search_jobs.go
@@ -16,7 +16,7 @@ type SearchJobsResolver interface {
 	DeleteSearchJob(ctx context.Context, args *DeleteSearchJobArgs) (*EmptyResponse, error)
 
 	// Queries
-	SearchJobs(ctx context.Context, args *SearchJobsArgs) (SearchJobsConnectionResolver, error)
+	SearchJobs(ctx context.Context, args *SearchJobsArgs) (*graphqlutil.ConnectionResolver[SearchJobResolver], error)
 
 	NodeResolvers() map[string]NodeByIDFunc
 }
@@ -81,8 +81,7 @@ type SearchJobArgs struct {
 }
 
 type SearchJobsArgs struct {
-	First      int32
-	After      *string
+	graphqlutil.ConnectionResolverArgs
 	Query      *string
 	States     *[]string
 	OrderBy    string

--- a/cmd/frontend/graphqlbackend/search_jobs.graphql
+++ b/cmd/frontend/graphqlbackend/search_jobs.graphql
@@ -53,6 +53,10 @@ extend type Query {
         """
         before: String
         """
+        List of users ids by which we will filter out search jobs list.
+        """
+        userIDs : [ID!]
+        """
         The query to filter the results by.
         """
         query: String
@@ -63,7 +67,7 @@ extend type Query {
         """
         The order by which to sort the results.
         """
-        orderBy: SearchJobsOrderBy = CREATED_DATE
+        orderBy: SearchJobsOrderBy = CREATED_AT
         """
         The determines the order of the returned searches. Defaults to ascending.
         """
@@ -110,11 +114,11 @@ enum SearchJobsOrderBy {
     """
     QUERY
     """
-    Sort search jobs by their created date.
+    Sort search jobs by their creation date.
     """
-    CREATED_DATE
+    CREATED_AT
     """
-    Sort search jobs by their started date.
+    Sort search jobs by their state.
     """
     STATE
 }

--- a/cmd/frontend/graphqlbackend/search_jobs.graphql
+++ b/cmd/frontend/graphqlbackend/search_jobs.graphql
@@ -36,7 +36,7 @@ extend type Query {
     """
     searchJobs(
         """
-        The number of results to return. Defaults to 50.
+        The number of results to return.
         """
         first: Int
         """

--- a/cmd/frontend/graphqlbackend/search_jobs.graphql
+++ b/cmd/frontend/graphqlbackend/search_jobs.graphql
@@ -55,7 +55,7 @@ extend type Query {
         """
         List of users ids by which we will filter out search jobs list.
         """
-        userIDs : [ID!]
+        userIDs: [ID!]
         """
         The query to filter the results by.
         """

--- a/cmd/frontend/graphqlbackend/search_jobs.graphql
+++ b/cmd/frontend/graphqlbackend/search_jobs.graphql
@@ -38,11 +38,20 @@ extend type Query {
         """
         The number of results to return. Defaults to 50.
         """
-        first: Int = 50
+        first: Int
+        """
+        Note: Use either last or first (see above) in the query. Setting both will
+        return an error.
+        """
+        last: Int
         """
         The cursor to start at.
         """
         after: String
+        """
+        Opaque pagination cursor to be used when paginating backwards.
+        """
+        before: String
         """
         The query to filter the results by.
         """
@@ -86,7 +95,9 @@ enum SearchJobState {
     The search job has completed.
     """
     COMPLETED
-
+    """
+    The search job was canceled.
+    """
     CANCELED
 }
 

--- a/cmd/frontend/internal/search/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/search/resolvers/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/database",
         "//internal/gqlutil",
         "//internal/search/exhaustive/service",
+        "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
         "//lib/errors",
         "//lib/pointers",

--- a/cmd/frontend/internal/search/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/search/resolvers/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/types",
+        "//internal/types",
         "//lib/errors",
         "//lib/pointers",
         "@com_github_graph_gophers_graphql_go//:graphql-go",

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -87,7 +87,6 @@ func newSearchJobConnectionResolver(db database.DB, service *service.Service, ar
 }
 
 type searchJobsConnectionStore struct {
-	ctx     context.Context
 	db      database.DB
 	service *service.Service
 	states  []string
@@ -137,7 +136,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 	case "created_at":
 		value = fmt.Sprintf("'%v'", node.CreatedAt().Format("2006-01-02 15:04:05.999999"))
 	case "state":
-		value = fmt.Sprintf("'%v'", strings.ToLower(node.State(s.ctx)))
+		value = fmt.Sprintf("'%v'", strings.ToLower(node.State()))
 	default:
 		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expeced one of (created_at, state). Actual: %s", column))
 	}

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -143,8 +143,10 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 		value = fmt.Sprintf("'%v'", node.CreatedAt().Format(time.RFC3339))
 	case "state":
 		value = fmt.Sprintf("'%v'", strings.ToLower(node.State()))
+	case "query":
+		value = fmt.Sprintf("'%v'", node.Query())
 	default:
-		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expeced one of (created_at, state). Actual: %s", column))
+		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expected one of (created_at, state, query). Actual: %s", column))
 	}
 
 	id, err := UnmarshalSearchJobID(node.ID())
@@ -177,17 +179,20 @@ func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy datab
 		return nil, errors.New(fmt.Sprintf("expected a %q cursor, got %q", column, spec.Column))
 	}
 
-	csv := ""
-	values := strings.Split(spec.Value, "@")
-	if len(values) != 2 {
+	i := strings.LastIndex(spec.Value, "@")
+	if i == -1 {
 		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, spec.Value))
 	}
 
-	// TODO (stefan) handle column "query"
+	values := []string{spec.Value[0:i], spec.Value[i+1:]}
+
+	csv := ""
 	switch column {
 	case "created_at":
 		csv = fmt.Sprintf("%v, %v", values[0], values[1])
 	case "state":
+		csv = fmt.Sprintf("%v, %v", values[0], values[1])
+	case "query":
 		csv = fmt.Sprintf("%v, %v", values[0], values[1])
 	default:
 		return nil, errors.New("Invalid OrderBy Field.")

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -71,11 +71,16 @@ func newSearchJobConnectionResolver(db database.DB, service *service.Service, ar
 		}
 	}
 
+	query := ""
+	if args.Query != nil {
+		query = *args.Query
+	}
+
 	s := &searchJobsConnectionStore{
 		db:      db,
 		service: service,
 		states:  states,
-		query:   args.Query,
+		query:   query,
 		userIDs: ids,
 	}
 	return graphqlutil.NewConnectionResolver[graphqlbackend.SearchJobResolver](
@@ -91,7 +96,7 @@ type searchJobsConnectionStore struct {
 	db      database.DB
 	service *service.Service
 	states  []string
-	query   *string
+	query   string
 	userIDs []int32
 }
 

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -134,7 +135,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 	var value string
 	switch column {
 	case "created_at":
-		value = fmt.Sprintf("'%v'", node.CreatedAt().Format("2006-01-02 15:04:05.999999"))
+		value = fmt.Sprintf("'%v'", node.CreatedAt().Format(time.RFC3339))
 	case "state":
 		value = fmt.Sprintf("'%v'", strings.ToLower(node.State()))
 	default:
@@ -162,10 +163,10 @@ func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy datab
 	if err := relay.UnmarshalSpec(graphql.ID(cursor), &spec); err != nil {
 		return nil, err
 	}
+
 	if len(orderBy) == 0 {
 		return nil, errors.New("no OrderBy provided")
 	}
-
 	column := orderBy[0].Field
 	if spec.Column != column {
 		return nil, errors.New(fmt.Sprintf("expected a %q cursor, got %q", column, spec.Column))
@@ -177,6 +178,7 @@ func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy datab
 		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, spec.Value))
 	}
 
+	// TODO (stefan) handle column "query"
 	switch column {
 	case "created_at":
 		csv = fmt.Sprintf("%v, %v", values[0], values[1])

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -39,7 +39,7 @@ func (r searchJobResolver) Query() string {
 	return r.Job.Query
 }
 
-func (r searchJobResolver) State(ctx context.Context) string {
+func (r searchJobResolver) State() string {
 	return r.Job.State.ToGraphQL()
 }
 

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -145,7 +145,7 @@ func (s *Service) GetSearchJob(ctx context.Context, id int64) (_ *types.Exhausti
 	return s.store.GetExhaustiveSearchJob(ctx, id)
 }
 
-func (s *Service) ListSearchJobs(ctx context.Context) (jobs []*types.ExhaustiveSearchJob, err error) {
+func (s *Service) ListSearchJobs(ctx context.Context, args store.ListArgs) (jobs []*types.ExhaustiveSearchJob, err error) {
 	ctx, _, endObservation := s.operations.listSearchJobs.With(ctx, &err, observation.Args{})
 	defer func() {
 		endObservation(1, opAttrs(
@@ -153,7 +153,7 @@ func (s *Service) ListSearchJobs(ctx context.Context) (jobs []*types.ExhaustiveS
 		))
 	}()
 
-	return s.store.ListExhaustiveSearchJobs(ctx)
+	return s.store.ListExhaustiveSearchJobs(ctx, args)
 }
 
 func getPrefix(id int64) string {

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -271,8 +270,6 @@ func (s *Store) ListExhaustiveSearchJobs(ctx context.Context, args ListArgs) (jo
 		q = pagination.AppendOrderToQuery(q)
 		q = pagination.AppendLimitToQuery(q)
 	}
-
-	fmt.Println(q.Query(sqlf.PostgresBindVar), q.Args())
 
 	return scanExhaustiveSearchJobs(s.Store.Query(ctx, q))
 }

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -197,7 +197,7 @@ LIMIT 1
 
 type ListArgs struct {
 	*database.PaginationArgs
-	Query   *string
+	Query   string
 	States  []string
 	UserIDs []int32
 }
@@ -218,8 +218,8 @@ func (s *Store) ListExhaustiveSearchJobs(ctx context.Context, args ListArgs) (jo
 	var conds []*sqlf.Query
 
 	// Filter by query.
-	if args.Query != nil && *args.Query != "" {
-		conds = append(conds, sqlf.Sprintf("query LIKE %s", "%"+*args.Query+"%"))
+	if args.Query != "" {
+		conds = append(conds, sqlf.Sprintf("query LIKE %s", "%"+args.Query+"%"))
 	}
 
 	// Filter by state.

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -176,7 +176,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	}
 
 	// Now list them all
-	haveJobs, err := s.ListExhaustiveSearchJobs(ctx)
+	haveJobs, err := s.ListExhaustiveSearchJobs(ctx, store.ListArgs{})
 	require.NoError(t, err)
 	require.Equal(t, len(haveJobs), len(jobs))
 

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -192,7 +192,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 			name: "query: 1 job",
 			ctx:  ctx,
 			args: store.ListArgs{
-				Query: strptr("job1"),
+				Query: "job1",
 			},
 			wantIDs: []int64{jobs[0].ID},
 		},
@@ -200,7 +200,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 			name: "query: all jobs",
 			ctx:  ctx,
 			args: store.ListArgs{
-				Query: strptr("repo"),
+				Query: "repo",
 			},
 			wantIDs: []int64{jobs[0].ID, jobs[1].ID, jobs[2].ID},
 		},
@@ -217,7 +217,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 			ctx:  ctx,
 			args: store.ListArgs{
 				PaginationArgs: &database.PaginationArgs{First: intptr(1), Ascending: true},
-				Query:          strptr("repo"),
+				Query:          "repo",
 			},
 			wantIDs: []int64{jobs[0].ID},
 		},
@@ -226,7 +226,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 			name: "query: no result",
 			ctx:  ctx,
 			args: store.ListArgs{
-				Query: strptr("foo"),
+				Query: "foo",
 			},
 			wantIDs: []int64{},
 		},
@@ -280,5 +280,4 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	}
 }
 
-func strptr(s string) *string { return &s }
-func intptr(s int) *int       { return &s }
+func intptr(s int) *int { return &s }


### PR DESCRIPTION
This updates the GraphQL schema for repo jobs and implements pagination and filtering for `searchJobs`.

## Test plan:
- new unit test for list logic
- manual testing via API Console

I tested variations of this query
```graphql
query q {
  searchJobs(first: 3, query: "rev3", userIDs: ["VXNlcjox"], states: [COMPLETED]) {
    nodes {
      id
      query
      startedAt
      state
      creator {
        id
        username
      }
    }
  }
}

```

https://github.com/sourcegraph/sourcegraph/assets/26413131/52b8b91b-75ff-4c3f-a446-77c6de294cc8

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
