### PR TITLE
telemetry: make parameters optional, improve docstrings

### DIFF
--- a/internal/telemetry/besteffort.go
+++ b/internal/telemetry/besteffort.go
@@ -22,7 +22,9 @@ func NewBestEffortEventRecorder(logger log.Logger, recorder *EventRecorder) *Bes
 	return &BestEffortEventRecorder{logger: logger, recorder: recorder}
 }
 
-func (r *BestEffortEventRecorder) Record(ctx context.Context, feature eventFeature, action eventAction, parameters EventParameters) {
+// Record records a single telemetry event with the context's Sourcegraph
+// actor, logging any recording errors it encounters. Parameters are optional.
+func (r *BestEffortEventRecorder) Record(ctx context.Context, feature eventFeature, action eventAction, parameters *EventParameters) {
 	if err := r.recorder.Record(ctx, feature, action, parameters); err != nil {
 		trace.Logger(ctx, r.logger).Error("failed to record telemetry event",
 			log.String("feature", string(feature)),

--- a/internal/telemetry/teestore/option.go
+++ b/internal/telemetry/teestore/option.go
@@ -7,7 +7,8 @@ type contextKey int
 const withoutV1Key contextKey = iota
 
 // WithoutV1 adds a special flag to context that indicates to an underlying
-// events teestore.Store that it should not persist the event as a V1 event.
+// events teestore.Store that it should not persist the event as a V1 event
+// (i.e. event_logs).
 //
 // This is useful for callsites where the shape of the legacy event must be
 // preserved, such that it continues to be logged manually.

--- a/internal/telemetry/teestore/teestore.go
+++ b/internal/telemetry/teestore/teestore.go
@@ -61,7 +61,7 @@ func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Eve
 			InsertID: nil, // not required on insert
 
 			// Identifiers
-			Name: fmt.Sprintf("V2:%s.%s", e.GetFeature(), e.GetAction()),
+			Name: fmt.Sprintf("%s.%s", e.GetFeature(), e.GetAction()),
 			Timestamp: func() time.Time {
 				if e.GetTimestamp() == nil {
 					return now()

--- a/internal/telemetry/teestore/teestore_test.go
+++ b/internal/telemetry/teestore/teestore_test.go
@@ -33,7 +33,7 @@ func TestToEventLogs(t *testing.T) {
 			expectEventLogs: autogold.Expect(`[
   {
     "ID": 0,
-    "Name": "V2:.",
+    "Name": ".",
     "URL": "",
     "UserID": 0,
     "AnonymousUserID": "",
@@ -61,7 +61,7 @@ func TestToEventLogs(t *testing.T) {
 			expectEventLogs: autogold.Expect(`[
   {
     "ID": 0,
-    "Name": "V2:.",
+    "Name": ".",
     "URL": "",
     "UserID": 0,
     "AnonymousUserID": "",
@@ -120,7 +120,7 @@ func TestToEventLogs(t *testing.T) {
 			expectEventLogs: autogold.Expect(`[
   {
     "ID": 0,
-    "Name": "V2:CodeSearch.Search",
+    "Name": "CodeSearch.Search",
     "URL": "sourcegraph.com/foobar",
     "UserID": 1234,
     "AnonymousUserID": "anonymous",

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -34,7 +34,7 @@ func TestRecorderEndToEnd(t *testing.T) {
 	t.Run("Record and BatchRecord", func(t *testing.T) {
 		assert.NoError(t, recorder.Record(ctx,
 			"Test", "Action1",
-			telemetry.EventParameters{
+			&telemetry.EventParameters{
 				Metadata: telemetry.EventMetadata{
 					"metadata": 1,
 				},
@@ -67,7 +67,7 @@ func TestRecorderEndToEnd(t *testing.T) {
 
 	t.Run("record without v1", func(t *testing.T) {
 		ctx := teestore.WithoutV1(ctx)
-		assert.NoError(t, recorder.Record(ctx, "Test", "Action1", telemetry.EventParameters{}))
+		assert.NoError(t, recorder.Record(ctx, "Test", "Action1", &telemetry.EventParameters{}))
 
 		telemetryEvents, err := db.TelemetryEventsExportQueue().ListForExport(ctx, 999)
 		require.NoError(t, err)

--- a/internal/telemetry/telemetrygateway.go
+++ b/internal/telemetry/telemetrygateway.go
@@ -18,8 +18,14 @@ func newTelemetryGatewayEvent(
 	newUUID func() string,
 	feature eventFeature,
 	action eventAction,
-	parameters EventParameters,
+	parameters *EventParameters,
 ) *telemetrygatewayv1.Event {
+	// Assign zero value for ease of reference, and in the proto spec, parameters
+	// is not optional.
+	if parameters == nil {
+		parameters = &EventParameters{}
+	}
+
 	event := telemetrygatewayv1.NewEventWithDefaults(ctx, now, newUUID)
 	event.Feature = string(feature)
 	event.Action = string(action)

--- a/internal/telemetry/telemetrygateway_test.go
+++ b/internal/telemetry/telemetrygateway_test.go
@@ -140,7 +140,7 @@ func TestMakeRawEvent(t *testing.T) {
 				func() string { return tc.name },
 				tc.event.Feature,
 				tc.event.Action,
-				tc.event.Parameters)
+				&tc.event.Parameters)
 
 			protodata, err := protojson.Marshal(got)
 			require.NoError(t, err)


### PR DESCRIPTION
- Make `parameters` a pointer, so that you can just provide `nil` - a bit easier to manage at callsites
- Remove the `V2:` prefix on translated events, which were a bit confusing to look at - the V2 scheme does not matter to admins.
- Improved docstrings here and there on the new telemetry stuff

## Test plan

See https://github.com/sourcegraph/sourcegraph/pull/56924