### PR TITLE
always enable applySearchQuerySuggestionOnEnter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - indexed-search has removed the deprecated environment variable ZOEKT_ENABLE_LAZY_DOC_SECTIONS [zoekt#620](https://github.com/sourcegraph/zoekt/pull/620)
 - The federation feature that could redirect users from their own Sourcegraph instance to public repositories on Sourcegraph.com has been removed. It allowed users to open a repository URL on their own Sourcegraph instance and, if the repository wasn't found on that instance, the user would be redirect to the repository on Sourcegraph.com, where it was possibly found. The feature has been broken for over a year though and we don't know that it was used. If you want to use it, please open a feature-request issue and tag the `@sourcegraph/source` team. [#55161](https://github.com/sourcegraph/sourcegraph/pull/55161)
+- The `applySearchQuerySuggestionOnEnter` experimental feature flag in user settings was removed, and this behavior is now always enabled. Previously, this behavior was on by default, but it was possible to disable it.
 
 ## 5.1.9
 

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -44,14 +44,6 @@ export interface CodeMirrorQueryInputFacadeProps extends QueryInputProps {
     }
 
     /**
-     * If set suggestions can be applied by pressing enter. In the past we
-     * didn't enable this behavior because it interfered with loading
-     * suggestions asynchronously, but CodeMirror allows us to disable selecting
-     * a suggestion by default. This is currently an experimental feature.
-     */
-    applySuggestionsOnEnter?: boolean
-
-    /**
      * When provided the query input will allow the user to "cycle" through the
      * serach history by pressing arrow up/down when the input is empty.
      */
@@ -95,8 +87,6 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
     ariaInvalid,
     ariaBusy,
     tabIndex = 0,
-    // CodeMirror implementation specific options
-    applySuggestionsOnEnter = false,
     searchHistory,
     onSelectSearchFromHistory,
     // Used by the VSCode extension (which doesn't use this component directly,
@@ -129,9 +119,8 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
                     fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpec)),
                 isSourcegraphDotCom,
                 navigate,
-                applyOnEnter: applySuggestionsOnEnter,
             }),
