### PR TITLE
JetBrains: Fix: don't try to display inlays on not supported editor instances

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteActionHandler.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteActionHandler.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
+import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteElementRenderer
 import com.sourcegraph.cody.vscode.InlineAutocompleteItem
@@ -14,15 +15,17 @@ open class AutocompleteActionHandler : EditorActionHandler() {
 
   override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
     // Returns false to fall back to normal action if there is no suggestion at the caret.
-    val project = editor.project
-    return if (project != null &&
-        CodyEditorUtil.isEditorInstanceSupported(editor) &&
-        CodyAgent.isConnected(project)) {
-      getAgentAutocompleteItem(caret) != null
-    } else {
-      AutocompleteText.atCaret(caret).isPresent
-    }
+    val project = editor.project ?: return false
+    return CodyEditorUtil.isEditorInstanceSupported(editor) &&
+        hasAnyAutocompleteItems(project, caret)
   }
+
+  private fun hasAnyAutocompleteItems(project: Project, caret: Caret) =
+      if (CodyAgent.isConnected(project)) {
+        getAgentAutocompleteItem(caret) != null
+      } else {
+        AutocompleteText.atCaret(caret).isPresent
+      }
 
   /**
    * Returns the autocompletion item for the first inlay of type `CodyAutocompleteElementRenderer`

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteActionHandler.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/AutocompleteActionHandler.kt
@@ -20,12 +20,8 @@ open class AutocompleteActionHandler : EditorActionHandler() {
         hasAnyAutocompleteItems(project, caret)
   }
 
-  private fun hasAnyAutocompleteItems(project: Project, caret: Caret) =
-      if (CodyAgent.isConnected(project)) {
-        getAgentAutocompleteItem(caret) != null
-      } else {
-        AutocompleteText.atCaret(caret).isPresent
-      }
+  private fun hasAnyAutocompleteItems(project: Project, caret: Caret): Boolean =
+      CodyAgent.isConnected(project) && getAgentAutocompleteItem(caret) != null
 
   /**
    * Returns the autocompletion item for the first inlay of type `CodyAutocompleteElementRenderer`


### PR DESCRIPTION
Closes #https://github.com/sourcegraph/sourcegraph/issues/56895

But the root cause of the issue for the user was that the agent didn't start, that's why even when the editor is not supported we moved to the else branch and the exception appears because we will try to display inlays on not supported editor 

## Test plan
- I have no idea how to reproduce it... 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
