### PR TITLE
sg/msp: improve DX by enforcing repo structure

### DIFF
--- a/dev/sg/msp/repo/repo.go
+++ b/dev/sg/msp/repo/repo.go
@@ -1,0 +1,33 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+)
+
+// UseManagedServicesRepo is a cli.BeforeFunc that enforces that we are in the
+// sourcegraph/managed-services repository by setting the current working
+// directory.
+func UseManagedServicesRepo(c *cli.Context) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	repoRoot, err := repositoryRoot(cwd)
+	if err != nil {
+		return err
+	}
+	if repoRoot != cwd {
+		std.Out.WriteSuggestionf("Using repo root %s as working directory", repoRoot)
+		return os.Chdir(repoRoot)
+	}
+	return nil
+}
+
+func ServiceYAMLPath(serviceID string) string {
+	return filepath.Join("services", serviceID, "service.yaml")
+}

--- a/dev/sg/msp/repo/root.go
+++ b/dev/sg/msp/repo/root.go
@@ -1,0 +1,50 @@
+package repo
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var once sync.Once
+var repositoryRootValue string
+var repositoryRootError error
+
+var ErrNotInsideManagedServices = errors.New("not running inside sourcegraph/managed-services")
+
+// RepositoryRoot caches and returns the value of findRoot.
+func repositoryRoot(cwd string) (string, error) {
+	once.Do(func() {
+		if forcedRoot := os.Getenv("SG_MSP_FORCE_REPO_ROOT"); forcedRoot != "" {
+			repositoryRootValue = forcedRoot
+		} else {
+			repositoryRootValue, repositoryRootError = findRoot(cwd)
+		}
+	})
+	return repositoryRootValue, repositoryRootError
+}
+
+// findRoot finds the root path of sourcegraph/managed-services from wd
+func findRoot(wd string) (string, error) {
+	for {
+		contents, err := os.ReadFile(filepath.Join(wd, ".repository"))
+		if err == nil {
+			for _, line := range strings.Split(string(contents), "\n") {
+				if strings.HasPrefix(line, "sourcegraph/managed-services") {
+					return wd, nil
+				}
+			}
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		if parent := filepath.Dir(wd); parent != wd {
+			wd = parent
+			continue
+		}
+
+		return "", ErrNotInsideManagedServices
+	}
+}


### PR DESCRIPTION
Previously, the command expected the full YAML path, which is a bit annoying to write. Now, we just codify the repo structure of https://github.com/sourcegraph/managed-services and allow users to just use the service ID from anywhere in the repository.

## Test plan

```sh
$ sg msp generate telemetry-gateway dev
Terraform assets generated in "services/telemetry-gateway/terraform/dev"!
$ cd services/telemetry-gateway/terraform/dev/stacks/project
$ sg msp generate telemetry-gateway dev
💡 Using repo root /Users/robert@sourcegraph.com/Projects/sourcegraph/managed-services as working directory
Terraform assets generated in "services/telemetry-gateway/terraform/dev"!
```