### PR TITLE
[config]: Reverting External URL Update and Removal of sync.Once

### DIFF
--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -61,16 +61,6 @@ func ExternalURL() *url.URL {
 	return externalURL.Load().(*url.URL)
 }
 
-// ExternalURLString returns the fully-resolved, externally accessible frontend URL string or empty string if default is set.
-func ExternalURLString() string {
-	url := externalURL.Load().(*url.URL)
-	if url.Host == "example.com" {
-		return ""
-	}
-
-	return url.String()
-}
-
 // SetExternalURL sets the fully-resolved, externally accessible frontend URL.
 func SetExternalURL(u *url.URL) {
 	externalURL.Store(u)

--- a/cmd/frontend/internal/auth/saml/BUILD.bazel
+++ b/cmd/frontend/internal/auth/saml/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//cmd/frontend/auth",
         "//cmd/frontend/external/session",
-        "//cmd/frontend/globals",
         "//internal/actor",
         "//internal/auth/providers",
         "//internal/conf",
@@ -51,7 +50,6 @@ go_test(
     deps = [
         "//cmd/frontend/auth",
         "//cmd/frontend/external/session",
-        "//cmd/frontend/globals",
         "//internal/actor",
         "//internal/auth/providers",
         "//internal/conf",

--- a/cmd/frontend/internal/auth/saml/config.go
+++ b/cmd/frontend/internal/auth/saml/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -141,7 +140,7 @@ func validateConfig(c conftypes.SiteConfigQuerier) (problems conf.Problems) {
 
 func withConfigDefaults(pc *schema.SAMLAuthProvider) *schema.SAMLAuthProvider {
 	if pc.ServiceProviderIssuer == "" {
-		externalURL := globals.ExternalURLString()
+		externalURL := conf.Get().ExternalURL
 		if externalURL == "" {
 			// An empty issuer will be detected as an error later.
 			return pc

--- a/cmd/frontend/internal/auth/saml/provider.go
+++ b/cmd/frontend/internal/auth/saml/provider.go
@@ -20,8 +20,8 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -175,7 +175,7 @@ func getServiceProvider(ctx context.Context, pc *schema.SAMLAuthProvider) (*saml
 			"invalid SAML Service Provider configuration: issuer is empty (and default issuer could not be derived from empty externalURL)",
 		)
 	}
-	externalURL, err := url.Parse(globals.ExternalURLString())
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return nil, errors.WithMessage(err, "parsing external URL for SAML Service Provider")
 	}

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/hooks"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app"
@@ -251,7 +250,7 @@ func handleCORSRequest(w http.ResponseWriter, r *http.Request, policy crossOrigi
 	// early. We do not write ANY Access-Control-Allow-* CORS headers, which triggers the browsers
 	// default (and strict) behavior of not allowing cross-origin requests.
 	//
-	// We could instead parse the domain from globals.ExternalURL().String() and use that in the response,
+	// We could instead parse the domain from conf.Get().ExternalURL and use that in the response,
 	// to make things more explicit, but it would add more logic here to think about and you would
 	// also want to think about whether or not `OPTIONS` requests should be handled and if the other
 	// headers (-Credentials, -Methods, -Headers, etc.) should be sent back in such a situation.
@@ -351,7 +350,7 @@ func isTrustedOrigin(r *http.Request) bool {
 		isCORSAllowedRequest = isAllowedOrigin(requestOrigin, strings.Fields(corsOrigin))
 	}
 
-	if externalURL := strings.TrimSuffix(globals.ExternalURLString(), "/"); externalURL != "" && requestOrigin == externalURL {
+	if externalURL := strings.TrimSuffix(conf.Get().ExternalURL, "/"); externalURL != "" && requestOrigin == externalURL {
 		isCORSAllowedRequest = true
 	}
 

--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/dotcom/productsubscription",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//internal/actor",
@@ -85,7 +84,6 @@ go_test(
         "requires-network",
     ],
     deps = [
-        "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/audit/audittest",

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -163,7 +162,7 @@ func checkP50CallTimeForLicense(ctx context.Context, logger log.Logger, db datab
 
 	logger.Warn("license check call time anomaly detected", log.String("licenseID", license.ID), log.Int64("time diff seconds", timeDiff))
 
-	externalURL, err := url.Parse(globals.ExternalURLString())
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		logger.Error("parsing external URL from site config", log.Error(err))
 	}

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
@@ -93,6 +93,7 @@ func TestCheckAnomalies(t *testing.T) {
 			Dotcom: &schema.Dotcom{
 				SlackLicenseAnomallyWebhook: "https://slack.com/webhook",
 			},
+			ExternalURL: "https://sourcegraph.acme.com",
 		},
 	})
 

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
@@ -88,8 +87,6 @@ func TestCheckAnomalies(t *testing.T) {
 
 	siteID := "02a5a9e6-b45e-4e1a-b2a0-f812620e6dff"
 	licenseID := "22e0cc8e-57ad-4dd9-be54-0f94d6e9964d"
-
-	globals.SetExternalURL(&url.URL{Scheme: "https", Host: "sourcegraph.acme.com"})
 
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{

--- a/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -66,7 +65,7 @@ To fix it, <https://app.golinks.io/internal-licensing-faq-slack-multiple|follow 
 `
 
 func sendSlackMessage(logger log.Logger, license *dbLicense, siteID string) {
-	externalURL, err := url.Parse(globals.ExternalURLString())
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		logger.Error("parsing external URL from site config", log.Error(err))
 		return

--- a/cmd/frontend/internal/repos/webhooks/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/repos/webhooks/resolvers/BUILD.bazel
@@ -8,10 +8,10 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/backend",
-        "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//internal/auth",
+        "//internal/conf",
         "//internal/database",
         "//internal/encryption/keyring",
         "//internal/errcode",
@@ -29,7 +29,6 @@ go_test(
     srcs = ["resolver_test.go"],
     embed = [":resolvers"],
     deps = [
-        "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/conf",

--- a/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
+++ b/cmd/frontend/internal/repos/webhooks/resolvers/resolver.go
@@ -10,10 +10,10 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -264,7 +264,7 @@ func (r *webhookResolver) UUID() string {
 }
 
 func (r *webhookResolver) URL() (string, error) {
-	externalURL, err := url.Parse(globals.ExternalURLString())
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return "", errors.Wrap(err, "could not parse site config external URL")
 	}

--- a/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/repos/webhooks/resolvers/resolver_test.go
@@ -3,14 +3,12 @@ package resolvers
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 
 	"github.com/google/uuid"
@@ -586,7 +584,6 @@ func TestGetWebhookWithURL(t *testing.T) {
 	invalidURL := "https://invalid.com/%+o"
 	webhookID := int32(1)
 	webhookIDMarshaled := marshalWebhookID(webhookID)
-	globals.SetExternalURL(&url.URL{Scheme: "https", Host: "testurl.com"})
 
 	conf.Mock(
 		&conf.Unified{
@@ -646,7 +643,6 @@ func TestGetWebhookWithURL(t *testing.T) {
 		},
 	)
 
-	globals.SetExternalURL(&url.URL{Scheme: "https", Host: "invalid.com/%+o"})
 	graphqlbackend.RunTest(t, &graphqlbackend.Test{
 		Label:          "error if external URL invalid",
 		Context:        ctx,
@@ -657,7 +653,7 @@ func TestGetWebhookWithURL(t *testing.T) {
 			{
 				Message: strings.Join([]string{
 					"could not parse site config external URL:",
-					` parse "https://invalid.com%2F%25+o": invalid URL escape "%2F"`,
+					` parse "https://invalid.com/%+o": invalid URL escape "%+o"`,
 				}, ""),
 				Path: []any{"node", "url"},
 			},

--- a/cmd/frontend/internal/search/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/search/resolvers/BUILD.bazel
@@ -10,9 +10,9 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/resolvers",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
-        "//cmd/frontend/globals",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
+        "//internal/conf",
         "//internal/database",
         "//internal/gqlutil",
         "//internal/search/exhaustive/service",

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -9,8 +9,8 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
@@ -94,7 +94,7 @@ func (r *searchJobResolver) FinishedAt(ctx context.Context) *gqlutil.DateTime {
 
 func (r *searchJobResolver) URL(ctx context.Context) (*string, error) {
 	if r.Job.State == types.JobStateCompleted {
-		exportPath, err := url.JoinPath(globals.ExternalURLString(), fmt.Sprintf("/.api/search/export/%d.csv", r.Job.ID))
+		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d.csv", r.Job.ID))
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func (r *searchJobResolver) URL(ctx context.Context) (*string, error) {
 
 func (r *searchJobResolver) LogURL(ctx context.Context) (*string, error) {
 	if r.Job.State == types.JobStateCompleted {
-		exportPath, err := url.JoinPath(globals.ExternalURLString(), fmt.Sprintf("/.api/search/export/%d.log", r.Job.ID))
+		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d.log", r.Job.ID))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/batches/reconciler/BUILD.bazel
+++ b/internal/batches/reconciler/BUILD.bazel
@@ -49,7 +49,6 @@ go_test(
         "requires-network",
     ],
     deps = [
-        "//cmd/frontend/globals",
         "//internal/actor",
         "//internal/batches/sources",
         "//internal/batches/sources/testing",

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 
@@ -1216,8 +1214,6 @@ func TestDecorateChangesetBody(t *testing.T) {
 	ns.GetByIDFunc.SetDefaultHook(func(_ context.Context, _ int32, user int32) (*database.Namespace, error) {
 		return &database.Namespace{Name: "my-user", User: user}, nil
 	})
-
-	globals.SetExternalURL(&url.URL{Scheme: "https", Host: "sourcegraph.test"})
 
 	fs := &FakeStore{
 		GetBatchChangeMock: func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -1215,6 +1215,8 @@ func TestDecorateChangesetBody(t *testing.T) {
 		return &database.Namespace{Name: "my-user", User: user}, nil
 	})
 
+	mockExternalURL(t, "https://sourcegraph.test")
+
 	fs := &FakeStore{
 		GetBatchChangeMock: func(ctx context.Context, opts store.GetBatchChangeOpts) (*btypes.BatchChange, error) {
 			return &btypes.BatchChange{ID: 1234, Name: "reconciler-test-batch-change"}, nil

--- a/internal/batches/types/BUILD.bazel
+++ b/internal/batches/types/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/batches/types",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//cmd/frontend/globals",
         "//internal/api",
         "//internal/batches/sources/azuredevops",
         "//internal/batches/sources/bitbucketcloud",
@@ -73,10 +72,10 @@ go_test(
     ],
     embed = [":types"],
     deps = [
-        "//cmd/frontend/globals",
         "//internal/batches/sources/azuredevops",
         "//internal/batches/sources/bitbucketcloud",
         "//internal/batches/sources/gerrit",
+        "//internal/conf",
         "//internal/database",
         "//internal/executor",
         "//internal/extsvc",

--- a/internal/batches/types/batch_change.go
+++ b/internal/batches/types/batch_change.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -67,7 +67,7 @@ func (c *BatchChange) State() BatchChangeState {
 
 func (c *BatchChange) URL(ctx context.Context, namespaceName string) (string, error) {
 	// To build the absolute URL, we need to know where Sourcegraph is!
-	extURL, err := url.Parse(globals.ExternalURLString())
+	extURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing external Sourcegraph URL")
 	}

--- a/internal/batches/types/batch_change_test.go
+++ b/internal/batches/types/batch_change_test.go
@@ -2,22 +2,22 @@ package types
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 )
 
 func TestBatchChange_URL(t *testing.T) {
 	ctx := context.Background()
 	bc := &BatchChange{Name: "bar", NamespaceOrgID: 123}
-	globals.SetExternalURL(&url.URL{Scheme: "foo", Host: "//:bar"})
+
 	t.Run("errors", func(t *testing.T) {
-		for _, name := range []string{
-			"invalid URL",
+		for name, url := range map[string]string{
+			"invalid URL": "foo://:bar",
 		} {
 			t.Run(name, func(t *testing.T) {
+				mockExternalURL(t, url)
 				if _, err := bc.URL(ctx, "namespace"); err == nil {
 					t.Error("unexpected nil error")
 				}
@@ -26,7 +26,6 @@ func TestBatchChange_URL(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		globals.SetExternalURL(&url.URL{Scheme: "https", Host: "sourcegraph.test"})
 		url, err := bc.URL(
 			ctx,
 			"foo",
@@ -66,4 +65,12 @@ func TestNamespaceURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mockExternalURL(t *testing.T, url string) {
+	oldConf := conf.Get()
+	newConf := *oldConf
+	newConf.ExternalURL = url
+	conf.Mock(&newConf)
+	t.Cleanup(func() { conf.Mock(oldConf) })
 }

--- a/internal/batches/types/batch_change_test.go
+++ b/internal/batches/types/batch_change_test.go
@@ -26,6 +26,7 @@ func TestBatchChange_URL(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		mockExternalURL(t, "https://sourcegraph.test")
 		url, err := bc.URL(
 			ctx,
 			"foo",

--- a/internal/codemonitors/background/BUILD.bazel
+++ b/internal/codemonitors/background/BUILD.bazel
@@ -64,10 +64,12 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",
         "//internal/search/result",
         "//internal/txemail",
+        "//schema",
         "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_sourcegraph_log//logtest",

--- a/internal/codemonitors/background/BUILD.bazel
+++ b/internal/codemonitors/background/BUILD.bazel
@@ -20,10 +20,10 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/codemonitors/background",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//cmd/frontend/globals",
         "//internal/actor",
         "//internal/api",
         "//internal/codemonitors",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/errcode",

--- a/internal/codemonitors/background/email.go
+++ b/internal/codemonitors/background/email.go
@@ -5,11 +5,9 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
-	"sync"
 
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -152,24 +150,6 @@ func getCodeMonitorURL(externalURL *url.URL, monitorID int64, utmSource string) 
 
 func getCommitURL(externalURL *url.URL, repoName, oid, utmSource string) string {
 	return sourcegraphURL(externalURL, fmt.Sprintf("%s/-/commit/%s", repoName, oid), "", utmSource)
-}
-
-var (
-	externalURLOnce  sync.Once
-	externalURLValue *url.URL
-	externalURLError error
-)
-
-func getExternalURL() (*url.URL, error) {
-	if MockExternalURL != nil {
-		return MockExternalURL(), nil
-	}
-
-	externalURLOnce.Do(func() {
-		externalURLStr := globals.ExternalURLString()
-		externalURLValue, externalURLError = url.Parse(externalURLStr)
-	})
-	return externalURLValue, externalURLError
 }
 
 func sourcegraphURL(externalURL *url.URL, path, query, utmSource string) string {

--- a/internal/codemonitors/background/email_test.go
+++ b/internal/codemonitors/background/email_test.go
@@ -2,22 +2,25 @@ package background
 
 import (
 	"bytes"
-	"net/url"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestEmail(t *testing.T) {
 	template := txemail.MustParseTemplate(newSearchResultsEmailTemplates)
 
-	MockExternalURL = func() *url.URL {
-		externalURL, _ := url.Parse("https://www.sourcegraph.com")
-		return externalURL
-	}
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExternalURL: "https://www.sourcegraph.com",
+		},
+	})
+	defer conf.Mock(nil)
 
 	t.Run("test message", func(t *testing.T) {
 		templateData := NewTestTemplateDataForNewSearchResults("My test monitor")

--- a/internal/codemonitors/background/workers.go
+++ b/internal/codemonitors/background/workers.go
@@ -3,6 +3,7 @@ package background
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codemonitors"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
@@ -248,7 +250,7 @@ func (r *actionRunner) handleEmail(ctx context.Context, j *database.ActionJob) e
 		return errors.Wrap(err, "ListRecipients")
 	}
 
-	externalURL, err := getExternalURL()
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return err
 	}
@@ -301,7 +303,7 @@ func (r *actionRunner) handleWebhook(ctx context.Context, j *database.ActionJob)
 		return errors.Wrap(err, "GetWebhookAction")
 	}
 
-	externalURL, err := getExternalURL()
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return err
 	}
@@ -337,7 +339,7 @@ func (r *actionRunner) handleSlackWebhook(ctx context.Context, j *database.Actio
 		return errors.Wrap(err, "GetSlackWebhookAction")
 	}
 
-	externalURL, err := getExternalURL()
+	externalURL, err := url.Parse(conf.Get().ExternalURL)
 	if err != nil {
 		return err
 	}

--- a/internal/codemonitors/background/workers_test.go
+++ b/internal/codemonitors/background/workers_test.go
@@ -10,12 +10,21 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestActionRunner(t *testing.T) {
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExternalURL: "https://www.sourcegraph.com",
+		},
+	})
+	defer conf.Mock(nil)
+
 	logger := logtest.Scoped(t)
 	tests := []struct {
 		name           string


### PR DESCRIPTION
In light of recent failures, this Pull Request reverts the changes made to the external URL in a [previous PR](https://github.com/sourcegraph/sourcegraph/pull/56916), ensuring stability and functionality. This PR is a proactive measure to unblock the system by reverting to a stable state, with a follow-up PR planned to address the reference to the global external URL variable. Additionally, an unnecessary `sync.Once` has been removed, a likely culprit in needing to restart the server when externalURL is updated.

#### Changes:

1. **Reversion of External URL Update**:
   - The external URL has been reverted to its prior state by undoing changes from the previous PR. This change stabilizes the system and unblocks current failures.

2. **Removal of Unnecessary sync.Once**:
   - Removed an extraneous `sync.Once`, streamlining the codebase and removing unneeded synchronization.

#### Next Steps

- **Upcoming PR**: An additional Pull Request will follow that eliminates any reference to the global external URL variable, further refining and improving the codebase.

## Test plan

- Extensive testing has been performed to ensure that the reversion and removal actions do not introduce further issues.
- Automated tests have been updated to reflect these changes, ensuring ongoing stability.
