### PR TITLE
JetBrains: set .editorconfig indent size for java + kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_size = 4
 [*.go]
 indent_style = tab
 
-[{*.lua,*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc}]
+[{*.kt,*.java,*.kts,*.lua,*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc}]
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
My intellij wont default to 2 indent without setting this :shrug: 

## Test plan

N/A setting style in .editorconfig