### PR TITLE
wolfi: update server / gitserver base images for p4-fusion revert

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,13 +52,13 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:fcec683559bff49e16bca0861da67bca22cee217fce30a1f37ad585995a980fb",
+        digest = "sha256:2294c8b766cd6e34bb2496f14c3cc8788dc7de9073381b2e33be8bc6b748cb2d",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:993bf37e759e40f13cc0598453e17a1faec04ebd10cc87a7e706cd9b6d7b793f",
+        digest = "sha256:d7f7b5b0130399f67f72c1be7bed3a7a87237be8c8d5566e6bca4037b2bd71f1",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,13 +52,13 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:2294c8b766cd6e34bb2496f14c3cc8788dc7de9073381b2e33be8bc6b748cb2d",
+        digest = "sha256:660d9d15fd1a3e31fe60619ed98bb8c28dbbb9dc3dd4158b6301c9aec23b50d2",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:d7f7b5b0130399f67f72c1be7bed3a7a87237be8c8d5566e6bca4037b2bd71f1",
+        digest = "sha256:3a020c29b781ac183aacb5584cf76ba337b1acb12f17fdf1a2666a0daf1374de",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 


### PR DESCRIPTION
This will put the right image hashes in place so we can build `gitserver` and `server` with the version 1.12.0 of `p4-fusion`. 

Follow up from:
- https://github.com/sourcegraph/sourcegraph/pull/57113
- https://github.com/sourcegraph/sourcegraph/pull/57129

## Test plan
Pulled and tested the p4-fusion version is 1.12.0 in the docker images.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
