### PR TITLE
updatecheck: call `conf.Get` only in running on dotcom

### DIFF
--- a/internal/updatecheck/build.go
+++ b/internal/updatecheck/build.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -31,6 +32,9 @@ type Notification struct {
 }
 
 func getNotifications(clientVersionString string) []Notification {
+	if !envvar.SourcegraphDotComMode() {
+		return []Notification{}
+	}
 	return calcNotifications(clientVersionString, conf.Get().Dotcom.AppNotifications)
 }
 


### PR DESCRIPTION
In non-dotcom deployment, there is no frontend to respond to `conf.Get` and ~~seems to be~~is the cause of leaking goroutines/mem overtime:

<img width="1081" alt="CleanShot 2023-09-19 at 16 02 56@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/b3a6ad03-4807-49d3-8fa4-d8517920e977">


## Test plan

CI
