### PR TITLE
JetBrains: validate git url in codebase selection asynchronously without blocking the EDT

### DIFF
--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -1,43 +1,95 @@
 package com.sourcegraph.cody.auth.ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task.Backgroundable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.DocumentAdapter
 import com.intellij.ui.components.fields.ExtendableTextField
 import com.intellij.ui.dsl.builder.panel
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.protocol.GetRepoID
+import com.sourcegraph.cody.ui.LoadingLayerUI
 import java.awt.event.ActionEvent
 import java.util.concurrent.TimeUnit
-import javax.swing.*
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.AbstractAction
+import javax.swing.JComponent
+import javax.swing.JLayer
+import javax.swing.event.DocumentEvent
 
 class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Context Selection") {
   val logger = logger<EditCodebaseContextAction>()
+  private val currentIndicator: AtomicReference<ProgressIndicator> = AtomicReference()
 
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
     val gitURL =
         ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+    val loadingLayerUI = LoadingLayerUI()
+    val layeredGitURL = JLayer(gitURL, loadingLayerUI)
 
     init {
       init()
       title = "Context Selection"
       setValidationDelay(1000)
+
+      gitURL.document.addDocumentListener(
+          object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) {
+              isOKActionEnabled = false
+              validateInput()
+            }
+          })
     }
 
-    override fun doValidate(): ValidationInfo? {
+    private fun validateInput() {
       val repoName = gitURL.text
-      if (repoName.isNotEmpty()) {
-        try {
-          val server = CodyAgent.getInitializedServer(project).get(1, TimeUnit.SECONDS)
-          server?.getRepoId(GetRepoID(repoName))?.get(4, TimeUnit.SECONDS)
-              ?: return ValidationInfo("Repository $repoName does not exist", gitURL)
-        } catch (e: Exception) {
-          logger.warn("failed to validate git url", e)
-          return null
-        }
-      }
-      return null
+      currentIndicator.get()?.cancel()
+
+      ProgressManager.getInstance()
+          .runProcessWithProgressAsynchronously(
+              object : Backgroundable(project, "Validating git url") {
+                override fun run(indicator: ProgressIndicator) {
+                  currentIndicator.set(indicator)
+                  if (indicator.isCanceled) {
+                    return
+                  }
+                  try {
+                    loadingLayerUI.startLoading()
+                    val server = CodyAgent.getInitializedServer(project).get(1, TimeUnit.SECONDS)
+                    val isRepoIdValid =
+                        server?.getRepoId(GetRepoID(repoName))?.get(4, TimeUnit.SECONDS) != null
+                    setOKButtonIcon(null)
+                    loadingLayerUI.stopLoading()
+                    ApplicationManager.getApplication().invokeLater {
+                      if (!indicator.isCanceled) {
+                        if (isRepoIdValid) {
+                          isOKActionEnabled = true
+                          setErrorText(null, gitURL)
+                        } else {
+                          isOKActionEnabled = false
+                          setErrorText("Repository $repoName does not exist", gitURL)
+                        }
+                      }
+                    }
+                  } catch (e: Exception) {
+                    if (!indicator.isCanceled) {
+                      ApplicationManager.getApplication().invokeLater {
+                        isOKActionEnabled = false
+                        setErrorText("Failed to validate git url", gitURL)
+                      }
+                    }
+                    logger.warn("Failed to validate git url", e)
+                  } finally {
+                    loadingLayerUI.stopLoading()
+                  }
+                }
+              },
+              EmptyProgressIndicator())
     }
 
     override fun doOKAction() {
@@ -49,7 +101,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
       return panel {
         row {
               label("Git URL:")
-              cell(gitURL)
+              cell(layeredGitURL)
             }
             .rowComment("Example: github.com/sourcegraph/cody")
         row { text("The URL will be used to retrieve the code context from the Cody API.") }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/LoadingLayerUI.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/ui/LoadingLayerUI.kt
@@ -1,0 +1,31 @@
+package com.sourcegraph.cody.ui
+
+import com.intellij.ui.AnimatedIcon
+import com.intellij.ui.components.fields.ExtendableTextField
+import java.awt.Graphics
+import javax.swing.JComponent
+import javax.swing.JLayer
+import javax.swing.plaf.LayerUI
+
+class LoadingLayerUI : LayerUI<ExtendableTextField>() {
+
+  private var isLoading = false
+  private val icon: AnimatedIcon = AnimatedIcon.Default.INSTANCE
+
+  fun startLoading() {
+    isLoading = true
+  }
+
+  fun stopLoading() {
+    isLoading = false
+  }
+
+  override fun paint(g: Graphics, c: JComponent) {
+    super.paint(g, c)
+    if (isLoading && c is JLayer<*>) {
+      val x = c.getWidth() - icon.iconWidth - 5
+      val y = (c.getHeight() - icon.iconHeight) / 2
+      icon.paintIcon(c, g, x, y)
+    }
+  }
+}


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/56949

This PR fixes the issue that when changing the codebase git url the EDT thread was blocked on every validation. Now the EDT thread is not blocked and user can easily edit the input field while validation happens in background. We also display loading icon in the input field to indicate that validation is in progress

https://github.com/sourcegraph/sourcegraph/assets/7345368/2f121247-c92f-4c8c-8782-37031259cb70

## Test plan
- Edit codebase url and see that validation works and it doesn't block the EDT thread

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
