### PR TITLE
Qdrant: make migrateToQdrant a mutation

### DIFF
--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -88,11 +88,6 @@ extend type Query {
         state: String
     ): RepoEmbeddingJobsConnection!
 
-    """
-    TEMPORARY: creates a new embedding job for all completed embeddings
-    jobs so that they will be moved from blobstore to qdrant
-    """
-    migrateToQdrant: EmptyResponse!
 }
 
 extend type Mutation {
@@ -105,6 +100,11 @@ extend type Mutation {
     Experimental: Cancels the embedding job with the given ID. The job must exist and be in either 'processing' or 'queued' state.
     """
     cancelRepoEmbeddingJob(job: ID!): EmptyResponse!
+    """
+    TEMPORARY: creates a new embedding job for all completed embeddings
+    jobs so that they will be moved from blobstore to qdrant
+    """
+    migrateToQdrant: EmptyResponse!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -87,7 +87,6 @@ extend type Query {
         """
         state: String
     ): RepoEmbeddingJobsConnection!
-
 }
 
 extend type Mutation {


### PR DESCRIPTION
I accidentally put `migrateToQdrant` in the `Query` block rather than the `Mutation` block. Whoops.

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
