### PR TITLE
sec: use constant time comparison

### DIFF
--- a/cmd/pings/shared/main.go
+++ b/cmd/pings/shared/main.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -79,7 +80,7 @@ func newServerHandler(logger log.Logger, config *Config) (http.Handler, error) {
 	}
 	r.Path("/-/healthz").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		secret := strings.TrimPrefix(strings.ToLower(r.Header.Get("Authorization")), "bearer ")
-		if secret != config.DiagnosticsSecret {
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(config.DiagnosticsSecret)) == 0 {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Since we are comparing a secret against user supplied input, we need to use constant time comparisons to make sure we aren't susceptible to timing attacks.

## Test plan
CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
