### PR TITLE
telemetry/teestore: add marker for if event can be exported

### DIFF
--- a/internal/telemetry/teestore/teestore.go
+++ b/internal/telemetry/teestore/teestore.go
@@ -76,10 +76,15 @@ func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Eve
 			// GetParameters.Metadata
 			PublicArgument: func() json.RawMessage {
 				md := e.GetParameters().GetMetadata()
-				if len(md) == 0 {
-					return nil
+				mdPayload := make(map[string]any, len(md))
+				for k, v := range md {
+					mdPayload[k] = v
 				}
-				data, err := json.Marshal(md)
+				// Attach a simple indicator to denote if this event will
+				// be exported.
+				mdPayload["telemetry.event.exportable"] = true
+
+				data, err := json.Marshal(mdPayload)
 				if err != nil {
 					data, _ = json.Marshal(map[string]string{"marshal.error": err.Error()})
 				}
@@ -95,7 +100,7 @@ func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Eve
 
 				// Attach a simple indicator to denote if this metadata will
 				// be exported.
-				md["privateMetadata.export"] = sensitiveMetadataAllowlist.IsAllowed(e)
+				md["telemetry.privateMetadata.exportable"] = sensitiveMetadataAllowlist.IsAllowed(e)
 
 				data, err := json.Marshal(md)
 				if err != nil {

--- a/internal/telemetry/teestore/teestore_test.go
+++ b/internal/telemetry/teestore/teestore_test.go
@@ -38,7 +38,9 @@ func TestToEventLogs(t *testing.T) {
     "UserID": 0,
     "AnonymousUserID": "",
     "Argument": null,
-    "PublicArgument": null,
+    "PublicArgument": {
+      "telemetry.event.exportable": true
+    },
     "Source": "BACKEND",
     "Version": "",
     "Timestamp": "2022-11-03T02:00:00Z",
@@ -66,7 +68,9 @@ func TestToEventLogs(t *testing.T) {
     "UserID": 0,
     "AnonymousUserID": "",
     "Argument": null,
-    "PublicArgument": null,
+    "PublicArgument": {
+      "telemetry.event.exportable": true
+    },
     "Source": "BACKEND",
     "Version": "",
     "Timestamp": "2022-11-03T02:00:00Z",
@@ -126,10 +130,11 @@ func TestToEventLogs(t *testing.T) {
     "AnonymousUserID": "anonymous",
     "Argument": {
       "private": "sensitive-data",
-      "privateMetadata.export": false
+      "telemetry.privateMetadata.exportable": false
     },
     "PublicArgument": {
-      "public": 2
+      "public": 2,
+      "telemetry.event.exportable": true
     },
     "Source": "VSCODE",
     "Version": "dev",


### PR DESCRIPTION
Inject a clear marker to argument if a v2 event tee'd into `event_logs` can be exported, until we have a more robust system for revealing `telemetry_events_export_queue` to site admins.

This is not robust, as it does not work for usages of `teestore.WithoutV1` - https://github.com/sourcegraph/sourcegraph/issues/57027 tracks implementing a way to get a "real" list of exported events.

## Test plan

Golden tests