### PR TITLE
search jobs: add resetter workers

### DIFF
--- a/enterprise/cmd/worker/internal/search/exhaustive_search.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search.go
@@ -84,3 +84,17 @@ func (h *exhaustiveSearchHandler) Handle(ctx context.Context, logger log.Logger,
 
 	return it.Err()
 }
+
+func newExhaustiveSearchWorkerResetter(
+	observationCtx *observation.Context,
+	workerStore dbworkerstore.Store[*types.ExhaustiveSearchJob],
+) *dbworker.Resetter[*types.ExhaustiveSearchJob] {
+	options := dbworker.ResetterOptions{
+		Name:     "exhaustive_search_worker_resetter",
+		Interval: 1 * time.Minute,
+		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_worker"),
+	}
+
+	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	return resetter
+}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo.go
@@ -94,3 +94,17 @@ func (h *exhaustiveSearchRepoHandler) Handle(ctx context.Context, logger log.Log
 
 	return nil
 }
+
+func newExhaustiveSearchRepoWorkerResetter(
+	observationCtx *observation.Context,
+	workerStore dbworkerstore.Store[*types.ExhaustiveSearchRepoJob],
+) *dbworker.Resetter[*types.ExhaustiveSearchRepoJob] {
+	options := dbworker.ResetterOptions{
+		Name:     "exhaustive_search_repo_worker_resetter",
+		Interval: 1 * time.Minute,
+		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_repo_worker"),
+	}
+
+	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	return resetter
+}

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
@@ -79,4 +80,18 @@ func (h *exhaustiveSearchRepoRevHandler) Handle(ctx context.Context, logger log.
 	}
 
 	return err
+}
+
+func newExhaustiveSearchRepoRevisionWorkerResetter(
+	observationCtx *observation.Context,
+	workerStore dbworkerstore.Store[*types.ExhaustiveSearchRepoRevisionJob],
+) *dbworker.Resetter[*types.ExhaustiveSearchRepoRevisionJob] {
+	options := dbworker.ResetterOptions{
+		Name:     "exhaustive_search_repo_revision_worker_resetter",
+		Interval: 1 * time.Minute,
+		Metrics:  dbworker.NewResetterMetrics(observationCtx, "exhaustive_search_repo_revision_worker"),
+	}
+
+	resetter := dbworker.NewResetter(observationCtx.Logger, workerStore, options)
+	return resetter
 }

--- a/enterprise/cmd/worker/internal/search/job.go
+++ b/enterprise/cmd/worker/internal/search/job.go
@@ -111,6 +111,11 @@ func (j *searchJob) newSearchJobRoutines(
 			newExhaustiveSearchWorker(workCtx, observationCtx, searchWorkerStore, exhaustiveSearchStore, newSearcher, j.config),
 			newExhaustiveSearchRepoWorker(workCtx, observationCtx, repoWorkerStore, exhaustiveSearchStore, newSearcher, j.config),
 			newExhaustiveSearchRepoRevisionWorker(workCtx, observationCtx, revWorkerStore, exhaustiveSearchStore, newSearcher, uploadStore, j.config),
+
+			// resetters
+			newExhaustiveSearchWorkerResetter(observationCtx, searchWorkerStore),
+			newExhaustiveSearchRepoWorkerResetter(observationCtx, repoWorkerStore),
+			newExhaustiveSearchRepoRevisionWorkerResetter(observationCtx, revWorkerStore),
 		}
 	})
 

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -19,6 +19,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+const maxNumResets = 5
+const maxNumRetries = 3
+
 var exhaustiveSearchJobWorkerOpts = dbworkerstore.Options[*types.ExhaustiveSearchJob]{
 	Name:              "exhaustive_search_worker_store",
 	TableName:         "exhaustive_search_jobs",
@@ -29,10 +32,10 @@ var exhaustiveSearchJobWorkerOpts = dbworkerstore.Options[*types.ExhaustiveSearc
 	OrderByExpression: sqlf.Sprintf("exhaustive_search_jobs.state = 'errored', exhaustive_search_jobs.updated_at DESC"),
 
 	StalledMaxAge: 60 * time.Second,
-	MaxNumResets:  0,
+	MaxNumResets:  maxNumResets,
 
 	RetryAfter:    5 * time.Second,
-	MaxNumRetries: 0,
+	MaxNumRetries: maxNumRetries,
 }
 
 // NewExhaustiveSearchJobWorkerStore returns a dbworkerstore.Store that wraps the "exhaustive_search_jobs" table.

--- a/internal/search/exhaustive/store/exhaustive_search_repo_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_jobs.go
@@ -24,10 +24,10 @@ var repoSearchJobWorkerOpts = dbworkerstore.Options[*types.ExhaustiveSearchRepoJ
 	OrderByExpression: sqlf.Sprintf("exhaustive_search_repo_jobs.state = 'errored', exhaustive_search_repo_jobs.updated_at DESC"),
 
 	StalledMaxAge: 60 * time.Second,
-	MaxNumResets:  0,
+	MaxNumResets:  maxNumResets,
 
 	RetryAfter:    5 * time.Second,
-	MaxNumRetries: 0,
+	MaxNumRetries: maxNumRetries,
 }
 
 // NewRepoSearchJobWorkerStore returns a dbworkerstore.Store that wraps the "exhaustive_search_repo_jobs" table.

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs.go
@@ -24,10 +24,10 @@ var revSearchJobWorkerOpts = dbworkerstore.Options[*types.ExhaustiveSearchRepoRe
 	OrderByExpression: sqlf.Sprintf("exhaustive_search_repo_revision_jobs.state = 'errored', exhaustive_search_repo_revision_jobs.updated_at DESC"),
 
 	StalledMaxAge: 60 * time.Second,
-	MaxNumResets:  0,
+	MaxNumResets:  maxNumResets,
 
 	RetryAfter:    5 * time.Second,
-	MaxNumRetries: 0,
+	MaxNumRetries: maxNumRetries,
 }
 
 // NewRevSearchJobWorkerStore returns a dbworkerstore.Store that wraps the "exhaustive_search_repo_revision_jobs" table.

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -216,7 +216,7 @@ type Options[T workerutil.Record] struct {
 
 	// MaxNumResets is the maximum number of times a record can be implicitly reset back to the queued
 	// state (via `ResetStalled`). If a record's reset attempts counter reaches this threshold, it will
-	// be moved into the errored state rather than queued on its next reset to prevent an infinite retry
+	// be moved into the "failed" state rather than queued on its next reset to prevent an infinite retry
 	// cycle of the same input.
 	MaxNumResets int
 


### PR DESCRIPTION
This adds a resetter for each of our 3 search job workers and enables resets and retries.

Test plan:
manual testing
- I set an old, completed job to "processing" and verified that the resetter reset it to "failed".
- I set a recent, completed job to "processing" and verified that the resetter reset it to "queued".