### PR TITLE
sg/msp: set up command so that docs are rendered

### DIFF
--- a/dev/sg/msp/command.go
+++ b/dev/sg/msp/command.go
@@ -2,6 +2,8 @@
 package msp
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -10,22 +12,41 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 )
 
+const commandDescription = `WARNING: This is currently still an experimental project.
+To learm more, refer to go/rfc-msp and go/msp (https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform)`
+
+const buildCommand = "go build -tags=msp -o=./sg ./dev/sg && ./sg install -f -p=false"
+
 // Command is currently only implemented with the 'msp' build tag - see sg_msp.go
 //
 // The default implementation is hidden by default and offers some help text for
 // for installing 'sg' with 'sg msp' enabled.
 var Command = &cli.Command{
-	Hidden:      true,
-	Name:        "managed-services-platform",
-	Aliases:     []string{"msp"},
-	Usage:       "Generate and manage services deployed on the Sourcegraph Managed Services Platform",
-	Description: `WARNING: This is currently still an experimental project. To learm more, see go/rfc-msp`,
-	Category:    category.Company,
+	Name:    "managed-services-platform",
+	Aliases: []string{"msp"},
+	Usage:   "EXPERIMENTAL: Generate and manage services deployed on the Sourcegraph Managed Services Platform",
+	Description: fmt.Sprintf(`%s
+
+MSP commands are currently build-flagged to avoid increasing 'sg' binary sizes. To install a build of 'sg' that includes 'sg msp', run:
+
+	%s
+
+MSP commands should then be available under 'sg msp --help'.`, commandDescription, buildCommand),
+	UsageText: `
+# Create a service specification
+sg msp init $SERVICE
+
+# Provision Terraform Cloud workspaces
+sg msp tfc sync $SERVICE $ENVIRONMENT
+
+# Generate Terraform manifests
+sg msp generate $SERVICE $ENVIRONMENT
+`,
+	Category: category.Company,
 	Action: func(c *cli.Context) error {
 		std.Out.WriteWarningf("'sg msp' is not available in this build of 'sg'.")
 		std.Out.Write("To install a build of 'sg' that includes 'sg msp', run:")
-		if err := std.Out.WriteCode("bash",
-			"go build -tags=msp -o=./sg ./dev/sg && ./sg install -f -p=false"); err != nil {
+		if err := std.Out.WriteCode("bash", buildCommand); err != nil {
 			return err
 		}
 		return errors.New("command unimplemented")

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -43,6 +43,8 @@ func init() {
 	// Override no-op implementation with our real implementation.
 	Command.Hidden = false
 	Command.Action = nil
+	// Trim description to just be the command description
+	Command.Description = commandDescription
 	// All 'sg msp ...' subcommands
 	Command.Subcommands = []*cli.Command{
 		{

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -1718,6 +1718,34 @@ Flags:
 
 * `--feedback`: provide feedback about this command by opening up a GitHub discussion
 
+## sg managed-services-platform
+
+EXPERIMENTAL: Generate and manage services deployed on the Sourcegraph Managed Services Platform.
+
+WARNING: This is currently still an experimental project.
+To learm more, refer to go/rfc-msp and go/msp (https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform)
+
+MSP commands are currently build-flagged to avoid increasing 'sg' binary sizes. To install a build of 'sg' that includes 'sg msp', run:
+
+	go build -tags=msp -o=./sg ./dev/sg && ./sg install -f -p=false
+
+MSP commands should then be available under 'sg msp --help'.
+
+```sh
+# Create a service specification
+$ sg msp init $SERVICE
+
+# Provision Terraform Cloud workspaces
+$ sg msp tfc sync $SERVICE $ENVIRONMENT
+
+# Generate Terraform manifests
+$ sg msp generate $SERVICE $ENVIRONMENT
+```
+
+Flags:
+
+* `--feedback`: provide feedback about this command by opening up a GitHub discussion
+
 ## sg help
 
 Get help and docs about sg.


### PR DESCRIPTION
This configures the stub `sg msp` command such that we now get a docstring with installation instructions in the `sg` reference.

As the tooling is still experimental, I'm opting to keep this in its own build variant for now, as it still represents a bit of a binary size increase to `sg`. Backlog issue: https://github.com/sourcegraph/sourcegraph/issues/56845

## Test plan

Rendered docs

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@sg-msp-install-instructions)