### PR TITLE
Removing duplicate line about forks in "GitHub code search vs. Source…

### DIFF
--- a/doc/getting-started/github-vs-sourcegraph.md
+++ b/doc/getting-started/github-vs-sourcegraph.md
@@ -120,7 +120,7 @@ GitHub allows you to search indexed code, but not all code is indexed. GitHub’
 
 With GitHub, only the default **branch** is searchable (though GitHub is planning to support branch search in the future). 
 
-**Forks** are included in the index, but they are subject to the same limitations as other repositories, so not all forks are indexed.
+**Forks** are included in the index, but they are subject to the same limitations as other repositories, so not all forks are indexed. You may need to include the fork filter to retrieve results for the fork repos, but an admin can adjust global settings to automatically include forks in search query results. 
 
 GitHub code search supports searching across issues, pull requests, and discussions. In addition to searching your private code, GitHub has indexed over 7 million public GitHub repositories which are also searchable.
 
@@ -133,8 +133,6 @@ Sourcegraph allows you to search indexed and [unindexed](https://docs.sourcegrap
 * Files other than UTF-8 are excluded 
 
 With Sourcegraph, typically, the latest code on the default **branch** of each repository is indexed (usually the master or main), but Sourcegraph can also index other non-default branches, such as long-running branches like release branches. If you’re searching outside of indexed branches, you can use unindexed search. You should expect slightly slower results when searching unindexed code.  
-
-**Forks** are included in the index, but they are subject to the same limitations as other repositories, so not all forks are indexed. You may need to include the fork filter to retrieve results for the fork repos, but an admin can adjust global settings to automatically include forks in search query results. 
 
 In addition to searching your organization’s private code, you can use Sourcegraph.com to search across 2.8 million public repositories from multiple code hosts. 
 


### PR DESCRIPTION
…graph"

There was a duplicate line on the page, removed the second one.



## Test plan
Previewed Locally

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@morgangauth-patch-1)