### PR TITLE
JetBrains: bump kotlin to 1.9.10

### DIFF
--- a/client/jetbrains/build.gradle.kts
+++ b/client/jetbrains/build.gradle.kts
@@ -14,7 +14,7 @@ val isAgentEnabled = findProperty("enableAgent") != "false"
 plugins {
   id("java")
   // Dependencies are locked at this version to work with JDK 11 on CI.
-  id("org.jetbrains.kotlin.jvm") version "1.7.0"
+  id("org.jetbrains.kotlin.jvm") version "1.9.10"
   id("org.jetbrains.intellij") version "1.13.3"
   id("org.jetbrains.changelog") version "1.3.1"
   id("com.diffplug.spotless") version "6.21.0"

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/SelectOptionPopupUI.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/SelectOptionPopupUI.kt
@@ -85,7 +85,7 @@ class SelectOptionPopupUI(
     get() = mySearchField
 
   private fun executeCommand() {
-    val selectedValue = myResultsList.selectedValue as String ?: return
+    val selectedValue = (myResultsList.selectedValue ?: return) as String
     runOnSelect.accept(selectedValue)
     mySearchField.text = ""
     searchFinishedHandler.run()
@@ -212,6 +212,7 @@ class SelectOptionPopupUI(
     return DefaultListCellRenderer()
   }
 
+  @Deprecated("Deprecated in Java")
   override fun createTopLeftPanel(): JPanel {
     val myTextFieldTitle = JLabel("Select option")
     val topPanel: JPanel = NonOpaquePanel(BorderLayout())
@@ -237,6 +238,7 @@ class SelectOptionPopupUI(
     return topPanel
   }
 
+  @Deprecated("Deprecated in Java")
   override fun createSettingsPanel(): JPanel {
     return JPanel()
   }


### PR DESCRIPTION
Unlocks indexing of the plugin with scip-java (see [here for example](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b71b22ef9584dc8441f9195f2decd52a53a9e2fb/-/blob/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt?L10:7&popover=pinned#tab=references)). 



## Test plan

`./gradlew compileKotlin` and (hopefully) covered by CI too