### PR TITLE
e2e tst: add actions to create github users

### DIFF
--- a/dev/codehost_testing/BUILD.bazel
+++ b/dev/codehost_testing/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     srcs = [
         "github_client.go",
         "org.go",
+        "repo.go",
         "reporter.go",
         "scenario.go",
+        "team.go",
         "user.go",
         "util.go",
     ],
@@ -18,7 +20,6 @@ go_library(
         "//lib/errors",
         "@com_github_google_go_github_v55//github",
         "@com_github_google_uuid//:uuid",
-        "@org_golang_x_oauth2//:oauth2",
     ],
 )
 

--- a/dev/codehost_testing/BUILD.bazel
+++ b/dev/codehost_testing/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "org.go",
         "reporter.go",
         "scenario.go",
+        "user.go",
         "util.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/codehost_testing",

--- a/dev/codehost_testing/README.md
+++ b/dev/codehost_testing/README.md
@@ -1,0 +1,110 @@
+# Codehost Testing Library
+
+This library makes it easier to setup Codehost resources in a predicatable and reproducible manner. It accomplishes this by introducing the concept of a scenario.
+
+A scenario describes the state a collection of related resources on a codehost must be in. A collection of resources can at it's most basic just be an Organisation or at it's most complex be an Organisation with various teams and repositories with varying permissions.
+
+Supported Codehosts:
+
+- GitHub
+
+## Configuration
+
+The following configuration is required by this library
+
+```json
+{
+  "github": {
+    "url": "https://path.codehost.org",
+    "adminUser": "dude",
+    "password": "whereismycar",
+    "token": "do_not_leak_me"
+  },
+  "sourcegraph": {
+    "url": "https://path.sourcegraph.org",
+    "user": "boi",
+    "password": "towers_of_hanoi",
+    "token": "do_not_leak_me_plz"
+  }
+}
+```
+
+Additionally, the GitHub token is **required** to have the following scopes:
+
+- admin:enterprise
+- delete_repo
+- repo
+- site_admin
+- user
+- write:org
+
+To load your configuration you can use `config.FromFile` as per the snippet below.
+
+```golang
+	cfg, err := config.FromFile("config.json")
+	if err != nil {
+		t.Fatalf("error loading scenario config: %v\n", err)
+	}
+```
+
+## Usage
+
+We first need to create a scenario. A scenario exposes various methods to add or alter the scenario. In the below snippet we create a scenario that describes the following:
+
+- One Organization
+- One normal user
+- One Admin
+- Two teams. One team with the normal user and the other team with the Admin
+- Two repositories are forked. One repository is public while the other is private and only accessible by the private team.
+
+```golang
+	scenario, err := scenario.NewGitHubScenario(t, *cfg)
+	if err != nil {
+		t.Fatalf("error creating scenario: %v\n", err)
+	}
+	org := scenario.CreateOrg("tst-org")
+	user := scenario.CreateUser("tst-user")
+	admin := scenario.GetAdmin()
+
+	org.AllowPrivateForks()
+	team := org.CreateTeam("team-1")
+	team.AddUser(user)
+	adminTeam := org.CreateTeam("team-admin")
+	adminTeam.AddUser(admin)
+
+	publicRepo := org.CreateRepoFork("sgtest/go-diff")
+	publicRepo.AddTeam(team)
+	privateRepo := org.CreateRepoFork("sgtest/private")
+	privateRepo.AddTeam(adminTeam)
+```
+
+Adding a resource to the scenario does not immediately create or alter it. Instead, when adding a resource to the scenario, what you are actually doing is telling the library that "I want this resource to exist with this particular make up". The scenario keeps track of how all these resources that should be created and altered as **Actions** to be applied sequentially. Thus when calling `scenario.CreateOrg` the Org isn't immediately created, instead, an action is added that \_will create it when the scenario is applied.
+
+We can see what actions our scenario **plans** to apply by calling `Plan` as per the below snippet. `Plan` returns a string that prints out the action names that will be applied by the scenario.
+
+```golang
+	fmt.Println(scenario.Plan())
+```
+
+As was mentioned before, since we haven't applied the scenario, nothing exists yet on the Codehost. To create the resources described by the scenario `Apply` has to be called. In the snippet below the verbosity of the scenario is increased so that we can see how and when the actions are applied.
+
+```
+	scenario.SetVerbose()
+	if err := scenario.Apply(context.Background()); err != nil {
+		t.Fatalf("error applying scenario: %v", err)
+	}
+```
+
+When `Apply` is called on the scenario, the scenario will not only apply all the actions but will also register a corresponding cleanup method with `testing.T` to teardown all resources that will be created by this scenario. Thus, if anything fails, the resources that _have been_ created up and till that point, will be properly
+cleaned up.
+
+After the scenario has been successfully been applied, the corresponding Codehost resource can be retrieved by calling the `Get()` on the scenario resource. For example on the below snippet, the `github.Organization` is retrieved.
+
+```golang
+  ghOrg, err := org.Get(ctx)
+  if err != nil {
+    t.Fatalf("failed to get Organzation: %v", err)
+  }
+```
+
+**IMPORTANT** Calling `Get()` on any scenario resource before the scenario has been applied will result in an error. **Get() will only return the Codehost resource if the scenario has been applied**.

