### PR TITLE
ci: fix diff.Only predicate wrongly returning true

### DIFF
--- a/enterprise/dev/ci/internal/ci/changed/diff.go
+++ b/enterprise/dev/ci/internal/ci/changed/diff.go
@@ -295,6 +295,11 @@ func (d Diff) Has(target Diff) bool {
 
 // Only checks that only the target Diff flag is set
 func (d Diff) Only(target Diff) bool {
+	// If no changes are detected, d will be zero and the bitwise &^ below
+	// will always evaluate to zero, even if the target bit is not set.
+	if d == 0 {
+		return false
+	}
 	// This line performs a bitwise AND between d and the inverted bits of target.
 	// It then compares the result to 0.
 	// This evaluates to true only if target is the only bit set in d.


### PR DESCRIPTION
@burmudar the bitwise trickery for `diff.Only` has an edgecase, which is when no changes at all are detected. Because `d` is at `0`, the comparison will always return 0 regardless, essentially saying that "yes that diff is the only one present" whereas there are no diffs at all. 

## Test plan

Locally tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
