### PR TITLE
userpasswd: add v2 events for signup

### DIFF
--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -63,12 +63,12 @@ func NewHandler(db database.DB, logger log.Logger, githubAppSetupHandler http.Ha
 	r.Get(router.UI).Handler(ui.Router())
 
 	lockoutStore := userpasswd.NewLockoutStoreFromConf(conf.AuthLockout())
-	events := telemetryrecorder.NewBestEffort(logger, db)
+	eventRecorder := telemetryrecorder.New(db)
 
-	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(logger, db)))
+	r.Get(router.SignUp).Handler(trace.Route(userpasswd.HandleSignUp(logger, db, eventRecorder)))
 	r.Get(router.RequestAccess).Handler(trace.Route(accessrequest.HandleRequestAccess(logger, db)))
-	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(logger, db)))
-	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore, events)))
+	r.Get(router.SiteInit).Handler(trace.Route(userpasswd.HandleSiteInit(logger, db, eventRecorder)))
+	r.Get(router.SignIn).Handler(trace.Route(userpasswd.HandleSignIn(logger, db, lockoutStore, eventRecorder)))
 	r.Get(router.SignOut).Handler(trace.Route(serveSignOutHandler(logger, db)))
 	r.Get(router.UnlockAccount).Handler(trace.Route(userpasswd.HandleUnlockAccount(logger, db, lockoutStore)))
 	r.Get(router.UnlockUserAccount).Handler(trace.Route(userpasswd.HandleUnlockUserAccount(logger, db, lockoutStore)))

--- a/internal/auth/userpasswd/handlers_test.go
+++ b/internal/auth/userpasswd/handlers_test.go
@@ -146,9 +146,7 @@ func TestHandleSignIn_Lockout(t *testing.T) {
 	if testing.Verbose() {
 		logger = logtest.Scoped(t)
 	}
-	events := telemetry.NewBestEffortEventRecorder(logger,
-		telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
-	h := HandleSignIn(logger, db, lockout, events)
+	h := HandleSignIn(logger, db, lockout, telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
 
 	// Normal authentication fail before lockout
 	{
@@ -357,7 +355,8 @@ func TestHandleSignUp(t *testing.T) {
 			logger = logtest.Scoped(t)
 		}
 
-		h := HandleSignUp(logger, db)
+		events := telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore())
+		h := HandleSignUp(logger, db, events)
 
 		req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
 		require.NoError(t, err)
@@ -390,7 +389,7 @@ func TestHandleSignUp(t *testing.T) {
 			logger = logtest.Scoped(t)
 		}
 
-		h := HandleSignUp(logger, db)
+		h := HandleSignUp(logger, db, telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
 
 		req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(`{}`))
 		require.NoError(t, err)
@@ -457,7 +456,7 @@ func TestHandleSignUp(t *testing.T) {
 			logger = logtest.Scoped(t)
 		}
 
-		h := HandleSignUp(logger, db)
+		h := HandleSignUp(logger, db, telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
 
 		body := strings.NewReader(`{
 			"email": "test@test.com",
@@ -487,7 +486,7 @@ func TestHandleSiteInit(t *testing.T) {
 			logger = logtest.Scoped(t)
 		}
 
-		h := HandleSiteInit(logger, db)
+		h := HandleSiteInit(logger, db, telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
 
 		req, err := http.NewRequest(http.MethodGet, "/", strings.NewReader(`{}`))
 		require.NoError(t, err)
@@ -533,7 +532,7 @@ func TestHandleSiteInit(t *testing.T) {
 			logger = logtest.Scoped(t)
 		}
 
-		h := HandleSiteInit(logger, db)
+		h := HandleSiteInit(logger, db, telemetry.NewEventRecorder(telemetrytest.NewMockEventsStore()))
 
 		body := strings.NewReader(`{
 			"email": "test@test.com",

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -13,6 +13,7 @@ const (
 
 	FeatureSignIn  eventFeature = "signIn"
 	FeatureSignOut eventFeature = "signOut"
+	FeatureSignUp  eventFeature = "signUp"
 )
 
 // eventAction defines the action associated with an event. Values should

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,6 +17,15 @@ type constString string
 // Keys must be const strings.
 type EventMetadata map[constString]int64
 
+// MetadataBool returns 1 for true and 0 for false, for use in EventMetadata's
+// restricted int64 values.
+func MetadataBool(value bool) int64 {
+	if value {
+		return 1 // true
+	}
+	return 0 // 0
+}
+
 // EventBillingMetadata records metadata that attributes the event to product
 // billing categories.
 type EventBillingMetadata struct {


### PR DESCRIPTION
Uses the updated approach I've been taking so far for now, which is to retain the legacy events, using `teestore.WithoutV1` to avoid changing the shape of the legacy events.

## Test plan

CI