--- a/dev/codehost_testing/example/BUILD.bazel
+++ b/dev/codehost_testing/example/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//dev:go_defs.bzl", "go_test")
+
+go_test(
+    name = "example_test",
+    srcs = ["example_test.go"],
+    deps = [
+        "//dev/codehost_testing",
+        "//dev/codehost_testing/config",
+    ],
+)

--- a/dev/codehost_testing/example/example_test.go
+++ b/dev/codehost_testing/example/example_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	scenario "github.com/sourcegraph/sourcegraph/dev/codehost_testing"
+	"github.com/sourcegraph/sourcegraph/dev/codehost_testing/config"
+)
+
+var runGithub bool
+
+func TestGithubScenario(t *testing.T) {
+	if !runGithub {
+		t.Skip("`run.github` flag not provided - skipping github scenario as this is only an example test")
+	}
+	cfg, err := config.FromFile("config.json")
+	if err != nil {
+		t.Fatalf("error loading scenario config: %v\n", err)
+	}
+	scenario, err := scenario.NewGitHubScenario(t, *cfg)
+	if err != nil {
+		t.Fatalf("error creating scenario: %v\n", err)
+	}
+	org := scenario.CreateOrg("tst-org")
+	user := scenario.CreateUser("tst-user")
+	otherUser := scenario.CreateUser("other-user")
+	admin := scenario.GetAdmin()
+
+	org.AllowPrivateForks()
+	team := org.CreateTeam("team-1")
+	team.AddUser(user)
+	team.AddUser(otherUser)
+	adminTeam := org.CreateTeam("team-admin")
+	adminTeam.AddUser(admin)
+
+	publicRepo := org.CreateRepoFork("sgtest/go-diff")
+	publicRepo.AddTeam(team)
+	privateRepo := org.CreateRepoFork("sgtest/private")
+	privateRepo.AddTeam(adminTeam)
+
+	fmt.Println(scenario.Plan())
+	ctx := context.Background()
+	// Get the Organization WILL FAIL since the scenario has not been applied yet
+	_, err = org.Get(ctx)
+	if err != nil {
+		t.Logf("failed to get github.Organization since it hasn't been applied yet: %v", err)
+	}
+
+	scenario.SetVerbose()
+	if err := scenario.Apply(ctx); err != nil {
+		t.Fatalf("error applying scenario: %v", err)
+	}
+
+	// Get the Organization
+	ghOrg, err := org.Get(ctx)
+	if err != nil {
+		t.Fatalf("failed to get github.Organization: %v", err)
+	}
+
+	t.Logf("GitHub Organization: %s", ghOrg.GetLogin())
+}
+
+func TestMain(m *testing.M) {
+	flag.BoolVar(&runGithub, "run.github", false, "Run example github scenario setup")
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/dev/codehost_testing/org.go
+++ b/dev/codehost_testing/org.go
@@ -3,6 +3,7 @@ package codehost_testing
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v55/github"
 
@@ -62,50 +63,143 @@ func (o *Org) AllowPrivateForks() {
 
 // CreateTeam adds an action to the scenario to create a team with the given name for the org.
 // The Scenario ID will be added as a suffix to the given name.
-func (o *Org) CreateTeam(name string) any {
-	createTeam := &Action{
+func (o *Org) CreateTeam(name string) *Team {
+	baseTeam := &Team{
+		s:    o.s,
+		org:  o,
+		name: name,
+	}
+
+	action := &Action{
 		Name: "org:team:create:" + name,
 		Apply: func(ctx context.Context) error {
+			name := fmt.Sprintf("team-%s-%s", name, o.s.id)
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+			team, err := o.s.client.CreateTeam(ctx, org, name)
+			if err != nil {
+				return err
+			}
+			baseTeam.name = team.GetName()
 			return nil
 		},
 		Teardown: func(ctx context.Context) error {
-			return nil
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+			return o.s.client.DeleteTeam(ctx, org, baseTeam.name)
 		},
 	}
+	o.s.Append(action)
 
-	o.s.Append(createTeam)
-
-	return nil
+	return baseTeam
 }
 
 // CreateRepo adds an action to the scenario to create a repo with the given name and visibility for the org.
-func (o *Org) CreateRepo(name string, public bool) any {
+func (o *Org) CreateRepo(name string, public bool) *Repo {
+	baseRepo := &Repo{
+		s:    o.s,
+		org:  o,
+		name: name,
+	}
 	action := &Action{
 		Name: fmt.Sprintf("repo:create:%s", name),
 		Apply: func(ctx context.Context) error {
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			var repoName string
+			parts := strings.Split(name, "/")
+			if len(parts) >= 2 {
+				repoName = parts[1]
+			} else {
+				return errors.Newf("incorrect repo format for %q - expecting {owner}/{name}")
+			}
+
+			repo, err := o.s.client.CreateRepo(ctx, org, repoName, public)
+			if err != nil {
+				return err
+			}
+
+			baseRepo.name = repo.GetFullName()
 			return nil
 		},
 		Teardown: func(ctx context.Context) error {
-			return nil
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			repo, err := baseRepo.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			return o.s.client.DeleteRepo(ctx, org, repo)
 		},
 	}
 	o.s.Append(action)
 
-	return nil
+	return baseRepo
 }
 
 // CreateRepoFork adds an action to the scenario to fork a target repo into the org.
-func (o *Org) CreateRepoFork(target string) any {
+//
+// NOTE: This method actually adds two actions to the scenario. One which performs the Fork and a subsequent
+// action which waits till the forked repo exists on GitHub.
+func (o *Org) CreateRepoFork(target string) *Repo {
+	baseRepo := &Repo{
+		s:    o.s,
+		org:  o,
+		name: target,
+	}
 	action := &Action{
 		Name: fmt.Sprintf("repo:fork:%s", target),
 		Apply: func(ctx context.Context) error {
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			var owner, repoName string
+			parts := strings.Split(target, "/")
+			if len(parts) >= 2 {
+				owner = parts[0]
+				repoName = parts[1]
+			} else {
+				return errors.Newf("incorrect repo format for %q - expecting {owner}/{name}")
+			}
+
+			err = o.s.client.ForkRepo(ctx, org, owner, repoName)
+			if err != nil {
+				return err
+			}
+
+			// Wait till fork has synced
+			baseRepo.name = repoName
 			return nil
 		},
 		Teardown: func(ctx context.Context) error {
-			return nil
+			org, err := o.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			repo, err := baseRepo.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			return o.s.client.DeleteRepo(ctx, org, repo)
 		},
 	}
 	o.s.Append(action)
+	baseRepo.WaitTillExists()
 
-	return nil
+	return baseRepo
 }

--- a/dev/codehost_testing/repo.go
+++ b/dev/codehost_testing/repo.go
@@ -1,0 +1,127 @@
+package codehost_testing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v55/github"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Repo represents a GitHub repository in the scenario
+type Repo struct {
+	// s is the GithubScenario instance this repo is part of. Actions it creates will be added to this scenario
+	s *GitHubScenario
+	// team is the team this repo belongs to
+	team *Team
+	// org is the Org that owns this repo
+	org *Org
+	// name is the name of the repo
+	name string
+}
+
+// Get returns the corresponding GitHub Repository object that was created by the `CreateOrg`
+//
+// This method will only return a Repository if the Scenario that created it has been applied otherwise
+// it will panic.
+func (r *Repo) Get(ctx context.Context) (*github.Repository, error) {
+	if r.s.IsApplied() {
+		return r.get(ctx)
+	}
+	r.s.t.Fatal("cannot retrieve repo before scenario is applied")
+	return nil, nil
+}
+
+// get retrieves the GitHub repository without panicking if not applied. It is meant as an
+// internal helper method while actions are getting applied.
+func (r *Repo) get(ctx context.Context) (*github.Repository, error) {
+	return r.s.client.GetRepo(ctx, r.org.name, r.name)
+}
+
+// AddTeam creats an action that will update the repo permissions so that the given team
+// has access to this repo.
+func (r *Repo) AddTeam(team *Team) {
+	r.team = team
+	action := &Action{
+		Name: fmt.Sprintf("repo:team:%s:membership:%s", team.name, r.name),
+		Apply: func(ctx context.Context) error {
+			org, err := r.org.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			repo, err := r.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			team, err := r.team.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = r.s.client.UpdateTeamRepoPermissions(ctx, org, team, repo)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Teardown: nil,
+	}
+
+	r.s.Append(action)
+}
+
+// SetPermissions adds an action that will set the permissions (public or private) for the repository
+func (r *Repo) SetPermissions(private bool) {
+	permissionKey := "private"
+	if !private {
+		permissionKey = "public"
+	}
+	action := &Action{
+		Name: fmt.Sprintf("repo:permissions:%s:%s", r.name, permissionKey),
+		Apply: func(ctx context.Context) error {
+			repo, err := r.get(ctx)
+			if err != nil {
+				return err
+			}
+			repo.Private = &private
+
+			org, err := r.org.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			_, err = r.s.client.UpdateRepo(ctx, org, repo)
+			if err != nil {
+				return err
+			}
+			return err
+		},
+	}
+
+	r.s.Append(action)
+}
+
+// WaitTillExists creates an action that waits for the repository to exist on GitHub. This action is especially
+// useful for when a repo is forked since a forked repo doesn't immediately exist when requested on GitHub.
+func (r *Repo) WaitTillExists() {
+	action := &Action{
+		Name: fmt.Sprintf("repo:exists:%s", r.name),
+		Apply: func(ctx context.Context) error {
+			var err error
+			for i := 0; i < 5; i++ {
+				time.Sleep(1 * time.Second)
+				_, err = r.get(ctx)
+				if err == nil {
+					return nil
+				}
+			}
+			return errors.Newf("repo %q did not exist after waiting: %v", r.name, err)
+		},
+	}
+
+	r.s.Append(action)
+}

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -252,3 +252,40 @@ func (s *GitHubScenario) CreateOrg(name string) *Org {
 	s.Append(createOrg)
 	return baseOrg
 }
+
+func (s *GithubScenario) CreateUser(name string) *User {
+	baseUser := &User{
+		s:    s,
+		name: name,
+	}
+
+	createUser := &action{
+		name: "user:create:" + name,
+		apply: func(ctx context.Context) error {
+			name := fmt.Sprintf("user-%s-%s", name, s.id)
+			email := "test-user-e2e@sourcegraph.com"
+			user, err := s.client.CreateUser(ctx, name, email)
+			if err != nil {
+				return err
+			}
+
+			baseUser.name = user.GetLogin()
+			return nil
+		},
+		teardown: func(ctx context.Context) error {
+			return s.client.DeleteUser(ctx, baseUser.name)
+		},
+	}
+
+	s.append(createUser)
+	return baseUser
+}
+
+func (s *GithubScenario) GetAdmin() *User {
+	baseUser := &User{
+		s:    s,
+		name: s.client.cfg.AdminUser,
+	}
+
+	return baseUser
+}

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -261,9 +261,9 @@ func (s *GitHubScenario) CreateUser(name string) *User {
 		name: name,
 	}
 
-	createUser := &action{
-		name: "user:create:" + name,
-		apply: func(ctx context.Context) error {
+	createUser := &Action{
+		Name: "user:create:" + name,
+		Apply: func(ctx context.Context) error {
 			name := fmt.Sprintf("user-%s-%s", name, s.id)
 			email := "test-user-e2e@sourcegraph.com"
 			user, err := s.client.CreateUser(ctx, name, email)
@@ -274,12 +274,12 @@ func (s *GitHubScenario) CreateUser(name string) *User {
 			baseUser.name = user.GetLogin()
 			return nil
 		},
-		teardown: func(ctx context.Context) error {
+		Teardown: func(ctx context.Context) error {
 			return s.client.DeleteUser(ctx, baseUser.name)
 		},
 	}
 
-	s.append(createUser)
+	s.Append(createUser)
 	return baseUser
 }
 

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -63,6 +63,7 @@ type GitHubScenario struct {
 	actions       []*Action
 	reporter      Reporter
 	nextActionIdx int
+	adminUser     *User
 }
 
 var _ Scenario = (*GitHubScenario)(nil)
@@ -79,13 +80,19 @@ func NewGitHubScenario(t *testing.T, cfg config.Config) (*GitHubScenario, error)
 	}
 	uid := []byte(uuid.NewString())
 	id := base64.RawStdEncoding.EncodeToString(uid[:])[:10]
-	return &GitHubScenario{
+	scenario := &GitHubScenario{
 		id:       id,
 		t:        t,
 		client:   client,
 		actions:  make([]*Action, 0),
 		reporter: NoopReporter{},
-	}, nil
+	}
+	scenario.adminUser = &User{
+		s:    scenario,
+		name: cfg.GitHub.AdminUser,
+	}
+
+	return scenario, err
 }
 
 // Verbose sets the reporter to ConsoleReporter to enable verbose output
@@ -289,10 +296,5 @@ func (s *GitHubScenario) CreateUser(name string) *User {
 // require that the scenario has been applied before the admin user can be retrieved - even though
 // it is not strictly required as the Admin already exists.
 func (s *GitHubScenario) GetAdmin() *User {
-	baseUser := &User{
-		s:    s,
-		name: s.client.cfg.AdminUser,
-	}
-
-	return baseUser
+	return s.adminUser
 }

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -253,6 +253,8 @@ func (s *GitHubScenario) CreateOrg(name string) *Org {
 	return baseOrg
 }
 
+// CreateUser adds an action to the scenario that will create a GitHub user with the given name. The username of the
+// user will have the following format `user-{name}-{scenario id}` and email `test-user-e2e@sourcegraph.com`.
 func (s *GithubScenario) CreateUser(name string) *User {
 	baseUser := &User{
 		s:    s,
@@ -281,6 +283,11 @@ func (s *GithubScenario) CreateUser(name string) *User {
 	return baseUser
 }
 
+// GetAdmin returns a User representing the GitHub admin user configured in the client.
+//
+// NOTE: this method does not actually add an explicit action to the scenario, but will still
+// require that the scenario has been applied before the admin user can be retrieved - even though
+// it is not strictly required as the Admin already exists.
 func (s *GithubScenario) GetAdmin() *User {
 	baseUser := &User{
 		s:    s,

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -2,7 +2,9 @@ package codehost_testing
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
@@ -272,7 +274,8 @@ func (s *GitHubScenario) CreateUser(name string) *User {
 		Name: "user:create:" + name,
 		Apply: func(ctx context.Context) error {
 			name := fmt.Sprintf("user-%s-%s", name, s.id)
-			email := fmt.Sprintf("test-user-e2e+%s@sourcegraph.com", s.id)
+			emailID := md5.Sum([]byte(s.id + time.Now().String()))
+			email := fmt.Sprintf("test-user-e2e-%s@sourcegraph.com", hex.EncodeToString(emailID[:]))
 			user, err := s.client.CreateUser(ctx, name, email)
 			if err != nil {
 				return err

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -272,7 +272,7 @@ func (s *GitHubScenario) CreateUser(name string) *User {
 		Name: "user:create:" + name,
 		Apply: func(ctx context.Context) error {
 			name := fmt.Sprintf("user-%s-%s", name, s.id)
-			email := "test-user-e2e@sourcegraph.com"
+			email := fmt.Sprintf("test-user-e2e+%s@sourcegraph.com", s.id)
 			user, err := s.client.CreateUser(ctx, name, email)
 			if err != nil {
 				return err

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -87,7 +87,7 @@ func NewGitHubScenario(t *testing.T, cfg config.Config) (*GitHubScenario, error)
 		t:        t,
 		client:   client,
 		actions:  make([]*Action, 0),
-		reporter: NoopReporter{},
+		reporter: &NoopReporter{},
 	}
 	scenario.adminUser = &User{
 		s:    scenario,
@@ -104,7 +104,7 @@ func (s *GitHubScenario) SetVerbose() {
 
 // Quiet sets the reporter to a no-op reporter to reduce output
 func (s *GitHubScenario) SetQuiet() {
-	s.reporter = NoopReporter{}
+	s.reporter = &NoopReporter{}
 }
 
 func (s *GitHubScenario) Append(actions ...*Action) {
@@ -175,11 +175,11 @@ func (s *GitHubScenario) Apply(ctx context.Context) error {
 		duration := time.Now().UTC().Sub(now)
 
 		if err != nil {
+			errs = errors.Append(errs, err)
 			s.reporter.Writef("FAILED (%s)\n", duration.String())
 			if failFast {
 				break
 			}
-			errs = errors.Append(errs, err)
 		} else {
 			s.nextActionIdx++
 			s.reporter.Writef("SUCCESS (%s)\n", duration.String())

--- a/dev/codehost_testing/scenario.go
+++ b/dev/codehost_testing/scenario.go
@@ -255,7 +255,7 @@ func (s *GitHubScenario) CreateOrg(name string) *Org {
 
 // CreateUser adds an action to the scenario that will create a GitHub user with the given name. The username of the
 // user will have the following format `user-{name}-{scenario id}` and email `test-user-e2e@sourcegraph.com`.
-func (s *GithubScenario) CreateUser(name string) *User {
+func (s *GitHubScenario) CreateUser(name string) *User {
 	baseUser := &User{
 		s:    s,
 		name: name,
@@ -288,7 +288,7 @@ func (s *GithubScenario) CreateUser(name string) *User {
 // NOTE: this method does not actually add an explicit action to the scenario, but will still
 // require that the scenario has been applied before the admin user can be retrieved - even though
 // it is not strictly required as the Admin already exists.
-func (s *GithubScenario) GetAdmin() *User {
+func (s *GitHubScenario) GetAdmin() *User {
 	baseUser := &User{
 		s:    s,
 		name: s.client.cfg.AdminUser,

--- a/dev/codehost_testing/scenario_test.go
+++ b/dev/codehost_testing/scenario_test.go
@@ -70,7 +70,7 @@ func TestScenarioApplyAndTeardown(t *testing.T) {
 		}
 
 		err := scenario.Apply(context.TODO())
-		if err != nil && err != fakeErr {
+		if err != nil && !errors.Is(err, fakeErr) {
 			t.Fatalf("failed to apply test scenario with mock actions: %v", err)
 		}
 

--- a/dev/codehost_testing/team.go
+++ b/dev/codehost_testing/team.go
@@ -1,0 +1,66 @@
+package codehost_testing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v55/github"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// Team represents a GitHub team and provdes actions that operate on a GitHub team.
+//
+// All methods except Get, create actions which are added to the parent GitHubScenario this
+// team belongs to.
+type Team struct {
+	// s is the GithubScenario instance this team was created from
+	s *GitHubScenario
+	// org is the Org this team belongs to, and is ultimately the one who created this team
+	org *Org
+	// name is the name of the team
+	name string
+}
+
+// Get returns the corresponding GitHub Team object that was created by the `CreateTeam`
+//
+// This method will only return a Team if the Scenario that created it has been applied otherwise
+// it will panic.
+func (team *Team) Get(ctx context.Context) (*github.Team, error) {
+	if team.s.IsApplied() {
+		return team.get(ctx)
+	}
+	return nil, errors.New("cannot retrieve org before scenario is applied")
+}
+
+// get retrieves the GitHub team without panicking if not applied. It is meant as an
+// internal helper method while actions are getting applied.
+func (team *Team) get(ctx context.Context) (*github.Team, error) {
+	return team.s.client.GetTeam(ctx, team.org.name, team.name)
+}
+
+// AddUser adds an action that will add the given user to this team
+func (tm *Team) AddUser(u *User) {
+	assignTeamMembership := &Action{
+		Name: fmt.Sprintf("team:membership:%s:%s", tm.name, u.name),
+		Apply: func(ctx context.Context) error {
+			org, err := tm.org.get(ctx)
+			if err != nil {
+				return err
+			}
+			team, err := tm.get(ctx)
+			if err != nil {
+				return err
+			}
+			user, err := u.get(ctx)
+			if err != nil {
+				return err
+			}
+			_, err = tm.s.client.AssignTeamMembership(ctx, org, team, user)
+			return err
+		},
+		Teardown: nil,
+	}
+
+	tm.s.Append(assignTeamMembership)
+}

--- a/dev/codehost_testing/user.go
+++ b/dev/codehost_testing/user.go
@@ -1,0 +1,23 @@
+package codehost_scenario
+
+import (
+	"context"
+
+	"github.com/google/go-github/v53/github"
+)
+
+type User struct {
+	s    *GithubScenario
+	name string
+}
+
+func (u *User) Get(ctx context.Context) (*github.User, error) {
+	if u.s.IsApplied() {
+		return u.get(ctx)
+	}
+	panic("cannot retrieve user before scenario is applied")
+}
+
+func (u *User) get(ctx context.Context) (*github.User, error) {
+	return u.s.client.GetUser(ctx, u.name)
+}

--- a/dev/codehost_testing/user.go
+++ b/dev/codehost_testing/user.go
@@ -1,4 +1,4 @@
-package codehost_scenario
+package codehost_testing
 
 import (
 	"context"

--- a/dev/codehost_testing/user.go
+++ b/dev/codehost_testing/user.go
@@ -6,11 +6,16 @@ import (
 	"github.com/google/go-github/v53/github"
 )
 
+// User represents a GitHub user in the scenario.
 type User struct {
 	s    *GithubScenario
 	name string
 }
 
+// Get returns the corresponding GitHub user object that was created by the `CreateUser`
+//
+// This method will only return a User if the Scenario that created it has been applied otherwise
+// it will panic.
 func (u *User) Get(ctx context.Context) (*github.User, error) {
 	if u.s.IsApplied() {
 		return u.get(ctx)
@@ -18,6 +23,8 @@ func (u *User) Get(ctx context.Context) (*github.User, error) {
 	panic("cannot retrieve user before scenario is applied")
 }
 
+// get retrieves the GitHub user without panicking if not applied. It is meant as an
+// internal helper method while actions are getting applied.
 func (u *User) get(ctx context.Context) (*github.User, error) {
 	return u.s.client.GetUser(ctx, u.name)
 }

--- a/dev/codehost_testing/user.go
+++ b/dev/codehost_testing/user.go
@@ -3,12 +3,14 @@ package codehost_testing
 import (
 	"context"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // User represents a GitHub user in the scenario.
 type User struct {
-	s    *GithubScenario
+	s    *GitHubScenario
 	name string
 }
 
@@ -20,7 +22,7 @@ func (u *User) Get(ctx context.Context) (*github.User, error) {
 	if u.s.IsApplied() {
 		return u.get(ctx)
 	}
-	panic("cannot retrieve user before scenario is applied")
+	return nil, errors.New("cannot retrieve user before scenario is applied")
 }
 
 // get retrieves the GitHub user without panicking if not applied. It is meant as an


### PR DESCRIPTION
add actions to create github users and also remove created users.

note: we cannot create admins so instead of search and map a user to the
Admin user

## Test plan
tested in wb/e2e/poc

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
