### PR TITLE
Backport 57133 to 5.2: wolfi: update server / gitserver base images for p4-fusion revert

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -52,13 +52,13 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:21071210e80868f891570d657c3915d25eb40da9fabad46f4d71e2fe028b6ba9",
+        digest = "sha256:660d9d15fd1a3e31fe60619ed98bb8c28dbbb9dc3dd4158b6301c9aec23b50d2",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:5a567927a3a4723c2b5a4eb3bc3dd31fe09761ef3fd2fab72467a5938fc805e2",
+        digest = "sha256:3a020c29b781ac183aacb5584cf76ba337b1acb12f17fdf1a2666a0daf1374de",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 


### PR DESCRIPTION
This change should be backported as the current version of p4-fusion, 1.13, segfaults under some conditions. See https://github.com/sourcegraph/sourcegraph/pull/57113 for more details.

This will put the right image hashes in place so we can build `gitserver` and `server` with the version 1.12.0 of `p4-fusion`. 

Follow up from:
- https://github.com/sourcegraph/sourcegraph/pull/57113
- https://github.com/sourcegraph/sourcegraph/pull/57129

## Test plan
Pulled and tested the p4-fusion version is 1.12.0 in the docker images.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
