### PR TITLE
JetBrains: use "Sourcegraph & Cody" title in settings UI

### DIFF
--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -32,7 +32,7 @@
             parentId="tools"
             instance="com.sourcegraph.cody.config.ui.AccountConfigurable"
             id="com.sourcegraph.cody.config.ui.AccountConfigurable"
-            displayName="Sourcegraph"
+            displayName="Sourcegraph &amp; Cody"
             nonDefaultProject="false"
         />
         <projectConfigurable
@@ -194,7 +194,6 @@
             icon="/icons/codyLogoSm.svg"/>
 
 
-
         <action
             id="cody.enableCodyAutocomplete"
             class="com.sourcegraph.cody.statusbar.CodyEnableAutocompleteAction"
@@ -245,7 +244,7 @@
     </actions>
 
     <projectListeners>
-    <listener topic="com.intellij.openapi.command.CommandListener"
-              class="com.sourcegraph.cody.editor.CodyCommandListener"/>
+        <listener topic="com.intellij.openapi.command.CommandListener"
+                  class="com.sourcegraph.cody.editor.CodyCommandListener"/>
     </projectListeners>
 </idea-plugin>


### PR DESCRIPTION

## Test plan
This is how it looks like
<img width="153" alt="CleanShot 2023-09-15 at 10 42 13@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/b6c05d85-5adb-4c34-b4f6-3c678911af3e">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
