### PR TITLE
batches: change condition for closable changesets

### DIFF
--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -1708,7 +1708,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 
 		// can changeset be published
 		isChangesetCommentable := isChangesetOpen || isChangesetDraft || isChangesetMerged || isChangesetClosed
-		isChangesetClosable := isChangesetOpen || isChangesetDraft || isChangesetJobFailed
+		isChangesetClosable := isChangesetOpen || isChangesetDraft
 
 		// check what operations this changeset support, most likely from the state
 		// so get the changeset then derive the operations from it's state.

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -1708,7 +1708,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 
 		// can changeset be published
 		isChangesetCommentable := isChangesetOpen || isChangesetDraft || isChangesetMerged || isChangesetClosed
-		isChangesetClosable := isChangesetOpen || isChangesetDraft
+		isChangesetClosable := changeset.ExternalState != ""
 
 		// check what operations this changeset support, most likely from the state
 		// so get the changeset then derive the operations from it's state.

--- a/internal/batches/service/service.go
+++ b/internal/batches/service/service.go
@@ -1708,7 +1708,7 @@ func (s *Service) GetAvailableBulkOperations(ctx context.Context, opts GetAvaila
 
 		// can changeset be published
 		isChangesetCommentable := isChangesetOpen || isChangesetDraft || isChangesetMerged || isChangesetClosed
-		isChangesetClosable := changeset.ExternalState != ""
+		isChangesetClosable := isChangesetOpen || isChangesetDraft
 
 		// check what operations this changeset support, most likely from the state
 		// so get the changeset then derive the operations from it's state.

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -2837,7 +2837,7 @@ changesetTemplate:
 				t.Fatal(err)
 			}
 
-			expectedBulkOperations := []string{"REENQUEUE", "PUBLISH", "CLOSE"}
+			expectedBulkOperations := []string{"REENQUEUE", "PUBLISH"}
 			if !assert.ElementsMatch(t, expectedBulkOperations, bulkOperations) {
 				t.Errorf("wrong bulk operation type returned. want=%q, have=%q", expectedBulkOperations, bulkOperations)
 			}


### PR DESCRIPTION
When calculating available bulk operations for changesets, we activate the `Close Changeset` operation on changesets that are in a failed state.

However, in this case, it shouldn't be because the changesets might not have been published, so it's impossible to close it.

## Test plan

* Manual testing
* Updated unit tests