### PR TITLE
Bug: fix nil panic

### DIFF
--- a/internal/embeddings/db/conf.go
+++ b/internal/embeddings/db/conf.go
@@ -53,6 +53,9 @@ func NewDBFromConfFunc(logger log.Logger, def VectorDB) func() (VectorDB, error)
 
 	return func() (VectorDB, error) {
 		curr := ptr.Load()
+		if curr == nil {
+			return def, nil
+		}
 		if curr.err != nil {
 			return nil, curr.err
 		}


### PR DESCRIPTION
This fixes a case that can trigger a nil panic when qdrant is enabled in config, but no endpoint is configured. This should be a very rare situation.

## Test plan

Manually tested that the situation that was panicking locally no longer panics.
