### PR TITLE
label-notify: add search-platform and apis

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -27,3 +27,5 @@ jobs:
                   iam=@sourcegraph/source
                   team/source=@sourcegraph/source
                   cody-gateway=@unknwon @eseliger @bobheadxi @efritz @ggilmore
+                  team/search-platform=@sourcegraph/search-platform
+                  team/apis=@sourcegraph/apis


### PR DESCRIPTION
This just makes sure we get pinged if assigned to a ticket.

## Test plan

- N/A