### PR TITLE
search: validate query before creating exhaustive job

### DIFF
--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -35,7 +35,7 @@ func TestServeSearchJobDownload(t *testing.T) {
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	bs := basestore.NewWithHandle(db.Handle())
 	s := store.New(db, observation.TestContextTB(t))
-	svc := service.New(observationCtx, s, mockUploadStore)
+	svc := service.New(observationCtx, s, mockUploadStore, service.NewSearcherFake())
 
 	router := mux.NewRouter()
 	router.HandleFunc("/{id}.csv", ServeSearchJobDownload(logger, svc))
@@ -59,7 +59,7 @@ func TestServeSearchJobDownload(t *testing.T) {
 		userCtx := actor.WithActor(context.Background(), &actor.Actor{
 			UID: userID,
 		})
-		_, err = svc.CreateSearchJob(userCtx, "foo")
+		_, err = svc.CreateSearchJob(userCtx, "1@rev1")
 		require.NoError(t, err)
 
 		req, err := http.NewRequest(http.MethodGet, "/1.csv", nil)

--- a/cmd/frontend/internal/search/init.go
+++ b/cmd/frontend/internal/search/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/search/client"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	uploadstore "github.com/sourcegraph/sourcegraph/internal/search/exhaustive/uploadstore"
@@ -36,7 +37,10 @@ func Init(
 		return err
 	}
 
-	svc := service.New(observationCtx, store, uploadStore)
+	searchClient := client.New(logger, db)
+	newSearcher := service.FromSearchClient(searchClient)
+
+	svc := service.New(observationCtx, store, uploadStore, newSearcher)
 
 	enterpriseServices.SearchJobsResolver = resolvers.New(logger, db, svc)
 	enterpriseServices.SearchJobsDataExportHandler = httpapi.ServeSearchJobDownload(logger, svc)

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -38,7 +38,7 @@ func TestExhaustiveSearch(t *testing.T) {
 	mockUploadStore, bucket := newMockUploadStore(t)
 	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	s := store.New(db, observation.TestContextTB(t))
-	svc := service.New(observationCtx, s, mockUploadStore)
+	svc := service.New(observationCtx, s, mockUploadStore, service.NewSearcherFake())
 
 	userID := insertRow(t, s.Store, "users", "username", "alice")
 	userBadID := insertRow(t, s.Store, "users", "username", "mallory")


### PR DESCRIPTION
Right now we don't have a good way to give feedback if a worker fails due to the query not being passed. Right now we validate in the frontend, but the validation isn't always aligned so it is possible to hit this path. This commits adds a step in the job creation service which first sees if the query parses.

Test Plan: go test should be sufficient.

Fixes https://github.com/sourcegraph/sourcegraph/issues/57181
