### PR TITLE
JetBrains: Cody: Add actions for opening settings from the status bar

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
@@ -1,0 +1,12 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.cody.config.ui.AccountConfigurable
+
+class CodyManageAccountsAction : DumbAwareAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    ShowSettingsUtil.getInstance().showSettingsDialog(e.project, AccountConfigurable::class.java)
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
@@ -1,0 +1,12 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.cody.config.ui.CodyConfigurable
+
+class CodyOpenSettingsAction : DumbAwareAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    ShowSettingsUtil.getInstance().showSettingsDialog(e.project, CodyConfigurable::class.java)
+  }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -210,6 +210,16 @@
             id="cody.disableLanguageForCodyAutocomplete"
             class="com.sourcegraph.cody.statusbar.CodyDisableLanguageForAutocompleteAction"/>
 
+        <action
+            id="cody.statusBar.manageAccounts"
+            class="com.sourcegraph.cody.statusbar.CodyManageAccountsAction"
+            text="Manage Accounts"/>
+
+        <action
+            id="cody.statusBar.openSettings"
+            class="com.sourcegraph.cody.statusbar.CodyOpenSettingsAction"
+            text="Open Settings"/>
+
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>
             <reference ref="cody.refreshCodyAppDetection"/>
@@ -238,6 +248,8 @@
             <reference ref="cody.disableCodyAutocomplete"/>
             <reference ref="cody.enableLanguageForCodyAutocomplete"/>
             <reference ref="cody.disableLanguageForCodyAutocomplete"/>
+            <reference ref="cody.statusBar.manageAccounts"/>
+            <reference ref="cody.statusBar.openSettings"/>
         </group>
 
         <group id="Cody.Accounts.AddAccount">


### PR DESCRIPTION
Fixes #56616

https://github.com/sourcegraph/sourcegraph/assets/18601388/6bb52d92-ca8b-4208-8fd5-9e4bca28ee79

## Test plan
- ensure the `Manage Accounts` & `Open Settings` actions are in place on the status bar
- ensure they actually do open the correct settings pages
