### PR TITLE
search: RepositoryRevSpecs returns an iterator

### DIFF
--- a/enterprise/cmd/worker/internal/search/exhaustive_search.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search.go
@@ -63,18 +63,15 @@ func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger,
 		return err
 	}
 
-	repoRevSpecs, err := q.RepositoryRevSpecs(ctx)
-	if err != nil {
-		return err
-	}
-
 	tx, err := h.store.Transact(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	for _, repoRevSpec := range repoRevSpecs {
+	it := q.RepositoryRevSpecs(ctx)
+	for it.Next() {
+		repoRevSpec := it.Current()
 		_, err := tx.CreateExhaustiveSearchRepoJob(ctx, types.ExhaustiveSearchRepoJob{
 			RepoID:      repoRevSpec.Repository,
 			RefSpec:     repoRevSpec.RevisionSpecifiers.String(),
@@ -85,5 +82,5 @@ func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger,
 		}
 	}
 
-	return nil
+	return it.Err()
 }

--- a/internal/search/exhaustive/service/searcher_test.go
+++ b/internal/search/exhaustive/service/searcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
 )
 
 func TestBackendFake(t *testing.T) {
@@ -314,7 +315,7 @@ func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher,
 	assert.NoError(err)
 
 	// Test RepositoryRevSpecs
-	refSpecs, err := searcher.RepositoryRevSpecs(ctx)
+	refSpecs, err := iterator.Collect(searcher.RepositoryRevSpecs(ctx))
 	assert.NoError(err)
 	assert.Equal(tc.WantRefSpecs, joinStringer(refSpecs))
 


### PR DESCRIPTION
This can be a very large list and the underlying repos resolver relies on an iterator to avoid the large list appearing in memory. So this commit adjusts the interface to also use an iterator reducing memory usage the first step of exhaustive search.

Test Plan: go test should be sufficient