### PR TITLE
monitoring: add queue growth panel and alert

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -7480,6 +7480,43 @@ Generated query for warning alert: `max((rate(src_telemetry_job_total{op="SendEv
 
 <br />
 
+## telemetry: telemetry_gateway_exporter_queue_growth
+
+<p class="subtitle">rate of growth of export queue over 30m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> telemetry: 1+ rate of growth of export queue over 30m for 1h0m0s
+- <span class="badge badge-critical">critical</span> telemetry: 1+ rate of growth of export queue over 30m for 36h0m0s
+
+**Next steps**
+
+- Increase `TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE` to export more events per batch.
+- Reduce `TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL` to schedule more export jobs.
+- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details to see if any export errors are occuring - if logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#telemetry-telemetry-gateway-exporter-queue-growth).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_telemetry_telemetry_gateway_exporter_queue_growth",
+  "critical_telemetry_telemetry_gateway_exporter_queue_growth"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
+
+Generated query for critical alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
+
+</details>
+
+<br />
+
 ## telemetry: telemetrygatewayexporter_exporter_errors_total
 
 <p class="subtitle">events exporter operation errors every 30m</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -30829,6 +30829,27 @@ Query: `sum(src_telemetrygatewayexporter_queue_size)`
 
 <br />
 
+#### telemetry: telemetry_gateway_exporter_queue_growth
+
+<p class="subtitle">Rate of growth of export queue over 30m</p>
+
+A positive value indicates the queue is growing.
+
+Refer to the [alerts reference](./alerts.md#telemetry-telemetry-gateway-exporter-queue-growth) for 2 alerts related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100301` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max(deriv(src_telemetrygatewayexporter_queue_size[30m]))`
+
+</details>
+
+<br />
+
 #### telemetry: src_telemetrygatewayexporter_exported_events
 
 <p class="subtitle">Events exported from queue per hour</p>
@@ -30837,7 +30858,7 @@ The number of events being exported.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100301` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100310` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30858,7 +30879,7 @@ The number of events exported in each batch.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100302` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100311` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 

--- a/monitoring/definitions/telemetry.go
+++ b/monitoring/definitions/telemetry.go
@@ -39,6 +39,25 @@ func Telemetry() *monitoring.Dashboard {
 							Interpretation: "The number of events queued to be exported.",
 						},
 						{
+							Name:           "telemetry_gateway_exporter_queue_growth",
+							Description:    "rate of growth of export queue over 30m",
+							Owner:          monitoring.ObservableOwnerDataAnalytics,
+							Query:          `max(deriv(src_telemetrygatewayexporter_queue_size[30m]))`,
+							Panel:          monitoring.Panel().LegendFormat("growth").MinAuto(),
+							Interpretation: `A positive value indicates the queue is growing.`,
+							// Warn when steadily growing
+							Warning: monitoring.Alert().Greater(1).For(1 * time.Hour),
+							// Critical when it grows without ever reducing
+							Critical: monitoring.Alert().Greater(1).For(36 * time.Hour),
+							NextSteps: `
+								- Increase 'TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE' to export more events per batch.
+								- Reduce 'TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL' to schedule more export jobs.
+								- See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details to see if any export errors are occuring - if logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph's Telemetry Gateway service.
+							`,
+						},
+					},
+					{
+						{
 							Name:           "src_telemetrygatewayexporter_exported_events",
 							Description:    "events exported from queue per hour",
 							Owner:          monitoring.ObservableOwnerDataAnalytics,


### PR DESCRIPTION
This includes 1 critical alert - if the export queue grows without decreasing for a very long time (36h). This is a real problem as it can mean there is a very large amount of data accumulating in the DB.

## Test plan

Against Sourcegraph.com data:

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/090b5586-a017-48ce-abd0-93104a41aac6)



## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@telemetry-export-critical-alert)