### PR TITLE
cody-gateway: downgrade recording errors to warn

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -133,7 +133,7 @@ func NewAnthropicHandler(
 
 					// Record flagged prompts in hotpath - they usually take a long time on the backend side, so this isn't going to make things meaningfully worse
 					if err := promptRecorder.Record(ctx, ar.Prompt); err != nil {
-						logger.Error("failed to record flagged prompt", log.Error(err))
+						logger.Warn("failed to record flagged prompt", log.Error(err))
 					}
 				}
 


### PR DESCRIPTION
We are seeing requests flagged from App users, which we don't currently record out of an abundance of caution. Failure to record generates an error that is causing some noise in #alerts-cody-gateway.

[Question was raised about what to do here](https://sourcegraph.slack.com/archives/C05Q75F9ES3/p1694722458698469), but some of this usage seems fairly innocent, and the errors are not that high frequency (31 occurrences so far, from a small set of users). It doesn't seem to be a high priority right now, and I don't know if anyone is even using the recorded prompts, so let's just downgrade this log to a warning for now, and possibly remove the functionality entirely in the future.

## Test plan

n/a