### PR TITLE
Enable "Test connection" for Perforce code hosts

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -64,6 +64,7 @@ var availabilityCheck = map[string]bool{
 	extsvc.KindBitbucketServer: true,
 	extsvc.KindBitbucketCloud:  true,
 	extsvc.KindAzureDevOps:     true,
+	extsvc.KindPerforce:        true,
 }
 
 func externalServiceByID(ctx context.Context, db database.DB, gqlID graphql.ID) (*externalServiceResolver, error) {

--- a/cmd/gitserver/server/vcs_syncer_perforce.go
+++ b/cmd/gitserver/server/vcs_syncer_perforce.go
@@ -70,6 +70,10 @@ func (s *PerforceDepotSyncer) Type() string {
 	return "perforce"
 }
 
+func (s *PerforceDepotSyncer) CanConnect(ctx context.Context, host, username, password string) error {
+	return p4testWithTrust(ctx, host, username, password)
+}
+
 // IsCloneable checks to see if the Perforce remote URL is cloneable.
 func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, _ api.RepoName, remoteURL *vcs.URL) error {
 	username, password, host, path, err := decomposePerforceRemoteURL(remoteURL)

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -45,9 +45,9 @@ func newPerforceSource(svc *types.ExternalService, c *schema.PerforceConnection)
 	}, nil
 }
 
-// CheckConnection at this point assumes availability and relies on errors returned
-// from the subsequent calls. This is going to be expanded as part of issue #44683
-// to actually only return true if the source can serve requests.
+// CheckConnection tests the code host connection to make sure it works.
+// For Perforce, it uses the host (p4.port), username (p4.user) and password (p4.passwd)
+// from the code host configuration.
 func (s PerforceSource) CheckConnection(ctx context.Context) error {
 	// currently the only tool to use for connecting to the Perforce server
 	// is the syncer because connecting requires the `p4` CLI binary, which is on `gitserver`


### PR DESCRIPTION
Enable the "Test connection" button in the code host page UI

## Test plan

Click the "Test connection" button in the code host connection UI. A message with an orange border will display, "Checking code host connection..." and then "Code host is reachable" should display with a green border.
<img width="1148" alt="Screenshot 2023-09-15 at 14 17 00" src="https://github.com/sourcegraph/sourcegraph/assets/129280/a4c30d9b-ceff-4afe-b966-f7bd1c0385d9">
