### PR TITLE
nix: wrap gradle with x11 libs for intellij plugin

### DIFF
--- a/client/jetbrains/flake.nix
+++ b/client/jetbrains/flake.nix
@@ -9,13 +9,27 @@
   outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
     let
       pkgs = nixpkgs.legacyPackages.${system};
+      libraries = pkgs.lib.makeLibraryPath (with pkgs; with xorg; [
+        libXtst
+        libXext
+        libX11
+        libXrender
+        libXi
+        freetype.out
+        fontconfig.lib
+        zlib.out
+      ]);
+      gradle-wrapped = pkgs.writeShellScriptBin "gradle" ''
+        export LD_LIBRARY_PATH=${libraries}
+        exec ${pkgs.gradle.override {
+            javaToolchains = [ "${pkgs.jdk8}/lib/openjdk" "${pkgs.jdk11}/lib/openjdk" "${pkgs.jdk17}/lib/openjdk" ];
+          }}/bin/gradle "$@"
+      '';
     in
     {
       devShells.default = pkgs.mkShell {
-        buildInputs = with pkgs; [
-          gradle
-          jdk11
-
+        nativeBuildInputs = with pkgs; [
+          gradle-wrapped
           nodejs_20
           nodejs_20.pkgs.pnpm
           nodejs_20.pkgs.typescript


### PR DESCRIPTION
Couldve done `LD_LIBRARY_PATH = libraries;` but didnt want it to mess with more stuff than needed (e.g. opening intellij from cli)

## Test plan

N/A nix stuff
