### PR TITLE
search jobs: check query for explicit type filters

### DIFF
--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
@@ -36,6 +36,14 @@ describe('exhaustive search validation', () => {
             expect(validateQueryForExhaustiveSearch('insights and batch-changes').length).toStrictEqual(1)
         })
 
+        test('[other than type:file]', () => {
+            expect(validateQueryForExhaustiveSearch('foo type:file type:diff').length).toStrictEqual(1)
+            expect(validateQueryForExhaustiveSearch('foo type:diff').length).toStrictEqual(1)
+            expect(validateQueryForExhaustiveSearch('foo type:file type:file')).toStrictEqual([])
+            expect(validateQueryForExhaustiveSearch('foo type:file')).toStrictEqual([])
+            expect(validateQueryForExhaustiveSearch('foo')).toStrictEqual([])
+        })
+
         test('[all cases combined]', () => {
             expect(
                 validateQueryForExhaustiveSearch(

--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
@@ -44,6 +44,18 @@ export function validateQueryForExhaustiveSearch(query: string): ValidationError
             })
         }
 
+        const hasTypeFiltersOtherThanFile: boolean =
+            filters
+                .filter(filter => resolveFilter(filter.field.value)?.type === FilterType.type && filter.value)
+                .some(filter => filter.value?.value !== 'file')
+
+        if (hasTypeFiltersOtherThanFile) {
+            validationErrors.push({
+                type: ValidationErrorType.INVALID_QUERY,
+                reason: 'only type:file is supported',
+            })
+        }
+
         const hasRegexpPattern = filters.some(
             filter =>
                 resolveFilter(filter.field.value)?.type === FilterType.patterntype && filter.value?.value === 'regexp'

--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
@@ -44,10 +44,9 @@ export function validateQueryForExhaustiveSearch(query: string): ValidationError
             })
         }
 
-        const hasTypeFiltersOtherThanFile: boolean =
-            filters
-                .filter(filter => resolveFilter(filter.field.value)?.type === FilterType.type && filter.value)
-                .some(filter => filter.value?.value !== 'file')
+        const hasTypeFiltersOtherThanFile: boolean = filters
+            .filter(filter => resolveFilter(filter.field.value)?.type === FilterType.type && filter.value)
+            .some(filter => filter.value?.value !== 'file')
 
         if (hasTypeFiltersOtherThanFile) {
             validationErrors.push({


### PR DESCRIPTION
The backend only supports queries with `type:file` filters. Here I add a check to the client, so that users cannot create search jobs for queries with other `type:` filters.

Test plan:
updated unit test
