### PR TITLE
Fix typo: condeintel_db to codeintel_db

### DIFF
--- a/doc/admin/deploy/docker-compose/operations.md
+++ b/doc/admin/deploy/docker-compose/operations.md
@@ -117,7 +117,7 @@ docker cp codeintel_db.out codeintel-db:/tmp/codeintel_db.out
 
 ```bash
 docker exec pgsql sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/sourcegraph_db.out sg'
-docker exec codeintel-db sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/condeintel_db.out sg'
+docker exec codeintel-db sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/codeintel_db.out sg'
 ```
 
 5\. Start the remaining Sourcegraph services
@@ -184,7 +184,7 @@ docker cp codeintel_db.out codeintel-db:/tmp/codeintel_db.out
 
 ```bash
 docker exec pgsql sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/sourcegraph_db.out sg'
-docker exec codeintel-db sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/condeintel_db.out sg'
+docker exec codeintel-db sh -c 'psql -v ERROR_ON_STOP=1 --username sg -f /tmp/codeintel_db.out sg'
 ```
 
 5\. Start the remaining Sourcegraph services


### PR DESCRIPTION

## Test plan
Fixed typo from `/tmp/condeintel_db.out` to `/tmp/codeintel_db.out`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
