### PR TITLE
JetBrains: add button to change codebase context

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -71,7 +71,7 @@ java {
     // Always compile the codebase with Java 11 regardless of what Java
     // version is installed on the computer. Gradle will download Java 11
     // even if you already have it installed on your computer.
-    languageVersion.set(JavaLanguageVersion.of(11))
+    languageVersion.set(JavaLanguageVersion.of(properties("javaVersion").toInt()))
   }
 }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -569,6 +569,12 @@ public class CodyToolWindowContent implements UpdatableChat {
                 }
               } else {
                 logger.warn("Agent is disabled, can't use chat.");
+                this.addMessageToChat(
+                    ChatMessage.createAssistantMessage(
+                        "Cody is not able to reply at the moment. "
+                            + "This is a bug, please report an issue to the sourcegraph/sourcegraph "
+                            + "repository and try to include relevant context from idea.log if possible."));
+                this.finishMessageProcessing();
               }
               GraphQlLogger.logCodyEvent(this.project, "recipe:chat-question", "executed");
             });

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -11,26 +11,38 @@ class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Pr
 
   // TODO: This should ideally be persisted as a project-wide setting. Down the road, it should also
   // support a list of repository names instead of only a single codebase.
-  var currentCodebase: String? = null
+  private var inferredCodebase: String = ""
+  private var explicitCodebase: String = ""
 
   init {
     ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(project, RepoUtil.findRepositoryName(project, null))
+      onRepositoryName(RepoUtil.findRepositoryName(project, null))
     }
   }
+
+  fun onNewExplicitCodebase(codebase: String) {
+    explicitCodebase = codebase
+    onPropagateConfiguration()
+  }
+
+  fun currentCodebase(): String? = explicitCodebase.ifEmpty { inferredCodebase }.ifEmpty { null }
 
   fun onFileOpened(project: Project, file: VirtualFile) {
     ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(project, RepoUtil.findRepositoryName(project, file))
+      onRepositoryName(RepoUtil.findRepositoryName(project, file))
     }
   }
 
