### PR TITLE
user onboarding: Add dynamic queries to user onboarding

### DIFF
--- a/client/shared/src/settings/temporary/tourState.ts
+++ b/client/shared/src/settings/temporary/tourState.ts
@@ -11,16 +11,13 @@
 import type { Optional } from 'utility-types'
 
 /**
- * Tour supported languages
+ * Tour supported icons
  */
-export enum TourLanguage {
-    C = 'C',
-    Go = 'Go',
-    Java = 'Java',
-    Javascript = 'JavaScript',
-    Php = 'PHP',
-    Python = 'Python',
-    Typescript = 'TypeScript',
+export enum TourIcon {
+    Search = 'Search',
+    Cody = 'Cody',
+    Extension = 'Extension',
+    Check= 'Check'
 }
 
 /**
@@ -29,8 +26,9 @@ export enum TourLanguage {
 export interface TourTaskType {
     title?: string
     dataAttributes?: {}
-    icon?: React.ReactNode
+    icon?: TourIcon
     steps: TourTaskStepType[]
+    requiredSteps?: number
     /**
      * Completion percentage, 0-100. Dynamically calculated field
      */
@@ -44,21 +42,26 @@ export interface TourTaskStepType {
     action:
         | {
               type: 'video'
-              value: string | Record<TourLanguage, string>
+              value: string
           }
         | {
               type: 'link' | 'new-tab-link'
               variant?: 'button-primary'
-              value: string | Record<TourLanguage, string>
+              value: string
           }
         | {
               type: 'restart'
               value: string
           }
+        | {
+              type: 'search-query'
+              query: string
+              snippets?: string[]|Record<string,string[]>
+          }
     /**
-     * HTML string, which will be displayed in info box when navigating to a step link.
+     * String, which will be displayed in info box when navigating to a step link.
      */
-    info?: JSX.Element
+    info?: string
     /**
      * The step will be marked as completed only if one of the "completeAfterEvents" will be triggered
      */
@@ -72,7 +75,6 @@ export interface TourTaskStepType {
 export interface TourState {
     completedStepIds?: string[]
     status?: 'closed' | 'completed'
-    language?: TourLanguage
 }
 
 export type TourListState = Optional<Record<string, TourState>>

--- a/client/shared/src/settings/temporary/tourState.ts
+++ b/client/shared/src/settings/temporary/tourState.ts
@@ -17,7 +17,7 @@ export enum TourIcon {
     Search = 'Search',
     Cody = 'Cody',
     Extension = 'Extension',
-    Check= 'Check'
+    Check = 'Check',
 }
 
 /**
@@ -56,7 +56,7 @@ export interface TourTaskStepType {
         | {
               type: 'search-query'
               query: string
-              snippets?: string[]|Record<string,string[]>
+              snippets?: string[] | Record<string, string[]>
           }
     /**
      * String, which will be displayed in info box when navigating to a step link.

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1670,6 +1670,7 @@ ts_project(
         "src/team/new/team-select/backend.ts",
         "src/tour/GettingStartedTour.tsx",
         "src/tour/components/ItemPicker.tsx",
+        "src/tour/components/Tour/SearchTask.tsx",
         "src/tour/components/Tour/Tour.tsx",
         "src/tour/components/Tour/TourAgent.tsx",
         "src/tour/components/Tour/TourContent.tsx",

--- a/client/web/src/tour/components/Tour/SearchTask.tsx
+++ b/client/web/src/tour/components/Tour/SearchTask.tsx
@@ -1,0 +1,182 @@
+import { type FC, useState, useEffect, useMemo } from 'react'
+
+import { Subscriber, Subscription, fromEvent, of } from 'rxjs'
+import { map } from 'rxjs/operators'
+import {noop, memoize} from 'lodash'
+
+import {
+    LATEST_VERSION,
+    MessageHandlers,
+    SearchMatch,
+    messageHandlers,
+    search,
+    switchAggregateSearchResults,
+    observeMessages,
+    SearchEvent,
+} from '@sourcegraph/shared/src/search/stream'
+import { Link } from '@sourcegraph/wildcard'
+
+import { SearchPatternType } from '../../../graphql-operations'
+import { defaultSnippets } from '../../data'
+import classNames from 'classnames'
+import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+
+interface SearchTaskProps {
+    label: string
+    template: string
+    snippets?: string[]|Record<string, string[]>
+    handleLinkClick: (event: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>) => void
+}
+
+export const SearchTask: FC<SearchTaskProps> = ({ template, snippets, label, handleLinkClick }) => {
+    const [selectedQuery, setSelectedQuery] = useState<string>('')
+
+    const [org] = useState<string>('sourcegraph')
+    const [repo] = useState<string>('sourcegraph')
+    const [lang] = useState<string>('go')
+
+    const hasSnippet = hasSnippetPlaceholder(template)
+    const baseQuery = useMemo(() => org && repo && lang ? buildQuery(template, {
+        [QueryPlacholder.Org]: org,
+        [QueryPlacholder.Repo]: repo,
+        [QueryPlacholder.Lang]: lang,
+    }) : null, [org, repo, lang])
+
+    useEffect(() => {
+        if (baseQuery && hasSnippet && lang) {
+
+            const snippetsQueue = [
+                // Configures snippets (if any)
+                snippets ? Array.isArray(snippets) ? snippets : getLanguageSnippets(snippets, lang) : null,
+                // Hardcoded default language snippets
+                getLanguageSnippets(defaultSnippets, lang),
+                // Hardcoded default snippets for all languages
+                defaultSnippets['*'],
+            ].filter((snippets): snippets is string[] => snippets !== null)
+
+            findQueryFromQueue(baseQuery, snippetsQueue).then(
+                setSelectedQuery,
+                () => setSelectedQuery(buildQuery(baseQuery, {[QueryPlacholder.Snippet]: ""}))
+            )
+        } else if (baseQuery) {
+            setSelectedQuery(buildQuery(baseQuery, {[QueryPlacholder.Snippet]: ""}))
+        }
+    }, [baseQuery, hasSnippet, snippets, lang])
+
+    return selectedQuery ?
+        <Link
+            className={classNames('flex-grow-1')}
+            to={`/search?${buildSearchURLQuery(selectedQuery, SearchPatternType.standard, false)}`}
+            onClick={handleLinkClick}
+        >
+            {label}
+        </Link> : null
+}
+
+function getLanguageSnippets(snippets: Record<string, string[]>, language: string): string[]|null {
+    const languageLower = language.toLowerCase()
+    for (const [langKey, values] of Object.entries(snippets)) {
+        if (langKey.toLowerCase() === languageLower) {
+            return values
+        }
+    }
+    return null
+}
+
+function findQuery(baseQuery: string, snippets: string[]): Promise<string> {
+    let promises = []
+    for (const snippet of snippets) {
+        const query = buildQuery(baseQuery, {[QueryPlacholder.Snippet]: snippet})
+        promises.push(isQuerySuccessful(query).then(isSuccessful => isSuccessful ? query : Promise.reject()))
+    }
+
+    return Promise.any(promises)
+}
+
+async function findQueryFromQueue(query: string, queue: string[][]): Promise<string> {
+    for (const next of queue) {
+        try {
+            return await findQuery(query, next)
+        } catch {}
+    }
+    throw new Error('Unable to determine query that produces results')
+}
+
+enum QueryPlacholder {
+    Snippet = '$$snippet',
+    Org = '$$userorg',
+    Repo = '$$userrepo',
+    Lang = '$$userlang',
+}
+
+function hasSnippetPlaceholder(queryTemplate: string): boolean {
+    return queryTemplate.includes(QueryPlacholder.Snippet)
+}
+
+/**
+ * Replaces '$$abc' variables in a query template with the corresponding value from the
+ * `variables` map.
+ */
+function buildQuery(template: string, variables: Record<string, string>): string {
+    return template.replaceAll(/\$\$\w+/g, match => {
+        return variables[match] ?? match
+    })
+}
+
+/**
+ * Executes the a "restricted" version of the provided query to determine whether
+ * the query returns results or not.
+ */
+function isQuerySuccessful(query: string): Promise<boolean> {
+    let dynamicQuery = `${query} timeout:3s count:1`
+
+    if (!query.includes('type:')) {
+        dynamicQuery += ' select:content'
+    }
+
+    return fetchStreamSuggestions(dynamicQuery)
+        .then(results => results.length > 0)
+        .catch(() => false)
+}
+
+const noopHandler = <T extends SearchEvent>(
+    type: T['type'],
+    eventSource: EventSource,
+    _observer: Subscriber<SearchEvent>
+): Subscription => fromEvent(eventSource, type).subscribe(noop)
+
+const firstMatchMessageHandlers: MessageHandlers = {
+    ...messageHandlers,
+    matches: (type, eventSource, observer) =>
+        observeMessages(type, eventSource).subscribe(data => {
+            observer.next(data)
+            // Once we observer the first `matches` event, complete the stream and close the event source.
+            observer.complete()
+            eventSource.close()
+        }),
+    progress: noopHandler,
+    filters: noopHandler,
+    alert: noopHandler,
+}
+
+/**
+ * Initiates a streaming search, stop at the first `matches` event, and aggregate the results.
+ */
+const fetchStreamSuggestions = memoize((query: string, sourcegraphURL?: string): Promise<SearchMatch[]> => {
+    return search(
+        of(query),
+        {
+            version: LATEST_VERSION,
+            patternType: SearchPatternType.standard,
+            caseSensitive: false,
+            trace: undefined,
+            sourcegraphURL,
+        },
+        firstMatchMessageHandlers
+    )
+        .pipe(
+            switchAggregateSearchResults,
+            map(suggestions => suggestions.results)
+        )
+        .toPromise()
+}, (query, sourcegraphURL) => `${query} + ${sourcegraphURL}`)

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -2,7 +2,7 @@ import { render, cleanup, type RenderResult, fireEvent, act } from '@testing-lib
 import { MemoryRouter } from 'react-router-dom'
 import sinon from 'sinon'
 
-import { TourLanguage, type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
+import { type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -25,34 +25,18 @@ const StepLink: TourTaskStepType = {
         value: '#',
     },
 }
-const StepRestart: TourTaskStepType = {
+const StepRestart = {
     id: 'Restart',
     label: 'Restart',
     action: {
         type: 'restart',
         value: 'Restart button title',
     },
-}
-const StepLanguageSpecificLink: TourTaskStepType = {
-    id: 'LanguageSpecificLink',
-    label: 'Language Specific Link',
-    action: {
-        type: 'link',
-        value: {
-            [TourLanguage.C]: '#',
-            [TourLanguage.Go]: '#',
-            [TourLanguage.Java]: '#',
-            [TourLanguage.Javascript]: '#',
-            [TourLanguage.Php]: '#',
-            [TourLanguage.Python]: '#',
-            [TourLanguage.Typescript]: '#',
-        },
-    },
-}
+} satisfies TourTaskStepType
 const mockedTasks: TourTaskType[] = [
     {
         title: 'Task 1',
-        steps: [StepLink, StepVideo, StepLanguageSpecificLink, StepRestart],
+        steps: [StepLink, StepVideo, StepRestart],
     },
 ]
 
@@ -120,34 +104,6 @@ describe('Tour.tsx', () => {
                 TourId + StepLink.id + 'Clicked',
                 { language: undefined },
                 { language: undefined }
-            ).calledOnce
-        ).toBeTruthy()
-    })
-
-    test('handles "type=link" language specific step and triggers event log', () => {
-        const { getByText } = setup()
-        fireEvent.click(getByText(StepLanguageSpecificLink.label))
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + StepLanguageSpecificLink.id + 'Clicked',
-                { language: undefined },
-                { language: undefined }
-            ).calledOnce
-        ).toBeTruthy()
-        fireEvent.click(getByText(TourLanguage.Javascript))
-
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + 'LanguageClicked',
-                { language: TourLanguage.Javascript },
-                { language: TourLanguage.Javascript }
-            ).calledOnce
-        ).toBeTruthy()
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + StepLanguageSpecificLink.id + 'Clicked',
-                { language: TourLanguage.Javascript },
-                { language: TourLanguage.Javascript }
             ).calledOnce
         ).toBeTruthy()
     })

