### PR TITLE
build-tracker: only send notifications when a build is finished

### DIFF
--- a/dev/build-tracker/build/build.go
+++ b/dev/build-tracker/build/build.go
@@ -115,11 +115,21 @@ func (b *Build) GetAuthorEmail() string {
 	return b.Author.Email
 }
 
+func (b *Build) GetWebURL() string {
+	if b.WebURL == nil {
+		return ""
+	}
+	return util.Strp(b.WebURL)
+}
+
 func (b *Build) GetState() string {
 	return util.Strp(b.State)
 }
 
 func (b *Build) GetCommit() string {
+	if b.Commit == nil {
+		return ""
+	}
 	return util.Strp(b.Commit)
 }
 
@@ -132,6 +142,9 @@ func (b *Build) GetBranch() string {
 }
 
 func (b *Build) GetMessage() string {
+	if b.Message == nil {
+		return ""
+	}
 	return util.Strp(b.Message)
 }
 

--- a/dev/build-tracker/build/build.go
+++ b/dev/build-tracker/build/build.go
@@ -272,7 +272,8 @@ func (s *Store) Add(event *Event) {
 	newJob := event.WrappedJob()
 	err := build.AddJob(newJob)
 	if err != nil {
-		s.logger.Warn("job for step has no name - not added",
+		s.logger.Warn("job not added",
+			log.Error(err),
 			log.Int("buildNumber", event.GetBuildNumber()),
 			log.Object("job", log.String("name", newJob.GetName()), log.String("id", newJob.GetID())),
 			log.Int("totalSteps", len(build.Steps)),
@@ -287,7 +288,6 @@ func (s *Store) Add(event *Event) {
 		)
 
 	}
-
 }
 
 func (s *Store) Set(build *Build) {

--- a/dev/build-tracker/build/build.go
+++ b/dev/build-tracker/build/build.go
@@ -54,9 +54,15 @@ type BuildStatus string
 
 const (
 	BuildStatusUnknown BuildStatus = ""
+	BuildInProgress    BuildStatus = "InProgress"
 	BuildPassed        BuildStatus = "Passed"
 	BuildFailed        BuildStatus = "Failed"
 	BuildFixed         BuildStatus = "Fixed"
+
+	EventJobFinished   = "job.finished"
+	EventBuildFinished = "build.finished"
+
+	JobFinishedState = "finished"
 )
 
 func (b *Build) AddJob(j *Job) error {
@@ -173,11 +179,11 @@ func (b *Event) WrappedPipeline() *Pipeline {
 }
 
 func (b *Event) IsBuildFinished() bool {
-	return b.Name == "build.finished"
+	return b.Name == EventBuildFinished
 }
 
 func (b *Event) IsJobFinished() bool {
-	return b.Name == "job.finished"
+	return b.Name == EventJobFinished
 }
 
 func (b *Event) GetJobName() string {

--- a/dev/build-tracker/build/build_test.go
+++ b/dev/build-tracker/build/build_test.go
@@ -25,7 +25,7 @@ func TestUpdateFromEvent(t *testing.T) {
 	}
 
 	event := Event{
-		Name: "build.finished",
+		Name: EventBuildFinished,
 		Build: buildkite.Build{
 			Message: &msg,
 			WebURL:  &url,
@@ -79,11 +79,11 @@ func TestBuildStoreAdd(t *testing.T) {
 	failed := "failed"
 	pipeline := "bobheadxi"
 	eventFailed := func(n int) *Event {
-		return &Event{Name: "build.finished", Build: buildkite.Build{State: &failed, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
+		return &Event{Name: EventBuildFinished, Build: buildkite.Build{State: &failed, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
 	}
 	eventSucceeded := func(n int) *Event {
 		// no state === not failed
-		return &Event{Name: "build.finished", Build: buildkite.Build{State: nil, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
+		return &Event{Name: EventBuildFinished, Build: buildkite.Build{State: nil, Number: &n}, Pipeline: buildkite.Pipeline{Name: &pipeline}}
 	}
 
 	store := NewBuildStore(logtest.Scoped(t))
@@ -122,11 +122,16 @@ func TestBuildStoreAdd(t *testing.T) {
 }
 
 func TestBuildFailedJobs(t *testing.T) {
-	state := "done"
+	buildState := "done"
 	pipeline := "bobheadxi"
 	exitCode := 1
+	jobState := JobFinishedState
 	eventFailed := func(name string, buildNumber int) *Event {
-		return &Event{Name: "job.finished", Build: buildkite.Build{State: &state, Number: &buildNumber}, Pipeline: buildkite.Pipeline{Name: &pipeline}, Job: buildkite.Job{Name: &name, ExitStatus: &exitCode}}
+		return &Event{
+			Name:     EventJobFinished,
+			Build:    buildkite.Build{State: &buildState, Number: &buildNumber},
+			Pipeline: buildkite.Pipeline{Name: &pipeline},
+			Job:      buildkite.Job{Name: &name, ExitStatus: &exitCode, State: &jobState}}
 	}
 
 	store := NewBuildStore(logtest.Scoped(t))

--- a/dev/build-tracker/build/steps.go
+++ b/dev/build-tracker/build/steps.go
@@ -11,9 +11,10 @@ import (
 type JobStatus string
 
 const (
-	JobFixed  JobStatus = JobStatus(BuildFixed)
-	JobFailed JobStatus = JobStatus(BuildFailed)
-	JobPassed JobStatus = JobStatus(BuildPassed)
+	JobFixed      JobStatus = JobStatus(BuildFixed)
+	JobFailed     JobStatus = JobStatus(BuildFailed)
+	JobPassed     JobStatus = JobStatus(BuildPassed)
+	JobInProgress JobStatus = JobStatus(BuildInProgress)
 )
 
 func (js JobStatus) ToBuildStatus() BuildStatus {
@@ -45,14 +46,18 @@ func (j *Job) finished() bool {
 }
 
 func (j *Job) state() string {
-	return strings.ToTitle(util.Strp(j.State))
+	return strings.ToLower(util.Strp(j.State))
 }
 
 func (j *Job) status() JobStatus {
-	if j.failed() {
+	switch {
+	case !j.finished():
+		return JobInProgress
+	case j.failed():
 		return JobFailed
+	default:
+		return JobPassed
 	}
-	return JobPassed
 }
 
 func (j *Job) hasTimedOut() bool {

--- a/dev/build-tracker/build/steps.go
+++ b/dev/build-tracker/build/steps.go
@@ -40,6 +40,10 @@ func (j *Job) failed() bool {
 	return !j.SoftFailed && j.exitStatus() > 0
 }
 
+func (j *Job) finished() bool {
+	return j.state() == JobFinishedState
+}
+
 func (j *Job) state() string {
 	return strings.ToTitle(util.Strp(j.State))
 }

--- a/dev/build-tracker/integration_test.go
+++ b/dev/build-tracker/integration_test.go
@@ -261,7 +261,7 @@ func TestSlackNotification(t *testing.T) {
 			":four: fake step":  build.NewStepFromJob(newJob(t, ":four: fake step", exit)),
 		}
 
-		info := toBuildNotification(b)
+		info := determineBuildStatusNotification(b)
 		err := client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -289,7 +289,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 
 		// post a new notification
-		info := toBuildNotification(b)
+		info := determineBuildStatusNotification(b)
 		err := client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -300,7 +300,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 		// now update the notification with additional jobs that failed
 		b.AddJob(newJob(t, ":alarm_clock: delayed job", exit))
-		info = toBuildNotification(b)
+		info = determineBuildStatusNotification(b)
 		err = client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -324,7 +324,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 
 		// post a new notification
-		info := toBuildNotification(b)
+		info := determineBuildStatusNotification(b)
 		err := client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -335,7 +335,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 
 		b.AddJob(newJob(t, ":alarm: outlier", 1))
-		info = toBuildNotification(b)
+		info = determineBuildStatusNotification(b)
 		err = client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -345,7 +345,7 @@ func TestSlackNotification(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			b.AddJob(newJob(t, fmt.Sprintf(":alarm_clock: delayed job %d", i), exit))
 		}
-		info = toBuildNotification(b)
+		info = determineBuildStatusNotification(b)
 		err = client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -364,7 +364,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 
 		// post a new notification
-		info := toBuildNotification(b)
+		info := determineBuildStatusNotification(b)
 		err := client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -378,7 +378,7 @@ func TestSlackNotification(t *testing.T) {
 		for _, s := range b.Steps {
 			b.AddJob(newJob(t, s.Name, 0))
 		}
-		info = toBuildNotification(b)
+		info = determineBuildStatusNotification(b)
 		if info.BuildStatus != string(build.BuildFixed) {
 			t.Errorf("all jobs are fixed, build status should be fixed")
 		}
@@ -403,7 +403,7 @@ func TestSlackNotification(t *testing.T) {
 		}
 
 		// post a new notification
-		info := toBuildNotification(b)
+		info := determineBuildStatusNotification(b)
 		err := client.Send(info)
 		if err != nil {
 			t.Fatalf("failed to send slack notification: %v", err)
@@ -421,7 +421,7 @@ func TestSlackNotification(t *testing.T) {
 			}
 			count++
 		}
-		info = toBuildNotification(b)
+		info = determineBuildStatusNotification(b)
 		if info.BuildStatus != string(build.BuildFailed) {
 			t.Errorf("some jobs are still failed so overall build status should be Failed")
 		}

--- a/dev/build-tracker/integration_test.go
+++ b/dev/build-tracker/integration_test.go
@@ -34,10 +34,12 @@ func (l *TestJobLine) LogURL() string {
 func newJob(t *testing.T, name string, exit int) *build.Job {
 	t.Helper()
 
+	state := build.JobFinishedState
 	return &build.Job{
 		Job: buildkite.Job{
 			Name:       &name,
 			ExitStatus: &exit,
+			State:      &state,
 		},
 	}
 }

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -36,7 +36,7 @@ type Server struct {
 	logger       log.Logger
 	store        *build.Store
 	config       *config.Config
-	notifyClient *notify.Client
+	notifyClient notify.NotificationClient
 	http         *http.Server
 }
 
@@ -225,11 +225,8 @@ func (s *Server) processEvent(event *build.Event) {
 	s.store.Add(event)
 	b := s.store.GetByBuildNumber(event.GetBuildNumber())
 	if event.IsBuildFinished() {
-		shouldNotify := b.IsFailed() && event.IsJobFinished()
-		if shouldNotify {
-			if err := s.notifyIfFailed(b); err != nil {
-				s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
-			}
+		if err := s.notifyIfFailed(b); err != nil {
+			s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
 		}
 	}
 }

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -222,10 +222,12 @@ func (s *Server) processEvent(event *build.Event) {
 	s.logger.Info("processing event", log.String("eventName", event.Name), log.Int("buildNumber", event.GetBuildNumber()), log.String("jobName", event.GetJobName()))
 	s.store.Add(event)
 	b := s.store.GetByBuildNumber(event.GetBuildNumber())
-	shouldNotify := event.IsBuildFinished() || (b.IsFailed() && event.IsJobFinished())
-	if shouldNotify {
-		if err := s.notifyIfFailed(b); err != nil {
-			s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
+	if event.IsBuildFinished() {
+		shouldNotify := b.IsFailed() && event.IsJobFinished()
+		if shouldNotify {
+			if err := s.notifyIfFailed(b); err != nil {
+				s.logger.Error("failed to send notification for build", log.Int("buildNumber", event.GetBuildNumber()), log.Error(err))
+			}
 		}
 	}
 }

--- a/dev/build-tracker/main.go
+++ b/dev/build-tracker/main.go
@@ -241,7 +241,7 @@ func toBuildNotification(b *build.Build) *notify.BuildNotification {
 		Message:            b.GetMessage(),
 		Commit:             b.GetCommit(),
 		BuildStatus:        "",
-		BuildURL:           *b.WebURL,
+		BuildURL:           b.GetWebURL(),
 		Fixed:              []notify.JobLine{},
 		Failed:             []notify.JobLine{},
 	}

--- a/dev/build-tracker/main_test.go
+++ b/dev/build-tracker/main_test.go
@@ -44,7 +44,7 @@ func TestToBuildNotification(t *testing.T) {
 			},
 		}
 
-		notification := toBuildNotification(b)
+		notification := determineBuildStatusNotification(b)
 
 		if len(notification.Failed) != 2 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 2)
@@ -82,7 +82,7 @@ func TestToBuildNotification(t *testing.T) {
 			},
 		}
 
-		notification := toBuildNotification(b)
+		notification := determineBuildStatusNotification(b)
 		if len(notification.Failed) != 2 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 2)
 		}
@@ -95,7 +95,7 @@ func TestToBuildNotification(t *testing.T) {
 			t.Fatalf("failed to add job to build: %v", err)
 		}
 
-		notification = toBuildNotification(b)
+		notification = determineBuildStatusNotification(b)
 		if len(notification.Failed) != 3 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 3)
 		}
@@ -132,7 +132,7 @@ func TestToBuildNotification(t *testing.T) {
 			},
 		}
 
-		notification := toBuildNotification(b)
+		notification := determineBuildStatusNotification(b)
 		if len(notification.Failed) != 2 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 2)
 		}
@@ -146,7 +146,7 @@ func TestToBuildNotification(t *testing.T) {
 			t.Fatalf("failed to add job to build: %v", err)
 		}
 
-		notification = toBuildNotification(b)
+		notification = determineBuildStatusNotification(b)
 		if len(notification.Failed) != 1 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 1)
 		}
@@ -164,7 +164,7 @@ func TestToBuildNotification(t *testing.T) {
 			t.Fatalf("failed to add job to build: %v", err)
 		}
 
-		notification = toBuildNotification(b)
+		notification = determineBuildStatusNotification(b)
 		// All jobs should be fixed now
 		if len(notification.Failed) != 0 {
 			t.Errorf("got %d, wanted %d for failed jobs in BuildNotification", len(notification.Failed), 2)

--- a/dev/build-tracker/notify/slack.go
+++ b/dev/build-tracker/notify/slack.go
@@ -30,6 +30,11 @@ func newCacheItem[T any](value T) *cacheItem[T] {
 	}
 }
 
+type NotificationClient interface {
+	Send(info *BuildNotification) error
+	GetNotification(buildNumber int) *SlackNotification
+}
+
 type Client struct {
 	slack   slack.Client
 	team    team.TeammateResolver

--- a/dev/build-tracker/server_test.go
+++ b/dev/build-tracker/server_test.go
@@ -276,7 +276,7 @@ func TestProcessEvent(t *testing.T) {
 		require.Equal(t, "passed", *builds[0].State)
 	})
 
-	t.Run("passed build sends notification", func(t *testing.T) {
+	t.Run("failed build, then passed build sends fixed notification", func(t *testing.T) {
 		server := NewServer(logger, config.Config{})
 		mockNotifyClient := &MockNotificationClient{}
 		server.notifyClient = mockNotifyClient

--- a/dev/build-tracker/server_test.go
+++ b/dev/build-tracker/server_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/build"
 	"github.com/sourcegraph/sourcegraph/dev/build-tracker/config"
+	"github.com/sourcegraph/sourcegraph/dev/build-tracker/notify"
 )
 
 func TestGetBuild(t *testing.T) {
@@ -21,7 +22,6 @@ func TestGetBuild(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodGet, "/-/debug/1234", nil)
 	req = mux.SetURLVars(req, map[string]string{"buildNumber": "1234"})
-
 	t.Run("401 Unauthorized when in production mode and incorrect credentials", func(t *testing.T) {
 		server := NewServer(logger, config.Config{Production: true, DebugPassword: "this is a test"})
 		rec := httptest.NewRecorder()
@@ -171,4 +171,136 @@ func TestOldBuildsGetDeleted(t *testing.T) {
 		}
 	})
 
+}
+
+type MockNotificationClient struct {
+	sendCalled            int
+	getNotificationCalled int
+	GetNotificationFunc   func(int) *notify.SlackNotification
+	SendFunc              func(*notify.BuildNotification) error
+}
+
+func (m *MockNotificationClient) Reset() {
+	m.sendCalled = 0
+	m.getNotificationCalled = 0
+}
+
+// GetNotification implements notify.NotificationClient.
+func (m *MockNotificationClient) GetNotification(buildNumber int) *notify.SlackNotification {
+	m.getNotificationCalled++
+	if m.GetNotificationFunc != nil {
+		return m.GetNotificationFunc(buildNumber)
+	}
+	return &notify.SlackNotification{}
+}
+
+// Send implements notify.NotificationClient.
+func (m *MockNotificationClient) Send(info *notify.BuildNotification) error {
+	m.sendCalled++
+	if m.SendFunc != nil {
+		return m.SendFunc(info)
+	}
+	return nil
+}
+
+var _ notify.NotificationClient = (*MockNotificationClient)(nil)
+
+func TestProcessEvent(t *testing.T) {
+	logger := logtest.Scoped(t)
+	newJobEvent := func(name string, buildNumber int, jobExitCode int) *build.Event {
+		state := "done"
+		pipelineID := "pipeline"
+		pipeline := &buildkite.Pipeline{
+			ID:   &pipelineID,
+			Name: &pipelineID,
+		}
+		jobState := build.JobFinishedState
+		job := buildkite.Job{Name: &name, ExitStatus: &jobExitCode, State: &jobState}
+		return &build.Event{Name: build.EventJobFinished, Build: buildkite.Build{State: &state, Number: &buildNumber, Pipeline: pipeline}, Job: job}
+	}
+	newBuildEvent := func(name string, buildNumber int, state string, jobExitCode int) *build.Event {
+		job := newJobEvent(name, buildNumber, jobExitCode)
+		pipelineID := "pipeline"
+		pipeline := &buildkite.Pipeline{
+			ID:   &pipelineID,
+			Name: &pipelineID,
+		}
+		return &build.Event{Name: build.EventBuildFinished, Build: buildkite.Build{State: &state, Number: &buildNumber, Pipeline: pipeline}, Job: job.Job}
+	}
+	t.Run("no send notification on unfinished builds", func(t *testing.T) {
+		server := NewServer(logger, config.Config{})
+		mockNotifyClient := &MockNotificationClient{}
+		server.notifyClient = mockNotifyClient
+		buildNumber := 1234
+		buildStartedEvent := newBuildEvent("test 2", buildNumber, "failed", 1)
+		buildStartedEvent.Name = "build.started"
+		server.processEvent(buildStartedEvent)
+		require.Equal(t, 0, mockNotifyClient.sendCalled)
+		server.processEvent(newJobEvent("test", buildNumber, 0))
+		// build is not finished so we should send nothing
+		require.Equal(t, 0, mockNotifyClient.sendCalled)
+
+		builds := server.store.FinishedBuilds()
+		require.Equal(t, 1, len(builds))
+	})
+
+	t.Run("failed build sends notification", func(t *testing.T) {
+		server := NewServer(logger, config.Config{})
+		mockNotifyClient := &MockNotificationClient{}
+		server.notifyClient = mockNotifyClient
+		buildNumber := 1234
+		server.processEvent(newJobEvent("test", buildNumber, 0))
+		server.processEvent(newBuildEvent("test 2", buildNumber, "failed", 1))
+
+		require.Equal(t, 1, mockNotifyClient.sendCalled)
+
+		builds := server.store.FinishedBuilds()
+		require.Equal(t, 1, len(builds))
+		require.Equal(t, 1234, *builds[0].Number)
+		require.Equal(t, "failed", *builds[0].State)
+	})
+
+	t.Run("passed build sends notification", func(t *testing.T) {
+		server := NewServer(logger, config.Config{})
+		mockNotifyClient := &MockNotificationClient{}
+		server.notifyClient = mockNotifyClient
+		buildNumber := 1234
+		server.processEvent(newJobEvent("test", buildNumber, 0))
+		server.processEvent(newBuildEvent("test 2", buildNumber, "passed", 0))
+
+		require.Equal(t, 0, mockNotifyClient.sendCalled)
+
+		builds := server.store.FinishedBuilds()
+		require.Equal(t, 1, len(builds))
+		require.Equal(t, 1234, *builds[0].Number)
+		require.Equal(t, "passed", *builds[0].State)
+	})
+
+	t.Run("passed build sends notification", func(t *testing.T) {
+		server := NewServer(logger, config.Config{})
+		mockNotifyClient := &MockNotificationClient{}
+		server.notifyClient = mockNotifyClient
+		buildNumber := 1234
+
+		server.processEvent(newJobEvent("test 1", buildNumber, 1))
+		server.processEvent(newBuildEvent("test 2", buildNumber, "failed", 1))
+
+		require.Equal(t, 1, mockNotifyClient.sendCalled)
+
+		builds := server.store.FinishedBuilds()
+		require.Equal(t, 1, len(builds))
+		require.Equal(t, 1234, *builds[0].Number)
+		require.Equal(t, "failed", *builds[0].State)
+
+		server.processEvent(newJobEvent("test 1", buildNumber, 0))
+		server.processEvent(newBuildEvent("test 2", buildNumber, "passed", 0))
+
+		builds = server.store.FinishedBuilds()
+		require.Equal(t, 1, len(builds))
+		require.Equal(t, 1234, *builds[0].Number)
+		require.Equal(t, "passed", *builds[0].State)
+
+		// fixed notification
+		require.Equal(t, 2, mockNotifyClient.sendCalled)
+	})
 }


### PR DESCRIPTION
Previously, a notification could be sent **if**:
* the build finished
** OR **
* the job is finished or failed

Sometimes a notification can slip through, where a build is finished but not really failed. Now a notification  will only be sent once we recieve the `build.finished` event. We then determined whether the build is failed / fixed / passed and if it hasn't passed, we send a notification

## Test plan
* `go test //dev/build-tracker/...`
* `go test //dev/build-tracker/... -run TestSlackNotification -RunSlackIntegrationTest`
