### PR TITLE
grpc: searcher: convert well-known errors to proper grpc status codes

### DIFF
--- a/cmd/searcher/internal/search/BUILD.bazel
+++ b/cmd/searcher/internal/search/BUILD.bazel
@@ -58,6 +58,8 @@ go_library(
         "@com_github_sourcegraph_zoekt//ignore",
         "@com_github_sourcegraph_zoekt//query",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",
         "@org_uber_go_atomic//:atomic",
     ] + select({
@@ -118,6 +120,7 @@ go_test(
         "paxheader_110_test.go",
         "paxheader_19_test.go",
         "retry_test.go",
+        "search_grpc_test.go",
         "search_regex_test.go",
         "search_structural_test.go",
         "search_test.go",
@@ -155,6 +158,8 @@ go_test(
         "@com_github_sourcegraph_zoekt//web",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_x_net//context/ctxhttp",
     ],
 )

--- a/cmd/searcher/internal/search/search_grpc.go
+++ b/cmd/searcher/internal/search/search_grpc.go
@@ -1,10 +1,14 @@
 package search
 
 import (
+	"context"
+	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	proto "github.com/sourcegraph/sourcegraph/internal/searcher/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Server struct {
@@ -34,7 +38,7 @@ func (s *Server) Search(req *proto.SearchRequest, stream proto.SearcherService_S
 
 	err := s.Service.search(ctx, &unmarshaledReq, matchStream)
 	if err != nil {
-		return err
+		return convertToGRPCError(ctx, err)
 	}
 
 	return stream.Send(&proto.SearchResponse{
@@ -44,4 +48,40 @@ func (s *Server) Search(req *proto.SearchRequest, stream proto.SearcherService_S
 			},
 		},
 	})
+}
+
+// convertToGRPCError converts an error into a gRPC status error code.
+//
+// If err is nil, it returns nil.
+//
+// If err is already a gRPC status error, it is returned as-is.
+//
+// If the provided context has expired, a grpc codes.Canceled / DeadlineExceeded error is returned.
+//
+// If the err is a well-known error (such as a process getting killed, etc.),
+// it's mapped to the appropriate gRPC status code.
+//
+// Otherwise, err is converted to an Unknown gRPC error code.
+func convertToGRPCError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// don't convert an existing status error
+	if statusErr, ok := status.FromError(err); ok {
+		return statusErr.Err()
+	}
+
+	// if the context expired, just return that
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return status.FromContextError(ctxErr).Err()
+	}
+
+	// otherwise convert to a status error
+	grpcCode := codes.Unknown
+	if strings.Contains(err.Error(), "signal: killed") {
+		grpcCode = codes.Aborted
+	}
+
+	return status.New(grpcCode, err.Error()).Err()
 }

--- a/cmd/searcher/internal/search/search_grpc_test.go
+++ b/cmd/searcher/internal/search/search_grpc_test.go
@@ -1,0 +1,78 @@
+package search
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestConvertToGRPCError(t *testing.T) {
+	expiredContext, done := context.WithDeadline(context.Background(), time.Now().Add(-time.Minute))
+	t.Cleanup(func() {
+		done()
+	})
+
+	testCases := []struct {
+		name string
+
+		ctx context.Context
+		err error
+
+		want error
+	}{
+		{
+			name: "nil error",
+
+			ctx: context.Background(),
+			err: nil,
+
+			want: nil,
+		},
+		{
+			name: "existing status error",
+
+			ctx: context.Background(),
+			err: status.Error(codes.InvalidArgument, "invalid"),
+
+			want: status.Error(codes.InvalidArgument, "invalid"),
+		},
+		{
+			name: "context error",
+
+			ctx: expiredContext,
+			err: errors.New("some other error"),
+
+			want: status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error()),
+		},
+		{
+			name: "unknown error",
+
+			ctx: context.Background(),
+			err: errors.New("unknown"),
+
+			want: status.Error(codes.Unknown, "unknown"),
+		},
+		{
+			name: "killed error",
+
+			ctx: context.Background(),
+			err: errors.New("failed to wait for executing comby command: signal: killed"),
+
+			want: status.Error(codes.Aborted, "failed to wait for executing comby command: signal: killed"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := convertToGRPCError(tc.ctx, tc.err)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("convertToGRPCError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Errors like the following are popping up in searcher.Search error logs (https://cloudlogging.app.goo.gl/TMkmbxYSQth6qN2E8):

- "rpc error: code = Unknown desc = Write: write |1: broken pipe"
- "rpc error: code = Unknown desc = failed to wait for executing comby command: signal: killed"
- "rpc error: code = Unknown desc = WriteHeader: write |1: broken pipe"

I believe a lot of these can be given proper grpc error codes (not just codes.Unknown) by special casing some special errors:

1. If an error occurred and the context also expired, just return a context error (codes.DeadlineExceeded or codes.Cancelled) (there is an implicit assumption here that an expired context is the cause of the error)
1. If an error occurred and the error contains "signal: killed", return codes.Aborted

See https://grpc.github.io/grpc/core/md_doc_statuscodes.html for more guidance.



## Test plan

Unit tests