### PR TITLE
search jobs: make searcherFake more robust

### DIFF
--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -241,11 +241,14 @@ func (backendFake) NewSearch(ctx context.Context, q string) (SearchQuery, error)
 	for _, part := range strings.Fields(q) {
 		var r types.RepositoryRevision
 		if n, err := fmt.Sscanf(part, "%d@%s", &r.Repository, &r.Revision); n != 2 || err != nil {
-			return nil, errors.Errorf("failed to parse repository revision %q", part)
+			continue
 		}
 		r.RepositoryRevSpec.Repository = r.Repository
 		r.RepositoryRevSpec.RevisionSpecifier = "spec"
 		repoRevs = append(repoRevs, r)
+	}
+	if len(repoRevs) == 0 {
+		return nil, errors.Errorf("no repository revisions found in %q", q)
 	}
 	return searcherFake{repoRevs: repoRevs}, nil
 }


### PR DESCRIPTION
searcherFake breaks with query elements like context:global or patternType:standard. This makes it hard to test the UI while the mock is still connected.

Test plan:
CI
