### PR TITLE
search jobs: serve logs

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -42,6 +42,7 @@ type Services struct {
 
 	// Handler for exporting search jobs data.
 	SearchJobsDataExportHandler http.Handler
+	SearchJobsLogsHandler       http.Handler
 
 	// Handler for completions stream.
 	NewChatCompletionsStreamHandler NewChatCompletionsStreamHandler
@@ -120,6 +121,7 @@ func DefaultServices() Services {
 		NewChatCompletionsStreamHandler: func() http.Handler { return makeNotFoundHandler("chat completions streaming endpoint") },
 		NewCodeCompletionsHandler:       func() http.Handler { return makeNotFoundHandler("code completions streaming endpoint") },
 		SearchJobsDataExportHandler:     makeNotFoundHandler("search jobs data export handler"),
+		SearchJobsLogsHandler:           makeNotFoundHandler("search jobs logs handler"),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_jobs.go
+++ b/cmd/frontend/graphqlbackend/search_jobs.go
@@ -44,6 +44,7 @@ type SearchJobResolver interface {
 	StartedAt(ctx context.Context) *gqlutil.DateTime
 	FinishedAt(ctx context.Context) *gqlutil.DateTime
 	URL(ctx context.Context) (*string, error)
+	LogURL(ctx context.Context) (*string, error)
 	RepoStats(ctx context.Context) (SearchJobStatsResolver, error)
 }
 

--- a/cmd/frontend/graphqlbackend/search_jobs.graphql
+++ b/cmd/frontend/graphqlbackend/search_jobs.graphql
@@ -160,6 +160,10 @@ type SearchJob implements Node {
     """
     URL: String
     """
+    The url to download search job logs.
+    """
+    logURL: String
+    """
     The repository stats for the search job.
     """
     repoStats: SearchJobStats!

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -292,6 +292,7 @@ func makeExternalAPI(db database.DB, logger sglog.Logger, schema *graphql.Schema
 			NewComputeStreamHandler:         enterprise.NewComputeStreamHandler,
 			CodeInsightsDataExportHandler:   enterprise.CodeInsightsDataExportHandler,
 			SearchJobsDataExportHandler:     enterprise.SearchJobsDataExportHandler,
+			SearchJobsLogsHandler:           enterprise.SearchJobsLogsHandler,
 			NewDotcomLicenseCheckHandler:    enterprise.NewDotcomLicenseCheckHandler,
 			NewChatCompletionsStreamHandler: enterprise.NewChatCompletionsStreamHandler,
 			NewCodeCompletionsHandler:       enterprise.NewCodeCompletionsHandler,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -76,6 +76,7 @@ type Handlers struct {
 
 	// Search jobs
 	SearchJobsDataExportHandler http.Handler
+	SearchJobsLogsHandler       http.Handler
 
 	// Dotcom license check
 	NewDotcomLicenseCheckHandler enterprise.NewDotcomLicenseCheckHandler
@@ -182,6 +183,7 @@ func NewHandler(
 
 	m.Get(apirouter.SearchStream).Handler(trace.Route(frontendsearch.StreamHandler(db)))
 	m.Get(apirouter.SearchJob).Handler(trace.Route(handlers.SearchJobsDataExportHandler))
+	m.Get(apirouter.SearchJobLogs).Handler(trace.Route(handlers.SearchJobsLogsHandler))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCli).Handler(trace.Route(newSrcCliVersionHandler(logger)))

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -16,6 +16,7 @@ const (
 
 	SearchStream          = "search.stream"
 	SearchJob             = "search.job"
+	SearchJobLogs         = "search.job.logs"
 	ComputeStream         = "compute.stream"
 	GitBlameStream        = "git.blame.stream"
 	ChatCompletionsStream = "completions.stream"
@@ -79,6 +80,7 @@ func New(base *mux.Router) *mux.Router {
 	base.Path("/scip/upload").Methods("HEAD").Name(SCIPUploadExists)
 	base.Path("/search/stream").Methods("GET").Name(SearchStream)
 	base.Path("/search/export/{id}").Methods("GET").Name(SearchJob)
+	base.Path("/search/export/{id}/logs").Methods("GET").Name(SearchJobLogs)
 	base.Path("/compute/stream").Methods("GET", "POST").Name(ComputeStream)
 	base.Path("/blame/" + routevar.Repo + routevar.RepoRevSuffix + "/stream/{Path:.*}").Methods("GET").Name(GitBlameStream)
 	base.Path("/src-cli/versions/{rest:.*}").Methods("GET", "POST").Name(SrcCliVersionCache)

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -42,7 +42,6 @@ func ServeSearchJobLogs(svc *service.Service) http.HandlerFunc {
 		jobIDStr := mux.Vars(r)["id"]
 		jobID, err := strconv.Atoi(jobIDStr)
 		if err != nil {
-			fmt.Sprintf("error parsing job id: %s", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -50,7 +49,6 @@ func ServeSearchJobLogs(svc *service.Service) http.HandlerFunc {
 		w.Header().Set("Content-Type", "text/csv")
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%d.log\"", jobID))
 
-		fmt.Println("writing search job logs")
 		err = svc.WriteSearchJobLogs(r.Context(), w, int64(jobID))
 		if err != nil {
 			if errors.Is(err, auth.ErrMustBeSiteAdminOrSameUser) {

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -36,3 +36,29 @@ func ServeSearchJobDownload(svc *service.Service) http.HandlerFunc {
 
 	}
 }
+
+func ServeSearchJobLogs(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		jobIDStr := mux.Vars(r)["id"]
+		jobID, err := strconv.Atoi(jobIDStr)
+		if err != nil {
+			fmt.Sprintf("error parsing job id: %s", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%d.log\"", jobID))
+
+		fmt.Println("writing search job logs")
+		err = svc.WriteSearchJobLogs(r.Context(), w, int64(jobID))
+		if err != nil {
+			if errors.Is(err, auth.ErrMustBeSiteAdminOrSameUser) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/cmd/frontend/internal/search/init.go
+++ b/cmd/frontend/internal/search/init.go
@@ -39,6 +39,7 @@ func Init(
 
 	enterpriseServices.SearchJobsResolver = resolvers.New(observationCtx.Logger, db, svc)
 	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(svc)
+	enterpriseServices.SearchJobsLogsHandler = httpapi.ServeSearchJobLogs(svc)
 
 	return nil
 }

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -80,6 +80,16 @@ func (r searchJobResolver) URL(ctx context.Context) (*string, error) {
 	}
 	return nil, nil
 }
+func (r searchJobResolver) LogURL(ctx context.Context) (*string, error) {
+	if r.Job.State == types.JobStateCompleted {
+		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d/logs", r.Job.ID))
+		if err != nil {
+			return nil, err
+		}
+		return pointers.Ptr(exportPath), nil
+	}
+	return nil, nil
+}
 
 func (r searchJobResolver) RepoStats(ctx context.Context) (graphqlbackend.SearchJobStatsResolver, error) {
 	repoRevStats, err := r.svc.GetAggregateRepoRevState(ctx, r.Job.ID)

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -131,7 +131,10 @@ func TestExhaustiveSearch(t *testing.T) {
 		}, stats)
 	}
 
+	// Assert that we can write the job logs to a writer and that the number of
+	// lines and columns matches our expectation.
 	{
+		service.JobLogsIterLimit = 2
 		buf := bytes.Buffer{}
 		err = svc.WriteSearchJobLogs(userCtx, &buf, job.ID)
 		require.NoError(err)
@@ -139,6 +142,9 @@ func TestExhaustiveSearch(t *testing.T) {
 		// 1 header + 3 rows + 1 newline
 		require.Equal(5, len(lines), fmt.Sprintf("got %q", buf))
 		require.Equal("repo,rev,start,end,status,failure_message", lines[0])
+		// We should use the CSV reader to parse this but since we know none of the
+		// columns have a "," in the context of this test, this is fine.
+		require.Equal(6, len(strings.Split(lines[1], ",")))
 	}
 
 	// Assert that cancellation affects the number of rows we expect. This is a bit

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -1,9 +1,12 @@
 package search
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -126,6 +129,16 @@ func TestExhaustiveSearch(t *testing.T) {
 			Failed:     0,
 			InProgress: 0,
 		}, stats)
+	}
+
+	{
+		buf := bytes.Buffer{}
+		err = svc.WriteSearchJobLogs(userCtx, &buf, job.ID)
+		require.NoError(err)
+		lines := strings.Split(buf.String(), "\n")
+		// 1 header + 3 rows + 1 newline
+		require.Equal(5, len(lines), fmt.Sprintf("got %q", buf))
+		require.Equal("repo,rev,start,end,status,failure_message", lines[0])
 	}
 
 	// Assert that cancellation affects the number of rows we expect. This is a bit

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -171,7 +171,14 @@ func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64)
 	cw := csv.NewWriter(w)
 	defer cw.Flush()
 
-	header := []string{"repo", "rev", "start", "end", "status"}
+	header := []string{
+		"repo",
+		"rev",
+		"start",
+		"end",
+		"status",
+		"failure_message",
+	}
 	err = cw.Write(header)
 	if err != nil {
 		return err
@@ -184,6 +191,7 @@ func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64)
 			formatOrNULL(job.StartedAt),
 			formatOrNULL(job.FinishedAt),
 			string(job.State),
+			job.FailureMessage,
 		})
 		if err != nil {
 			return err

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -199,7 +199,10 @@ func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64)
 	return iter.Err()
 }
 
-var JobLogsIterLimit = 1000
+// JobLogsIterLimit is the number of lines the iterator will read from the
+// database per page. Assuming 100 bytes per line, this will be ~1MB of memory
+// per 10k repo-rev jobs.
+var JobLogsIterLimit = 10_000
 
 func (s *Service) getJobLogsIter(ctx context.Context, id int64) *iterator.Iterator[types.SearchJobLog] {
 	var cursor int64

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -345,7 +344,7 @@ func (s *Store) GetAggregateRepoRevState(ctx context.Context, id int64) (_ map[s
 	return m, nil
 }
 
-const getRepoRevJobsSpecFmtStr = `
+const getJobLogsFmtStr = `
 SELECT
 rjj.id,
 rj.repo_id,
@@ -365,7 +364,7 @@ type GetJobLogsOpts struct {
 }
 
 func (s *Store) GetJobLogs(ctx context.Context, id int64, opts *GetJobLogsOpts) ([]types.SearchJobLog, error) {
-	// 🚨 SECURITY: only someone with access to the job may cancel the job
+	// 🚨 SECURITY: only someone with access to the job may access the logs
 	_, err := s.GetExhaustiveSearchJob(ctx, id)
 	if err != nil {
 		return nil, err
@@ -384,14 +383,12 @@ func (s *Store) GetJobLogs(ctx context.Context, id int64, opts *GetJobLogsOpts) 
 	}
 
 	q := sqlf.Sprintf(
-		getRepoRevJobsSpecFmtStr,
+		getJobLogsFmtStr,
 		sqlf.Sprintf("WHERE %s ORDER BY id ASC", sqlf.Join(conds, "AND")),
 	)
 	if limit != nil {
 		q = sqlf.Sprintf("%v %v", q, limit)
 	}
-
-	fmt.Printf("q=%v args=%v\n", q.Query(sqlf.PostgresBindVar), q.Args())
 
 	rows, err := s.Store.Query(ctx, q)
 	if err != nil {

--- a/internal/search/exhaustive/types/exhaustive_search_repo_revision_job.go
+++ b/internal/search/exhaustive/types/exhaustive_search_repo_revision_job.go
@@ -26,3 +26,12 @@ func (j *ExhaustiveSearchRepoRevisionJob) RecordID() int {
 func (j *ExhaustiveSearchRepoRevisionJob) RecordUID() string {
 	return strconv.FormatInt(j.ID, 10)
 }
+
+type SearchJobLog struct {
+	Revision string
+
+	State          JobState
+	FailureMessage string
+	StartedAt      time.Time
+	FinishedAt     time.Time
+}

--- a/internal/search/exhaustive/types/exhaustive_search_repo_revision_job.go
+++ b/internal/search/exhaustive/types/exhaustive_search_repo_revision_job.go
@@ -3,6 +3,8 @@ package types
 import (
 	"strconv"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 // ExhaustiveSearchRepoRevisionJob is a job that runs the exhaustive search on a revision of a repository.
@@ -28,6 +30,8 @@ func (j *ExhaustiveSearchRepoRevisionJob) RecordUID() string {
 }
 
 type SearchJobLog struct {
+	ID       int64
+	RepoID   api.RepoID
 	Revision string
 
 	State          JobState


### PR DESCRIPTION
We assemble logs in MEM and serve them as CSV on `/search/export/{id}/logs`.

Test plan:
- updated unit test
- manual testing

```
mutation create {
  createSearchJob(query: "1@rev1 2@rev5 3@rev6") {
    id
  }
}

query logURL {
  node(id: "U2VhcmNoSm9iOjgy") {
    ... on SearchJob {
      logURL
    }
  }
}

curl -X GET -H 'Authorization: token <SECRET>' <LOG URL>

repo,rev,start,end,status,failure_message
1,rev1,2023-09-18T13:25:58Z,2023-09-18T13:25:58Z,completed,
2,rev5,2023-09-18T13:25:58Z,2023-09-18T13:25:58Z,completed,
3,rev6,2023-09-18T13:25:58Z,2023-09-18T13:25:58Z,completed,
```
