### PR TITLE
pubsub: downgrade logging client to debug

### DIFF
--- a/internal/pubsub/topic.go
+++ b/internal/pubsub/topic.go
@@ -100,8 +100,12 @@ func (c *noopTopicClient) Stop()                                    {}
 // NewLoggingTopicClient creates a Pub/Sub client that just logs all messages,
 // and does nothing otherwise. This is also a useful stub implementation of the
 // TopicClient for testing/debugging purposes.
+//
+// Log entries are generated at debug level.
 func NewLoggingTopicClient(logger log.Logger) TopicClient {
-	return &loggingTopicClient{logger: logger.Scoped("pubsub", "")}
+	return &loggingTopicClient{
+		logger: logger.Scoped("pubsub", "pubsub message printer for use in development"),
+	}
 }
 
 type loggingTopicClient struct {
@@ -112,7 +116,7 @@ type loggingTopicClient struct {
 func (c *loggingTopicClient) Publish(ctx context.Context, messages ...[]byte) error {
 	l := trace.Logger(ctx, c.logger)
 	for _, m := range messages {
-		l.Info("Publish", log.String("message", string(m)))
+		l.Debug("Publish", log.String("message", string(m)))
 	}
 	return nil
 }


### PR DESCRIPTION
Telemetry Gateway, which uses this in local dev, quickly becomes very noisy. I'll add a note about this in https://github.com/sourcegraph/sourcegraph/pull/56868 that if you want to see it, you have to configure a custom log level

## Test plan

telemetry-gateway no longer emits messages by default