### PR TITLE
JetBrains: Cody: Refresh commands panel on first login

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -328,6 +328,7 @@ public class CodyToolWindowContent implements UpdatableChat {
           e -> {
             CodyApplicationSettings.getInstance().setOnboardingGuidanceDismissed(true);
             updateVisibilityOfContentPanels();
+            refreshRecipes();
           });
       if (displayName != null) {
         if (codyOnboardingGuidancePanel != null


### PR DESCRIPTION
Fixes #57022 

https://github.com/sourcegraph/sourcegraph/assets/18601388/d33414e8-1b18-423d-8a2a-627f2801cf69

## Test plan
- commands panel should be loaded after logging in an account on a clean setup