### PR TITLE
search: exhaustive handlers validate input before writing CSV

### DIFF
--- a/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/search/exhaustive/store",
         "//lib/errors",
         "@com_github_gorilla_mux//:mux",
+        "@com_github_sourcegraph_log//:log",
     ],
 )
 

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -3,12 +3,14 @@ package httpapi
 import (
 	"database/sql"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
 
+	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
@@ -16,11 +18,13 @@ import (
 )
 
 // search-jobs_<job-id>_2020-07-01_150405
-func filename(jobID int) string {
+func filenamePrefix(jobID int) string {
 	return fmt.Sprintf("search-jobs_%d_%s", jobID, time.Now().Format("2006-01-02_150405"))
 }
 
-func ServeSearchJobDownload(svc *service.Service) http.HandlerFunc {
+func ServeSearchJobDownload(logger log.Logger, svc *service.Service) http.HandlerFunc {
+	logger = logger.With(log.String("handler", "ServeSearchJobDownload"))
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		jobIDStr := mux.Vars(r)["id"]
 		jobID, err := strconv.Atoi(jobIDStr)
@@ -29,21 +33,20 @@ func ServeSearchJobDownload(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.csv\"", filename(jobID)))
-
-		n, err := svc.WriteSearchJobCSV(r.Context(), w, int64(jobID))
+		csvWriterTo, err := svc.GetSearchJobCSVWriterTo(r.Context(), int64(jobID))
 		if err != nil {
 			httpError(w, err)
 			return
 		}
-		if n == 0 {
-			w.WriteHeader(http.StatusNoContent)
-		}
+
+		filename := filenamePrefix(jobID) + ".csv"
+		writeCSV(logger.With(log.Int("jobID", jobID)), w, filename, csvWriterTo)
 	}
 }
 
-func ServeSearchJobLogs(svc *service.Service) http.HandlerFunc {
+func ServeSearchJobLogs(logger log.Logger, svc *service.Service) http.HandlerFunc {
+	logger = logger.With(log.String("handler", "ServeSearchJobLogs"))
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		jobIDStr := mux.Vars(r)["id"]
 		jobID, err := strconv.Atoi(jobIDStr)
@@ -52,14 +55,24 @@ func ServeSearchJobLogs(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "text/csv")
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.log\"", filename(jobID)))
-
-		err = svc.WriteSearchJobLogs(r.Context(), w, int64(jobID))
+		csvWriterTo, err := svc.GetSearchJobLogsWriterTo(r.Context(), int64(jobID))
 		if err != nil {
 			httpError(w, err)
+			return
 		}
 
+		filename := filenamePrefix(jobID) + ".log"
+		writeCSV(logger.With(log.Int("jobID", jobID)), w, filename, csvWriterTo)
+	}
+}
+
+func writeCSV(logger log.Logger, w http.ResponseWriter, filenameNoQuotes string, writerTo io.WriterTo) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filenameNoQuotes))
+	w.WriteHeader(200)
+	n, err := writerTo.WriteTo(w)
+	if err != nil {
+		logger.Warn("failed while writing search job csv response", log.String("filename", filenameNoQuotes), log.Int64("bytesWritten", n), log.Error(err))
 	}
 }
 

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -61,7 +61,7 @@ func ServeSearchJobLogs(logger log.Logger, svc *service.Service) http.HandlerFun
 			return
 		}
 
-		filename := filenamePrefix(jobID) + ".log"
+		filename := filenamePrefix(jobID) + ".log.csv"
 		writeCSV(logger.With(log.Int("jobID", jobID)), w, filename, csvWriterTo)
 	}
 }

--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,7 @@ func TestServeSearchJobDownload(t *testing.T) {
 	svc := service.New(observationCtx, s, mockUploadStore)
 
 	router := mux.NewRouter()
-	router.HandleFunc("/{id}.csv", ServeSearchJobDownload(svc))
+	router.HandleFunc("/{id}.csv", ServeSearchJobDownload(logger, svc))
 
 	// no job
 	{
@@ -66,9 +67,11 @@ func TestServeSearchJobDownload(t *testing.T) {
 
 		req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: userID}))
 		w := httptest.NewRecorder()
+		w.Body = &bytes.Buffer{}
 		router.ServeHTTP(w, req)
 
-		require.Equal(t, http.StatusNoContent, w.Code)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "", w.Body.String())
 	}
 
 	// wrong user

--- a/cmd/frontend/internal/search/init.go
+++ b/cmd/frontend/internal/search/init.go
@@ -28,6 +28,7 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
+	logger := observationCtx.Logger
 	store := store.New(db, observationCtx)
 
 	uploadStore, err := uploadstore.New(ctx, observationCtx, uploadstore.ConfigInst)
@@ -37,9 +38,9 @@ func Init(
 
 	svc := service.New(observationCtx, store, uploadStore)
 
-	enterpriseServices.SearchJobsResolver = resolvers.New(observationCtx.Logger, db, svc)
-	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(svc)
-	enterpriseServices.SearchJobsLogsHandler = httpapi.ServeSearchJobLogs(svc)
+	enterpriseServices.SearchJobsResolver = resolvers.New(logger, db, svc)
+	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(logger, svc)
+	enterpriseServices.SearchJobsLogsHandler = httpapi.ServeSearchJobLogs(logger, svc)
 
 	return nil
 }


### PR DESCRIPTION
This commit makes it such that both CSV handlers for exhaustive search validate the job ID before setting any CSV headers or writing data. This makes it possible to distingiush between errors that happen before we write out CSVs and during.

Another benefit is we now call WriteHeader, which avoids long delays between clicking the download button and the download starting. Before until go decides to flush there may be several seconds before the headers are sent.

To achieve this change we adjust the service interface to instead return an io.WriterTo. A more generic API would return an io.Reader (involving the use of an io.Pipe). However, we can specialize to io.WriterTo since that is exactly the interface we want to use (and is an underlying optimization used by io.Copy)

Additionally we add instrumentation to the logs service as well as making the instrumentation able to distingiush between the fast bits (speaking to our store) and the slow bits (writing to client).

Test Plan: I have a lot of confidence in our go tests to catch bugs here. However, we do not have as rock solid automated tests for these handlers. So did manual testing on the happy case. I am confident enough to wait until a few commits later to do more intensive manual tests.

Fixes https://github.com/sourcegraph/sourcegraph/issues/57167