### PR TITLE
search: return status forbidden on download exhaustive logs

### DIFF
--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     ],
     deps = [
         "//internal/actor",
+        "//internal/auth",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbtest",

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -163,6 +163,11 @@ func (s *Service) ListSearchJobs(ctx context.Context, args store.ListArgs) (jobs
 }
 
 func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64) (err error) {
+	// 🚨 SECURITY: only someone with access to the job may copy the blobs
+	if _, err := s.GetSearchJob(ctx, id); err != nil {
+		return err
+	}
+
 	iter := s.getJobLogsIter(ctx, id)
 
 	cw := csv.NewWriter(w)

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -166,7 +166,6 @@ func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64)
 	iter := s.getJobLogsIter(ctx, id)
 
 	cw := csv.NewWriter(w)
-	defer cw.Flush()
 
 	header := []string{
 		"repository",
@@ -196,7 +195,13 @@ func (s *Service) WriteSearchJobLogs(ctx context.Context, w io.Writer, id int64)
 		}
 	}
 
-	return iter.Err()
+	if err := iter.Err(); err != nil {
+		return err
+	}
+
+	// Flush data before checking for any final write errors.
+	cw.Flush()
+	return cw.Error()
 }
 
 // JobLogsIterLimit is the number of lines the iterator will read from the


### PR DESCRIPTION
Previously we would always write a header line before actually checking if we can view a job. This automatically lead to status 200 and us ignoring the later error. This adjusts the service call to return before any writes.

Test Plan: a test was added which ensures we don't write anything in case of auth failure.

Fixes https://github.com/sourcegraph/sourcegraph/issues/57087