### PR TITLE
auth: return 401 for invalid auth headers on DotCom

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/audit"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -56,9 +57,9 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 			var err error
 			token, sudoUser, err = authz.ParseAuthorizationHeader(logger, r, headerValue)
 			if err != nil {
-				if authz.IsUnrecognizedScheme(err) {
+				if !envvar.SourcegraphDotComMode() && authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.
-					// 🚨 SECURITY: md5sum the authorization header value so we redact it
+					// 🚨 SECURITY: sha256 the authorization header value so we redact it
 					// while still retaining the ability to link it back to a token, assuming
 					// the logs reader has the value in clear.
 					var redactedValue string


### PR DESCRIPTION
In our current setup, when a request with incorrect authentication headers reaches DotCom, it's mistakenly treated with a 429 status code due to how we handle rate limits for anonymous requests. DotCom mode-specific behaviour was identified: the system keeps forwarding the wrong header until it reaches the [middleware that checks if we allow anonymous access](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/auth/non_public.go?L23-37).
This middleware passes the check as it's configured to identify if we are operating in [DotCom mode](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/conf/auth.go?L28-33).

I propose to check if we are in DotCom mode when we have an invalid header, to prevent us from treating users that supply (invalid) authorization headers as anonymous users. 

See Slack for context: https://sourcegraph.slack.com/archives/C05Q75F9ES3/p1695786335453289.

## Test plan
Tested locally with an instance in DotCom mode.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 

They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
