### PR TITLE
codeintel: Improve GetIndexers method

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -16914,6 +16914,16 @@
           "ConstraintDefinition": ""
         },
         {
+          "Name": "lsif_indexes_repository_id_indexer",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_indexes_repository_id_indexer ON lsif_indexes USING btree (repository_id, indexer)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
           "Name": "lsif_indexes_state",
           "IsPrimaryKey": false,
           "IsUnique": false,
@@ -18048,6 +18058,16 @@
           "IsExclusion": false,
           "IsDeferrable": false,
           "IndexDefinition": "CREATE INDEX lsif_uploads_repository_id_commit ON lsif_uploads USING btree (repository_id, commit)",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
+        },
+        {
+          "Name": "lsif_uploads_repository_id_indexer",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX lsif_uploads_repository_id_indexer ON lsif_uploads USING btree (repository_id, indexer)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -2345,6 +2345,7 @@ Indexes:
     "lsif_indexes_dequeue_order_idx" btree ((enqueuer_user_id > 0) DESC, queued_at DESC, id) WHERE state = 'queued'::text OR state = 'errored'::text
     "lsif_indexes_queued_at_id" btree (queued_at DESC, id)
     "lsif_indexes_repository_id_commit" btree (repository_id, commit)
+    "lsif_indexes_repository_id_indexer" btree (repository_id, indexer)
     "lsif_indexes_state" btree (state)
 Check constraints:
     "lsif_uploads_commit_valid_chars" CHECK (commit ~ '^[a-z0-9]{40}$'::text)
@@ -2573,6 +2574,7 @@ Indexes:
     "lsif_uploads_committed_at" btree (committed_at) WHERE state = 'completed'::text
     "lsif_uploads_last_reconcile_at" btree (last_reconcile_at, id) WHERE state = 'completed'::text
     "lsif_uploads_repository_id_commit" btree (repository_id, commit)
+    "lsif_uploads_repository_id_indexer" btree (repository_id, indexer)
     "lsif_uploads_state" btree (state)
     "lsif_uploads_uploaded_at_id" btree (uploaded_at DESC, id) WHERE state <> 'deleted'::text
 Check constraints:

--- a/migrations/frontend/1695152835_add_index_for_upload_indexers/down.sql
+++ b/migrations/frontend/1695152835_add_index_for_upload_indexers/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lsif_uploads_repository_id_indexer;

--- a/migrations/frontend/1695152835_add_index_for_upload_indexers/metadata.yaml
+++ b/migrations/frontend/1695152835_add_index_for_upload_indexers/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add index for indexers
+parents: [1691759644, 1693825517]
+createIndexConcurrently: true

--- a/migrations/frontend/1695152835_add_index_for_upload_indexers/up.sql
+++ b/migrations/frontend/1695152835_add_index_for_upload_indexers/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_uploads_repository_id_indexer ON lsif_uploads(repository_id, indexer);

--- a/migrations/frontend/1695152902_add_index_for_index_indexers/down.sql
+++ b/migrations/frontend/1695152902_add_index_for_index_indexers/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lsif_indexes_repository_id_indexer;

--- a/migrations/frontend/1695152902_add_index_for_index_indexers/metadata.yaml
+++ b/migrations/frontend/1695152902_add_index_for_index_indexers/metadata.yaml
@@ -1,0 +1,3 @@
+name: Add index for index indexers
+parents: [1695152835]
+createIndexConcurrently: true

--- a/migrations/frontend/1695152902_add_index_for_index_indexers/up.sql
+++ b/migrations/frontend/1695152902_add_index_for_index_indexers/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_indexes_repository_id_indexer ON lsif_indexes(repository_id, indexer);

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -6140,6 +6140,8 @@ CREATE INDEX lsif_indexes_queued_at_id ON lsif_indexes USING btree (queued_at DE
 
 CREATE INDEX lsif_indexes_repository_id_commit ON lsif_indexes USING btree (repository_id, commit);
 
+CREATE INDEX lsif_indexes_repository_id_indexer ON lsif_indexes USING btree (repository_id, indexer);
+
 CREATE INDEX lsif_indexes_state ON lsif_indexes USING btree (state);
 
 CREATE INDEX lsif_nearest_uploads_links_repository_id_ancestor_commit_bytea ON lsif_nearest_uploads_links USING btree (repository_id, ancestor_commit_bytea);
@@ -6173,6 +6175,8 @@ CREATE INDEX lsif_uploads_last_reconcile_at ON lsif_uploads USING btree (last_re
 CREATE INDEX lsif_uploads_repository_id_commit ON lsif_uploads USING btree (repository_id, commit);
 
 CREATE UNIQUE INDEX lsif_uploads_repository_id_commit_root_indexer ON lsif_uploads USING btree (repository_id, commit, root, indexer) WHERE (state = 'completed'::text);
+
+CREATE INDEX lsif_uploads_repository_id_indexer ON lsif_uploads USING btree (repository_id, indexer);
 
 CREATE INDEX lsif_uploads_state ON lsif_uploads USING btree (state);
 


### PR DESCRIPTION
Fix the slow "list indexers" GraphQL endpoint, which is especially problematic on the upload/index list view when not scoped to a particular repository.

## Test plan

Created indexes in dotcom and hand-tested that new queries use the proper index.