### PR TITLE
monitoring: make email_delivery_failures on percentage, not count

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1216,12 +1216,12 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*(frontend|sou
 
 ## frontend: email_delivery_failures
 
-<p class="subtitle">email delivery failures over 30 minutes</p>
+<p class="subtitle">email delivery failure rate over 30 minutes</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 0%+ email delivery failures over 30 minutes
-- <span class="badge badge-critical">critical</span> frontend: 10%+ email delivery failures over 30 minutes
+- <span class="badge badge-warning">warning</span> frontend: 0%+ email delivery failure rate over 30 minutes
+- <span class="badge badge-critical">critical</span> frontend: 10%+ email delivery failure rate over 30 minutes
 
 **Next steps**
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1216,18 +1216,19 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*(frontend|sou
 
 ## frontend: email_delivery_failures
 
-<p class="subtitle">email delivery failures every 30 minutes</p>
+<p class="subtitle">email delivery failures over 30 minutes</p>
 
 **Descriptions**
 
-- <span class="badge badge-warning">warning</span> frontend: 1+ email delivery failures every 30 minutes
-- <span class="badge badge-critical">critical</span> frontend: 2+ email delivery failures every 30 minutes
+- <span class="badge badge-warning">warning</span> frontend: 0%+ email delivery failures over 30 minutes
+- <span class="badge badge-critical">critical</span> frontend: 10%+ email delivery failures over 30 minutes
 
 **Next steps**
 
 - Check your SMTP configuration in site configuration.
-- Check frontend logs for more detailed error messages.
+- Check `sourcegraph-frontend` logs for more detailed error messages.
 - Check your SMTP provider for more detailed error messages.
+- Use `sum(increase(src_email_send{success="false"}[30m]))` to check the raw count of delivery failures.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#frontend-email-delivery-failures).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1243,9 +1244,9 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*(frontend|sou
 <details>
 <summary>Technical details</summary>
 
-Generated query for warning alert: `max((sum(increase(src_email_send{success="false"}[30m]))) >= 1)`
+Generated query for warning alert: `max((sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100) > 0)`
 
-Generated query for critical alert: `max((sum(increase(src_email_send{success="false"}[30m]))) >= 2)`
+Generated query for critical alert: `max((sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100) >= 10)`
 
 </details>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5126,7 +5126,7 @@ Query: `sum(increase(zoekt_final_aggregate_size_count{reason="timer_expired"}[1d
 
 #### frontend: email_delivery_failures
 
-<p class="subtitle">Email delivery failures over 30 minutes</p>
+<p class="subtitle">Email delivery failure rate over 30 minutes</p>
 
 Refer to the [alerts reference](./alerts.md#frontend-email-delivery-failures) for 2 alerts related to this panel.
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5126,7 +5126,7 @@ Query: `sum(increase(zoekt_final_aggregate_size_count{reason="timer_expired"}[1d
 
 #### frontend: email_delivery_failures
 
-<p class="subtitle">Email delivery failures every 30 minutes</p>
+<p class="subtitle">Email delivery failures over 30 minutes</p>
 
 Refer to the [alerts reference](./alerts.md#frontend-email-delivery-failures) for 2 alerts related to this panel.
 
@@ -5137,7 +5137,7 @@ To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=103600`
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_email_send{success="false"}[30m]))`
+Query: `sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100`
 
 </details>
 

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -786,7 +786,7 @@ func Frontend() *monitoring.Dashboard {
 				Rows: []monitoring.Row{{
 					{
 						Name:        "email_delivery_failures",
-						Description: "email delivery failures over 30 minutes",
+						Description: "email delivery failure rate over 30 minutes",
 						Query:       `sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100`,
 						Panel: monitoring.Panel().
 							LegendFormat("failures").

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -786,17 +786,24 @@ func Frontend() *monitoring.Dashboard {
 				Rows: []monitoring.Row{{
 					{
 						Name:        "email_delivery_failures",
-						Description: "email delivery failures every 30 minutes",
-						Query:       `sum(increase(src_email_send{success="false"}[30m]))`,
-						Panel:       monitoring.Panel().LegendFormat("failures"),
-						Warning:     monitoring.Alert().GreaterOrEqual(1),
-						Critical:    monitoring.Alert().GreaterOrEqual(2),
+						Description: "email delivery failures over 30 minutes",
+						Query:       `sum(increase(src_email_send{success="false"}[30m])) / sum(increase(src_email_send[30m])) * 100`,
+						Panel: monitoring.Panel().
+							LegendFormat("failures").
+							Unit(monitoring.Percentage).
+							Max(100).Min(0),
+
+						// Any failure is worth warning on, as failed email
+						// deliveries directly impact user experience.
+						Warning:  monitoring.Alert().Greater(0),
+						Critical: monitoring.Alert().GreaterOrEqual(10),
 
 						Owner: monitoring.ObservableOwnerDevOps,
 						NextSteps: `
 							- Check your SMTP configuration in site configuration.
-							- Check frontend logs for more detailed error messages.
+							- Check 'sourcegraph-frontend' logs for more detailed error messages.
 							- Check your SMTP provider for more detailed error messages.
+							- Use 'sum(increase(src_email_send{success="false"}[30m]))' to check the raw count of delivery failures.
 						`,
 					},
 				}, {


### PR DESCRIPTION
This changes the threshold to critical-alert on 10% failure rate, and warn on any non-zero failure rate (as all email delivery failures impact user experience).

## Test plan

Test query (dotcom): https://sourcegraph.com/-/debug/grafana/explore?orgId=1&left=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22sum(increase(src_email_send%7Bsuccess%3D%5C%22false%5C%22%7D%5B30m%5D))%20%2F%20sum(increase(src_email_send%5B30m%5D))%20*%20100%22,%22requestId%22:%22Q-c1441862-6745-442a-9745-ba1bf9d80a4e-0A%22%7D%5D&right=%5B%22now-2d%22,%22now%22,%22Prometheus%22,%7B%22exemplar%22:true,%22expr%22:%22sum(increase(src_email_send%7Bsuccess%3D%5C%22false%5C%22%7D%5B30m%5D))%22,%22requestId%22:%22Q-4b1e1c07-aa04-4f9b-ab5d-fef8100a5b24-0Q-c8739f02-df38-476b-8cb0-fc9ddc0fd71c-1A%22%7D,%7B%22exemplar%22:true,%22expr%22:%22sum(increase(src_email_send%5B30m%5D))%22,%22requestId%22:%22Q-4b1e1c07-aa04-4f9b-ab5d-fef8100a5b24-0Q-c8739f02-df38-476b-8cb0-fc9ddc0fd71c-1B%22%7D%5D

Test dashboard: follow https://docs.sourcegraph.com/dev/how-to/monitoring_local_dev#grafana to point to Sourcegraph.com:

<img width="1516" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/d2bab902-06ba-481a-840a-bee9cc455c8a">



## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@monitoring-emails-percentage-failures)