### PR TITLE
updatecheck: forward ping requests to pings.sourcegraph.com

### DIFF
--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -167,7 +167,7 @@ func NewHandler(
 		m.Path("/app/latest").Name(codyapp.RouteCodyAppLatestVersion).Handler(trace.Route(codyapp.LatestVersionHandler(logger)))
 		m.Path("/license/check").Methods("POST").Name("dotcom.license.check").Handler(trace.Route(handlers.NewDotcomLicenseCheckHandler()))
 
-		updatecheckHandler, err := updatecheck.ForwardHandler(logger)
+		updatecheckHandler, err := updatecheck.ForwardHandler()
 		if err != nil {
 			return nil, errors.Errorf("create updatecheck handler: %v", err)
 		}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -167,7 +167,7 @@ func NewHandler(
 		m.Path("/app/latest").Name(codyapp.RouteCodyAppLatestVersion).Handler(trace.Route(codyapp.LatestVersionHandler(logger)))
 		m.Path("/license/check").Methods("POST").Name("dotcom.license.check").Handler(trace.Route(handlers.NewDotcomLicenseCheckHandler()))
 
-		updatecheckHandler, err := updatecheck.HandlerWithLog(logger)
+		updatecheckHandler, err := updatecheck.ForwardHandler(logger)
 		if err != nil {
 			return nil, errors.Errorf("create updatecheck handler: %v", err)
 		}

--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -111,7 +111,7 @@ func newServerHandler(logger log.Logger, config *Config) (http.Handler, error) {
 	r.Path("/updates").
 		Methods(http.MethodGet, http.MethodPost).
 		HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			updatecheck.HandlePingRequest(logger, pubsubClient, w, r)
+			updatecheck.Handle(logger, pubsubClient, w, r)
 		})
 	return r, nil
 }

--- a/internal/updatecheck/client.go
+++ b/internal/updatecheck/client.go
@@ -756,11 +756,12 @@ func externalServiceKinds(ctx context.Context, db database.DB) (kinds []string, 
 	return kinds, err
 }
 
+const defaultUpdateCheckURL = "https://pings.sourcegraph.com/updates"
+
 // updateCheckURL returns an URL to the update checks route on Sourcegraph.com or
 // if provided through "UPDATE_CHECK_BASE_URL", that specific endpoint instead, to
 // accomodate network limitations on the customer side.
 func updateCheckURL(logger log.Logger) string {
-	const defaultUpdateCheckURL = "https://pings.sourcegraph.com/updates"
 	base := os.Getenv("UPDATE_CHECK_BASE_URL")
 	if base == "" {
 		return defaultUpdateCheckURL

--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"sort"
 	"strconv"
@@ -67,30 +68,31 @@ func getLatestRelease(deployType string) pingResponse {
 	}
 }
 
-// HandlerWithLog creates an HTTP handler that responds with information about
-// software updates for Sourcegraph. Using the given logger, a scoped logger is
-// created and the handler that is returned uses the logger internally.
-func HandlerWithLog(logger log.Logger) (http.HandlerFunc, error) {
-	logger = logger.Scoped("updatecheck.handler", "handler that responds with information about software updates")
-
-	var pubsubClient pubsub.TopicClient
-	if pubSubPingsTopicID == "" {
-		pubsubClient = pubsub.NewNoopTopicClient()
-	} else {
-		var err error
-		pubsubClient, err = pubsub.NewDefaultTopicClient(pubSubPingsTopicID)
-		if err != nil {
-			return nil, errors.Errorf("create Pub/Sub client: %v", err)
-		}
+// ForwardHandler returns a handler that forwards the request to
+// https://pings.sourcegraph.com.
+func ForwardHandler(logger log.Logger) (http.HandlerFunc, error) {
+	remote, err := url.Parse(defaultUpdateCheckURL)
+	if err != nil {
+		return nil, errors.Errorf("parse default update check URL: %v", err)
 	}
+
+	// If remote has a path, the proxy server will always append an unnecessary "/" to the path.
+	remotePath := remote.Path
+	remote.Path = ""
+	proxy := httputil.NewSingleHostReverseProxy(remote)
+
+	logger = logger.Scoped("updatecheck.forwardHandler", "handler that that forwards the request to https://pings.sourcegraph.com")
 	return func(w http.ResponseWriter, r *http.Request) {
-		HandlePingRequest(logger, pubsubClient, w, r)
+		r.Host = remote.Host
+		r.URL.Path = remotePath
+		fmt.Println("updatecheck.forwardHandler", 222, r.URL)
+		proxy.ServeHTTP(w, r)
 	}, nil
 }
 
-// HandlePingRequest handles the ping requests and responds with information
-// about software updates for Sourcegraph.
-func HandlePingRequest(logger log.Logger, pubsubClient pubsub.TopicClient, w http.ResponseWriter, r *http.Request) {
+// Handle handles the ping requests and responds with information about software
+// updates for Sourcegraph.
+func Handle(logger log.Logger, pubsubClient pubsub.TopicClient, w http.ResponseWriter, r *http.Request) {
 	requestCounter.Inc()
 
 	pr, err := readPingRequest(r)

--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -70,7 +70,7 @@ func getLatestRelease(deployType string) pingResponse {
 
 // ForwardHandler returns a handler that forwards the request to
 // https://pings.sourcegraph.com.
-func ForwardHandler(logger log.Logger) (http.HandlerFunc, error) {
+func ForwardHandler() (http.HandlerFunc, error) {
 	remote, err := url.Parse(defaultUpdateCheckURL)
 	if err != nil {
 		return nil, errors.Errorf("parse default update check URL: %v", err)
@@ -80,8 +80,6 @@ func ForwardHandler(logger log.Logger) (http.HandlerFunc, error) {
 	remotePath := remote.Path
 	remote.Path = ""
 	proxy := httputil.NewSingleHostReverseProxy(remote)
-
-	logger = logger.Scoped("updatecheck.forwardHandler", "handler that that forwards the request to https://pings.sourcegraph.com")
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.Host = remote.Host
 		r.URL.Path = remotePath

--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -83,7 +83,6 @@ func ForwardHandler() (http.HandlerFunc, error) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		r.Host = remote.Host
 		r.URL.Path = remotePath
-		fmt.Println("updatecheck.forwardHandler", 222, r.URL)
 		proxy.ServeHTTP(w, r)
 	}, nil
 }


### PR DESCRIPTION
Now we have pings.sourcegraph.com as the official pings service, dotcom would actually forward than consuming those pings directly (for backward compatibility for SG instances older than 5.2.0).

## Test plan

1. Grab the ping request body from https://sourcegraph.com/site-admin/pings and save it as a file named `dotcom-ping.json`
2. Boot up local instance in dotcom mode: `sg start dotcom`
3. `curl -X POST -H "Content-Type: application/json" -d @dotcom-ping.json https://sourcegraph.test:3443/.api/updates`

Then in BigQuery table:

<img width="704" alt="CleanShot 2023-09-15 at 18 36 43@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/20db98ea-48f7-4bed-b8e6-79a6f5dd2b1e">
