### PR TITLE
fix incorrect theme colors in esbuild css output

### DIFF
--- a/client/wildcard/src/global-styles/base.scss
+++ b/client/wildcard/src/global-styles/base.scss
@@ -44,7 +44,6 @@ input[type='checkbox'] {
 @import 'react-resizable/css/styles';
 // Global styles provided by @reach packages. Should be imported once in the global scope.
 @import '@reach/combobox/styles';
-@import '@reach/menu-button/styles';
 
 // stylelint-disable-next-line selector-max-id
 html,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/51504.

The intent was to NOT include the @reach/menu-button styles (as evidenced by the comment right below in `base.css`). Omitting them does not cause any ill effects.




## Test plan

Previewed locally in Webpack and esbuild (checked that the UserNavItem dropdown has the correct color).