### PR TITLE
chore: clean up CODENOTIFY for @sourcegraph/delivery

### DIFF
--- a/.github/test.CODEOWNERS
+++ b/.github/test.CODEOWNERS
@@ -60,7 +60,6 @@
 
 /dev/gqltest/**/* @unknwon
 
-/doc/**/admin/** @sourcegraph/delivery
 /doc/dev/background-information/adding_ping_data.md @ebrodymoore @dadlerj
 
 /doc/batch_changes/**/* @eseliger
@@ -76,8 +75,6 @@
 /docker-images/cadvisor/**/* @bobheadxi
 
 /docker-images/grafana/**/* @bobheadxi
-
-/docker-images/postgres-12-alpine/**/* @sourcegraph/delivery
 
 /docker-images/prometheus/**/* @bobheadxi
 
@@ -222,7 +219,7 @@
 
 /lib/servicecatalog/**/* @sourcegraph/cloud @sourcegraph/security
 
-/monitoring/**/* @bobheadxi @slimsag @sourcegraph/delivery
+/monitoring/**/* @bobheadxi @slimsag
 /monitoring/frontend.go @efritz
 /monitoring/precise_code_intel_* @efritz @sourcegraph/code-intelligence
 

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -19,7 +19,6 @@ jobs:
                   team/search-product=@sourcegraph/search-product
                   team/search-core=@sourcegraph/search-core
                   team/code-insights=@vovakulikov
-                  team/delivery=@sourcegraph/delivery
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
                   team/devops=@sourcegraph/cloud-devops

--- a/doc/CODENOTIFY
+++ b/doc/CODENOTIFY
@@ -1,2 +1,1 @@
-**/admin/** @sourcegraph/delivery
 dev/background-information/adding_ping_data.md @ebrodymoore @dadlerj

--- a/docker-images/postgres-12-alpine/CODENOTIFY
+++ b/docker-images/postgres-12-alpine/CODENOTIFY
@@ -1,3 +1,0 @@
-# See https://github.com/sourcegraph/codenotify for documentation.
-
-**/* @sourcegraph/delivery

--- a/monitoring/CODENOTIFY
+++ b/monitoring/CODENOTIFY
@@ -2,7 +2,6 @@
 
 **/* @bobheadxi
 **/* @slimsag
-**/* @sourcegraph/delivery
 
 frontend.go @efritz
 precise_code_intel_* @efritz


### PR DESCRIPTION
The GitHub team has been deleted. If you think other teams want to get notified, feel free to suggest edits!

## Test plan

CI

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@jc/codenotify-delivery)