### PR TITLE
Make `sg wolfi update-hashes` work on single images

### DIFF
--- a/dev/sg/internal/wolfi/update_hashes.go
+++ b/dev/sg/internal/wolfi/update_hashes.go
@@ -99,6 +99,7 @@ func getImageManifest(image string, tag string) (string, error) {
 
 func UpdateHashes(ctx *cli.Context, updateImageName string) error {
 	if updateImageName != "" {
+		updateImageName = strings.ReplaceAll(updateImageName, "-", "_")
 		updateImageName = fmt.Sprintf("wolfi_%s_base", updateImageName)
 	}
 

--- a/dev/sg/internal/wolfi/update_hashes.go
+++ b/dev/sg/internal/wolfi/update_hashes.go
@@ -97,7 +97,10 @@ func getImageManifest(image string, tag string) (string, error) {
 	return digest, nil
 }
 
-func UpdateHashes(ctx *cli.Context) error {
+func UpdateHashes(ctx *cli.Context, updateImageName string) error {
+	if updateImageName != "" {
+		updateImageName = fmt.Sprintf("wolfi_%s_base", updateImageName)
+	}
 
 	root, err := root.RepositoryRoot()
 
@@ -105,7 +108,8 @@ func UpdateHashes(ctx *cli.Context) error {
 		return err
 	}
 
-	bzl_deps := filepath.Join(root, "dev/oci_deps.bzl")
+	bzl_deps_file := "dev/oci_deps.bzl"
+	bzl_deps := filepath.Join(root, bzl_deps_file)
 
 	file, err := os.Open(bzl_deps)
 	if err != nil {
@@ -122,9 +126,14 @@ func UpdateHashes(ctx *cli.Context) error {
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	std.Out.Write("Checking for image updates...")
 
-	var updated bool
+	if updateImageName == "" {
+		std.Out.Write("Checking for hash updates to all images...")
+	} else {
+		std.Out.Writef("Checking for hash updates to '%s'...", updateImageName)
+	}
+
+	var updated, updateImageNameMatch bool
 
 	var currentImage *ImageInfo
 	for i, line := range lines {
@@ -132,7 +141,13 @@ func UpdateHashes(ctx *cli.Context) error {
 		case namePattern.MatchString(line):
 			match := namePattern.FindStringSubmatch(line)
 			if len(match) > 1 {
-				currentImage = &ImageInfo{Name: strings.Trim(match[1], `"`)}
+				imageName := strings.Trim(match[1], `"`)
+
+				// Only update an image if updateImageName matches the name, or if it's empty (in which case update all images)
+				if updateImageName == imageName || updateImageName == "" {
+					updateImageNameMatch = true
+					currentImage = &ImageInfo{Name: imageName}
+				}
 			}
 		case digestPattern.MatchString(line):
 			match := digestPattern.FindStringSubmatch(line)
@@ -177,7 +192,19 @@ func UpdateHashes(ctx *cli.Context) error {
 			fmt.Fprintln(writer, line)
 		}
 		writer.Flush()
-		std.Out.WriteSuccessf("Succesfully updated digests in %s", "oci_deps.bzl")
+		std.Out.WriteSuccessf("Succesfully updated digests in %s", bzl_deps_file)
+
+	} else {
+		// No digests were updated - determine why and print status message
+		if updateImageName == "" {
+			std.Out.WriteSuccessf("No digests needed to be updated in %s", bzl_deps_file)
+		} else {
+			if updateImageNameMatch {
+				std.Out.WriteSuccessf("No digests needed to be updated in %s", bzl_deps_file)
+			} else {
+				std.Out.WriteFailuref("Did not find any images matching '%s' in %s", updateImageName, bzl_deps_file)
+			}
+		}
 	}
 
 	return nil

--- a/dev/sg/sg_wolfi.go
+++ b/dev/sg/sg_wolfi.go
@@ -16,6 +16,7 @@ var (
 		UsageText: `
 # Update base image hashes
 sg wolfi update-hashes
+sg wolfi update-hashes jaeger-agent
 
 # Build a specific package using a manifest from wolfi-packages/
 sg wolfi package jaeger
@@ -111,14 +112,26 @@ It can also be used for local development by updating its path and hash in the '
 				},
 			},
 			{
-				Name:  "update-hashes",
-				Usage: "Update Wolfi base images hashes to the latest versions",
+				Name:      "update-hashes",
+				ArgsUsage: "<base-image-name>",
+				Usage:     "Update Wolfi base images hashes to the latest versions",
 				UsageText: `
-Update the hash references for all Wolfi base images in the 'dev/oci_deps.bzl' file.
+Update the hash references for Wolfi base images in the 'dev/oci_deps.bzl' file.
+By default all hashes will be updated; pass in a base image name to update a specific image.
 
-This is done by fetching the ':latest' tag for each base image from the registry, and updating the corresponding hash in 'dev/oci_deps.bzl'.
+Hash references are updated by fetching the ':latest' tag for each base image from the registry, and updating the corresponding hash in 'dev/oci_deps.bzl'.
 `,
-				Action: wolfi.UpdateHashes,
+				Action: func(ctx *cli.Context) error {
+					args := ctx.Args().Slice()
+					var imageName string
+					if len(args) == 1 {
+						imageName = args[0]
+					}
+
+					wolfi.UpdateHashes(ctx, imageName)
+
+					return nil
+				},
 			}},
 	}
 )

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1191,6 +1191,7 @@ Build Wolfi packages and images locally, and update base image hashes
 ```sh
 # Update base image hashes
 $ sg wolfi update-hashes
+$ sg wolfi update-hashes jaeger-agent
 
 # Build a specific package using a manifest from wolfi-packages/
 $ sg wolfi package jaeger
@@ -1239,9 +1240,10 @@ Flags:
 Update Wolfi base images hashes to the latest versions.
 
 ```sh
-$ Update the hash references for all Wolfi base images in the 'dev/oci_deps.bzl' file.
+$ Update the hash references for Wolfi base images in the 'dev/oci_deps.bzl' file.
+$ By default all hashes will be updated; pass in a base image name to update a specific image.
 
-$ This is done by fetching the ':latest' tag for each base image from the registry, and updating the corresponding hash in 'dev/oci_deps.bzl'.
+$ Hash references are updated by fetching the ':latest' tag for each base image from the registry, and updating the corresponding hash in 'dev/oci_deps.bzl'.
 ```
 
 Flags:


### PR DESCRIPTION
Allows `update-hashes` to run against a single image. This is useful when you're updating a package and don't want to update everything.

Also improve the final summary message to better indicate what actions were performed and why.

```
> go run ./ wolfi update-hashes jaeger_agent
Checking for hash updates to 'wolfi_jaeger_agent_base'...
✅ Found new digest for index.docker.io/sourcegraph/wolfi-jaeger-agent-base
Updating file ...
✅ Succesfully updated digests in dev/oci_deps.bzl

> go run ./ wolfi update-hashes jaeger_agent_foobar
Checking for hash updates to 'wolfi_jaeger_agent_foobar_base'...
❌ Did not find any images matching 'wolfi_jaeger_agent_foobar_base' in dev/oci_deps.bzl

> go run ./ wolfi update-hashes
Checking for hash updates to all images...
✅ No digests needed to be updated in dev/oci_deps.bzl
```


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

- Tested locally