### PR TITLE
JetBrains: Move referrer setting to site-wide

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -179,14 +179,6 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
         setNote(REQUESTERS[requestFrom].name)
     }, [isSourcegraphDotCom, isSourcegraphApp, location.search, navigate, requestFrom, requester, port, destination])
 
-    // Add referrer policy to the page to prevent passing it on after the redirect.
-    // JetBrains needs this.
-    useEffect(() => {
-        document
-            .querySelector('head')
-            ?.insertAdjacentHTML('beforeend', '<meta name="referrer" content="strict-origin-when-cross-origin">')
-    }, [])
-
     /**
      * We use this to handle token creation request from redirections.
      * Don't create token if this page wasn't linked to from a valid

--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -8,7 +8,7 @@
 	<meta name="google" content="notranslate">
 	<meta http-equiv="Content-Language" content="en">
 	<meta name="viewport" content="width=device-width, viewport-fit=cover" />
-	<meta name="referrer" content="origin-when-cross-origin"/>
+	<meta name="referrer" content="strict-origin-when-cross-origin"/>
 	<meta name="color-scheme" content="light dark"/>
 	{{with .Metadata}}
 	<meta name='description' content="{{.Description}}" />


### PR DESCRIPTION
We used a temporary hack to set the `referrer` meta header to `strict-origin-when-cross-origin` rather than `origin-when-cross-origin` on a single page. But it looks like it's actually fine to use the former site-wide.

## Test plan

- Tested the JetBrains plugin auth process with dotcom; it still works.
- CI