### PR TITLE
JetBrains: Cody: Add a setting for accepting non-trusted certificates automatically

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -118,7 +118,8 @@ class CodyAgent(private val project: Project) : Disposable {
     val binary = agentBinary()
     logger.info("starting Cody agent " + binary.absolutePath)
     val processBuilder = ProcessBuilder(binary.absolutePath)
-    if (java.lang.Boolean.getBoolean("cody.accept-non-trusted-certificates-automatically")) {
+    if (java.lang.Boolean.getBoolean("cody.accept-non-trusted-certificates-automatically") ||
+        ConfigUtil.getShouldAcceptNonTrustedCertificatesAutomatically()) {
       processBuilder.environment()["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
     }
 

--- a/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/config/ConfigUtil.java
@@ -143,4 +143,9 @@ public class ConfigUtil {
   public static List<String> getBlacklistedAutocompleteLanguageIds() {
     return CodyApplicationSettings.getInstance().getBlacklistedLanguageIds();
   }
+
+  public static boolean getShouldAcceptNonTrustedCertificatesAutomatically() {
+    return CodyApplicationSettings.getInstance()
+        .getShouldAcceptNonTrustedCertificatesAutomatically();
+  }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -18,6 +18,7 @@ data class CodyApplicationSettings(
     var customAutocompleteColor: Int? = null,
     var blacklistedLanguageIds: List<String> = listOf(),
     var isOnboardingGuidanceDismissed: Boolean = false,
+    var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
 ) : PersistentStateComponent<CodyApplicationSettings> {
   override fun getState(): CodyApplicationSettings = this
 
@@ -33,6 +34,8 @@ data class CodyApplicationSettings(
     this.customAutocompleteColor = state.customAutocompleteColor
     this.blacklistedLanguageIds = state.blacklistedLanguageIds
     this.isOnboardingGuidanceDismissed = state.isOnboardingGuidanceDismissed
+    this.shouldAcceptNonTrustedCertificatesAutomatically =
+        state.shouldAcceptNonTrustedCertificatesAutomatically
   }
 
   companion object {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -12,4 +12,5 @@ data class SettingsModel(
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Color? = null,
     var blacklistedLanguageIds: List<String> = listOf(),
+    var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
 )

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -45,6 +45,11 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
               .enabledIf(enableCodyCheckbox.selected)
               .bindSelected(settingsModel::isCodyVerboseDebugEnabled)
         }
+        row {
+          checkBox("Accept non-trusted certificates")
+              .enabledIf(enableCodyCheckbox.selected)
+              .bindSelected(settingsModel::shouldAcceptNonTrustedCertificatesAutomatically)
+        }
       }
 
       group("Autocomplete") {
@@ -92,6 +97,8 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
         // note: this sets the same value for both light & dark mode, currently
         codyApplicationSettings.customAutocompleteColor?.let { JBColor(it, it) }
     settingsModel.blacklistedLanguageIds = codyApplicationSettings.blacklistedLanguageIds
+    settingsModel.shouldAcceptNonTrustedCertificatesAutomatically =
+        codyApplicationSettings.shouldAcceptNonTrustedCertificatesAutomatically
     dialogPanel.reset()
   }
 
@@ -119,6 +126,8 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
         settingsModel.isCustomAutocompleteColorEnabled
     codyApplicationSettings.customAutocompleteColor = settingsModel.customAutocompleteColor?.rgb
     codyApplicationSettings.blacklistedLanguageIds = settingsModel.blacklistedLanguageIds
+    codyApplicationSettings.shouldAcceptNonTrustedCertificatesAutomatically =
+        settingsModel.shouldAcceptNonTrustedCertificatesAutomatically
 
     publisher.afterAction(context)
   }


### PR DESCRIPTION
Fixes #56984

<img width="718" alt="Screenshot 2023-09-25 at 13 16 27" src="https://github.com/sourcegraph/sourcegraph/assets/18601388/c1590b0f-2316-47c6-becb-66f78201b329">

## Test plan
- the `Accept non-trusted certificates` setting should be respected