### PR TITLE
search: alert reposExist helper handles empty pages

### DIFF
--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -48,8 +48,16 @@ type Observer struct {
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
 	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(), o.Searcher, o.Zoekt)
-	resolved, err := repositoryResolver.Resolve(ctx, options)
-	return err == nil && len(resolved.RepoRevs) > 0
+	it := repositoryResolver.Iterator(ctx, options)
+	for it.Next() {
+		resolved := it.Current()
+		// Due to filtering (eg hasCommitAfter) this page of results may be
+		// empty, so we only return early if we find a repo that exists.
+		if len(resolved.RepoRevs) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *search.Alert {


### PR DESCRIPTION
This was a likely very rare to trigger bug. The more likely bug to
trigger was it asserted err was nil, but you can find a repo but have
some revs missing (which would result in an error). So this changes
behaviour, but looking at the call sites, function name and
documentation this is now the correct behaviour.

Note: I plan on adding an API which only communicates with the DB and
avoids slower gitserver calls. That may be useful to use here in the
future since this helper is only used for suggestions.

Test Plan: CI
