### PR TITLE
site-config: fix invalid default values for repo purge worker

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -991,8 +991,8 @@
       "group": "External services",
       "additionalProperties": false,
       "default": {
-        "interval": 15,
-        "deletedTTL": 60
+        "intervalMinutes": 15,
+        "deletedTTLMinutes": 60
       },
       "properties": {
         "intervalMinutes": {


### PR DESCRIPTION
This fixes #56980


## Test plan

- `sg start`, open site-config, add `repoPurgeWorker`, see defaults

<img width="318" alt="screenshot_2023-09-27_13 52 32@2x" src="https://github.com/sourcegraph/sourcegraph/assets/1185253/a05a815f-f120-44ac-85da-c092ece909bc">
