### PR TITLE
Embeddings: tolerate some failure when generating embeddings

### DIFF
--- a/enterprise/cmd/worker/internal/embeddings/repo/handler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/handler.go
@@ -42,6 +42,7 @@ const (
 	embeddingChunkTokensThreshold           = 256
 	embeddingChunkEarlySplitTokensThreshold = embeddingChunkTokensThreshold - 32
 	embeddingsBatchSize                     = 512
+	embeddingsTolerableFailureRatio         = 0.10
 )
 
 var splitOptions = codeintelContext.SplitOptions{
@@ -133,11 +134,12 @@ func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.
 			IncludePatterns:  includedFiles,
 			MaxFileSizeBytes: embeddingsConfig.FileFilters.MaxFileSizeBytes,
 		},
-		SplitOptions:      splitOptions,
-		MaxCodeEmbeddings: embeddingsConfig.MaxCodeEmbeddingsPerRepo,
-		MaxTextEmbeddings: embeddingsConfig.MaxTextEmbeddingsPerRepo,
-		BatchSize:         embeddingsBatchSize,
-		ExcludeChunks:     embeddingsConfig.ExcludeChunkOnError,
+		SplitOptions:          splitOptions,
+		MaxCodeEmbeddings:     embeddingsConfig.MaxCodeEmbeddingsPerRepo,
+		MaxTextEmbeddings:     embeddingsConfig.MaxTextEmbeddingsPerRepo,
+		BatchSize:             embeddingsBatchSize,
+		ExcludeChunks:         embeddingsConfig.ExcludeChunkOnError,
+		TolerableFailureRatio: embeddingsTolerableFailureRatio,
 	}
 
 	if previousIndex != nil {

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -274,7 +274,7 @@ func embedFiles(
 			return nil, errors.Newf("expected embeddings for batch to have length %d, got %d", expected, len(batchEmbeddings.Embeddings))
 		}
 
-		if len(batchEmbeddings.Failed) > 0 && !excludeChunksOnError {
+		if !excludeChunksOnError && len(batchEmbeddings.Failed) > 0 {
 			// if at least one chunk failed then return an error instead of completing the embedding indexing
 			return nil, errors.Newf("batch failed on file %q", batch[batchEmbeddings.Failed[0]].FileName)
 		}

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -270,13 +270,13 @@ func embedFiles(
 			}
 		}
 
+		if expected := len(batchChunks) * dimensions; len(batchEmbeddings.Embeddings) != expected {
+			return nil, errors.Newf("expected embeddings for batch to have length %d, got %d", expected, len(batchEmbeddings.Embeddings))
+		}
+
 		if len(batchEmbeddings.Failed) > 0 && !excludeChunksOnError {
 			// if at least one chunk failed then return an error instead of completing the embedding indexing
 			return nil, errors.Newf("batch failed on file %q", batch[batchEmbeddings.Failed[0]].FileName)
-		}
-
-		if expected := len(batchChunks) * dimensions; len(batchEmbeddings.Embeddings) != expected {
-			return nil, errors.Newf("expected embeddings for batch to have length %d, got %d", expected, len(batchEmbeddings.Embeddings))
 		}
 
 		// When excluding failed chunks we


### PR DESCRIPTION
We regularly run into a problem where a customer with a large repo tries to embed that repo, gets part way, but then flakiness from OpenAI, their network, or whatever else causes the whole embeddings job to fail. This is very frustrating on the side of the customer, and is the source of a lot of delays when getting customers up and running with Cody. We already retry in the HTTP layer, but sometimes this isn't enough, especially since failures seem to be correlated with the content being sent.

Instead, this PR allows some requests to fail. We already allow some _chunks_ to fail (which is the most common failure case where openAI just returns a null vector), but this extends that setting to now also include full request failures. 

To avoid jobs succeeding when there is a configuration error, some persistent connection error, or the like, we allow some chunks to fail, but if more than 10% of the chunks fail to embed, we fail the whole job. This number is arbitrary, but it probably doesn't matter too much as long as it's greater than zero and less than 100. 

## Test plan

Added two unit tests for "a little failure" and "much failure".

Manually tested that a broken token will still cause the job to fail, that a normal job passes, and that a transient failure will allow the job to pass.