### PR TITLE
nix: separate nixpkgs-unstable pin from nixpkgs pin for static binaries

### DIFF
--- a/dev/nix/nodejs.nix
+++ b/dev/nix/nodejs.nix
@@ -1,5 +1,5 @@
 { pkgs, fetchurl }:
-pkgs.nodejs-16_x.overrideAttrs (oldAttrs: {
+pkgs.nodejs-18_x.overrideAttrs (oldAttrs: {
   # don't override version here, as it won't be in binary cache
   # and building is super expensive
   # version = "16.19.0";
@@ -13,12 +13,12 @@ pkgs.nodejs-16_x.overrideAttrs (oldAttrs: {
         sha512 = "sha512-wRS8ap/SPxBqbUMzcUNkoA0suLqk9BqMlvi8dM2FRuhwUDgqVGYLc5jQ6Ww3uqVc+84zJvN2GYmTWCubaoWPtQ==";
       };
     };
-    typescript = oldAttrs.passthru.pkgs.typescript.override rec {
-      version = "4.9.5";
+    typescript = oldAttrs.passthru.pkgs.typescript.overrideAttrs (oldAttrs: rec {
+      version = "5.2.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/typescript/-/typescript-${version}.tgz";
-        sha512 = "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==";
+        sha512 = "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==";
       };
-    };
+    });
   };
 })

--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,21 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1695227375,
+        "narHash": "sha256-76WTkeCu3npPZDkay2hB2Dj3cOuCiF0P41dbmXWUKtA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fe977679240ac2027b151ecca1bc6ce808c2e8af",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-bins": {
+      "locked": {
         "lastModified": 1682268651,
         "narHash": "sha256-2eZriMhnD24Pmb8ideZWZDiXaAVe6LzJrHQiNPck+Lk=",
         "owner": "NixOS",
@@ -37,7 +52,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-bins": "nixpkgs-bins"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,15 @@
   inputs = {
     nixpkgs.url = "nixpkgs/nixpkgs-unstable";
     # separate nixpkgs pin for more stable changes to binaries we build
-    nixpkgs-bins.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-bins, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-stable, flake-utils }:
     let
-      xcompileTargets = with nixpkgs-bins.lib.systems.examples; {
-        "aarch64-darwin" = nixpkgs-bins.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
-        "x86_64-darwin" = import nixpkgs-bins { system = "x86_64-darwin"; crossSystem = aarch64-darwin; };
+      xcompileTargets = with nixpkgs-stable.lib.systems.examples; {
+        "aarch64-darwin" = nixpkgs-stable.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
+        "x86_64-darwin" = import nixpkgs-stable { system = "x86_64-darwin"; crossSystem = aarch64-darwin; };
       };
       inherit (import ./dev/nix/util.nix { inherit (nixpkgs) lib; }) xcompilify;
     in
@@ -20,7 +20,7 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          pkgsBins = nixpkgs-bins.legacyPackages.${system};
+          pkgsBins = nixpkgs-stable.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;
         in

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,17 @@
   description = "The Sourcegraph developer environment & packages Nix Flake";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    # separate nixpkgs pin for more stable changes to binaries we build
+    nixpkgs-bins.url = "github:NixOS/nixpkgs/e78d25df6f1036b3fa76750ed4603dd9d5fe90fc";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-bins, flake-utils }:
     let
-      xcompileTargets = with nixpkgs.lib.systems.examples; {
-        "aarch64-darwin" = nixpkgs.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
-        "x86_64-darwin" = import nixpkgs { system = "x86_64-darwin"; crossSystem = aarch64-darwin; };
+      xcompileTargets = with nixpkgs-bins.lib.systems.examples; {
+        "aarch64-darwin" = nixpkgs-bins.legacyPackages.aarch64-darwin.pkgsx86_64Darwin;
+        "x86_64-darwin" = import nixpkgs-bins { system = "x86_64-darwin"; crossSystem = aarch64-darwin; };
       };
       inherit (import ./dev/nix/util.nix { inherit (nixpkgs) lib; }) xcompilify;
     in
@@ -18,19 +20,21 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
+          pkgsBins = nixpkgs-bins.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;
         in
         {
           legacyPackages = pkgs';
 
-          packages = xcompilify { inherit pkgs pkgsX; }
-            (pkgs: {
-              ctags = pkgs.callPackage ./dev/nix/ctags.nix { };
-              comby = pkgs.callPackage ./dev/nix/comby.nix { };
-              p4-fusion = pkgs.callPackage ./dev/nix/p4-fusion.nix { };
+          packages = xcompilify { inherit pkgsX; pkgs = pkgsBins; }
+            (p: {
+              ctags = p.callPackage ./dev/nix/ctags.nix { };
+              comby = p.callPackage ./dev/nix/comby.nix { };
+              p4-fusion = p.callPackage ./dev/nix/p4-fusion.nix { };
             }) // {
-            nodejs-16_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
+            # doesnt need the same stability as those above
+            nodejs-18_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
           };
 
           # We use pkgs (not pkgs') intentionally to avoid doing extra work of
@@ -43,7 +47,7 @@
       overlays = {
         ctags = final: prev: { universal-ctags = self.packages.${prev.system}.ctags; };
         comby = final: prev: { comby = self.packages.${prev.system}.comby; };
-        nodejs-16_x = final: prev: { nodejs-16_x = self.packages.${prev.system}.nodejs-16_x; };
+        nodejs-18_x = final: prev: { nodejs-16_x = self.packages.${prev.system}.nodejs-18_x; };
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };
       };
     };


### PR DESCRIPTION
We want to get newer stuff in the devshell, but keep a stabler pin for the static binaries (until darwin stdenv stabilizes, most notably the big brain work over at https://github.com/NixOS/nixpkgs/pull/256590)

## Test plan

N/A nix stuff :clueless: