### PR TITLE
ci: update Go version for sg binary releases

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: 1.20.8
 
       - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/249

We didn't update the Go version in the GH Workflow that releases `sg`. This PR fixes it. 

## Test plan

<img width="1327" alt="CleanShot 2023-09-22 at 18 21 35@2x" src="https://github.com/sourcegraph/sourcegraph/assets/10151/2387fc28-f249-4c7e-ab1a-40c3e6d7de71">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
