### PR TITLE
gitserver: Don't attempt to clone repos without auth when DB fails

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -844,6 +845,12 @@ func (s *Server) isRepoCloneable(ctx context.Context, repo api.RepoName) (protoc
 	// the endpoint is only available internally so it's low risk.
 	remoteURL, err := s.getRemoteURL(actor.WithInternalActor(ctx), repo)
 	if err != nil {
+		// For non-not found errors, we should error out instead, and not attempt
+		// to try an authless git clone.
+		if !errcode.IsNotFound(err) {
+			return protocol.IsRepoCloneableResponse{}, err
+		}
+
 		// We use this endpoint to verify if a repo exists without consuming
 		// API rate limit, since many users visit private or bogus repos,
 		// so we deduce the unauthenticated clone URL from the repo name.
@@ -861,11 +868,11 @@ func (s *Server) isRepoCloneable(ctx context.Context, repo api.RepoName) (protoc
 	resp := protocol.IsRepoCloneableResponse{
 		Cloned: repoCloned(repoDirFromName(s.ReposDir, repo)),
 	}
-	if err := syncer.IsCloneable(ctx, repo, remoteURL); err == nil {
-		resp.Cloneable = true
-	} else {
+	err = syncer.IsCloneable(ctx, repo, remoteURL)
+	if err != nil {
 		resp.Reason = err.Error()
 	}
+	resp.Cloneable = err == nil
 
 	return resp, nil
 }


### PR DESCRIPTION
We have a code path for dotcom where we try to see if a repo is cloneable if it doesn't exist in the DB yet. However, we assume that any error from the getRemoteURL means that the repo is not existing and we should try to clone the repo without auth from a madeup URL. This could cause unauthed clone attempts to repos that actually DO exist in the instance, so added an additional check here if the error is actually a "repo isn't found" error.

## Test plan

CI and integration tests.