### PR TITLE
fix nocgo stub file

### DIFF
--- a/cmd/symbols/internal/api/handler_nocgo.go
+++ b/cmd/symbols/internal/api/handler_nocgo.go
@@ -46,6 +46,7 @@ func (s *grpcService) LocalCodeIntel(request *proto.LocalCodeIntelRequest, ss pr
 	default:
 		ss.Send(&proto.LocalCodeIntelResponse{})
 	}
+	return nil
 }
 
 // SymbolInfo is a no-op in the non-cgo variant.


### PR DESCRIPTION
This file is used to run with CGO_ENABLED=0 for faster recompilation during local dev. For local dev only.




## Test plan

CI