### PR TITLE
JetBrains: Cody: Improve autocomplete custom color setting

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.editor.impl.FontInfo;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.ui.JBColor;
 import com.sourcegraph.cody.autocomplete.InlayModelUtils;
-import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +24,6 @@ public class AutocompleteRenderUtils {
 
   public static TextAttributes getTextAttributesForEditor(@NotNull Editor editor) {
     try {
-      //noinspection MissingRecentApi
       return editor
           .getColorsScheme()
           .getAttributes(DefaultLanguageHighlighterColors.INLAY_TEXT_WITHOUT_BACKGROUND);

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtils.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.impl.FontInfo;
 import com.intellij.openapi.editor.markup.TextAttributes;
+import com.intellij.ui.JBColor;
 import com.sourcegraph.cody.autocomplete.InlayModelUtils;
 import java.awt.Color;
 import java.awt.Font;
@@ -37,7 +38,7 @@ public class AutocompleteRenderUtils {
 
   public static TextAttributes getCustomTextAttributes(
       @NotNull Editor editor, @NotNull Integer fontColor) {
-    Color color = new Color(fontColor);
+    JBColor color = new JBColor(fontColor, fontColor); // set light & dark mode colors explicitly
     TextAttributes attrs = getTextAttributesForEditor(editor).clone();
     attrs.setForegroundColor(color);
     return attrs;

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.markup.TextAttributes;
 import com.sourcegraph.cody.vscode.InlineAutocompleteItem;
 import java.awt.*;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,10 +30,14 @@ public abstract class CodyAutocompleteElementRenderer implements EditorCustomEle
       @Nullable AutocompleteRendererType type) {
     this.text = text;
     this.completionItem = completionItem;
+    Supplier<TextAttributes> textAttributesFallback =
+        () -> AutocompleteRenderUtils.getTextAttributesForEditor(editor);
     this.themeAttributes =
         isCustomAutocompleteColorEnabled()
-            ? AutocompleteRenderUtils.getCustomTextAttributes(editor, getCustomAutocompleteColor())
-            : AutocompleteRenderUtils.getTextAttributesForEditor(editor);
+            ? Optional.ofNullable(getCustomAutocompleteColor())
+                .map(c -> AutocompleteRenderUtils.getCustomTextAttributes(editor, c))
+                .orElseGet(textAttributesFallback)
+            : textAttributesFallback.get();
     this.editor = editor;
     this.type = type;
   }

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -116,7 +116,7 @@ public class ConfigUtil {
     return CodyApplicationSettings.getInstance().isCustomAutocompleteColorEnabled();
   }
 
-  public static Integer getCustomAutocompleteColor() {
+  public static @Nullable Integer getCustomAutocompleteColor() {
     return CodyApplicationSettings.getInstance().getCustomAutocompleteColor();
   }
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.ColorPanel
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
@@ -15,7 +16,6 @@ import com.sourcegraph.cody.config.notification.CodySettingChangeContext
 import com.sourcegraph.cody.config.ui.lang.AutocompleteLanguageTable
 import com.sourcegraph.cody.config.ui.lang.AutocompleteLanguageTableWrapper
 import com.sourcegraph.config.ConfigUtil
-import java.awt.Color
 
 class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY_DISPLAY_NAME) {
   private lateinit var dialogPanel: DialogPanel
@@ -89,7 +89,8 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
     settingsModel.isCustomAutocompleteColorEnabled =
         codyApplicationSettings.isCustomAutocompleteColorEnabled
     settingsModel.customAutocompleteColor =
-        codyApplicationSettings.customAutocompleteColor?.let { Color(it) }
+        // note: this sets the same value for both light & dark mode, currently
+        codyApplicationSettings.customAutocompleteColor?.let { JBColor(it, it) }
     settingsModel.blacklistedLanguageIds = codyApplicationSettings.blacklistedLanguageIds
     dialogPanel.reset()
   }


### PR DESCRIPTION
Some small fixes for autocomplete color:
- it's been possible to cause an NPE by enabling a custom color in the settings, but then not picking any particular color (which produced a null); there's now a fallback for this case
- we now explicitly set (the same) color for light & dark theme
  - we could have a separate setting for either type of theme, or just only set for the current one in the future
  - for now, we explicitly set the custom value for all themes

What should still be done later:
  - #56996

https://github.com/sourcegraph/sourcegraph/assets/18601388/3da99531-4037-411d-bff6-73217046b22b

## Test plan
- when enabling custom autocomplete coloring, but not explicitly picking any color (effectively leaving it a null), no NullPointerExceptions or other errors should happen for now