### PR TITLE
bzl: bump oci_rules to 1.3.4 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,9 +85,9 @@ http_archive(
 # Container rules
 http_archive(
     name = "rules_oci",
-    sha256 = "db57efd706f01eb3ce771468366baa1614b5b25f4cce99757e2b8d942155b8ec",
-    strip_prefix = "rules_oci-1.0.0",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.0.0/rules_oci-v1.0.0.tar.gz",
+    sha256 = "c71c25ed333a4909d2dd77e0b16c39e9912525a98c7fa85144282be8d04ef54c",
+    strip_prefix = "rules_oci-1.3.4",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.3.4/rules_oci-v1.3.4.tar.gz",
 )
 
 http_archive(

--- a/testing/tools/integration_runner.sh
+++ b/testing/tools/integration_runner.sh
@@ -95,6 +95,9 @@ function _run_server_image() {
 
   echo "--- Loading server image"
   echo "Loading $image_tarball in Docker"
+  echo "--- TESTING"
+  echo "$image_tarball"
+  echo "$(ls -al $image_tarball)"
   docker load --input "$image_tarball"
 
   echo "-- Starting $image_name"

--- a/testing/tools/integration_runner.sh
+++ b/testing/tools/integration_runner.sh
@@ -95,13 +95,10 @@ function _run_server_image() {
 
   echo "--- Loading server image"
   echo "Loading $image_tarball in Docker"
-  echo "--- TESTING"
-  echo "$image_tarball"
-  echo "$(ls -al $image_tarball)"
-  docker load --input "$image_tarball"
+  "$image_tarball" # this is a shell script
 
   echo "-- Starting $image_name"
-  # echo "Listening at: $url"
+  echo "Listening at: $url"
   echo "Data and config volume bounds: $data"
   echo "Database startup timeout: $DB_STARTUP_TIMEOUT"
   echo "License key generator present: $(is_present "$SOURCEGRAPH_LICENSE_GENERATION_KEY")"


### PR DESCRIPTION
I fixed a bug in the pipeline generation in between and this time the tests were run properly (and they're green). 

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
