### PR TITLE
database, usagestats: mark deprecation of direct event_logs recording

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -112,6 +112,7 @@ type EventLogStore interface {
 	// CountUsersWithSetting returns the number of users wtih the given temporary setting set to the given value.
 	CountUsersWithSetting(ctx context.Context, setting string, value any) (int, error)
 
+	// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
 	Insert(ctx context.Context, e *Event) error
 
 	// LatestPing returns the most recently recorded ping event.

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -67,6 +67,8 @@ type Event struct {
 }
 
 // LogBackendEvent is a convenience function for logging backend events.
+//
+// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
 func LogBackendEvent(db database.DB, userID int32, deviceID, eventName string, argument, publicArgument json.RawMessage, evaluatedFlagSet featureflag.EvaluatedFlagSet, cohortID *string) error {
 	insertID, _ := uuid.NewRandom()
 	insertIDFinal := insertID.String()
@@ -104,11 +106,15 @@ func LogBackendEvent(db database.DB, userID int32, deviceID, eventName string, a
 }
 
 // LogEvent logs an event.
+//
+// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
 func LogEvent(ctx context.Context, db database.DB, args Event) error {
 	return LogEvents(ctx, db, []Event{args})
 }
 
 // LogEvents logs a batch of events.
+//
+// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
 func LogEvents(ctx context.Context, db database.DB, events []Event) error {
 	if !conf.EventLoggingEnabled() {
 		return nil


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/56813 - see https://github.com/sourcegraph/sourcegraph/pull/56868 for docs!

## Test plan

n/a