### PR TITLE
repository changelist resolver: correctly handle changelist id not found

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -22,13 +22,13 @@ import (
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -300,7 +300,7 @@ func (r *RepositoryResolver) Changelist(ctx context.Context, args *RepositoryCha
 
 	rc, err := r.db.RepoCommitsChangelists().GetRepoCommitChangelist(ctx, repo.ID, cid)
 	if err != nil {
-		if errors.HasType(err, &perforce.ChangelistNotFoundError{}) {
+		if errcode.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -135,6 +135,7 @@ go_library(
         "//internal/lazyregexp",
         "//internal/own/codeowners/v1:codeowners",
         "//internal/own/types",
+        "//internal/perforce",
         "//internal/randstring",
         "//internal/ratelimit",
         "//internal/rbac/types",

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -292,6 +292,7 @@ go_test(
         "//internal/jsonc",
         "//internal/own/codeowners/v1:codeowners",
         "//internal/own/types",
+        "//internal/perforce",
         "//internal/rbac/types",
         "//internal/search/result",
         "//internal/temporarysettings",

--- a/internal/database/repo_commits_changelists_test.go
+++ b/internal/database/repo_commits_changelists_test.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRepoCommitsChangelists(t *testing.T) {
@@ -149,10 +151,16 @@ func TestRepoCommitsChangelists(t *testing.T) {
 		})
 
 		t.Run("non existing row", func(t *testing.T) {
-			gotRow, err := s.GetRepoCommitChangelist(ctx, 2, 999)
+			_, err := s.GetRepoCommitChangelist(ctx, 2, 999)
 			require.Error(t, err)
-			require.True(t, errors.Is(err, sql.ErrNoRows))
-			require.Nil(t, gotRow)
+
+			var notFoundError *perforce.ChangelistNotFoundError
+			if errors.As(err, &notFoundError) {
+				require.Equal(t, api.RepoID(2), notFoundError.RepoID)
+				require.Equal(t, int64(999), notFoundError.ID)
+			} else {
+				t.Fatalf("wrong error type, want ChangelistNotFoundError, got %T", err)
+			}
 		})
 	})
 }

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -36,12 +36,12 @@ func GetP4ChangelistID(body string) (string, error) {
 
 // ChangelistNotFoundError is an error that reports a revision doesn't exist.
 type ChangelistNotFoundError struct {
-	Repo api.RepoName
-	ID   string
+	RepoID api.RepoID
+	ID     int64
 }
 
 func (e *ChangelistNotFoundError) Error() string {
-	return fmt.Sprintf("revision not found: %s@%s", e.Repo, e.ID)
+	return fmt.Sprintf("changelist ID not found. repo=%d, changelist id=%d", e.RepoID, e.ID)
 }
 
 type BadChangelistError struct {

--- a/internal/perforce/changelist.go
+++ b/internal/perforce/changelist.go
@@ -40,6 +40,8 @@ type ChangelistNotFoundError struct {
 	ID     int64
 }
 
+func (e *ChangelistNotFoundError) NotFound() bool { return true }
+
 func (e *ChangelistNotFoundError) Error() string {
 	return fmt.Sprintf("changelist ID not found. repo=%d, changelist id=%d", e.RepoID, e.ID)
 }


### PR DESCRIPTION
This produced an uncaught error when the commit SHA was an actual integer (`5123123`) and we parsed it correctly as an int and then tried to query.

## Test plan

- Manual testing by cloning `sourcegraph/cody` and accessing https://sourcegraph.test:3443/github.com/sourcegraph/cody@5816435/-/blob/vscode/src/completions/providers/unstable-azure-openai.ts (note the `5816435`)