### PR TITLE
e2e tst: add actions to create repos

### DIFF
--- a/dev/codehost_testing/BUILD.bazel
+++ b/dev/codehost_testing/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "github_client.go",
         "org.go",
+        "repo.go",
         "reporter.go",
         "scenario.go",
         "team.go",

--- a/dev/codehost_testing/org.go
+++ b/dev/codehost_testing/org.go
@@ -148,6 +148,9 @@ func (o *Org) CreateRepo(name string, public bool) *Repo {
 }
 
 // CreateRepoFork adds an action to the scenario to fork a target repo into the org.
+//
+// NOTE: This method actually adds two actions to the scenario. One which performs the Fork and a subsequent
+// action which waits till the forked repo exists on GitHub.
 func (o *Org) CreateRepoFork(target string) *Repo {
 	baseRepo := &Repo{
 		s:    o.s,

--- a/dev/codehost_testing/org.go
+++ b/dev/codehost_testing/org.go
@@ -3,6 +3,7 @@ package codehost_testing
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v55/github"
 
@@ -180,7 +181,6 @@ func (o *Org) CreateRepoFork(target string) *Repo {
 			}
 
 			// Wait till fork has synced
-			time.Sleep(1 * time.Second)
 			baseRepo.name = repoName
 			return nil
 		},

--- a/dev/codehost_testing/org.go
+++ b/dev/codehost_testing/org.go
@@ -105,9 +105,9 @@ func (o *Org) CreateRepo(name string, public bool) *Repo {
 		org:  o,
 		name: name,
 	}
-	action := &action{
-		name: fmt.Sprintf("repo:create:%s", name),
-		apply: func(ctx context.Context) error {
+	action := &Action{
+		Name: fmt.Sprintf("repo:create:%s", name),
+		Apply: func(ctx context.Context) error {
 			org, err := o.get(ctx)
 			if err != nil {
 				return err
@@ -129,7 +129,7 @@ func (o *Org) CreateRepo(name string, public bool) *Repo {
 			baseRepo.name = repo.GetFullName()
 			return nil
 		},
-		teardown: func(ctx context.Context) error {
+		Teardown: func(ctx context.Context) error {
 			org, err := o.get(ctx)
 			if err != nil {
 				return err
@@ -158,9 +158,9 @@ func (o *Org) CreateRepoFork(target string) *Repo {
 		org:  o,
 		name: target,
 	}
-	action := &action{
-		name: fmt.Sprintf("repo:fork:%s", target),
-		apply: func(ctx context.Context) error {
+	action := &Action{
+		Name: fmt.Sprintf("repo:fork:%s", target),
+		Apply: func(ctx context.Context) error {
 			org, err := o.get(ctx)
 			if err != nil {
 				return err
@@ -184,7 +184,7 @@ func (o *Org) CreateRepoFork(target string) *Repo {
 			baseRepo.name = repoName
 			return nil
 		},
-		teardown: func(ctx context.Context) error {
+		Teardown: func(ctx context.Context) error {
 			org, err := o.get(ctx)
 			if err != nil {
 				return err
@@ -198,7 +198,7 @@ func (o *Org) CreateRepoFork(target string) *Repo {
 			return o.s.client.DeleteRepo(ctx, org, repo)
 		},
 	}
-	o.s.append(action)
+	o.s.Append(action)
 	baseRepo.WaitTillExists()
 
 	return baseRepo

--- a/dev/codehost_testing/repo.go
+++ b/dev/codehost_testing/repo.go
@@ -1,0 +1,110 @@
+package codehost_scenario
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-github/v53/github"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Repo struct {
+	s    *GithubScenario
+	team *Team
+	org  *Org
+	name string
+}
+
+func (r *Repo) Get(ctx context.Context) (*github.Repository, error) {
+	if r.s.IsApplied() {
+		return r.get(ctx)
+	}
+	panic("cannot retrieve repo before scenario is applied")
+}
+
+func (r *Repo) get(ctx context.Context) (*github.Repository, error) {
+	return r.s.client.GetRepo(ctx, r.org.name, r.name)
+}
+
+func (r *Repo) AddTeam(team *Team) {
+	r.team = team
+	action := &action{
+		name: fmt.Sprintf("repo:team:%s:membership:%s", team.name, r.name),
+		apply: func(ctx context.Context) error {
+			org, err := r.org.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			repo, err := r.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			team, err := r.team.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			err = r.s.client.UpdateTeamRepoPermissions(ctx, org, team, repo)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		teardown: nil,
+	}
+
+	r.s.append(action)
+}
+
+func (r *Repo) SetPermissions(private bool) {
+	permissionKey := "private"
+	if !private {
+		permissionKey = "public"
+	}
+	action := &action{
+		name: fmt.Sprintf("repo:permissions:%s:%s", r.name, permissionKey),
+		apply: func(ctx context.Context) error {
+			repo, err := r.get(ctx)
+			if err != nil {
+				return err
+			}
+			repo.Private = &private
+
+			org, err := r.org.get(ctx)
+			if err != nil {
+				return err
+			}
+
+			_, err = r.s.client.UpdateRepo(ctx, org, repo)
+			if err != nil {
+				return err
+			}
+			return err
+		},
+	}
+
+	r.s.append(action)
+}
+
+func (r *Repo) WaitTillExists() {
+	action := &action{
+		name: fmt.Sprintf("repo:exists:%s", r.name),
+		apply: func(ctx context.Context) error {
+			var err error
+			for i := 0; i < 5; i++ {
+				time.Sleep(1 * time.Second)
+				_, err = r.get(ctx)
+				if err == nil {
+					return nil
+				}
+			}
+			return errors.Newf("repo %q did not exist after waiting: %v", r.name, err)
+		},
+	}
+
+	r.s.append(action)
+}

--- a/dev/codehost_testing/repo.go
+++ b/dev/codehost_testing/repo.go
@@ -1,4 +1,4 @@
-package codehost_scenario
+package codehost_testing
 
 import (
 	"context"

--- a/dev/codehost_testing/repo.go
+++ b/dev/codehost_testing/repo.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -13,7 +13,7 @@ import (
 // Repo represents a GitHub repository in the scenario
 type Repo struct {
 	// s is the GithubScenario instance this repo is part of. Actions it creates will be added to this scenario
-	s *GithubScenario
+	s *GitHubScenario
 	// team is the team this repo belongs to
 	team *Team
 	// org is the Org that owns this repo
@@ -30,7 +30,8 @@ func (r *Repo) Get(ctx context.Context) (*github.Repository, error) {
 	if r.s.IsApplied() {
 		return r.get(ctx)
 	}
-	panic("cannot retrieve repo before scenario is applied")
+	r.s.t.Fatal("cannot retrieve repo before scenario is applied")
+	return nil, nil
 }
 
 // get retrieves the GitHub repository without panicking if not applied. It is meant as an

--- a/dev/codehost_testing/repo.go
+++ b/dev/codehost_testing/repo.go
@@ -44,9 +44,9 @@ func (r *Repo) get(ctx context.Context) (*github.Repository, error) {
 // has access to this repo.
 func (r *Repo) AddTeam(team *Team) {
 	r.team = team
-	action := &action{
-		name: fmt.Sprintf("repo:team:%s:membership:%s", team.name, r.name),
-		apply: func(ctx context.Context) error {
+	action := &Action{
+		Name: fmt.Sprintf("repo:team:%s:membership:%s", team.name, r.name),
+		Apply: func(ctx context.Context) error {
 			org, err := r.org.get(ctx)
 			if err != nil {
 				return err
@@ -68,10 +68,10 @@ func (r *Repo) AddTeam(team *Team) {
 			}
 			return nil
 		},
-		teardown: nil,
+		Teardown: nil,
 	}
 
-	r.s.append(action)
+	r.s.Append(action)
 }
 
 // SetPermissions adds an action that will set the permissions (public or private) for the repository
@@ -80,9 +80,9 @@ func (r *Repo) SetPermissions(private bool) {
 	if !private {
 		permissionKey = "public"
 	}
-	action := &action{
-		name: fmt.Sprintf("repo:permissions:%s:%s", r.name, permissionKey),
-		apply: func(ctx context.Context) error {
+	action := &Action{
+		Name: fmt.Sprintf("repo:permissions:%s:%s", r.name, permissionKey),
+		Apply: func(ctx context.Context) error {
 			repo, err := r.get(ctx)
 			if err != nil {
 				return err
@@ -102,15 +102,15 @@ func (r *Repo) SetPermissions(private bool) {
 		},
 	}
 
-	r.s.append(action)
+	r.s.Append(action)
 }
 
 // WaitTillExists creates an action that waits for the repository to exist on GitHub. This action is especially
 // useful for when a repo is forked since a forked repo doesn't immediately exist when requested on GitHub.
 func (r *Repo) WaitTillExists() {
-	action := &action{
-		name: fmt.Sprintf("repo:exists:%s", r.name),
-		apply: func(ctx context.Context) error {
+	action := &Action{
+		Name: fmt.Sprintf("repo:exists:%s", r.name),
+		Apply: func(ctx context.Context) error {
 			var err error
 			for i := 0; i < 5; i++ {
 				time.Sleep(1 * time.Second)
@@ -123,5 +123,5 @@ func (r *Repo) WaitTillExists() {
 		},
 	}
 
-	r.s.append(action)
+	r.s.Append(action)
 }


### PR DESCRIPTION
Add actions to create github reposa and also to delete them. The added
actions are able to:

- fork repos
- push local repos
- make repos public / private

## Test plan
tested in wb/e2e/poc
