### PR TITLE
search: remove todo about recreating searches

### DIFF
--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -69,7 +69,6 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 			expectedErr: errors.New("missing query"),
 		},
 
-		// TODO(keegancsmith) for some reason we don't let users recreate searches.
 		{
 			name: "Search already exists",
 			setup: func(ctx context.Context, s *store.Store) error {
@@ -83,7 +82,6 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 				InitiatorID: userID,
 				Query:       "repo:^github\\.com/hashicorp/errwrap$ CreateExhaustiveSearchJob_exists",
 			},
-			expectedErr: nil,
 		},
 
 		// Security tests


### PR DESCRIPTION
We added support for this, the comment was just left behind.

Test Plan: n/a