### PR TITLE
search jobs: fix state

### DIFF
--- a/cmd/frontend/graphqlbackend/search_jobs.go
+++ b/cmd/frontend/graphqlbackend/search_jobs.go
@@ -38,7 +38,7 @@ type CreateSearchJobArgs struct {
 type SearchJobResolver interface {
 	ID() graphql.ID
 	Query() string
-	State() string
+	State(ctx context.Context) string
 	Creator(ctx context.Context) (*UserResolver, error)
 	CreatedAt() gqlutil.DateTime
 	StartedAt(ctx context.Context) *gqlutil.DateTime

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -60,7 +60,7 @@ func (r *Resolver) DeleteSearchJob(ctx context.Context, args *graphqlbackend.Del
 	return nil, r.svc.DeleteSearchJob(ctx, jobID)
 }
 
-func newSearchJobConnectionResolver(db database.DB, service *service.Service, args *graphqlbackend.SearchJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.SearchJobResolver], error) {
+func newSearchJobConnectionResolver(ctx context.Context, db database.DB, service *service.Service, args *graphqlbackend.SearchJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.SearchJobResolver], error) {
 	var states []string
 	if args.States != nil {
 		states = *args.States
@@ -83,6 +83,7 @@ func newSearchJobConnectionResolver(db database.DB, service *service.Service, ar
 	}
 
 	s := &searchJobsConnectionStore{
+		ctx:     ctx,
 		db:      db,
 		service: service,
 		states:  states,
@@ -99,6 +100,7 @@ func newSearchJobConnectionResolver(db database.DB, service *service.Service, ar
 }
 
 type searchJobsConnectionStore struct {
+	ctx     context.Context
 	db      database.DB
 	service *service.Service
 	states  []string
@@ -145,7 +147,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 	case "created_at":
 		value = fmt.Sprintf("'%v'", node.CreatedAt().Format(time.RFC3339))
 	case "state":
-		value = fmt.Sprintf("'%v'", strings.ToLower(node.State()))
+		value = fmt.Sprintf("'%v'", strings.ToLower(node.State(s.ctx)))
 	case "query":
 		value = fmt.Sprintf("'%v'", node.Query())
 	default:
@@ -204,8 +206,8 @@ func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy datab
 	return &csv, nil
 }
 
-func (r *Resolver) SearchJobs(_ context.Context, args *graphqlbackend.SearchJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.SearchJobResolver], error) {
-	return newSearchJobConnectionResolver(r.db, r.svc, args)
+func (r *Resolver) SearchJobs(ctx context.Context, args *graphqlbackend.SearchJobsArgs) (*graphqlutil.ConnectionResolver[graphqlbackend.SearchJobResolver], error) {
+	return newSearchJobConnectionResolver(ctx, r.db, r.svc, args)
 }
 
 func (r *Resolver) NodeResolvers() map[string]graphqlbackend.NodeByIDFunc {

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -25,10 +26,10 @@ func UnmarshalSearchJobID(id graphql.ID) (int64, error) {
 	return v, err
 }
 
-var _ graphqlbackend.SearchJobResolver = searchJobResolver{}
+var _ graphqlbackend.SearchJobResolver = &searchJobResolver{}
 
-func newSearchJobResolver(db database.DB, svc *service.Service, job *types.ExhaustiveSearchJob) searchJobResolver {
-	return searchJobResolver{Job: job, db: db, svc: svc}
+func newSearchJobResolver(db database.DB, svc *service.Service, job *types.ExhaustiveSearchJob) *searchJobResolver {
+	return &searchJobResolver{Job: job, db: db, svc: svc}
 }
 
 // You should call newSearchJobResolver to construct an instance.
@@ -36,21 +37,42 @@ type searchJobResolver struct {
 	Job *types.ExhaustiveSearchJob
 	db  database.DB
 	svc *service.Service
+
+	// call initStats to access stats and statsErr
+	once     sync.Once
+	statsErr error
+	stats    *types.RepoRevJobStats
 }
 
-func (r searchJobResolver) ID() graphql.ID {
+func (r *searchJobResolver) ID() graphql.ID {
 	return relay.MarshalID(searchJobIDKind, r.Job.ID)
 }
 
-func (r searchJobResolver) Query() string {
+func (r *searchJobResolver) Query() string {
 	return r.Job.Query
 }
 
-func (r searchJobResolver) State() string {
-	return r.Job.State.ToGraphQL()
+func (r *searchJobResolver) State(ctx context.Context) string {
+	// Once a search job has started processing, we have to look at the aggregate
+	// state of all sub-jobs to determine the state.
+	if r.Job.State == types.JobStateProcessing || r.Job.State == types.JobStateCompleted {
+		stats, statsErr := r.initStats(ctx)
+
+		if statsErr != nil || stats.Failed > 0 {
+			return types.JobStateFailed.ToGraphQL()
+		}
+
+		if stats.InProgress > 0 {
+			return types.JobStateProcessing.ToGraphQL()
+		}
+
+		return types.JobStateCompleted.ToGraphQL()
+	} else {
+		return r.Job.State.ToGraphQL()
+	}
 }
 
-func (r searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+func (r *searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
 	user, err := r.db.Users().GetByID(ctx, r.Job.InitiatorID)
 	if err != nil {
 		return nil, err
@@ -58,19 +80,19 @@ func (r searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserRes
 	return graphqlbackend.NewUserResolver(ctx, r.db, user), nil
 }
 
-func (r searchJobResolver) CreatedAt() gqlutil.DateTime {
+func (r *searchJobResolver) CreatedAt() gqlutil.DateTime {
 	return *gqlutil.FromTime(r.Job.CreatedAt)
 }
 
-func (r searchJobResolver) StartedAt(ctx context.Context) *gqlutil.DateTime {
+func (r *searchJobResolver) StartedAt(ctx context.Context) *gqlutil.DateTime {
 	return gqlutil.FromTime(r.Job.StartedAt)
 }
 
-func (r searchJobResolver) FinishedAt(ctx context.Context) *gqlutil.DateTime {
+func (r *searchJobResolver) FinishedAt(ctx context.Context) *gqlutil.DateTime {
 	return gqlutil.FromTime(r.Job.FinishedAt)
 }
 
-func (r searchJobResolver) URL(ctx context.Context) (*string, error) {
+func (r *searchJobResolver) URL(ctx context.Context) (*string, error) {
 	if r.Job.State == types.JobStateCompleted {
 		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d", r.Job.ID))
 		if err != nil {
@@ -80,7 +102,8 @@ func (r searchJobResolver) URL(ctx context.Context) (*string, error) {
 	}
 	return nil, nil
 }
-func (r searchJobResolver) LogURL(ctx context.Context) (*string, error) {
+
+func (r *searchJobResolver) LogURL(ctx context.Context) (*string, error) {
 	if r.Job.State == types.JobStateCompleted {
 		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d/logs", r.Job.ID))
 		if err != nil {
@@ -91,11 +114,23 @@ func (r searchJobResolver) LogURL(ctx context.Context) (*string, error) {
 	return nil, nil
 }
 
-func (r searchJobResolver) RepoStats(ctx context.Context) (graphqlbackend.SearchJobStatsResolver, error) {
-	repoRevStats, err := r.svc.GetAggregateRepoRevState(ctx, r.Job.ID)
-	if err != nil {
-		return nil, err
-	}
+func (r *searchJobResolver) initStats(ctx context.Context) (*types.RepoRevJobStats, error) {
+	r.once.Do(func() {
+		repoRevStats, err := r.svc.GetAggregateRepoRevState(ctx, r.Job.ID)
+		if err != nil {
+			r.statsErr = err
+			return
+		}
+		r.stats = repoRevStats
+	})
 
-	return &searchJobStatsResolver{repoRevStats}, nil
+	return r.stats, r.statsErr
+}
+
+func (r *searchJobResolver) RepoStats(ctx context.Context) (graphqlbackend.SearchJobStatsResolver, error) {
+	stats, statsErr := r.initStats(ctx)
+	if statsErr != nil {
+		return nil, statsErr
+	}
+	return &searchJobStatsResolver{stats}, nil
 }

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -124,8 +124,8 @@ func TestExhaustiveSearch(t *testing.T) {
 		stats, err := svc.GetAggregateRepoRevState(userCtx, job.ID)
 		require.NoError(err)
 		require.Equal(&types.RepoRevJobStats{
-			Total:      3,
-			Completed:  3,
+			Total:      6,
+			Completed:  6, // 1 search job + 2 repo jobs + 3 repo rev jobs
 			Failed:     0,
 			InProgress: 0,
 		}, stats)


### PR DESCRIPTION
searchJobResolver.State now returns a state based on the aggregate state of all (sub-)jobs related to the job.

Now, only if all (sub-)jobs completed successfuly will the job report the state "Completed". Previously, we reported "Complete" once the top-level finsihed, even if repo-rev jobs were still running.

Test plan:
- Updated unit test
- Manual testing

````
mutation create {
  createSearchJob(query: "context:global 1@rev1 2@rev5 3@rev6") {
    id
  }
}

query state {
  node(id: "U2VhcmNoSm9iOjEwNQ==") {
    ... on SearchJob {
      repoStats {
    	inProgress
        failed
        completed
        total
      }
      state
    }
  }
}

{
  "data": {
    "node": {
      "repoStats": {
        "inProgress": 0,
        "failed": 0,
        "completed": 7,
        "total": 7
      },
      "state": "COMPLETED"
    }
  }
}
````



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
