### PR TITLE
Qdrant: add endpoint to move all embeddings to qdrant

### DIFF
--- a/cmd/frontend/graphqlbackend/embeddings.go
+++ b/cmd/frontend/graphqlbackend/embeddings.go
@@ -14,6 +14,7 @@ type EmbeddingsResolver interface {
 	EmbeddingsMultiSearch(ctx context.Context, args EmbeddingsMultiSearchInputArgs) (EmbeddingsSearchResultsResolver, error)
 	IsContextRequiredForChatQuery(ctx context.Context, args IsContextRequiredForChatQueryInputArgs) (bool, error)
 	RepoEmbeddingJobs(ctx context.Context, args ListRepoEmbeddingJobsArgs) (*graphqlutil.ConnectionResolver[RepoEmbeddingJobResolver], error)
+	MigrateToQdrant(ctx context.Context) (*EmptyResponse, error)
 
 	ScheduleRepositoriesForEmbedding(ctx context.Context, args ScheduleRepositoriesForEmbeddingArgs) (*EmptyResponse, error)
 	CancelRepoEmbeddingJob(ctx context.Context, args CancelRepoEmbeddingJobArgs) (*EmptyResponse, error)

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -87,6 +87,8 @@ extend type Query {
         """
         state: String
     ): RepoEmbeddingJobsConnection!
+
+    migrateToQdrant(): EmptyResponse!
 }
 
 extend type Mutation {

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -92,7 +92,7 @@ extend type Query {
     TEMPORARY: creates a new embedding job for all completed embeddings
     jobs so that they will be moved from blobstore to qdrant
     """
-    migrateToQdrant(): EmptyResponse!
+    migrateToQdrant: EmptyResponse!
 }
 
 extend type Mutation {

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -88,6 +88,10 @@ extend type Query {
         state: String
     ): RepoEmbeddingJobsConnection!
 
+    """
+    TEMPORARY: creates a new embedding job for all completed embeddings
+    jobs so that they will be moved from blobstore to qdrant
+    """
     migrateToQdrant(): EmptyResponse!
 }
 

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -173,6 +173,7 @@ func (r *Resolver) MigrateToQdrant(ctx context.Context) (*graphqlbackend.EmptyRe
 		return nil, errors.New("qdrant is not enabled")
 	}
 
+	return &graphqlbackend.EmptyResponse{}, r.repoEmbeddingJobsStore.RescheduleAllRepos(ctx)
 }
 
 func (r *Resolver) CancelRepoEmbeddingJob(ctx context.Context, args graphqlbackend.CancelRepoEmbeddingJobArgs) (*graphqlbackend.EmptyResponse, error) {

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -163,6 +163,18 @@ func (r *Resolver) ScheduleRepositoriesForEmbedding(ctx context.Context, args gr
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r *Resolver) MigrateToQdrant(ctx context.Context) (*graphqlbackend.EmptyResponse, error) {
+	if !conf.EmbeddingsEnabled() {
+		return nil, errors.New("embeddings are not configured or disabled")
+	}
+
+	ec := conf.GetEmbeddingsConfig(conf.Get().SiteConfig())
+	if ec == nil || !ec.Qdrant.Enabled {
+		return nil, errors.New("qdrant is not enabled")
+	}
+
+}
+
 func (r *Resolver) CancelRepoEmbeddingJob(ctx context.Context, args graphqlbackend.CancelRepoEmbeddingJobArgs) (*graphqlbackend.EmptyResponse, error) {
 	// 🚨 SECURITY: check whether user is site-admin
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {

--- a/internal/embeddings/background/repo/mocks_temp.go
+++ b/internal/embeddings/background/repo/mocks_temp.go
@@ -58,6 +58,9 @@ type MockRepoEmbeddingJobsStore struct {
 	// ListRepoEmbeddingJobsFunc is an instance of a mock function object
 	// controlling the behavior of the method ListRepoEmbeddingJobs.
 	ListRepoEmbeddingJobsFunc *RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc
+	// RescheduleAllReposFunc is an instance of a mock function object
+	// controlling the behavior of the method RescheduleAllRepos.
+	RescheduleAllReposFunc *RepoEmbeddingJobsStoreRescheduleAllReposFunc
 	// TransactFunc is an instance of a mock function object controlling the
 	// behavior of the method Transact.
 	TransactFunc *RepoEmbeddingJobsStoreTransactFunc
@@ -129,6 +132,11 @@ func NewMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 		},
 		ListRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc{
 			defaultHook: func(context.Context, ListOpts) (r0 []*RepoEmbeddingJob, r1 error) {
+				return
+			},
+		},
+		RescheduleAllReposFunc: &RepoEmbeddingJobsStoreRescheduleAllReposFunc{
+			defaultHook: func(context.Context) (r0 error) {
 				return
 			},
 		},
@@ -210,6 +218,11 @@ func NewStrictMockRepoEmbeddingJobsStore() *MockRepoEmbeddingJobsStore {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.ListRepoEmbeddingJobs")
 			},
 		},
+		RescheduleAllReposFunc: &RepoEmbeddingJobsStoreRescheduleAllReposFunc{
+			defaultHook: func(context.Context) error {
+				panic("unexpected invocation of MockRepoEmbeddingJobsStore.RescheduleAllRepos")
+			},
+		},
 		TransactFunc: &RepoEmbeddingJobsStoreTransactFunc{
 			defaultHook: func(context.Context) (RepoEmbeddingJobsStore, error) {
 				panic("unexpected invocation of MockRepoEmbeddingJobsStore.Transact")
@@ -263,6 +276,9 @@ func NewMockRepoEmbeddingJobsStoreFrom(i RepoEmbeddingJobsStore) *MockRepoEmbedd
 		},
 		ListRepoEmbeddingJobsFunc: &RepoEmbeddingJobsStoreListRepoEmbeddingJobsFunc{
 			defaultHook: i.ListRepoEmbeddingJobs,
+		},
+		RescheduleAllReposFunc: &RepoEmbeddingJobsStoreRescheduleAllReposFunc{
+			defaultHook: i.RescheduleAllRepos,
 		},
 		TransactFunc: &RepoEmbeddingJobsStoreTransactFunc{
 			defaultHook: i.Transact,
@@ -1589,6 +1605,112 @@ func (c RepoEmbeddingJobsStoreListRepoEmbeddingJobsFuncCall) Args() []interface{
 // invocation.
 func (c RepoEmbeddingJobsStoreListRepoEmbeddingJobsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// RepoEmbeddingJobsStoreRescheduleAllReposFunc describes the behavior when
+// the RescheduleAllRepos method of the parent MockRepoEmbeddingJobsStore
+// instance is invoked.
+type RepoEmbeddingJobsStoreRescheduleAllReposFunc struct {
+	defaultHook func(context.Context) error
+	hooks       []func(context.Context) error
+	history     []RepoEmbeddingJobsStoreRescheduleAllReposFuncCall
+	mutex       sync.Mutex
+}
+
+// RescheduleAllRepos delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockRepoEmbeddingJobsStore) RescheduleAllRepos(v0 context.Context) error {
+	r0 := m.RescheduleAllReposFunc.nextHook()(v0)
+	m.RescheduleAllReposFunc.appendCall(RepoEmbeddingJobsStoreRescheduleAllReposFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the RescheduleAllRepos
+// method of the parent MockRepoEmbeddingJobsStore instance is invoked and
+// the hook queue is empty.
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) SetDefaultHook(hook func(context.Context) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// RescheduleAllRepos method of the parent MockRepoEmbeddingJobsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) PushHook(hook func(context.Context) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context) error {
+		return r0
+	})
+}
+
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) nextHook() func(context.Context) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) appendCall(r0 RepoEmbeddingJobsStoreRescheduleAllReposFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RepoEmbeddingJobsStoreRescheduleAllReposFuncCall objects describing the
+// invocations of this function.
+func (f *RepoEmbeddingJobsStoreRescheduleAllReposFunc) History() []RepoEmbeddingJobsStoreRescheduleAllReposFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoEmbeddingJobsStoreRescheduleAllReposFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoEmbeddingJobsStoreRescheduleAllReposFuncCall is an object that
+// describes an invocation of method RescheduleAllRepos on an instance of
+// MockRepoEmbeddingJobsStore.
+type RepoEmbeddingJobsStoreRescheduleAllReposFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoEmbeddingJobsStoreRescheduleAllReposFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoEmbeddingJobsStoreRescheduleAllReposFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
 }
 
 // RepoEmbeddingJobsStoreTransactFunc describes the behavior when the

--- a/internal/embeddings/background/repo/store.go
+++ b/internal/embeddings/background/repo/store.go
@@ -106,6 +106,7 @@ type RepoEmbeddingJobsStore interface {
 	CountRepoEmbeddingJobs(ctx context.Context, args ListOpts) (int, error)
 	GetEmbeddableRepos(ctx context.Context, opts EmbeddableRepoOpts) ([]EmbeddableRepo, error)
 	CancelRepoEmbeddingJob(ctx context.Context, job int) error
+	RescheduleAllRepos(ctx context.Context) error
 
 	UpdateRepoEmbeddingJobStats(ctx context.Context, jobID int, stats *EmbedRepoStats) error
 	GetRepoEmbeddingJobStats(ctx context.Context, jobID int) (EmbedRepoStats, error)
@@ -253,6 +254,24 @@ func (s *repoEmbeddingJobsStore) CreateRepoEmbeddingJob(ctx context.Context, rep
 	q := sqlf.Sprintf(createRepoEmbeddingJobFmtStr, repoID, revision)
 	id, _, err := basestore.ScanFirstInt(s.Query(ctx, q))
 	return id, err
+}
+
+func (s *repoEmbeddingJobsStore) RescheduleAllRepos(ctx context.Context) error {
+	const rescheduleAllQuery = `
+	INSERT INTO repo_embedding_jobs (repo_id, revision)
+	SELECT
+		DISTINCT repo_id,
+		(
+			SELECT r2.revision
+			FROM repo_embedding_jobs r2
+			WHERE r2.repo_id = r1.repo_id
+				AND state = 'completed'
+			ORDER BY finished_at
+			LIMIT 1
+		)
+	FROM repo_embedding_jobs r1
+	`
+	return s.Store.Exec(ctx, sqlf.Sprintf(rescheduleAllQuery))
 }
 
 var repoEmbeddingJobStatsColumns = []*sqlf.Query{

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -154,10 +154,25 @@ func TestRescheduleAll(t *testing.T) {
 	require.NoError(t, err)
 
 	repo2 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph2", URI: "github.com/sourcegraph/sourcegraph2", ExternalRepo: api.ExternalRepoSpec{}}
-	err = repoStore.Create(ctx, repo1)
+	err = repoStore.Create(ctx, repo2)
+	require.NoError(t, err)
+
+	// Insert three completed jobs from two repos
+	_, err = db.Handle().ExecContext(ctx, fmt.Sprintf(
+		"insert into repo_embedding_jobs (repo_id, revision, state) values (%d, 'rev1', 'completed'), (%d, 'rev2', 'completed'), (%d, 'rev3', 'completed')",
+		repo1.ID,
+		repo1.ID,
+		repo2.ID,
+	))
 	require.NoError(t, err)
 
 	store := NewRepoEmbeddingJobsStore(db)
+	err = store.RescheduleAllRepos(ctx)
+	require.NoError(t, err)
+
+	jobs, err := store.ListRepoEmbeddingJobs(ctx, ListOpts{PaginationArgs: &database.PaginationArgs{}})
+	require.NoError(t, err)
+	require.Len(t, jobs, 5)
 }
 
 func TestCancelRepoEmbeddingJob(t *testing.T) {

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -141,6 +141,25 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	})
 }
 
+func TestRescheduleAll(t *testing.T) {
+	t.Parallel()
+
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	repoStore := db.Repos()
+	ctx := context.Background()
+
+	repo1 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
+	err := repoStore.Create(ctx, repo1)
+	require.NoError(t, err)
+
+	repo2 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph2", URI: "github.com/sourcegraph/sourcegraph2", ExternalRepo: api.ExternalRepoSpec{}}
+	err = repoStore.Create(ctx, repo1)
+	require.NoError(t, err)
+
+	store := NewRepoEmbeddingJobsStore(db)
+}
+
 func TestCancelRepoEmbeddingJob(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When qdrant is enabled, an embeddings job will upload the embeddings to both blobstore and qdrant. This means that, after qdrant is enabled, we will naturally migrate the data if a policy is configured for a repo. However, there may be repos that were only embedded with a one-off job. This PR adds a GraphQL endpoint that just reschedules all repos that have a completed embeddings job, which will cause them to be uploaded to qdrant.

## Test plan

Added a test for the DB layer. Manual end-to-end test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
