### PR TITLE
updatecheck: use new pings endpoint

### DIFF
--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"math/rand"
 	"net/http"

--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -751,9 +751,6 @@ func authProviderTypes() []string {
 	return types
 }
 
-const defaultUpdateCheckBaseURL = "https://sourcegraph.com"
-const updateCheckPath = "/.api/updates"
-
 func externalServiceKinds(ctx context.Context, db database.DB) (kinds []string, err error) {
 	defer recordOperation("externalServiceKinds")(&err)
 	kinds, err = db.ExternalServices().DistinctKinds(ctx)
@@ -764,17 +761,21 @@ func externalServiceKinds(ctx context.Context, db database.DB) (kinds []string, 
 // if provided through "UPDATE_CHECK_BASE_URL", that specific endpoint instead, to
 // accomodate network limitations on the customer side.
 func updateCheckURL(logger log.Logger) string {
+	const defaultUpdateCheckURL = "https://pings.sourcegraph.com/updates"
 	base := os.Getenv("UPDATE_CHECK_BASE_URL")
 	if base == "" {
-		base = defaultUpdateCheckBaseURL
+		return defaultUpdateCheckURL
 	}
+
 	u, err := url.Parse(base)
-	if err != nil || u.Scheme != "https" {
+	if err == nil && u.Scheme != "https" {
+		logger.Warn(`UPDATE_CHECK_BASE_URL scheme should be "https"`, log.String("UPDATE_CHECK_BASE_URL", base))
+		return defaultUpdateCheckURL
+	} else if err != nil {
 		logger.Error("Invalid UPDATE_CHECK_BASE_URL", log.String("UPDATE_CHECK_BASE_URL", base))
-		// Revert to the default value
-		return fmt.Sprintf("%s%s", defaultUpdateCheckBaseURL, updateCheckPath)
+		return defaultUpdateCheckURL
 	}
-	u.Path = updateCheckPath
+	u.Path = "/.api/updates" // Use the old path for backwards compatibility
 	return u.String()
 }
 

--- a/internal/updatecheck/client_test.go
+++ b/internal/updatecheck/client_test.go
@@ -13,12 +13,12 @@ func TestUpdateCheckURL(t *testing.T) {
 		want           string
 		errorLogsCount int
 	}{
-		{name: "default OK", env: "", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 0},
-		{name: "specified default OK", env: "https://sourcegraph.com/", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 0},
-		{name: "http NOK", env: "http://sourcegraph.com/", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 1},
+		{name: "default OK", env: "", want: "https://pings.sourcegraph.com/updates", errorLogsCount: 0},
+		{name: "specified dotcom OK", env: "https://sourcegraph.com/", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 0},
+		{name: "http not OK", env: "http://sourcegraph.com/", want: "https://pings.sourcegraph.com/updates", errorLogsCount: 1},
 		{name: "env OK", env: "https://fourfegraph.com/", want: "https://fourfegraph.com/.api/updates", errorLogsCount: 0},
-		{name: "env no protocol NOK", env: "fourfegraph.com", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 1},
-		{name: "env garbage NOK", env: "garbage  foo", want: "https://sourcegraph.com/.api/updates", errorLogsCount: 1},
+		{name: "env no protocol not OK", env: "fourfegraph.com", want: "https://pings.sourcegraph.com/updates", errorLogsCount: 1},
+		{name: "env garbage not OK", env: "garbage  foo", want: "https://pings.sourcegraph.com/updates", errorLogsCount: 1},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Change the default Pings endpoint to be https://pings.sourcegraph.com.

Without a release, this is only realistically affecting dotcom.

## Test plan

Boot up locally

In request logs:
<img width="936" alt="CleanShot 2023-09-15 at 15 08 34@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/a407b9a0-7d2b-44ff-bb1f-0d4057f98591">


and in BQ:

<img width="757" alt="CleanShot 2023-09-15 at 15 05 52@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/cde31d6d-cfa2-4f4e-84bb-2f44b49f4950">
