### PR TITLE
JetBrains: correctly manage chat transcript

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -514,6 +514,7 @@ public class CodyToolWindowContent implements UpdatableChat {
               addWelcomeMessage();
               messagesPanel.revalidate();
               messagesPanel.repaint();
+              CodyAgent.getInitializedServer(project).thenAccept(CodyAgentServer::transcriptReset);
             });
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -47,6 +47,9 @@ public interface CodyAgentServer {
   @JsonNotification("exit")
   void exit();
 
+  @JsonNotification("transcript/reset")
+  void transcriptReset();
+
   @JsonNotification("extensionConfiguration/didChange")
   void configurationDidChange(ExtensionConfiguration document);
 


### PR DESCRIPTION
Previously, the state of the chat transcript went out of sync between what was visible in the JetBrains UI and what the Cody worker (aka. agent) modeled internally. This PR fixes the problem by sending a `transcript/reset` notification when the user triggers the "Reset conversation with Cody" action.

## Test plan

This PR must be tested alongside the PR https://github.com/sourcegraph/cody/pull/1073

- Add `console.log({messages})` statement to Cody file `lib/shared/src/chat/chat.ts`
- Run `./gradlew -PforceAgentBuild=true :runIDE` 
- Send chat message "Hello", confirm transcript has one "Hello" message
- Send chat message "Goodbye", confirm transcript has one "Hello" message and one "Goodbye" message
- Switch active account, send new message "Hello 2" and confirm transcript  has three messages
- Reset the conversation
- Send "Hello", confirm transcript has only one message 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
