### PR TITLE
JetBrains: Cody: Improve the languages table in Cody settings

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutoCompleteLanguageTableWrapper.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutoCompleteLanguageTableWrapper.kt
@@ -1,13 +1,22 @@
 package com.sourcegraph.cody.config
 
 import java.awt.BorderLayout
+import java.awt.Dimension
 import javax.swing.JPanel
 
 /** Wrapper to be used with JetBrains Kotlin UI DSL */
 class AutoCompleteLanguageTableWrapper(private val languageTable: AutocompleteLanguageTable) :
     JPanel(BorderLayout()) {
+
   init {
-    add(languageTable.component)
+    val tableComponent = languageTable.component
+    val customHeightDiff = 120
+    val customPreferredSize =
+        Dimension(
+            tableComponent.preferredSize.width,
+            tableComponent.preferredSize.height + customHeightDiff)
+    tableComponent.preferredSize = customPreferredSize
+    add(tableComponent)
   }
 
   fun getBlacklistedLanguageIds(): List<String> {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutoCompleteLanguageTableWrapper.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutoCompleteLanguageTableWrapper.kt
@@ -7,9 +7,9 @@ import javax.swing.JPanel
 /** Wrapper to be used with JetBrains Kotlin UI DSL */
 class AutoCompleteLanguageTableWrapper(private val languageTable: AutocompleteLanguageTable) :
     JPanel(BorderLayout()) {
+  private val tableComponent = languageTable.component
 
   init {
-    val tableComponent = languageTable.component
     val customHeightDiff = 120
     val customPreferredSize =
         Dimension(
@@ -25,5 +25,12 @@ class AutoCompleteLanguageTableWrapper(private val languageTable: AutocompleteLa
 
   fun setBlacklistedLanguageIds(blacklistedIds: List<String>) {
     languageTable.setBlacklistedLanguageIds(blacklistedIds)
+  }
+
+  override fun setEnabled(enabled: Boolean) {
+    super.setEnabled(enabled)
+    tableComponent.isEnabled = enabled
+    tableComponent.components.forEach { it.isEnabled = enabled }
+    languageTable.isEnabled = enabled
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutocompleteLanguageTable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutocompleteLanguageTable.kt
@@ -24,7 +24,7 @@ class AutocompleteLanguageTable : ListTableWithButtons<LanguageEntry>() {
   override fun createListModel(): ListTableModel<LanguageEntry> {
     val model =
         ListTableModel(
-            arrayOf<ColumnInfo<*, *>>(LanguageCheckboxColumn(this), LanguageEntryColumn()),
+            arrayOf<ColumnInfo<*, *>>(LanguageCheckboxColumn(this), LanguageEntryColumn(this)),
             listOf<LanguageEntry>(),
             1,
             SortOrder.ASCENDING)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutocompleteLanguageTable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AutocompleteLanguageTable.kt
@@ -16,13 +16,15 @@ class AutocompleteLanguageTable : ListTableWithButtons<LanguageEntry>() {
     setValues(LanguageEntry.getRegisteredLanguageEntries())
   }
 
+  var isEnabled: Boolean = true
+
   /** Use this rather than the component directly when working with JetBrains Kotlin UI DSL */
   val wrapperComponent: AutoCompleteLanguageTableWrapper = AutoCompleteLanguageTableWrapper(this)
 
   override fun createListModel(): ListTableModel<LanguageEntry> {
     val model =
         ListTableModel(
-            arrayOf<ColumnInfo<*, *>>(LanguageCheckboxColumn(), LanguageEntryColumn()),
+            arrayOf<ColumnInfo<*, *>>(LanguageCheckboxColumn(this), LanguageEntryColumn()),
             listOf<LanguageEntry>(),
             1,
             SortOrder.ASCENDING)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/LanguageCheckboxColumn.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/LanguageCheckboxColumn.kt
@@ -4,9 +4,10 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.util.ui.ColumnInfo
 import javax.swing.JTable
 
-class LanguageCheckboxColumn : ColumnInfo<LanguageEntry, Boolean>("") {
+class LanguageCheckboxColumn(private val languageTable: AutocompleteLanguageTable) :
+    ColumnInfo<LanguageEntry, Boolean>("") {
   override fun isCellEditable(languageEntry: LanguageEntry): Boolean {
-    return true
+    return languageTable.isEnabled
   }
 
   override fun getColumnClass(): Class<*> {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/LanguageEntryColumn.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/LanguageEntryColumn.kt
@@ -1,9 +1,22 @@
 package com.sourcegraph.cody.config
 
+import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.ColumnInfo
 import java.util.*
+import javax.swing.table.TableCellRenderer
 
-class LanguageEntryColumn : ColumnInfo<LanguageEntry, String>("Enabled Languages") {
+class LanguageEntryColumn(private val languageTable: AutocompleteLanguageTable) :
+    ColumnInfo<LanguageEntry, String>("Enabled Languages") {
+  override fun getCustomizedRenderer(
+      o: LanguageEntry?,
+      renderer: TableCellRenderer?
+  ): TableCellRenderer {
+    // the language entry shouldn't ever in fact be a null here
+    val label = JBLabel(o?.language?.displayName ?: "Unknown")
+    label.isEnabled = languageTable.isEnabled
+    return TableCellRenderer { _, _, _, _, _, _ -> label }
+  }
+
   override fun valueOf(languageEntry: LanguageEntry): String {
     return languageEntry.language.displayName
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -48,6 +48,7 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
       }
 
       group("Autocomplete") {
+        lateinit var enableAutocompleteCheckbox: Cell<JBCheckBox>
         row {
           val enableCustomAutocompleteColor =
               checkBox("Custom color for completions")
@@ -61,12 +62,14 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
               .visibleIf(enableCustomAutocompleteColor.selected)
         }
         row {
-          checkBox("Automatically trigger completions")
-              .enabledIf(enableCodyCheckbox.selected)
-              .bindSelected(settingsModel::isCodyAutocompleteEnabled)
+          enableAutocompleteCheckbox =
+              checkBox("Automatically trigger completions")
+                  .enabledIf(enableCodyCheckbox.selected)
+                  .bindSelected(settingsModel::isCodyAutocompleteEnabled)
         }
         row {
           autocompleteLanguageTable()
+              .enabledIf(enableAutocompleteCheckbox.selected)
               .horizontalAlign(HorizontalAlign.FILL)
               .bind(
                   AutoCompleteLanguageTableWrapper::getBlacklistedLanguageIds,


### PR DESCRIPTION
Fixes #56466

Some fixes for the languages table in Cody settings
- it should now have an increased height, so that it's easier to scroll
- the checkbox column gets disabled (can't enable/disable languages) when autocomplete is disabled
- I added a custom cell renderer for the language display name column, so that it now gets greyed out when autocomplete is disabled

https://github.com/sourcegraph/sourcegraph/assets/18601388/d94f08a9-7091-4419-a0bb-cc2ec312966e

## Test plan
- the table should work like in the screen recording
- enabling/disabling languages for autocomplete should work as expected