### PR TITLE
JetBrains: Return to IDE after token generation

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -322,12 +322,18 @@ public class CodyToolWindowContent implements UpdatableChat {
     signInWithSourcegraphButton.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, Boolean.TRUE);
     signInWithSourcegraphButton.addActionListener(
         e -> {
-          int port = ApplicationManager.getApplication().getService(BuiltInServerOptions.class).builtInServerPort;
-          BrowserUtil.browse(ConfigUtil.DOTCOM_URL
-              + "user/settings/tokens/new/callback"
-              + "?requestFrom=JETBRAINS"
-              + "&port=" + port
-              + "&destination=%2F" + project.getLocationHash());
+          int port =
+              ApplicationManager.getApplication()
+                  .getService(BuiltInServerOptions.class)
+                  .builtInServerPort;
+          BrowserUtil.browse(
+              ConfigUtil.DOTCOM_URL
+                  + "user/settings/tokens/new/callback"
+                  + "?requestFrom=JETBRAINS"
+                  + "&port="
+                  + port
+                  + "&destination=%2F"
+                  + project.getLocationHash());
           updateVisibilityOfContentPanels();
         });
     CodyOnboardingPanel codyOnboardingPanel =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -52,6 +52,7 @@ import com.sourcegraph.cody.ui.AutoGrowingTextArea;
 import com.sourcegraph.cody.ui.HtmlViewer;
 import com.sourcegraph.cody.ui.UnderlinedActionLink;
 import com.sourcegraph.cody.vscode.CancellationToken;
+import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import java.awt.*;
 import java.util.List;
