### PR TITLE
license: record CreatedAt in license info

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -130,6 +130,7 @@ func generateProductLicenseForSubscription(ctx context.Context, db database.DB, 
 	info := license.Info{
 		Tags:                     license.SanitizeTagsList(input.Tags),
 		UserCount:                uint(input.UserCount),
+		CreatedAt:                time.Now(),
 		ExpiresAt:                time.Unix(int64(input.ExpiresAt), 0),
 		SalesforceSubscriptionID: input.SalesforceSubscriptionID,
 		SalesforceOpportunityID:  input.SalesforceOpportunityID,

--- a/internal/license/generate-license.go
+++ b/internal/license/generate-license.go
@@ -47,6 +47,7 @@ func main() {
 	info := license.Info{
 		Tags:      license.ParseTagsInput(*tags),
 		UserCount: *users,
+		CreatedAt: time.Now(),
 		ExpiresAt: time.Now().UTC().Round(time.Second).Add(*expires),
 	}
 	b, err := json.MarshalIndent(info, "", "  ")

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -34,6 +34,9 @@ type Info struct {
 	Tags []string `json:"t"`
 	// UserCount is the number of users that this license is valid for
 	UserCount uint `json:"u"`
+	// CreatedAt is the date this license was created at. May be zero for
+	// licenses version less than 3.
+	CreatedAt time.Time `json:"c"`
 	// ExpiresAt is the date when this license expires
 	ExpiresAt time.Time `json:"e"`
 	// SalesforceSubscriptionID is the optional Salesforce subscription ID to link licenses
@@ -102,10 +105,15 @@ type encodedInfo struct {
 }
 
 func (l Info) Version() int {
+	// Before version 2, SalesforceSubscriptionID was not yet added.
 	if l.SalesforceSubscriptionID == nil {
 		return 1
 	}
-	return 2
+	// Before version 3, CreatedAt was not yet added.
+	if l.CreatedAt.IsZero() {
+		return 2
+	}
+	return 3
 }
 
 func (l Info) encode() ([]byte, error) {

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -57,7 +57,12 @@ func ParseProductLicenseKey(licenseKey string) (info *Info, signature string, er
 }
 
 func GetFreeLicenseInfo() (info *Info) {
-	return &Info{license.Info{Tags: []string{"plan:free-1"}, UserCount: 10, ExpiresAt: time.Now().Add(time.Hour * 8760)}}
+	return &Info{license.Info{
+		Tags:      []string{"plan:free-1"},
+		UserCount: 10,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(time.Hour * 8760),
+	}}
 }
 
 var MockParseProductLicenseKeyWithBuiltinOrGenerationKey func(licenseKey string) (*Info, string, error)


### PR DESCRIPTION
This change introduces a license version 3, which now records `CreatedAt` marking the creation of the license. This will apply to all licenses created when this change rolls out.

Recording this allows us to gate capabilities based on the time a license was created, namely for [telemetry export configuration](https://sourcegraph.slack.com/archives/C05BGNBEPKL/p1695750396124609?thread_ts=1695683252.874339&cid=C05BGNBEPKL).

I'm marking this as needing backport so that we can extract and use this new attribute.

## Test plan

CI