### PR TITLE
JetBrains: migrate from deprecated workspaceRootPath to workspaceRootUri

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -17,6 +17,7 @@ import com.sourcegraph.config.ConfigUtil
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
+import java.net.URI
 import java.nio.file.*
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -66,7 +67,7 @@ class CodyAgent(private val project: Project) : Disposable {
                       ClientInfo(
                           name = "JetBrains",
                           version = ConfigUtil.getPluginVersion(),
-                          workspaceRootPath = ConfigUtil.getWorkspaceRoot(project),
+                          workspaceRootUri = URI("file://${ConfigUtil.getWorkspaceRoot(project)}"),
                           extensionConfiguration = ConfigUtil.getAgentConfiguration(project)))
                   .get()
           logger.info("connected to Cody agent " + info.name)

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientInfo.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientInfo.kt
@@ -1,10 +1,11 @@
 package com.sourcegraph.cody.agent.protocol
 
 import com.sourcegraph.cody.agent.ExtensionConfiguration
+import java.net.URI
 
 data class ClientInfo(
     var name: String,
     var version: String,
-    var workspaceRootPath: String? = null,
+    var workspaceRootUri: URI,
     var extensionConfiguration: ExtensionConfiguration? = null
 )

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -114,13 +114,11 @@ object ConfigUtil {
       CodyApplicationSettings.getInstance().customAutocompleteColor
 
   @JvmStatic
-  fun getWorkspaceRoot(project: Project): String? {
-    return if (project.basePath != null) {
-      project.basePath
-    } else System.getProperty("user.home")
+  fun getWorkspaceRoot(project: Project): String {
     // The base path should only be null for the default project. The agent server assumes that the
     // workspace root is not null, so we have to provide some default value. Feel free to change to
     // something else than the home directory if this is causing problems.
+    return project.basePath ?: System.getProperty("user.home")
   }
 
   @JvmStatic


### PR DESCRIPTION
does what it says on the tin

## Test plan

Tested that agent accepts the uri that we send and it does: `2023-09-28 13:22:47,242 [   4056]   WARN - #c.s.c.a.CodyAgent - Cody Agent: handshake with client 'JetBrains' (version '3.4.0-alpha.1') at workspace root path 'file:///home/noah/Sourcegraph/lsif-kotlin'`