### PR TITLE
search jobs: Enforce passing in a non-zero userID

### DIFF
--- a/enterprise/cmd/worker/internal/search/exhaustive_search.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
@@ -54,7 +55,10 @@ var _ workerutil.Handler[*types.ExhaustiveSearchJob] = &exhaustiveSearchHandler{
 func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger, record *types.ExhaustiveSearchJob) (err error) {
 	// TODO observability? read other handlers to see if we are missing stuff
 
-	q, err := h.newSearcher.NewSearch(ctx, record.Query)
+	userID := record.InitiatorID
+	ctx = actor.WithActor(ctx, actor.FromUser(userID))
+
+	q, err := h.newSearcher.NewSearch(ctx, userID, record.Query)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
@@ -62,7 +63,10 @@ func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Log
 		return err
 	}
 
-	q, err := h.newSearcher.NewSearch(ctx, parent.Query)
+	userID := parent.InitiatorID
+	ctx = actor.WithActor(ctx, actor.FromUser(userID))
+
+	q, err := h.newSearcher.NewSearch(ctx, userID, parent.Query)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -63,6 +63,10 @@ func (h *exhaustiveSearchRepoRevHandler) Handle(ctx context.Context, logger log.
 		return err
 	}
 
+	// TODO update GetQueryRepoRev to return the data we need.
+	//userID := record.InitiatorID
+	//ctx = actor.WithActor(ctx, actor.FromUser(userID))
+
 	q, err := h.newSearcher.NewSearch(ctx, query)
 	if err != nil {
 		return err

--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     ],
     embed = [":service"],
     deps = [
+        "//internal/actor",
         "//internal/api",
         "//internal/database",
         "//internal/database/dbmocks",

--- a/internal/search/exhaustive/service/search_test.go
+++ b/internal/search/exhaustive/service/search_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
 )
@@ -39,7 +40,10 @@ type newSearcherTestCase struct {
 func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher, tc newSearcherTestCase) {
 	assert := require.New(t)
 
-	searcher, err := newSearcher.NewSearch(ctx, tc.Query)
+	userID := int32(1)
+	ctx = actor.WithActor(ctx, actor.FromMockUser(userID))
+
+	searcher, err := newSearcher.NewSearch(ctx, userID, tc.Query)
 	assert.NoError(err)
 
 	// Test RepositoryRevSpecs

--- a/internal/search/exhaustive/service/search_test.go
+++ b/internal/search/exhaustive/service/search_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
 )
@@ -67,6 +68,19 @@ func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher,
 		assert.NoError(err)
 	}
 	assert.Equal(tc.WantCSV, csv.buf.String())
+}
+
+func TestWrongUser(t *testing.T) {
+	assert := require.New(t)
+
+	userID1 := int32(1)
+	userID2 := int32(2)
+
+	ctx := actor.WithActor(context.Background(), actor.FromMockUser(userID1))
+
+	newSearcher := FromSearchClient(client.NewStrictMockSearchClient())
+	_, err := newSearcher.NewSearch(ctx, userID2, "foo")
+	assert.Error(err)
 }
 
 func joinStringer[T fmt.Stringer](xs []T) string {

--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -20,9 +20,10 @@ import (
 )
 
 func FromSearchClient(client client.SearchClient) NewSearcher {
-	return newSearcherFunc(func(ctx context.Context, q string) (SearchQuery, error) {
-		// TODO adjust NewSearch API to enforce the user passing in a user id.
-		// IE do not rely on ctx actor since that could easily lead to a bug.
+	return newSearcherFunc(func(ctx context.Context, userID int32, q string) (SearchQuery, error) {
+		if err := isSameUser(ctx, userID); err != nil {
+			return nil, err
+		}
 
 		// TODO this hack is an ugly workaround to get the plan and jobs to
 		// get into a shape we like. it will break in bad ways but works for
@@ -50,6 +51,7 @@ func FromSearchClient(client client.SearchClient) NewSearcher {
 		}
 
 		return searchQuery{
+			userID:     userID,
 			exhaustive: exhaustive,
 			clients:    client.JobClients(),
 		}, nil
@@ -57,13 +59,14 @@ func FromSearchClient(client client.SearchClient) NewSearcher {
 }
 
 // TODO maybe reuse for the fake
-type newSearcherFunc func(context.Context, string) (SearchQuery, error)
+type newSearcherFunc func(context.Context, int32, string) (SearchQuery, error)
 
-func (f newSearcherFunc) NewSearch(ctx context.Context, q string) (SearchQuery, error) {
-	return f(ctx, q)
+func (f newSearcherFunc) NewSearch(ctx context.Context, userID int32, q string) (SearchQuery, error) {
+	return f(ctx, userID, q)
 }
 
 type searchQuery struct {
+	userID     int32
 	exhaustive jobutil.Exhaustive
 	clients    job.RuntimeClients
 }
@@ -71,6 +74,10 @@ type searchQuery struct {
 // TODO make this an iterator return since the result could be large and the
 // underlying infra already relies on iterators
 func (s searchQuery) RepositoryRevSpecs(ctx context.Context) ([]types.RepositoryRevSpecs, error) {
+	if err := isSameUser(ctx, s.userID); err != nil {
+		return nil, err
+	}
+
 	var repoRevSpecs []types.RepositoryRevSpecs
 	it := s.exhaustive.RepositoryRevSpecs(ctx, s.clients)
 	for it.Next() {
@@ -102,6 +109,10 @@ func (s searchQuery) RepositoryRevSpecs(ctx context.Context) ([]types.Repository
 }
 
 func (s searchQuery) ResolveRepositoryRevSpec(ctx context.Context, repoRevSpec types.RepositoryRevSpecs) ([]types.RepositoryRevision, error) {
+	if err := isSameUser(ctx, s.userID); err != nil {
+		return nil, err
+	}
+
 	repoPagerRepoRevSpec, err := s.toRepoRevSpecs(ctx, repoRevSpec)
 	if err != nil {
 		return nil, err
@@ -152,6 +163,10 @@ func (s searchQuery) toRepoRevSpecs(ctx context.Context, repoRevSpec types.Repos
 }
 
 func (s searchQuery) Search(ctx context.Context, repoRev types.RepositoryRevision, w CSVWriter) error {
+	if err := isSameUser(ctx, s.userID); err != nil {
+		return err
+	}
+
 	repo, err := s.minimalRepo(ctx, repoRev.Repository)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adjusts the search API for exhaustive to enforce explicit passing in of a userID to ensure we always run searches as the correct user. This is to prevent accidently running as another user and thus exposing results from repos a user is not allowed to see.

Test Plan: 
- new unit test
- CI