### PR TITLE
revert p4-fusion to 1.12

### DIFF
--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: p4-fusion
-  version: 1.13
+  version: 1.12
   epoch: 6
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
@@ -36,7 +36,7 @@ pipeline:
   - uses: fetch
     with:
       uri: https://github.com/salesforce/p4-fusion/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: 8642a2caf384c2511ef8bf10c04f32edd799b352f4d0f2ae4766cf3d79bec1c0
+      expected-sha256: f5cbca35880aad2e6fac05c669dab6c13c3389aa62cbc5d5ee2ce73e77bcfe78
       extract: false
   - runs: |
       mkdir p4-fusion-src


### PR DESCRIPTION
Occasional core dumps with 1.13, most of them SIGSEGV

core dumps do not happen all of the time, but this command run on `gitserver` reliably reproduces them:

```shell
P4USER=<perforce user>
P4PASSWD=<user ticket>
P4PORT=<perforce host>
DEPOT=<depot name>
export P4USER P4PASSWD P4PORT
for x in 1 2 3 4 5
do
tmpdir=/data/repos/.tmp/test_p4-fusion-${RANDOM}
rm -rf "${tmpdir}"
mkdir -p "${tmpdir}"
echo "attempt ${x}"
p4-fusion-binary \
--path ${DEPOT}... \
--client "" \
--user ${P4USER} \
--src "${tmpdir}/.git" \
--networkThreads 16 \
--printBatch 10 \
--port ${P4PORT} \
--lookAhead 16 \
--maxChanges 32 \
--retries 100 \
--refresh 100000 \
--includeBinaries false \
--fsyncEnable true \
--noColor true 2>&1 | { grep "core dumped" || true; }
rc=$?
echo "return code: ${rc}"
rm -rf "${tmpdir}"
done
```
Note that `<perforce user>` needs to be replaced with a value user for the Perforce instance, `<user ticket>` needs to be replaced with the correct ticket for the user, `<perforce host>` replaced with the actual Perforce host + port #, and `<depot name>` with the depot name or path, including the leading `//` and trailing `/`.

## Test plan

Connect to `gitserver` via a terminal and run the above command. If using `p4-fusion` 1.13, it will fail some or all of the time with core dumps.

Example output:

```shell
attempt 1
qemu: uncaught target signal 6 (Aborted) - core dumped
Aborted
return code: 134
attempt 2
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
return code: 139
attempt 3
return code: 0
attempt 4
return code: 0
attempt 5
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
return code: 139
```

If using `p4-fusion` 1.12, the output will be all `return code: 0`, like this one:

```shell
attempt 1
return code: 0
attempt 2
return code: 0
attempt 3
return code: 0
attempt 4
return code: 0
attempt 5
return code: 0
```

Not that it helps here, but changing `lookAhead` to `1` seems to stop the core dumps, at the cost of cloning speed.


