### PR TITLE
Distributed Rate Limiter updates

### DIFF
--- a/internal/extsvc/github/globallock.go
+++ b/internal/extsvc/github/globallock.go
@@ -87,7 +87,11 @@ func restrictGitHubDotComConcurrency(logger log.Logger, doer httpcli.Doer, r *ht
 	if didGetLock {
 		if _, err := lock.UnlockContext(context.Background()); err != nil {
 			metricFailedUnlockRequestsGauge.Inc()
-			logger.Warn("failed to unlock mutex, GitHub.com requests may be delayed briefly", log.Error(err))
+			if errors.HasType(err, &redsync.ErrTaken{}) {
+				logger.Warn("failed to unlock mutex, GitHub.com requests may be delayed briefly", log.Error(err))
+			} else {
+				logger.Error("failed to unlock mutex, GitHub.com requests may be delayed briefly", log.Error(err))
+			}
 		}
 	}
 

--- a/internal/ratelimit/globallimitergettokens.lua
+++ b/internal/ratelimit/globallimitergettokens.lua
@@ -16,6 +16,7 @@ local burst_exists = redis.call('EXISTS', burst_key)
 if burst_exists == 0 then
   redis.call('SET', burst_key, default_burst)
 end
+redis.call('EXPIRE', burst_key, 86400)
 
 local burst = tonumber(redis.call('GET', burst_key))
 
@@ -27,6 +28,8 @@ if bucket_exists == 0 then
     redis.call('SET', bucket_key, burst)
     redis.call('SET', last_replenishment_timestamp_key, current_time)
 end
+redis.call('EXPIRE', bucket_key, 86400)
+redis.call('EXPIRE', last_replenishment_timestamp_key, 86400)
 
 -- Check if bucket quota key and replenishment interval keys both exist
 local rate_exists = redis.call('EXISTS', bucket_rate_key)
@@ -36,6 +39,8 @@ if rate_exists == 0 or bucket_replenishment_interval_exists == 0 then
 	redis.call('SET', bucket_rate_key, default_rate)
 	redis.call('SET', bucket_replenishment_interval_key, default_replenishment_interval)
 end
+redis.call('EXPIRE', bucket_rate_key, 86400)
+redis.call('EXPIRE', bucket_replenishment_interval_key, 86400)
 
 local bucket_rate = tonumber(redis.call('GET', bucket_rate_key))
 

--- a/internal/ratelimit/globallimitersettokenbucket.lua
+++ b/internal/ratelimit/globallimitersettokenbucket.lua
@@ -5,11 +5,6 @@ local bucket_quota = tonumber(ARGV[1])
 local bucket_replenish_interval = tonumber(ARGV[2])
 local allowed_burst = tonumber(ARGV[3])
 
-redis.call('SET', bucket_quota_key, bucket_quota)
-redis.call('EXPIRE', bucket_quota_key, 86400)
-
-redis.call('SET', replenish_interval_seconds_key, bucket_replenish_interval)
-redis.call('EXPIRE', replenish_interval_seconds_key, 86400)
-
-redis.call('SET', burst_key, allowed_burst)
-redis.call('EXPIRE', burst_key, 86400)
+redis.call('SET', bucket_quota_key, bucket_quota, 'EX', 86400)
+redis.call('SET', replenish_interval_seconds_key, bucket_replenish_interval, 'EX', 86400)
+redis.call('SET', burst_key, allowed_burst, 'EX', 86400)

--- a/internal/ratelimit/globallimitersettokenbucket.lua
+++ b/internal/ratelimit/globallimitersettokenbucket.lua
@@ -6,5 +6,10 @@ local bucket_replenish_interval = tonumber(ARGV[2])
 local allowed_burst = tonumber(ARGV[3])
 
 redis.call('SET', bucket_quota_key, bucket_quota)
+redis.call('EXPIRE', bucket_quota_key, 86400)
+
 redis.call('SET', replenish_interval_seconds_key, bucket_replenish_interval)
+redis.call('EXPIRE', replenish_interval_seconds_key, 86400)
+
 redis.call('SET', burst_key, allowed_burst)
+redis.call('EXPIRE', burst_key, 86400)


### PR DESCRIPTION
Changes as described in #55290 and #56548

- Check if a lock failure error is an `ErrTaken` error and if so, it logs a warning instead of an error.
- Add key expirations to redis rate limiter keys. If keys aren't refreshed in 1 day, they are deleted.
- The rate limiter retry func now randomises between 200 and 300 ms, instead of 50 and 250 ms
  - This brings the average wait time up to 8 seconds, which is the same amount of time it takes for a lock to expire. So if a lock failed to unlock, there is a greater chance that a new lock will be successfully grabbed.

## Test plan

Some local tests for now

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