--- a/client/web/src/tour/components/Tour/Tour.test.tsx
+++ b/client/web/src/tour/components/Tour/Tour.test.tsx
@@ -2,7 +2,7 @@ import { render, cleanup, type RenderResult, fireEvent, act } from '@testing-lib
 import { MemoryRouter } from 'react-router-dom'
 import sinon from 'sinon'
 
-import { type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
+import type { TourTaskStepType, TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -60,10 +60,7 @@ describe('Tour.tsx', () => {
     test('renders and triggers initial event log', () => {
         const { getByTestId } = setup()
         expect(getByTestId('tour-content')).toBeTruthy()
-        expect(
-            mockedTelemetryService.log.withArgs(TourId + 'Shown', { language: undefined }, { language: undefined })
-                .calledOnce
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + 'Shown').calledOnce).toBeTruthy()
     })
 
     test('handles closing tour and triggers event log', () => {
@@ -73,10 +70,7 @@ describe('Tour.tsx', () => {
         fireEvent.click(getByTestId('tour-close-btn'))
 
         expect(() => getByTestId('tour-content')).toThrow()
-        expect(
-            mockedTelemetryService.log.withArgs(TourId + 'Closed', { language: undefined }, { language: undefined })
-                .calledOnce
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + 'Closed').calledOnce).toBeTruthy()
     })
 
     test('handles "type=video" step and triggers event log', () => {
@@ -87,39 +81,21 @@ describe('Tour.tsx', () => {
 
         // click somewhere outside to close video modal
         fireEvent.click(getByTestId('modal-video-close'))
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + StepVideo.id + 'Clicked',
-                { language: undefined },
-                { language: undefined }
-            ).calledOnce
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + StepVideo.id + 'Clicked').calledOnce).toBeTruthy()
     })
 
     test('handles "type=link" step and triggers event log', () => {
         const { getByText } = setup()
         fireEvent.click(getByText(StepLink.label))
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + StepLink.id + 'Clicked',
-                { language: undefined },
-                { language: undefined }
-            ).calledOnce
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + StepLink.id + 'Clicked').calledOnce).toBeTruthy()
     })
 
     test('handles "type=restart" and triggers event log', () => {
         const { getByText } = setup()
 
-        fireEvent.click(getByText(StepRestart.action.value as string))
+        fireEvent.click(getByText(StepRestart.action.value))
 
-        expect(
-            mockedTelemetryService.log.withArgs(
-                TourId + StepRestart.id + 'Clicked',
-                { language: undefined },
-                { language: undefined }
-            ).callCount
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + StepRestart.id + 'Clicked').callCount).toBeTruthy()
     })
 
     test('handles completing tour and triggers event log', () => {
@@ -127,9 +103,6 @@ describe('Tour.tsx', () => {
         act(() => {
             fireEvent.click(getByText(StepLink.label))
         })
-        expect(
-            mockedTelemetryService.log.withArgs(TourId + 'Completed', { language: undefined }, { language: undefined })
-                .calledOnce
-        ).toBeTruthy()
+        expect(mockedTelemetryService.log.withArgs(TourId + 'Completed').calledOnce).toBeTruthy()
     })
 })

