### PR TITLE
remove old USE_EXTENSIONS env var

### DIFF
--- a/client/browser/config/webpack/development.config.ts
+++ b/client/browser/config/webpack/development.config.ts
@@ -26,7 +26,6 @@ export const config: webpack.Configuration = {
                 'process.env': {
                     NODE_ENV: JSON.stringify('development'),
                     BUNDLE_UID: JSON.stringify(generateBundleUID()),
-                    USE_EXTENSIONS: JSON.stringify(process.env.USE_EXTENSIONS),
                 },
             }),
         ]

--- a/client/browser/config/webpack/production.config.bazel.ts
+++ b/client/browser/config/webpack/production.config.bazel.ts
@@ -32,7 +32,6 @@ export const config: webpack.Configuration = {
                 'process.env': {
                     NODE_ENV: JSON.stringify('production'),
                     BUNDLE_UID: JSON.stringify(generateBundleUID()),
-                    USE_EXTENSIONS: JSON.stringify(process.env.USE_EXTENSIONS),
                 },
             }),
             new webpack.ProvidePlugin({

--- a/client/browser/config/webpack/production.config.ts
+++ b/client/browser/config/webpack/production.config.ts
@@ -32,7 +32,6 @@ export const config: webpack.Configuration = {
                 'process.env': {
                     NODE_ENV: JSON.stringify('production'),
                     BUNDLE_UID: JSON.stringify(generateBundleUID()),
-                    USE_EXTENSIONS: JSON.stringify(process.env.USE_EXTENSIONS),
                 },
             }),
             new webpack.ProvidePlugin({


### PR DESCRIPTION
This was used for the deprecated and removed Sourcegraph extension API support.




## Test plan

CI