-  private fun onRepositoryName(project: Project, repositoryName: String?) {
+  private fun onPropagateConfiguration() {
+    CodyToolWindowContent.getInstance(project).embeddingStatusView.updateEmbeddingStatus()
+    underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
+  }
+
+  private fun onRepositoryName(repositoryName: String?) {
     ApplicationManager.getApplication().invokeLater {
-      if (repositoryName != null && currentCodebase != repositoryName) {
-        currentCodebase = repositoryName
-        CodyToolWindowContent.getInstance(project).embeddingStatusView.updateEmbeddingStatus()
-        underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
+      if (repositoryName != null && inferredCodebase != repositoryName) {
+        inferredCodebase = repositoryName
+        onPropagateConfiguration()
       }
     }
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Interface for the server-part of the Cody agent protocol. The implementation of this interface is
@@ -38,7 +39,10 @@ public interface CodyAgentServer {
   CompletableFuture<String> currentUserId();
 
   @JsonRequest("graphql/getRepoIdIfEmbeddingExists")
-  CompletableFuture<String> getRepoIdIfEmbeddingExists(EmbeddingExistsParams repoName);
+  CompletableFuture<@Nullable String> getRepoIdIfEmbeddingExists(GetRepoID repoName);
+
+  @JsonRequest("graphql/getRepoId")
+  CompletableFuture<String> getRepoId(GetRepoID repoName);
 
   // Notifications
   @JsonNotification("initialized")

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/GetRepoID.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/protocol/GetRepoID.java
@@ -1,9 +1,9 @@
 package com.sourcegraph.cody.agent.protocol;
 
-public class EmbeddingExistsParams {
+public class GetRepoID {
   public final String repoName;
 
-  public EmbeddingExistsParams(String repoName) {
+  public GetRepoID(String repoName) {
     this.repoName = repoName;
   }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -46,7 +46,7 @@ public class ConfigUtil {
             .setAutocompleteAdvancedEmbeddings(UserLevelConfig.getAutocompleteAdvancedEmbeddings())
             .setDebug(isCodyDebugEnabled())
             .setVerboseDebug(isCodyVerboseDebugEnabled())
-            .setCodebase(codebase != null ? codebase.getCurrentCodebase() : null);
+            .setCodebase(codebase != null ? codebase.currentCodebase() : null);
 
     if (UserLevelConfig.getAutocompleteProviderType() != null) {
       config.setAutocompleteAdvancedProvider(

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -14,6 +14,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
     val gitURL =
         ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+
     init {
       init()
       title = "Context Selection"
@@ -52,6 +53,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
       }
     }
   }
+
   override fun actionPerformed(e: ActionEvent?) {
     EditCodebaseDialog().showAndGet()
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -44,8 +44,10 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
               cell(gitURL)
             }
             .rowComment("Example: github.com/sourcegraph/cody")
+        row { text("The URL will be used to retrieve the code context from the Cody API.") }
         row {
-          text("If left empty, Cody will automatically the URL from your project's Git metadata.")
+          text(
+              "If left empty, Cody will automatically infer the URL from your project's Git metadata.")
         }
       }
     }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -1,0 +1,56 @@
+package com.sourcegraph.cody.auth.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.components.fields.ExtendableTextField
+import com.intellij.ui.dsl.builder.panel
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.agent.protocol.GetRepoID
+import java.awt.event.ActionEvent
+import javax.swing.*
+
+class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Context Selection") {
+  private inner class EditCodebaseDialog : DialogWrapper(null, true) {
+    val gitURL =
+        ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+    init {
+      init()
+      title = "Context Selection"
+      setValidationDelay(1000)
+    }
+
+    override fun doValidate(): ValidationInfo? {
+      val repoName = gitURL.text
+      if (repoName.isNotEmpty()) {
+        val server = CodyAgent.getInitializedServer(project).get()
+        val id = server.getRepoId(GetRepoID(repoName)).get()
+        if (id == null) {
+          return ValidationInfo("Repository $repoName does not exist", gitURL)
+        }
+      }
+      return null
+    }
+
+    override fun doOKAction() {
+      CodyAgent.getClient(project).codebase?.onNewExplicitCodebase(gitURL.text)
+      super.doOKAction()
+    }
+
+    override fun createCenterPanel(): JComponent {
+      return panel {
+        row {
+              label("Git URL:")
+              cell(gitURL)
+            }
+            .rowComment("Example: github.com/sourcegraph/cody")
+        row {
+          text("If left empty, Cody will automatically the URL from your project's Git metadata.")
+        }
+      }
+    }
+  }
+  override fun actionPerformed(e: ActionEvent?) {
+    EditCodebaseDialog().showAndGet()
+  }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -39,7 +39,7 @@
             parentId="com.sourcegraph.cody.config.ui.AccountConfigurable"
             instance="com.sourcegraph.cody.config.ui.CodyConfigurable"
             id="com.sourcegraph.cody.config.ui.CodyConfigurable"
-            displayName="Cody AI"
+            displayName="Cody"
             nonDefaultProject="false"
         />
         <projectConfigurable


### PR DESCRIPTION
Previously, there was no way for users to hard-code a specific repository that should be used for the embeddings context. This PR fixes the problem by making the repository name a button that opens a form to change the codebase when you click on it. The name of the codebase is validated with the API so help the user prevent writing a typo.

![CleanShot 2023-09-15 at 16 31 33](https://github.com/sourcegraph/sourcegraph/assets/1408093/66838837-a3bb-405c-b65b-73a914d44541)


## Test plan
Test with this PR https://github.com/sourcegraph/cody/pull/1079

- Open a repository
- Open a file
- Open Cody sidebar
- Click on the repository name
- Try typing a repo that doesn't exist
- Update the text to be a repo that does exist
- Press OK confirm that the custom repo is selected
- Click on the repo again
- Make the input field empty
- Press OK
- Confirm that the repo name is inferred


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
