### PR TITLE
bazel: fix @universal-ctags-darwin-x86_64 -> @universal-ctags-darwin-amd64

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -59,7 +59,7 @@ def tool_deps():
 
     # universal-ctags #
     http_file(
-        name = "universal-ctags-darwin-x86_64",
+        name = "universal-ctags-darwin-amd64",
         sha256 = "b69501d497b62021e8438e840e0bea62fdbe91d60cf8375c388f2736cd58a1bf",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,


### PR DESCRIPTION
Fixes the error `ERROR: /home/noah/Sourcegraph/sourcegraph/dev/tools/BUILD.bazel:21:10: no such package '@universal-ctags-darwin-amd64//file': The repository '@universal-ctags-darwin-amd64' could not be resolved: Repository '@universal-ctags-darwin-amd64' is not defined and referenced by '//dev/tools:universal-ctags` when running e.g. `bazel query`

## Test plan

Run a command such as `bazel query 'kind("go_binary", rdeps(//..., //internal/env/...))' --keep_going` and see the above error disappear after this PR