### PR TITLE
Azure OpenAI: Fix autocomplete streaming 

### DIFF
--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -291,7 +291,6 @@ type azure struct {
 
 type openaiChoiceDelta struct {
 	Content string `json:"content"`
-	Text    string `json:"text"`
 }
 
 type openaiChoice struct {

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -108,7 +108,11 @@ func (c *azureCompletionClient) Stream(
 		}
 
 		if len(event.Choices) > 0 {
-			content += event.Choices[0].Delta.Content
+			if feature == types.CompletionsFeatureCode {
+				content += event.Choices[0].Text
+			} else {
+				content += event.Choices[0].Delta.Content
+			}
 			ev := types.CompletionResponse{
 				Completion: content,
 				StopReason: event.Choices[0].FinishReason,
@@ -287,6 +291,7 @@ type azure struct {
 
 type openaiChoiceDelta struct {
 	Content string `json:"content"`
+	Text    string `json:"text"`
 }
 
 type openaiChoice struct {


### PR DESCRIPTION
When using the completions endpoint instead of the chat/completions the streaming data needs to be accumulated from the Text field as there is no delta sent.
## Test plan
`sg start`  with completions configured for azure-openai
use VS Code extension to get autocomplete 
verify autocompletes are returned.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
