### PR TITLE
JetBrains: Sign in to sourcegraph.com with a webflow from action on settings page

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -44,9 +44,11 @@ import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
 import com.sourcegraph.cody.chat.Transcript;
 import com.sourcegraph.cody.config.AccountType;
+import com.sourcegraph.cody.config.AccountsHostProjectHolder;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
+import com.sourcegraph.cody.config.CodyPersistentAccountsHost;
 import com.sourcegraph.cody.context.ContextMessage;
 import com.sourcegraph.cody.context.EmbeddingStatusView;
 import com.sourcegraph.cody.localapp.LocalAppManager;
@@ -183,6 +185,8 @@ public class CodyToolWindowContent implements UpdatableChat {
     SignInWithSourcegraphPanel singInWithSourcegraphPanel = new SignInWithSourcegraphPanel();
     singInWithSourcegraphPanel.addMainButtonActionListener(
         e -> {
+          AccountsHostProjectHolder.getInstance(project)
+              .setAccountsHost(new CodyPersistentAccountsHost(project));
           int port =
               ApplicationManager.getApplication()
                   .getService(BuiltInServerOptions.class)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithSourcegraphAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithSourcegraphAction.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowFactory
-import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.config.CodyPersistentAccountsHost
 import com.sourcegraph.cody.config.signInWithSourcegrapDialog
 import com.sourcegraph.config.ConfigUtil
@@ -25,9 +24,6 @@ class SignInWithSourcegraphAction(private val defaultServer: String = ConfigUtil
     if (dialog.showAndGet()) {
       accountsHost.addAccount(dialog.server, dialog.login, dialog.displayName, dialog.token)
       if (project != null && ConfigUtil.isCodyEnabled()) {
-        // Notify Cody Agent about config changes.
-        CodyAgent.getServer(project)
-            ?.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
         // Open Cody sidebar
         val toolWindowManager = ToolWindowManager.getInstance(project)
         val toolWindow = toolWindowManager.getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AccountsHostProjectHolder.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/AccountsHostProjectHolder.kt
@@ -1,0 +1,23 @@
+package com.sourcegraph.cody.config
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+
+class AccountsHostProjectHolder {
+  var accountsHost: CodyAccountsHost? = null
+
+  companion object {
+    @JvmStatic
+    fun getInstance(project: Project): AccountsHostProjectHolder {
+      return project.service<AccountsHostProjectHolder>()
+    }
+
+    @JvmStatic
+    fun useAccountsHost(project: Project, block: (CodyAccountsHost) -> Unit) {
+      val accountsHostProjectHolder = getInstance(project)
+      val host = accountsHostProjectHolder.accountsHost ?: return
+      block(host)
+      accountsHostProjectHolder.accountsHost = null
+    }
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -73,6 +73,9 @@ class CodyAccountListModel(private val project: Project) :
       token: String
   ) {
     val account = CodyAccount.create(login, displayName, server)
+    if (accountsListModel.isEmpty) {
+      activeAccount = account
+    }
     accountsListModel.add(account)
     newCredentials[account] = token
     notifyCredentialsChanged(account)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
@@ -1,6 +1,8 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.config.ConfigUtil
 
 class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHost {
   override fun addAccount(
@@ -13,6 +15,9 @@ class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHo
     CodyAuthenticationManager.getInstance().updateAccountToken(codyAccount, token)
     if (project != null) {
       CodyAuthenticationManager.getInstance().setActiveAccount(project, codyAccount)
+      // Notify Cody Agent about config changes.
+      CodyAgent.getServer(project)
+          ?.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
     }
   }
 

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -252,7 +252,7 @@
         </group>
 
         <group id="Cody.Accounts.AddAccount">
-            <action id="Cody.Accounts.AddCodyAccountWithToken" text="Log In with Token to Sourcegraph"
+            <action id="Cody.Accounts.AddCodyAccountWithToken" text="Log In to Sourcegraph"
                     class="com.sourcegraph.cody.config.AddCodyAccountWithTokenAction"/>
             <action id="Cody.Accounts.AddCodyEnterpriseAccount"
                     text="Log In with Token to Sourcegraph Enterprise"

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -24,6 +24,7 @@
         <projectService serviceImplementation="com.sourcegraph.cody.config.CodyProjectSettings"/>
         <projectService serviceImplementation="com.sourcegraph.cody.config.notification.AccountSettingChangeListener"/>
         <projectService serviceImplementation="com.sourcegraph.cody.config.notification.CodySettingChangeListener"/>
+        <projectService serviceImplementation="com.sourcegraph.cody.config.AccountsHostProjectHolder"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyApplicationSettings"/>
         <applicationService serviceImplementation="com.sourcegraph.config.CodyApplicationService"/>
         <applicationService serviceImplementation="com.sourcegraph.cody.config.CodyAuthenticationManager"/>


### PR DESCRIPTION
Previously we displayed a dialog to configure server and access token manually to add sourcegraph.com account, now we start the web flow to authenticate user 

https://github.com/sourcegraph/sourcegraph/assets/7345368/7a15dd5e-8fe2-456c-9292-8e9253baca31


## Test plan
- Log in to Sourcegraph from settings page should start web authentication flow and should add account after successful authentication

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