--- a/client/web/src/tour/components/Tour/Tour.tsx
+++ b/client/web/src/tour/components/Tour/Tour.tsx
@@ -59,7 +59,7 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
             [onLogEvent, restart]
         )
 
-        let extendedTasks: TourTaskType[] = useMemo(
+        const extendedTasks: TourTaskType[] = useMemo(
             () =>
                 tasks.map(task => {
                     const extendedSteps = task.steps.map(step => ({
@@ -81,8 +81,9 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
 
         useEffect(() => {
             if (
-                !['completed', 'closed'].includes(status as string) &&
-                extendedTasks.filter(step => step.completed === 100).length === extendedTasks.length
+                status !== 'closed' &&
+                status !== 'completed' &&
+                extendedTasks.filter(task => task.completed === 100).length === extendedTasks.length
             ) {
                 onLogEvent('Completed')
                 setStatus('completed')
@@ -93,14 +94,15 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
             return null
         }
 
+        const finalTasks = [...extendedTasks]
         if (status === 'completed' && extraTask) {
-            extendedTasks = [extraTask, ...extendedTasks]
+            finalTasks.unshift(extraTask)
         }
 
         return (
             <TourContext.Provider value={{ onStepClick, onRestart }}>
                 <TourContent {...props} onClose={onClose} tasks={extendedTasks} />
-                <TourAgent tasks={extendedTasks} telemetryService={telemetryService} onStepComplete={onStepComplete} />
+                <TourAgent tasks={finalTasks} telemetryService={telemetryService} onStepComplete={onStepComplete} />
             </TourContext.Provider>
         )
     }

--- a/client/web/src/tour/components/Tour/Tour.tsx
+++ b/client/web/src/tour/components/Tour/Tour.tsx
@@ -16,20 +16,10 @@ export type TourProps = TelemetryProps & {
 
 export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> = React.memo(
     ({ id: tourId, tasks, extraTask, telemetryService, ...props }) => {
-        const {
-            completedStepIds = [],
-            status,
-            setStepCompleted,
-            setStatus,
-            restart,
-        } = useTour(tourId)
+        const { completedStepIds = [], status, setStepCompleted, setStatus, restart } = useTour(tourId)
         const onLogEvent = useCallback(
             (eventName: string, eventProperties?: any, publicArgument?: any) => {
-                telemetryService.log(
-                    tourId + eventName,
-                    { ...eventProperties },
-                    { ...publicArgument }
-                )
+                telemetryService.log(tourId + eventName, { ...eventProperties }, { ...publicArgument })
             },
             [telemetryService, tourId]
         )
@@ -81,7 +71,8 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
                         ...task,
                         steps: extendedSteps,
                         completed: Math.round(
-                            (100 * extendedSteps.filter(step => step.isCompleted).length) / (task.requiredSteps ?? extendedSteps.length)
+                            (100 * extendedSteps.filter(step => step.isCompleted).length) /
+                                (task.requiredSteps ?? extendedSteps.length)
                         ),
                     }
                 }),
@@ -108,11 +99,7 @@ export const Tour: React.FunctionComponent<React.PropsWithChildren<TourProps>> =
 
         return (
             <TourContext.Provider value={{ onStepClick, onRestart }}>
-                <TourContent
-                    {...props}
-                    onClose={onClose}
-                    tasks={extendedTasks}
-                />
+                <TourContent {...props} onClose={onClose} tasks={extendedTasks} />
                 <TourAgent tasks={extendedTasks} telemetryService={telemetryService} onStepComplete={onStepComplete} />
             </TourContext.Provider>
         )

--- a/client/web/src/tour/components/Tour/TourNewTabLink.tsx
+++ b/client/web/src/tour/components/Tour/TourNewTabLink.tsx
@@ -8,10 +8,7 @@ export interface NewTabLinkProps {
     variant: 'button' | 'link'
     className?: string
     to: string
-    onClick: (
-        event: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>,
-        step: TourTaskStepType
-    ) => void
+    onClick: (step: TourTaskStepType) => void
 }
 
 export const TourNewTabLink: FunctionComponent<NewTabLinkProps> = ({ step, onClick, variant, to }) => {
@@ -24,14 +21,14 @@ export const TourNewTabLink: FunctionComponent<NewTabLinkProps> = ({ step, onCli
 
     if (variant === 'button') {
         return (
-            <ButtonLink variant="primary" {...commonLinkProps} onSelect={event => onClick(event, step)}>
+            <ButtonLink variant="primary" {...commonLinkProps} onSelect={() => onClick(step)}>
                 {step.label}
             </ButtonLink>
         )
     }
 
     return (
-        <Link {...commonLinkProps} onClick={event => onClick(event, step)}>
+        <Link {...commonLinkProps} onClick={() => onClick(step)}>
             {step.label}
         </Link>
     )

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -1,22 +1,21 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, { useCallback, useContext, useMemo } from 'react'
+import type { FC } from 'react'
 
-import { mdiCheckCircle } from '@mdi/js'
+import { mdiCheckCircle, mdiMagnify, mdiPuzzleOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { CircularProgressbar } from 'react-circular-progressbar'
-import { useNavigate } from 'react-router-dom'
 
 import { ModalVideo } from '@sourcegraph/branded'
-import { isExternalLink } from '@sourcegraph/common'
-import { TourLanguage, type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
+import { TourIcon, type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
-
-import { ItemPicker } from '../ItemPicker'
 
 import { TourContext } from './context'
 import { TourNewTabLink } from './TourNewTabLink'
-import { isLanguageRequired, getTourTaskStepActionValue } from './utils'
 
 import styles from './Tour.module.scss'
+import { AskCodyIcon } from '@sourcegraph/cody-ui/dist/icons/AskCodyIcon'
+import { SearchTask } from './SearchTask'
+import { buildURIMarkers } from './utils'
 
 type TourTaskProps = TourTaskType & {
     variant?: 'small'
@@ -33,54 +32,26 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
     variant,
     dataAttributes = {},
 }) => {
-    const [selectedStep, setSelectedStep] = useState<TourTaskStepType>()
-    const [showLanguagePicker, setShowLanguagePicker] = useState(false)
-    const { language, onLanguageSelect, onStepClick, onRestart } = useContext(TourContext)
+    const { onStepClick, onRestart } = useContext(TourContext)
 
     const handleLinkClick = useCallback(
         (
-            event: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>,
             step: TourTaskStepType
         ) => {
-            onStepClick(step, language)
-            if (isLanguageRequired(step) && !language) {
-                event.preventDefault()
-                setShowLanguagePicker(true)
-                setSelectedStep(step)
-            }
+            onStepClick(step)
         },
-        [language, onStepClick]
+        [onStepClick]
     )
 
     const handleVideoToggle = useCallback(
         (isOpen: boolean, step: TourTaskStepType) => {
             if (!isOpen) {
-                onStepClick(step, language)
+                onStepClick(step)
             }
         },
-        [language, onStepClick]
+        [onStepClick]
     )
 
-    const onLanguageClose = useCallback(() => setShowLanguagePicker(false), [])
-
-    const navigate = useNavigate()
-    const handleLanguageSelect = useCallback(
-        (language: TourLanguage) => {
-            onLanguageSelect(language)
-            setShowLanguagePicker(false)
-            if (!selectedStep) {
-                return
-            }
-            onStepClick(selectedStep, language)
-            const url = getTourTaskStepActionValue(selectedStep, language)
-            if (isExternalLink(url)) {
-                window.open(url, '_blank')
-            } else {
-                navigate(url)
-            }
-        },
-        [onStepClick, onLanguageSelect, selectedStep, navigate]
-    )
     const attributes = useMemo(
         () =>
             Object.entries(dataAttributes).reduce(
@@ -89,18 +60,6 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
             ),
         [dataAttributes]
     )
-
-    if (showLanguagePicker) {
-        return (
-            <ItemPicker
-                title="Please select a language:"
-                className={classNames(variant !== 'small' && 'pl-2')}
-                items={Object.values(TourLanguage)}
-                onClose={onLanguageClose}
-                onSelect={handleLanguageSelect}
-            />
-        )
-    }
 
     const isMultiStep = steps.length > 1
     return (
@@ -111,11 +70,11 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
             )}
             {...attributes}
         >
-            {icon && variant !== 'small' && <span className={styles.taskIcon}>{icon}</span>}
+            {variant !== 'small' && icon && <TaskIcon icon={icon} />}
             <div className={classNames('flex-grow-1', variant !== 'small' && 'h-100 d-flex flex-column')}>
                 {title && (
                     <div className="d-flex justify-content-between position-relative">
-                        {icon && variant === 'small' && <span className={classNames(styles.taskIcon)}>{icon}</span>}
+                        {variant === 'small' && icon && <TaskIcon icon={icon} />}
                         <Text className={styles.title}>{title}</Text>
                         {completed === 100 && (
                             <Icon size="sm" className="text-success" aria-label="Completed" svgPath={mdiCheckCircle} />
@@ -139,11 +98,19 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                 >
                     {steps.map(step => (
                         <li key={step.id} className={classNames(styles.stepListItem, 'd-flex align-items-center')}>
+                            {step.action.type === 'search-query' && (
+                                <SearchTask
+                                    label={step.label}
+                                    template={step.action.query}
+                                    snippets={step.action.snippets}
+                                    handleLinkClick={() => handleLinkClick(step)}
+                                />
+                            )}
                             {step.action.type === 'link' && (
                                 <Link
                                     className="flex-grow-1"
-                                    to={getTourTaskStepActionValue(step, language)}
-                                    onClick={event => handleLinkClick(event, step)}
+                                    to={buildURIMarkers(step.action.value, step.id)}
+                                    onClick={() => handleLinkClick(step)}
                                 >
                                     {step.label}
                                 </Link>
@@ -153,7 +120,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                                     step={step}
                                     variant={step.action.variant === 'button-primary' ? 'button' : 'link'}
                                     className={classNames('flex-grow-1')}
-                                    to={getTourTaskStepActionValue(step, language)}
+                                    to={buildURIMarkers(step.action.value, step.id)}
                                     onClick={handleLinkClick}
                                 />
                             )}
@@ -178,7 +145,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
                                     title={step.label}
                                     className="flex-grow-1"
                                     titleClassName="shadow-none text-left p-0 m-0"
-                                    src={getTourTaskStepActionValue(step, language)}
+                                    src={buildURIMarkers(step.action.value, step.id)}
                                     onToggle={isOpen => handleVideoToggle(isOpen, step)}
                                 />
                             )}
@@ -196,4 +163,35 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
             </div>
         </div>
     )
+}
+
+const TaskIcon: FC<{icon: TourIcon}> = ({icon}) => {
+    if (icon === TourIcon.Cody) {
+        return <span className={styles.taskIcon}><AskCodyIcon /></span>
+    }
+
+    let svgPath: string
+    let className = ''
+
+    switch (icon) {
+        case TourIcon.Search:
+            svgPath = mdiMagnify
+            break
+        case TourIcon.Extension:
+            svgPath = mdiPuzzleOutline
+            break
+        case TourIcon.Check:
+            className = 'text-success'
+            svgPath = mdiCheckCircle
+            break
+    }
+
+    return <span className={styles.taskIcon}><Icon
+        className={className}
+        svgPath={svgPath}
+        inline={false}
+        aria-hidden={true}
+        height="2.3rem"
+        width="2.3rem"
+    /></span>
 }

--- a/client/web/src/tour/components/Tour/TourTask.tsx
+++ b/client/web/src/tour/components/Tour/TourTask.tsx
@@ -6,16 +6,16 @@ import classNames from 'classnames'
 import { CircularProgressbar } from 'react-circular-progressbar'
 
 import { ModalVideo } from '@sourcegraph/branded'
+import { AskCodyIcon } from '@sourcegraph/cody-ui/dist/icons/AskCodyIcon'
 import { TourIcon, type TourTaskStepType, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
 import { TourContext } from './context'
+import { SearchTask } from './SearchTask'
 import { TourNewTabLink } from './TourNewTabLink'
+import { buildURIMarkers } from './utils'
 
 import styles from './Tour.module.scss'
-import { AskCodyIcon } from '@sourcegraph/cody-ui/dist/icons/AskCodyIcon'
-import { SearchTask } from './SearchTask'
-import { buildURIMarkers } from './utils'
 
 type TourTaskProps = TourTaskType & {
     variant?: 'small'
@@ -35,9 +35,7 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
     const { onStepClick, onRestart } = useContext(TourContext)
 
     const handleLinkClick = useCallback(
-        (
-            step: TourTaskStepType
-        ) => {
+        (step: TourTaskStepType) => {
             onStepClick(step)
         },
         [onStepClick]
@@ -165,9 +163,13 @@ export const TourTask: React.FunctionComponent<React.PropsWithChildren<TourTaskP
     )
 }
 
-const TaskIcon: FC<{icon: TourIcon}> = ({icon}) => {
+const TaskIcon: FC<{ icon: TourIcon }> = ({ icon }) => {
     if (icon === TourIcon.Cody) {
-        return <span className={styles.taskIcon}><AskCodyIcon /></span>
+        return (
+            <span className={styles.taskIcon}>
+                <AskCodyIcon />
+            </span>
+        )
     }
 
     let svgPath: string
@@ -186,12 +188,16 @@ const TaskIcon: FC<{icon: TourIcon}> = ({icon}) => {
             break
     }
 
-    return <span className={styles.taskIcon}><Icon
-        className={className}
-        svgPath={svgPath}
-        inline={false}
-        aria-hidden={true}
-        height="2.3rem"
-        width="2.3rem"
-    /></span>
+    return (
+        <span className={styles.taskIcon}>
+            <Icon
+                className={className}
+                svgPath={svgPath}
+                inline={false}
+                aria-hidden={true}
+                height="2.3rem"
+                width="2.3rem"
+            />
+        </span>
+    )
 }

--- a/client/web/src/tour/components/Tour/context.tsx
+++ b/client/web/src/tour/components/Tour/context.tsx
@@ -1,22 +1,12 @@
 import React from 'react'
 
-import type { TourLanguage, TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
+import type { TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
 
 interface TourContextType {
     /**
-     * Language user has chosen initially for the tour
-     */
-    language?: TourLanguage
-
-    /**
-     * Stores context.language and triggers `${TourId}LanguageClicked` event log
-     */
-    onLanguageSelect: (language: TourLanguage) => void
-
-    /**
      * Marks step as completed and triggers `${TourId}${step.id}Clicked` event log
      */
-    onStepClick: (step: TourTaskStepType, language?: TourLanguage) => void
+    onStepClick: (step: TourTaskStepType) => void
 
     /**
      * Restarts tour and triggers `${TourId}${step.id}Clicked` event log

--- a/client/web/src/tour/components/Tour/useTour.test.tsx
+++ b/client/web/src/tour/components/Tour/useTour.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook, cleanup, act } from '@testing-library/react'
 import type { WrapperComponent } from '@testing-library/react-hooks'
 
-import { TourLanguage } from '@sourcegraph/shared/src/settings/temporary'
 import type { TemporarySettings } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 
@@ -34,13 +33,13 @@ describe('useTour.ts', () => {
     })
 
     test('returns initial state from temporary settings', () => {
-        const initialState: TourState = { completedStepIds: [], status: 'closed', language: TourLanguage.Typescript }
+        const initialState: TourState = { completedStepIds: [], status: 'closed' }
         const { result } = setup({ [TourId]: initialState })
         expect(getFieldsAsObject(result.current)).toMatchObject(initialState)
     })
 
     test('clears state when restart called', () => {
-        const initialState: TourState = { completedStepIds: [], status: 'closed', language: TourLanguage.Typescript }
+        const initialState: TourState = { completedStepIds: [], status: 'closed' }
         const { result } = setup({ [TourId]: initialState })
         expect(getFieldsAsObject(result.current)).toMatchObject(initialState)
         act(() => result.current.restart())
@@ -51,12 +50,6 @@ describe('useTour.ts', () => {
         const { result } = setup()
         act(() => result.current.setStatus('completed'))
         expect(result.current.status).toEqual('completed')
-    })
-
-    test('updates "language" when "setLanguage" called', () => {
-        const { result } = setup()
-        act(() => result.current.setLanguage(TourLanguage.Go))
-        expect(result.current.language).toEqual(TourLanguage.Go)
     })
 
     test('updates "completedStepIds" as unique array when "setStepCompleted" called', () => {

--- a/client/web/src/tour/components/Tour/useTour.ts
+++ b/client/web/src/tour/components/Tour/useTour.ts
@@ -3,18 +3,16 @@ import { useCallback } from 'react'
 import { omit, uniq } from 'lodash'
 import type { Optional } from 'utility-types'
 
-import { useTemporarySetting, type TourLanguage } from '@sourcegraph/shared/src/settings/temporary'
+import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 
 export interface TourState {
     completedStepIds?: string[]
     status?: 'closed' | 'completed'
-    language?: TourLanguage
 }
 
 export type TourListState = Optional<Record<string, TourState>>
 
 export type UseTourReturnType = TourState & {
-    setLanguage: (language: TourLanguage) => void
     setStepCompleted: (stepId: string) => void
     setStatus: (status: TourState['status']) => void
     restart: () => void
@@ -22,16 +20,6 @@ export type UseTourReturnType = TourState & {
 
 export function useTour(tourKey: string): UseTourReturnType {
     const [allToursSate, setAllToursState, loadStatus] = useTemporarySetting('onboarding.quickStartTour')
-
-    const setLanguage = useCallback(
-        (language: TourLanguage): void => {
-            setAllToursState(previousState => ({
-                ...previousState,
-                [tourKey]: { ...previousState?.[tourKey], language },
-            }))
-        },
-        [setAllToursState, tourKey]
-    )
 
     const setStepCompleted = useCallback(
         (stepId: string): void =>
@@ -63,7 +51,6 @@ export function useTour(tourKey: string): UseTourReturnType {
         ...allToursSate?.[tourKey],
         // To avoid rendering Tour.tsx when state is still loading
         ...(loadStatus !== 'loaded' ? { status: 'closed' } : {}),
-        setLanguage,
         setStepCompleted,
         setStatus,
         restart,

--- a/client/web/src/tour/components/Tour/utils.tsx
+++ b/client/web/src/tour/components/Tour/utils.tsx
@@ -1,7 +1,5 @@
 import isAbsoluteURL from 'is-absolute-url'
 
-import type { TourLanguage, TourTaskStepType } from '@sourcegraph/shared/src/settings/temporary'
-
 /**
  * Returns a new URL w/ tour state tracking query parameters. This is used to show/hide tour task info box.
  *
@@ -9,7 +7,7 @@ import type { TourLanguage, TourTaskStepType } from '@sourcegraph/shared/src/set
  * @param stepId TourTaskStepType id
  * @example /search?q=context:global+repo:my-repo&patternType=literal + &tour=true&stepId=DiffSearch
  */
-const buildURIMarkers = (href: string, stepId: string): string => {
+export const buildURIMarkers = (href: string, stepId: string): string => {
     const isRelative = !isAbsoluteURL(href)
 
     try {
@@ -31,18 +29,3 @@ export const parseURIMarkers = (searchParameters: string): { isTour: boolean; st
     const stepId = parameters.get('stepId')
     return { isTour, stepId }
 }
-
-/**
- * Check if given TourTaskStepType.action has a language specific value
- */
-export const isLanguageRequired = (step: TourTaskStepType): boolean => typeof step.action.value !== 'string'
-
-/**
- * Returns a TourTaskStepType.action.value if possible, '#' otherwise.
- */
-export const getTourTaskStepActionValue = (step: TourTaskStepType, language?: TourLanguage): string =>
-    typeof step.action.value === 'string'
-        ? buildURIMarkers(step.action.value, step.id)
-        : language
-        ? buildURIMarkers(step.action.value[language], step.id)
-        : '#'

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -56,7 +56,7 @@ export const authenticatedTasks: TourTaskType[] = [
                 action: {
                     type: 'new-tab-link',
                     value: 'https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai',
-                }
+                },
             },
             {
                 id: 'CodyJetbrains',
@@ -64,7 +64,7 @@ export const authenticatedTasks: TourTaskType[] = [
                 action: {
                     type: 'new-tab-link',
                     value: 'https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph',
-                }
+                },
             },
             {
                 id: 'CodyWeb',
@@ -72,7 +72,7 @@ export const authenticatedTasks: TourTaskType[] = [
                 action: {
                     type: 'new-tab-link',
                     value: '/cody',
-                }
+                },
             },
         ],
         requiredSteps: 1,
@@ -87,7 +87,7 @@ export const authenticatedTasks: TourTaskType[] = [
                 action: {
                     type: 'new-tab-link',
                     value: 'https://docs.sourcegraph.com/integration/browser_extension',
-                }
+                },
             },
         ],
     },

--- a/client/web/src/tour/data/index.tsx
+++ b/client/web/src/tour/data/index.tsx
@@ -1,150 +1,93 @@
-import { mdiCheckCircle, mdiMagnify, mdiPuzzleOutline, mdiShieldSearch, mdiNotebook, mdiCursorPointer } from '@mdi/js'
-
-import { TourLanguage, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
-import { Code, Icon } from '@sourcegraph/wildcard'
+import { TourIcon, type TourTaskType } from '@sourcegraph/shared/src/settings/temporary'
 
 /**
  * Tour tasks for authenticated users. Extended/all use-cases.
  */
 export const authenticatedTasks: TourTaskType[] = [
     {
-        title: 'Reuse existing code',
-        icon: <Icon svgPath={mdiMagnify} inline={false} aria-hidden={true} height="2.3rem" width="2.3rem" />,
+        title: 'Code search with filters',
+        icon: TourIcon.Search,
         steps: [
             {
-                id: 'ReuseExistingCode',
-                label: 'Discover and learn how to use existing libraries.',
+                id: 'CodeSearch',
+                label: 'Search all orgs or repositories matching a name for a literal code snippet',
                 action: {
-                    type: 'link',
-                    value: {
-                        [TourLanguage.C]: '/search?q=context:global+memcpy(+-file:test+lang:c+&patternType=regexp',
-                        [TourLanguage.Go]:
-                            '/search?q=context:global+repo:^github.com/golang/go%24+ReadResponse(+-file:test.go&patternType=regexp',
-                        [TourLanguage.Java]:
-                            '/search?q=context:global+repo:github.com/square/+lang:java+-file:test+GiftCard&patternType=literal',
-                        [TourLanguage.Javascript]:
-                            '/search?q=context:global+repo:react+lang:JavaScript+-file:test+createPortal&patternType=literal',
-                        [TourLanguage.Php]:
-                            '/search?q=context:global+repo:laravel+lang:php+-file:test+login%28&patternType=regexp&case=yes',
-                        [TourLanguage.Python]:
-                            '/search?q=context:global+repo:^github.com/pandas-dev/pandas%24++lang:python+-file:test+pd.DataFrame(&patternType=literal&case=yes',
-                        [TourLanguage.Typescript]:
-                            '/search?q=context:global+repo:react+lang:typescript+-file:test+createPortal%28&patternType=regexp&case=yes',
-                    },
-                },
-                info: (
-                    <>
-                        <strong>Discover code across multiple repositories</strong>
-                        <br />
-                        The <Code>repo:</Code> keyword allows searching in multiple repositories matching a term. Use it
-                        to reference all of your projects or find open source examples.
-                    </>
-                ),
-            },
-        ],
-    },
-    {
-        title: 'Install an IDE extension',
-        icon: <Icon svgPath={mdiPuzzleOutline} inline={false} aria-hidden={true} height="2.3rem" width="2.3rem" />,
-        steps: [
-            {
-                id: 'InstallIDEExtension',
-                label: 'Integrate Sourcegraph with your favorite IDE',
-                action: {
-                    type: 'new-tab-link',
-                    value: 'https://docs.sourcegraph.com/integration/editor?utm_medium=direct-traffic&utm_source=in-product&utm_content=getting-started',
+                    type: 'search-query',
+                    query: 'repo:$$userrepo lang:$$userlang $$snippet',
                 },
             },
         ],
     },
     {
-        title: 'Find and fix vulnerabilities',
-        icon: <Icon svgPath={mdiShieldSearch} inline={false} aria-hidden={true} height="2.3rem" width="2.3rem" />,
+        title: 'Commit search',
+        icon: TourIcon.Search,
         steps: [
             {
-                id: 'WatchVideo',
-                label: 'Watch the 60 second video',
-                action: { type: 'video', value: 'https://www.youtube.com/embed/13OqKPXqZXo' },
+                id: 'CommitSearch',
+                label: 'Search commit titles and messages with-in a specific organization and repository',
+                action: {
+                    type: 'search-query',
+                    query: 'repo:$$userorg/$$userrepo lang:$$userlang type:commit before:"last week"',
+                },
             },
+        ],
+    },
+    {
+        title: 'Diff search',
+        icon: TourIcon.Search,
+        steps: [
             {
                 id: 'DiffSearch',
-                label: 'Find problematic code in diffs',
+                label: 'Search diffs for changes in code via filters like before, after, and author',
                 action: {
-                    type: 'link',
-                    value: {
-                        [TourLanguage.C]:
-                            '/search?q=context:global+repo:chref/doh+type:diff+select:commit.diff.removed+mode&patternType=literal',
-                        [TourLanguage.Go]:
-                            '/search?q=context:global+repo:%5Egitlab%5C.com/sourcegraph/sourcegraph%24+type:diff+lang:go+select:commit.diff.removed+NameSpaceOrgId&patternType=literal',
-                        [TourLanguage.Java]:
-                            '/search?q=context:global+repo:sourcegraph-testing/sg-hadoop+lang:java+type:diff+select:commit.diff.removed+getConf&patternType=literal',
-                        [TourLanguage.Javascript]:
-                            '/search?q=context:global+repo:sourcegraph/sourcegraph%24+lang:javascript+-file:test+type:diff+select:commit.diff.removed+promise&patternType=literal',
-                        [TourLanguage.Php]:
-                            '/search?q=context:global+repo:laravel/laravel.*+lang:php++type:diff+select:commit.diff.removed+password&patternType=regexp&case=yes',
-                        [TourLanguage.Python]:
-                            '/search?q=context:global+repo:pallets/+lang:python+type:diff+select:commit.diff.removed+password&patternType=regexp&case=yes',
-                        [TourLanguage.Typescript]:
-                            '/search?q=context:global+repo:sourcegraph/sourcegraph%24+lang:typescript+type:diff+select:commit.diff.removed+authenticatedUser&patternType=regexp&case=yes',
-                    },
+                    type: 'search-query',
+                    query: 'repo:$$userorg/$$userrepo type:diff after:"last month" $$snippet',
                 },
-                info: (
-                    <>
-                        <strong>Searching diffs for removed code</strong>
-                        <br />
-                        Find removed code without browsing through history or trying to remember which file it was in.
-                    </>
-                ),
             },
         ],
     },
     {
-        title: 'Respond to incidents',
-        icon: <Icon svgPath={mdiNotebook} inline={false} aria-hidden={true} height="2.3rem" width="2.3rem" />,
+        title: 'Try Cody, our AI coding assistant',
+        icon: TourIcon.Cody,
         steps: [
             {
-                id: 'Notebook',
-                label: 'Document post mortems using search notebooks',
+                id: 'CodyVSCode',
+                label: 'Install for VS Code',
                 action: {
                     type: 'new-tab-link',
-                    value: 'https://sourcegraph.com/notebooks/Tm90ZWJvb2s6MQ==',
-                },
+                    value: 'https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai',
+                }
+            },
+            {
+                id: 'CodyJetbrains',
+                label: 'Install for Jetbrains',
+                action: {
+                    type: 'new-tab-link',
+                    value: 'https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph',
+                }
+            },
+            {
+                id: 'CodyWeb',
+                label: 'Try Cody in Sourcegraph',
+                action: {
+                    type: 'new-tab-link',
+                    value: '/cody',
+                }
             },
         ],
+        requiredSteps: 1,
     },
     {
-        title: 'Understand a new codebase',
-        icon: <Icon svgPath={mdiCursorPointer} inline={false} aria-hidden={true} height="2.3rem" width="2.3rem" />,
+        title: 'Improve PRs With Sourcegraph',
+        icon: TourIcon.Extension,
         steps: [
             {
-                id: 'PowerCodeNav',
-                label: 'Get IDE-like code navigation features across many repositories',
+                id: 'BrowserExtensions',
+                label: 'Install the browser extension and leverage Sourcegraph code intelligence in reviews',
                 action: {
-                    type: 'link',
-                    value: {
-                        [TourLanguage.C]: '/github.com/torvalds/linux/-/blob/arch/arm/kernel/atags_compat.c?L196:8',
-                        [TourLanguage.Go]:
-                            '/github.com/sourcegraph/sourcegraph/-/blob/internal/featureflag/featureflag.go?L9:6',
-                        [TourLanguage.Java]:
-                            '/github.com/square/okhttp/-/blob/samples/guide/src/main/java/okhttp3/recipes/PrintEvents.java?L126:27',
-                        [TourLanguage.Javascript]:
-                            '/github.com/mozilla/pdf.js/-/blob/src/display/display_utils.js?L261:16',
-                        [TourLanguage.Php]:
-                            '/github.com/square/connect-api-examples/-/blob/connect-examples/v1/php/payments-report.php?L164:32',
-                        [TourLanguage.Python]: '/github.com/google-research/bert/-/blob/extract_features.py?L152:7',
-                        [TourLanguage.Typescript]:
-                            '/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/query/hover.ts?L202:14',
-                    },
-                },
-                info: (
-                    <>
-                        <strong>Find References</strong>
-                        <br />
-                        Hover over a token in the highlighted line to open code intel, then click ‘Find References’ to
-                        locate all calls of this code.
-                    </>
-                ),
-                completeAfterEvents: ['findReferences'],
+                    type: 'new-tab-link',
+                    value: 'https://docs.sourcegraph.com/integration/browser_extension',
+                }
             },
         ],
     },
@@ -155,16 +98,7 @@ export const authenticatedTasks: TourTaskType[] = [
  */
 export const authenticatedExtraTask: TourTaskType = {
     title: 'All done!',
-    icon: (
-        <Icon
-            className="text-success"
-            svgPath={mdiCheckCircle}
-            inline={false}
-            aria-hidden={true}
-            height="2.3rem"
-            width="2.3rem"
-        />
-    ),
+    icon: TourIcon.Check,
     steps: [
         {
             id: 'RestartTour',
@@ -172,4 +106,10 @@ export const authenticatedExtraTask: TourTaskType = {
             action: { type: 'restart', value: 'Restart tour' },
         },
     ],
+}
+
+export const defaultSnippets: Record<string, string[]> = {
+    Go: ['stuct {', 'interface {', 'func ('],
+    C: ['switch(', 'static void', 'if(', 'etc', '){'],
+    '*': ['todo', 'fixme'],
 }

--- a/schema/onboardingtour.schema.json
+++ b/schema/onboardingtour.schema.json
@@ -18,10 +18,8 @@
             "description": "Title of this task",
             "type": "string"
           },
-          "dataAttributes": {
-            "description": "Additional attributes to add to the task HTML element as data-* attributes",
-            "type": "object",
-            "additionalProperties": true
+          "icon": {
+            "enum": ["Search", "Cody", "Extension", "Check"]
           },
           "steps": {
             "description": "Steps that need to be completed by the user",
@@ -53,7 +51,7 @@
                           "const": "video"
                         },
                         "value": {
-                          "$ref": "#/definitions/StepAction"
+                          "type": "string"
                         }
                       },
                       "required": ["type", "value"]
@@ -70,7 +68,7 @@
                           "const": "button-primary"
                         },
                         "value": {
-                          "$ref": "#/definitions/StepAction"
+                          "type": "string"
                         }
                       },
                       "required": ["type", "value"]
@@ -88,8 +86,47 @@
                         }
                       },
                       "required": ["type", "value"]
+                    },
+                    {
+                      "title": "Search step",
+                      "description": "Search query step",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "const": "search-query"
+                        },
+                        "query": {
+                          "description": "The query template to use.",
+                          "type": "string"
+                        },
+                        "snippets": {
+                          "description": "Possible code snippets for this query. Can also be a language -> code snippets map.",
+                          "oneOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "patternProperties": {
+                                "^.*$": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "required": ["type", "query"]
                     }
                   ]
+                },
+                "requriredSteps": {
+                  "description": "Set this property if only a subset of steps are required for this task to complete.",
+                  "type": "number"
                 },
                 "info": {
                   "type": "string"
@@ -112,23 +149,5 @@
     }
   },
   "required": ["tasks"],
-  "additionalProperties": false,
-  "definitions": {
-    "StepAction": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object",
-          "patternProperties": {
-            "^.*$": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    }
-  }
+  "additionalProperties": false
 }


### PR DESCRIPTION
Based on #56641 

This PR introduces a new "search query" step type to the onboarding tour. This type takes a query template and a list of code snippets. When the step is rendered it will make an "exploratory" query for each code snippet to find one that returns results. That query is then used in the onboarding tour.

The query template currently supports four variables: `$$userorg, `$$userrepo`, `$$userlang` and `$$snippet`.

The PR also removes the old logic for determining the user's language, which will be supplied by the user in a different way.

https://github.com/sourcegraph/sourcegraph/assets/179026/9d50aa1b-13b3-4ad9-baf0-acc20243d2d8

## Test plan

Existing tests. Run onboarding tour with hardcoded repo and language in browser.