### PR TITLE
search jobs: don't upload emtpy blobs

### DIFF
--- a/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     name = "httpapi_test",
     srcs = ["export_test.go"],
     embed = [":httpapi"],
+    tags = ["requires-network"],
     deps = [
         "//internal/actor",
         "//internal/database",

--- a/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -8,7 +9,28 @@ go_library(
     deps = [
         "//internal/auth",
         "//internal/search/exhaustive/service",
+        "//internal/search/exhaustive/store",
         "//lib/errors",
         "@com_github_gorilla_mux//:mux",
+    ],
+)
+
+go_test(
+    name = "httpapi_test",
+    srcs = ["export_test.go"],
+    embed = [":httpapi"],
+    deps = [
+        "//internal/actor",
+        "//internal/database",
+        "//internal/database/basestore",
+        "//internal/database/dbtest",
+        "//internal/observation",
+        "//internal/search/exhaustive/service",
+        "//internal/search/exhaustive/store",
+        "//internal/uploadstore/mocks",
+        "//lib/iterator",
+        "@com_github_gorilla_mux//:mux",
+        "@com_github_keegancsmith_sqlf//:sqlf",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -1,0 +1,94 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/keegancsmith/sqlf"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
+	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
+	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
+	"github.com/sourcegraph/sourcegraph/lib/iterator"
+)
+
+func TestServeSearchJobDownload(t *testing.T) {
+	observationCtx := observation.TestContextTB(t)
+	logger := observationCtx.Logger
+
+	mockUploadStore := mocks.NewMockStore()
+	mockUploadStore.ListFunc.SetDefaultHook(
+		func(ctx context.Context, prefix string) (*iterator.Iterator[string], error) {
+			return iterator.From([]string{}), nil
+		})
+
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	bs := basestore.NewWithHandle(db.Handle())
+	s := store.New(db, observation.TestContextTB(t))
+	svc := service.New(observationCtx, s, mockUploadStore)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/{id}.csv", ServeSearchJobDownload(svc))
+
+	// no job
+	{
+		req, err := http.NewRequest(http.MethodGet, "/99.csv", nil)
+		require.NoError(t, err)
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+	}
+
+	// no blobs
+	{
+		// create job
+		userID, err := createUser(bs, "bob")
+		require.NoError(t, err)
+		userCtx := actor.WithActor(context.Background(), &actor.Actor{
+			UID: userID,
+		})
+		_, err = svc.CreateSearchJob(userCtx, "foo")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "/1.csv", nil)
+		require.NoError(t, err)
+
+		req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: userID}))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusNoContent, w.Code)
+	}
+
+	// wrong user
+	{
+		userID, err := createUser(bs, "alice")
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "/1.csv", nil)
+		require.NoError(t, err)
+
+		req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: userID}))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Code)
+	}
+}
+
+func createUser(store *basestore.Store, username string) (int32, error) {
+	admin := username == "admin"
+	q := sqlf.Sprintf(`INSERT INTO users(username, site_admin) VALUES(%s, %s) RETURNING id`, username, admin)
+	return basestore.ScanAny[int32](store.QueryRow(context.Background(), q))
+}

