### PR TITLE
search jobs: check feature flag in CreateSearchJob

### DIFF
--- a/cmd/frontend/internal/search/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/search/httpapi/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     tags = ["requires-network"],
     deps = [
         "//internal/actor",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbtest",
@@ -31,6 +32,7 @@ go_test(
         "//internal/search/exhaustive/store",
         "//internal/uploadstore/mocks",
         "//lib/iterator",
+        "//schema",
         "@com_github_gorilla_mux//:mux",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_stretchr_testify//require",

--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 func TestServeSearchJobDownload(t *testing.T) {
-	observationCtx := observation.TestContextTB(t)
-	logger := observationCtx.Logger
-
 	enabled := true
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
 			ExperimentalFeatures: &schema.ExperimentalFeatures{SearchJobs: &enabled}}})
 	defer conf.Mock(nil)
+
+	observationCtx := observation.TestContextTB(t)
+	logger := observationCtx.Logger
 
 	mockUploadStore := mocks.NewMockStore()
 	mockUploadStore.ListFunc.SetDefaultHook(

--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -20,11 +21,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/lib/iterator"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestServeSearchJobDownload(t *testing.T) {
 	observationCtx := observation.TestContextTB(t)
 	logger := observationCtx.Logger
+
+	enabled := true
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{SearchJobs: &enabled}}})
+	defer conf.Mock(nil)
 
 	mockUploadStore := mocks.NewMockStore()
 	mockUploadStore.ListFunc.SetDefaultHook(

--- a/enterprise/cmd/worker/internal/search/BUILD.bazel
+++ b/enterprise/cmd/worker/internal/search/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     deps = [
         "//internal/actor",
         "//internal/auth",
+        "//internal/conf",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbtest",
@@ -53,6 +54,7 @@ go_test(
         "//internal/search/exhaustive/types",
         "//internal/uploadstore/mocks",
         "//lib/iterator",
+        "//schema",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_stretchr_testify//require",
     ],

--- a/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/enterprise/cmd/worker/internal/search/exhaustive_search_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -25,11 +26,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/types"
 	"github.com/sourcegraph/sourcegraph/internal/uploadstore/mocks"
 	"github.com/sourcegraph/sourcegraph/lib/iterator"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestExhaustiveSearch(t *testing.T) {
 	// This test exercises the full worker infra from the time a search job is
 	// created until it is done.
+
+	enabled := true
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{SearchJobs: &enabled}}})
+	defer conf.Mock(nil)
 
 	require := require.New(t)
 	observationCtx := observation.TestContextTB(t)


### PR DESCRIPTION
This checks `ExperimentalFeatures.SearchJobs` before kicking off a search job.

Test plan:
I unset `experimentalFeatures.searchJobs` locally and verified that the GraphQL API returns an error.

![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/3824a4ea-c3b4-4df1-bb84-ef5122caed4b)
