### PR TITLE
pings: call Cloud Profiler init logic

### DIFF
--- a/cmd/pings/shared/BUILD.bazel
+++ b/cmd/pings/shared/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/goroutine",
         "//internal/httpserver",
         "//internal/observation",
+        "//internal/profiler",
         "//internal/pubsub",
         "//internal/service",
         "//internal/updatecheck",

--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/pubsub"
 	"github.com/sourcegraph/sourcegraph/internal/service"
 	"github.com/sourcegraph/sourcegraph/internal/updatecheck"
@@ -23,6 +24,8 @@ import (
 )
 
 func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFunc, config *Config) error {
+	profiler.Init()
+
 	// Initialize our server
 	serverHandler, err := newServerHandler(obctx.Logger, config)
 	if err != nil {


### PR DESCRIPTION
Also need to set `GOOGLE_CLOUD_PROFILER_ENABLED=true` for the deployment.

## Test plan

CI
