### PR TITLE
docs: add "Getting started" section to Permissions docs

### DIFF
--- a/doc/admin/permissions/index.md
+++ b/doc/admin/permissions/index.md
@@ -8,21 +8,36 @@ see the entities that they can see on the code host. These permissions are enfor
 across the product for all the use cases that need to read data from a repository, 
 including the existence of such repository on the code host.
 
-## Example
-
 Imagine a scenario, with 2 users, `alice` and `bob`: 
 
-- `alice` can access repositories `horsegraph/global` and `horsegraph/alice` on the code host
-- `bob` has access to repositories `horsegraph/global` and `horsegraph/docs` on the code host
-- there is also a public repository `horsegraph/public`
-- all of the mentioned repositories are synced to Sourcegraph
+- `alice` can access repositories `my-organisation/global` and `my-organisation/alice` on the code host
+- `bob` has access to repositories `my-organisation/global` and `my-organisation/docs` on the code host
+- There is a public repository `my-organisation/public`
+- All of the mentioned repositories are synced to Sourcegraph
 
-If `alice` tries to run a search on Sourcegraph, the results will only contain data from the public `horsegraph/global` repository 
-and the ones she has access to (`horsegraph/global` and `horsegraph/alice`). `alice` will not be able to see results 
-from the `horsegraph/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
+With permissions set up, when `alice` tries to run a search on Sourcegraph, the results will only contain data from the public `my-organisation/global` repository and the ones she has access to (`my-organisation/global` and `my-organisation/alice`). `alice` will not be able to see results from the `my-organisation/docs`. If `alice` creates a code insight, she will only see results from the repositories she has access to.
 
-Same for `bob`, the search results or any other feature will not show him the existence of `horsegraph/alice` repository on 
-Sourcegraph, since `bob` does not have access to it on the code host.
+Same for `bob`, the search results or any other feature will not show him the existence of `my-organisation/alice` repository on Sourcegraph, since `bob` does not have access to it on the code host.
+
+## Getting started
+
+To set up permissions by [syncing them from a code host](syncing.md) you need two things: [an authentication provider](../auth/index.md) that can tell which users should see which repositories and [a code host connection](../external_service/index.md) with authorization enabled.
+
+1. Configure an authentication provider for the code host from which you want to sync permissions:
+    - [GitHub](../auth/index.md#github)
+    - [GitLab](../auth/index.md#gitlab)
+    - [Bitbucket Cloud](../auth/index.md#bitbucket-cloud)
+    - [Gerrit](../auth/index.md#gerrit)
+    - Bitbucket Server doesn't require an authentication provider, but has [other prerequisites](../external_service/bitbucket_server.md#prerequisites)
+    - Perforce doesn't need a separate authentication provider
+2. Configure the code host connection to use authorization:
+    - [GitHub](../external_service/github.md#repository-permissions)
+    - [GitLab](../external_service/gitlab.md#repository-permissions)
+    - [Bitbucket Cloud](../external_service/bitbucket_cloud.md#repository-permissions)
+    - [Gerrit](../external_service/gerrit.md#add-gerrit-as-an-authentication-provider)
+    - [Perforce](../repo/perforce.md#repository-permissions)
+
+It's also possible to use other methods to get permission data from a code host into the Sourcegraph instance.
 
 ## Supported methods to sync permissions
 


### PR DESCRIPTION
This adds a short section to "Permissions" so that users aren't completely lost. It links to the actual pages that tell the user how to configure things.

It's a first bandaid fix. We need to clean up this page.

## Before / After
| Before | After |
|--------|------|
| <img width="1260" alt="screenshot_2023-09-19_12 32 23@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/73047536-625a-47a0-b744-c71ffd272e9f"> | <img width="1172" alt="screenshot_2023-09-19_12 32 54@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/fc98e36d-594f-4796-a805-0970e0fb4edf"> |

## Test plan

- Local testing

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@mrn/docs-permissions)