### PR TITLE
signout: instrument with v2 events

### DIFF
--- a/cmd/frontend/internal/app/BUILD.bazel
+++ b/cmd/frontend/internal/app/BUILD.bazel
@@ -56,6 +56,8 @@ go_library(
         "//internal/otlpenv",
         "//internal/session",
         "//internal/src-prometheus",
+        "//internal/telemetry",
+        "//internal/telemetry/telemetryrecorder",
         "//internal/trace",
         "//internal/usagestats",
         "//lib/errors",

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -67,7 +67,7 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 	r.Get(router.RequestAccess).Handler(trace.Route(accessrequest.HandleRequestAccess(logger, db)))
 	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(logger, db)))
 	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore)))
-	r.Get(router.SignOut).Handler(trace.Route(serveSignOutHandler(db)))
+	r.Get(router.SignOut).Handler(trace.Route(serveSignOutHandler(logger, db)))
 	r.Get(router.UnlockAccount).Handler(trace.Route(userpasswd.HandleUnlockAccount(logger, db, lockoutStore)))
 	r.Get(router.UnlockUserAccount).Handler(trace.Route(userpasswd.HandleUnlockUserAccount(logger, db, lockoutStore)))
 	r.Get(router.ResetPasswordInit).Handler(trace.Route(userpasswd.HandleResetPasswordInit(logger, db)))


### PR DESCRIPTION
Replaces the signout event logging with our new telemetry recorder, so we can start exporting some events in testing environments.

I intentionally left out `Attempted` events because in all cases we record either a success or a failure anyway.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/56922
Part of https://github.com/sourcegraph/sourcegraph/issues/56815

## Test plan

See https://github.com/sourcegraph/sourcegraph/pull/56924