### PR TITLE
nix: fix shellhook and add extra libs for jetbrains plugin

### DIFF
--- a/client/jetbrains/flake.nix
+++ b/client/jetbrains/flake.nix
@@ -15,9 +15,10 @@
         libX11
         libXrender
         libXi
-        freetype.out
+        freetype
         fontconfig.lib
-        zlib.out
+        zlib
+        libsecret
       ]);
       gradle-wrapped = pkgs.writeShellScriptBin "gradle" ''
         export LD_LIBRARY_PATH=${libraries}

--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -28,7 +28,7 @@ fi
 # We run this check afterwards so we can read the values exported by the
 # start-*.sh scripts. We need to smuggle in these envvars for tests on both
 # linux and darwin.
-cat <<EOF > .bazelrc-nix
+cat <<EOF >> .bazelrc-nix
 build --action_env=PATH=$BAZEL_ACTION_PATH
 build --action_env=REDIS_ENDPOINT
 build --action_env=PGHOST


### PR DESCRIPTION
Whoopsie in the shellhook that never came up coz we're not really using bazel yet locally :clueless:

## Test plan

N/A nix
