### PR TITLE
search: explicitly use HEAD instead of empty string for exhaustive

### DIFF
--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//internal/search/streaming",
         "//internal/types",
         "//internal/uploadstore/mocks",
+        "//lib/errors",
         "//lib/iterator",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_zoekt//:zoekt",

--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -77,7 +77,13 @@ func (s searchQuery) RepositoryRevSpecs(ctx context.Context) ([]types.Repository
 		repoRev := it.Current()
 		var revspecs []string
 		for _, rev := range repoRev.Revs {
-			revspecs = append(revspecs, rev.String())
+			revStr := rev.String()
+			// avoid storing empty string since our DB expects non-empty
+			// string + this is easier to read in the DB.
+			if revStr == "" {
+				revStr = "HEAD"
+			}
+			revspecs = append(revspecs, revStr)
 		}
 		repoRevSpecs = append(repoRevSpecs, types.RepositoryRevSpecs{
 			Repository:         repoRev.Repo.ID,


### PR DESCRIPTION
Our DB enforces this field is non-empty. This is good from a debuggability point and an accidental use of a the default value of a string. So we update the code to convert empty revspecs from the search layer into explicit queries for HEAD.

Test Plan: updated unit tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/56784