### PR TITLE
search: exhaustive RepositoryRevSpec -> RepositoryRevSpecs

### DIFF
--- a/enterprise/cmd/worker/internal/search/exhaustive_search.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search.go
@@ -73,7 +73,7 @@ func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger,
 	for _, repoRevSpec := range repoRevSpecs {
 		_, err := tx.CreateExhaustiveSearchRepoJob(ctx, types.ExhaustiveSearchRepoJob{
 			RepoID:      repoRevSpec.Repository,
-			RefSpec:     repoRevSpec.RevisionSpecifier,
+			RefSpec:     repoRevSpec.RevisionSpecifiers.String(),
 			SearchJobID: record.ID,
 		})
 		if err != nil {

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -52,9 +52,9 @@ type exhaustiveSearchRepoHandler struct {
 var _ workerutil.Handler[*types.ExhaustiveSearchRepoJob] = &exhaustiveSearchRepoHandler{}
 
 func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Logger, record *types.ExhaustiveSearchRepoJob) error {
-	repoRevSpec := types.RepositoryRevSpec{
-		Repository:        record.RepoID,
-		RevisionSpecifier: record.RefSpec,
+	repoRevSpec := types.RepositoryRevSpecs{
+		Repository:         record.RepoID,
+		RevisionSpecifiers: types.RevisionSpecifiers(record.RefSpec),
 	}
 
 	parent, err := h.store.GetExhaustiveSearchJob(ctx, record.SearchJobID)

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs.go
@@ -103,7 +103,7 @@ func (s *Store) GetQueryRepoRev(ctx context.Context, job *types.ExhaustiveSearch
 	err error,
 ) {
 	row := s.QueryRow(ctx, sqlf.Sprintf(getRepoRevSpecFmtStr, job.SearchRepoJobID))
-	err = row.Scan(&id, &query, &repoRev.Repository, &repoRev.RevisionSpecifier)
+	err = row.Scan(&id, &query, &repoRev.Repository, &repoRev.RevisionSpecifiers)
 	if err != nil {
 		return 0, "", types.RepositoryRevision{}, err
 	}

--- a/internal/search/exhaustive/types/exhaustive_search.go
+++ b/internal/search/exhaustive/types/exhaustive_search.go
@@ -2,31 +2,47 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
-// RepositoryRevSpec represents zero or more revisions we need to search in a
+// RevisionSpecifiers is something that still needs to be resolved on
+// gitserver. This is a serialized version of []query.RevisionSpecifier.
+//
+// We need to store a list since specifiers interact. For example a glob
+// pattern can be coupled with a negative glob pattern.
+type RevisionSpecifiers string
+
+func (s RevisionSpecifiers) String() string {
+	return string(s)
+}
+
+// Get returns the marshalled version of []query.RevisionSpecifier
+func (s RevisionSpecifiers) Get() []string {
+	// : is the same seperator we use in our query language.
+	return strings.Split(string(s), ":")
+}
+
+// RepositoryRevSpecs represents zero or more revisions we need to search in a
 // repository for a revision specifier. This can be inferred relatively
 // cheaply from parsing a query and the repos table.
 //
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
 //
-// Note: this is like a search/repos.RepoRevSpecs except we store 1 revision
-// specifier per repository. It may be worth updating this to instead store a
-// slice of RevisionSpecifiers.
-type RepositoryRevSpec struct {
+// Note: this is serializable version of search/repos.RepoRevSpecs.
+type RepositoryRevSpecs struct {
 	// Repository is the repository to search.
 	Repository api.RepoID
 
-	// RevisionSpecifier is something that still needs to be resolved on gitserver. This
-	// is a serialiazed version of query.RevisionSpecifier.
-	RevisionSpecifier string
+	// RevisionSpecifiers is something that still needs to be resolved on
+	// gitserver. This is a serialized version of query.RevisionSpecifier.
+	RevisionSpecifiers RevisionSpecifiers
 }
 
-func (r RepositoryRevSpec) String() string {
-	return fmt.Sprintf("RepositoryRevSpec{%d@%s}", r.Repository, r.RevisionSpecifier)
+func (r RepositoryRevSpecs) String() string {
+	return fmt.Sprintf("RepositoryRevSpec{%d@%s}", r.Repository, r.RevisionSpecifiers)
 }
 
 // RepositoryRevision represents the smallest unit we can search over, a
@@ -35,8 +51,8 @@ func (r RepositoryRevSpec) String() string {
 // This type needs to be serializable so that we can persist it to a database
 // or queue.
 type RepositoryRevision struct {
-	// RepositoryRevSpec is where this RepositoryRevision got resolved from.
-	RepositoryRevSpec
+	// RepositoryRevSpecs is where this RepositoryRevision got resolved from.
+	RepositoryRevSpecs
 
 	// Revision is a resolved revision specifier. eg HEAD, branch-name,
 	// commit-hash, etc.


### PR DESCRIPTION
Previously we would create a worker job per repo@refspec. However, we actually need the list of refspecs from a query to live together since they influence each other. For example the negated glob can remove refs from the final generated list of refs to search.

This commit keeps the string type and doesn't change anything in the DB. However, it updates naming and documentation to reflect that it is a list of refspecs.

I think there are database constraints around this, but I think once we have stuff working in a nice way we should revisit things like the schema and adjust it then.

Test Plan: CI