### PR TITLE
populate monitors_enabled_unique_users and last_run_errored

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1837,12 +1837,14 @@ type CodeMonitoringUsageStatistics struct {
 	WebhookActionsEnabledUniqueUsers              *int32
 	MonitorsEnabled                               *int32
 	MonitorsEnabledUniqueUsers                    *int32
-	MonitorsEnabledLastRunErrored                 *int32
-	ReposMonitored                                *int32
-	TriggerRuns                                   *int32
-	TriggerRunsErrored                            *int32
-	P50TriggerRunTimeSeconds                      *float32
-	P90TriggerRunTimeSeconds                      *float32
+	// (TODO @jasonhawkharris ) Currently, MonitorsEnabledLastRunErrored is unpopulated
+	// It will require adjusting the query to select a row inside of a group
+	MonitorsEnabledLastRunErrored *int32
+	ReposMonitored                *int32
+	TriggerRuns                   *int32
+	TriggerRunsErrored            *int32
+	P50TriggerRunTimeSeconds      *float32
+	P90TriggerRunTimeSeconds      *float32
 }
 
 type NotebooksUsageStatistics struct {

--- a/internal/usagestats/code_monitoring.go
+++ b/internal/usagestats/code_monitoring.go
@@ -47,7 +47,6 @@ func GetCodeMonitoringUsageStatistics(ctx context.Context, db database.DB) (*typ
 		&stats.P90TriggerRunTimeSeconds,
 		&stats.MonitorsEnabled,
 		&stats.MonitorsEnabledUniqueUsers,
-		&stats.MonitorsEnabledLastRunErrored,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/code_monitoring.go
+++ b/internal/usagestats/code_monitoring.go
@@ -46,6 +46,8 @@ func GetCodeMonitoringUsageStatistics(ctx context.Context, db database.DB) (*typ
 		&stats.P50TriggerRunTimeSeconds,
 		&stats.P90TriggerRunTimeSeconds,
 		&stats.MonitorsEnabled,
+		&stats.MonitorsEnabledUniqueUsers,
+		&stats.MonitorsEnabledLastRunErrored,
 	); err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/code_monitoring_test.go
+++ b/internal/usagestats/code_monitoring_test.go
@@ -251,6 +251,8 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 		P50TriggerRunTimeSeconds:                      ptr(float32(3)),
 		P90TriggerRunTimeSeconds:                      ptr(float32(6)),
 		MonitorsEnabled:                               ptr(int32(8)),
+		MonitorsEnabledUniqueUsers:                    ptr(int32(8)),
+		MonitorsEnabledLastRunErrored:                 ptr(int32(8)),
 	}
 	require.Equal(t, want, have)
 }

--- a/internal/usagestats/code_monitoring_test.go
+++ b/internal/usagestats/code_monitoring_test.go
@@ -252,7 +252,6 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 		P90TriggerRunTimeSeconds:                      ptr(float32(6)),
 		MonitorsEnabled:                               ptr(int32(8)),
 		MonitorsEnabledUniqueUsers:                    ptr(int32(8)),
-		MonitorsEnabledLastRunErrored:                 ptr(int32(8)),
 	}
 	require.Equal(t, want, have)
 }

--- a/internal/usagestats/code_monitoring_usage_stats.sql
+++ b/internal/usagestats/code_monitoring_usage_stats.sql
@@ -126,7 +126,15 @@ SELECT
     -- monitors_enabled
     COALESCE(slack_actions.slack_actions_enabled, 0) +
     COALESCE(email_actions.email_actions_enabled, 0) +
-    COALESCE(webhook_actions.webhook_actions_enabled, 0) AS monitors_enabled
+    COALESCE(webhook_actions.webhook_actions_enabled, 0) AS monitors_enabled,
+    -- monitors_enabled_unique_users
+    COALESCE(slack_actions.slack_actions_enabled_unique_users, 0) +
+    COALESCE(email_actions.email_actions_enabled_unique_users, 0) +
+    COALESCE(webhook_actions.webhook_actions_enabled_unique_users, 0) AS monitors_enabled_unique_users,
+    -- monitors_enabled_last_run_errored
+    COALESCE(action_jobs.slack_actions_errored, 0) +
+    COALESCE(action_jobs.email_actions_errored, 0) +
+    COALESCE(action_jobs.webhook_actions_errored, 0) AS monitors_enabled_last_run_errored
 FROM
     event_log_stats,
     email_actions,

--- a/internal/usagestats/code_monitoring_usage_stats.sql
+++ b/internal/usagestats/code_monitoring_usage_stats.sql
@@ -130,11 +130,7 @@ SELECT
     -- monitors_enabled_unique_users
     COALESCE(slack_actions.slack_actions_enabled_unique_users, 0) +
     COALESCE(email_actions.email_actions_enabled_unique_users, 0) +
-    COALESCE(webhook_actions.webhook_actions_enabled_unique_users, 0) AS monitors_enabled_unique_users,
-    -- monitors_enabled_last_run_errored
-    COALESCE(action_jobs.slack_actions_errored, 0) +
-    COALESCE(action_jobs.email_actions_errored, 0) +
-    COALESCE(action_jobs.webhook_actions_errored, 0) AS monitors_enabled_last_run_errored
+    COALESCE(webhook_actions.webhook_actions_enabled_unique_users, 0) AS monitors_enabled_unique_users
 FROM
     event_log_stats,
     email_actions,


### PR DESCRIPTION
Before, `monitors_enabled_unique_users` and `monitors_enabled_last_run_errored` returned null values every time. This commit makes it so that they populate with the correct data. 

## Test plan
1. Adjust unit tests to account for newly populated monitor fields. 
2. Shipped with all tests passing. 