### PR TITLE
Remove docs link for downloading code search app

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -9,9 +9,8 @@ Sourcegraph makes it easy to read, write, and fix code—even in big, complex co
 
 ## Usage
 
-- [**Download Sourcegraph**](https://about.sourcegraph.com/app) for macOS and Linux
 - [**Get Cody**](cody/overview/index.md), the AI coding assistant
-- [Use Sourcegraph on the cloud or self-hosted](admin/deploy/index.md)
+- [**Use Sourcegraph on the cloud or self-hosted**](admin/deploy/index.md)
 - [Sourcegraph.com public code search](https://sourcegraph.com/search)
 
 <br>


### PR DESCRIPTION
There was a link to the /app page for downloading code search. Since the app doesn't run code search anymore, I've removed that CTA, and bumped up the CTA to deploy a Sourcegraph instance.

## Test plan

Docs only.

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@docs-cs-patch)