### PR TITLE
chore: Remove indexes that existed for a short time

### DIFF
--- a/migrations/frontend/1695747321_remove_drift/down.sql
+++ b/migrations/frontend/1695747321_remove_drift/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS event_logs_name_is_cody_active_event;
+DROP INDEX IF EXISTS event_logs_name_is_cody_explanation_event;
+DROP INDEX IF EXISTS event_logs_name_is_cody_generation_event;

--- a/migrations/frontend/1695747321_remove_drift/down.sql
+++ b/migrations/frontend/1695747321_remove_drift/down.sql
@@ -1,3 +1,1 @@
-DROP INDEX IF EXISTS event_logs_name_is_cody_active_event;
-DROP INDEX IF EXISTS event_logs_name_is_cody_explanation_event;
-DROP INDEX IF EXISTS event_logs_name_is_cody_generation_event;
+-- Empty

--- a/migrations/frontend/1695747321_remove_drift/metadata.yaml
+++ b/migrations/frontend/1695747321_remove_drift/metadata.yaml
@@ -1,0 +1,2 @@
+name: Remove drift
+parents: [1694806099]

--- a/migrations/frontend/1695747321_remove_drift/up.sql
+++ b/migrations/frontend/1695747321_remove_drift/up.sql
@@ -1,0 +1,11 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.

--- a/migrations/frontend/1695747321_remove_drift/up.sql
+++ b/migrations/frontend/1695747321_remove_drift/up.sql
@@ -1,11 +1,3 @@
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
---    is defined per file, and that each such statement is NOT wrapped in a transaction.
---    Each such migration must also declare "createIndexConcurrently: true" in their
---    associated metadata.yaml file.
---  * If you are modifying Postgres extensions, you must also declare "privileged: true"
---    in the associated metadata.yaml file.
+DROP INDEX IF EXISTS event_logs_name_is_cody_active_event;
+DROP INDEX IF EXISTS event_logs_name_is_cody_explanation_event;
+DROP INDEX IF EXISTS event_logs_name_is_cody_generation_event;


### PR DESCRIPTION
See [slack context](https://sourcegraph.slack.com/archives/C05MS02FW81/p1692216344341539?thread_ts=1692126487.083519&cid=C05MS02FW81) and the [release blocking thread](https://sourcegraph.slack.com/archives/C032Z79NZQC/p1695747244024459).

For permanence, #55893 was merged, then reverted, and merged into the 5.1 branch and reverted. For some instances the original index ran, but is no longer in the "squashed" form of the schema. This clears out any indexes that have hit this path so there's no drift.

## Test plan

Existing unit tests.