### PR TITLE
actor: propagate anonymous UID from 'X-Sourcegraph-Actor-Anonymous-UID'

### DIFF
--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -28,7 +28,8 @@ type Actor struct {
 	// Only set if the current actor is an authenticated user.
 	UID int32 `json:",omitempty"`
 
-	// AnonymousUID is the user's semi-stable anonymousID from the request cookie.
+	// AnonymousUID is the user's semi-stable anonymousID from the request cookie
+	// or the 'X-Sourcegraph-Actor-Anonymous-UID' request header.
 	// Only set if the user is unauthenticated and the request contains an anonymousID.
 	AnonymousUID string `json:",omitempty"`
 

--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -172,12 +172,20 @@ func AnonymousUIDMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Don't clobber an existing authenticated actor
 		if a := FromContext(req.Context()); !a.IsAuthenticated() && !a.IsInternal() {
-			if anonymousUID, ok := cookie.AnonymousUID(req); ok {
-				ctx := WithActor(req.Context(), FromAnonymousUser(anonymousUID))
-				next.ServeHTTP(rw, req.WithContext(ctx))
-				return
+			var anonymousUID string
+
+			// Get from cookie if available, otherwise get from header
+			if cookieAnonymousUID, ok := cookie.AnonymousUID(req); ok {
+				anonymousUID = cookieAnonymousUID
+			} else if headerAnonymousUID := req.Header.Get(headerKeyActorAnonymousUID); headerAnonymousUID != "" {
+				anonymousUID = headerAnonymousUID
 			}
+
+			ctx := WithActor(req.Context(), FromAnonymousUser(anonymousUID))
+			next.ServeHTTP(rw, req.WithContext(ctx))
+			return
 		}
+
 		next.ServeHTTP(rw, req)
 	})
 }

--- a/internal/actor/http.go
+++ b/internal/actor/http.go
@@ -181,7 +181,11 @@ func AnonymousUIDMiddleware(next http.Handler) http.Handler {
 				anonymousUID = headerAnonymousUID
 			}
 
-			ctx := WithActor(req.Context(), FromAnonymousUser(anonymousUID))
+			// If we found an anonymous UID, use that as the actor context
+			ctx := req.Context()
+			if anonymousUID != "" {
+				ctx = WithActor(ctx, FromAnonymousUser(anonymousUID))
+			}
 			next.ServeHTTP(rw, req.WithContext(ctx))
 			return
 		}

--- a/internal/actor/http_test.go
+++ b/internal/actor/http_test.go
@@ -148,6 +148,18 @@ func TestAnonymousUIDMiddleware(t *testing.T) {
 		handler.ServeHTTP(httptest.NewRecorder(), req)
 	})
 
+	t.Run("header value is respected", func(t *testing.T) {
+		handler := AnonymousUIDMiddleware(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			got := FromContext(r.Context())
+			require.Equal(t, "anon", got.AnonymousUID)
+		}))
+
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		require.NoError(t, err)
+		req.Header.Set(headerKeyActorAnonymousUID, "anon")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	})
+
 	t.Run("cookie doesn't overwrite existing middleware", func(t *testing.T) {
 		handler := http.Handler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			got := FromContext(r.Context())


### PR DESCRIPTION
Cookie anonymous UID continues to take precedence, but this is helpful for clients that don't use cookies to track anonymous UID (i.e. VSCode), and especially relevant in the context of our new telemetry mutations, which now use real actors to determine the user, instead of asking clients to tell us who the user is.

## Test plan

Unit test