### PR TITLE
search-jobs: add AND to query validation

### DIFF
--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
@@ -32,6 +32,10 @@ describe('exhaustive search validation', () => {
             expect(validateQueryForExhaustiveSearch('insights or batch-changes').length).toStrictEqual(1)
         })
 
+        test('[and operator]', () => {
+            expect(validateQueryForExhaustiveSearch('insights and batch-changes').length).toStrictEqual(1)
+        })
+
         test('[all cases combined]', () => {
             expect(
                 validateQueryForExhaustiveSearch(

--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
@@ -9,6 +9,7 @@ enum ValidationErrorType {
     HAS_CONTENT_PREDICATE = 'has_content_predicate',
     HAS_FILE_PREDICATE = 'has_file_predicate',
     OR_OPERATOR = 'or_operator',
+    AND_OPERATOR = 'and_operator',
 }
 
 interface ValidationError {
@@ -79,7 +80,16 @@ export function validateQueryForExhaustiveSearch(query: string): ValidationError
         if (hasOr) {
             validationErrors.push({
                 type: ValidationErrorType.OR_OPERATOR,
-                reason: 'Or operator is not compatible for exhaustive search',
+                reason: 'OR operator is not compatible',
+            })
+        }
+
+        const hasAnd = keywords.some(filter => filter.kind === 'and')
+
+        if (hasAnd) {
+            validationErrors.push({
+                type: ValidationErrorType.AND_OPERATOR,
+                reason: 'AND operator is not compatible',
             })
         }
     }


### PR DESCRIPTION
Closes #57131 

We only allow flat queries in the backend, which implies no AND or OR.

Test plan:
- updated test
- checked locally that it is not possible to create a search job from a query with "AND" operator.


