### PR TITLE
search jobs: fix bug in bidirectional pagination

### DIFF
--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -143,7 +143,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 	var value string
 	switch column {
 	case "created_at":
-		value = fmt.Sprintf("'%v'", node.CreatedAt().Format(time.RFC3339))
+		value = fmt.Sprintf("'%v'", node.CreatedAt().Format(time.RFC3339Nano))
 	case "state":
 		value = fmt.Sprintf("'%v'", strings.ToLower(node.State()))
 	case "query":


### PR DESCRIPTION
Fixes #56783

The accuracy of the cursor was less than the accuracy of the dates in the db. The rounding errors caused the pagination to behave oddly.

Test plan:
- Manual testing

https://github.com/sourcegraph/sourcegraph/assets/26413131/0e7dfafa-0a32-49bc-9f9e-0cdc3c4482d1

