### PR TITLE
search jobs: add more tests for query validation

### DIFF
--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -29,6 +29,13 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 		return Exhaustive{}, errors.New("only works for exhaustive search inputs")
 	}
 
+	// This doesn't lead to an error, but we will drop result types other than
+	// "file" which might be surprising to users.
+	types, _ := inputs.Query.StringValues(query.FieldType)
+	if len(types) != 1 || types[0] != "file" {
+		return Exhaustive{}, errors.Errorf("expected \"type:file\" only. Got %v", types)
+	}
+
 	if len(inputs.Plan) != 1 {
 		return Exhaustive{}, errors.Errorf("expected a simple expression (no and/or/etc). Got multiple jobs to run %v", inputs.Plan)
 	}
@@ -37,6 +44,22 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 	term, ok := b.Pattern.(query.Pattern)
 	if !ok {
 		return Exhaustive{}, errors.Errorf("expected a simple expression (no and/or/etc). Got %v", b.Pattern)
+	}
+
+	// no predicates
+	if inputs.Query.Exists(query.FieldRepoHasFile) {
+		return Exhaustive{}, errors.Errorf("repoHasFile is not supported")
+	}
+	if pred, ok := hasPredicates(query.FieldRepo, inputs.Query); ok {
+		return Exhaustive{}, errors.Errorf("repo: predicates are not supported. Got %v", pred)
+	}
+	if pred, ok := hasPredicates(query.FieldFile, inputs.Query); ok {
+		return Exhaustive{}, errors.Errorf("field: predicates are not supported. Got %v", pred)
+	}
+
+	// This is a very weak protection but should be enough to catch simple misuse.
+	if inputs.PatternType == query.SearchTypeRegex && term.Value == ".*" {
+		return Exhaustive{}, errors.Errorf("regex search with .* is not supported")
 	}
 
 	planJob, err := NewFlatJob(inputs, query.Flat{Parameters: b.Parameters, Pattern: &term})
@@ -52,6 +75,17 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 	return Exhaustive{
 		repoPagerJob: repoPagerJob,
 	}, nil
+}
+
+func hasPredicates(field string, q query.Q) (pred string, ok bool) {
+	values, negated := q.StringValues(field)
+	for _, v := range append(values, negated...) {
+		pred, _, ok = query.ScanPredicate(field, []byte(v), query.DefaultPredicateRegistry)
+		if ok {
+			break
+		}
+	}
+	return
 }
 
 func (e Exhaustive) Job(repoRevs *search.RepositoryRevisions) job.Job {

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -61,7 +61,7 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "",
+			Name:  "only pattern",
 			Query: "type:file index:no content",
 			WantPager: autogold.Expect(`
 (REPOPAGER
@@ -85,7 +85,7 @@ func TestNewExhaustive(t *testing.T) {
 `),
 		},
 		{
-			Name:  "",
+			Name:  "regexp",
 			Query: "type:file index:no foo.*bar patterntype:regexp",
 			WantPager: autogold.Expect(`
 (REPOPAGER
@@ -139,7 +139,7 @@ func sPrintSexpMax(j job.Describer) string {
 	return "\n" + printer.SexpVerbose(j, job.VerbosityMax, true) + "\n"
 }
 
-// The queries are validated before the reach exhaustive search, hence we only
+// The queries are validated before they reach exhaustive search, hence we only
 // have to worry about valid queries we don't want to process for now.
 func TestNewExhaustive_negative(t *testing.T) {
 
@@ -164,8 +164,8 @@ func TestNewExhaustive_negative(t *testing.T) {
 	}
 
 	for _, c := range tc {
-		t.Run(c.query, func(t *testing.T) {
-			patternType := query.SearchTypeLiteral
+		t.Run("", func(t *testing.T) {
+			patternType := query.SearchTypeStandard
 			if c.isPatterntypeRegex {
 				patternType = query.SearchTypeRegex
 			}
@@ -183,7 +183,7 @@ func TestNewExhaustive_negative(t *testing.T) {
 			}
 
 			_, err = NewExhaustive(inputs)
-			require.Error(t, err)
+			require.Error(t, err, "failed query: %q", c.query)
 		})
 	}
 }


### PR DESCRIPTION
This improves our test coverage for `NewExhaustive`. The goal is to make sure we won't process unsupported or extremely expensive queries.

## Test plan
CI