### PR TITLE
search: unexport repos.Resolver.Resolve

### DIFF
--- a/internal/search/alert/observer.go
+++ b/internal/search/alert/observer.go
@@ -48,8 +48,16 @@ type Observer struct {
 // query does not contain any repos to search.
 func (o *Observer) reposExist(ctx context.Context, options search.RepoOptions) bool {
 	repositoryResolver := searchrepos.NewResolver(o.Logger, o.Db, gitserver.NewClient(), o.Searcher, o.Zoekt)
-	resolved, err := repositoryResolver.Resolve(ctx, options)
-	return err == nil && len(resolved.RepoRevs) > 0
+	it := repositoryResolver.Iterator(ctx, options)
+	for it.Next() {
+		resolved := it.Current()
+		// Due to filtering (eg hasCommitAfter) this page of results may be
+		// empty, so we only return early if we find a repo that exists.
+		if len(resolved.RepoRevs) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Observer) alertForNoResolvedRepos(ctx context.Context, q query.Q) *search.Alert {


### PR DESCRIPTION
We only use the iterator outside of this package. Additionally we don't
need to export Next from the Resolved struct since that is hidden by the
iterator.

Test Plan: go test
