### PR TITLE
JetBrains: fix bug for access token description

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -52,7 +52,8 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
     }, [telemetryService])
 
     /** The contents of the note input field. */
-    const [note, setNote] = useState<string>('')
+    const defaultNoteValue = new URLSearchParams(location.search).get('description') || undefined
+    const [note, setNote] = useState<string>(defaultNoteValue ?? '')
     /** The selected scopes checkboxes. */
     const [scopes, setScopes] = useState<string[]>([AccessTokenScopes.UserAll])
 
@@ -92,8 +93,6 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
         )
     )
 
-    const defaultDescriptionValue = new URLSearchParams(location.search).get('description') || undefined
-
     return (
         <div className="user-settings-create-access-token-page">
             <PageTitle title="Create access token" />
@@ -108,7 +107,7 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
                         required={true}
                         autoFocus={true}
                         placeholder="What's this token for?"
-                        defaultValue={defaultDescriptionValue}
+                        defaultValue={defaultNoteValue}
                         className="form-group"
                         label="Token description"
                     />


### PR DESCRIPTION
Previously, the "Description" field got auto-populated with the name of the JetBrains IDE but the name wasn't correctly persisted after the user created the token. In the UI, it would say "No description".

This PR fixes the problem by passing the default description value as the initial value to the appropriate `setState` React hook.

Thank you @taylorsperry for reporting this issue!

## Test plan

- Used web-standalone with dotcom mode
- Created access token with default value "IDEA" from the URL parameter
- Validated that the access token had the description "IDEA" after creating the token
<img width="238" alt="CleanShot 2023-09-21 at 16 26 34@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1408093/386bc9a2-6915-481a-b004-84ce7c73a572">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
