### PR TITLE
call it "Cody" not "Cody AI"

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 public class ConfigUtil {
   public static final String DOTCOM_URL = "https://sourcegraph.com/";
   public static final String SERVICE_DISPLAY_NAME = "Sourcegraph Cody + Code Search";
-  public static final String CODY_DISPLAY_NAME = "Cody AI";
+  public static final String CODY_DISPLAY_NAME = "Cody";
   public static final String CODE_SEARCH_DISPLAY_NAME = "Code Search";
   public static final String SOURCEGRAPH_DISPLAY_NAME = "Sourcegraph";
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeActionNotifier.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeActionNotifier.kt
@@ -7,7 +7,7 @@ interface CodySettingChangeActionNotifier {
     @JvmStatic
     val TOPIC =
         Topic.create(
-            "Sourcegraph Cody + Code Search: Cody AI settings have changed",
+            "Sourcegraph Cody + Code Search: Cody settings have changed",
             CodySettingChangeActionNotifier::class.java)
   }
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -25,7 +25,7 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
   override fun createPanel(): DialogPanel {
     dialogPanel = panel {
       lateinit var enableCodyCheckbox: Cell<JBCheckBox>
-      group("Cody AI") {
+      group("Cody") {
         row {
           enableCodyCheckbox =
               checkBox("Enable Cody")

--- a/client/vscode/README.md
+++ b/client/vscode/README.md
@@ -12,7 +12,7 @@ Sourcegraph’s Code Intelligence feature provides fast, cross-repository naviga
 
 You can read more about Sourcegraph on our [website](https://about.sourcegraph.com/).
 
-Not the extension you're looking for? Download our [Cody AI extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+Not the extension you're looking for? Download the [Cody extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) for code AI assistance.
 
 ## Installation
 

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -159,7 +159,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
 
     return (
         <Page className={classNames('d-flex flex-column', styles.page)}>
-            <PageTitle title="Cody AI Chat" />
+            <PageTitle title="Cody chat" />
             {!isSourcegraphDotCom && !isCTADismissed && !isCodyApp && (
                 <MarketingBlock
                     wrapperClassName="mb-5"

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -113,7 +113,7 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
 
     return (
         <Page>
-            <PageTitle title="Cody AI" />
+            <PageTitle title="Cody" />
             <PageHeader
                 description={
                     <>
@@ -126,7 +126,7 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                 <PageHeader.Heading as="h2" styleAs="h1">
                     <PageHeader.Breadcrumb icon={CodyColorIcon}>
                         <div className={classNames('d-inline-flex align-items-center', styles.pageHeaderBreadcrumb)}>
-                            Cody AI
+                            Cody
                         </div>
                     </PageHeader.Breadcrumb>
                 </PageHeader.Heading>

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -173,7 +173,7 @@ const ExternalServicesPrivacyAlert: FC<ExternalServicesPrivacyAlertProps> = ({ d
             code data to Sourcegraph.com or any other destination. Your code is kept private on this installation.
         </Text>
         <Text>
-            When <Link to="/help/cody/overview">Cody AI</Link> is enabled, some of your data, including code, repository
+            When <Link to="/help/cody/overview">Cody</Link> is enabled, some of your data, including code, repository
             names, file names, and other specific code details, might be shared temporarily with our trusted LLM
             partner. We have established a zero retention policy agreement with the LLM company, to ensure the highest
             levels of data protection and confidentiality.

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -245,7 +245,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         ))}
                     <NavItem icon={CodyLogo}>
                         <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Cody}>
-                            Cody AI
+                            Cody
                         </NavLink>
                     </NavItem>
                     {showSearchNotebook && (

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`GlobalNavbar default 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody AI
+                Cody
               </span>
             </span>
           </a>

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -133,7 +133,7 @@ const AuthUserWidgetContent: React.FC<WidgetContentProps> = ({ type, theme, isSo
                   image: `https://storage.googleapis.com/sourcegraph-assets/app-images/cody-action-bar-${theme}.png`,
               }
             : {
-                  title: 'Try Cody AI assist on this repo',
+                  title: 'Try Cody on this repository',
                   useCases: [
                       'Click the Ask Cody button above and to the right of this banner',
                       'Ask Cody a question like “Explain the structure of this repository”',
@@ -142,12 +142,12 @@ const AuthUserWidgetContent: React.FC<WidgetContentProps> = ({ type, theme, isSo
               }
         : type === 'blob'
         ? {
-              title: 'Try Cody AI assist on this file',
+              title: 'Try Cody on this file',
               useCases: ['Select code in the file below', 'Select an action with Cody widget'],
               image: `https://storage.googleapis.com/sourcegraph-assets/app-images/cody-action-bar-${theme}.png`,
           }
         : {
-              title: 'Try Cody AI assist on this repo',
+              title: 'Try Cody on this repository',
               useCases: [
                   'Click the Ask Cody button above and to the right of this banner',
                   'Ask Cody a question like “Explain the structure of this repository”',

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -116,7 +116,7 @@ describe('TreePage', () => {
                 </MockedProvider>
             )
 
-            expect(screen.getByText('Try Cody AI assist on this repo')).toBeVisible()
+            expect(screen.getByText('Try Cody on this repository')).toBeVisible()
             expect(screen.getByText('Click the Ask Cody button above and to the right of this banner')).toBeVisible()
             expect(
                 screen.getByText('Ask Cody a question like “Explain the structure of this repository”')

--- a/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
@@ -171,7 +171,7 @@ export const TryCodyCtaSection: React.FC<TryCodyCtaSectionProps> = ({
             ) : (
                 <>
                     <div className="d-flex flex-column justify-content-center p-4">
-                        <H3>Try Cody AI in the web application</H3>
+                        <H3>Try Cody in the web application</H3>
                         <Text>
                             Cody for Sourcegraph explains, generates, and translates code, right in the web interface.
                         </Text>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -67,7 +67,7 @@ const REQUESTERS: Record<string, TokenRequester> = {
         forwardDestination: true,
     },
     CODY: {
-        name: 'Cody AI by Sourcegraph - VS Code Extension',
+        name: 'Cody - VS Code Extension',
         redirectURL: 'vscode://sourcegraph.cody-ai?code=$TOKEN',
         successMessage: 'Now opening VS Code...',
         infoMessage:
@@ -75,7 +75,7 @@ const REQUESTERS: Record<string, TokenRequester> = {
         callbackType: 'new-tab',
     },
     CODY_INSIDERS: {
-        name: 'Cody AI by Sourcegraph - VS Code Insiders Extension',
+        name: 'Cody - VS Code Insiders Extension',
         redirectURL: 'vscode-insiders://sourcegraph.cody-ai?code=$TOKEN',
         successMessage: 'Now opening VS Code...',
         infoMessage:

--- a/doc/cody/explanations/cody_clients.md
+++ b/doc/cody/explanations/cody_clients.md
@@ -59,7 +59,7 @@ This represents the _current availability_. Notes on future availability and fea
 
 Cody is accessible via the web interface for Sourcegraph Enterprise in 2 ways:
 
-- The "Cody AI" tab in the web app: Use the chat window to ask Cody questions or request Cody fix/analyze/write code snippets.
+- The "Cody" tab in the web app: Use the chat window to ask Cody questions or request Cody fix/analyze/write code snippets.
 - In the Sourcegraph blob view: Use the "Ask Cody" sidebar to ask Cody questions. Or, double-click on a symbol in the blob view to get a list of Cody commands including explaining code, translating code language, or providing code smells.
 
 [cody-app]: ../overview/app/index.md

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -119,12 +119,9 @@ Yes!
 
 ### Can I use with my Cloud IDE?
 
-Yes, we support the following cloud development environments, Gitpod and GitHub Codespaces.
+Yes, we support the following cloud development environments:
 
-- [Gitpod instructions](https://www.gitpod.io/blog/boosting-developer-productivity-unleashing-the-power-of-sourcegraph-cody-in-gitpod)
-- GitHub Codespaces
-  - Open Codespaces
-  - Install Cody AI by Sourcegraph
-  - Copy the url in the browser, e.g. `vscode://sourcegraph.cody-ai...`
-  - Open the Command Pallet <kbd>⌘ cmd/ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> 
-    - Choose `Developer: Open URL` and paste the URL, then press <kbd>return</kbd>/<kbd>enter</kbd>
+- vscode.dev and GitHub Codespaces (install from the VS Code extension marketplace)
+- Any editor supporting the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai), including:
+  - Gitpod ([blog post](https://www.gitpod.io/blog/boosting-developer-productivity-unleashing-the-power-of-sourcegraph-cody-in-gitpod))
+  - Coder and `code-server` (install from the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai))

--- a/doc/cody/overview/index.md
+++ b/doc/cody/overview/index.md
@@ -94,7 +94,7 @@ td:first-child {
 }
 </style>
 
-# <picture title="Cody"><img class="theme-dark-only" alt="Cody AI" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" alt="Cody AI" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
+# <picture title="Cody"><img class="theme-dark-only" alt="Cody" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-white.png" width="200"><img class="theme-light-only" alt="Cody" src="https://storage.googleapis.com/sourcegraph-assets/cody/20230417/logomark-default-text-black.png" width="200"><div style="display:none">Cody</div></picture>
 
 <aside class="beta">
 <p>

--- a/doc/cody/overview/install-vscode.md
+++ b/doc/cody/overview/install-vscode.md
@@ -77,7 +77,7 @@
 
 <p class="subtitle">Learn how to use Cody and its features with the VS Code editor.</p>
 
-The Cody AI extension by Sourcegraph enhances your coding experience in VS Code by providing intelligent code sugsgestions, context-aware completions, and advanced code analysis. This guide will walk you through the steps to install and set up the Cody within your VS Code environment.
+The Cody extension by Sourcegraph enhances your coding experience in VS Code by providing intelligent code sugsgestions, context-aware completions, and advanced code analysis. This guide will walk you through the steps to install and set up the Cody within your VS Code environment.
 
 <ul class="limg">
   <li>
@@ -129,10 +129,10 @@ Click `Continue with Sourcegraph.com` in the Cody extension. From there, you'll 
 
 ## Verifying the installation
 
-Once connected, click the Cody icon from the sidebar again, and a panel will open. To verify that the Cody AI extension has been successfully installed and is working as expected:
+Once connected, click the Cody icon from the sidebar again, and a panel will open. To verify that the Cody extension has been successfully installed and is working as expected:
 
 - Open a file in a supported programming language like JavaScript, Python, Go, etc.
-- As you start typing, Cody AI should begin providing intelligent suggestions and context-aware completions based on your coding patterns and the context of your code
+- As you start typing, Cody should begin providing intelligent suggestions and context-aware completions based on your coding patterns and the context of your code
 
 ## Commands
 

--- a/windows/installer/cody/package.en-us.wxl
+++ b/windows/installer/cody/package.en-us.wxl
@@ -5,7 +5,7 @@
 
     <String Id="DowngradeError" Value="A newer version of [ProductName] is already installed." />
 
-    <String Id="CodyDescription" Value="Cody AI desktop application." />
+    <String Id="CodyDescription" Value="Cody desktop application." />
     <String Id="BackendDescription" Value="Sourcegraph main server, responsible for indexing, embeddings, and repo management." />
 
 </WixLocalization>


### PR DESCRIPTION
"Cody AI" was one way we referred to Cody in its first couple months to make it clear that it's an
AI product. That is no longer needed, and it sounds stilted/hype-y.

The one place where we do need to say "Cody AI" is when referring to Cody's name on the VS Code
extension marketplace. There, the name `Cody` by itself is taken, so we need `Cody AI` (or something
else that is not just `Cody`, and we're sticking with `Cody AI` for now).




## Test plan

CI

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@sqs/cody-ai-naming)