-        [isSourcegraphDotCom, navigate, applySuggestionsOnEnter, fetchStreamSuggestions, selectedSearchContextSpec]
+        [isSourcegraphDotCom, navigate, fetchStreamSuggestions, selectedSearchContextSpec]
     )
 
     const extensions = useMemo(() => {

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -33,13 +33,7 @@ export interface SearchBoxProps
         PlatformContextProps<'requestGraphQL'>,
         Pick<
             LazyQueryInputProps,
-            | 'autoFocus'
-            | 'onFocus'
-            | 'onSubmit'
-            | 'interpretComments'
-            | 'onChange'
-            | 'onCompletionItemSelected'
-            | 'applySuggestionsOnEnter'
+            'autoFocus' | 'onFocus' | 'onSubmit' | 'interpretComments' | 'onChange' | 'onCompletionItemSelected'
         > {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean // significant for query suggestions
@@ -194,7 +188,6 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                         patternType={props.patternType}
                         queryState={queryState}
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
-                        applySuggestionsOnEnter={props.applySuggestionsOnEnter}
                         searchHistory={recentSearchesWithoutSearchContext}
                         onSelectSearchFromHistory={onInlineSearchHistorySelect}
                     />

--- a/client/branded/src/search-ui/input/codemirror/completion.test.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.test.ts
@@ -102,7 +102,7 @@ describe('codmirror completions', () => {
                 'type',
                 'visibility',
                 ...shorthandSuggestions,
-                'RepoRoutes',
+                'variable RepoRoutes',
             ].filter(label => label.toLowerCase().includes('re'))
         )
     })
@@ -359,7 +359,7 @@ describe('codmirror completions', () => {
         `)
     })
 
-    const suggestionType = (query: string): string => suggestionTypeFromTokens(getTokens(query), { applyOnEnter: true })
+    const suggestionType = (query: string): string => suggestionTypeFromTokens(getTokens(query))
     test('suggests repos for global queries', async () => {
         expect(suggestionType('sourcegraph')).toStrictEqual('repo')
     })

--- a/client/branded/src/search-ui/input/codemirror/completion.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.ts
@@ -154,13 +154,7 @@ const theme = EditorView.theme({
  * searchQueryAutocompletion registers extensions for automcompletion, using the
  * provided suggestion sources.
  */
-export function searchQueryAutocompletion(
-    sources: StandardSuggestionSource[],
-    navigate?: NavigateFunction,
-    // By default we do not enable suggestion selection with enter because that
-    // interferes with the query submission logic.
-    applyOnEnter = false
-): Extension {
+export function searchQueryAutocompletion(sources: StandardSuggestionSource[], navigate?: NavigateFunction): Extension {
     const override: CompletionSource[] = sources.map(source => context => {
         const position = context.pos
         const query = context.state.facet(queryTokens)
@@ -178,7 +172,7 @@ export function searchQueryAutocompletion(
         {
             render(completion) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                if (applyOnEnter && (completion as any)?.url) {
+                if ((completion as any)?.url) {
                     return createSVGIcon(mdiLightningBoltCircle, '')
                 }
                 const icon = createSVGIcon(
@@ -235,61 +229,53 @@ export function searchQueryAutocompletion(
 
     return [
         Prec.highest(
-            keymap.of(
-                applyOnEnter
-                    ? [
-                          ...completionKeymap.map(keybinding => {
-                              const { run } = keybinding
-                              if (keybinding.key !== 'Enter' || run === undefined) {
-                                  return keybinding
-                              }
-                              // Override `Enter` into `Tab` and automatically
-                              // accept the first suggestion without an explicit
-                              // `DownArrow` to mirror the behavior of the old
-                              // "Tab to complete" behavior.
-                              return {
-                                  ...keybinding,
-                                  key: 'Tab',
-                                  run(view: EditorView) {
-                                      if (selectedCompletion(view.state) === null) {
-                                          // No completion is selected because we
-                                          // disable the `selectOnOpen` option
-                                          // when applyOnEnter is true.
-                                          if (currentCompletions(view.state).length > 0) {
-                                              view.dispatch({ effects: setSelectedCompletion(0) })
-                                              acceptCompletion(view)
-                                              return true
-                                          }
-                                          return false
-                                      }
-                                      return run(view)
-                                  },
-                              }
-                          }),
-                          {
-                              key: 'Enter',
-                              run(view) {
-                                  const selected = selectedCompletion(view.state)
-                                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-                                  const url = (selected as any)?.url
-                                  if (navigate && typeof url === 'string') {
-                                      navigate(url)
-                                      return true
-                                  }
-                                  // Otherwise apply the selected completion item
-                                  const hasUserPressedDownArrow = selectedCompletion(view.state) !== null
-                                  if (hasUserPressedDownArrow) {
-                                      return acceptCompletion(view)
-                                  }
-                                  return false
-                              },
-                          },
-                      ]
-                    : // Uses the default keymapping but changes accepting suggestions from Enter to Tab
-                      completionKeymap.map(keybinding =>
-                          keybinding.key === 'Enter' ? { ...keybinding, key: 'Tab' } : keybinding
-                      )
-            )
+            keymap.of([
+                ...completionKeymap.map(keybinding => {
+                    const { run } = keybinding
+                    if (keybinding.key !== 'Enter' || run === undefined) {
+                        return keybinding
+                    }
+                    // Override `Enter` into `Tab` and automatically
+                    // accept the first suggestion without an explicit
+                    // `DownArrow` to mirror the behavior of the old
+                    // "Tab to complete" behavior.
+                    return {
+                        ...keybinding,
+                        key: 'Tab',
+                        run(view: EditorView) {
+                            if (selectedCompletion(view.state) === null) {
+                                // No completion is selected because we
+                                // disable the `selectOnOpen` option.
+                                if (currentCompletions(view.state).length > 0) {
+                                    view.dispatch({ effects: setSelectedCompletion(0) })
+                                    acceptCompletion(view)
+                                    return true
+                                }
+                                return false
+                            }
+                            return run(view)
+                        },
+                    }
+                }),
+                {
+                    key: 'Enter',
+                    run(view) {
+                        const selected = selectedCompletion(view.state)
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+                        const url = (selected as any)?.url
+                        if (navigate && typeof url === 'string') {
+                            navigate(url)
+                            return true
+                        }
+                        // Otherwise apply the selected completion item
+                        const hasUserPressedDownArrow = selectedCompletion(view.state) !== null
+                        if (hasUserPressedDownArrow) {
+                            return acceptCompletion(view)
+                        }
+                        return false
+                    },
+                },
+            ])
         ),
         theme,
         EditorView.updateListener.of(update => {
@@ -310,7 +296,7 @@ export function searchQueryAutocompletion(
             optionClass: completionItem => 'completion-type-' + (completionItem.type ?? ''),
             icons: false,
             closeOnBlur: true,
-            selectOnOpen: !applyOnEnter,
+            selectOnOpen: false,
             addToOptions,
         }),
     ]
@@ -319,7 +305,6 @@ export function searchQueryAutocompletion(
 export interface DefaultSuggestionSourcesOptions {
     fetchSuggestions: (query: string, onAbort: (listener: () => void) => void) => Promise<SearchMatch[]>
     isSourcegraphDotCom: boolean
-    applyOnEnter?: boolean
     disableFilterCompletion?: true
     disableSymbolCompletion?: true
     showWhenEmpty?: boolean
@@ -479,7 +464,7 @@ export function createDefaultSuggestionSources(
                 }
 
                 const results: SearchMatch[] = await options.fetchSuggestions(
-                    getSuggestionQuery(tokens, token, suggestionTypeFromTokens(tokens, options)),
+                    getSuggestionQuery(tokens, token, suggestionTypeFromTokens(tokens)),
                     context.onAbort
                 )
                 if (results.length === 0) {
@@ -504,10 +489,7 @@ export function createDefaultSuggestionSources(
 }
 
 // Returns what kind of type to query for based on existing tokens in the query
-export function suggestionTypeFromTokens(
-    tokens: Token[],
-    options: Pick<DefaultSuggestionSourcesOptions, 'applyOnEnter'>
-): SearchMatch['type'] {
+export function suggestionTypeFromTokens(tokens: Token[]): SearchMatch['type'] {
     let isWithinRepo = false
     let isWithinFile = false
     for (const token of tokens) {
@@ -539,9 +521,6 @@ export function suggestionTypeFromTokens(
                 isWithinFile = true
                 break
         }
-    }
-    if (!options.applyOnEnter) {
-        return 'symbol'
     }
     // We don't suggest paths because it's easier to get completions for files
     // with the `file:QUERY` filter compared to `type:symbol QUERY`.
@@ -594,16 +573,13 @@ function completionFromSearchMatch(
             ]
         case 'symbol':
             return match.symbols.map(symbol => ({
-                label:
-                    (options.applyOnEnter && params?.isDefaultSource ? `${symbol.kind.toLowerCase()} ` : '') +
-                    symbol.name,
+                label: (params?.isDefaultSource ? `${symbol.kind.toLowerCase()} ` : '') + symbol.name,
                 type: symbol.kind,
                 url: hasNonActivePatternTokens ? undefined : symbol.url,
                 apply: symbol.name + ' ',
-                detail:
-                    options.applyOnEnter && params?.isDefaultSource
-                        ? basename(match.path)
-                        : `${startCase(symbol.kind.toLowerCase())} | ${basename(match.path)}`,
+                detail: params?.isDefaultSource
+                    ? basename(match.path)
+                    : `${startCase(symbol.kind.toLowerCase())} | ${basename(match.path)}`,
                 info: match.repository,
             }))
         default:

--- a/client/branded/src/search-ui/input/codemirror/index.ts
+++ b/client/branded/src/search-ui/input/codemirror/index.ts
@@ -64,10 +64,6 @@ export const singleLine = EditorState.transactionFilter.of(transaction => {
 interface CreateDefaultSuggestionsOptions extends Omit<DefaultSuggestionSourcesOptions, 'fetchSuggestions'> {
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
     navigate?: NavigateFunction
-    /**
-     * Whether or not to allow suggestions selection by Enter key.
-     */
-    applyOnEnter?: boolean
 }
 
 /**
@@ -80,7 +76,6 @@ export const createDefaultSuggestions = ({
     disableFilterCompletion,
     disableSymbolCompletion,
     navigate,
-    applyOnEnter,
     showWhenEmpty,
 }: CreateDefaultSuggestionsOptions): Extension => [
     searchQueryAutocompletion(
@@ -90,10 +85,8 @@ export const createDefaultSuggestions = ({
             disableSymbolCompletion,
             disableFilterCompletion,
             showWhenEmpty,
-            applyOnEnter,
         }),
-        navigate,
-        applyOnEnter
+        navigate
     ),
     loadingIndicator(),
 ]

--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -311,7 +311,6 @@ const defaultFeatures: SettingsExperimentalFeatures = {
     codeInsightsCompute: false,
     editor: 'codemirror6',
     codeInsightsRepoUI: 'search-query-or-strict-list',
-    applySearchQuerySuggestionOnEnter: false,
     isInitialized: true,
     searchQueryInput: 'experimental',
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -8,7 +8,6 @@ import { LazyQueryInput } from '@sourcegraph/branded'
 import type { QueryState } from '@sourcegraph/shared/src/search'
 import { FilterType, resolveFilter, validateFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { Button, Link, Card, Icon, Checkbox, Code, H3, Tooltip } from '@sourcegraph/wildcard'
 
@@ -125,9 +124,6 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
 
     const [queryState, setQueryState] = useState<QueryState>({ query: query || '' })
 
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-
     useEffect(() => {
         const value = queryState.query
         const tokens = scanSearchQuery(value)
@@ -242,7 +238,6 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     onChange={setQueryState}
                                     preventNewLine={true}
                                     autoFocus={true}
-                                    applySuggestionsOnEnter={applySuggestionsOnEnter}
                                 />
                             </div>
                             <div className={styles.queryInputPreviewLink}>

--- a/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
+++ b/client/web/src/enterprise/insights/components/form/monaco-field/MonacoField.tsx
@@ -93,7 +93,6 @@ export const MonacoField = forwardRef<HTMLInputElement, MonacoFieldProps>((props
             editorOptions={monacoOptions}
             autoFocus={autoFocus}
             onBlur={onBlur}
-            applySuggestionsOnEnter={false}
             tabIndex={tabIndex}
         />
     )

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -16,7 +16,6 @@ import {
 } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { QueryState, SearchContextProps } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -143,8 +142,6 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
         props
     const navigate = useNavigate()
     const isLightTheme = useIsLightTheme()
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
     const [name, setName] = useState(searchContext ? searchContext.name : '')
     const [description, setDescription] = useState(searchContext ? searchContext.description : '')
@@ -441,7 +438,6 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                                 queryState={queryState}
                                 onChange={setQueryState}
                                 preventNewLine={false}
-                                applySuggestionsOnEnter={applySuggestionsOnEnter}
                             />
                         </div>
                         <div className={classNames(styles.searchContextFormQueryLabel, 'text-muted')}>

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.tsx
@@ -8,7 +8,6 @@ import { createDefaultSuggestions } from '@sourcegraph/branded'
 import { isMacPlatform as isMacPlatformFunc } from '@sourcegraph/common'
 import type { PathMatch } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { Icon, Button, Input, InputStatus } from '@sourcegraph/wildcard'
 
 import type { BlockProps, FileBlockInput } from '../..'
@@ -46,9 +45,6 @@ const editorAttributes = [
 export const NotebookFileBlockInputs: React.FunctionComponent<
     React.PropsWithChildren<NotebookFileBlockInputsProps>
 > = ({ id, lineRange, onFileSelected, onLineRangeChange, isSourcegraphDotCom, ...inputProps }) => {
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-
     const [lineRangeInput, setLineRangeInput] = useState(serializeLineRange(lineRange))
     const debouncedOnLineRangeChange = useMemo(() => debounce(onLineRangeChange, 300), [onLineRangeChange])
 
@@ -99,9 +95,8 @@ export const NotebookFileBlockInputs: React.FunctionComponent<
             createDefaultSuggestions({
                 isSourcegraphDotCom,
                 fetchSuggestions: fetchStreamSuggestions,
-                applyOnEnter: applySuggestionsOnEnter,
             }),
-        [isSourcegraphDotCom, applySuggestionsOnEnter]
+        [isSourcegraphDotCom]
     )
 
     return (

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -16,7 +16,7 @@ import { editorHeight } from '@sourcegraph/shared/src/components/CodeMirrorEdito
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
-import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
@@ -77,8 +77,6 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         const [editor, setEditor] = useState<EditorView>()
         const searchResults = useObservable(output ?? of(undefined))
         const [executedQuery, setExecutedQuery] = useState<string>(input.query)
-        const applySuggestionsOnEnter =
-            useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
         const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
         const searchMode = useNavbarQueryState(state => state.searchMode)
@@ -136,9 +134,8 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                 createDefaultSuggestions({
                     isSourcegraphDotCom,
                     fetchSuggestions: fetchStreamSuggestions,
-                    applyOnEnter: applySuggestionsOnEnter,
                 }),
-            [isSourcegraphDotCom, applySuggestionsOnEnter]
+            [isSourcegraphDotCom]
         )
 
         // Focus editor on component creation if necessary

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlockInput.tsx
@@ -40,9 +40,6 @@ const editorAttributes = [
 export const NotebookSymbolBlockInput: React.FunctionComponent<
     React.PropsWithChildren<NotebookSymbolBlockInputProps>
 > = ({ onSymbolSelected, isSourcegraphDotCom, ...inputProps }) => {
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-
     const fetchSymbolSuggestions = useCallback(
         (query: string) =>
             fetchSuggestions(
@@ -70,10 +67,9 @@ export const NotebookSymbolBlockInput: React.FunctionComponent<
             createDefaultSuggestions({
                 isSourcegraphDotCom,
                 fetchSuggestions: fetchStreamSuggestions,
-                applyOnEnter: applySuggestionsOnEnter,
                 disableSymbolCompletion: true,
             }),
-        [isSourcegraphDotCom, applySuggestionsOnEnter]
+        [isSourcegraphDotCom]
     )
 
     return (

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -5,7 +5,6 @@ import type { Omit } from 'utility-types'
 
 import { LazyQueryInput } from '@sourcegraph/branded'
 import type { QueryState } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import {
     Container,
     PageHeader,
@@ -94,9 +93,6 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
 
     const { query, description, notify, notifySlack, slackWebhookURL } = values
 
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
-
     const [queryState, setQueryState] = useState<QueryState>({ query: query || '' })
 
     useEffect(() => {
@@ -133,13 +129,12 @@ export const SavedSearchForm: React.FunctionComponent<React.PropsWithChildren<Sa
                             queryState={queryState}
                             onChange={setQueryState}
                             preventNewLine={true}
-                            applySuggestionsOnEnter={applySuggestionsOnEnter}
                         />
                     </Label>
                     {props.defaultValues?.notify && (
                         <div className="form-group mb-0">
                             {/* Label is for visual benefit, input has more specific label attached */}
-                            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                            {}
                             <Label className={styles.label} id="saved-search-form-email-notifications">
                                 Email notifications
                             </Label>

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -16,7 +16,6 @@ import {
 } from '@sourcegraph/branded'
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { LoadingSpinner, Button, useObservable } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
@@ -40,9 +39,6 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
     const location = useLocation()
     const navigate = useNavigate()
     const { streamSearch, isSourcegraphDotCom } = props
-    const { applySuggestionsOnEnter } = useExperimentalFeatures(features => ({
-        applySuggestionsOnEnter: features.applySearchQuerySuggestionOnEnter ?? true,
-    }))
     const searchQuery = useMemo(
         () => new BehaviorSubject<string>(parseSearchURLQuery(location.search) ?? ''),
         [location.search]
@@ -73,9 +69,8 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
             createDefaultSuggestions({
                 fetchSuggestions: query => fetchStreamSuggestions(query),
                 isSourcegraphDotCom,
-                applyOnEnter: applySuggestionsOnEnter,
             }),
-        [isSourcegraphDotCom, applySuggestionsOnEnter]
+        [isSourcegraphDotCom]
     )
 
     const extensions = useMemo(

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -6,7 +6,7 @@ import shallow from 'zustand/shallow'
 import { SearchBox, Toggles } from '@sourcegraph/branded'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
-import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Form } from '@sourcegraph/wildcard'
 
@@ -53,8 +53,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
         useNavbarQueryState(selectQueryState, shallow)
 
     const [experimentalQueryInput] = useExperimentalQueryInput()
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
     const { recentSearches } = useRecentSearches()
 
@@ -130,7 +128,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
             <SearchBox
                 {...props}
                 autoFocus={false}
-                applySuggestionsOnEnter={applySuggestionsOnEnter}
                 showSearchContext={props.searchContextsEnabled}
                 showSearchContextManagement={true}
                 caseSensitive={searchCaseSensitivity}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -15,7 +15,6 @@ import {
     type SearchModeProps,
     getUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Form } from '@sourcegraph/wildcard'
 
@@ -76,8 +75,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
     const isLightTheme = useIsLightTheme()
     const { caseSensitive, patternType, searchMode } = useNavbarQueryState(queryStateSelector, shallow)
     const [experimentalQueryInput] = useExperimentalQueryInput()
-    const applySuggestionsOnEnter =
-        useExperimentalFeatures(features => features.applySearchQuerySuggestionOnEnter) ?? true
 
     const { recentSearches } = useRecentSearches()
 
@@ -191,7 +188,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             autoFocus={!isTouchOnlyDevice}
             isExternalServicesUserModeAll={window.context.externalServicesUserMode === 'all'}
             structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
-            applySuggestionsOnEnter={applySuggestionsOnEnter}
             showSearchHistory={true}
             recentSearches={recentSearches}
         />

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -169,14 +169,6 @@
             "pointer": true
           }
         },
-        "applySearchQuerySuggestionOnEnter": {
-          "description": "This changes the behavior of the autocompletion feature in the search query input. If set the first suggestion won't be selected by default and a selected suggestion can be selected by pressing Enter (application by pressing Tab continues to work)",
-          "type": "boolean",
-          "default": false,
-          "!go": {
-            "pointer": true
-          }
-        },
         "searchResultsAggregations": {
           "description": "Display aggregations for your search results on the search screen.",
           "type": "boolean",


### PR DESCRIPTION
This makes it so that the previously on-by-default behavior is now the only behavior. This only affects the old query input, not the new query input. The behavior is confusing to describe, but it basically means that as you type in the old query input, there is no autocomplete item selected until you press the down arrow, so pressing <kbd>Enter</kbd> does not confusingly accept an autocomplete item that you did not intend.
    
This was set to on by default on https://sourcegraph.com 9 months ago at https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/17546, and has been on by default in all other instances for 1 year.



## Test plan

With the old query input enabled, ensure that the 1st autocomplete item is not selected until you press the down arrow.