@@ -68,6 +69,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.plaf.ButtonUI;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.builtInWebServer.BuiltInServerOptions;
 
 public class CodyToolWindowContent implements UpdatableChat {
   public static Logger logger = Logger.getInstance(CodyToolWindowContent.class);
@@ -320,7 +322,12 @@ public class CodyToolWindowContent implements UpdatableChat {
     signInWithSourcegraphButton.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, Boolean.TRUE);
     signInWithSourcegraphButton.addActionListener(
         e -> {
-          BrowserUtil.browse("https://about.sourcegraph.com/app");
+          int port = ApplicationManager.getApplication().getService(BuiltInServerOptions.class).builtInServerPort;
+          BrowserUtil.browse(ConfigUtil.DOTCOM_URL
+              + "user/settings/tokens/new/callback"
+              + "?requestFrom=JETBRAINS"
+              + "&port=" + port
+              + "&destination=%2F" + project.getLocationHash());
           updateVisibilityOfContentPanels();
         });
     CodyOnboardingPanel codyOnboardingPanel =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -331,9 +331,7 @@ public class CodyToolWindowContent implements UpdatableChat {
                   + "user/settings/tokens/new/callback"
                   + "?requestFrom=JETBRAINS"
                   + "&port="
-                  + port
-                  + "&destination=%2F"
-                  + project.getLocationHash());
+                  + port);
           updateVisibilityOfContentPanels();
         });
     CodyOnboardingPanel codyOnboardingPanel =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -325,7 +325,7 @@ public class CodyToolWindowContent implements UpdatableChat {
           int port =
               ApplicationManager.getApplication()
                   .getService(BuiltInServerOptions.class)
-                  .builtInServerPort;
+                  .getEffectiveBuiltInServerPort();
           BrowserUtil.browse(
               ConfigUtil.DOTCOM_URL
                   + "user/settings/tokens/new/callback"

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -21,7 +21,8 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
 
   @Nullable
   @Override
-  public String execute(@NotNull QueryStringDecoder queryStringDecoder,
+  public String execute(
+      @NotNull QueryStringDecoder queryStringDecoder,
       @NotNull FullHttpRequest request,
       @NotNull ChannelHandlerContext context) {
     final boolean keepAlive = HttpUtil.isKeepAlive(request);
@@ -29,14 +30,21 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
 
     QueryStringDecoder urlDecoder = new QueryStringDecoder(request.uri());
     if (urlDecoder.path().startsWith("/" + PREFIX + "/" + getServiceName() + "/")) {
-      urlDecoder = new QueryStringDecoder(
-          urlDecoder.path().substring(1 + PREFIX.length() + 1 + getServiceName().length()));
+      urlDecoder =
+          new QueryStringDecoder(
+              urlDecoder.path().substring(1 + PREFIX.length() + 1 + getServiceName().length()));
 
       String accessToken = urlDecoder.parameters().get("token").get(0);
-      String destination = urlDecoder.parameters().get("destination").get(0); // Destination is "/projectLocationHash"
-      String projectLocationHash = (destination != null && destination.length() > 1) ? destination.substring(1) : null;
-      if (accessToken == null || projectLocationHash == null || !projectLocationHash.equals(
-          project.getLocationHash())) {
+      String destination =
+          urlDecoder
+              .parameters()
+              .get("destination")
+              .get(0); // Destination is "/projectLocationHash"
+      String projectLocationHash =
+          (destination != null && destination.length() > 1) ? destination.substring(1) : null;
+      if (accessToken == null
+          || projectLocationHash == null
+          || !projectLocationHash.equals(project.getLocationHash())) {
         sendStatus(HttpResponseStatus.BAD_REQUEST, keepAlive, channel);
         return null;
       }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -2,7 +2,6 @@ package com.sourcegraph.cody;
 
 import com.sourcegraph.config.AccessTokenStorage;
 import io.netty.buffer.Unpooled;
-import io.netty.util.CharsetUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -13,6 +12,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.util.CharsetUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,12 +38,13 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
       AccessTokenStorage.setApplicationDotComAccessToken(accessToken);
 
       // Send response
-      String htmlContent = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Token saved correctly.</title></head><body><p>Token saved correctly.</p><p>You can close this window.</p></body></html>";
-      FullHttpResponse response = new DefaultFullHttpResponse(
-          HttpVersion.HTTP_1_1,
-          HttpResponseStatus.OK,
-          Unpooled.copiedBuffer(htmlContent, CharsetUtil.UTF_8)
-      );
+      String htmlContent =
+          "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Token saved correctly.</title></head><body><p>Token saved correctly.</p><p>You can close this window.</p></body></html>";
+      FullHttpResponse response =
+          new DefaultFullHttpResponse(
+              HttpVersion.HTTP_1_1,
+              HttpResponseStatus.OK,
+              Unpooled.copiedBuffer(htmlContent, CharsetUtil.UTF_8));
       response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
       response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
       sendResponse(request, context, response);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.sourcegraph.cody.config.CodyPersistentAccountsHost;
 import com.sourcegraph.cody.config.SourcegraphServerPath;
-import com.sourcegraph.config.AccessTokenStorage;
 import com.sourcegraph.config.ConfigUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -42,7 +41,8 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
       // Save token
       Project project = ProjectManager.getInstance().getOpenProjects()[0];
       var accountsHost = new CodyPersistentAccountsHost(project);
-      accountsHost.addAccount(new SourcegraphServerPath(ConfigUtil.DOTCOM_URL, ""), "", accessToken);
+      accountsHost.addAccount(
+          new SourcegraphServerPath(ConfigUtil.DOTCOM_URL, ""), "", accessToken);
 
       // Send response
       String htmlContent =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -1,6 +1,11 @@
 package com.sourcegraph.cody;
 
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.sourcegraph.cody.config.CodyPersistentAccountsHost;
+import com.sourcegraph.cody.config.SourcegraphServerPath;
 import com.sourcegraph.config.AccessTokenStorage;
+import com.sourcegraph.config.ConfigUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -35,7 +40,9 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
       }
 
       // Save token
-      AccessTokenStorage.setApplicationDotComAccessToken(accessToken);
+      Project project = ProjectManager.getInstance().getOpenProjects()[0];
+      var accountsHost = new CodyPersistentAccountsHost(project);
+      accountsHost.addAccount(new SourcegraphServerPath(ConfigUtil.DOTCOM_URL, ""), "", accessToken);
 
       // Send response
       String htmlContent =

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -1,24 +1,22 @@
 package com.sourcegraph.cody;
 
-import com.intellij.openapi.project.Project;
 import com.sourcegraph.config.AccessTokenStorage;
+import io.netty.buffer.Unpooled;
+import io.netty.util.CharsetUtil;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
-  Project project;
-
-  // By saving the project we can make sure that we only handle calls in one IDE window
-  public SaveAccessTokenHttpService(Project project) {
-    this.project = project;
-  }
-
   @Nullable
   @Override
   public String execute(
@@ -30,28 +28,27 @@ public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
 
     QueryStringDecoder urlDecoder = new QueryStringDecoder(request.uri());
     if (urlDecoder.path().startsWith("/" + PREFIX + "/" + getServiceName() + "/")) {
-      urlDecoder =
-          new QueryStringDecoder(
-              urlDecoder.path().substring(1 + PREFIX.length() + 1 + getServiceName().length()));
-
       String accessToken = urlDecoder.parameters().get("token").get(0);
-      String destination =
-          urlDecoder
-              .parameters()
-              .get("destination")
-              .get(0); // Destination is "/projectLocationHash"
-      String projectLocationHash =
-          (destination != null && destination.length() > 1) ? destination.substring(1) : null;
-      if (accessToken == null
-          || projectLocationHash == null
-          || !projectLocationHash.equals(project.getLocationHash())) {
+      if (accessToken == null) {
         sendStatus(HttpResponseStatus.BAD_REQUEST, keepAlive, channel);
         return null;
       }
 
+      // Save token
       AccessTokenStorage.setApplicationDotComAccessToken(accessToken);
-      sendStatus(HttpResponseStatus.OK, keepAlive, channel);
+
+      // Send response
+      String htmlContent = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>Token saved correctly.</title></head><body><p>Token saved correctly.</p><p>You can close this window.</p></body></html>";
+      FullHttpResponse response = new DefaultFullHttpResponse(
+          HttpVersion.HTTP_1_1,
+          HttpResponseStatus.OK,
+          Unpooled.copiedBuffer(htmlContent, CharsetUtil.UTF_8)
+      );
+      response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
+      response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+      sendResponse(request, context, response);
     }
+
     return null;
   }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java
@@ -1,0 +1,55 @@
+package com.sourcegraph.cody;
+
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.config.AccessTokenStorage;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SaveAccessTokenHttpService extends org.jetbrains.ide.RestService {
+  Project project;
+
+  // By saving the project we can make sure that we only handle calls in one IDE window
+  public SaveAccessTokenHttpService(Project project) {
+    this.project = project;
+  }
+
+  @Nullable
+  @Override
+  public String execute(@NotNull QueryStringDecoder queryStringDecoder,
+      @NotNull FullHttpRequest request,
+      @NotNull ChannelHandlerContext context) {
+    final boolean keepAlive = HttpUtil.isKeepAlive(request);
+    final Channel channel = context.channel();
+
+    QueryStringDecoder urlDecoder = new QueryStringDecoder(request.uri());
+    if (urlDecoder.path().startsWith("/" + PREFIX + "/" + getServiceName() + "/")) {
+      urlDecoder = new QueryStringDecoder(
+          urlDecoder.path().substring(1 + PREFIX.length() + 1 + getServiceName().length()));
+
+      String accessToken = urlDecoder.parameters().get("token").get(0);
+      String destination = urlDecoder.parameters().get("destination").get(0); // Destination is "/projectLocationHash"
+      String projectLocationHash = (destination != null && destination.length() > 1) ? destination.substring(1) : null;
+      if (accessToken == null || projectLocationHash == null || !projectLocationHash.equals(
+          project.getLocationHash())) {
+        sendStatus(HttpResponseStatus.BAD_REQUEST, keepAlive, channel);
+        return null;
+      }
+
+      AccessTokenStorage.setApplicationDotComAccessToken(accessToken);
+      sendStatus(HttpResponseStatus.OK, keepAlive, channel);
+    }
+    return null;
+  }
+
+  @NotNull
+  @Override
+  protected String getServiceName() {
+    return "sourcegraph";
+  }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -27,7 +27,7 @@
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyApplicationSettings"/>
         <applicationService serviceImplementation="com.sourcegraph.config.CodyApplicationService"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyAuthenticationManager"/>
-        <projectService serviceImplementation="com.sourcegraph.cody.SaveAccessTokenHttpService"/>
+        <httpRequestHandler implementation="com.sourcegraph.cody.SaveAccessTokenHttpService"/>
 
         <projectConfigurable
             parentId="tools"

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,7 @@
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyApplicationSettings"/>
         <applicationService serviceImplementation="com.sourcegraph.config.CodyApplicationService"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyAuthenticationManager"/>
+        <projectService serviceImplementation="com.sourcegraph.cody.SaveAccessTokenHttpService"/>
 
         <projectConfigurable
             parentId="tools"

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -84,7 +84,7 @@ const REQUESTERS: Record<string, TokenRequester> = {
     },
     JETBRAINS: {
         name: 'JetBrains IDE',
-        redirectURL: 'http://localhost:11111/api/sourcegraph/token?token=$TOKEN',
+        redirectURL: 'http://localhost:$PORT/api/sourcegraph/token?token=$TOKEN',
         successMessage: 'Now opening your IDE...',
         infoMessage:
             'Please make sure you still have your IDE (IntelliJ, GoLand, PyCharm, etc.) running on your machine when clicking this link.',
@@ -204,9 +204,9 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                                 if (requester) {
                                     onDidCreateAccessToken(result)
                                     setNewToken(result.token)
-                                    let uri = replaceToken(requester?.redirectURL, result.token)
-                                    if (requestFrom === 'JETBRAINS') {
-                                        uri = uri.replace('11111', port ?? '11111')
+                                    let uri = replacePlaceholder(requester?.redirectURL, 'TOKEN', result.token)
+                                    if (requestFrom === 'JETBRAINS' && port) {
+                                        uri = replacePlaceholder(uri, 'PORT', port)
                                     }
 
                                     // If we're in App, override the callbackType
@@ -305,7 +305,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     )
 }
 
-function replaceToken(url: string, token: string): string {
+function replacePlaceholder(subject: string, search: string, replace: string): string {
     // %24 is the URL encoded version of $
-    return url.replace('$TOKEN', token).replace('%24TOKEN', token)
+    return subject.replace('$' + search, replace).replace('%24' + search, replace)
 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -86,10 +86,9 @@ const REQUESTERS: Record<string, TokenRequester> = {
         name: 'JetBrains IDE',
         redirectURL: 'http://localhost:11111/api/sourcegraph/token?token=$TOKEN',
         successMessage: 'Now opening your IDE...',
-        infoMessage: 'Please make sure you still have your IDE running on your machine when clicking this link.',
+        infoMessage:
+            'Please make sure you still have your IDE (IntelliJ, GoLand, PyCharm, etc.) running on your machine when clicking this link.',
         callbackType: 'open',
-        onlyDotCom: false,
-        forwardDestination: true,
     },
 }
 

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -178,6 +178,14 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
         setNote(REQUESTERS[requestFrom].name)
     }, [isSourcegraphDotCom, isSourcegraphApp, location.search, navigate, requestFrom, requester, port, destination])
 
+    // Add referrer policy to the page to prevent passing it on after the redirect.
+    // JetBrains needs this.
+    useEffect(() => {
+        document
+            .querySelector('head')
+            ?.insertAdjacentHTML('beforeend', '<meta name="referrer" content="strict-origin-when-cross-origin">')
+    }, [])
+
     /**
      * We use this to handle token creation request from redirections.
      * Don't create token if this page wasn't linked to from a valid

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -151,6 +151,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
             return
         }
 
+        // SECURITY: If the request is coming from JetBrains, verify if the port is valid
         if (requestFrom === 'JETBRAINS' && (!port || !Number.isInteger(Number(port)))) {
             navigate('../..', { relative: 'path' })
             return


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/56384

Three main changes:
- Hooked up the "Sign in free with Sourcegraph.com" button to open the correct remote URL. (It needed some iteration to reach a format that works well with the existing logic).
- Adjusted the "Authorize" page to accept our requests, display the correct text, and redirect to the right localhost URL. Generated URLs look like this, and they work: `http://localhost:63342/api/sourcegraph/token?token=sgp_67f78fdd4a115f580c40fd32523fb818f6b3abb5`
- Created a `RestService` to handle deep links to the plugin, and hooked it up with `plugin.xml`. It adds the account correctly.

Caveats:
- I haven't had time to figure out how to call [this function](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphSecurityUtil.kt?L10) to get the login name correctly [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/jetbrains-avoid-access-token-copy-paste/-/blob/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java?L45), but the avatar is being loaded, so we might be fine with this.
- `httpRequestHandler` ([here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/jetbrains-avoid-access-token-copy-paste/-/blob/client/jetbrains/src/main/resources/META-INF/plugin.xml?L30%3A10-30%3A28)) runs in the _application_ context rather than a project context, so I can't get a great `Project` object to pass to `CodyPersistentAccountsHost`, so I'm just using `ProjectManager.getInstance().getOpenProjects()[0]`. Not sure if this will get the correct Project in all cases—but then I'm also not sure if that's really needed because accounts are stored on the application level.

## Test plan

[1-min Loom](https://www.loom.com/share/Main-photo-viewer-indexhtml-15-September-2023-626dd4e90ea44d7c8952d1638ba015a2?sid=bee99b7f-60df-4659-9f7a-d10a8e7e4c72) – the 404 problem mentioned in the video is fixed now.

To test this until the current problem:
- Run `sh start dotcom` locally
- Set `public static final String DOTCOM_URL = "https://sourcegraph.test:3443/";` in `ConfigUtil.java` [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java?L27%3A3-27%3A76).
- Run the plugin
- Remove all accounts to get to the "Welcome to Cody" page in the sidebar
- Click the blue button
- ✅ Get redirected to the correct URL
- Click "Authorize"
- ✅ Get to the URL in the browser, which will trigger the IDE.
- ✅ The access token gets saved [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dv/jetbrains-avoid-access-token-copy-paste/-/blob/client/jetbrains/src/main/java/com/sourcegraph/cody/SaveAccessTokenHttpService.java?L43).
- ✅ The UI updates, chat and completions are available