### PR TITLE
Typo fix in Cody FAQ docs

### DIFF
--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -191,7 +191,7 @@ You can install from the VS Code extension marketplace. To do so:
 - Open Codespaces
 - Install Cody AI by Sourcegraph
 - Copy the URL in the browser, for example, `vscode://sourcegraph.cody-ai...`
-- Open the Command Pallet <kbd>⌘ Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
+- Open the Command Palette <kbd>⌘ Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
 - Choose `Developer: Open URL` and paste the URL, then press <kbd>return</kbd>/<kbd>Enter</kbd>
 
 #### Editors supporting the Open VSX Registry

--- a/doc/cody/faq.md
+++ b/doc/cody/faq.md
@@ -184,22 +184,8 @@ Yes! you can use your own API keys.
 
 Yes, Cody supports the following cloud development environments:
 
-#### vscode.dev and GitHub Codespaces
-
-You can install from the VS Code extension marketplace. To do so:
-
-- Open Codespaces
-- Install Cody AI by Sourcegraph
-- Copy the URL in the browser, for example, `vscode://sourcegraph.cody-ai...`
-- Open the Command Palette <kbd>⌘ Cmd/Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
-- Choose `Developer: Open URL` and paste the URL, then press <kbd>return</kbd>/<kbd>Enter</kbd>
-
-#### Editors supporting the Open VSX Registry
-
-Any editor supporting the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai), including:
-
-- [Gitpod](https://www.gitpod.io/blog/boosting-developer-productivity-unleashing-the-power-of-sourcegraph-cody-in-gitpod)
-- Coder and `code-server` (you can install from the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai))
+- vscode.dev and GitHub Codespaces (install from the VS Code extension marketplace)
+- Any editor supporting the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai), including [Gitpod](https://www.gitpod.io/blog/boosting-developer-productivity-unleashing-the-power-of-sourcegraph-cody-in-gitpod), Coder, and `code-server` (install from the [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai))
 
 ## More resources
 


### PR DESCRIPTION
Fix a typo error in Cody's FAQ docs.

## Test plan

Docs added

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@typo-fix)