### PR TITLE
msp: provision Cloud Profiler API access and roles

### DIFF
--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -53,6 +53,8 @@ var (
 		// Allow service to emit observability
 		{ID: "role_cloudtrace_agent", Role: "roles/cloudtrace.agent"},
 		{ID: "role_monitoring_metricwriter", Role: "roles/monitoring.metricWriter"},
+		// Allow service to publish Cloud Profiler profiles
+		{ID: "role_cloudprofiler_agent", Role: "roles/cloudprofiler.agent"},
 	}
 	// servicePort is provided to the container as $PORT in Cloud Run:
 	// https://cloud.google.com/run/docs/configuring/services/containers#configure-port

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -35,6 +35,7 @@ var gcpServices = []string{
 	"storage-api.googleapis.com",
 	"storage-component.googleapis.com",
 	"bigquery.googleapis.com",
+	"cloudprofiler.googleapis.com",
 }
 
 const (


### PR DESCRIPTION
## Test plan

Has enabled and been working for [Pings service project](https://console.cloud.google.com/profiler;timespan=30m/pings;type=HEAP/inuse_space?project=pings-prod-2f4f73edf1db).