### PR TITLE
telemetry/teestore: generate anonymous ID if user and anonymous ID are empty

### DIFF
--- a/internal/telemetry/teestore/BUILD.bazel
+++ b/internal/telemetry/teestore/BUILD.bazel
@@ -25,9 +25,13 @@ go_test(
     srcs = ["teestore_test.go"],
     embed = [":teestore"],
     deps = [
+        "//internal/database",
+        "//internal/database/dbtest",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_sourcegraph_log//logtest",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_golang_google_protobuf//types/known/timestamppb",

--- a/internal/telemetry/teestore/BUILD.bazel
+++ b/internal/telemetry/teestore/BUILD.bazel
@@ -24,6 +24,10 @@ go_test(
     name = "teestore_test",
     srcs = ["teestore_test.go"],
     embed = [":teestore"],
+    tags = [
+        # Test requires localhost database
+        "requires-network",
+    ],
     deps = [
         "//internal/database",
         "//internal/database/dbtest",

--- a/internal/telemetry/teestore/teestore.go
+++ b/internal/telemetry/teestore/teestore.go
@@ -49,6 +49,8 @@ func (s *Store) StoreEvents(ctx context.Context, events []*telemetrygatewayv1.Ev
 	return wg.Wait()
 }
 
+// toEventLogs is the mechanism translating the new exportable telemetry events
+// into the legacy event_logs table for convenience.
 func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Event) []*database.Event {
 	sensitiveMetadataAllowlist := sensitivemetadataallowlist.AllowedEventTypes()
 
@@ -56,6 +58,7 @@ func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Eve
 	for i, e := range telemetryEvents {
 		// Note that all generated proto getters are nil-safe, so use those to
 		// get fields rather than accessing fields directly.
+		userID := e.GetUser().GetUserId()
 		eventLogs[i] = &database.Event{
 			ID:       0,   // not required on insert
 			InsertID: nil, // not required on insert
@@ -70,8 +73,15 @@ func toEventLogs(now func() time.Time, telemetryEvents []*telemetrygatewayv1.Eve
 			}(),
 
 			// User
-			UserID:          uint32(e.GetUser().GetUserId()),
-			AnonymousUserID: e.GetUser().GetAnonymousUserId(),
+			UserID: uint32(userID),
+			AnonymousUserID: func() string {
+				// One of userID, anonymousUserID must be set in event_logs
+				anonymous := e.GetUser().GetAnonymousUserId()
+				if userID == 0 && anonymous == "" {
+					return "unknown"
+				}
+				return anonymous
+			}(),
 
 			// GetParameters.Metadata
 			PublicArgument: func() json.RawMessage {


### PR DESCRIPTION
The `event_logs` table requires that either the user or an anonymous user ID is provided, so some events can fail to insert when translated by `telemetry/teestore`. This change makes sure we always have either the user ID or anonymous ID.

## Test plan

I added an integration test to make sure translated events will always insert successfully without being caught by constraints. Existing unit tests + autogold show the new generated anonymous ID.