### PR TITLE
search: ignore empty repositories in exhaustive search

### DIFF
--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/api",
         "//internal/conf",
         "//internal/database",
+        "//internal/gitserver/gitdomain",
         "//internal/metrics",
         "//internal/observation",
         "//internal/search",


### PR DESCRIPTION
When searching HEAD we don't validate the revision exists until search time. This means for empty repositories it is possible to attempt to search them, leading to a revision not found error in the logs.

Non-exhaustive search would present an error as an alert. But for exhaustive we work around this by just not writing any CSV and treating the job as success. To build trust we likely need to think how to communicate empty repos in the logs, but for now this is a relatively easy thing to trigger so this is good enough for EAP.

Test Plan: updated tests to simulate an empty repo

Fixes https://github.com/sourcegraph/sourcegraph/issues/57179
