### PR TITLE
Use redis server time for distributed rate limiter scripts

### DIFF
--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -195,7 +195,6 @@ func (r *globalRateLimiter) waitn(ctx context.Context, n int, requestTime time.T
 		getTokensScript,
 		connection,
 		keys.BucketKey, keys.LastReplenishmentTimestampKey, keys.RateKey, keys.ReplenishmentIntervalSecondsKey, keys.BurstKey,
-		requestTime.Unix(),
 		maxWaitTime,
 		int32(fallbackRateLimit),
 		int32(time.Hour/time.Second),
@@ -319,7 +318,6 @@ var (
 // bucket_quota_key: the key in Redis that stores how many tokens the bucket should refill in a `bucket_replenishment_interval` period of time, e.g. v2:rate_limiters:github.com:api_tokens:config:bucket_quota.
 // bucket_replenishment_interval_key: the key in Redis that stores how often (in seconds), the bucket should be replenished bucket_quota tokens, e.g. v2:rate_limiters:github.com:api_tokens:config:bucket_replenishment_interval_seconds.
 // burst: the amount of tokens the bucket can hold, always bucketMaxCapacity right now.
-// current_time: current time (seconds since epoch).
 // max_time_to_wait_for_token: the maximum amount of time (in seconds) the requester is willing to wait before acquiring/using a token.
 //
 //go:embed globallimitergettokens.lua

--- a/internal/ratelimit/globallimiter.go
+++ b/internal/ratelimit/globallimiter.go
@@ -131,7 +131,7 @@ func (r *globalRateLimiter) WaitN(ctx context.Context, n int) (err error) {
 	}
 
 	// Reserve a token from the bucket.
-	timeToWait, err := r.waitn(ctx, n, now, waitLimit)
+	timeToWait, err := r.waitn(ctx, n, waitLimit)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (r *globalRateLimiter) newTimer(d time.Duration) (<-chan time.Time, func() 
 	return timer.C, timer.Stop
 }
 
-func (r *globalRateLimiter) waitn(ctx context.Context, n int, requestTime time.Time, maxTimeToWait time.Duration) (timeToWait time.Duration, err error) {
+func (r *globalRateLimiter) waitn(ctx context.Context, n int, maxTimeToWait time.Duration) (timeToWait time.Duration, err error) {
 	metricLimiterAttempts.Inc()
 	metricLimiterWaiting.Inc()
 	defer metricLimiterWaiting.Dec()

--- a/internal/ratelimit/globallimitergettokens.lua
+++ b/internal/ratelimit/globallimitergettokens.lua
@@ -3,12 +3,13 @@ local last_replenishment_timestamp_key = KEYS[2]
 local bucket_rate_key = KEYS[3]
 local bucket_replenishment_interval_key = KEYS[4]
 local burst_key = KEYS[5]
-local current_time = tonumber(ARGV[1])
-local max_time_to_wait_for_tokens = tonumber(ARGV[2])
-local default_rate = tonumber(ARGV[3])
-local default_replenishment_interval = tonumber(ARGV[4])
-local default_burst = tonumber(ARGV[5])
-local tokens_to_grant = tonumber(ARGV[6])
+local max_time_to_wait_for_tokens = tonumber(ARGV[1])
+local default_rate = tonumber(ARGV[2])
+local default_replenishment_interval = tonumber(ARGV[3])
+local default_burst = tonumber(ARGV[4])
+local tokens_to_grant = tonumber(ARGV[5])
+
+local current_time = redis.call('TIME')[1]
 
 -- Ensure the bucket burst capacity is configured. Otherwise,
 -- fall back to the provided default.


### PR DESCRIPTION
The redis lua script takes the current time as an argument, which can lead to weird situations where the "time elapsed" is negative because of time drift between services.

The current time is taken as an argument so that the script remains deterministic. However, script determinism only matters when redis is set up with replication, which Sourcegraph does not use. When there is only a single master redis instance, we can use the time from the redis instance in the script instead.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
