### PR TITLE
Set epoch for p4-fusion 1.12

### DIFF
--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -16,7 +16,7 @@ contents:
 
     - coursier@sourcegraph
     - p4cli@sourcegraph
-    - p4-fusion=1.12@sourcegraph
+    - p4-fusion=1.12-r6@sourcegraph
 
 paths:
   - path: /data/repos

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -36,7 +36,7 @@ contents:
     - ctags@sourcegraph
     - coursier@sourcegraph
     - p4cli@sourcegraph
-    - p4-fusion=1.12@sourcegraph
+    - p4-fusion=1.12-r6@sourcegraph
     - s3proxy@sourcegraph
     - grafana@chainguard
 


### PR DESCRIPTION
Previously we didn't set the epoch, this makes sure we are on latest 1.12 for p4-fusion.

## Test plan
Tested the version is correct and p4-fusion-binary and wrapper script are available.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
