### PR TITLE
search: make it possible to mock any RuntimeClients in client

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -509,6 +509,7 @@ go_test(
         "//internal/search",
         "//internal/search/backend",
         "//internal/search/client",
+        "//internal/search/job",
         "//internal/search/query",
         "//internal/search/repos",
         "//internal/search/result",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/settings"
@@ -322,7 +323,11 @@ func TestSearchResultsHydration(t *testing.T) {
 
 	query := `foobar index:only count:350`
 	literalPatternType := "literal"
-	cli := client.MockedZoekt(logtest.Scoped(t), db, z)
+	cli := client.Mocked(job.RuntimeClients{
+		Logger: logtest.Scoped(t),
+		DB:     db,
+		Zoekt:  z,
+	})
 	searchInputs, err := cli.Plan(
 		ctx,
 		"V2",
@@ -558,7 +563,11 @@ func TestEvaluateAnd(t *testing.T) {
 			db.ReposFunc.SetDefaultReturn(repos)
 
 			literalPatternType := "literal"
-			cli := client.MockedZoekt(logtest.Scoped(t), db, z)
+			cli := client.Mocked(job.RuntimeClients{
+				Logger: logtest.Scoped(t),
+				DB:     db,
+				Zoekt:  z,
+			})
 			searchInputs, err := cli.Plan(
 				context.Background(),
 				"V2",
@@ -668,7 +677,11 @@ func TestSubRepoFiltering(t *testing.T) {
 			})
 
 			literalPatternType := "literal"
-			cli := client.MockedZoekt(logtest.Scoped(t), db, mockZoekt)
+			cli := client.Mocked(job.RuntimeClients{
+				Logger: logtest.Scoped(t),
+				DB:     db,
+				Zoekt:  mockZoekt,
+			})
 			searchInputs, err := cli.Plan(
 				context.Background(),
 				"V2",

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -354,8 +355,12 @@ func BenchmarkSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			client: client.MockedZoekt(logtest.Scoped(b), db, z),
-			db:     db,
+			client: client.Mocked(job.RuntimeClients{
+				Logger: logtest.Scoped(b),
+				DB:     db,
+				Zoekt:  z,
+			}),
+			db: db,
 			SearchInputs: &search.Inputs{
 				Plan:         plan,
 				Query:        plan.ToQ(),

--- a/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
+++ b/cmd/frontend/internal/guardrails/attribution/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//internal/observation",
         "//internal/search/backend",
         "//internal/search/client",
+        "//internal/search/job",
         "//internal/types",
         "@com_github_google_go_cmp//cmp",
         "@com_github_khan_genqlient//graphql",

--- a/cmd/frontend/internal/guardrails/attribution/attribution_test.go
+++ b/cmd/frontend/internal/guardrails/attribution/attribution_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/client"
+	"github.com/sourcegraph/sourcegraph/internal/search/job"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -101,7 +102,11 @@ func mockSearchClient(t testing.TB, repoNames []string) client.SearchClient {
 		}},
 	}
 
-	return client.MockedZoekt(logtest.Scoped(t), db, mockZoekt)
+	return client.Mocked(job.RuntimeClients{
+		Logger: logtest.Scoped(t),
+		DB:     db,
+		Zoekt:  mockZoekt,
+	})
 }
 
 func mockDotComClient(t testing.TB, repoNames []string) dotcom.Client {

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -46,7 +46,7 @@ func run(w io.Writer, args []string) error {
 	envvar.MockSourcegraphDotComMode(*dotCom)
 	logger := log.Scoped("search-plan", "")
 
-	cli := client.MockedZoekt(logger, nil, nil)
+	cli := client.Mocked(job.RuntimeClients{Logger: logger})
 
 	inputs, err := cli.Plan(
 		context.Background(),

--- a/internal/search/client/BUILD.bazel
+++ b/internal/search/client/BUILD.bazel
@@ -15,10 +15,8 @@ go_library(
         "//internal/actor",
         "//internal/conf",
         "//internal/database",
-        "//internal/endpoint",
         "//internal/featureflag",
         "//internal/gitserver",
-        "//internal/grpc/defaults",
         "//internal/search",
         "//internal/search/job",
         "//internal/search/job/jobutil",
@@ -33,7 +31,6 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
-        "@com_github_sourcegraph_zoekt//:zoekt",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -58,6 +58,7 @@ func New(logger log.Logger, db database.DB) SearchClient {
 			Zoekt:                       search.Indexed(),
 			SearcherURLs:                search.SearcherURLs(),
 			SearcherGRPCConnectionCache: search.SearcherGRPCConnectionCache(),
+			Gitserver:                   gitserver.NewClient(),
 		},
 		settingsService:       settings.NewService(db),
 		sourcegraphDotComMode: envvar.SourcegraphDotComMode(),
@@ -166,9 +167,7 @@ func (s *searchClient) Execute(
 }
 
 func (s *searchClient) JobClients() job.RuntimeClients {
-	clients := s.runtimeClients
-	clients.Gitserver = gitserver.NewClient()
-	return clients
+	return s.runtimeClients
 }
 
 func sanitizeSearchPatterns(ctx context.Context, db database.DB, log log.Logger) []*regexp.Regexp {

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -65,15 +64,10 @@ func New(logger log.Logger, db database.DB) SearchClient {
 	}
 }
 
-// MockedZoekt will return a search client for tests which uses the mocked
-// zoektStreamer.
-func MockedZoekt(logger log.Logger, db database.DB, zoektStreamer zoekt.Streamer) SearchClient {
+// Mocked will return a search client for tests which uses runtimeClients.
+func Mocked(runtimeClients job.RuntimeClients) SearchClient {
 	return &searchClient{
-		runtimeClients: job.RuntimeClients{
-			Logger: logger,
-			DB:     db,
-			Zoekt:  zoektStreamer,
-		},
+		runtimeClients:        runtimeClients,
 		settingsService:       settings.Mock(&schema.Settings{}),
 		sourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 	}


### PR DESCRIPTION
My goal is to mock gitserver client in another PR. This PR contains a few commits refactoring the search client to make this possible. It does this by storing inside of the search client the runtime clients and moving the creation of the gitserver client into that field.

Please review commit by commit, it contains motivation in the commit messages.

Test Plan: CI is sufficient for this change.