### PR TITLE
sg/msp: add project ID validation

### DIFF
--- a/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//dev/managedservicesplatform/internal/stack/options/googleprovider",
         "//dev/managedservicesplatform/internal/stack/options/randomprovider",
         "//dev/managedservicesplatform/spec",
+        "//lib/errors",
         "//lib/pointers",
         "@com_github_aws_jsii_runtime_go//:jsii-runtime-go",
         "@com_github_grafana_regexp//:regexp",

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/googleprovider"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/randomprovider"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
@@ -81,6 +82,12 @@ type Variables struct {
 
 const StackName = "project"
 
+const (
+	// https://cloud.google.com/resource-manager/reference/rest/v1/projects
+	projectIDMaxLength              = 30
+	projectIDRandomizedSuffixLength = 6
+)
+
 // NewStack creates a stack that provisions a GCP project.
 func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 	stack := stacks.New(StackName,
@@ -91,8 +98,13 @@ func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 	// Name all stack resources after the desired project ID
 	id := resourceid.New(vars.ProjectIDPrefix)
 
+	// The project ID must leave room for a randomized suffix and a separator.
+	if afterSuffixLength := len(vars.ProjectIDPrefix) + 1 + projectIDRandomizedSuffixLength; afterSuffixLength > projectIDMaxLength {
+		return nil, errors.Newf("project ID prefix %q (%d characters) is too long (max %d characters) after adding random suffix (%d characters)",
+			vars.ProjectIDPrefix, afterSuffixLength, projectIDMaxLength, projectIDRandomizedSuffixLength)
+	}
 	projectID := random.New(stack, id, random.Config{
-		ByteLength: 6,
+		ByteLength: projectIDRandomizedSuffixLength,
 		Prefix:     vars.ProjectIDPrefix,
 	})
 

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -100,8 +100,8 @@ func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 
 	// The project ID must leave room for a randomized suffix and a separator.
 	if afterSuffixLength := len(vars.ProjectIDPrefix) + 1 + projectIDRandomizedSuffixLength; afterSuffixLength > projectIDMaxLength {
-		return nil, errors.Newf("project ID prefix %q (%d characters) is too long (max %d characters) after adding random suffix (%d characters)",
-			vars.ProjectIDPrefix, afterSuffixLength, projectIDMaxLength, projectIDRandomizedSuffixLength)
+		return nil, errors.Newf("project ID prefix %q is too long after adding random suffix (%d characters) - got %d characters, but maximum is %d characters",
+			vars.ProjectIDPrefix, projectIDRandomizedSuffixLength, afterSuffixLength, projectIDMaxLength)
 	}
 	projectID := random.New(stack, id, random.Config{
 		ByteLength: projectIDRandomizedSuffixLength,


### PR DESCRIPTION
Validates generated project ID does not exceed GCP maximum (30 characters)

## Test plan
n/a