### PR TITLE
Push VS Cody install events to HubSpot

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -125,16 +125,6 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 		return nil, nil
 	}
 
-	decode := func(v *string) (payload json.RawMessage, _ error) {
-		if v != nil {
-			if err := json.Unmarshal([]byte(*v), &payload); err != nil {
-				return nil, err
-			}
-		}
-
-		return payload, nil
-	}
-
 	userID := actor.FromContext(ctx).UID
 	userPrimaryEmail := ""
 	if envvar.SourcegraphDotComMode() {
@@ -169,10 +159,22 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 		}
 
 		// On Sourcegraph.com only, log a HubSpot event indicating when the user installed a Cody client.
-		if envvar.SourcegraphDotComMode() && args.Event == "CodyInstalled" && userID != 0 && userPrimaryEmail != "" {
-			hubspotutil.SyncUser(userPrimaryEmail, hubspotutil.CodyClientInstalledEventID, &hubspot.ContactProperties{
-				DatabaseID: userID,
-			})
+		// if envvar.SourcegraphDotComMode() && args.Event == "CodyInstalled" && userID != 0 && userPrimaryEmail != "" {
+		if envvar.SourcegraphDotComMode() && args.Event == "CodyInstalled" {
+			emailsEnabled := false
+
+			ide := getIdeFromEvent(&args)
+
+			if ide == "vscode" {
+				if ffs := featureflag.FromContext(ctx); ffs != nil {
+					emailsEnabled = ffs.GetBoolOr("vscodeCodyEmailsEnabled", false)
+				}
+			}
+
+			hubspotutil.SyncUserWithEventParams(userPrimaryEmail, hubspotutil.CodyClientInstalledEventID, &hubspot.ContactProperties{
+				DatabaseID:                   userID,
+				VSCodyInstalledEmailsEnabled: emailsEnabled,
+			}, map[string]string{"ide": ide, "emailsEnabled": strconv.FormatBool(emailsEnabled)})
 		}
 
 		// On Sourcegraph.com only, log a HubSpot event indicating when the user clicks button to downloads Cody App.
@@ -229,6 +231,39 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 	}
 
 	return nil, nil
+}
+
+func decode(v *string) (payload json.RawMessage, _ error) {
+	if v != nil {
+		if err := json.Unmarshal([]byte(*v), &payload); err != nil {
+			return nil, err
+		}
+	}
+
+	return payload, nil
+}
+
+type VSCodeEventExtensionDetails struct {
+	Ide string `json:"ide"`
+}
+
+type VSCodeEventPublicArgument struct {
+	ExtensionDetails VSCodeEventExtensionDetails `json:"extensionDetails"`
+}
+
+func getIdeFromEvent(args *Event) string {
+	payload, err := decode(args.PublicArgument)
+	if err != nil {
+		return ""
+	}
+
+	var argument VSCodeEventPublicArgument
+
+	if err := json.Unmarshal(payload, &argument); err != nil {
+		return ""
+	}
+
+	return argument.ExtensionDetails.Ide
 }
 
 var (

--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -43,14 +43,15 @@ func (c *Client) baseContactURL(email string) *url.URL {
 
 // ContactProperties represent HubSpot user properties
 type ContactProperties struct {
-	UserID          string `json:"user_id"`
-	IsServerAdmin   bool   `json:"is_server_admin"`
-	LatestPing      int64  `json:"latest_ping"`
-	AnonymousUserID string `json:"anonymous_user_id"`
-	FirstSourceURL  string `json:"first_source_url"`
-	LastSourceURL   string `json:"last_source_url"`
-	DatabaseID      int32  `json:"database_id"`
-	HasAgreedToToS  bool   `json:"has_agreed_to_tos_and_pp"`
+	UserID                       string `json:"user_id"`
+	IsServerAdmin                bool   `json:"is_server_admin"`
+	LatestPing                   int64  `json:"latest_ping"`
+	AnonymousUserID              string `json:"anonymous_user_id"`
+	FirstSourceURL               string `json:"first_source_url"`
+	LastSourceURL                string `json:"last_source_url"`
+	DatabaseID                   int32  `json:"database_id"`
+	HasAgreedToToS               bool   `json:"has_agreed_to_tos_and_pp"`
+	VSCodyInstalledEmailsEnabled bool   `json:"vs_cody_installed_emails_enabled"`
 }
 
 // ContactResponse represents HubSpot user properties returned


### PR DESCRIPTION
closes part of https://github.com/sourcegraph/cody/issues/954

- Pass a new event `VSCodyInstalled` to HubSpot
- Pass a new bool property `VsCodyInstallEmailsEnabled` based on feature flag for AB testing. 

## Test plan
- enable the feature flag
- Install VS Code sign in should log event to hub spot with property true.