### PR TITLE
Update docker dind image to 24.0.6 to fix vulns

### DIFF
--- a/docker-images/dind/Dockerfile
+++ b/docker-images/dind/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:23.0.6-dind@sha256:eb9f1d80fbe98f6343fd432d8f89db19d5de324096498e67886c4a984f6ac670
+FROM docker:24.0.6-dind@sha256:154bd903f793987eb2926aa9bb0f11e2596bec9e8a338c1695d4615d52b4ff91
 
 RUN rm -f /usr/libexec/docker/cli-plugins/docker-compose && \
     rm -f /usr/libexec/docker/cli-plugins/docker-buildx

--- a/docker-images/dind/Dockerfile
+++ b/docker-images/dind/Dockerfile
@@ -3,8 +3,6 @@ FROM docker:24.0.6-dind@sha256:154bd903f793987eb2926aa9bb0f11e2596bec9e8a338c169
 RUN rm -f /usr/libexec/docker/cli-plugins/docker-compose && \
     rm -f /usr/libexec/docker/cli-plugins/docker-buildx
 
-RUN apk update && apk add --no-cache 'e2fsprogs>=1.46.6-r0' 'libcom_err>=1.46.6-r0' 'e2fsprogs-libs>=1.46.6-r0' 'libcrypto3>=3.0.8-r3' 'libssl3>=3.0.8-r3' 'openssl>=3.0.8-r3'
-
 ARG COMMIT_SHA="unknown"
 ARG DATE="unknown"
 ARG VERSION="unknown"


### PR DESCRIPTION
Update docker dind image to 24.0.6 to patch [CVE-2022-48174](https://access.redhat.com/security/cve/CVE-2022-48174)

## Test plan

- Scan for vulns in updated image
- Confirm new image is compatible

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
