### PR TITLE
JetBrains: remove old onboarding about cody app

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -44,7 +44,6 @@ import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
 import com.sourcegraph.cody.chat.Transcript;
-import com.sourcegraph.cody.config.AccountType;
 import com.sourcegraph.cody.config.AccountsHostProjectHolder;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
@@ -52,7 +51,6 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager;
 import com.sourcegraph.cody.config.CodyPersistentAccountsHost;
 import com.sourcegraph.cody.context.ContextMessage;
 import com.sourcegraph.cody.context.EmbeddingStatusView;
-import com.sourcegraph.cody.localapp.LocalAppManager;
 import com.sourcegraph.cody.ui.AutoGrowingTextArea;
 import com.sourcegraph.cody.vscode.CancellationToken;
 import com.sourcegraph.config.ConfigUtil;
@@ -345,19 +343,9 @@ public class CodyToolWindowContent implements UpdatableChat {
       isChatVisible = false;
       return;
     }
-    if (LocalAppManager.isPlatformSupported()
-        && codyAuthenticationManager.getActiveAccountType(project) == AccountType.LOCAL_APP) {
-      if (!LocalAppManager.isLocalAppRunning()) {
-        allContentLayout.show(allContentPanel, "appNotRunningPanel");
-        isChatVisible = false;
-      } else {
-        allContentLayout.show(allContentPanel, "tabbedPane");
-        isChatVisible = true;
-      }
-    } else {
-      allContentLayout.show(allContentPanel, "tabbedPane");
-      isChatVisible = true;
-    }
+
+    allContentLayout.show(allContentPanel, "tabbedPane");
+    isChatVisible = true;
   }
 
   @NotNull


### PR DESCRIPTION
Removed old onboarding as we don't support this in the new onboarding flow

## Test plan
- Green CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
