### PR TITLE
search: introduce repos.Resolver.IterateRepoRevs

### DIFF
--- a/internal/search/repos/BUILD.bazel
+++ b/internal/search/repos/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "//internal/search/streaming",
         "//internal/types",
         "//lib/errors",
+        "//lib/iterator",
         "@com_github_derision_test_go_mockgen//testutil/require",
         "@com_github_google_go_cmp//cmp",
         "@com_github_grafana_regexp//:regexp",
@@ -80,5 +81,6 @@ go_test(
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
     ],
 )


### PR DESCRIPTION
This exports an API which allows search jobs to get the revisions that would be searched. This is currently unused but will be used in an upcoming commit.

Test Plan: added unit tests
