### PR TITLE
source: Implement redaction for recorded commands

### DIFF
--- a/cmd/frontend/graphqlbackend/recorded_commands.go
+++ b/cmd/frontend/graphqlbackend/recorded_commands.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 )
@@ -102,11 +101,8 @@ func (r *recordedCommandResolver) Duration() float64 {
 	return r.command.Duration
 }
 
-var urlRegex = lazyregexp.New(`((https?|ssh|git)://[^:@]+:)[^@]+(@)`)
-
 func (r *recordedCommandResolver) Command() string {
-	redacted := urlRegex.ReplaceAllString(strings.Join(r.command.Args, " "), "$1<REDACTED>$3")
-	return redacted
+	return strings.Join(r.command.Args, " ")
 }
 
 func (r *recordedCommandResolver) Dir() string {

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -369,8 +369,8 @@ func (s *Server) repoRemoteRefs(ctx context.Context, remoteURL *vcs.URL, repoNam
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	r := newURLRedactor(remoteURL)
-	_, err := runCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, nil, api.RepoName(repoName), cmd).WithRedactorFunc(r.redact))
+	r := urlredactor.New(remoteURL)
+	_, err := runCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, nil, api.RepoName(repoName), cmd).WithRedactorFunc(r.Redact))
 	if err != nil {
 		stderr := stderr.Bytes()
 		if len(stderr) > 200 {

--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -369,7 +369,8 @@ func (s *Server) repoRemoteRefs(ctx context.Context, remoteURL *vcs.URL, repoNam
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	_, err := runCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, nil, api.RepoName(repoName), cmd))
+	r := newURLRedactor(remoteURL)
+	_, err := runCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, nil, api.RepoName(repoName), cmd).WithRedactorFunc(r.redact))
 	if err != nil {
 		stderr := stderr.Bytes()
 		if len(stderr) > 200 {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -2105,7 +2105,7 @@ func (s *Server) doClone(
 
 	go readCloneProgress(s.DB, logger, redactor, lock, pr, repo)
 
-	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, s.Logger, repo, cmd), true, pw)
+	output, err := runRemoteGitCommand(ctx, s.RecordingCommandFactory.WrapWithRepoName(ctx, s.Logger, repo, cmd).WithRedactorFunc(redactor.Redact), true, pw)
 	redactedOutput := redactor.Redact(string(output))
 	// best-effort update the output of the clone
 	if err := s.DB.GitserverRepos().SetLastOutput(context.Background(), repo, redactedOutput); err != nil {
@@ -2578,7 +2578,8 @@ func setHEAD(ctx context.Context, logger log.Logger, rcf *wrexec.RecordingComman
 		return errors.Wrap(err, "get remote show command")
 	}
 	dir.Set(cmd)
-	output, err := runRemoteGitCommand(ctx, rcf.WrapWithRepoName(ctx, logger, repoName, cmd), true, nil)
+	r := urlredactor.New(remoteURL)
+	output, err := runRemoteGitCommand(ctx, rcf.WrapWithRepoName(ctx, logger, repoName, cmd).WithRedactorFunc(r.Redact), true, nil)
 	if err != nil {
 		logger.Error("Failed to fetch remote info", log.Error(err), log.String("output", string(output)))
 		return errors.Wrap(err, "failed to fetch remote info")

--- a/cmd/gitserver/server/vcs_syncer_git.go
+++ b/cmd/gitserver/server/vcs_syncer_git.go
@@ -46,9 +46,9 @@ func (s *gitRepoSyncer) IsCloneable(ctx context.Context, repoName api.RepoName, 
 	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
 	defer cancel()
 
-	r := newURLRedactor(remoteURL)
+	r := urlredactor.New(remoteURL)
 	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.redact), true, nil)
+	out, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.Redact), true, nil)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = ctxerr
@@ -82,8 +82,8 @@ func (s *gitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.URL, tm
 func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, repoName api.RepoName, dir common.GitDir, _ string) ([]byte, error) {
 	cmd, configRemoteOpts := s.fetchCommand(ctx, remoteURL)
 	dir.Set(cmd)
-	r := newURLRedactor(remoteURL)
-	output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.redact), configRemoteOpts, nil)
+	r := urlredactor.New(remoteURL)
+	output, err := runRemoteGitCommand(ctx, s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.Redact), configRemoteOpts, nil)
 	if err != nil {
 		return nil, &common.GitCommandError{Err: err, Output: urlredactor.New(remoteURL).Redact(string(output))}
 	}

--- a/internal/wrexec/recording_cmd.go
+++ b/internal/wrexec/recording_cmd.go
@@ -47,7 +47,10 @@ type RecordingCmd struct {
 	recording    bool
 	start        time.Time
 	done         bool
+	redactorFunc RedactorFunc
 }
+
+type RedactorFunc func(string) string
 
 // ShouldRecordFunc is a predicate to signify if a command should be recorded or just pass through.
 type ShouldRecordFunc func(context.Context, *exec.Cmd) bool
@@ -96,6 +99,19 @@ func (rc *RecordingCmd) before(ctx context.Context, _ log.Logger, cmd *exec.Cmd)
 	return nil
 }
 
+// WithRedactorFunc sets a redaction function f that will be called to redact  the command's arguments
+// and output before recording.
+//
+// The redaction function f accepts the raw argument or output string as input and returns the
+// redacted string.
+//
+// This allows sensitive arguments or output to be redacted before recording.
+// Returns the RecordingCmd to allow chaining.
+func (rc *RecordingCmd) WithRedactorFunc(f RedactorFunc) *RecordingCmd {
+	rc.redactorFunc = f
+	return rc
+}
+
 func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cmd) {
 	// ensure we don't record ourselves twice if the caller calls Wait() twice for example.
 	defer func() { rc.done = true }()
@@ -108,16 +124,31 @@ func (rc *RecordingCmd) after(_ context.Context, logger log.Logger, cmd *exec.Cm
 		return
 	}
 
+	commandArgs := cmd.Args
+	commandOutput := rc.Cmd.GetExecutionOutput()
+
+	if rc.redactorFunc != nil {
+		commandOutput = rc.redactorFunc(commandOutput)
+
+		redactedArgs := make([]string, len(commandArgs))
+		for i, arg := range commandArgs {
+			redactedArgs[i] = rc.redactorFunc(arg)
+		}
+		// We don't directly modify the commandArgs above because we want to avoid
+		// overwriting the original args (cmd.Args).
+		commandArgs = redactedArgs
+	}
+
 	// record this command in redis
 	val := RecordedCommand{
 		Start:    rc.start,
 		Duration: time.Since(rc.start).Seconds(),
-		Args:     cmd.Args,
+		Args:     commandArgs,
 		Dir:      cmd.Dir,
 		Path:     cmd.Path,
 
 		IsSuccess: cmd.ProcessState.Success(),
-		Output:    rc.Cmd.GetExecutionOutput(),
+		Output:    commandOutput,
 	}
 
 	data, err := json.Marshal(&val)


### PR DESCRIPTION
Closes [#56041](https://github.com/sourcegraph/sourcegraph/issues/56041)

This PR implements redaction for recorded commands. With this, we will be storing redacted command args and output.

## Test plan

* Manual testing