### PR TITLE
pings: always expose error count metric

### DIFF
--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -147,6 +147,7 @@ func newServerHandler(logger log.Logger, config *Config) (http.Handler, error) {
 	if err != nil {
 		return nil, errors.Errorf("create request counter: %v", err)
 	}
+	errorCounter.Add(context.Background(), 0) // Add a zero value to ensure the metric is visible to scrapers.
 	meter := &updatecheck.Meter{
 		RequestCounter:          requestCounter,
 		RequestHasUpdateCounter: requestHasUpdateCounter,


### PR DESCRIPTION
GCP monitoring dashboard can't create graph and alert for a metric that is not visible.

## Test plan

```
$ sg run pings
$ curl -sS http://localhost:7011/metrics | grep "error_count"
# HELP pings_error_count_total number of errors that occur while publishing server pings
# TYPE pings_error_count_total counter
pings_error_count_total{otel_scope_name="pings/shared",otel_scope_version=""} 0
```