### PR TITLE
JetBrains: Cody: Restart agent when certificate setting changes

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
@@ -36,4 +36,10 @@ object CodyAgentManager {
     val service = project.getService(CodyAgent::class.java) ?: return
     service.shutdown()
   }
+
+  @JvmStatic
+  fun restartAgent(project: Project) {
+    stopAgent(project)
+    startAgent(project)
+  }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeContext.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeContext.kt
@@ -10,5 +10,7 @@ class CodySettingChangeContext(
     val oldCustomAutocompleteColor: Int?,
     val customAutocompleteColor: Int?,
     val oldBlacklistedAutocompleteLanguageIds: List<String>,
-    val newBlacklistedAutocompleteLanguageIds: List<String>
+    val newBlacklistedAutocompleteLanguageIds: List<String>,
+    val oldShouldAcceptNonTrustedCertificatesAutomatically: Boolean,
+    val newShouldAcceptNonTrustedCertificatesAutomatically: Boolean
 )

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -76,6 +76,10 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
             if (languageIdsToClear.isNotEmpty())
                 CodyAutocompleteManager.getInstance()
                     .clearAutocompleteSuggestionsForLanguageIds(languageIdsToClear)
+
+            if (context.oldShouldAcceptNonTrustedCertificatesAutomatically !=
+                context.newShouldAcceptNonTrustedCertificatesAutomatically)
+                CodyAgentManager.restartAgent(project)
           }
         })
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -120,7 +120,9 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
             codyApplicationSettings.customAutocompleteColor,
             settingsModel.customAutocompleteColor?.rgb,
             codyApplicationSettings.blacklistedLanguageIds,
-            settingsModel.blacklistedLanguageIds)
+            settingsModel.blacklistedLanguageIds,
+            codyApplicationSettings.shouldAcceptNonTrustedCertificatesAutomatically,
+            settingsModel.shouldAcceptNonTrustedCertificatesAutomatically)
     codyApplicationSettings.isCodyEnabled = settingsModel.isCodyEnabled
     codyApplicationSettings.isCodyAutocompleteEnabled = settingsModel.isCodyAutocompleteEnabled
     codyApplicationSettings.isCodyDebugEnabled = settingsModel.isCodyDebugEnabled


### PR DESCRIPTION
A followup to https://github.com/sourcegraph/sourcegraph/pull/56999#pullrequestreview-1642248534

## Test plan
- Cody agent should restart after changing the `Accept non-trusted certificates automatically` setting
- The setting should thus be respected without restarting one's IDE