### PR TITLE
JetBrains: don't block forever on event thread

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.protocol.GetRepoID
 import java.awt.event.ActionEvent
+import java.util.concurrent.TimeUnit
 import javax.swing.*
 
 class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Context Selection") {
@@ -24,10 +25,14 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
     override fun doValidate(): ValidationInfo? {
       val repoName = gitURL.text
       if (repoName.isNotEmpty()) {
-        val server = CodyAgent.getInitializedServer(project).get()
-        val id = server.getRepoId(GetRepoID(repoName)).get()
-        if (id == null) {
-          return ValidationInfo("Repository $repoName does not exist", gitURL)
+        try {
+          val server = CodyAgent.getInitializedServer(project).get(1, TimeUnit.SECONDS)
+          val id = server.getRepoId(GetRepoID(repoName)).get(4, TimeUnit.SECONDS)
+          if (id == null) {
+            return ValidationInfo("Repository $repoName does not exist", gitURL)
+          }
+        } catch (e: Exception) {
+          return null
         }
       }
       return null

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.auth.ui
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
@@ -12,6 +13,7 @@ import java.util.concurrent.TimeUnit
 import javax.swing.*
 
 class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Context Selection") {
+  val logger = logger<EditCodebaseContextAction>()
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
     val gitURL =
         ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
@@ -32,6 +34,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
             return ValidationInfo("Repository $repoName does not exist", gitURL)
           }
         } catch (e: Exception) {
+          logger.warn("failed to validate git url", e)
           return null
         }
       }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -14,6 +14,7 @@ import javax.swing.*
 
 class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Context Selection") {
   val logger = logger<EditCodebaseContextAction>()
+
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
     val gitURL =
         ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)


### PR DESCRIPTION
Previously, we were sending a blocking network request on the IntelliJ event thread while validating that a repository name exists on the Sourcegraph instance in the dialog to select the Cody codebase context. If the validation didn't return then the IDE was completely frozen. The only wan to fix the problem was to force quit IntelliJ.

This PR fixes the problem by setting a timeout on the blocking requests so that the user at least regains control over their IntelliJ instance.

## Test plan
n/a
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
