### PR TITLE
Fix typo in open-in-editor docs

### DIFF
--- a/doc/integration/open_in_editor.md
+++ b/doc/integration/open_in_editor.md
@@ -20,14 +20,14 @@ set up.
 
 If you haven’t used the feature, find this button on the right side of your screen:
 
-<img src="img/open-in-editor.svg" width="20" height="20" alt="Open in Editor icon" style="margin:0 5px;" /> 
+<img src="img/open-in-editor.svg" width="20" height="20" alt="Open in Editor icon" style="margin:0 5px;" />
 
 When you click it, a small popup appears where you’ll need to set two things: a projects path and your editor.
 
 - The **projects path** is the folder where you store your projects. Enter any Linux, Windows, or macOS absolute path.
   - Example: If your projects path is `/home/username/projects`, one of your repos
     is https://github.com/sourcegraph/sourcegraph/, and you want to open `README.md` in the root folder of the repo,
-    then the feature will look for the file at `/home/username/project/sourcegraph/README.md`.
+    then the feature will look for the file at `/home/username/projects/sourcegraph/README.md`.
 - Then choose your **preferred editor** from the list. We support VS Code, Atom, Sublime Text, and JetBrains IDEs (
   AppCode, CLion, GoLand, IntelliJ IDEA, PhpStorm, PyCharm, Rider, RubyMine, WebStorm, and all new IDEs that JetBrains
   releases). If you use a different editor, check out “Advanced config” below.


### PR DESCRIPTION
Makes paths consistent in intro. (Typo alluded to in #57065.)



## Test plan

Previewed manually via https://github.com/sourcegraph/sourcegraph/pull/57066/files?short_path=eb4d92f#diff-eb4d92feb3455c15051710354942f3a5b64f870b78dab440c364cb341af85b9a.

![image](https://github.com/sourcegraph/sourcegraph/assets/222581/b1f97a33-3d96-43e4-82cd-ded57639567f)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
