### PR TITLE
[Search Jobs]: Fix big search jobs avatars

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobCard/SearchJobCard.module.scss
+++ b/client/web/src/enterprise/search-jobs/SearchJobCard/SearchJobCard.module.scss
@@ -18,4 +18,10 @@
 .creator {
     display: flex;
     gap: 0.25rem;
+    align-items: center;
+}
+
+.avatar {
+    width: 1.5rem;
+    height: 1.5rem;
 }

--- a/client/web/src/enterprise/search-jobs/SearchJobCard/SearchJobCard.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobCard/SearchJobCard.tsx
@@ -42,7 +42,7 @@ export const SearchJobCard: FC<SearchJobCardProps> = props => {
             <tr className={styles.row}>
                 <td className={styles.label}>Author</td>
                 <td className={styles.creator}>
-                    <UserAvatar user={searchJob.creator!} />
+                    <UserAvatar user={searchJob.creator!} className={styles.avatar} />
                     {searchJob.creator?.displayName ?? searchJob.creator?.username}
                 </td>
             </tr>

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.module.scss
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.module.scss
@@ -133,6 +133,11 @@
         }
     }
 
+    &-avatar {
+        width: 1.5rem;
+        height: 1.5rem;
+    }
+
     &-actions {
         display: flex;
         gap: 0.5rem;

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -177,7 +177,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                 path={[{ icon: LayersSearchOutlineIcon, text: 'Search Jobs' }]}
                 description={
                     <>
-                        Run search queries over all repositories, branches, commit and revisions.{' '}
+                        Manage Sourcegraph queries that have been run exhaustively to return all results.{' '}
                         <Link to="">Learn more</Link> about search jobs.
                     </>
                 }
@@ -328,7 +328,7 @@ const SearchJob: FC<SearchJobProps> = props => {
 
             {withCreatorColumn && (
                 <span className={styles.jobCreator}>
-                    <UserAvatar user={job.creator!} />
+                    <UserAvatar user={job.creator!} className={styles.jobAvatar} />
                     {job.creator?.displayName ?? job.creator?.username}
                 </span>
             )}


### PR DESCRIPTION
This PR fixes weirdly big avatar sizes in the search jobs list and search job modal UI

## Test plan
- Check the search jobs list page with real image avatars (not just with display name short letter-generated avatar)
- Make sure that the avatar has a proper size  in the search jobs list and search job modal UIs

