### PR TITLE
ci: fix bazel prechecks not detecting untracked changes

### DIFF
--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -34,6 +34,9 @@ echo "--- :bazel: Running bazel configure"
 bazel "${bazelrc[@]}" configure
 
 echo "--- Checking if BUILD.bazel files were updated"
+# Account for the possibility of a BUILD.bazel to be totally new, and thus untracked.
+git ls-files --exclude-standard --others | grep BUILD.bazel | xargs git add --intent-to-add
+
 git diff --exit-code || EXIT_CODE=$? # do not fail on non-zero exit
 
 # if we get a non-zero exit code, bazel configure updated files


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/251

This issue was happening because it's possible to end up with a clean diff, when `bazel configure` creates _new_ `BUILD.bazel` files. 

So instead, we add them with `--intent-to-add` which make them show up in `git diff`. 

## Test plan

Tested over a QA branch: `/reblochon/file.go` and `/camembert/file.go` were added without a buildfile, and this is the result: 

![image](https://github.com/sourcegraph/sourcegraph/assets/10151/3b3fff24-bbfd-4d9a-b2cd-ed56fb53d249)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
