### PR TITLE
search jobs: compute aggregate state in db

### DIFF
--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -101,14 +101,10 @@ func newSearchJobConnectionResolver(ctx context.Context, db database.DB, service
 
 func normalize(orderBy string) string {
 	switch orderBy {
-	case "CREATED_AT":
-		return "created_at"
 	case "STATE":
 		return "agg_state"
-	case "QUERY":
-		return "query"
 	default:
-		return "created_at"
+		return strings.ToLower(orderBy)
 	}
 }
 

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -47,7 +47,7 @@ func (r *searchJobResolver) Query() string {
 }
 
 func (r *searchJobResolver) State(ctx context.Context) string {
-	// At job creation we don't set the AggState
+	// We don't set the AggState during job creation
 	if r.Job.AggState != "" {
 		return r.Job.AggState.ToGraphQL()
 	}

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -53,23 +53,10 @@ func (r *searchJobResolver) Query() string {
 }
 
 func (r *searchJobResolver) State(ctx context.Context) string {
-	// Once a search job has started processing, we have to look at the aggregate
-	// state of all sub-jobs to determine the state.
-	if r.Job.State == types.JobStateProcessing || r.Job.State == types.JobStateCompleted {
-		stats, statsErr := r.initStats(ctx)
-
-		if statsErr != nil || stats.Failed > 0 {
-			return types.JobStateFailed.ToGraphQL()
-		}
-
-		if stats.InProgress > 0 {
-			return types.JobStateProcessing.ToGraphQL()
-		}
-
-		return types.JobStateCompleted.ToGraphQL()
-	} else {
-		return r.Job.State.ToGraphQL()
+	if r.Job.AggState != "" {
+		return r.Job.AggState.ToGraphQL()
 	}
+	return r.Job.State.ToGraphQL()
 }
 
 func (r *searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -53,7 +53,11 @@ func (r *searchJobResolver) Query() string {
 }
 
 func (r *searchJobResolver) State(ctx context.Context) string {
-	return r.Job.AggState.ToGraphQL()
+	// At job creation we don't set the AggState
+	if r.Job.AggState != "" {
+		return r.Job.AggState.ToGraphQL()
+	}
+	return r.Job.State.ToGraphQL()
 }
 
 func (r *searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -53,10 +53,7 @@ func (r *searchJobResolver) Query() string {
 }
 
 func (r *searchJobResolver) State(ctx context.Context) string {
-	if r.Job.AggState != "" {
-		return r.Job.AggState.ToGraphQL()
-	}
-	return r.Job.State.ToGraphQL()
+	return r.Job.AggState.ToGraphQL()
 }
 
 func (r *searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
@@ -101,6 +98,7 @@ func (r *searchJobResolver) LogURL(ctx context.Context) (*string, error) {
 	return nil, nil
 }
 
+// TODO: don't need init anymore
 func (r *searchJobResolver) initStats(ctx context.Context) (*types.RepoRevJobStats, error) {
 	r.once.Do(func() {
 		repoRevStats, err := r.svc.GetAggregateRepoRevState(ctx, r.Job.ID)

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -71,6 +71,15 @@ func TestExhaustiveSearch(t *testing.T) {
 	{
 		jobs, err := svc.ListSearchJobs(userCtx, store.ListArgs{})
 		require.NoError(err)
+
+		// HACK: Don't test agg state. Here we compare a result from GetSearchJob and
+		// ListSearchJobs. However, AggState is only set in ListSearchJobs.
+		//
+		// We don't want to set AggState in GetSearchJob because it is fairly expensive,
+		// and we call GetSearchJob a lot as part of the security checks, so we want to
+		// keep it as lean as possible.
+		jobs[0].AggState = job.AggState
+
 		require.Equal([]*types.ExhaustiveSearchJob{job}, jobs)
 	}
 
@@ -121,6 +130,7 @@ func TestExhaustiveSearch(t *testing.T) {
 		// only assert on State since the rest are non-deterministic.
 		require.Equal(types.JobStateCompleted, job2.State)
 		job2.WorkerJob = job.WorkerJob
+		job2.AggState = job.AggState
 		require.Equal(job, job2)
 	}
 

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -123,7 +123,6 @@ func (s *Service) CreateSearchJob(ctx context.Context, query string) (_ *types.E
 		return nil, err
 	}
 
-	// TODO (stefan) make GetExhaustiveSearchJob return the agg state for the tests
 	return tx.GetExhaustiveSearchJob(ctx, jobID)
 }
 

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -123,6 +123,7 @@ func (s *Service) CreateSearchJob(ctx context.Context, query string) (_ *types.E
 		return nil, err
 	}
 
+	// TODO (stefan) make GetExhaustiveSearchJob return the agg state for the tests
 	return tx.GetExhaustiveSearchJob(ctx, jobID)
 }
 

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -271,7 +271,7 @@ func (s *Store) ListExhaustiveSearchJobs(ctx context.Context, args ListArgs) (jo
 
 	// Filter by query.
 	if args.Query != "" {
-		conds = append(conds, sqlf.Sprintf("sj.query LIKE %s", "%"+args.Query+"%"))
+		conds = append(conds, sqlf.Sprintf("query LIKE %s", "%"+args.Query+"%"))
 	}
 
 	// Filter by state.

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -190,13 +190,12 @@ func (s *Store) GetExhaustiveSearchJob(ctx context.Context, id int64) (_ *types.
 }
 
 // aggStateSubQuery takes the results from getAggregateStateTable and computes a
-// single, aggregate state of the job cascade. We use this sub-query to an
-// aggregate state to a search job that reflects the state of the entire search
-// job better than the worker state
+// single aggregate state that reflects the state of the entire search job
+// cascade better than the state of the top-level worker.
 //
 // The processing chain is as follows:
 //
-// Call getAggregateStateTable -> transpose table -> compute aggregate state
+// Execute getAggregateStateTable -> transpose table -> compute aggregate state
 //
 // # The result looks like this:
 //

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -491,13 +491,12 @@ func (s *Store) GetJobLogs(ctx context.Context, id int64, opts *GetJobLogsOpts) 
 	return jobs, nil
 }
 
-func scanExhaustiveSearchJob(sc dbutil.Scanner) (*types.ExhaustiveSearchJob, error) {
-	var job types.ExhaustiveSearchJob
+func defaultScanTargets(job *types.ExhaustiveSearchJob) []any {
 	// required field for the sync worker, but
 	// the value is thrown out here
 	var executionLogs *[]any
 
-	return &job, sc.Scan(
+	return []any{
 		&job.ID,
 		&job.InitiatorID,
 		&job.State,
@@ -513,33 +512,25 @@ func scanExhaustiveSearchJob(sc dbutil.Scanner) (*types.ExhaustiveSearchJob, err
 		&job.Cancel,
 		&job.CreatedAt,
 		&job.UpdatedAt,
+	}
+}
+
+func scanExhaustiveSearchJob(sc dbutil.Scanner) (*types.ExhaustiveSearchJob, error) {
+	var job types.ExhaustiveSearchJob
+
+	return &job, sc.Scan(
+		defaultScanTargets(&job)...,
 	)
 }
 
-// TODO: share code with above
 func scanExhaustiveSearchJobList(sc dbutil.Scanner) (*types.ExhaustiveSearchJob, error) {
 	var job types.ExhaustiveSearchJob
-	// required field for the sync worker, but
-	// the value is thrown out here
-	var executionLogs *[]any
 
 	return &job, sc.Scan(
-		&job.ID,
-		&job.InitiatorID,
-		&job.State,
-		&job.Query,
-		&dbutil.NullString{S: &job.FailureMessage},
-		&dbutil.NullTime{Time: &job.StartedAt},
-		&dbutil.NullTime{Time: &job.FinishedAt},
-		&dbutil.NullTime{Time: &job.ProcessAfter},
-		&job.NumResets,
-		&job.NumFailures,
-		&executionLogs,
-		&job.WorkerHostname,
-		&job.Cancel,
-		&job.CreatedAt,
-		&job.UpdatedAt,
-		&job.AggState,
+		append(
+			defaultScanTargets(&job),
+			&job.AggState,
+		)...,
 	)
 }
 

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -2,9 +2,11 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -278,4 +280,249 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	}
 }
 
+// TestStore_GetSearchJobNotFound tests that ListExhaustiveSearchJobs returns
+// the proper aggregated state.
+func TestStore_AggregateStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	bs := basestore.NewWithHandle(db.Handle())
+
+	_, err := createRepo(db, "repo1")
+	require.NoError(t, err)
+
+	s := store.New(db, &observation.TestContext)
+
+	tc := []struct {
+		name string
+		c    stateCascade
+		want types.JobState
+	}{
+		{
+			name: "only repo rev jobs running",
+			c: stateCascade{
+				searchJob:   types.JobStateCompleted,
+				repoJobs:    []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{types.JobStateProcessing},
+			},
+			want: types.JobStateProcessing,
+		},
+		{
+			name: "processing, because at least 1 job is running",
+			c: stateCascade{
+				searchJob: types.JobStateProcessing,
+				repoJobs:  []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{
+					types.JobStateProcessing,
+					types.JobStateQueued,
+					types.JobStateCompleted,
+				},
+			},
+			want: types.JobStateProcessing,
+		},
+		{
+			name: "processing, although some job are failed",
+			c: stateCascade{
+				searchJob: types.JobStateCompleted,
+				repoJobs:  []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{
+					types.JobStateProcessing,
+					types.JobStateFailed,
+				},
+			},
+			want: types.JobStateProcessing,
+		},
+		{
+			name: "all jobs finished, at least 1 failed",
+			c: stateCascade{
+				searchJob:   types.JobStateCompleted,
+				repoJobs:    []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{types.JobStateCompleted, types.JobStateFailed},
+			},
+			want: types.JobStateFailed,
+		},
+		{
+			name: "all jobs finished",
+			c: stateCascade{
+				searchJob:   types.JobStateCompleted,
+				repoJobs:    []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{types.JobStateCompleted, types.JobStateCompleted},
+			},
+			want: types.JobStateCompleted,
+		},
+		{
+			name: "search job was canceled, but some jobs haven't stopped yet",
+			c: stateCascade{
+				searchJob:   types.JobStateCanceled,
+				repoJobs:    []types.JobState{types.JobStateCompleted},
+				repoRevJobs: []types.JobState{types.JobStateProcessing, types.JobStateFailed},
+			},
+			want: types.JobStateCanceled,
+		},
+		{
+			name: "top-level search job finished, but the other jobs haven't started yet",
+			c: stateCascade{
+				searchJob: types.JobStateCompleted,
+				repoJobs:  []types.JobState{types.JobStateQueued},
+			},
+			want: types.JobStateQueued,
+		},
+		{
+			name: "search job is queued, but no other job has been created yet",
+			c: stateCascade{
+				searchJob: types.JobStateQueued,
+			},
+			want: types.JobStateQueued,
+		},
+	}
+
+	for i, tt := range tc {
+		t.Run("", func(t *testing.T) {
+			userID, err := createUser(bs, fmt.Sprintf("user_%d", i))
+			require.NoError(t, err)
+
+			ctx := actor.WithActor(context.Background(), actor.FromUser(userID))
+			jobID := createJobCascade(t, ctx, s, tt.c)
+
+			jobs, err := s.ListExhaustiveSearchJobs(ctx, store.ListArgs{})
+			require.NoError(t, err)
+			require.Equal(t, 1, len(jobs))
+			require.Equal(t, jobID, jobs[0].ID)
+			assert.Equal(t, tt.want, jobs[0].AggState)
+		})
+	}
+}
+
+// createJobCascade creates a cascade of jobs (1 search job -> 1 repo job -> n
+// repo rev jobs) with proper references.
+//
+// This is a fairly large test helper, because don't want to start the worker
+// routines, but instead we want to create a snapshot of the state of the jobs
+// at a given point in time.
+func createJobCascade(
+	t *testing.T,
+	ctx context.Context,
+	s *store.Store,
+	c stateCascade,
+) (searchJobID int64) {
+	t.Helper()
+
+	searchJob := types.ExhaustiveSearchJob{
+		InitiatorID: actor.FromContext(ctx).UID,
+		Query:       "repo:job1",
+		WorkerJob:   types.WorkerJob{State: c.searchJob},
+	}
+
+	repoJobs := make([]types.ExhaustiveSearchRepoJob, len(c.repoJobs))
+	for i, r := range c.repoJobs {
+		repoJobs[i] = types.ExhaustiveSearchRepoJob{
+			WorkerJob: types.WorkerJob{State: r},
+			RepoID:    1, // same repo for all tests
+			RefSpec:   "HEAD",
+		}
+	}
+
+	repoRevJobs := make([]types.ExhaustiveSearchRepoRevisionJob, len(c.repoRevJobs))
+	for i, rr := range c.repoRevJobs {
+		repoRevJobs[i] = types.ExhaustiveSearchRepoRevisionJob{
+			WorkerJob: types.WorkerJob{State: rr},
+			Revision:  "HEAD",
+		}
+	}
+
+	// TODO (stefan): set state explicitly because it is not set by the store
+	// TODO (stefan): remove UNION ALL query
+	jobID, err := s.CreateExhaustiveSearchJob(ctx, searchJob)
+	require.NoError(t, err)
+	assert.NotZero(t, jobID)
+
+	err = s.Exec(ctx, sqlf.Sprintf("UPDATE exhaustive_search_jobs SET state = %s WHERE id = %s", c.searchJob, jobID))
+	require.NoError(t, err)
+
+	for i, r := range repoJobs {
+		r.SearchJobID = jobID
+		repoJobID, err := s.CreateExhaustiveSearchRepoJob(ctx, r)
+		require.NoError(t, err)
+		assert.NotZero(t, repoJobID)
+
+		err = s.Exec(ctx, sqlf.Sprintf("UPDATE exhaustive_search_repo_jobs SET state = %s WHERE id = %s", c.repoJobs[i], repoJobID))
+		require.NoError(t, err)
+
+		for j, rr := range repoRevJobs {
+			rr.SearchRepoJobID = repoJobID
+			repoRevJobID, err := s.CreateExhaustiveSearchRepoRevisionJob(ctx, rr)
+			require.NoError(t, err)
+			assert.NotZero(t, repoRevJobID)
+			require.NoError(t, err)
+
+			err = s.Exec(ctx, sqlf.Sprintf("UPDATE exhaustive_search_repo_revision_jobs SET state = %s WHERE id = %s", c.repoRevJobs[j], repoRevJobID))
+			require.NoError(t, err)
+		}
+	}
+
+	return jobID
+}
+
+type stateCascade struct {
+	searchJob   types.JobState
+	repoJobs    []types.JobState
+	repoRevJobs []types.JobState
+}
+
+func setStateSearchJob(ctx context.Context, s *store.Store, id int64, state types.JobState) error {
+	return s.Exec(ctx, sqlf.Sprintf("UPDATE exhaustive_search_jobs SET state = %s WHERE id = %s", state, id))
+}
+
+//	type searchJobMinimal struct {
+//		ID        int64
+//		initiator int32
+//		query     string
+//		state     types.JobState
+//	}
+//
+//	func (j searchJobMinimal) toJob() types.ExhaustiveSearchJob {
+//		return types.ExhaustiveSearchJob{
+//			InitiatorID: j.initiator,
+//			Query:       j.query,
+//			WorkerJob:   types.WorkerJob{State: j.state},
+//		}
+//	}
+//
+//	type repoJobMinimal struct {
+//		state       types.JobState
+//		repoID      api.RepoID
+//		searchJobID int64
+//		refSpec     string
+//	}
+//
+//	func (j repoJobMinimal) toJob(searchJobID int64) types.ExhaustiveSearchRepoJob {
+//		return types.ExhaustiveSearchRepoJob{
+//			WorkerJob:   types.WorkerJob{State: j.state},
+//			RepoID:      j.repoID,
+//			SearchJobID: searchJobID,
+//			RefSpec:     j.refSpec,
+//		}
+//	}
+//
+//	type repoRevJobMinimal struct {
+//		state    types.JobState
+//		revision string
+//	}
+//
+//	func (j repoRevJobMinimal) toJob(repoJobID int64) types.ExhaustiveSearchRepoRevisionJob {
+//		return types.ExhaustiveSearchRepoRevisionJob{
+//			WorkerJob:       types.WorkerJob{State: j.state},
+//			SearchRepoJobID: repoJobID,
+//			Revision:        j.revision,
+//		}
+//	}
+//
+//	type jobCascade struct {
+//		searchJob  searchJobMinimal
+//		repoJobs   []repoJobMinimal
+//		repoRevJobs []repoRevJobMinimal
+//	}
 func intptr(s int) *int { return &s }

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -280,8 +280,8 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	}
 }
 
-// TestStore_GetSearchJobNotFound tests that ListExhaustiveSearchJobs returns
-// the proper aggregated state.
+// TestStore_GetAggregateStatus tests that ListExhaustiveSearchJobs returns the
+// proper aggregated state.
 func TestStore_AggregateStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -324,7 +324,7 @@ func TestStore_AggregateStatus(t *testing.T) {
 			want: types.JobStateProcessing,
 		},
 		{
-			name: "processing, although some job are failed",
+			name: "processing, although some jobs failed",
 			c: stateCascade{
 				searchJob: types.JobStateCompleted,
 				repoJobs:  []types.JobState{types.JobStateCompleted},
@@ -345,7 +345,7 @@ func TestStore_AggregateStatus(t *testing.T) {
 			want: types.JobStateFailed,
 		},
 		{
-			name: "all jobs finished",
+			name: "all jobs finished successfully",
 			c: stateCascade{
 				searchJob:   types.JobStateCompleted,
 				repoJobs:    []types.JobState{types.JobStateCompleted},

--- a/internal/search/exhaustive/types/exhaustive_search_job.go
+++ b/internal/search/exhaustive/types/exhaustive_search_job.go
@@ -20,6 +20,8 @@ type ExhaustiveSearchJob struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+
+	AggState JobState
 }
 
 func (j *ExhaustiveSearchJob) RecordID() int {

--- a/internal/search/exhaustive/types/exhaustive_search_job.go
+++ b/internal/search/exhaustive/types/exhaustive_search_job.go
@@ -21,6 +21,9 @@ type ExhaustiveSearchJob struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 
+	// The aggregate state of the job. This is only set when the job is returned
+	// from ListSearchJobs. This state is different from WorkerJob.State, because it
+	// reflects the combined state of all jobs created as part of the search job.
 	AggState JobState
 }
 


### PR DESCRIPTION
Closes #56937
Closes #56935

This PR moves the logic for computing the aggregate state from the resolver to the store.

Why?

To filter and sort by the aggregate state and make use of the paging helpers, we have to return the aggregate state from db instead of computing it in the resolver. 

Note:

There is a bit of awkwardness because only `ListSearchJobs` computes the aggregate state, but not `GetSearchJob`. I don't want to set `AggState` in `GetSearchJob` because it is fairly expensive to calculate, and we call `GetSearchJob` a lot as part of the security checks, so I wanted to keep it as lean as possible. 

In the future we should have a dedicated call to the db for security checks and use `GetSearchJob` only when we create a search job. Then we can calculate the aggregate state on GetSearchJob, too, and remove the special casing in the code. 

Test plan:
- New unit test
- manual testing: I ran a couple of search jobs locally to confirm whether the aggregate state properly reflect the state of the underlying jobs. 



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
