### PR TITLE
pings: lower server write timeout

### DIFF
--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -34,7 +34,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 		addr,
 		&http.Server{
 			ReadTimeout:  75 * time.Second,
-			WriteTimeout: 10 * time.Minute,
+			WriteTimeout: 2 * time.Minute,
 			Handler:      serverHandler,
 		},
 	)


### PR DESCRIPTION
The initial write timeout was copied from Cody Gateway, but Pings service shouldn't be needing that much long timeout for writing responses.

## Test plan

CI
