### PR TITLE
chore: clean up obsolete tagging of the @sourcegraph/apis

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -28,4 +28,3 @@ jobs:
                   team/source=@sourcegraph/source
                   cody-gateway=@unknwon @eseliger @bobheadxi @efritz @ggilmore
                   team/search-platform=@sourcegraph/search-platform
-                  team/apis=@sourcegraph/apis


### PR DESCRIPTION
Follow-up of https://github.com/sourcegraph/background-jobs/pull/57

## Test plan

n/a
