### PR TITLE
release: close 5.1.9 and activate 5.2.0

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -20,11 +20,19 @@
       "captainGitHubUsername": "unknwon",
       "captainSlackUsername": "joe"
     },
-    "5.1.9": {
-      "codeFreezeDate": "2023-09-13T10:00:00.000-07:00",
-      "securityApprovalDate": "2023-09-13T10:00:00.000-07:00",
-      "releaseDate": "2023-09-20T10:00:00.000-07:00",
-      "current": "5.1.9",
+    "5.2.0": {
+      "codeFreezeDate": "2023-09-27T10:00:00.000-07:00",
+      "securityApprovalDate": "2023-09-27T10:00:00.000-07:00",
+      "releaseDate": "2023-10-04T10:00:00.000-07:00",
+      "patches": [
+        "2023-10-18T10:00:00.000-07:00",
+        "2023-11-01T10:00:00.000-07:00",
+        "2023-11-15T10:00:00.000-08:00",
+        "2023-11-29T10:00:00.000-08:00",
+        "2023-12-13T10:00:00.000-08:00",
+        "2023-12-27T10:00:00.000-08:00"
+      ],
+      "current": "5.2.0",
       "captainGitHubUsername": "unknwon",
       "captainSlackUsername": "joe"
     }
@@ -41,8 +49,8 @@
     "captainSlackUsername": "joe",
     "releases": [
       {
-        "version": "5.1.9",
-        "previous": "5.1.8"
+        "version": "5.2.0",
+        "previous": "5.1.9"
       }
     ]
   }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/56794
## Test plan

🤞 