--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -193,6 +193,10 @@ func (c *BlobstoreCSVWriter) startNewFile(ctx context.Context, key string) {
 
 	closeFn := func() error {
 		csvWriter.Flush()
+		// Don't upload empty files.
+		if c.buf.Len() == 0 {
+			return nil
+		}
 		_, err := c.store.Upload(ctx, key, &c.buf)
 		return err
 	}

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -281,8 +281,8 @@ func (s *Service) DeleteSearchJob(ctx context.Context, id int64) (err error) {
 }
 
 // WriteSearchJobCSV copies all CSVs associated with a search job to the given
-// writer.
-func (s *Service) WriteSearchJobCSV(ctx context.Context, w io.Writer, id int64) (err error) {
+// writer. It returns the number of bytes written and any error encountered.
+func (s *Service) WriteSearchJobCSV(ctx context.Context, w io.Writer, id int64) (n int64, err error) {
 	ctx, _, endObservation := s.operations.writeSearchJobCSV.With(ctx, &err, opAttrs(
 		attribute.Int64("id", id)))
 	defer endObservation(1, observation.Args{})
@@ -290,19 +290,20 @@ func (s *Service) WriteSearchJobCSV(ctx context.Context, w io.Writer, id int64) 
 	// 🚨 SECURITY: only someone with access to the job may copy the blobs
 	_, err = s.GetSearchJob(ctx, id)
 	if err != nil {
-		return err
+		return
 	}
 
 	iter, err := s.uploadStore.List(ctx, getPrefix(id))
 	if err != nil {
-		return err
+		return
 	}
 
-	err = writeSearchJobCSV(ctx, iter, s.uploadStore, w)
+	n, err = writeSearchJobCSV(ctx, iter, s.uploadStore, w)
 	if err != nil {
-		return errors.Wrapf(err, "writing csv for job %d", id)
+		return n, errors.Wrapf(err, "writing csv for job %d", id)
 	}
-	return nil
+
+	return n, nil
 }
 
 // GetAggregateRepoRevState returns the map of state -> count for all repo
@@ -353,14 +354,14 @@ func discardUntil(br *bufio.Reader, delim byte) error {
 	}
 }
 
-func writeSearchJobCSV(ctx context.Context, iter *iterator.Iterator[string], uploadStore uploadstore.Store, w io.Writer) error {
+func writeSearchJobCSV(ctx context.Context, iter *iterator.Iterator[string], uploadStore uploadstore.Store, w io.Writer) (int64, error) {
 	// keep a single bufio.Reader so we can reuse its buffer.
 	var br bufio.Reader
-	writeKey := func(key string, skipHeader bool) error {
+	writeKey := func(key string, skipHeader bool) (int64, error) {
 		rc, err := uploadStore.Get(ctx, key)
 		if err != nil {
 			_ = rc.Close()
-			return err
+			return 0, err
 		}
 		defer rc.Close()
 
@@ -372,25 +373,27 @@ func writeSearchJobCSV(ctx context.Context, iter *iterator.Iterator[string], upl
 			if err == io.EOF {
 				// reached end of file before finding the newline. Write
 				// nothing
-				return nil
+				return 0, nil
 			} else if err != nil {
-				return err
+				return 0, err
 			}
 		}
 
-		_, err = br.WriteTo(w)
-		return err
+		return br.WriteTo(w)
 	}
 
 	// For the first blob we want the header, for the rest we don't
 	skipHeader := false
+	var n int64
 	for iter.Next() {
 		key := iter.Current()
-		if err := writeKey(key, skipHeader); err != nil {
-			return errors.Wrapf(err, "writing csv for key %q", key)
+		m, err := writeKey(key, skipHeader)
+		n += m
+		if err != nil {
+			return n, errors.Wrapf(err, "writing csv for key %q", key)
 		}
 		skipHeader = true
 	}
 
-	return iter.Err()
+	return n, iter.Err()
 }

--- a/internal/search/exhaustive/service/service_test.go
+++ b/internal/search/exhaustive/service/service_test.go
@@ -28,8 +28,9 @@ func Test_copyBlobs(t *testing.T) {
 
 	w := &bytes.Buffer{}
 
-	err := writeSearchJobCSV(context.Background(), keysIter, blobstore, w)
+	n, err := writeSearchJobCSV(context.Background(), keysIter, blobstore, w)
 	require.NoError(t, err)
+	require.Equal(t, int64(24), n)
 
 	want := "h/h/h\na/a/a\nb/b/b\nc/c/c\n"
 	require.Equal(t, want, w.String())


### PR DESCRIPTION
Closes #57032 

We already don't write CSV headers if we don't find matches, so all we have to do is skip the upload.

Test plan:
- new and updated unit test
- ran a "needle in the haystack" query locally and confirmed that now we upload 1 CSV (for the needle) instead of 1 per revision.
