### PR TITLE
JetBrains: Fix CodyInstalled event logging

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -20,7 +20,7 @@ public class GraphQlLogger {
 
   public static CompletableFuture<Boolean> logInstallEvent(@NotNull Project project) {
     CodyApplicationSettings codyApplicationSettings = CodyApplicationSettings.getInstance();
-    if (codyApplicationSettings.getAnonymousUserId() != null && project.isDisposed()) {
+    if (codyApplicationSettings.getAnonymousUserId() != null && !project.isDisposed()) {
       var event = createEvent(ConfigUtil.getServerPath(project), "CodyInstalled", new JsonObject());
       return logEvent(project, event);
     }


### PR DESCRIPTION
@kelsey-brown wrote: "I’m still not seeing any JetBrains values for extensionDetails.ide on the CodyInstalled event"

I've found no problem with the logging format, but the condition deciding whether we do the logging in the first place seemed wrong.
The condition was added on 2023-08-14 by @olafurpg.
Not sure if it's possible that we were not only missing the `extensionDetails` in the event details, but the whole logging was not triggered since mid-August?

## Test plan

Ran it in debug mode and saw that the condition was successfully triggered.