### PR TITLE
managedservicesplatform: include env ID in display name

### DIFF
--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -67,8 +67,8 @@ type Variables struct {
 	// '-${randomizedSuffix}' will be added, as project IDs must be unique.
 	ProjectIDPrefix string
 
-	// Name is a display name for the project. It does not need to be unique.
-	Name string
+	// DisplayName is a display name for the project. It does not need to be unique.
+	DisplayName string
 
 	// Labels to apply to the project.
 	Labels map[string]string
@@ -113,7 +113,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 		Project: project.NewProject(stack,
 			id.ResourceID("project"),
 			&project.ProjectConfig{
-				Name:              pointers.Ptr(vars.Name),
+				Name:              pointers.Ptr(vars.DisplayName),
 				ProjectId:         &projectID.HexValue,
 				AutoCreateNetwork: false,
 				BillingAccount:    pointers.Ptr(BillingAccountID),

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -73,8 +73,9 @@ func (r *Renderer) RenderEnvironment(
 	// Render all required CDKTF stacks for this environment
 	projectOutput, err := project.NewStack(stacks, project.Variables{
 		ProjectIDPrefix: projectIDPrefix,
-		Name:            pointers.Deref(svc.Name, svc.ID),
-		Category:        env.Category,
+		DisplayName: fmt.Sprintf("%s (%s)",
+			pointers.Deref(svc.Name, svc.ID), env.ID),
+		Category: env.Category,
 		Labels: map[string]string{
 			"service":     svc.ID,
 			"environment": env.ID,


### PR DESCRIPTION
Makes it easier to identify the project

## Test plan

n/a