### PR TITLE
managedservicesplatform: fix project ID length detection, add config to shorten it

### DIFF
--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -67,6 +67,10 @@ type Variables struct {
 	// '-${randomizedSuffix}' will be added, as project IDs must be unique.
 	ProjectIDPrefix string
 
+	// ProjectIDSuffixLength is the length of the randomized suffix added to
+	// to the project.
+	ProjectIDSuffixLength *int
+
 	// DisplayName is a display name for the project. It does not need to be unique.
 	DisplayName string
 
@@ -85,8 +89,9 @@ const StackName = "project"
 
 const (
 	// https://cloud.google.com/resource-manager/reference/rest/v1/projects
-	projectIDMaxLength              = 30
-	projectIDRandomizedSuffixLength = 6
+	projectIDMaxLength                 = 30
+	projectIDRandomizedSuffixLength    = 6
+	projectIDMinRandomizedSuffixLength = 2
 )
 
 // NewStack creates a stack that provisions a GCP project.
@@ -100,12 +105,17 @@ func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 	id := resourceid.New(vars.ProjectIDPrefix)
 
 	// The project ID must leave room for a randomized suffix and a separator.
-	if afterSuffixLength := len(vars.ProjectIDPrefix) + 1 + projectIDRandomizedSuffixLength; afterSuffixLength > projectIDMaxLength {
+	suffixLength := projectIDRandomizedSuffixLength
+	if vars.ProjectIDSuffixLength != nil {
+		suffixLength = *vars.ProjectIDSuffixLength / 2
+	}
+	realSuffixLength := suffixLength * 2 // after converting to hex
+	if afterSuffixLength := len(vars.ProjectIDPrefix) + 1 + realSuffixLength; afterSuffixLength > projectIDMaxLength {
 		return nil, errors.Newf("project ID prefix %q is too long after adding random suffix (%d characters) - got %d characters, but maximum is %d characters",
 			vars.ProjectIDPrefix, projectIDRandomizedSuffixLength, afterSuffixLength, projectIDMaxLength)
 	}
 	projectID := random.New(stack, id, random.Config{
-		ByteLength: projectIDRandomizedSuffixLength,
+		ByteLength: suffixLength,
 		Prefix:     vars.ProjectIDPrefix,
 	})
 

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -72,9 +72,12 @@ func (r *Renderer) RenderEnvironment(
 
 	// Render all required CDKTF stacks for this environment
 	projectOutput, err := project.NewStack(stacks, project.Variables{
-		ProjectIDPrefix: projectIDPrefix,
+		ProjectIDPrefix:       projectIDPrefix,
+		ProjectIDSuffixLength: svc.ProjectIDSuffixLength,
+
 		DisplayName: fmt.Sprintf("%s (%s)",
 			pointers.Deref(svc.Name, svc.ID), env.ID),
+
 		Category: env.Category,
 		Labels: map[string]string{
 			"service":     svc.ID,

--- a/dev/managedservicesplatform/spec/service.go
+++ b/dev/managedservicesplatform/spec/service.go
@@ -1,5 +1,7 @@
 package spec
 
+import "github.com/sourcegraph/sourcegraph/lib/errors"
+
 type ServiceSpec struct {
 	// ID is an all-lowercase, hyphen-delimited identifier for the service,
 	// e.g. "cody-gateway".
@@ -19,10 +21,19 @@ type ServiceSpec struct {
 	// with. If empty, the service uses HTTP. To use gRPC, configure 'h2c':
 	// https://cloud.google.com/run/docs/configuring/http2
 	Protocol *Protocol `json:"protocol,omitempty"`
+
+	// ProjectIDSuffixLength can be configured to truncate the length of the
+	// service's generated project IDs.
+	ProjectIDSuffixLength *int `json:"projectIDSuffixLength,omitempty"`
 }
 
 func (s ServiceSpec) Validate() []error {
 	var errs []error
+
+	if s.ProjectIDSuffixLength != nil && *s.ProjectIDSuffixLength < 4 {
+		errs = append(errs, errors.New("projectIDSuffixLength must be >= 4"))
+	}
+
 	// TODO: Add validation
 	return errs
 }


### PR DESCRIPTION
This is rather finicky - we need to be careful not to change the defaults or existing projects

## Test plan

https://github.com/sourcegraph/managed-services/pull/7