### PR TITLE
JetBrains: display icon only instead of a button for embedding status

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -17,7 +17,7 @@ import javax.swing.JPanel
 import javax.swing.border.EmptyBorder
 
 class EmbeddingStatusView(private val project: Project) : JPanel() {
-  private val embeddingStatusContent: JButton
+  private val embeddingStatusContent: JBLabel
   private val codebaseSelector: JButton
   private val openedFileContent: JBLabel
   private var embeddingStatus: EmbeddingStatus
@@ -25,7 +25,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
   init {
     setLayout(FlowLayout(FlowLayout.LEFT))
     val innerPanel = Box.createHorizontalBox()
-    embeddingStatusContent = JButton()
+    embeddingStatusContent = JBLabel()
     codebaseSelector = JButton(EditCodebaseContextAction(project))
 
     openedFileContent = JBLabel()


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/56879 

Previously:
<img width="510" alt="Screenshot 2023-09-21 at 10 12 32" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/99027517-57c6-4645-845c-8eca8d3c50b6">
Now:
<img width="510" alt="Screenshot 2023-09-21 at 10 10 53" src="https://github.com/sourcegraph/sourcegraph/assets/7345368/e07e9355-b177-4c27-aeac-69344f46555f">

## Test plan
- Only icon should be displayed for embedding status

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
