### PR TITLE
codeintel: Increase Node heap size for scip-python

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lua/python.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/python.lua
@@ -78,6 +78,8 @@ local handle_one_pkg_info = function(libraries, filepath, content)
   })
 end
 
+local increase_node_mem_step = 'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
+
 local make_job = function(root, name, version, additional_args)
   return {
     steps = {
@@ -88,6 +90,7 @@ local make_job = function(root, name, version, additional_args)
         commands = { "pip install . || true" },
       },
     },
+    local_steps = {increase_node_mem_step},
     root = root,
     indexer = indexer,
     indexer_args = {
@@ -177,7 +180,7 @@ return recognizer.new_path_recognizer {
       for root in pairs(roots) do
         table.insert(jobs, {
           steps = {},
-          local_steps = {"pip install . || true"},
+          local_steps = {"pip install . || true", increase_node_mem_step},
           root = root,
           indexer = indexer,
           indexer_args = {"scip-python", "index"},

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_config_files_at_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_config_files_at_root.yaml
@@ -1,6 +1,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: x
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_roots.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_roots.yaml
@@ -1,6 +1,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: first_root
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:
@@ -11,6 +12,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: second_root
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_1.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_1.yaml
@@ -3,7 +3,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_2.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_2.yaml
@@ -3,7 +3,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:
@@ -23,7 +24,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: src
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_3.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_3.yaml
@@ -3,7 +3,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:
@@ -23,7 +24,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: nested/lib
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:
@@ -41,7 +43,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: src
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_with_pyproject.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_with_pyproject.yaml
@@ -3,7 +3,8 @@
       image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
       commands:
         - pip install . || true
-  local_steps: []
+  local_steps:
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_pyproject.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_pyproject.yaml
@@ -1,6 +1,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_requirements.txt.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_requirements.txt.yaml
@@ -1,6 +1,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_setup.py.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_setup.py.yaml
@@ -1,6 +1,7 @@
 - steps: []
   local_steps:
     - pip install . || true
+    - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
   indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
   indexer_args:


### PR DESCRIPTION
The default heap size for Node is 1400MB on 64-bit, which is
generally much less than the total memory available to an
auto-indexing VM. This can cause unnecessary OOMs, such
as when indexing django.

We already have the same local step in the scip-typescript
auto-indexing script, which also uses Node.

## Test plan

Updated snapshots