### PR TITLE
JetBrains: Cody: Check if the project wasn't disposed when getting the active account

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -41,11 +41,13 @@ class CodyAuthenticationManager internal constructor() {
   internal fun updateAccountToken(account: CodyAccount, newToken: String) =
       accountManager.updateAccount(account, newToken)
 
-  fun getActiveAccount(project: Project): CodyAccount? =
-      project.service<CodyProjectActiveAccountHolder>().account
+  fun getActiveAccount(project: Project): CodyAccount? {
+    return if (!project.isDisposed) project.service<CodyProjectActiveAccountHolder>().account
+    else null
+  }
 
   fun setActiveAccount(project: Project, account: CodyAccount?) {
-    project.service<CodyProjectActiveAccountHolder>().account = account
+    if (!project.isDisposed) project.service<CodyProjectActiveAccountHolder>().account = account
   }
 
   fun getActiveAccountType(project: Project): AccountType {


### PR DESCRIPTION
Fixes #56894 

Couldn't replicate the error, but I added some extra checks in place just in case.

## Test plan
- authentication flow should work as normal
- the error described in #56894 shouldn't be replicable